### PR TITLE
export mediawiki outputs content and structure

### DIFF
--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -1635,6 +1635,20 @@ $cfg['Export']['mediawiki_structure_or_data'] = 'data';
 /**
  *
  *
+ * @global boolean $cfg['Export']['mediawiki_caption']
+ */
+
+$cfg['Export']['mediawiki_caption'] = true;
+/**
+ *
+ *
+ * @global boolean $cfg['Export']['mediawiki_headers']
+ */
+$cfg['Export']['mediawiki_headers'] = true;
+
+/**
+ *
+ *
  * @global string $cfg['Export']['ods_structure_or_data']
  */
 $cfg['Export']['ods_structure_or_data'] = 'data';

--- a/libraries/database_interface.lib.php
+++ b/libraries/database_interface.lib.php
@@ -1129,6 +1129,27 @@ function PMA_DBI_get_columns($database, $table, $column = null, $full = false, $
 }
 
 /**
+ * Returns all column names in given table
+ *
+ * @param string  $database name of database
+ * @param string  $table    name of table to retrieve columns from
+ * @param mixed   $link     mysql link resource
+ *
+ * @return  null|array
+ */
+function PMA_DBI_get_column_names($database, $table, $link = null)
+{
+    $sql = PMA_DBI_get_columns_sql($database, $table);
+    // We only need the 'Field' column which contains the table's column names
+    $fields = array_keys(PMA_DBI_fetch_result($sql, 'Field', null, $link));
+
+    if ( ! is_array($fields) || count($fields) == 0 ) {
+        return null;
+    }
+    return $fields;
+}
+
+/**
 * Returns SQL for fetching information on table indexes (SHOW INDEXES)
 *
 * @param string $database name of database

--- a/libraries/export/mediawiki.php
+++ b/libraries/export/mediawiki.php
@@ -1,10 +1,10 @@
 <?php
 /* vim: set expandtab sw=4 ts=4 sts=4: */
 /**
- * Set of functions used to build MediaWiki dumps of tables
+ *  Set of functions used to build MediaWiki dumps of tables
  *
- * @package PhpMyAdmin-Export
- * @subpackage MediaWiki
+ *  @package PhpMyAdmin-Export
+ *  @subpackage MediaWiki
  */
 if (! defined('PHPMYADMIN')) {
     exit;
@@ -13,16 +13,89 @@ if (! defined('PHPMYADMIN')) {
 if (isset($plugin_list)) {
     $plugin_list['mediawiki'] = array(
         'text' => __('MediaWiki Table'),
-        'extension' => 'txt',
+        'extension' => 'mediawiki',
         'mime_type' => 'text/plain',
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
-            array('type' => 'hidden', 'name' => 'structure_or_data'),
-            array('type' => 'end_group')
             ),
         'options_text' => __('Options'),
         );
+
+        // general options
+        $plugin_list['mediawiki']['options'][] = array(
+            'type' => 'begin_group',
+            'name' => 'general_opts');
+
+        // what to dump (structure/data/both)
+        $plugin_list['mediawiki']['options'][] = array(
+            'type' => 'begin_subgroup',
+            'subgroup_header' => array(
+                'type' => 'message_only',
+                'text' => __('Dump table')
+            ));
+        $plugin_list['mediawiki']['options'][] = array(
+            'type' => 'radio',
+            'name' => 'structure_or_data',
+            'values' => array(
+                'structure' => __('structure'),
+                'data' => __('data'),
+                'structure_and_data' => __('structure and data')
+            ));
+        $plugin_list['mediawiki']['options'][] = array(
+            'type' => 'end_subgroup'
+            );
+
+        // export table name
+        $plugin_list['mediawiki']['options'][] = array(
+            'type' => 'bool',
+            'name' => 'caption',
+            'text' => __('Export table names')
+            );
+
+        // export table headers
+        $plugin_list['mediawiki']['options'][] = array(
+            'type' => 'bool',
+            'name' => 'headers',
+            'text' => __('Export table headers')
+            );
+
+        // end general options
+        $plugin_list['mediawiki']['options'][] = array(
+            'type' => 'end_group'
+            );
 } else {
+
+    /**
+     * Outputs comments containing info about the exported tables
+     *
+     * @param string $text Text of comment
+     *
+     * @return string The formatted comment
+     *
+     * @access private
+     */
+    function PMA_exportComment($text = '')
+    {
+        // see http://www.mediawiki.org/wiki/Help:Formatting
+        $comment = PMA_exportCRLF();
+        $comment .= '<!--' . PMA_exportCRLF();
+        $comment .= $text  . PMA_exportCRLF();
+        $comment .= '-->'  . str_repeat(PMA_exportCRLF(), 2);
+
+        return $comment;
+    }
+
+    /**
+     * Outputs CRLF
+     *
+     * @return string CRLF
+     *
+     * @access private
+     */
+    function PMA_exportCRLF()
+    {
+        // The CRLF expected by the mediawiki format is "\n"
+        return "\n";
+    }
 
     /**
      * Outputs export footer
@@ -51,8 +124,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
-     * @return  bool        Whether it succeeded
+     * @param string $db Database name
+     *
+     * @return  bool     Whether it succeeded
      *
      * @access  public
      */
@@ -64,8 +138,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
-     * @return  bool        Whether it succeeded
+     * @param string $db Database name
+     *
+     * @return  bool     Whether it succeeded
      *
      * @access  public
      */
@@ -77,8 +152,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
-     * @return  bool        Whether it succeeded
+     * @param string $db Database name
+     *
+     * @return  bool     Whether it succeeded
      *
      * @access  public
      */
@@ -88,78 +164,169 @@ if (isset($plugin_list)) {
     }
 
     /**
-     * Outputs the content of a table in MediaWiki format
+     * Outputs table's structure
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
-     * @return  bool        Whether it succeeded
+     * @param string $db          database name
+     * @param string $table       table name
+     * @param string $crlf        the end of line sequence
+     * @param string $error_url   the url to go back in case of error
+     * 
+     * @param bool   $relation    whether to include relation comments
+     * @param bool   $comments    whether to include the pmadb-style column comments
+     *                            as comments in the structure; this is deprecated
+     *                            but the parameter is left here because export.php
+     *                            calls PMA_exportStructure() also for other export
+     *                            types which use this parameter
+     * @param bool   $mime        whether to include mime comments
+     * @param bool   $dates       whether to include creation/update/check dates
+     * @param string $export_mode 'create_table','triggers','create_view','stand_in'
+     * @param string $export_type 'server', 'database', 'table'
      *
-     * @access  public
+     * @return bool               Whether it succeeded
+     *
+     * @access public
      */
-    function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
-    {
-        $columns = PMA_DBI_get_columns($db, $table);
-        $columns = array_values($columns);
-        $row_cnt = count($columns);
+    function PMA_exportStructure(
+        $db, 
+        $table, 
+        $crlf, 
+        $error_url, 
+        $relation = false, 
+        $comments = false, 
+        $mime = false, 
+        $dates = false, 
+        $export_mode, 
+        $export_type
+    ) {
+        switch($export_mode) {
+        case 'create_table':
+            $columns = PMA_DBI_get_columns($db, $table);
+            $columns = array_values($columns);
+            $row_cnt = count($columns);
 
-        $output = "{| cellpadding=\"10\" cellspacing=\"0\" border=\"1\" style=\"text-align:center;\"\n";
-        $output .= "|+'''" . $table . "'''\n";
-        $output .= "|- style=\"background:#ffdead;\"\n";
-        $output .= "! style=\"background:#ffffff\" | \n";
-        for ($i = 0; $i < $row_cnt; ++$i) {
-            $output .= " | " . $columns[$i]['Field'];
-            if (($i + 1) != $row_cnt) {
-                $output .= "\n";
+            // Print structure comment
+            $output = PMA_exportComment(
+                "Table structure for "
+                . PMA_backquote($table)
+            );
+
+            // Begin the table construction
+            $output .= "{| class=\"wikitable\" style=\"text-align:center;\"" 
+                     . PMA_exportCRLF();
+
+            // Add the table name
+            if ($GLOBALS['mediawiki_caption']) {
+                $output .= "|+'''" . $table . "'''" . PMA_exportCRLF();
             }
-        }
-        $output .= "\n";
 
-        $output .= "|- style=\"background:#f9f9f9;\"\n";
-        $output .= "! style=\"background:#f2f2f2\" | Type\n";
-        for ($i = 0; $i < $row_cnt; ++$i) {
-            $output .= " | " . $columns[$i]['Type'];
-            if (($i + 1) != $row_cnt) {
-                $output .= "\n";
+            // Add the table headers
+            if ($GLOBALS['mediawiki_headers']) {
+                $output .= "|- style=\"background:#ffdead;\"" . PMA_exportCRLF();
+                $output .= "! style=\"background:#ffffff\" | " . PMA_exportCRLF();
+                for ($i = 0; $i < $row_cnt; ++$i) {
+                    $output .= " | " . $columns[$i]['Field']. PMA_exportCRLF();
+                }
             }
-        }
-        $output .= "\n";
 
-        $output .= "|- style=\"background:#f9f9f9;\"\n";
-        $output .= "! style=\"background:#f2f2f2\" | Null\n";
-        for ($i = 0; $i < $row_cnt; ++$i) {
-            $output .= " | " . $columns[$i]['Null'];
-            if (($i + 1) != $row_cnt) {
-                $output .= "\n";
+            // Add the table structure
+            $output .= "|-" .  PMA_exportCRLF();
+            $output .= "! Type" . PMA_exportCRLF();
+            for ($i = 0; $i < $row_cnt; ++$i) {
+                $output .= " | " . $columns[$i]['Type'] . PMA_exportCRLF();
             }
-        }
-        $output .= "\n";
 
-        $output .= "|- style=\"background:#f9f9f9;\"\n";
-        $output .= "! style=\"background:#f2f2f2\" | Default\n";
-        for ($i = 0; $i < $row_cnt; ++$i) {
-            $output .= " | " . $columns[$i]['Default'];
-            if (($i + 1) != $row_cnt) {
-                $output .= "\n";
+            $output .= "|-" .  PMA_exportCRLF();
+            $output .= "! Null" . PMA_exportCRLF();
+            for ($i = 0; $i < $row_cnt; ++$i) {
+                $output .= " | " . $columns[$i]['Null'] . PMA_exportCRLF();
             }
-        }
-        $output .= "\n";
 
-        $output .= "|- style=\"background:#f9f9f9;\"\n";
-        $output .= "! style=\"background:#f2f2f2\" | Extra\n";
-        for ($i = 0; $i < $row_cnt; ++$i) {
-            $output .= " | " . $columns[$i]['Extra'];
-            if (($i + 1) != $row_cnt) {
-                $output .= "\n";
+            $output .= "|-" .  PMA_exportCRLF();
+            $output .= "! Default" . PMA_exportCRLF();
+            for ($i = 0; $i < $row_cnt; ++$i) {
+                $output .= " | " . $columns[$i]['Default'] . PMA_exportCRLF();
             }
-        }
-        $output .= "\n";
 
-        $output .= "|}\n\n\n\n";
+            $output .= "|-" .  PMA_exportCRLF();
+            $output .= "! Extra" . PMA_exportCRLF();
+            for ($i = 0; $i < $row_cnt; ++$i) {
+                $output .= " | " . $columns[$i]['Extra'] . PMA_exportCRLF();
+            }
+
+            $output .= "|}" .  str_repeat(PMA_exportCRLF(), 2);
+            break;
+        } // end switch
+
         return PMA_exportOutputHandler($output);
     }
 
+    /**
+     * Outputs the content of a table in MediaWiki format
+     *
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
+     *
+     * @return  bool             Whether it succeeded
+     *
+     * @access  public
+     */
+    function PMA_exportData(
+        $db, 
+        $table, 
+        $crlf, 
+        $error_url, 
+        $sql_query
+    ) {
+        // Print data comment
+        $output = PMA_exportComment("Table data for ". PMA_backquote($table));
+
+        // Begin the table construction
+        // Use the "wikitable" class for style
+        // Use the "sortable"  class for allowing tables to be sorted by column
+        $output  .= "{| class=\"wikitable sortable\" style=\"text-align:center;\"" 
+                  . PMA_exportCRLF();
+
+        // Add the table name
+        if ($GLOBALS['mediawiki_caption']) {
+            $output .= "|+'''" . $table . "'''" . PMA_exportCRLF();
+        }
+
+        // Add the table headers
+        if ($GLOBALS['mediawiki_headers']) {
+            // Get column names
+            $column_names = PMA_DBI_get_column_names($db, $table);
+
+            // Add column names as table headers
+            if ( ! is_null($column_names) ) {
+                // Use '|-' for separating rows
+                $output .= "|-" . PMA_exportCRLF();
+
+                // Use '!' for separating table headers
+                foreach ($column_names as $column) {
+                    $output .= " ! " . $column . "" . PMA_exportCRLF();
+                }
+            }
+        }
+
+        // Get the table data from the database
+        $result = PMA_DBI_query($sql_query, null, PMA_DBI_QUERY_UNBUFFERED);
+        $fields_cnt = PMA_DBI_num_fields($result);
+
+        while ($row = PMA_DBI_fetch_row($result)) {
+            $output .= "|-" . PMA_exportCRLF();
+
+            // Use '|' for separating table columns
+            for ($i = 0; $i < $fields_cnt; ++ $i) {
+                $output .= " | " . $row[$i] . "" . PMA_exportCRLF();
+            }
+        }
+
+        // End table construction
+        $output .= "|}" . str_repeat(PMA_exportCRLF(), 2);
+        return PMA_exportOutputHandler($output);
+    }
 }
 ?>


### PR DESCRIPTION
Currently, the export plugin for the MediaWiki format only exports table structure ( the result of <a href="http://dev.mysql.com/doc/refman/5.0/en/show-columns.html">SHOW [FULL] COLUMNS </a> for MySQL and similar for Drizzle). I've modified it so that it can also export the actual content in the table.

<strong>ChangeLog</strong> for export mediawiki:
- Allows the user to select between exporting structure or data or both;
- Allows the user not to export table names or table headers.
- Uses the new PMA_DBI_get_column_names() function instead of PMA_DBI_get_columns(), in order to get only the results that matter for the table header;
- Removes the old colours: #ffdead and #f9f9f9, the border, cellpadding and cellspacing;
- Uses the "wikitable" class instead, with nice shades of gray and minimal cellpadding and cellspacing. Only kept the old text-align:center attribute. 
- Uses the "sortable" class, which allows sorting by every table column;
- Exports with the "mediawiki" extension;
- Has code refactoring by PEAR standards.
