### PR TITLE
Small fixes in libraries/transformations/global.inc.php

### DIFF
--- a/libraries/transformations/global.inc.php
+++ b/libraries/transformations/global.inc.php
@@ -25,7 +25,7 @@
 /**
  *
  */
-function PMA_transformation_global_html_replace($buffer, $options = array(), $meta = '')
+function PMA_transformation_global_html_replace($buffer, $options = array())
 {
     if ( ! isset($options['string']) ) {
         $options['string'] = '';

--- a/libraries/transformations/global.inc.php
+++ b/libraries/transformations/global.inc.php
@@ -27,11 +27,15 @@
  */
 function PMA_transformation_global_html_replace($buffer, $options = array(), $meta = '')
 {
-    if (!isset($options['string'])) {
+    if ( ! isset($options['string']) ) {
         $options['string'] = '';
     }
 
-    if (isset($options['regex']) && isset($options['regex_replace'])) {
+    if (
+          isset($options['regex'])
+          &&
+          isset($options['regex_replace'])
+    ) {
         $buffer = preg_replace('@' . str_replace('@', '\@', $options['regex']) . '@si', $options['regex_replace'], $buffer);
     }
 

--- a/libraries/transformations/global.inc.php
+++ b/libraries/transformations/global.inc.php
@@ -25,16 +25,6 @@
 /**
  *
  */
-function PMA_transformation_global_plain($buffer, $options = array(), $meta = '')
-{
-    return htmlspecialchars($buffer);
-}
-
-function PMA_transformation_global_html($buffer, $options = array(), $meta = '')
-{
-    return $buffer;
-}
-
 function PMA_transformation_global_html_replace($buffer, $options = array(), $meta = '')
 {
     if (!isset($options['string'])) {

--- a/libraries/transformations/global.inc.php
+++ b/libraries/transformations/global.inc.php
@@ -23,7 +23,20 @@
  */
 
 /**
+ * Replaces "[__BUFFER__]" occurences found in $options['string'] with the text
+ * in $buffer, after performing a regular expression search and replace on 
+ * $buffer using $options['regex'] and $options['regex_replace'].
  *
+ * @param string $buffer        text that will be replaced in $options['string'],
+ *                              after being formatted
+ * @param array  $options       the options required to format $buffer
+ *               = array (
+ *                 'string'          => 'string',    // text containing "[__BUFFER__]"
+ *                 'regex'           => 'mixed',     // the pattern to search for
+ *                 'regex_replace'   => 'mixed',     // string or array of strings to replace with
+ *               );
+ *
+ * @return string containing the text with all the replacements
  */
 function PMA_transformation_global_html_replace($buffer, $options = array())
 {


### PR DESCRIPTION
First of all, I've noticed that the two functions: 
  PMA_transformation_global_plain($buffer, $options = array(), $meta = '') and
  PMA_transformation_global_html($buffer, $options = array(), $meta = '')
are not used anywhere in the project, so I have removed them.

Also, the $meta argument is not used in the third function:
  PMA_transformation_global_html_replace($buffer, $options = array(), $meta = '')
so I have removed that argument as well.

The other two commits are for adding a PHPDoc comment to this function and improving readability.

Alex
