### PR TITLE
Turn off autocapitalize and autocorrect attributes in text boxes for iOS (BugID: 3508912)

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -626,6 +626,12 @@ $(document).ready(function() {
             PMA_addDatepicker($(this));
         });
     }
+    /**
+     * Add attribute to text boxes for iOS devices (based on bugID: 3508912)
+     */
+    if (navigator.userAgent.match(/(iphone|ipod|ipad)/i)) {
+        $('input[type=text]').attr('autocapitalize','off').attr('autocorrect','off');
+    }
 });
 
 /**


### PR DESCRIPTION
I've added code for BugID 3508912 (http://sourceforge.net/tracker/?func=detail&aid=3508912&group_id=23067&atid=377408) based on suggested solution in commends there. Attributes are set only for iP\* devices matched from UA identification. 

I've tried it on iPad 2 and it works well. I agree, to start writing with upper-case letter (in login, for new database, table etc.) is really annoying.
