### PR TITLE
import-export related fixes

### DIFF
--- a/libraries/export/xml.php
+++ b/libraries/export/xml.php
@@ -353,7 +353,7 @@ if (isset($plugin_list)) {
             $columns_cnt = PMA_DBI_num_fields($result);
             $columns = array();
             for ($i = 0; $i < $columns_cnt; $i++) {
-                $columns[$i] = stripslashes(str_replace(' ', '_', PMA_DBI_field_name($result, $i)));
+                $columns[$i] = stripslashes(PMA_DBI_field_name($result, $i));
             }
             unset($i);
 

--- a/libraries/import.lib.php
+++ b/libraries/import.lib.php
@@ -940,7 +940,7 @@ function PMA_buildSQL($db_name, &$tables, &$analyses = null, &$additional_sql = 
          *
          * $pattern = 'CREATE (TABLE|VIEW|TRIGGER|FUNCTION|PROCEDURE)';
          */
-        $pattern = '/CREATE .*(TABLE)/';
+        $pattern = '/CREATE [^`]*(TABLE)/';
         $replacement = 'CREATE \\1 IF NOT EXISTS';
 
         /* Change CREATE statements to CREATE IF NOT EXISTS to support inserting into existing structures */

--- a/libraries/plugin_interface.lib.php
+++ b/libraries/plugin_interface.lib.php
@@ -26,7 +26,7 @@ function PMA_getPlugins($plugins_dir, $plugin_param)
             // matches a file which does not start with a dot but ends
             // with ".php"
             if (is_file($plugins_dir . $file) && preg_match('@^[^\.](.)*\.php$@i', $file)) {
-                include $plugins_dir . $file;
+                include_once $plugins_dir . $file;
             }
         }
     }


### PR DESCRIPTION
<strong>1. export xml</strong>: 
In the exported files, inside <pma:table>, the column names in the CREATE TABLE statement contained spaces, but in the <column> tags, they were replaced with underscores, causing a mismatch. I've chosen to remove the replacement from the <column> tags instead of doing it again in the structure_schema section, so as to keep the original column names (with spaces) in the exported files.

<strong>2. import.lib.php </strong>: 
Say you have tables with generic names such as TABLE 1, TABLE 2, etc (which can be obtained by exporting a database in csv, and then importing it back). If you export this in xml, and then import it back, the pattern CREATE .*(TABLE) would match CREATE TABLE 'TABLE 1', resulting in a replacement such as CREATE TABLE IF NOT EXISTS 1  `.

<strong>3. PMA_getPlugins</strong>:
This should include plugins only once, avoiding redeclarations of functions, because for example after an import has been made, they have already been included in import.php when this function is called from display_import.lib.php. 
