### PR TITLE
PMA-Designer script is broken in current master branch. It is because of...

### DIFF
--- a/libraries/pmd_common.php
+++ b/libraries/pmd_common.php
@@ -3,14 +3,15 @@
 /**
  * @package PhpMyAdmin-Designer
  */
-if (! defined('PHPMYADMIN')) {
-    exit;
-}
-
 /**
  *
  */
 require_once './libraries/common.inc.php';
+
+if (! defined('PHPMYADMIN')) {
+    exit;
+}
+
 // not understand
 require_once './libraries/header_http.inc.php';
 


### PR DESCRIPTION
...

if (! defined('PHPMYADMIN')) {
    exit;
}

So, it should be after libraries/common.inc.php or because it is defined in common.inc.php
