### PR TITLE
ForceSSL fix see bug #3510196

### DIFF
--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -352,7 +352,7 @@ if ($GLOBALS['PMA_Config']->get('ForceSSL')
             $GLOBALS['PMA_Config']->get('PmaAbsoluteUri'))
         . PMA_generate_common_url($_GET, 'text'));
     // delete the current session, otherwise we get problems (see bug #2397877)
-    PMA_removeCookie($GLOBALS['session_name']);
+    $GLOBALS['PMA_Config']->PMA_removeCookie($GLOBALS['session_name']);
     exit;
 }
 

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -337,14 +337,22 @@ if (isset($_COOKIE)
  * check HTTPS connection
  */
 if ($GLOBALS['PMA_Config']->get('ForceSSL')
-    && ! $GLOBALS['PMA_Config']->get('is_https')
-) {
+  && !$GLOBALS['PMA_Config']->get('is_https')) {
+    // Make sure the SSL port isn't modified from the default 443
+    if($GLOBALS['PMA_Config']->get('SSLPort'))
+      $port_number = $GLOBALS['PMA_Config']->get('SSLPort');
+    else
+      $port_number = 443;
+
+    $url_find    = array('/^http/', '/:\d+/');
+    $url_replace = array('https', ':'.$port_number);
+
     PMA_sendHeaderLocation(
-        preg_replace('/^http/', 'https', $GLOBALS['PMA_Config']->get('PmaAbsoluteUri'))
-        . PMA_generate_common_url($_GET, 'text')
-    );
+        preg_replace($url_find, $url_replace,
+            $GLOBALS['PMA_Config']->get('PmaAbsoluteUri'))
+        . PMA_generate_common_url($_GET, 'text'));
     // delete the current session, otherwise we get problems (see bug #2397877)
-    $GLOBALS['PMA_Config']->removeCookie($GLOBALS['session_name']);
+    PMA_removeCookie($GLOBALS['session_name']);
     exit;
 }
 


### PR DESCRIPTION
This pull request addresses the following bug:

http://sourceforge.net/tracker/?func=detail&aid=3510196&group_id=23067&atid=377408

The two commenters disagree that it is a PHPMyAdmin issue, however I do not agree.  The OP's bug report is valid if you consider the fact that users can configure their server to run on a non-standard SSL port.   If you have set the PmaAbsoluteUri and reference the non-standard port number in that address, then phpMyAdmin will not use that port when ForceSSL is set to true.  This is addressed by keeping the port number in the URL when redirecting to SSL if it exists in PmaAbsoluteUri.

There is also a new config setting available called SSLPort.   If that is set, phpMyAdmin will redirect to that port number, otherwise the standard SSL port of 443 will be used.
