### PR TITLE
Multiple Navigation panels bug still present - ID: 3514490

### DIFF
--- a/libraries/auth/cookie.auth.lib.php
+++ b/libraries/auth/cookie.auth.lib.php
@@ -376,6 +376,10 @@ function PMA_auth_check()
         if ($GLOBALS['cfg']['AllowArbitraryServer'] && isset($_REQUEST['pma_servername'])) {
             $GLOBALS['pma_auth_server'] = $_REQUEST['pma_servername'];
         }
+        // The user logged in after his session had timed out
+        if (isset($_REQUEST['target']) && !empty($_REQUEST['target'])) {
+            $GLOBALS['target'] = $_REQUEST['target'];
+        }
         return true;
     }
 
@@ -603,3 +607,4 @@ function PMA_auth_fails()
 } // end of the 'PMA_auth_fails()' function
 
 ?>
+


### PR DESCRIPTION
I've fixed the multiple navigation panels bug. 
Short description: After session timed out, a user was forced to log in again. But after he logged in, the phpmyadmin did not remember where to redirect the user. Instead of redirecting him to the right place, multiple navigation panels were being recursively generated.
