### PR TITLE
Fixed bug #3509665 - Grid editing does not work after session expires

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ phpMyAdmin - ChangeLog
 + Patch #3506552 Contest-2: Show index information in the data dictionary
 + Patch #3510656 Contest-1: Ignoring foreign keys while dropping tables
 - Bug #3509686 Reverting sort on joined column does not work
+- bug #3509665 [AJAX] Grid editing does not work after session expires
 
 3.5.1.0 (not yet released)
 - bug #3510784 [edit] Limit clause ignored when sort order is remembered


### PR DESCRIPTION
Link to bugtracker: https://sourceforge.net/tracker/index.php?func=detail&aid=3509665&group_id=23067&atid=377408

What I did in the commit is move the initialisation of the 'is_ajax_request' (and 'make_grid', since they logically belong together) global variable to the top of common.inc.php where other variables are initialised, so that lower down in this file it can be checked in a standard way if we are dealing with an AJAX request.
Then if that's the case and the user is not authenticated, just reply with a "Session expired" message encoded as JSON.

Bye,
Rouslan
