### PR TITLE
Improve X-Content-Security-Policy header (BugID: 3426500)

### DIFF
--- a/libraries/header_http.inc.php
+++ b/libraries/header_http.inc.php
@@ -22,7 +22,8 @@ $GLOBALS['now'] = gmdate('D, d M Y H:i:s') . ' GMT';
 /* Prevent against ClickJacking by allowing frames only from same origin */
 if (!$GLOBALS['cfg']['AllowThirdPartyFraming']) {
     header('X-Frame-Options: SAMEORIGIN');
-    header('X-Content-Security-Policy: allow \'self\'; options inline-script eval-script; frame-ancestors \'self\'; img-src \'self\' data:; script-src \'self\' www.phpmyadmin.net');
+    header('X-Content-Security-Policy: allow \'self\'; options inline-script eval-script; frame-ancestors \'self\'; img-src \'self\' data:; script-src \'self\' http://www.phpmyadmin.net');
+    header('X-WebKit-CSP: default-src \'self\' \'unsafe-inline\'; img-src \'self\' data:; script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' http://www.phpmyadmin.net');
 }
 PMA_no_cache_header();
 if (!defined('IS_TRANSFORMATION_WRAPPER')) {


### PR DESCRIPTION
I've improved sending X-Content-Security-Policy header from BugID: 3426500 (http://sourceforge.net/tracker/?func=detail&aid=3426500&group_id=23067&atid=377408). There must be specified protocol when request is send from https version (I don't know why, CSP specification from W3C doesn't tell anything about it but I's guessing and this is my result). I've added last version of header for Chrome too.

Using this patch calling version.js script from https now works in FF (tested in 11), Opera (tested in 11.62) and Chrome (tested in Chromium 17), all in Debian Wheezy last updates. Calling is still disabled in main.php:242 because of eg. IE (I've tried in 8.0 at WinXP and a security error message was appeared). From W3C info, in IE10 will be some part of CSP implemented.

In addition, I suggest to detect browser by User-Agent string (in condition on main.php:242) and exclude calling for IE only (till MS will implement CSP), in other browsers it should work good now.
