### PR TITLE
Remove PMA_sanitize from Suhosin warning (escaping is made twice)

### DIFF
--- a/main.php
+++ b/main.php
@@ -373,12 +373,10 @@ if ($cfg['SuhosinDisableWarning'] == false
     && @ini_get('suhosin.request.max_value_length')
 ) {
     trigger_error(
-        PMA_sanitize(
-            sprintf(
-                __('Server running with Suhosin. Please refer to %sdocumentation%s for possible issues.'),
-                '[a@./Documentation.html#faq1_38@_blank]',
-                '[/a]'
-            )
+        sprintf(
+            __('Server running with Suhosin. Please refer to %sdocumentation%s for possible issues.'),
+            '[a@./Documentation.html#faq1_38@_blank]',
+            '[/a]'
         ),
         E_USER_WARNING
     );


### PR DESCRIPTION
I've installed suhosin extension (for testing) on server and warning in PMA is displayed. It's badly escaped. I see this string:
"Server running with Suhosin. Please refer to <a href="./Documentation.html#faq1_38" target="_blank">documentation</a> for possible issues."

There was escaping in trigger_error and second once is probably in message display. I've removed escaping from calling trigger_error. I hope it'll be good.
