### PR TITLE
Coding style for the export plugins

### DIFF
--- a/export.php
+++ b/export.php
@@ -478,7 +478,11 @@ do {
                     if ($GLOBALS[$what . '_structure_or_data'] == 'structure' || $GLOBALS[$what . '_structure_or_data'] == 'structure_and_data') {
                         // for a view, export a stand-in definition of the table
                         // to resolve view dependencies
-                        if (!PMA_exportStructure($current_db, $table, $crlf, $err_url, $do_relation, $do_comments, $do_mime, $do_dates, $is_view ? 'stand_in' : 'create_table', $export_type)) {
+                        if (! PMA_exportStructure(
+                            $current_db, $table, $crlf, $err_url,
+                            $is_view ? 'stand_in' : 'create_table', $export_type,
+                            $do_relation, $do_comments, $do_mime, $do_dates
+                        )) {
                             break 3;
                         }
                     }
@@ -492,7 +496,11 @@ do {
                     // now export the triggers (needs to be done after the data because
                     // triggers can modify already imported tables)
                     if ($GLOBALS[$what . '_structure_or_data'] == 'structure' || $GLOBALS[$what . '_structure_or_data'] == 'structure_and_data') {
-                        if (!PMA_exportStructure($current_db, $table, $crlf, $err_url, $do_relation, $do_comments, $do_mime, $do_dates, 'triggers', $export_type)) {
+                        if (! PMA_exportStructure(
+                            $current_db, $table, $crlf, $err_url,
+                            'triggers', $export_type,
+                            $do_relation, $do_comments, $do_mime, $do_dates
+                        )) {
                             break 2;
                         }
                     }
@@ -500,7 +508,11 @@ do {
                 foreach ($views as $view) {
                     // no data export for a view
                     if ($GLOBALS[$what . '_structure_or_data'] == 'structure' || $GLOBALS[$what . '_structure_or_data'] == 'structure_and_data') {
-                        if (!PMA_exportStructure($current_db, $view, $crlf, $err_url, $do_relation, $do_comments, $do_mime, $do_dates, 'create_view', $export_type)) {
+                        if (! PMA_exportStructure(
+                            $current_db, $view, $crlf, $err_url,
+                            'create_view', $export_type,
+                            $do_relation, $do_comments, $do_mime, $do_dates
+                        )) {
                             break 3;
                         }
                     }
@@ -532,7 +544,11 @@ do {
             if ($GLOBALS[$what . '_structure_or_data'] == 'structure' || $GLOBALS[$what . '_structure_or_data'] == 'structure_and_data') {
                 // for a view, export a stand-in definition of the table
                 // to resolve view dependencies
-                if (!PMA_exportStructure($db, $table, $crlf, $err_url, $do_relation, $do_comments, $do_mime, $do_dates, $is_view ? 'stand_in' : 'create_table', $export_type)) {
+                if (! PMA_exportStructure(
+                    $db, $table, $crlf, $err_url,
+                    $is_view ? 'stand_in' : 'create_table', $export_type,
+                    $do_relation, $do_comments, $do_mime, $do_dates
+                )) {
                     break 2;
                 }
             }
@@ -546,7 +562,11 @@ do {
             // now export the triggers (needs to be done after the data because
             // triggers can modify already imported tables)
             if ($GLOBALS[$what . '_structure_or_data'] == 'structure' || $GLOBALS[$what . '_structure_or_data'] == 'structure_and_data') {
-                if (!PMA_exportStructure($db, $table, $crlf, $err_url, $do_relation, $do_comments, $do_mime, $do_dates, 'triggers', $export_type)) {
+                if (! PMA_exportStructure(
+                    $db, $table, $crlf, $err_url,
+                    'triggers', $export_type,
+                    $do_relation, $do_comments, $do_mime, $do_dates
+                )) {
                     break 2;
                 }
             }
@@ -554,7 +574,11 @@ do {
         foreach ($views as $view) {
             // no data export for a view
             if ($GLOBALS[$what . '_structure_or_data'] == 'structure' || $GLOBALS[$what . '_structure_or_data'] == 'structure_and_data') {
-                if (!PMA_exportStructure($db, $view, $crlf, $err_url, $do_relation, $do_comments, $do_mime, $do_dates, 'create_view', $export_type)) {
+                if (! PMA_exportStructure(
+                    $db, $view, $crlf, $err_url,
+                    'create_view', $export_type,
+                    $do_relation, $do_comments, $do_mime, $do_dates
+                )) {
                     break 2;
                 }
             }
@@ -579,7 +603,11 @@ do {
 
         $is_view = PMA_Table::isView($db, $table);
         if ($GLOBALS[$what . '_structure_or_data'] == 'structure' || $GLOBALS[$what . '_structure_or_data'] == 'structure_and_data') {
-            if (!PMA_exportStructure($db, $table, $crlf, $err_url, $do_relation, $do_comments, $do_mime, $do_dates, $is_view ? 'create_view' : 'create_table', $export_type)) {
+            if (! PMA_exportStructure(
+                $db, $table, $crlf, $err_url,
+                $is_view ? 'create_view' : 'create_table', $export_type,
+                $do_relation, $do_comments, $do_mime, $do_dates
+            )) {
                 break;
             }
         }
@@ -605,7 +633,11 @@ do {
         // now export the triggers (needs to be done after the data because
         // triggers can modify already imported tables)
         if ($GLOBALS[$what . '_structure_or_data'] == 'structure' || $GLOBALS[$what . '_structure_or_data'] == 'structure_and_data') {
-            if (!PMA_exportStructure($db, $table, $crlf, $err_url, $do_relation, $do_comments, $do_mime, $do_dates, 'triggers', $export_type)) {
+            if (! PMA_exportStructure(
+                $db, $table, $crlf, $err_url,
+                'triggers', $export_type,
+                $do_relation, $do_comments, $do_mime, $do_dates
+            )) {
                 break 2;
             }
         }

--- a/libraries/export/codegen.php
+++ b/libraries/export/codegen.php
@@ -242,23 +242,23 @@ if (isset($plugin_list)) {
         }
         function formatCs($text)
         {
-            $text=str_replace("#name#", cgMakeIdentifier($this->name, false), $text);
+            $text = str_replace("#name#", cgMakeIdentifier($this->name, false), $text);
             return $this->format($text);
         }
         function formatXml($text)
         {
-            $text=str_replace("#name#", htmlspecialchars($this->name, ENT_COMPAT, 'UTF-8'), $text);
-            $text=str_replace("#indexName#", $this->getIndexName(), $text);
+            $text = str_replace("#name#", htmlspecialchars($this->name, ENT_COMPAT, 'UTF-8'), $text);
+            $text = str_replace("#indexName#", $this->getIndexName(), $text);
             return $this->format($text);
         }
         function format($text)
         {
-            $text=str_replace("#ucfirstName#", cgMakeIdentifier($this->name), $text);
-            $text=str_replace("#dotNetPrimitiveType#", $this->getDotNetPrimitiveType(), $text);
-            $text=str_replace("#dotNetObjectType#", $this->getDotNetObjectType(), $text);
-            $text=str_replace("#type#", $this->getPureType(), $text);
-            $text=str_replace("#notNull#", $this->isNotNull(), $text);
-            $text=str_replace("#unique#", $this->isUnique(), $text);
+            $text = str_replace("#ucfirstName#", cgMakeIdentifier($this->name), $text);
+            $text = str_replace("#dotNetPrimitiveType#", $this->getDotNetPrimitiveType(), $text);
+            $text = str_replace("#dotNetObjectType#", $this->getDotNetObjectType(), $text);
+            $text = str_replace("#type#", $this->getPureType(), $text);
+            $text = str_replace("#notNull#", $this->isNotNull(), $text);
+            $text = str_replace("#unique#", $this->isUnique(), $text);
             return $text;
         }
     }

--- a/libraries/export/codegen.php
+++ b/libraries/export/codegen.php
@@ -38,25 +38,27 @@ if (isset($plugin_list)) {
         'text' => 'CodeGen',
         'extension' => 'cs',
         'mime_type' => 'text/cs',
-        'options' => array(
-            array(
-                'type' => 'begin_group',
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'hidden',
-                'name' => 'structure_or_data'
-            ),
-            array('type' => 'select',
-                'name' => 'format',
-                'text' => __('Format:'),
-                'values' => $CG_FORMATS
-            ),
-            array(
-                'type' => 'end_group'
-            )
+        'options' => array(),
+        'options_text' => __('Options')
+    );
+
+    $plugin_list['codegen']['options'][] = array(
+        array(
+            'type' => 'begin_group',
+            'name' => 'general_opts'
         ),
-        'options_text' => __('Options'),
+        array(
+            'type' => 'hidden',
+            'name' => 'structure_or_data'
+        ),
+        array('type' => 'select',
+            'name' => 'format',
+            'text' => __('Format:'),
+            'values' => $CG_FORMATS
+        ),
+        array(
+            'type' => 'end_group'
+        )
     );
 } else {
 

--- a/libraries/export/codegen.php
+++ b/libraries/export/codegen.php
@@ -268,7 +268,7 @@ if (isset($plugin_list)) {
         // remove unsafe characters
         $str = preg_replace('/[^\p{L}\p{Nl}_]/u', '', $str);
         // make sure first character is a letter or _
-        if (!preg_match('/^\pL/u', $str)) {
+        if (! preg_match('/^\pL/u', $str)) {
             $str = '_' . $str;
         }
         if ($ucfirst) {

--- a/libraries/export/codegen.php
+++ b/libraries/export/codegen.php
@@ -159,7 +159,7 @@ if (isset($plugin_list)) {
 
     /**
      * TableProperty class
-     * 
+     *
      * @package    PhpMyAdmin-Export
      * @subpackage Codegen
      */

--- a/libraries/export/codegen.php
+++ b/libraries/export/codegen.php
@@ -42,7 +42,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['codegen']['options'][] = array(
+    $plugin_list['codegen']['options'] = array(
         array(
             'type' => 'begin_group',
             'name' => 'general_opts'

--- a/libraries/export/codegen.php
+++ b/libraries/export/codegen.php
@@ -21,8 +21,14 @@ if (! defined('CG_FORMAT_NHIBERNATE_CS')) {
     define("CG_HANDLER_NHIBERNATE_XML_BODY", "handleNHibernateXMLBody");
 }
 
-$CG_FORMATS = array(CG_FORMAT_NHIBERNATE_CS, CG_FORMAT_NHIBERNATE_XML);
-$CG_HANDLERS = array(CG_HANDLER_NHIBERNATE_CS_BODY, CG_HANDLER_NHIBERNATE_XML_BODY);
+$CG_FORMATS = array(
+    CG_FORMAT_NHIBERNATE_CS,
+    CG_FORMAT_NHIBERNATE_XML
+);
+$CG_HANDLERS = array(
+    CG_HANDLER_NHIBERNATE_CS_BODY,
+    CG_HANDLER_NHIBERNATE_XML_BODY
+);
 
 /**
  *
@@ -33,13 +39,25 @@ if (isset($plugin_list)) {
         'extension' => 'cs',
         'mime_type' => 'text/cs',
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
-            array('type' => 'hidden', 'name' => 'structure_or_data'),
-            array('type' => 'select', 'name' => 'format', 'text' => __('Format:'), 'values' => $CG_FORMATS),
-            array('type' => 'end_group')
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
             ),
+            array(
+                'type' => 'hidden',
+                'name' => 'structure_or_data'
+            ),
+            array('type' => 'select',
+                'name' => 'format',
+                'text' => __('Format:'),
+                'values' => $CG_FORMATS
+            ),
+            array(
+                'type' => 'end_group'
+            )
+        ),
         'options_text' => __('Options'),
-        );
+    );
 } else {
 
     /**
@@ -130,7 +148,9 @@ if (isset($plugin_list)) {
         global $CG_FORMATS, $CG_HANDLERS, $what;
         $format = $GLOBALS[$what . '_format'];
         if (isset($CG_FORMATS[$format])) {
-            return PMA_exportOutputHandler($CG_HANDLERS[$format]($db, $table, $crlf));
+            return PMA_exportOutputHandler(
+                $CG_HANDLERS[$format]($db, $table, $crlf)
+            );
         }
         return PMA_exportOutputHandler(sprintf("%s is not supported.", $format));
     }
@@ -232,7 +252,9 @@ if (isset($plugin_list)) {
         function getIndexName()
         {
             if (strlen($this->key) > 0) {
-                return "index=\"" . htmlspecialchars($this->name, ENT_COMPAT, 'UTF-8') . "\"";
+                return "index=\""
+                    . htmlspecialchars($this->name, ENT_COMPAT, 'UTF-8')
+                    . "\"";
             }
             return "";
         }
@@ -242,23 +264,59 @@ if (isset($plugin_list)) {
         }
         function formatCs($text)
         {
-            $text = str_replace("#name#", cgMakeIdentifier($this->name, false), $text);
+            $text = str_replace(
+                "#name#",
+                cgMakeIdentifier($this->name, false),
+                $text
+            );
             return $this->format($text);
         }
         function formatXml($text)
         {
-            $text = str_replace("#name#", htmlspecialchars($this->name, ENT_COMPAT, 'UTF-8'), $text);
-            $text = str_replace("#indexName#", $this->getIndexName(), $text);
+            $text = str_replace(
+                "#name#",
+                htmlspecialchars($this->name, ENT_COMPAT, 'UTF-8'),
+                $text
+            );
+            $text = str_replace(
+                "#indexName#",
+                $this->getIndexName(),
+                $text
+            );
             return $this->format($text);
         }
         function format($text)
         {
-            $text = str_replace("#ucfirstName#", cgMakeIdentifier($this->name), $text);
-            $text = str_replace("#dotNetPrimitiveType#", $this->getDotNetPrimitiveType(), $text);
-            $text = str_replace("#dotNetObjectType#", $this->getDotNetObjectType(), $text);
-            $text = str_replace("#type#", $this->getPureType(), $text);
-            $text = str_replace("#notNull#", $this->isNotNull(), $text);
-            $text = str_replace("#unique#", $this->isUnique(), $text);
+            $text = str_replace(
+                "#ucfirstName#",
+                cgMakeIdentifier($this->name),
+                $text
+            );
+            $text = str_replace(
+                "#dotNetPrimitiveType#",
+                $this->getDotNetPrimitiveType(),
+                $text
+            );
+            $text = str_replace(
+                "#dotNetObjectType#",
+                $this->getDotNetObjectType(),
+                $text
+            );
+            $text = str_replace(
+                "#type#",
+                $this->getPureType(),
+                $text
+            );
+            $text = str_replace(
+                "#notNull#",
+                $this->isNotNull(),
+                $text
+            );
+            $text = str_replace(
+                "#unique#",
+                $this->isUnique(),
+                $text
+            );
             return $text;
         }
     }
@@ -280,7 +338,9 @@ if (isset($plugin_list)) {
     function handleNHibernateCSBody($db, $table, $crlf)
     {
         $lines = array();
-        $result = PMA_DBI_query(sprintf('DESC %s.%s', PMA_backquote($db), PMA_backquote($table)));
+        $result = PMA_DBI_query(
+            sprintf('DESC %s.%s', PMA_backquote($db), PMA_backquote($table))
+        );
         if ($result) {
             $tableProperties = array();
             while ($row = PMA_DBI_fetch_row($result)) {
@@ -298,7 +358,9 @@ if (isset($plugin_list)) {
             $lines[] = '    {';
             $lines[] = '        #region Member Variables';
             foreach ($tableProperties as $tableProperty) {
-                $lines[] = $tableProperty->formatCs('        protected #dotNetPrimitiveType# _#name#;');
+                $lines[] = $tableProperty->formatCs(
+                    '        protected #dotNetPrimitiveType# _#name#;'
+                );
             }
             $lines[] = '        #endregion';
             $lines[] = '        #region Constructors';
@@ -306,14 +368,22 @@ if (isset($plugin_list)) {
             $temp = array();
             foreach ($tableProperties as $tableProperty) {
                 if (! $tableProperty->isPK()) {
-                    $temp[] = $tableProperty->formatCs('#dotNetPrimitiveType# #name#');
+                    $temp[] = $tableProperty->formatCs(
+                        '#dotNetPrimitiveType# #name#'
+                    );
                 }
             }
-            $lines[] = '        public ' . cgMakeIdentifier($table) . '(' . implode(', ', $temp) . ')';
+            $lines[] = '        public '
+                . cgMakeIdentifier($table)
+                . '('
+                . implode(', ', $temp)
+                . ')';
             $lines[] = '        {';
             foreach ($tableProperties as $tableProperty) {
                 if (! $tableProperty->isPK()) {
-                    $lines[] = $tableProperty->formatCs('            this._#name#=#name#;');
+                    $lines[] = $tableProperty->formatCs(
+                        '            this._#name#=#name#;'
+                    );
                 }
             }
             $lines[] = '        }';
@@ -321,7 +391,8 @@ if (isset($plugin_list)) {
             $lines[] = '        #region Public Properties';
             foreach ($tableProperties as $tableProperty) {
                 $lines[] = $tableProperty->formatCs(
-                    '        public virtual #dotNetPrimitiveType# #ucfirstName#' . "\n"
+                    '        public virtual #dotNetPrimitiveType# #ucfirstName#'
+                    . "\n"
                     . '        {' . "\n"
                     . '            get {return _#name#;}' . "\n"
                     . '            set {_#name#=value;}' . "\n"
@@ -346,21 +417,28 @@ if (isset($plugin_list)) {
         $lines[] = '    <class '
             . 'name="' . cgMakeIdentifier($table) . '" '
             . 'table="' . cgMakeIdentifier($table) . '">';
-        $result = PMA_DBI_query(sprintf("DESC %s.%s", PMA_backquote($db), PMA_backquote($table)));
+        $result = PMA_DBI_query(
+            sprintf("DESC %s.%s", PMA_backquote($db), PMA_backquote($table))
+        );
         if ($result) {
             while ($row = PMA_DBI_fetch_row($result)) {
                 $tableProperty = new TableProperty($row);
                 if ($tableProperty->isPK()) {
                     $lines[] = $tableProperty->formatXml(
-                        '        <id name="#ucfirstName#" type="#dotNetObjectType#" unsaved-value="0">' . "\n"
-                        . '            <column name="#name#" sql-type="#type#" not-null="#notNull#" unique="#unique#" index="PRIMARY"/>' . "\n"
+                        '        <id name="#ucfirstName#" type="#dotNetObjectType#"'
+                            . ' unsaved-value="0">' . "\n"
+                        . '            <column name="#name#" sql-type="#type#"'
+                            . ' not-null="#notNull#" unique="#unique#"'
+                            . ' index="PRIMARY"/>' . "\n"
                         . '            <generator class="native" />' . "\n"
                         . '        </id>'
                     );
                 } else {
                     $lines[] = $tableProperty->formatXml(
-                        '        <property name="#ucfirstName#" type="#dotNetObjectType#">' . "\n"
-                        . '            <column name="#name#" sql-type="#type#" not-null="#notNull#" #indexName#/>' . "\n"
+                        '        <property name="#ucfirstName#"'
+                            . ' type="#dotNetObjectType#">' . "\n"
+                        . '            <column name="#name#" sql-type="#type#"'
+                            . ' not-null="#notNull#" #indexName#/>' . "\n"
                         . '        </property>'
                     );
                 }

--- a/libraries/export/codegen.php
+++ b/libraries/export/codegen.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build NHibernate dumps of tables
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage Codegen
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/codegen.php
+++ b/libraries/export/codegen.php
@@ -69,9 +69,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -81,9 +81,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -93,11 +93,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -107,11 +107,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -121,11 +121,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -135,15 +135,15 @@ if (isset($plugin_list)) {
     /**
      * Outputs the content of a table in NHibernate format
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {
@@ -158,8 +158,9 @@ if (isset($plugin_list)) {
     }
 
     /**
-     *
-     * @package PhpMyAdmin-Export
+     * TableProperty class
+     * 
+     * @package    PhpMyAdmin-Export
      * @subpackage Codegen
      */
     class TableProperty
@@ -428,19 +429,19 @@ if (isset($plugin_list)) {
                 if ($tableProperty->isPK()) {
                     $lines[] = $tableProperty->formatXml(
                         '        <id name="#ucfirstName#" type="#dotNetObjectType#"'
-                            . ' unsaved-value="0">' . "\n"
+                        . ' unsaved-value="0">' . "\n"
                         . '            <column name="#name#" sql-type="#type#"'
-                            . ' not-null="#notNull#" unique="#unique#"'
-                            . ' index="PRIMARY"/>' . "\n"
+                        . ' not-null="#notNull#" unique="#unique#"'
+                        . ' index="PRIMARY"/>' . "\n"
                         . '            <generator class="native" />' . "\n"
                         . '        </id>'
                     );
                 } else {
                     $lines[] = $tableProperty->formatXml(
                         '        <property name="#ucfirstName#"'
-                            . ' type="#dotNetObjectType#">' . "\n"
+                        . ' type="#dotNetObjectType#">' . "\n"
                         . '            <column name="#name#" sql-type="#type#"'
-                            . ' not-null="#notNull#" #indexName#/>' . "\n"
+                        . ' not-null="#notNull#" #indexName#/>' . "\n"
                         . '        </property>'
                     );
                 }

--- a/libraries/export/csv.php
+++ b/libraries/export/csv.php
@@ -128,7 +128,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -142,7 +142,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -156,7 +156,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -170,11 +170,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs the content of a table in CSV format
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
      *
      * @return bool Whether it succeeded
      *
@@ -201,10 +201,10 @@ if (isset($plugin_list)) {
                 } else {
                     $schema_insert .= $csv_enclosed
                         . str_replace(
-                              $csv_enclosed,
-                              $csv_escaped . $csv_enclosed,
-                              stripslashes(PMA_DBI_field_name($result, $i))
-                          )
+                            $csv_enclosed,
+                            $csv_escaped . $csv_enclosed,
+                            stripslashes(PMA_DBI_field_name($result, $i))
+                        )
                         .  $csv_enclosed;
                 }
                 $schema_insert .= $csv_separator;
@@ -247,14 +247,14 @@ if (isset($plugin_list)) {
                         if ($csv_escaped != $csv_enclosed) {
                             $schema_insert .= $csv_enclosed
                                 . str_replace(
-                                      $csv_enclosed,
-                                      $csv_escaped . $csv_enclosed,
-                                      str_replace(
-                                          $csv_escaped,
-                                          $csv_escaped . $csv_escaped,
-                                          $row[$j]
-                                      )
-                                  )
+                                    $csv_enclosed,
+                                    $csv_escaped . $csv_enclosed,
+                                    str_replace(
+                                        $csv_escaped,
+                                        $csv_escaped . $csv_escaped,
+                                        $row[$j]
+                                    )
+                                )
                                 . $csv_enclosed;
                         } else {
                             // avoid a problem when escape string equals enclose

--- a/libraries/export/csv.php
+++ b/libraries/export/csv.php
@@ -23,45 +23,55 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['csv']['options'][] = array(
+    $plugin_list['csv']['options'] = array(
             array(
                 'type' => 'begin_group',
                 'name' => 'general_opts'
             ),
-            array('type' => 'text',
+            array(
+                'type' => 'text',
                 'name' => 'separator',
                 'text' => __('Columns separated with:')
             ),
-            array('type' => 'text',
+            array(
+                'type' => 'text',
                 'name' => 'enclosed',
                 'text' => __('Columns enclosed with:')
             ),
-            array('type' => 'text',
+            array(
+                'type' => 'text',
                 'name' => 'escaped',
                 'text' => __('Columns escaped with:')
             ),
-            array('type' => 'text',
+            array(
+                'type' => 'text',
                 'name' => 'terminated',
                 'text' => __('Lines terminated with:')
             ),
-            array('type' => 'text',
+            array(
+                'type' => 'text',
                 'name' => 'null',
                 'text' => __('Replace NULL with:')
             ),
-            array('type' => 'bool',
+            array(
+                'type' => 'bool',
                 'name' => 'removeCRLF',
                 'text' => __(
                     'Remove carriage return/line feed characters within columns'
                 )
             ),
-            array('type' => 'bool',
+            array(
+                'type' => 'bool',
                 'name' => 'columns',
                 'text' => __('Put columns names in the first row')
             ),
-            array('type' => 'hidden',
+            array(
+                'type' => 'hidden',
                 'name' => 'structure_or_data'
             ),
-            array('type' => 'end_group')
+            array(
+                'type' => 'end_group'
+            )
     );
 } else {
 

--- a/libraries/export/csv.php
+++ b/libraries/export/csv.php
@@ -19,7 +19,11 @@ if (isset($plugin_list)) {
         'text' => __('CSV'),
         'extension' => 'csv',
         'mime_type' => 'text/comma-separated-values',
-        'options' => array(
+        'options' => array(),
+        'options_text' => __('Options')
+    );
+
+    $plugin_list['csv']['options'][] = array(
             array(
                 'type' => 'begin_group',
                 'name' => 'general_opts'
@@ -57,9 +61,7 @@ if (isset($plugin_list)) {
             array('type' => 'hidden',
                 'name' => 'structure_or_data'
             ),
-            array('type' => 'end_group'),
-        ),
-        'options_text' => __('Options')
+            array('type' => 'end_group')
     );
 } else {
 

--- a/libraries/export/csv.php
+++ b/libraries/export/csv.php
@@ -68,9 +68,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -80,9 +80,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -130,9 +130,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -144,9 +144,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -158,9 +158,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -176,9 +176,9 @@ if (isset($plugin_list)) {
      * @param string  $error_url  the url to go back in case of error
      * @param string  $sql_query  SQL query for obtaining data
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {

--- a/libraries/export/csv.php
+++ b/libraries/export/csv.php
@@ -176,7 +176,7 @@ if (isset($plugin_list)) {
                 $schema_insert     .= $csv_separator;
             } // end for
             $schema_insert  =trim(substr($schema_insert, 0, -1));
-            if (!PMA_exportOutputHandler($schema_insert . $csv_terminated)) {
+            if (! PMA_exportOutputHandler($schema_insert . $csv_terminated)) {
                 return false;
             }
         } // end if
@@ -185,7 +185,7 @@ if (isset($plugin_list)) {
         while ($row = PMA_DBI_fetch_row($result)) {
             $schema_insert = '';
             for ($j = 0; $j < $fields_cnt; $j++) {
-                if (!isset($row[$j]) || is_null($row[$j])) {
+                if (! isset($row[$j]) || is_null($row[$j])) {
                     $schema_insert .= $GLOBALS[$what . '_null'];
                 } elseif ($row[$j] == '0' || $row[$j] != '') {
                     // always enclose fields
@@ -219,7 +219,7 @@ if (isset($plugin_list)) {
                 }
             } // end for
 
-            if (!PMA_exportOutputHandler($schema_insert . $csv_terminated)) {
+            if (! PMA_exportOutputHandler($schema_insert . $csv_terminated)) {
                 return false;
             }
         } // end while

--- a/libraries/export/csv.php
+++ b/libraries/export/csv.php
@@ -3,7 +3,7 @@
 /**
  * CSV export code
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage CSV
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/csv.php
+++ b/libraries/export/csv.php
@@ -20,19 +20,47 @@ if (isset($plugin_list)) {
         'extension' => 'csv',
         'mime_type' => 'text/comma-separated-values',
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
-            array('type' => 'text', 'name' => 'separator', 'text' => __('Columns separated with:')),
-            array('type' => 'text', 'name' => 'enclosed', 'text' => __('Columns enclosed with:')),
-            array('type' => 'text', 'name' => 'escaped', 'text' => __('Columns escaped with:')),
-            array('type' => 'text', 'name' => 'terminated', 'text' => __('Lines terminated with:')),
-            array('type' => 'text', 'name' => 'null', 'text' => __('Replace NULL with:')),
-            array('type' => 'bool', 'name' => 'removeCRLF', 'text' => __('Remove carriage return/line feed characters within columns')),
-            array('type' => 'bool', 'name' => 'columns', 'text' => __('Put columns names in the first row')),
-            array('type' => 'hidden', 'name' => 'structure_or_data'),
-            array('type' => 'end_group'),
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
             ),
-        'options_text' => __('Options'),
-        );
+            array('type' => 'text',
+                'name' => 'separator',
+                'text' => __('Columns separated with:')
+            ),
+            array('type' => 'text',
+                'name' => 'enclosed',
+                'text' => __('Columns enclosed with:')
+            ),
+            array('type' => 'text',
+                'name' => 'escaped',
+                'text' => __('Columns escaped with:')
+            ),
+            array('type' => 'text',
+                'name' => 'terminated',
+                'text' => __('Lines terminated with:')
+            ),
+            array('type' => 'text',
+                'name' => 'null',
+                'text' => __('Replace NULL with:')
+            ),
+            array('type' => 'bool',
+                'name' => 'removeCRLF',
+                'text' => __(
+                    'Remove carriage return/line feed characters within columns'
+                )
+            ),
+            array('type' => 'bool',
+                'name' => 'columns',
+                'text' => __('Put columns names in the first row')
+            ),
+            array('type' => 'hidden',
+                'name' => 'structure_or_data'
+            ),
+            array('type' => 'end_group'),
+        ),
+        'options_text' => __('Options')
+    );
 } else {
 
     /**
@@ -170,10 +198,14 @@ if (isset($plugin_list)) {
                     $schema_insert .= stripslashes(PMA_DBI_field_name($result, $i));
                 } else {
                     $schema_insert .= $csv_enclosed
-                                   . str_replace($csv_enclosed, $csv_escaped . $csv_enclosed, stripslashes(PMA_DBI_field_name($result, $i)))
-                                   . $csv_enclosed;
+                        . str_replace(
+                              $csv_enclosed,
+                              $csv_escaped . $csv_enclosed,
+                              stripslashes(PMA_DBI_field_name($result, $i))
+                          )
+                        .  $csv_enclosed;
                 }
-                $schema_insert     .= $csv_separator;
+                $schema_insert .= $csv_separator;
             } // end for
             $schema_insert = trim(substr($schema_insert, 0, -1));
             if (! PMA_exportOutputHandler($schema_insert . $csv_terminated)) {
@@ -193,8 +225,18 @@ if (isset($plugin_list)) {
                         $row[$j] = preg_replace("/\015(\012)?/", "\012", $row[$j]);
                     }
                     // remove CRLF characters within field
-                    if (isset($GLOBALS[$what . '_removeCRLF']) && $GLOBALS[$what . '_removeCRLF']) {
-                        $row[$j] = str_replace("\n", "", str_replace("\r", "", $row[$j]));
+                    if (isset($GLOBALS[$what . '_removeCRLF'])
+                        && $GLOBALS[$what . '_removeCRLF']
+                    ) {
+                        $row[$j] = str_replace(
+                            "\n",
+                            "",
+                            str_replace(
+                                "\r",
+                                "",
+                                $row[$j]
+                            )
+                        );
                     }
                     if ($csv_enclosed == '') {
                         $schema_insert .= $row[$j];
@@ -202,13 +244,25 @@ if (isset($plugin_list)) {
                         // also double the escape string if found in the data
                         if ($csv_escaped != $csv_enclosed) {
                             $schema_insert .= $csv_enclosed
-                                       . str_replace($csv_enclosed, $csv_escaped . $csv_enclosed, str_replace($csv_escaped, $csv_escaped . $csv_escaped, $row[$j]))
-                                       . $csv_enclosed;
+                                . str_replace(
+                                      $csv_enclosed,
+                                      $csv_escaped . $csv_enclosed,
+                                      str_replace(
+                                          $csv_escaped,
+                                          $csv_escaped . $csv_escaped,
+                                          $row[$j]
+                                      )
+                                  )
+                                . $csv_enclosed;
                         } else {
                             // avoid a problem when escape string equals enclose
                             $schema_insert .= $csv_enclosed
-                                       . str_replace($csv_enclosed, $csv_escaped . $csv_enclosed, $row[$j])
-                                       . $csv_enclosed;
+                            . str_replace(
+                                $csv_enclosed,
+                                $csv_escaped . $csv_enclosed,
+                                $row[$j]
+                            )
+                            . $csv_enclosed;
                         }
                     }
                 } else {

--- a/libraries/export/csv.php
+++ b/libraries/export/csv.php
@@ -77,20 +77,20 @@ if (isset($plugin_list)) {
                 $csv_separator = ',';
                 break;
             }
-            $csv_enclosed           = '"';
-            $csv_escaped            = '"';
+            $csv_enclosed = '"';
+            $csv_escaped  = '"';
             if (isset($GLOBALS['excel_columns'])) {
                 $GLOBALS['csv_columns'] = 'yes';
             }
         } else {
             if (empty($csv_terminated) || strtolower($csv_terminated) == 'auto') {
-                $csv_terminated  = $GLOBALS['crlf'];
+                $csv_terminated = $GLOBALS['crlf'];
             } else {
-                $csv_terminated  = str_replace('\\r', "\015", $csv_terminated);
-                $csv_terminated  = str_replace('\\n', "\012", $csv_terminated);
-                $csv_terminated  = str_replace('\\t', "\011", $csv_terminated);
+                $csv_terminated = str_replace('\\r', "\015", $csv_terminated);
+                $csv_terminated = str_replace('\\n', "\012", $csv_terminated);
+                $csv_terminated = str_replace('\\t', "\011", $csv_terminated);
             } // end if
-            $csv_separator          = str_replace('\\t', "\011", $csv_separator);
+            $csv_separator = str_replace('\\t', "\011", $csv_separator);
         }
         return true;
     }
@@ -159,8 +159,8 @@ if (isset($plugin_list)) {
         global $csv_escaped;
 
         // Gets the data from the database
-        $result      = PMA_DBI_query($sql_query, null, PMA_DBI_QUERY_UNBUFFERED);
-        $fields_cnt  = PMA_DBI_num_fields($result);
+        $result     = PMA_DBI_query($sql_query, null, PMA_DBI_QUERY_UNBUFFERED);
+        $fields_cnt = PMA_DBI_num_fields($result);
 
         // If required, get fields name at the first line
         if (isset($GLOBALS['csv_columns'])) {
@@ -175,7 +175,7 @@ if (isset($plugin_list)) {
                 }
                 $schema_insert     .= $csv_separator;
             } // end for
-            $schema_insert  =trim(substr($schema_insert, 0, -1));
+            $schema_insert = trim(substr($schema_insert, 0, -1));
             if (! PMA_exportOutputHandler($schema_insert . $csv_terminated)) {
                 return false;
             }
@@ -190,7 +190,7 @@ if (isset($plugin_list)) {
                 } elseif ($row[$j] == '0' || $row[$j] != '') {
                     // always enclose fields
                     if ($what == 'excel') {
-                        $row[$j]       = preg_replace("/\015(\012)?/", "\012", $row[$j]);
+                        $row[$j] = preg_replace("/\015(\012)?/", "\012", $row[$j]);
                     }
                     // remove CRLF characters within field
                     if (isset($GLOBALS[$what . '_removeCRLF']) && $GLOBALS[$what . '_removeCRLF']) {

--- a/libraries/export/excel.php
+++ b/libraries/export/excel.php
@@ -19,10 +19,27 @@ if (isset($plugin_list)) {
         'extension' => 'csv',
         'mime_type' => 'text/comma-separated-values',
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
-            array('type' => 'text', 'name' => 'null', 'text' => __('Replace NULL with:')),
-            array('type' => 'bool', 'name' => 'removeCRLF', 'text' => __('Remove carriage return/line feed characters within columns')),
-            array('type' => 'bool', 'name' => 'columns', 'text' => __('Put columns names in the first row')),
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
+            ),
+            array(
+                'type' => 'text',
+                'name' => 'null',
+                'text' => __('Replace NULL with:')
+            ),
+            array(
+                'type' => 'bool',
+                'name' => 'removeCRLF',
+                'text' => __(
+                    'Remove carriage return/line feed characters within columns'
+                )
+            ),
+            array(
+                'type' => 'bool',
+                'name' => 'columns',
+                'text' => __('Put columns names in the first row')
+            ),
             array(
                 'type' => 'select',
                 'name' => 'edition',
@@ -31,11 +48,16 @@ if (isset($plugin_list)) {
                     'mac_excel2003' => 'Excel 2003 / Macintosh',
                     'mac_excel2008' => 'Excel 2008 / Macintosh'),
                 'text' => __('Excel edition:')),
-            array('type' => 'hidden', 'name' => 'structure_or_data'),
-            array('type' => 'end_group'),
-            ),
+                array(
+                    'type' => 'hidden',
+                    'name' => 'structure_or_data'
+                ),
+                array(
+                    'type' => 'end_group'
+                ),
+        ),
         'options_text' => __('Options'),
-        );
+    );
 } else {
     /* Everything rest is coded in csv plugin */
     include './libraries/export/csv.php';

--- a/libraries/export/excel.php
+++ b/libraries/export/excel.php
@@ -18,45 +18,47 @@ if (isset($plugin_list)) {
         'text' => __('CSV for MS Excel'),
         'extension' => 'csv',
         'mime_type' => 'text/comma-separated-values',
-        'options' => array(
-            array(
-                'type' => 'begin_group',
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'text',
-                'name' => 'null',
-                'text' => __('Replace NULL with:')
-            ),
-            array(
-                'type' => 'bool',
-                'name' => 'removeCRLF',
-                'text' => __(
-                    'Remove carriage return/line feed characters within columns'
-                )
-            ),
-            array(
-                'type' => 'bool',
-                'name' => 'columns',
-                'text' => __('Put columns names in the first row')
-            ),
-            array(
-                'type' => 'select',
-                'name' => 'edition',
-                'values' => array(
-                    'win' => 'Windows',
-                    'mac_excel2003' => 'Excel 2003 / Macintosh',
-                    'mac_excel2008' => 'Excel 2008 / Macintosh'),
-                'text' => __('Excel edition:')),
-                array(
-                    'type' => 'hidden',
-                    'name' => 'structure_or_data'
-                ),
-                array(
-                    'type' => 'end_group'
-                ),
+        'options' => array(),
+        'options_text' => __('Options')
+    );
+
+    $plugin_list['excel']['options'][] = array(
+        array(
+            'type' => 'begin_group',
+            'name' => 'general_opts'
         ),
-        'options_text' => __('Options'),
+        array(
+            'type' => 'text',
+            'name' => 'null',
+            'text' => __('Replace NULL with:')
+        ),
+        array(
+            'type' => 'bool',
+            'name' => 'removeCRLF',
+            'text' => __(
+                'Remove carriage return/line feed characters within columns'
+            )
+        ),
+        array(
+            'type' => 'bool',
+            'name' => 'columns',
+            'text' => __('Put columns names in the first row')
+        ),
+        array(
+            'type' => 'select',
+            'name' => 'edition',
+            'values' => array(
+                'win' => 'Windows',
+                'mac_excel2003' => 'Excel 2003 / Macintosh',
+                'mac_excel2008' => 'Excel 2008 / Macintosh'),
+            'text' => __('Excel edition:')),
+            array(
+                'type' => 'hidden',
+                'name' => 'structure_or_data'
+            ),
+            array(
+                'type' => 'end_group'
+            )
     );
 } else {
     /* Everything rest is coded in csv plugin */

--- a/libraries/export/excel.php
+++ b/libraries/export/excel.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build CSV dumps of tables for excel
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage CSV-Excel
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/excel.php
+++ b/libraries/export/excel.php
@@ -22,7 +22,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['excel']['options'][] = array(
+    $plugin_list['excel']['options'] = array(
         array(
             'type' => 'begin_group',
             'name' => 'general_opts'

--- a/libraries/export/htmlword.php
+++ b/libraries/export/htmlword.php
@@ -23,7 +23,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['htmlword']['options'][] = array(
+    $plugin_list['htmlword']['options'] = array(
         /* what to dump (structure/data/both) */
         array(
             'type' => 'begin_group',
@@ -459,17 +459,17 @@ if (isset($plugin_list)) {
             $dump .= '<tr class="print-category">';
             $dump .= '<td class="print">'
                 . htmlspecialchars($trigger['name'])
-                . '</td>';
-            $dump .= '<td class="print">'
+                . '</td>'
+                . '<td class="print">'
                 . htmlspecialchars($trigger['action_timing'])
-                . '</td>';
-            $dump .= '<td class="print">'
+                . '</td>'
+                . '<td class="print">'
                 . htmlspecialchars($trigger['event_manipulation'])
-                . '</td>';
-            $dump .= '<td class="print">'
+                . '</td>'
+                . '<td class="print">'
                 . htmlspecialchars($trigger['definition'])
-                . '</td>';
-            $dump .= '</tr>';
+                . '</td>'
+                . '</tr>';
         }
 
         $dump .= '</table>';

--- a/libraries/export/htmlword.php
+++ b/libraries/export/htmlword.php
@@ -19,48 +19,50 @@ if (isset($plugin_list)) {
         'extension' => 'doc',
         'mime_type' => 'application/vnd.ms-word',
         'force_file' => true,
-        'options' => array(
-            /* what to dump (structure/data/both) */
-            array(
-                'type' => 'begin_group',
-                'name' => 'dump_what',
-                'text' => __('Dump table')
-            ),
-            array(
-                'type' => 'radio',
-                'name' => 'structure_or_data',
-                'values' => array(
-                    'structure' => __('structure'),
-                    'data' => __('data'),
-                    'structure_and_data' => __('structure and data')
-                )
-            ),
-            array(
-                'type' => 'end_group'
-            ),
+        'options' => array(),
+        'options_text' => __('Options')
+    );
 
-            /* data options */
-            array(
-                'type' => 'begin_group',
-                'name' => 'data',
-                'text' => __('Data dump options'),
-                'force' => 'structure'
-            ),
-            array(
-                'type' => 'text',
-                'name' => 'null',
-                'text' => __('Replace NULL with:')
-            ),
-            array(
-                'type' => 'bool',
-                'name' => 'columns',
-                'text' => __('Put columns names in the first row')
-            ),
-            array(
-                'type' => 'end_group'
-            ),
+    $plugin_list['htmlword']['options'][] = array(
+        /* what to dump (structure/data/both) */
+        array(
+            'type' => 'begin_group',
+            'name' => 'dump_what',
+            'text' => __('Dump table')
         ),
-        'options_text' => __('Options'),
+        array(
+            'type' => 'radio',
+            'name' => 'structure_or_data',
+            'values' => array(
+                'structure' => __('structure'),
+                'data' => __('data'),
+                'structure_and_data' => __('structure and data')
+            )
+        ),
+        array(
+            'type' => 'end_group'
+        ),
+
+        /* data options */
+        array(
+            'type' => 'begin_group',
+            'name' => 'data',
+            'text' => __('Data dump options'),
+            'force' => 'structure'
+        ),
+        array(
+            'type' => 'text',
+            'name' => 'null',
+            'text' => __('Replace NULL with:')
+        ),
+        array(
+            'type' => 'bool',
+            'name' => 'columns',
+            'text' => __('Put columns names in the first row')
+        ),
+        array(
+            'type' => 'end_group'
+        )
     );
 } else {
 

--- a/libraries/export/htmlword.php
+++ b/libraries/export/htmlword.php
@@ -69,9 +69,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -81,9 +81,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -109,9 +109,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -125,9 +125,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -139,9 +139,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -157,9 +157,9 @@ if (isset($plugin_list)) {
      * @param string  $error_url  the url to go back in case of error
      * @param string  $sql_query  SQL query for obtaining data
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {
@@ -499,7 +499,7 @@ if (isset($plugin_list)) {
      *
      * @return bool      Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportStructure(
         $db,

--- a/libraries/export/htmlword.php
+++ b/libraries/export/htmlword.php
@@ -557,8 +557,8 @@ if (isset($plugin_list)) {
     /**
      * Formats the definition for one column 
      *
-     * @param array $column      info about this column 
-     * @param array $unique_keys unique keys of the table 
+     * @param array $column      info about this column
+     * @param array $unique_keys unique keys of the table
      *
      * @return string Formatted column definition
      *
@@ -602,9 +602,9 @@ if (isset($plugin_list)) {
         $definition .= '<td class="print">' 
             . htmlspecialchars(
                 isset($column['Default'])
-                ? $column['Default'] 
+                ? $column['Default']
                 : ''
-            ) 
+            )
             . '</td>';
 
         return $definition;

--- a/libraries/export/htmlword.php
+++ b/libraries/export/htmlword.php
@@ -94,11 +94,11 @@ if (isset($plugin_list)) {
             xmlns="http://www.w3.org/TR/REC-html40">
 
             <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"'
-              . ' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+            . ' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
             <html>
             <head>
                 <meta http-equiv="Content-type" content="text/html;charset='
-                   . (isset($charset_of_file) ? $charset_of_file : 'utf-8') . '" />
+            . (isset($charset_of_file) ? $charset_of_file : 'utf-8') . '" />
             </head>
             <body>'
         );
@@ -107,7 +107,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -123,7 +123,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -137,7 +137,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -151,11 +151,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs the content of a table in HTML (Microsoft Word) format
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
      *
      * @return bool Whether it succeeded
      *
@@ -405,10 +405,10 @@ if (isset($plugin_list)) {
                 $schema_insert .= '<td class="print">'
                     . (isset($res_rel[$field_name])
                         ? htmlspecialchars(
-                              $res_rel[$field_name]['foreign_table']
-                              . ' (' . $res_rel[$field_name]['foreign_field']
-                              . ')'
-                          )
+                            $res_rel[$field_name]['foreign_table']
+                            . ' (' . $res_rel[$field_name]['foreign_field']
+                            . ')'
+                        )
                         : '') . '</td>';
             }
             if ($do_comments && $cfgRelation['commwork']) {
@@ -436,10 +436,10 @@ if (isset($plugin_list)) {
     /**
      * Outputs triggers
      *
-     * @param string $db     database name
-     * @param string $table  table name
+     * @param string $db    database name
+     * @param string $table table name
      *
-     * @return string        Formatted triggers list
+     * @return string Formatted triggers list
      *
      * @access public
      */
@@ -477,27 +477,26 @@ if (isset($plugin_list)) {
     }
 
     /**
-
      * Outputs table's structure
      *
-     * @param string  $db           database name
-     * @param string  $table        table name
-     * @param string  $crlf         the end of line sequence
-     * @param string  $error_url    the url to go back in case of error
-     * @param bool    $do_relation  whether to include relation comments
-     * @param bool    $do_comments  whether to include the pmadb-style column
+     * @param string $db          database name
+     * @param string $table       table name
+     * @param string $crlf        the end of line sequence
+     * @param string $error_url   the url to go back in case of error
+     * @param bool   $do_relation whether to include relation comments
+     * @param bool   $do_comments whether to include the pmadb-style column
      *                                comments as comments in the structure;
      *                                this is deprecated but the parameter is
      *                                left here because export.php calls
      *                                PMA_exportStructure() also for other
      *                                export types which use this parameter
-     * @param bool    $do_mime      whether to include mime comments
-     * @param bool    $dates        whether to include creation/update/check dates
-     * @param string  $export_mode  'create_table', 'triggers', 'create_view',
-     *                              'stand_in'
-     * @param string  $export_type  'server', 'database', 'table'
+     * @param bool   $do_mime     whether to include mime comments
+     * @param bool   $dates       whether to include creation/update/check dates
+     * @param string $export_mode 'create_table', 'triggers', 'create_view',
+     *                            'stand_in'
+     * @param string $export_type 'server', 'database', 'table'
      *
-     * @return bool      Whether it succeeded
+     * @return bool Whether it succeeded
      *
      * @access public
      */
@@ -558,10 +557,10 @@ if (isset($plugin_list)) {
     /**
      * Formats the definition for one column 
      *
-     * @param array $column  info about this column 
-     * @param array $unique_keys  unique keys of the table 
+     * @param array $column      info about this column 
+     * @param array $unique_keys unique keys of the table 
      *
-     * @return string        Formatted column definition
+     * @return string Formatted column definition
      *
      * @access public
      */
@@ -601,9 +600,11 @@ if (isset($plugin_list)) {
                 : __('Yes')) 
             . '</td>';
         $definition .= '<td class="print">' 
-            . htmlspecialchars(isset($column['Default'])
+            . htmlspecialchars(
+                isset($column['Default'])
                 ? $column['Default'] 
-                : '') 
+                : ''
+            ) 
             . '</td>';
 
         return $definition;

--- a/libraries/export/htmlword.php
+++ b/libraries/export/htmlword.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to export a set of queries to a MS Word document
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage HTMLWord
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/htmlword.php
+++ b/libraries/export/htmlword.php
@@ -137,8 +137,8 @@ if (isset($plugin_list)) {
         }
 
         // Gets the data from the database
-        $result      = PMA_DBI_query($sql_query, null, PMA_DBI_QUERY_UNBUFFERED);
-        $fields_cnt  = PMA_DBI_num_fields($result);
+        $result     = PMA_DBI_query($sql_query, null, PMA_DBI_QUERY_UNBUFFERED);
+        $fields_cnt = PMA_DBI_num_fields($result);
 
         // If required, get fields name at the first line
         if (isset($GLOBALS['htmlword_columns'])) {

--- a/libraries/export/htmlword.php
+++ b/libraries/export/htmlword.php
@@ -483,6 +483,9 @@ if (isset($plugin_list)) {
      * @param string $table       table name
      * @param string $crlf        the end of line sequence
      * @param string $error_url   the url to go back in case of error
+     * @param string $export_mode 'create_table', 'triggers', 'create_view',
+     *                            'stand_in'
+     * @param string $export_type 'server', 'database', 'table'
      * @param bool   $do_relation whether to include relation comments
      * @param bool   $do_comments whether to include the pmadb-style column
      *                                comments as comments in the structure;
@@ -492,9 +495,6 @@ if (isset($plugin_list)) {
      *                                export types which use this parameter
      * @param bool   $do_mime     whether to include mime comments
      * @param bool   $dates       whether to include creation/update/check dates
-     * @param string $export_mode 'create_table', 'triggers', 'create_view',
-     *                            'stand_in'
-     * @param string $export_type 'server', 'database', 'table'
      *
      * @return bool Whether it succeeded
      *
@@ -505,12 +505,12 @@ if (isset($plugin_list)) {
         $table,
         $crlf,
         $error_url,
+        $export_mode,
+        $export_type,
         $do_relation = false,
         $do_comments = false,
         $do_mime = false,
-        $dates = false,
-        $export_mode,
-        $export_type
+        $dates = false
     ) {
         $dump = '';
 

--- a/libraries/export/htmlword.php
+++ b/libraries/export/htmlword.php
@@ -21,17 +21,47 @@ if (isset($plugin_list)) {
         'force_file' => true,
         'options' => array(
             /* what to dump (structure/data/both) */
-            array('type' => 'begin_group', 'name' => 'dump_what', 'text' => __('Dump table')),
-            array('type' => 'radio', 'name' => 'structure_or_data', 'values' => array('structure' => __('structure'), 'data' => __('data'), 'structure_and_data' => __('structure and data'))),
-            array('type' => 'end_group'),
-            /* data options */
-            array('type' => 'begin_group', 'name' => 'data', 'text' => __('Data dump options'), 'force' => 'structure'),
-            array('type' => 'text', 'name' => 'null', 'text' => __('Replace NULL with:')),
-            array('type' => 'bool', 'name' => 'columns', 'text' => __('Put columns names in the first row')),
-            array('type' => 'end_group'),
+            array(
+                'type' => 'begin_group',
+                'name' => 'dump_what',
+                'text' => __('Dump table')
             ),
+            array(
+                'type' => 'radio',
+                'name' => 'structure_or_data',
+                'values' => array(
+                    'structure' => __('structure'),
+                    'data' => __('data'),
+                    'structure_and_data' => __('structure and data')
+                )
+            ),
+            array(
+                'type' => 'end_group'
+            ),
+
+            /* data options */
+            array(
+                'type' => 'begin_group',
+                'name' => 'data',
+                'text' => __('Data dump options'),
+                'force' => 'structure'
+            ),
+            array(
+                'type' => 'text',
+                'name' => 'null',
+                'text' => __('Replace NULL with:')
+            ),
+            array(
+                'type' => 'bool',
+                'name' => 'columns',
+                'text' => __('Put columns names in the first row')
+            ),
+            array(
+                'type' => 'end_group'
+            ),
+        ),
         'options_text' => __('Options'),
-        );
+    );
 } else {
 
     /**
@@ -61,10 +91,12 @@ if (isset($plugin_list)) {
             xmlns:x="urn:schemas-microsoft-com:office:word"
             xmlns="http://www.w3.org/TR/REC-html40">
 
-            <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+            <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"'
+              . ' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
             <html>
             <head>
-                <meta http-equiv="Content-type" content="text/html;charset=' . (isset($charset_of_file) ? $charset_of_file : 'utf-8') . '" />
+                <meta http-equiv="Content-type" content="text/html;charset='
+                   . (isset($charset_of_file) ? $charset_of_file : 'utf-8') . '" />
             </head>
             <body>'
         );
@@ -81,7 +113,9 @@ if (isset($plugin_list)) {
      */
     function PMA_exportDBHeader($db)
     {
-        return PMA_exportOutputHandler('<h1>' . __('Database') . ' ' . htmlspecialchars($db) . '</h1>');
+        return PMA_exportOutputHandler(
+            '<h1>' . __('Database') . ' ' . htmlspecialchars($db) . '</h1>'
+        );
     }
 
     /**
@@ -129,10 +163,16 @@ if (isset($plugin_list)) {
     {
         global $what;
 
-        if (! PMA_exportOutputHandler('<h2>' . __('Dumping data for table') . ' ' . htmlspecialchars($table) . '</h2>')) {
+        if (! PMA_exportOutputHandler(
+            '<h2>'
+            . __('Dumping data for table') . ' ' . htmlspecialchars($table)
+            . '</h2>'
+        )) {
             return false;
         }
-        if (! PMA_exportOutputHandler('<table class="width100" cellspacing="1">')) {
+        if (! PMA_exportOutputHandler(
+            '<table class="width100" cellspacing="1">'
+        )) {
             return false;
         }
 
@@ -144,7 +184,11 @@ if (isset($plugin_list)) {
         if (isset($GLOBALS['htmlword_columns'])) {
             $schema_insert = '<tr class="print-category">';
             for ($i = 0; $i < $fields_cnt; $i++) {
-                $schema_insert .= '<td class="print"><strong>' . htmlspecialchars(stripslashes(PMA_DBI_field_name($result, $i))) . '</strong></td>';
+                $schema_insert .= '<td class="print"><strong>'
+                    . htmlspecialchars(
+                        stripslashes(PMA_DBI_field_name($result, $i))
+                    )
+                    . '</strong></td>';
             } // end for
             $schema_insert .= '</tr>';
             if (! PMA_exportOutputHandler($schema_insert)) {
@@ -163,7 +207,9 @@ if (isset($plugin_list)) {
                 } else {
                     $value = '';
                 }
-                $schema_insert .= '<td class="print">' . htmlspecialchars($value) . '</td>';
+                $schema_insert .= '<td class="print">'
+                    . htmlspecialchars($value)
+                    . '</td>';
             } // end for
             $schema_insert .= '</tr>';
             if (! PMA_exportOutputHandler($schema_insert)) {
@@ -195,10 +241,18 @@ if (isset($plugin_list)) {
 
         $columns_cnt = 4;
         $schema_insert .= '<tr class="print-category">';
-        $schema_insert .= '<th class="print">' . __('Column') . '</th>';
-        $schema_insert .= '<td class="print"><strong>' . __('Type') . '</strong></td>';
-        $schema_insert .= '<td class="print"><strong>' . __('Null') . '</strong></td>';
-        $schema_insert .= '<td class="print"><strong>' . __('Default') . '</strong></td>';
+        $schema_insert .= '<th class="print">'
+            . __('Column')
+            . '</th>';
+        $schema_insert .= '<td class="print"><strong>'
+            . __('Type')
+            . '</strong></td>';
+        $schema_insert .= '<td class="print"><strong>'
+            . __('Null')
+            . '</strong></td>';
+        $schema_insert .= '<td class="print"><strong>'
+            . __('Default')
+            . '</strong></td>';
         $schema_insert .= '</tr>';
 
         /**
@@ -230,22 +284,34 @@ if (isset($plugin_list)) {
      * @param string $crlf          the end of line sequence
      * @param string $error_url     the url to go back in case of error
      * @param bool   $do_relation   whether to include relation comments
-     * @param bool   $do_comments   whether to include the pmadb-style column comments
-     *                                as comments in the structure; this is deprecated
-     *                                but the parameter is left here because export.php
-     *                                calls PMA_exportStructure() also for other export
-     *                                types which use this parameter
+     * @param bool   $do_comments   whether to include the pmadb-style column
+     *                                comments as comments in the structure;
+     *                                this is deprecated but the parameter is
+     *                                left here because export.php calls
+     *                                PMA_exportStructure() also for other
+     *                                export types which use this parameter
      * @param bool   $do_mime       whether to include mime comments
      * @param bool   $show_dates    whether to include creation/update/check dates
-     * @param bool   $add_semicolon whether to add semicolon and end-of-line at the end
+     * @param bool   $add_semicolon whether to add semicolon and end-of-line
+     *                                at the end
      * @param bool   $view          whether we're handling a view
      *
      * @return string resulting schema
      *
      * @access public
      */
-    function PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime, $show_dates = false, $add_semicolon = true, $view = false)
-    {
+    function PMA_getTableDef(
+        $db,
+        $table,
+        $crlf,
+        $error_url,
+        $do_relation,
+        $do_comments,
+        $do_mime,
+        $show_dates = false,
+        $add_semicolon = true,
+        $view = false
+    ) {
         global $cfgRelation;
 
         $schema_insert = '';
@@ -287,19 +353,33 @@ if (isset($plugin_list)) {
         }
 
         $schema_insert .= '<tr class="print-category">';
-        $schema_insert .= '<th class="print">' . __('Column') . '</th>';
-        $schema_insert .= '<td class="print"><strong>' . __('Type') . '</strong></td>';
-        $schema_insert .= '<td class="print"><strong>' . __('Null') . '</strong></td>';
-        $schema_insert .= '<td class="print"><strong>' . __('Default') . '</strong></td>';
+        $schema_insert .= '<th class="print">'
+            . __('Column')
+            . '</th>';
+        $schema_insert .= '<td class="print"><strong>'
+            . __('Type')
+            . '</strong></td>';
+        $schema_insert .= '<td class="print"><strong>'
+            . __('Null')
+            . '</strong></td>';
+        $schema_insert .= '<td class="print"><strong>'
+            . __('Default')
+            . '</strong></td>';
         if ($do_relation && $have_rel) {
-            $schema_insert .= '<td class="print"><strong>' . __('Links to') . '</strong></td>';
+            $schema_insert .= '<td class="print"><strong>'
+                . __('Links to')
+                . '</strong></td>';
         }
         if ($do_comments) {
-            $schema_insert .= '<td class="print"><strong>' . __('Comments') . '</strong></td>';
+            $schema_insert .= '<td class="print"><strong>'
+                . __('Comments')
+                . '</strong></td>';
             $comments = PMA_getComments($db, $table);
         }
         if ($do_mime && $cfgRelation['mimework']) {
-            $schema_insert .= '<td class="print"><strong>' . htmlspecialchars('MIME') . '</strong></td>';
+            $schema_insert .= '<td class="print"><strong>'
+                . htmlspecialchars('MIME')
+                . '</strong></td>';
             $mime_map = PMA_getMIME($db, $table, true);
         }
         $schema_insert .= '</tr>';
@@ -320,13 +400,28 @@ if (isset($plugin_list)) {
             $field_name = $column['Field'];
 
             if ($do_relation && $have_rel) {
-                $schema_insert .= '<td class="print">' . (isset($res_rel[$field_name]) ? htmlspecialchars($res_rel[$field_name]['foreign_table'] . ' (' . $res_rel[$field_name]['foreign_field'] . ')') : '') . '</td>';
+                $schema_insert .= '<td class="print">'
+                    . (isset($res_rel[$field_name])
+                        ? htmlspecialchars(
+                              $res_rel[$field_name]['foreign_table']
+                              . ' (' . $res_rel[$field_name]['foreign_field']
+                              . ')'
+                          )
+                        : '') . '</td>';
             }
             if ($do_comments && $cfgRelation['commwork']) {
-                $schema_insert .= '<td class="print">' . (isset($comments[$field_name]) ? htmlspecialchars($comments[$field_name]) : '') . '</td>';
+                $schema_insert .= '<td class="print">'
+                    . (isset($comments[$field_name])
+                        ? htmlspecialchars($comments[$field_name])
+                        : '') . '</td>';
             }
             if ($do_mime && $cfgRelation['mimework']) {
-                $schema_insert .= '<td class="print">' . (isset($mime_map[$field_name]) ? htmlspecialchars(str_replace('_', '/', $mime_map[$field_name]['mimetype'])) : '') . '</td>';
+                $schema_insert .= '<td class="print">'
+                    . (isset($mime_map[$field_name]) ?
+                    htmlspecialchars(
+                        str_replace('_', '/', $mime_map[$field_name]['mimetype'])
+                    )
+                    : '') . '</td>';
             }
 
             $schema_insert .= '</tr>';
@@ -360,10 +455,18 @@ if (isset($plugin_list)) {
 
         foreach ($triggers as $trigger) {
             $dump .= '<tr class="print-category">';
-            $dump .= '<td class="print">' . htmlspecialchars($trigger['name']) . '</td>';
-            $dump .= '<td class="print">' . htmlspecialchars($trigger['action_timing']) . '</td>';
-            $dump .= '<td class="print">' . htmlspecialchars($trigger['event_manipulation']) . '</td>';
-            $dump .= '<td class="print">' . htmlspecialchars($trigger['definition']) . '</td>';
+            $dump .= '<td class="print">'
+                . htmlspecialchars($trigger['name'])
+                . '</td>';
+            $dump .= '<td class="print">'
+                . htmlspecialchars($trigger['action_timing'])
+                . '</td>';
+            $dump .= '<td class="print">'
+                . htmlspecialchars($trigger['event_manipulation'])
+                . '</td>';
+            $dump .= '<td class="print">'
+                . htmlspecialchars($trigger['definition'])
+                . '</td>';
             $dump .= '</tr>';
         }
 
@@ -372,6 +475,7 @@ if (isset($plugin_list)) {
     }
 
     /**
+
      * Outputs table's structure
      *
      * @param string  $db           database name
@@ -379,43 +483,69 @@ if (isset($plugin_list)) {
      * @param string  $crlf         the end of line sequence
      * @param string  $error_url    the url to go back in case of error
      * @param bool    $do_relation  whether to include relation comments
-     * @param bool    $do_comments  whether to include the pmadb-style column comments
-     *                                as comments in the structure; this is deprecated
-     *                                but the parameter is left here because export.php
-     *                                calls PMA_exportStructure() also for other export
-     *                                types which use this parameter
+     * @param bool    $do_comments  whether to include the pmadb-style column
+     *                                comments as comments in the structure;
+     *                                this is deprecated but the parameter is
+     *                                left here because export.php calls
+     *                                PMA_exportStructure() also for other
+     *                                export types which use this parameter
      * @param bool    $do_mime      whether to include mime comments
      * @param bool    $dates        whether to include creation/update/check dates
-     * @param string  $export_mode  'create_table', 'triggers', 'create_view', 'stand_in'
+     * @param string  $export_mode  'create_table', 'triggers', 'create_view',
+     *                              'stand_in'
      * @param string  $export_type  'server', 'database', 'table'
      *
      * @return bool      Whether it succeeded
      *
      * @access  public
      */
-    function PMA_exportStructure($db, $table, $crlf, $error_url, $do_relation = false, $do_comments = false, $do_mime = false, $dates = false, $export_mode, $export_type)
-    {
+    function PMA_exportStructure(
+        $db,
+        $table,
+        $crlf,
+        $error_url,
+        $do_relation = false,
+        $do_comments = false,
+        $do_mime = false,
+        $dates = false,
+        $export_mode,
+        $export_type
+    ) {
         $dump = '';
 
         switch($export_mode) {
         case 'create_table':
-            $dump .= '<h2>' . __('Table structure for table') . ' ' . htmlspecialchars($table) . '</h2>';
-            $dump .= PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime, $dates);
+            $dump .= '<h2>'
+                . __('Table structure for table') . ' ' . htmlspecialchars($table)
+                . '</h2>';
+            $dump .= PMA_getTableDef(
+                $db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime,
+                $dates
+            );
             break;
         case 'triggers':
             $dump = '';
             $triggers = PMA_DBI_get_triggers($db, $table);
             if ($triggers) {
-                $dump .= '<h2>' . __('Triggers') . ' ' . htmlspecialchars($table) . '</h2>';
+                $dump .= '<h2>'
+                    . __('Triggers') . ' ' . htmlspecialchars($table)
+                    . '</h2>';
                 $dump .= PMA_getTriggers($db, $table);
             }
             break;
         case 'create_view':
-            $dump .= '<h2>' . __('Structure for view') . ' ' . htmlspecialchars($table) . '</h2>';
-            $dump .= PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime, $dates, true, true);
+            $dump .= '<h2>'
+                . __('Structure for view') . ' ' . htmlspecialchars($table)
+                . '</h2>';
+            $dump .= PMA_getTableDef(
+                $db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime,
+                $dates, true, true
+            );
             break;
         case 'stand_in':
-            $dump .=  '<h2>' . __('Stand-in structure for view') . ' ' . htmlspecialchars($table) . '</h2>';
+            $dump .=  '<h2>'
+                . __('Stand-in structure for view') . ' ' . htmlspecialchars($table)
+                . '</h2>';
             // export a stand-in definition to resolve view dependencies
             $dump .= PMA_getTableDefStandIn($db, $table, $crlf);
         } // end switch

--- a/libraries/export/json.php
+++ b/libraries/export/json.php
@@ -18,20 +18,22 @@ if (isset($plugin_list)) {
         'text' => 'JSON',
         'extension' => 'json',
         'mime_type' => 'text/plain',
-        'options' => array(
-            array(
-                'type' => 'begin_group',
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'hidden',
-                'name' => 'structure_or_data',
-            ),
-            array(
-                'type' => 'end_group'
-            )
+        'options' => array(),
+        'options_text' => __('Options')
+    );
+
+    $plugin_list['json']['options'][] = array(
+        array(
+            'type' => 'begin_group',
+            'name' => 'general_opts'
         ),
-        'options_text' => __('Options'),
+        array(
+            'type' => 'hidden',
+            'name' => 'structure_or_data',
+        ),
+        array(
+            'type' => 'end_group'
+        )
     );
 } else {
 

--- a/libraries/export/json.php
+++ b/libraries/export/json.php
@@ -44,9 +44,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -56,9 +56,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -76,9 +76,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -91,9 +91,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -105,9 +105,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -123,9 +123,9 @@ if (isset($plugin_list)) {
      * @param string  $error_url  the url to go back in case of error
      * @param string  $sql_query  SQL query for obtaining data
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {

--- a/libraries/export/json.php
+++ b/libraries/export/json.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build dumps of tables as JSON
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage JSON
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/json.php
+++ b/libraries/export/json.php
@@ -74,7 +74,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -89,7 +89,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -103,7 +103,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -117,11 +117,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs the content of a table in JSON format
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
      *
      * @return bool Whether it succeeded
      *

--- a/libraries/export/json.php
+++ b/libraries/export/json.php
@@ -15,10 +15,10 @@ if (! defined('PHPMYADMIN')) {
  */
 if (isset($plugin_list)) {
     $plugin_list['json'] = array(
-        'text'          => 'JSON',
-        'extension'     => 'json',
-        'mime_type'     => 'text/plain',
-        'options'       => array(
+        'text' => 'JSON',
+        'extension' => 'json',
+        'mime_type' => 'text/plain',
+        'options' => array(
             array('type' => 'begin_group', 'name' => 'general_opts'),
             array(
                 'type' => 'hidden',
@@ -26,7 +26,7 @@ if (isset($plugin_list)) {
             ),
             array('type' => 'end_group')
         ),
-        'options_text'  => __('Options'),
+        'options_text' => __('Options'),
     );
 } else {
 

--- a/libraries/export/json.php
+++ b/libraries/export/json.php
@@ -19,12 +19,17 @@ if (isset($plugin_list)) {
         'extension' => 'json',
         'mime_type' => 'text/plain',
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
+            ),
             array(
                 'type' => 'hidden',
                 'name' => 'structure_or_data',
             ),
-            array('type' => 'end_group')
+            array(
+                'type' => 'end_group'
+            )
         ),
         'options_text' => __('Options'),
     );
@@ -155,11 +160,20 @@ if (isset($plugin_list)) {
                 $column = $columns[$i];
 
                 if (is_null($record[$i])) {
-                    $buffer .= '"' . addslashes($column) . '": null' . (! $isLastLine ? ',' : '');
+                    $buffer .= '"' . addslashes($column)
+                        . '": null'
+                        . (! $isLastLine ? ',' : '');
                 } elseif ($fields_meta[$i]->numeric) {
-                    $buffer .= '"' . addslashes($column) . '": ' . $record[$i] . (! $isLastLine ? ',' : '');
+                    $buffer .= '"' . addslashes($column)
+                        . '": '
+                        . $record[$i]
+                        . (! $isLastLine ? ',' : '');
                 } else {
-                    $buffer .= '"' . addslashes($column) . '": "' . addslashes($record[$i]) . '"' . (! $isLastLine ? ',' : '');
+                    $buffer .= '"' . addslashes($column)
+                        . '": "'
+                        . addslashes($record[$i])
+                        . '"'
+                        . (! $isLastLine ? ',' : '');
                 }
             }
 

--- a/libraries/export/json.php
+++ b/libraries/export/json.php
@@ -22,7 +22,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['json']['options'][] = array(
+    $plugin_list['json']['options'] = array(
         array(
             'type' => 'begin_group',
             'name' => 'general_opts'

--- a/libraries/export/latex.php
+++ b/libraries/export/latex.php
@@ -28,58 +28,129 @@ if (isset($plugin_list)) {
         'extension' => 'tex',
         'mime_type' => 'application/x-tex',
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
-            array('type' => 'bool', 'name' => 'caption', 'text' => __('Include table caption')),
-            array('type' => 'end_group')
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
             ),
+            array(
+                'type' => 'bool',
+                'name' => 'caption',
+                'text' => __('Include table caption')
+            ),
+            array(
+                'type' => 'end_group'
+            )
+        ),
         'options_text' => __('Options'),
-        );
+    );
 
     /* what to dump (structure/data/both) */
-    $plugin_list['latex']['options'][]
-        = array('type' => 'begin_group', 'name' => 'dump_what', 'text' => __('Dump table'));
-    $plugin_list['latex']['options'][]
-        = array('type' => 'radio', 'name' => 'structure_or_data', 'values' => array('structure' => __('structure'), 'data' => __('data'), 'structure_and_data' => __('structure and data')));
-    $plugin_list['latex']['options'][] = array('type' => 'end_group');
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'begin_group',
+        'name' => 'dump_what',
+        'text' => __('Dump table')
+    );
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'radio',
+        'name' => 'structure_or_data',
+        'values' => array(
+            'structure' => __('structure'),
+            'data' => __('data'),
+            'structure_and_data' => __('structure and data')
+        )
+    );
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'end_group'
+    );
 
     /* Structure options */
     if (! $hide_structure) {
-        $plugin_list['latex']['options'][]
-            = array('type' => 'begin_group', 'name' => 'structure', 'text' => __('Object creation options'), 'force' => 'data');
-        $plugin_list['latex']['options'][]
-            = array('type' => 'text', 'name' => 'structure_caption', 'text' => __('Table caption'), 'doc' => 'faq6_27');
-        $plugin_list['latex']['options'][]
-            = array('type' => 'text', 'name' => 'structure_continued_caption', 'text' => __('Table caption (continued)'), 'doc' => 'faq6_27');
-        $plugin_list['latex']['options'][]
-            = array('type' => 'text', 'name' => 'structure_label', 'text' => __('Label key'), 'doc' => 'faq6_27');
+        $plugin_list['latex']['options'][] = array(
+            'type' => 'begin_group',
+            'name' => 'structure',
+            'text' => __('Object creation options'),
+            'force' => 'data'
+        );
+        $plugin_list['latex']['options'][] = array(
+            'type' => 'text',
+            'name' => 'structure_caption',
+            'text' => __('Table caption'),
+            'doc' => 'faq6_27'
+        );
+        $plugin_list['latex']['options'][] = array(
+            'type' => 'text',
+            'name' => 'structure_continued_caption',
+            'text' => __('Table caption (continued)'),
+            'doc' => 'faq6_27'
+        );
+        $plugin_list['latex']['options'][] = array(
+            'type' => 'text',
+            'name' => 'structure_label',
+            'text' => __('Label key'),
+            'doc' => 'faq6_27'
+        );
         if (! empty($GLOBALS['cfgRelation']['relation'])) {
-            $plugin_list['latex']['options'][]
-                = array('type' => 'bool', 'name' => 'relation', 'text' => __('Display foreign key relationships'));
+            $plugin_list['latex']['options'][] = array(
+                'type' => 'bool',
+                'name' => 'relation',
+                'text' => __('Display foreign key relationships')
+            );
         }
-        $plugin_list['latex']['options'][]
-            = array('type' => 'bool', 'name' => 'comments', 'text' => __('Display comments'));
+        $plugin_list['latex']['options'][] = array(
+            'type' => 'bool',
+            'name' => 'comments',
+            'text' => __('Display comments')
+        );
         if (! empty($GLOBALS['cfgRelation']['mimework'])) {
-            $plugin_list['latex']['options'][]
-                = array('type' => 'bool', 'name' => 'mime', 'text' => __('Display MIME types'));
+            $plugin_list['latex']['options'][] = array(
+                'type' => 'bool',
+                'name' => 'mime',
+                'text' => __('Display MIME types')
+            );
         }
-        $plugin_list['latex']['options'][]
-            = array('type' => 'end_group');
+        $plugin_list['latex']['options'][] = array(
+            'type' => 'end_group'
+        );
     }
+
     /* Data */
-    $plugin_list['latex']['options'][]
-        = array('type' => 'begin_group', 'name' => 'data', 'text' => __('Data dump options'), 'force' => 'structure');
-    $plugin_list['latex']['options'][]
-        = array('type' => 'bool', 'name' => 'columns', 'text' => __('Put columns names in the first row'));
-    $plugin_list['latex']['options'][]
-        = array('type' => 'text', 'name' => 'data_caption', 'text' => __('Table caption'), 'doc' => 'faq6_27');
-    $plugin_list['latex']['options'][]
-        = array('type' => 'text', 'name' => 'data_continued_caption', 'text' => __('Table caption (continued)'), 'doc' => 'faq6_27');
-    $plugin_list['latex']['options'][]
-        = array('type' => 'text', 'name' => 'data_label', 'text' => __('Label key'), 'doc' => 'faq6_27');
-    $plugin_list['latex']['options'][]
-        = array('type' => 'text', 'name' => 'null', 'text' => __('Replace NULL with:'));
-    $plugin_list['latex']['options'][]
-        = array('type' => 'end_group');
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'begin_group',
+        'name' => 'data',
+        'text' => __('Data dump options'),
+        'force' => 'structure'
+    );
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'bool',
+        'name' => 'columns',
+        'text' => __('Put columns names in the first row')
+    );
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'text',
+        'name' => 'data_caption',
+        'text' => __('Table caption'),
+        'doc' => 'faq6_27'
+    );
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'text',
+        'name' => 'data_continued_caption',
+        'text' => __('Table caption (continued)'),
+        'doc' => 'faq6_27'
+    );
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'text',
+        'name' => 'data_label',
+        'text' => __('Label key'),
+        'doc' => 'faq6_27'
+    );
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'text',
+        'name' => 'null',
+        'text' => __('Replace NULL with:')
+    );
+    $plugin_list['latex']['options'][] = array(
+        'type' => 'end_group'
+    );
 } else {
 
     /**
@@ -277,10 +348,13 @@ if (isset($plugin_list)) {
             $buffer = '';
             // print each row
             for ($i = 0; $i < $columns_cnt; $i++) {
-                if (isset($record[$columns[$i]])
-                    && (! function_exists('is_null') || ! is_null($record[$columns[$i]]))
+                if ((! function_exists('is_null')
+                    || ! is_null($record[$columns[$i]]))
+                    && isset($record[$columns[$i]])
                 ) {
-                    $column_value = PMA_texEscape(stripslashes($record[$columns[$i]]));
+                    $column_value = PMA_texEscape(
+                        stripslashes($record[$columns[$i]])
+                    );
                 } else {
                     $column_value = $GLOBALS['latex_null'];
                 }
@@ -316,21 +390,33 @@ if (isset($plugin_list)) {
      * @param string $crlf        the end of line sequence
      * @param string $error_url   the url to go back in case of error
      * @param bool   $do_relation whether to include relation comments
-     * @param bool   $do_comments whether to include the pmadb-style column comments
-     *                            as comments in the structure; this is deprecated
-     *                            but the parameter is left here because export.php
-     *                            calls PMA_exportStructure() also for other export
-     *                            types which use this parameter
+     * @param bool   $do_comments whether to include the pmadb-style column
+     *                                comments as comments in the structure;
+     *                                this is deprecated but the parameter is
+     *                                left here because export.php calls
+     *                                PMA_exportStructure() also for other
+     *                                export types which use this parameter
      * @param bool   $do_mime     whether to include mime comments
      * @param bool   $dates       whether to include creation/update/check dates
-     * @param string $export_mode 'create_table', 'triggers', 'create_view', 'stand_in'
+     * @param string $export_mode 'create_table', 'triggers', 'create_view',
+     *                            'stand_in'
      * @param string $export_type 'server', 'database', 'table'
      *
      * @return bool Whether it succeeded
      *
      * @access public
      */
-    function PMA_exportStructure($db, $table, $crlf, $error_url, $do_relation = false, $do_comments = false, $do_mime = false, $dates = false, $export_mode, $export_type)
+    function PMA_exportStructure(
+        $db,
+        $table,
+        $crlf,
+        $error_url,
+        $do_relation = false,
+        $do_comments = false,
+        $do_mime = false,
+        $dates = false,
+        $export_mode,
+        $export_type)
     {
         global $cfgRelation;
 
@@ -423,7 +509,8 @@ if (isset($plugin_list)) {
                 )
                 . '} \\\\' . $crlf;
         }
-        $buffer .= $header . ' \\\\ \\hline \\hline' . $crlf . '\\endfirsthead' . $crlf;
+        $buffer .= $header . ' \\\\ \\hline \\hline' . $crlf
+            . '\\endfirsthead' . $crlf;
         // Table caption on next pages
         if (isset($GLOBALS['latex_caption'])) {
             $buffer .= ' \\caption{'
@@ -457,7 +544,8 @@ if (isset($plugin_list)) {
             $field_name = $row['Field'];
 
             $local_buffer = $field_name . "\000" . $type . "\000"
-                . (($row['Null'] == '' || $row['Null'] == 'NO') ? __('No') : __('Yes'))
+                . (($row['Null'] == '' || $row['Null'] == 'NO')
+                    ? __('No') : __('Yes'))
                 . "\000" . (isset($row['Default']) ? $row['Default'] : '');
 
             if ($do_relation && $have_rel) {
@@ -476,17 +564,27 @@ if (isset($plugin_list)) {
             if ($do_mime && $cfgRelation['mimework']) {
                 $local_buffer .= "\000";
                 if (isset($mime_map[$field_name])) {
-                    $local_buffer .= str_replace('_', '/', $mime_map[$field_name]['mimetype']);
+                    $local_buffer .= str_replace(
+                        '_',
+                        '/',
+                        $mime_map[$field_name]['mimetype']
+                    );
                 }
             }
             $local_buffer = PMA_texEscape($local_buffer);
             if ($row['Key']=='PRI') {
                 $pos=strpos($local_buffer, "\000");
-                $local_buffer = '\\textit{' . substr($local_buffer, 0, $pos) . '}' . substr($local_buffer, $pos);
+                $local_buffer = '\\textit{'
+                    . substr(
+                        $local_buffer, 0, $pos) . '}' . substr($local_buffer, $pos
+                    );
             }
             if (in_array($field_name, $unique_keys)) {
                 $pos=strpos($local_buffer, "\000");
-                $local_buffer = '\\textbf{' . substr($local_buffer, 0, $pos) . '}' . substr($local_buffer, $pos);
+                $local_buffer = '\\textbf{'
+                    . substr(
+                        $local_buffer, 0, $pos) . '}' . substr($local_buffer, $pos
+                    );
             }
             $buffer = str_replace("\000", ' & ', $local_buffer);
             $buffer .= ' \\\\ \\hline ' . $crlf;

--- a/libraries/export/latex.php
+++ b/libraries/export/latex.php
@@ -31,7 +31,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['latex']['options'][] = array(
+    $plugin_list['latex']['options'] = array(
         array(
             'type' => 'begin_group',
             'name' => 'general_opts'

--- a/libraries/export/latex.php
+++ b/libraries/export/latex.php
@@ -161,7 +161,7 @@ if (isset($plugin_list)) {
      *
      * @return string      the converted string with escape codes
      *
-     * @access  private
+     * @access private
      */
     function PMA_texEscape($string)
     {
@@ -176,9 +176,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {

--- a/libraries/export/latex.php
+++ b/libraries/export/latex.php
@@ -95,7 +95,7 @@ if (isset($plugin_list)) {
     {
         $escape = array('$', '%', '{', '}',  '&',  '#', '_', '^');
         $cnt_escape = count($escape);
-        for ($k=0; $k < $cnt_escape; $k++) {
+        for ($k = 0; $k < $cnt_escape; $k++) {
             $string = str_replace($escape[$k], '\\' . $escape[$k], $string);
         }
         return $string;
@@ -445,7 +445,7 @@ if (isset($plugin_list)) {
             $extracted_columnspec = PMA_extractColumnSpec($row['Type']);
             $type = $extracted_columnspec['print_type'];
             if (empty($type)) {
-                $type     = ' ';
+                $type = ' ';
             }
 
             if (! isset($row['Default'])) {

--- a/libraries/export/latex.php
+++ b/libraries/export/latex.php
@@ -159,7 +159,7 @@ if (isset($plugin_list)) {
      *
      * @param string $string the string to convert
      *
-     * @return string      the converted string with escape codes
+     * @return string the converted string with escape codes
      *
      * @access private
      */
@@ -417,8 +417,8 @@ if (isset($plugin_list)) {
         $do_mime = false,
         $dates = false,
         $export_mode,
-        $export_type)
-    {
+        $export_type
+    ) {
         global $cfgRelation;
 
         /**
@@ -576,16 +576,14 @@ if (isset($plugin_list)) {
             if ($row['Key']=='PRI') {
                 $pos=strpos($local_buffer, "\000");
                 $local_buffer = '\\textit{'
-                    . substr(
-                        $local_buffer, 0, $pos) . '}' . substr($local_buffer, $pos
-                    );
+                    . substr($local_buffer, 0, $pos)
+                    . '}' . substr($local_buffer, $pos);
             }
             if (in_array($field_name, $unique_keys)) {
                 $pos=strpos($local_buffer, "\000");
                 $local_buffer = '\\textbf{'
-                    . substr(
-                        $local_buffer, 0, $pos) . '}' . substr($local_buffer, $pos
-                    );
+                    . substr($local_buffer, 0, $pos)
+                    . '}' . substr($local_buffer, $pos);
             }
             $buffer = str_replace("\000", ' & ', $local_buffer);
             $buffer .= ' \\\\ \\hline ' . $crlf;

--- a/libraries/export/latex.php
+++ b/libraries/export/latex.php
@@ -27,23 +27,24 @@ if (isset($plugin_list)) {
         'text' => __('LaTeX'),
         'extension' => 'tex',
         'mime_type' => 'application/x-tex',
-        'options' => array(
-            array(
-                'type' => 'begin_group',
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'bool',
-                'name' => 'caption',
-                'text' => __('Include table caption')
-            ),
-            array(
-                'type' => 'end_group'
-            )
-        ),
-        'options_text' => __('Options'),
+        'options' => array(),
+        'options_text' => __('Options')
     );
 
+    $plugin_list['latex']['options'][] = array(
+        array(
+            'type' => 'begin_group',
+            'name' => 'general_opts'
+        ),
+        array(
+            'type' => 'bool',
+            'name' => 'caption',
+            'text' => __('Include table caption')
+        ),
+        array(
+            'type' => 'end_group'
+        )
+    );
     /* what to dump (structure/data/both) */
     $plugin_list['latex']['options'][] = array(
         'type' => 'begin_group',

--- a/libraries/export/latex.php
+++ b/libraries/export/latex.php
@@ -390,6 +390,9 @@ if (isset($plugin_list)) {
      * @param string $table       table name
      * @param string $crlf        the end of line sequence
      * @param string $error_url   the url to go back in case of error
+     * @param string $export_mode 'create_table', 'triggers', 'create_view',
+     *                            'stand_in'
+     * @param string $export_type 'server', 'database', 'table'
      * @param bool   $do_relation whether to include relation comments
      * @param bool   $do_comments whether to include the pmadb-style column
      *                                comments as comments in the structure;
@@ -399,9 +402,6 @@ if (isset($plugin_list)) {
      *                                export types which use this parameter
      * @param bool   $do_mime     whether to include mime comments
      * @param bool   $dates       whether to include creation/update/check dates
-     * @param string $export_mode 'create_table', 'triggers', 'create_view',
-     *                            'stand_in'
-     * @param string $export_type 'server', 'database', 'table'
      *
      * @return bool Whether it succeeded
      *
@@ -412,12 +412,12 @@ if (isset($plugin_list)) {
         $table,
         $crlf,
         $error_url,
+        $export_mode,
+        $export_type,
         $do_relation = false,
         $do_comments = false,
         $do_mime = false,
-        $dates = false,
-        $export_mode,
-        $export_type
+        $dates = false
     ) {
         global $cfgRelation;
 

--- a/libraries/export/latex.php
+++ b/libraries/export/latex.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build LaTeX dumps of tables
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage Latex
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/mediawiki.php
+++ b/libraries/export/mediawiki.php
@@ -172,7 +172,7 @@ if (isset($plugin_list)) {
      * @param string $table       table name
      * @param string $crlf        the end of line sequence
      * @param string $error_url   the url to go back in case of error
-     * @param string $export_mode 'create_table','triggers','create_view', 
+     * @param string $export_mode 'create_table','triggers','create_view',
      *                            'stand_in'
      * @param string $export_type 'server', 'database', 'table'
      * @param bool   $do_relation whether to include relation comments

--- a/libraries/export/mediawiki.php
+++ b/libraries/export/mediawiki.php
@@ -172,17 +172,17 @@ if (isset($plugin_list)) {
      * @param string $table       table name
      * @param string $crlf        the end of line sequence
      * @param string $error_url   the url to go back in case of error
-     *
-     * @param bool   $relation    whether to include relation comments
-     * @param bool   $comments    whether to include the pmadb-style column comments
+     * @param string $export_mode 'create_table','triggers','create_view', 
+     *                            'stand_in'
+     * @param string $export_type 'server', 'database', 'table'
+     * @param bool   $do_relation whether to include relation comments
+     * @param bool   $do_comments whether to include the pmadb-style column comments
      *                            as comments in the structure; this is deprecated
      *                            but the parameter is left here because export.php
      *                            calls PMA_exportStructure() also for other export
      *                            types which use this parameter
-     * @param bool   $mime        whether to include mime comments
+     * @param bool   $do_mime     whether to include mime comments
      * @param bool   $dates       whether to include creation/update/check dates
-     * @param string $export_mode 'create_table','triggers','create_view','stand_in'
-     * @param string $export_type 'server', 'database', 'table'
      *
      * @return bool               Whether it succeeded
      *
@@ -193,12 +193,12 @@ if (isset($plugin_list)) {
         $table,
         $crlf,
         $error_url,
-        $relation = false,
-        $comments = false,
-        $mime = false,
-        $dates = false,
         $export_mode,
-        $export_type
+        $export_type,
+        $do_relation = false,
+        $do_comments = false,
+        $do_mime = false,
+        $dates = false
     ) {
         switch($export_mode) {
         case 'create_table':

--- a/libraries/export/mediawiki.php
+++ b/libraries/export/mediawiki.php
@@ -15,53 +15,55 @@ if (isset($plugin_list)) {
         'text' => __('MediaWiki Table'),
         'extension' => 'mediawiki',
         'mime_type' => 'text/plain',
-        'options' => array(
-            ),
-        'options_text' => __('Options'),
-        );
+        'options' => array(),
+        'options_text' => __('Options')
+    );
 
-        // general options
-        $plugin_list['mediawiki']['options'][] = array(
-            'type' => 'begin_group',
-            'name' => 'general_opts');
+    // general options
+    $plugin_list['mediawiki']['options'][] = array(
+        'type' => 'begin_group',
+        'name' => 'general_opts'
+    );
 
-        // what to dump (structure/data/both)
-        $plugin_list['mediawiki']['options'][] = array(
-            'type' => 'begin_subgroup',
-            'subgroup_header' => array(
-                'type' => 'message_only',
-                'text' => __('Dump table')
-            ));
-        $plugin_list['mediawiki']['options'][] = array(
-            'type' => 'radio',
-            'name' => 'structure_or_data',
-            'values' => array(
-                'structure' => __('structure'),
-                'data' => __('data'),
-                'structure_and_data' => __('structure and data')
-            ));
-        $plugin_list['mediawiki']['options'][] = array(
-            'type' => 'end_subgroup'
-            );
+    // what to dump (structure/data/both)
+    $plugin_list['mediawiki']['options'][] = array(
+        'type' => 'begin_subgroup',
+        'subgroup_header' => array(
+            'type' => 'message_only',
+            'text' => __('Dump table')
+        )
+    );
+    $plugin_list['mediawiki']['options'][] = array(
+        'type' => 'radio',
+        'name' => 'structure_or_data',
+        'values' => array(
+            'structure' => __('structure'),
+            'data' => __('data'),
+            'structure_and_data' => __('structure and data')
+        )
+    );
+    $plugin_list['mediawiki']['options'][] = array(
+        'type' => 'end_subgroup'
+    );
 
-        // export table name
-        $plugin_list['mediawiki']['options'][] = array(
-            'type' => 'bool',
-            'name' => 'caption',
-            'text' => __('Export table names')
-            );
+    // export table name
+    $plugin_list['mediawiki']['options'][] = array(
+        'type' => 'bool',
+        'name' => 'caption',
+        'text' => __('Export table names')
+    );
 
-        // export table headers
-        $plugin_list['mediawiki']['options'][] = array(
-            'type' => 'bool',
-            'name' => 'headers',
-            'text' => __('Export table headers')
-            );
+    // export table headers
+    $plugin_list['mediawiki']['options'][] = array(
+        'type' => 'bool',
+        'name' => 'headers',
+        'text' => __('Export table headers')
+    );
 
-        // end general options
-        $plugin_list['mediawiki']['options'][] = array(
-            'type' => 'end_group'
-            );
+    // end general options
+    $plugin_list['mediawiki']['options'][] = array(
+        'type' => 'end_group'
+    );
 } else {
 
     /**

--- a/libraries/export/mediawiki.php
+++ b/libraries/export/mediawiki.php
@@ -3,7 +3,7 @@
 /**
  *  Set of functions used to build MediaWiki dumps of tables
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage MediaWiki
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/mediawiki.php
+++ b/libraries/export/mediawiki.php
@@ -102,9 +102,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -114,9 +114,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -130,7 +130,7 @@ if (isset($plugin_list)) {
      *
      * @return bool     Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -144,7 +144,7 @@ if (isset($plugin_list)) {
      *
      * @return bool     Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -158,7 +158,7 @@ if (isset($plugin_list)) {
      *
      * @return bool     Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -273,7 +273,7 @@ if (isset($plugin_list)) {
      *
      * @return bool             Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData(
         $db,

--- a/libraries/export/ods.php
+++ b/libraries/export/ods.php
@@ -199,14 +199,14 @@ if (isset($plugin_list)) {
             $field_flags[$j] = PMA_DBI_field_flags($result, $j);
         }
 
-        $GLOBALS['ods_buffer'] .= 
+        $GLOBALS['ods_buffer'] .=
             '<table:table table:name="' . htmlspecialchars($table) . '">';
 
         // If required, get fields name at the first line
         if (isset($GLOBALS[$what . '_columns'])) {
             $GLOBALS['ods_buffer'] .= '<table:table-row>';
             for ($i = 0; $i < $fields_cnt; $i++) {
-                $GLOBALS['ods_buffer'] .= 
+                $GLOBALS['ods_buffer'] .=
                     '<table:table-cell office:value-type="string">'
                     . '<text:p>'
                     . htmlspecialchars(

--- a/libraries/export/ods.php
+++ b/libraries/export/ods.php
@@ -54,9 +54,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -77,9 +77,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -136,9 +136,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -150,9 +150,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -164,9 +164,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -182,9 +182,9 @@ if (isset($plugin_list)) {
      * @param string  $error_url  the url to go back in case of error
      * @param string  $sql_query  SQL query for obtaining data
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {

--- a/libraries/export/ods.php
+++ b/libraries/export/ods.php
@@ -66,9 +66,9 @@ if (isset($plugin_list)) {
         if (! PMA_exportOutputHandler(
             PMA_createOpenDocument(
                 'application/vnd.oasis.opendocument.spreadsheet',
-                $GLOBALS['ods_buffer'])
+                $GLOBALS['ods_buffer']
             )
-        ) {
+        )) {
             return false;
         }
         return true;
@@ -134,7 +134,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -148,7 +148,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -162,7 +162,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -176,11 +176,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs the content of a table in ODS format
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
      *
      * @return bool Whether it succeeded
      *
@@ -229,9 +229,10 @@ if (isset($plugin_list)) {
                         . htmlspecialchars($GLOBALS[$what . '_null'])
                         . '</text:p>'
                         . '</table:table-cell>';
-                // ignore BLOB
                 } elseif (stristr($field_flags[$j], 'BINARY')
-                        && $fields_meta[$j]->blob) {
+                    && $fields_meta[$j]->blob
+                ) {
+                    // ignore BLOB
                     $GLOBALS['ods_buffer'] .=
                         '<table:table-cell office:value-type="string">'
                         . '<text:p></text:p>'

--- a/libraries/export/ods.php
+++ b/libraries/export/ods.php
@@ -23,7 +23,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['ods']['options'][] = array(
+    $plugin_list['ods']['options'] = array(
         array(
             'type' => 'begin_group',
             'name' => 'general_opts'

--- a/libraries/export/ods.php
+++ b/libraries/export/ods.php
@@ -20,14 +20,30 @@ if (isset($plugin_list)) {
         'mime_type' => 'application/vnd.oasis.opendocument.spreadsheet',
         'force_file' => true,
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
-            array('type' => 'text', 'name' => 'null', 'text' => __('Replace NULL with:')),
-            array('type' => 'bool', 'name' => 'columns', 'text' => __('Put columns names in the first row')),
-            array('type' => 'hidden', 'name' => 'structure_or_data'),
-            array('type' => 'end_group'),
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
             ),
+            array(
+                'type' => 'text',
+                'name' => 'null',
+                'text' => __('Replace NULL with:')
+            ),
+            array(
+                'type' => 'bool',
+                'name' => 'columns',
+                'text' => __('Put columns names in the first row')
+            ),
+            array(
+                'type' => 'hidden',
+                'name' => 'structure_or_data'
+            ),
+            array(
+                'type' => 'end_group'
+            ),
+        ),
         'options_text' => __('Options'),
-        );
+    );
 } else {
 
     $GLOBALS['ods_buffer'] = '';
@@ -45,7 +61,12 @@ if (isset($plugin_list)) {
         $GLOBALS['ods_buffer'] .= '</office:spreadsheet>'
             . '</office:body>'
             . '</office:document-content>';
-        if (! PMA_exportOutputHandler(PMA_createOpenDocument('application/vnd.oasis.opendocument.spreadsheet', $GLOBALS['ods_buffer']))) {
+        if (! PMA_exportOutputHandler(
+            PMA_createOpenDocument(
+                'application/vnd.oasis.opendocument.spreadsheet',
+                $GLOBALS['ods_buffer'])
+            )
+        ) {
             return false;
         }
         return true;
@@ -61,9 +82,11 @@ if (isset($plugin_list)) {
     function PMA_exportHeader()
     {
         $GLOBALS['ods_buffer'] .= '<?xml version="1.0" encoding="utf-8"?' . '>'
-            . '<office:document-content '. $GLOBALS['OpenDocumentNS'] . 'office:version="1.0">'
+            . '<office:document-content '
+                . $GLOBALS['OpenDocumentNS'] . 'office:version="1.0">'
             . '<office:automatic-styles>'
-                . '<number:date-style style:name="N37" number:automatic-order="true">'
+                . '<number:date-style style:name="N37"'
+                    .' number:automatic-order="true">'
                 . '<number:month number:style="long"/>'
                 . '<number:text>/</number:text>'
                 . '<number:day number:style="long"/>'
@@ -79,7 +102,9 @@ if (isset($plugin_list)) {
                 . '<number:text> </number:text>'
                 . '<number:am-pm/>'
               . '</number:time-style>'
-              . '<number:date-style style:name="N50" number:automatic-order="true" number:format-source="language">'
+              . '<number:date-style style:name="N50"'
+                    . ' number:automatic-order="true"'
+                    . ' number:format-source="language">'
                 . '<number:month/>'
                 . '<number:text>/</number:text>'
                 . '<number:day/>'
@@ -92,9 +117,12 @@ if (isset($plugin_list)) {
                 . '<number:text> </number:text>'
                 . '<number:am-pm/>'
               . '</number:date-style>'
-              . '<style:style style:name="DateCell" style:family="table-cell" style:parent-style-name="Default" style:data-style-name="N37"/>'
-              . '<style:style style:name="TimeCell" style:family="table-cell" style:parent-style-name="Default" style:data-style-name="N43"/>'
-              . '<style:style style:name="DateTimeCell" style:family="table-cell" style:parent-style-name="Default" style:data-style-name="N50"/>'
+              . '<style:style style:name="DateCell" style:family="table-cell"'
+                . ' style:parent-style-name="Default" style:data-style-name="N37"/>'
+              . '<style:style style:name="TimeCell" style:family="table-cell"'
+                . ' style:parent-style-name="Default" style:data-style-name="N43"/>'
+              . '<style:style style:name="DateTimeCell" style:family="table-cell"'
+                . ' style:parent-style-name="Default" style:data-style-name="N50"/>'
             . '</office:automatic-styles>'
             . '<office:body>'
             . '<office:spreadsheet>';
@@ -169,14 +197,20 @@ if (isset($plugin_list)) {
             $field_flags[$j] = PMA_DBI_field_flags($result, $j);
         }
 
-        $GLOBALS['ods_buffer'] .= '<table:table table:name="' . htmlspecialchars($table) . '">';
+        $GLOBALS['ods_buffer'] .= 
+            '<table:table table:name="' . htmlspecialchars($table) . '">';
 
         // If required, get fields name at the first line
         if (isset($GLOBALS[$what . '_columns'])) {
             $GLOBALS['ods_buffer'] .= '<table:table-row>';
             for ($i = 0; $i < $fields_cnt; $i++) {
-                $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="string">'
-                    . '<text:p>' . htmlspecialchars(stripslashes(PMA_DBI_field_name($result, $i))) . '</text:p>'
+                $GLOBALS['ods_buffer'] .= 
+                    '<table:table-cell office:value-type="string">'
+                    . '<text:p>'
+                    . htmlspecialchars(
+                        stripslashes(PMA_DBI_field_name($result, $i))
+                    )
+                    . '</text:p>'
                     . '</table:table-cell>';
             } // end for
             $GLOBALS['ods_buffer'] .= '</table:table-row>';
@@ -187,34 +221,66 @@ if (isset($plugin_list)) {
             $GLOBALS['ods_buffer'] .= '<table:table-row>';
             for ($j = 0; $j < $fields_cnt; $j++) {
                 if (! isset($row[$j]) || is_null($row[$j])) {
-                    $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="string">'
-                        . '<text:p>' . htmlspecialchars($GLOBALS[$what . '_null']) . '</text:p>'
+                    $GLOBALS['ods_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
+                        . '<text:p>'
+                        . htmlspecialchars($GLOBALS[$what . '_null'])
+                        . '</text:p>'
                         . '</table:table-cell>';
                 // ignore BLOB
                 } elseif (stristr($field_flags[$j], 'BINARY')
                         && $fields_meta[$j]->blob) {
-                    $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="string">'
+                    $GLOBALS['ods_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
                         . '<text:p></text:p>'
                         . '</table:table-cell>';
                 } elseif ($fields_meta[$j]->type == "date") {
-                    $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="date" office:date-value="' . date("Y-m-d", strtotime($row[$j])) . '" table:style-name="DateCell">'
-                        . '<text:p>' . htmlspecialchars($row[$j]) . '</text:p>'
+                    $GLOBALS['ods_buffer'] .=
+                        '<table:table-cell office:value-type="date"'
+                            . ' office:date-value="'
+                            . date("Y-m-d", strtotime($row[$j]))
+                            . '" table:style-name="DateCell">'
+                        . '<text:p>'
+                        . htmlspecialchars($row[$j])
+                        . '</text:p>'
                         . '</table:table-cell>';
                 } elseif ($fields_meta[$j]->type == "time") {
-                    $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="time" office:time-value="' . date("\P\TH\Hi\Ms\S", strtotime($row[$j])) . '" table:style-name="TimeCell">'
-                        . '<text:p>' . htmlspecialchars($row[$j]) . '</text:p>'
+                    $GLOBALS['ods_buffer'] .=
+                        '<table:table-cell office:value-type="time"'
+                            . ' office:time-value="'
+                            . date("\P\TH\Hi\Ms\S", strtotime($row[$j]))
+                            . '" table:style-name="TimeCell">'
+                        . '<text:p>'
+                        . htmlspecialchars($row[$j])
+                        . '</text:p>'
                         . '</table:table-cell>';
                 } elseif ($fields_meta[$j]->type == "datetime") {
-                    $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="date" office:date-value="' . date("Y-m-d\TH:i:s", strtotime($row[$j])) . '" table:style-name="DateTimeCell">'
-                        . '<text:p>' . htmlspecialchars($row[$j]) . '</text:p>'
+                    $GLOBALS['ods_buffer'] .=
+                        '<table:table-cell office:value-type="date"'
+                            . ' office:date-value="'
+                            . date("Y-m-d\TH:i:s", strtotime($row[$j]))
+                            . '" table:style-name="DateTimeCell">'
+                        . '<text:p>'
+                        . htmlspecialchars($row[$j])
+                        . '</text:p>'
                         . '</table:table-cell>';
-                } elseif ($fields_meta[$j]->numeric && $fields_meta[$j]->type != 'timestamp' && ! $fields_meta[$j]->blob) {
-                    $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="float" office:value="' . $row[$j] . '" >'
-                        . '<text:p>' . htmlspecialchars($row[$j]) . '</text:p>'
+                } elseif ($fields_meta[$j]->numeric
+                    && $fields_meta[$j]->type != 'timestamp'
+                    && ! $fields_meta[$j]->blob
+                ) {
+                    $GLOBALS['ods_buffer'] .=
+                        '<table:table-cell office:value-type="float"'
+                            . ' office:value="' . $row[$j] . '" >'
+                        . '<text:p>'
+                        . htmlspecialchars($row[$j])
+                        . '</text:p>'
                         . '</table:table-cell>';
                 } else {
-                    $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="string">'
-                        . '<text:p>' . htmlspecialchars($row[$j]) . '</text:p>'
+                    $GLOBALS['ods_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
+                        . '<text:p>'
+                        . htmlspecialchars($row[$j])
+                        . '</text:p>'
                         . '</table:table-cell>';
                 }
             } // end for

--- a/libraries/export/ods.php
+++ b/libraries/export/ods.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build OpenDocument Spreadsheet dumps of tables
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage ODS
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/ods.php
+++ b/libraries/export/ods.php
@@ -45,7 +45,7 @@ if (isset($plugin_list)) {
         $GLOBALS['ods_buffer'] .= '</office:spreadsheet>'
             . '</office:body>'
             . '</office:document-content>';
-        if (!PMA_exportOutputHandler(PMA_createOpenDocument('application/vnd.oasis.opendocument.spreadsheet', $GLOBALS['ods_buffer']))) {
+        if (! PMA_exportOutputHandler(PMA_createOpenDocument('application/vnd.oasis.opendocument.spreadsheet', $GLOBALS['ods_buffer']))) {
             return false;
         }
         return true;
@@ -186,7 +186,7 @@ if (isset($plugin_list)) {
         while ($row = PMA_DBI_fetch_row($result)) {
             $GLOBALS['ods_buffer'] .= '<table:table-row>';
             for ($j = 0; $j < $fields_cnt; $j++) {
-                if (!isset($row[$j]) || is_null($row[$j])) {
+                if (! isset($row[$j]) || is_null($row[$j])) {
                     $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="string">'
                         . '<text:p>' . htmlspecialchars($GLOBALS[$what . '_null']) . '</text:p>'
                         . '</table:table-cell>';

--- a/libraries/export/ods.php
+++ b/libraries/export/ods.php
@@ -19,30 +19,32 @@ if (isset($plugin_list)) {
         'extension' => 'ods',
         'mime_type' => 'application/vnd.oasis.opendocument.spreadsheet',
         'force_file' => true,
-        'options' => array(
-            array(
-                'type' => 'begin_group',
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'text',
-                'name' => 'null',
-                'text' => __('Replace NULL with:')
-            ),
-            array(
-                'type' => 'bool',
-                'name' => 'columns',
-                'text' => __('Put columns names in the first row')
-            ),
-            array(
-                'type' => 'hidden',
-                'name' => 'structure_or_data'
-            ),
-            array(
-                'type' => 'end_group'
-            ),
+        'options' => array(),
+        'options_text' => __('Options')
+    );
+
+    $plugin_list['ods']['options'][] = array(
+        array(
+            'type' => 'begin_group',
+            'name' => 'general_opts'
         ),
-        'options_text' => __('Options'),
+        array(
+            'type' => 'text',
+            'name' => 'null',
+            'text' => __('Replace NULL with:')
+        ),
+        array(
+            'type' => 'bool',
+            'name' => 'columns',
+            'text' => __('Put columns names in the first row')
+        ),
+        array(
+            'type' => 'hidden',
+            'name' => 'structure_or_data'
+        ),
+        array(
+            'type' => 'end_group'
+        )
     );
 } else {
 

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -15,7 +15,7 @@ if (! defined('PHPMYADMIN')) {
  */
 if (isset($plugin_list)) {
     $hide_structure = false;
-    if ($plugin_param['export_type'] == 'table' && !$plugin_param['single_table']) {
+    if ($plugin_param['export_type'] == 'table' && ! $plugin_param['single_table']) {
         $hide_structure = true;
     }
     $plugin_list['odt'] = array(
@@ -35,16 +35,16 @@ if (isset($plugin_list)) {
     $plugin_list['odt']['options'][] = array('type' => 'end_group');
 
     /* Structure options */
-    if (!$hide_structure) {
+    if (! $hide_structure) {
         $plugin_list['odt']['options'][]
             = array('type' => 'begin_group', 'name' => 'structure', 'text' => __('Object creation options'), 'force' => 'data');
-        if (!empty($GLOBALS['cfgRelation']['relation'])) {
+        if (! empty($GLOBALS['cfgRelation']['relation'])) {
             $plugin_list['odt']['options'][]
                 = array('type' => 'bool', 'name' => 'relation', 'text' => __('Display foreign key relationships'));
         }
         $plugin_list['odt']['options'][]
             = array('type' => 'bool', 'name' => 'comments', 'text' => __('Display comments'));
-        if (!empty($GLOBALS['cfgRelation']['mimework'])) {
+        if (! empty($GLOBALS['cfgRelation']['mimework'])) {
             $plugin_list['odt']['options'][]
                 = array('type' => 'bool', 'name' => 'mime', 'text' => __('Display MIME types'));
         }
@@ -189,7 +189,7 @@ if (isset($plugin_list)) {
         while ($row = PMA_DBI_fetch_row($result)) {
             $GLOBALS['odt_buffer'] .= '<table:table-row>';
             for ($j = 0; $j < $fields_cnt; $j++) {
-                if (!isset($row[$j]) || is_null($row[$j])) {
+                if (! isset($row[$j]) || is_null($row[$j])) {
                     $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
                         . '<text:p>' . htmlspecialchars($GLOBALS[$what . '_null']) . '</text:p>'
                         . '</table:table-cell>';
@@ -300,7 +300,7 @@ if (isset($plugin_list)) {
         PMA_DBI_select_db($db);
 
         // Check if we can use Relations
-        if ($do_relation && !empty($cfgRelation['relation'])) {
+        if ($do_relation && ! empty($cfgRelation['relation'])) {
             // Find which tables are related with the current one and write it in
             // an array
             $res_rel = PMA_getForeigners($db, $table);

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -25,8 +25,8 @@ if (isset($plugin_list)) {
         'extension' => 'odt',
         'mime_type' => 'application/vnd.oasis.opendocument.text',
         'force_file' => true,
-        'options' => array(), /* Filled later */
-        'options_text' => __('Options'),
+        'options' => array(),
+        'options_text' => __('Options')
     );
 
     /* what to dump (structure/data/both) */

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -580,6 +580,9 @@ if (isset($plugin_list)) {
      * @param string $table       table name
      * @param string $crlf        the end of line sequence
      * @param string $error_url   the url to go back in case of error
+     * @param string $export_mode 'create_table', 'triggers', 'create_view',
+     *                            'stand_in'
+     * @param string $export_type 'server', 'database', 'table'
      * @param bool   $do_relation whether to include relation comments
      * @param bool   $do_comments whether to include the pmadb-style column
      *                                comments as comments in the structure;
@@ -588,9 +591,6 @@ if (isset($plugin_list)) {
      *                                PMA_exportStructure() also for other
      * @param bool   $do_mime     whether to include mime comments
      * @param bool   $dates       whether to include creation/update/check dates
-     * @param string $export_mode 'create_table', 'triggers', 'create_view',
-     *                            'stand_in'
-     * @param string $export_type 'server', 'database', 'table'
      *
      * @return bool Whether it succeeded
      *
@@ -601,12 +601,12 @@ if (isset($plugin_list)) {
         $table,
         $crlf,
         $error_url,
+        $export_mode,
+        $export_type,
         $do_relation = false,
         $do_comments = false,
         $do_mime = false,
-        $dates = false,
-        $export_mode,
-        $export_type
+        $dates = false
     ) {
         switch($export_mode) {
         case 'create_table':

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -15,7 +15,9 @@ if (! defined('PHPMYADMIN')) {
  */
 if (isset($plugin_list)) {
     $hide_structure = false;
-    if ($plugin_param['export_type'] == 'table' && ! $plugin_param['single_table']) {
+    if ($plugin_param['export_type'] == 'table'
+        && ! $plugin_param['single_table']
+    ) {
         $hide_structure = true;
     }
     $plugin_list['odt'] = array(
@@ -25,41 +27,79 @@ if (isset($plugin_list)) {
         'force_file' => true,
         'options' => array(), /* Filled later */
         'options_text' => __('Options'),
-        );
+    );
 
     /* what to dump (structure/data/both) */
-    $plugin_list['odt']['options'][]
-        = array('type' => 'begin_group', 'text' => __('Dump table') , 'name' => 'general_opts');
-    $plugin_list['odt']['options'][]
-        = array('type' => 'radio', 'name' => 'structure_or_data', 'values' => array('structure' => __('structure'), 'data' => __('data'), 'structure_and_data' => __('structure and data')));
-    $plugin_list['odt']['options'][] = array('type' => 'end_group');
+    $plugin_list['odt']['options'][] = array(
+        'type' => 'begin_group',
+        'text' => __('Dump table'),
+        'name' => 'general_opts'
+    );
+    $plugin_list['odt']['options'][] = array(
+        'type' => 'radio',
+        'name' => 'structure_or_data',
+        'values' => array(
+            'structure' => __('structure'),
+            'data' => __('data'),
+            'structure_and_data' => __('structure and data')
+        )
+    );
+    $plugin_list['odt']['options'][] = array(
+        'type' => 'end_group'
+    );
 
     /* Structure options */
     if (! $hide_structure) {
-        $plugin_list['odt']['options'][]
-            = array('type' => 'begin_group', 'name' => 'structure', 'text' => __('Object creation options'), 'force' => 'data');
+        $plugin_list['odt']['options'][] = array(
+            'type' => 'begin_group',
+            'name' => 'structure',
+            'text' => __('Object creation options'),
+            'force' => 'data'
+        );
         if (! empty($GLOBALS['cfgRelation']['relation'])) {
-            $plugin_list['odt']['options'][]
-                = array('type' => 'bool', 'name' => 'relation', 'text' => __('Display foreign key relationships'));
+            $plugin_list['odt']['options'][] = array(
+                'type' => 'bool',
+                'name' => 'relation',
+                'text' => __('Display foreign key relationships')
+            );
         }
-        $plugin_list['odt']['options'][]
-            = array('type' => 'bool', 'name' => 'comments', 'text' => __('Display comments'));
+        $plugin_list['odt']['options'][] = array(
+            'type' => 'bool',
+            'name' => 'comments',
+            'text' => __('Display comments')
+        );
         if (! empty($GLOBALS['cfgRelation']['mimework'])) {
-            $plugin_list['odt']['options'][]
-                = array('type' => 'bool', 'name' => 'mime', 'text' => __('Display MIME types'));
+            $plugin_list['odt']['options'][] = array(
+                'type' => 'bool',
+                'name' => 'mime',
+                'text' => __('Display MIME types')
+            );
         }
-        $plugin_list['odt']['options'][]
-            = array('type' => 'end_group');
+        $plugin_list['odt']['options'][] = array(
+            'type' => 'end_group'
+        );
     }
+
     /* Data */
-    $plugin_list['odt']['options'][]
-        = array('type' => 'begin_group', 'name' => 'data', 'text' => __('Data dump options'), 'force' => 'structure');
-    $plugin_list['odt']['options'][]
-        = array('type' => 'bool', 'name' => 'columns', 'text' => __('Put columns names in the first row'));
-    $plugin_list['odt']['options'][]
-        = array('type' => 'text', 'name' => 'null', 'text' => __('Replace NULL with:'));
-    $plugin_list['odt']['options'][]
-        = array('type' => 'end_group');
+    $plugin_list['odt']['options'][] = array(
+        'type' => 'begin_group',
+        'name' => 'data',
+        'text' => __('Data dump options'),
+        'force' => 'structure'
+    );
+    $plugin_list['odt']['options'][] = array(
+        'type' => 'bool',
+        'name' => 'columns',
+        'text' => __('Put columns names in the first row')
+    );
+    $plugin_list['odt']['options'][] = array(
+        'type' => 'text',
+        'name' => 'null',
+        'text' => __('Replace NULL with:')
+    );
+    $plugin_list['odt']['options'][] = array(
+        'type' => 'end_group'
+    );
 } else {
 
     $GLOBALS['odt_buffer'] = '';
@@ -77,7 +117,11 @@ if (isset($plugin_list)) {
         $GLOBALS['odt_buffer'] .= '</office:text>'
             . '</office:body>'
             . '</office:document-content>';
-        if (! PMA_exportOutputHandler(PMA_createOpenDocument('application/vnd.oasis.opendocument.text', $GLOBALS['odt_buffer']))) {
+        if (! PMA_exportOutputHandler(
+            PMA_createOpenDocument(
+                'application/vnd.oasis.opendocument.text', $GLOBALS['odt_buffer'])
+            )
+        ) {
             return false;
         }
         return true;
@@ -93,7 +137,8 @@ if (isset($plugin_list)) {
     function PMA_exportHeader()
     {
         $GLOBALS['odt_buffer'] .= '<?xml version="1.0" encoding="utf-8"?' . '>'
-            . '<office:document-content '. $GLOBALS['OpenDocumentNS'] . 'office:version="1.0">'
+            . '<office:document-content '
+                . $GLOBALS['OpenDocumentNS'] . 'office:version="1.0">'
             . '<office:body>'
             . '<office:text>';
         return true;
@@ -110,8 +155,11 @@ if (isset($plugin_list)) {
      */
     function PMA_exportDBHeader($db)
     {
-        $GLOBALS['odt_buffer'] .= '<text:h text:outline-level="1" text:style-name="Heading_1" text:is-list-header="true">'
-            . __('Database') . ' ' . htmlspecialchars($db) . '</text:h>';
+        $GLOBALS['odt_buffer'] .=
+            '<text:h text:outline-level="1" text:style-name="Heading_1"'
+                . ' text:is-list-header="true">'
+            . __('Database') . ' ' . htmlspecialchars($db)
+            . '</text:h>';
         return true;
     }
 
@@ -169,17 +217,29 @@ if (isset($plugin_list)) {
             $field_flags[$j] = PMA_DBI_field_flags($result, $j);
         }
 
-        $GLOBALS['odt_buffer'] .= '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
-            . __('Dumping data for table') . ' ' . htmlspecialchars($table) . '</text:h>';
-        $GLOBALS['odt_buffer'] .= '<table:table table:name="' . htmlspecialchars($table) . '_structure">';
-        $GLOBALS['odt_buffer'] .= '<table:table-column table:number-columns-repeated="' . $fields_cnt . '"/>';
+        $GLOBALS['odt_buffer'] .=
+            '<text:h text:outline-level="2" text:style-name="Heading_2"'
+                . ' text:is-list-header="true">'
+            . __('Dumping data for table') . ' ' . htmlspecialchars($table)
+            . '</text:h>';
+        $GLOBALS['odt_buffer'] .=
+            '<table:table'
+            . ' table:name="' . htmlspecialchars($table) . '_structure">';
+        $GLOBALS['odt_buffer'] .=
+            '<table:table-column'
+            . ' table:number-columns-repeated="' . $fields_cnt . '"/>';
 
         // If required, get fields name at the first line
         if (isset($GLOBALS[$what . '_columns'])) {
             $GLOBALS['odt_buffer'] .= '<table:table-row>';
             for ($i = 0; $i < $fields_cnt; $i++) {
-                $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                    . '<text:p>' . htmlspecialchars(stripslashes(PMA_DBI_field_name($result, $i))) . '</text:p>'
+                $GLOBALS['odt_buffer'] .=
+                    '<table:table-cell office:value-type="string">'
+                    . '<text:p>'
+                        . htmlspecialchars(
+                            stripslashes(PMA_DBI_field_name($result, $i))
+                        )
+                    . '</text:p>'
                     . '</table:table-cell>';
             } // end for
             $GLOBALS['odt_buffer'] .= '</table:table-row>';
@@ -190,22 +250,36 @@ if (isset($plugin_list)) {
             $GLOBALS['odt_buffer'] .= '<table:table-row>';
             for ($j = 0; $j < $fields_cnt; $j++) {
                 if (! isset($row[$j]) || is_null($row[$j])) {
-                    $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                        . '<text:p>' . htmlspecialchars($GLOBALS[$what . '_null']) . '</text:p>'
+                    $GLOBALS['odt_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
+                        . '<text:p>'
+                        . htmlspecialchars($GLOBALS[$what . '_null'])
+                        . '</text:p>'
                         . '</table:table-cell>';
                 // ignore BLOB
                 } elseif (stristr($field_flags[$j], 'BINARY')
                         && $fields_meta[$j]->blob) {
-                    $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+                    $GLOBALS['odt_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
                         . '<text:p></text:p>'
                         . '</table:table-cell>';
-                } elseif ($fields_meta[$j]->numeric && $fields_meta[$j]->type != 'timestamp' && ! $fields_meta[$j]->blob) {
-                    $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="float" office:value="' . $row[$j] . '" >'
-                        . '<text:p>' . htmlspecialchars($row[$j]) . '</text:p>'
+                } elseif ($fields_meta[$j]->numeric
+                    && $fields_meta[$j]->type != 'timestamp'
+                    && ! $fields_meta[$j]->blob
+                ) {
+                    $GLOBALS['odt_buffer'] .=
+                        '<table:table-cell office:value-type="float"'
+                            . ' office:value="' . $row[$j] . '" >'
+                        . '<text:p>'
+                        . htmlspecialchars($row[$j])
+                        . '</text:p>'
                         . '</table:table-cell>';
                 } else {
-                    $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                        . '<text:p>' . htmlspecialchars($row[$j]) . '</text:p>'
+                    $GLOBALS['odt_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
+                        . '<text:p>'
+                        . htmlspecialchars($row[$j])
+                        . '</text:p>'
                         . '</table:table-cell>';
                 }
             } // end for
@@ -239,9 +313,13 @@ if (isset($plugin_list)) {
         /**
          * Displays the table structure
          */
-        $GLOBALS['odt_buffer'] .= '<table:table table:name="' . htmlspecialchars($table) . '_data">';
+        $GLOBALS['odt_buffer'] .=
+            '<table:table table:name="'
+            . htmlspecialchars($table) . '_data">';
         $columns_cnt = 4;
-        $GLOBALS['odt_buffer'] .= '<table:table-column table:number-columns-repeated="' . $columns_cnt . '"/>';
+        $GLOBALS['odt_buffer'] .= 
+            '<table:table-column'
+            . ' table:number-columns-repeated="' . $columns_cnt . '"/>';
         /* Header */
         $GLOBALS['odt_buffer'] .= '<table:table-row>';
         $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
@@ -276,22 +354,33 @@ if (isset($plugin_list)) {
      * @param string $crlf          the end of line sequence
      * @param string $error_url     the url to go back in case of error
      * @param bool   $do_relation   whether to include relation comments
-     * @param bool   $do_comments   whether to include the pmadb-style column comments
-     *                                as comments in the structure; this is deprecated
-     *                                but the parameter is left here because export.php
-     *                                calls PMA_exportStructure() also for other export
-     *                                types which use this parameter
+     * @param bool   $do_comments   whether to include the pmadb-style column
+     *                                comments as comments in the structure;
+     *                                this is deprecated but the parameter is
+     *                                left here because export.php calls
+     *                                PMA_exportStructure() also for other
      * @param bool   $do_mime       whether to include mime comments
      * @param bool   $show_dates    whether to include creation/update/check dates
-     * @param bool   $add_semicolon whether to add semicolon and end-of-line at the end
+     * @param bool   $add_semicolon whether to add semicolon and end-of-line at 
+     *                              the end
      * @param bool   $view          whether we're handling a view
      *
      * @return bool true
      *
      * @access public
      */
-    function PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime, $show_dates = false, $add_semicolon = true, $view = false)
-    {
+    function PMA_getTableDef(
+        $db,
+        $table,
+        $crlf,
+        $error_url,
+        $do_relation,
+        $do_comments,
+        $do_mime,
+        $show_dates = false,
+        $add_semicolon = true,
+        $view = false
+    ) {
         global $cfgRelation;
 
         /**
@@ -317,7 +406,8 @@ if (isset($plugin_list)) {
         /**
          * Displays the table structure
          */
-        $GLOBALS['odt_buffer'] .= '<table:table table:name="' . htmlspecialchars($table) . '_structure">';
+        $GLOBALS['odt_buffer'] .= '<table:table table:name="'
+            . htmlspecialchars($table) . '_structure">';
         $columns_cnt = 4;
         if ($do_relation && $have_rel) {
             $columns_cnt++;
@@ -328,7 +418,8 @@ if (isset($plugin_list)) {
         if ($do_mime && $cfgRelation['mimework']) {
             $columns_cnt++;
         }
-        $GLOBALS['odt_buffer'] .= '<table:table-column table:number-columns-repeated="' . $columns_cnt . '"/>';
+        $GLOBALS['odt_buffer'] .= '<table:table-column'
+            . ' table:number-columns-repeated="' . $columns_cnt . '"/>';
         /* Header */
         $GLOBALS['odt_buffer'] .= '<table:table-row>';
         $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
@@ -368,29 +459,45 @@ if (isset($plugin_list)) {
 
             if ($do_relation && $have_rel) {
                 if (isset($res_rel[$field_name])) {
-                    $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                        . '<text:p>' . htmlspecialchars($res_rel[$field_name]['foreign_table'] . ' (' . $res_rel[$field_name]['foreign_field'] . ')') . '</text:p>'
+                    $GLOBALS['odt_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
+                        . '<text:p>'
+                        . htmlspecialchars(
+                            $res_rel[$field_name]['foreign_table']
+                            . ' (' . $res_rel[$field_name]['foreign_field'] . ')'
+                        )
+                        . '</text:p>'
                         . '</table:table-cell>';
                 }
             }
             if ($do_comments) {
                 if (isset($comments[$field_name])) {
-                    $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                        . '<text:p>' . htmlspecialchars($comments[$field_name]) . '</text:p>'
+                    $GLOBALS['odt_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
+                        . '<text:p>'
+                        . htmlspecialchars($comments[$field_name])
+                        . '</text:p>'
                         . '</table:table-cell>';
                 } else {
-                    $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+                    $GLOBALS['odt_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
                         . '<text:p></text:p>'
                         . '</table:table-cell>';
                 }
             }
             if ($do_mime && $cfgRelation['mimework']) {
                 if (isset($mime_map[$field_name])) {
-                    $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                        . '<text:p>' . htmlspecialchars(str_replace('_', '/', $mime_map[$field_name]['mimetype'])) . '</text:p>'
+                    $GLOBALS['odt_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
+                        . '<text:p>'
+                        . htmlspecialchars(
+                            str_replace('_', '/', $mime_map[$field_name]['mimetype'])
+                        )
+                        . '</text:p>'
                         . '</table:table-cell>';
                 } else {
-                    $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+                    $GLOBALS['odt_buffer'] .=
+                        '<table:table-cell office:value-type="string">'
                         . '<text:p></text:p>'
                         . '</table:table-cell>';
                 }
@@ -413,8 +520,10 @@ if (isset($plugin_list)) {
      */
     function PMA_getTriggers($db, $table)
     {
-        $GLOBALS['odt_buffer'] .= '<table:table table:name="' . htmlspecialchars($table) . '_triggers">';
-        $GLOBALS['odt_buffer'] .= '<table:table-column table:number-columns-repeated="4"/>';
+        $GLOBALS['odt_buffer'] .= '<table:table'
+            . ' table:name="' . htmlspecialchars($table) . '_triggers">';
+        $GLOBALS['odt_buffer'] .= '<table:table-column'
+            . ' table:number-columns-repeated="4"/>';
         $GLOBALS['odt_buffer'] .= '<table:table-row>';
         $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Name') . '</text:p>'
@@ -435,16 +544,24 @@ if (isset($plugin_list)) {
         foreach ($triggers as $trigger) {
             $GLOBALS['odt_buffer'] .= '<table:table-row>';
             $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                . '<text:p>' . htmlspecialchars($trigger['name']) . '</text:p>'
+                . '<text:p>'
+                . htmlspecialchars($trigger['name'])
+                . '</text:p>'
                 . '</table:table-cell>';
             $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                . '<text:p>' . htmlspecialchars($trigger['action_timing']) . '</text:p>'
+                . '<text:p>'
+                . htmlspecialchars($trigger['action_timing'])
+                . '</text:p>'
                 . '</table:table-cell>';
             $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                . '<text:p>' . htmlspecialchars($trigger['event_manipulation']) . '</text:p>'
+                . '<text:p>'
+                . htmlspecialchars($trigger['event_manipulation'])
+                . '</text:p>'
                 . '</table:table-cell>';
             $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
-                . '<text:p>' . htmlspecialchars($trigger['definition']) . '</text:p>'
+                . '<text:p>'
+                . htmlspecialchars($trigger['definition'])
+                . '</text:p>'
                 . '</table:table-cell>';
             $GLOBALS['odt_buffer'] .= '</table:table-row>';
         }
@@ -461,44 +578,75 @@ if (isset($plugin_list)) {
      * @param string $crlf        the end of line sequence
      * @param string $error_url   the url to go back in case of error
      * @param bool   $do_relation whether to include relation comments
-     * @param bool   $do_comments whether to include the pmadb-style column comments
-     *                            as comments in the structure; this is deprecated
-     *                            but the parameter is left here because export.php
-     *                            calls PMA_exportStructure() also for other export
-     *                            types which use this parameter
+     * @param bool   $do_comments whether to include the pmadb-style column
+     *                                comments as comments in the structure;
+     *                                this is deprecated but the parameter is
+     *                                left here because export.php calls
+     *                                PMA_exportStructure() also for other
      * @param bool   $do_mime     whether to include mime comments
      * @param bool   $dates       whether to include creation/update/check dates
-     * @param string $export_mode 'create_table', 'triggers', 'create_view', 'stand_in'
+     * @param string $export_mode 'create_table', 'triggers', 'create_view',
+     *                            'stand_in'
      * @param string $export_type 'server', 'database', 'table'
      *
      * @return bool Whether it succeeded
      *
      * @access public
      */
-    function PMA_exportStructure($db, $table, $crlf, $error_url, $do_relation = false, $do_comments = false, $do_mime = false, $dates = false, $export_mode, $export_type)
+    function PMA_exportStructure(
+        $db,
+        $table,
+        $crlf,
+        $error_url,
+        $do_relation = false,
+        $do_comments = false,
+        $do_mime = false,
+        $dates = false,
+        $export_mode,
+        $export_type)
     {
         switch($export_mode) {
         case 'create_table':
-            $GLOBALS['odt_buffer'] .= '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
-                . __('Table structure for table') . ' ' . htmlspecialchars($table) . '</text:h>';
-            PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime, $dates);
+            $GLOBALS['odt_buffer'] .=
+                '<text:h text:outline-level="2" text:style-name="Heading_2"'
+                . ' text:is-list-header="true">'
+                . __('Table structure for table') . ' ' .
+                htmlspecialchars($table)
+                . '</text:h>';
+            PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation,
+                $do_comments, $do_mime, $dates
+            );
             break;
         case 'triggers':
             $triggers = PMA_DBI_get_triggers($db, $table);
             if ($triggers) {
-                $GLOBALS['odt_buffer'] .= '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
-                . __('Triggers') . ' ' . htmlspecialchars($table) . '</text:h>';
+                $GLOBALS['odt_buffer'] .=
+                '<text:h text:outline-level="2" text:style-name="Heading_2"'
+                . ' text:is-list-header="true">'
+                . __('Triggers') . ' '
+                . htmlspecialchars($table)
+                . '</text:h>';
                 PMA_getTriggers($db, $table);
             }
             break;
         case 'create_view':
-            $GLOBALS['odt_buffer'] .= '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
-                . __('Structure for view') . ' ' . htmlspecialchars($table) . '</text:h>';
-            PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime, $dates, true, true);
+            $GLOBALS['odt_buffer'] .=
+                '<text:h text:outline-level="2" text:style-name="Heading_2"'
+                . ' text:is-list-header="true">'
+                . __('Structure for view') . ' '
+                . htmlspecialchars($table)
+                . '</text:h>';
+            PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation,
+                $do_comments, $do_mime, $dates, true, true
+            );
             break;
         case 'stand_in':
-            $GLOBALS['odt_buffer'] .=  '<text:h text:outline-level="2" text:style-name="Heading_2" text:is-list-header="true">'
-                . __('Stand-in structure for view') . ' ' . htmlspecialchars($table) . '</text:h>';
+            $GLOBALS['odt_buffer'] .=
+                '<text:h text:outline-level="2" text:style-name="Heading_2"'
+                    . ' text:is-list-header="true">'
+                . __('Stand-in structure for view') . ' '
+                . htmlspecialchars($table)
+                . '</text:h>';
             // export a stand-in definition to resolve view dependencies
             PMA_getTableDefStandIn($db, $table, $crlf);
         } // end switch

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build OpenDocument Text dumps of tables
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage ODT
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -527,7 +527,7 @@ if (isset($plugin_list)) {
         $extracted_columnspec = PMA_extractColumnSpec($column['Type']);
         $type = htmlspecialchars($extracted_columnspec['print_type']);
         if (empty($type)) {
-            $type     = '&nbsp;';
+            $type = '&nbsp;';
         }
 
         $definition .= '<table:table-cell office:value-type="string">'

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -319,7 +319,7 @@ if (isset($plugin_list)) {
             '<table:table table:name="'
             . htmlspecialchars($table) . '_data">';
         $columns_cnt = 4;
-        $GLOBALS['odt_buffer'] .= 
+        $GLOBALS['odt_buffer'] .=
             '<table:table-column'
             . ' table:number-columns-repeated="' . $columns_cnt . '"/>';
         /* Header */
@@ -363,7 +363,7 @@ if (isset($plugin_list)) {
      *                                PMA_exportStructure() also for other
      * @param bool   $do_mime       whether to include mime comments
      * @param bool   $show_dates    whether to include creation/update/check dates
-     * @param bool   $add_semicolon whether to add semicolon and end-of-line at 
+     * @param bool   $add_semicolon whether to add semicolon and end-of-line at
      *                              the end
      * @param bool   $view          whether we're handling a view
      *
@@ -662,7 +662,7 @@ if (isset($plugin_list)) {
     /**
      * Formats the definition for one column 
      *
-     * @param array $column info about this column 
+     * @param array $column info about this column
      *
      * @return string Formatted column definition
      *

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -119,9 +119,10 @@ if (isset($plugin_list)) {
             . '</office:document-content>';
         if (! PMA_exportOutputHandler(
             PMA_createOpenDocument(
-                'application/vnd.oasis.opendocument.text', $GLOBALS['odt_buffer'])
+                'application/vnd.oasis.opendocument.text',
+                $GLOBALS['odt_buffer']
             )
-        ) {
+        )) {
             return false;
         }
         return true;
@@ -256,9 +257,10 @@ if (isset($plugin_list)) {
                         . htmlspecialchars($GLOBALS[$what . '_null'])
                         . '</text:p>'
                         . '</table:table-cell>';
-                // ignore BLOB
                 } elseif (stristr($field_flags[$j], 'BINARY')
-                        && $fields_meta[$j]->blob) {
+                    && $fields_meta[$j]->blob
+                ) {
+                    // ignore BLOB
                     $GLOBALS['odt_buffer'] .=
                         '<table:table-cell office:value-type="string">'
                         . '<text:p></text:p>'
@@ -512,8 +514,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs triggers
      *
-     * @param string $db     database name
-     * @param string $table  table name
+     * @param string $db    database name
+     * @param string $table table name
+     *
      * @return bool true
      *
      * @access public
@@ -603,8 +606,8 @@ if (isset($plugin_list)) {
         $do_mime = false,
         $dates = false,
         $export_mode,
-        $export_type)
-    {
+        $export_type
+    ) {
         switch($export_mode) {
         case 'create_table':
             $GLOBALS['odt_buffer'] .=
@@ -613,8 +616,9 @@ if (isset($plugin_list)) {
                 . __('Table structure for table') . ' ' .
                 htmlspecialchars($table)
                 . '</text:h>';
-            PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation,
-                $do_comments, $do_mime, $dates
+            PMA_getTableDef(
+                $db, $table, $crlf, $error_url, $do_relation, $do_comments,
+                $do_mime, $dates
             );
             break;
         case 'triggers':
@@ -636,8 +640,9 @@ if (isset($plugin_list)) {
                 . __('Structure for view') . ' '
                 . htmlspecialchars($table)
                 . '</text:h>';
-            PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation,
-                $do_comments, $do_mime, $dates, true, true
+            PMA_getTableDef(
+                $db, $table, $crlf, $error_url, $do_relation, $do_comments,
+                $do_mime, $dates, true, true
             );
             break;
         case 'stand_in':
@@ -657,15 +662,14 @@ if (isset($plugin_list)) {
     /**
      * Formats the definition for one column 
      *
-     * @param array $column  info about this column 
+     * @param array $column info about this column 
      *
-     * @return string        Formatted column definition
+     * @return string Formatted column definition
      *
      * @access public
      */
-    function PMA_formatOneColumnDefinition(
-        $column
-    ) {
+    function PMA_formatOneColumnDefinition($column)
+    {
         $field_name = $column['Field'];
         $definition =  '<table:table-row>';
         $definition .= '<table:table-cell office:value-type="string">'

--- a/libraries/export/pdf.php
+++ b/libraries/export/pdf.php
@@ -23,7 +23,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['pdf']['options'][] = array(
+    $plugin_list['pdf']['options'] = array(
         array(
             'type' => 'begin_group',
             'name' => 'general_opts'

--- a/libraries/export/pdf.php
+++ b/libraries/export/pdf.php
@@ -3,7 +3,7 @@
 /**
  * Produce a PDF report (export) from a query
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage PDF
  */
 if (! defined('PHPMYADMIN')) {
@@ -54,7 +54,7 @@ if (isset($plugin_list)) {
 
     /**
      * Adapted from a LGPL script by Philip Clarke
-     * @package PhpMyAdmin-Export
+     * @package    PhpMyAdmin-Export
      * @subpackage PDF
      */
     class PMA_Export_PDF extends PMA_PDF

--- a/libraries/export/pdf.php
+++ b/libraries/export/pdf.php
@@ -54,6 +54,7 @@ if (isset($plugin_list)) {
 
     /**
      * Adapted from a LGPL script by Philip Clarke
+     *
      * @package    PhpMyAdmin-Export
      * @subpackage PDF
      */
@@ -78,23 +79,20 @@ if (isset($plugin_list)) {
                     $this->AddPage($this->CurOrientation);
                     $this->y = $this->dataY;
                     $oldpage = $this->page - 1;
+
+                    $this_page_orm = $this->pagedim[$this->page]['orm'];
+                    $old_page_orm = $this->pagedim[$oldpage]['orm'];
+                    $this_page_olm = $this->pagedim[$this->page]['olm'];
+                    $old_page_olm = $this->pagedim[$oldpage]['olm'];
                     if ($this->rtl) {
-                        if ($this->pagedim[$this->page]['orm']
-                            != $this->pagedim[$oldpage]['orm']
-                        ) {
-                            $this->x = $x
-                                - ($this->pagedim[$this->page]['orm']
-                                - $this->pagedim[$oldpage]['orm']);
+                        if ($this_page_orm!= $old_page_orm) {
+                            $this->x = $x - ($this_page_orm - $old_page_orm);
                         } else {
                             $this->x = $x;
                         }
                     } else {
-                        if ($this->pagedim[$this->page]['olm']
-                            != $this->pagedim[$oldpage]['olm']
-                        ) {
-                            $this->x = $x
-                                + ($this->pagedim[$this->page]['olm']
-                                - $this->pagedim[$oldpage]['olm']);
+                        if ($this_page_olm != $old_page_olm) {
+                            $this->x = $x + ($this_page_olm - $old_page_olm);
                         } else {
                             $this->x = $x;
                         }
@@ -134,7 +132,7 @@ if (isset($plugin_list)) {
                     0,
                     $this->FontSizePt,
                     __('Database') . ': ' . $this->currentDb . ',  '
-                        . __('Table') . ': ' . $this->currentTable,
+                    . __('Table') . ': ' . $this->currentTable,
                     0, 1, 'L'
                 );
                 $l = ($this->lMargin);

--- a/libraries/export/pdf.php
+++ b/libraries/export/pdf.php
@@ -268,7 +268,7 @@ if (isset($plugin_list)) {
             $this->tMargin = $topMargin;
         }
 
-        function mysql_report($query)
+        function mysqlReport($query)
         {
             unset($this->tablewidths);
             unset($this->colTitles);
@@ -405,7 +405,7 @@ if (isset($plugin_list)) {
             $this->morepagestable($this->FontSizePt);
             PMA_DBI_free_result($this->results);
 
-        } // end of mysql_report function
+        } // end of mysqlReport function
 
     } // end of PMA_Export_PDF class
 
@@ -512,7 +512,7 @@ if (isset($plugin_list)) {
 
         $attr = array('currentDb' => $db, 'currentTable' => $table);
         $pdf->setAttributes($attr);
-        $pdf->mysql_report($sql_query);
+        $pdf->mysqlReport($sql_query);
 
         return true;
     } // end of the 'PMA_exportData()' function

--- a/libraries/export/pdf.php
+++ b/libraries/export/pdf.php
@@ -20,14 +20,32 @@ if (isset($plugin_list)) {
         'mime_type' => 'application/pdf',
         'force_file' => true,
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
-            array('type' => 'message_only', 'name' => 'explanation', 'text' => __('(Generates a report containing the data of a single table)')),
-            array('type' => 'text', 'name' => 'report_title', 'text' => __('Report title:')),
-            array('type' => 'hidden', 'name' => 'structure_or_data'),
-            array('type' => 'end_group')
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
             ),
+            array(
+                'type' => 'message_only',
+                'name' => 'explanation',
+                'text' => __(
+                    '(Generates a report containing the data of a single table)'
+                )
+            ),
+            array(
+                'type' => 'text',
+                'name' => 'report_title',
+                'text' => __('Report title:')
+            ),
+            array(
+                'type' => 'hidden',
+                'name' => 'structure_or_data'
+            ),
+            array(
+                'type' => 'end_group'
+            )
+        ),
         'options_text' => __('Options'),
-        );
+    );
 } else {
 
     include_once './libraries/PDF.class.php';
@@ -48,7 +66,10 @@ if (isset($plugin_list)) {
                 $y = $this->y;
             }
             $current_page = $this->page;
-            if ((($y + $h) > $this->PageBreakTrigger) AND (! $this->InFooter) AND ($this->AcceptPageBreak())) {
+            if ((($y + $h) > $this->PageBreakTrigger)
+                AND (! $this->InFooter)
+                AND ($this->AcceptPageBreak())
+            ) {
                 if ($addpage) {
                     //Automatic page break
                     $x = $this->x;
@@ -56,14 +77,22 @@ if (isset($plugin_list)) {
                     $this->y = $this->dataY;
                     $oldpage = $this->page - 1;
                     if ($this->rtl) {
-                        if ($this->pagedim[$this->page]['orm'] != $this->pagedim[$oldpage]['orm']) {
-                            $this->x = $x - ($this->pagedim[$this->page]['orm'] - $this->pagedim[$oldpage]['orm']);
+                        if ($this->pagedim[$this->page]['orm']
+                            != $this->pagedim[$oldpage]['orm']
+                        ) {
+                            $this->x = $x
+                                - ($this->pagedim[$this->page]['orm']
+                                - $this->pagedim[$oldpage]['orm']);
                         } else {
                             $this->x = $x;
                         }
                     } else {
-                        if ($this->pagedim[$this->page]['olm'] != $this->pagedim[$oldpage]['olm']) {
-                            $this->x = $x + ($this->pagedim[$this->page]['olm'] - $this->pagedim[$oldpage]['olm']);
+                        if ($this->pagedim[$this->page]['olm']
+                            != $this->pagedim[$oldpage]['olm']
+                        ) {
+                            $this->x = $x
+                                + ($this->pagedim[$this->page]['olm']
+                                - $this->pagedim[$oldpage]['olm']);
                         } else {
                             $this->x = $x;
                         }
@@ -89,19 +118,31 @@ if (isset($plugin_list)) {
                 }
                 $this->SetY(($this->tMargin) - ($this->FontSizePt / $this->k) * 5);
                 $this->cellFontSize = $this->FontSizePt ;
-                $this->SetFont(PMA_PDF_FONT, '', ($this->titleFontSize ? $this->titleFontSize : $this->FontSizePt));
+                $this->SetFont(
+                    PMA_PDF_FONT,
+                    '',
+                    ($this->titleFontSize
+                    ? $this->titleFontSize
+                    : $this->FontSizePt)
+                );
                 $this->Cell(0, $this->FontSizePt, $this->titleText, 0, 1, 'C');
                 $this->SetFont(PMA_PDF_FONT, '', $this->cellFontSize);
                 $this->SetY(($this->tMargin) - ($this->FontSizePt / $this->k) * 2.5);
                 $this->Cell(
-                    0, $this->FontSizePt,
-                    __('Database') . ': ' . $this->currentDb . ',  ' . __('Table') . ': ' . $this->currentTable,
+                    0,
+                    $this->FontSizePt,
+                    __('Database') . ': ' . $this->currentDb . ',  '
+                        . __('Table') . ': ' . $this->currentTable,
                     0, 1, 'L'
                 );
                 $l = ($this->lMargin);
                 foreach ($this->colTitles as $col => $txt) {
                     $this->SetXY($l, ($this->tMargin));
-                    $this->MultiCell($this->tablewidths[$col], $this->FontSizePt, $txt);
+                    $this->MultiCell(
+                        $this->tablewidths[$col],
+                        $this->FontSizePt,
+                        $txt
+                    );
                     $l += $this->tablewidths[$col] ;
                     $maxY = ($maxY < $this->getY()) ? $this->getY() : $maxY ;
                 }
@@ -110,9 +151,23 @@ if (isset($plugin_list)) {
                 $l = ($this->lMargin);
                 foreach ($this->colTitles as $col => $txt) {
                     $this->SetXY($l, $this->tMargin);
-                    $this->cell($this->tablewidths[$col], $maxY-($this->tMargin), '', 1, 0, 'L', 1);
+                    $this->cell(
+                        $this->tablewidths[$col],
+                        $maxY-($this->tMargin),
+                        '',
+                        1,
+                        0,
+                        'L',
+                        1
+                    );
                     $this->SetXY($l, $this->tMargin);
-                    $this->MultiCell($this->tablewidths[$col], $this->FontSizePt, $txt, 0, 'C');
+                    $this->MultiCell(
+                        $this->tablewidths[$col],
+                        $this->FontSizePt,
+                        $txt,
+                        0,
+                        'C'
+                    );
                     $l += $this->tablewidths[$col];
                 }
                 $this->setFillColor(255, 255, 255);
@@ -150,7 +205,13 @@ if (isset($plugin_list)) {
                     $this->page = $currpage;
                     $this->SetXY($l, $h);
                     if ($this->tablewidths[$col] > 0) {
-                        $this->MultiCell($this->tablewidths[$col], $lineheight, $txt, 0, $this->colAlign[$col]);
+                        $this->MultiCell(
+                            $this->tablewidths[$col],
+                            $lineheight,
+                            $txt,
+                            0,
+                            $this->colAlign[$col]
+                        );
                         $l += $this->tablewidths[$col];
                     }
 
@@ -228,8 +289,10 @@ if (isset($plugin_list)) {
             $this->sColWidth = $availableWidth / $this->numFields;
             $totalTitleWidth = 0;
 
-            // loop through results header and set initial col widths/ titles/ alignment
-            // if a col title is less than the starting col width, reduce that column size
+            // loop through results header and set initial
+            // col widths/ titles/ alignment
+            // if a col title is less than the starting col width,
+            // reduce that column size
             $colFits = array();
             for ($i = 0; $i < $this->numFields; $i++) {
                 $stringWidth = $this->getstringwidth($this->fields[$i]->name) + 6 ;
@@ -237,7 +300,8 @@ if (isset($plugin_list)) {
                 $titleWidth[$i] = $stringWidth;
                 $totalTitleWidth += $stringWidth;
 
-                // set any column titles less than the start width to the column title width
+                // set any column titles less than the start width to
+                // the column title width
                 if ($stringWidth < $this->sColWidth) {
                     $colFits[$i] = $stringWidth ;
                 }
@@ -295,7 +359,9 @@ if (isset($plugin_list)) {
                         // if data's width is bigger than the current column width,
                         // enlarge the column (but avoid enlarging it if the
                         // data's width is very big)
-                        if ($stringWidth > $val && $stringWidth < ($this->sColWidth * 3)) {
+                        if ($stringWidth > $val
+                            && $stringWidth < ($this->sColWidth * 3)
+                        ) {
                             $colFits[$key] = $stringWidth ;
                         }
                     }

--- a/libraries/export/pdf.php
+++ b/libraries/export/pdf.php
@@ -416,9 +416,9 @@ if (isset($plugin_list)) {
     /**
      * Finalize the pdf.
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -435,9 +435,9 @@ if (isset($plugin_list)) {
     /**
      * Initialize the pdf to export data.
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {

--- a/libraries/export/pdf.php
+++ b/libraries/export/pdf.php
@@ -19,32 +19,34 @@ if (isset($plugin_list)) {
         'extension' => 'pdf',
         'mime_type' => 'application/pdf',
         'force_file' => true,
-        'options' => array(
-            array(
-                'type' => 'begin_group',
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'message_only',
-                'name' => 'explanation',
-                'text' => __(
-                    '(Generates a report containing the data of a single table)'
-                )
-            ),
-            array(
-                'type' => 'text',
-                'name' => 'report_title',
-                'text' => __('Report title:')
-            ),
-            array(
-                'type' => 'hidden',
-                'name' => 'structure_or_data'
-            ),
-            array(
-                'type' => 'end_group'
+        'options' => array(),
+        'options_text' => __('Options')
+    );
+
+    $plugin_list['pdf']['options'][] = array(
+        array(
+            'type' => 'begin_group',
+            'name' => 'general_opts'
+        ),
+        array(
+            'type' => 'message_only',
+            'name' => 'explanation',
+            'text' => __(
+                '(Generates a report containing the data of a single table)'
             )
         ),
-        'options_text' => __('Options'),
+        array(
+            'type' => 'text',
+            'name' => 'report_title',
+            'text' => __('Report title:')
+        ),
+        array(
+            'type' => 'hidden',
+            'name' => 'structure_or_data'
+        ),
+        array(
+            'type' => 'end_group'
+        )
     );
 } else {
 

--- a/libraries/export/pdf.php
+++ b/libraries/export/pdf.php
@@ -154,7 +154,7 @@ if (isset($plugin_list)) {
                         $l += $this->tablewidths[$col];
                     }
 
-                    if (!isset($tmpheight[$row.'-'.$this->page])) {
+                    if (! isset($tmpheight[$row.'-'.$this->page])) {
                         $tmpheight[$row.'-'.$this->page] = 0;
                     }
                     if ($tmpheight[$row.'-'.$this->page] < $this->GetY()) {
@@ -318,7 +318,7 @@ if (isset($plugin_list)) {
             }
 
             for ($i=0; $i < $this->numFields; $i++) {
-                if (!in_array($i, array_keys($colFits))) {
+                if (! in_array($i, array_keys($colFits))) {
                     $this->tablewidths[$i] = $this->sColWidth + $surplusToAdd;
                 }
                 if ($this->display_column[$i] == false) {
@@ -357,7 +357,7 @@ if (isset($plugin_list)) {
         global $pdf;
 
         // instead of $pdf->Output():
-        if (!PMA_exportOutputHandler($pdf->getPDFData())) {
+        if (! PMA_exportOutputHandler($pdf->getPDFData())) {
             return false;
         }
 

--- a/libraries/export/pdf.php
+++ b/libraries/export/pdf.php
@@ -317,7 +317,7 @@ if (isset($plugin_list)) {
                 $surplusToAdd = 0;
             }
 
-            for ($i=0; $i < $this->numFields; $i++) {
+            for ($i = 0; $i < $this->numFields; $i++) {
                 if (! in_array($i, array_keys($colFits))) {
                     $this->tablewidths[$i] = $this->sColWidth + $surplusToAdd;
                 }
@@ -444,7 +444,7 @@ if (isset($plugin_list)) {
     {
         global $pdf;
 
-        $attr=array('currentDb' => $db, 'currentTable' => $table);
+        $attr = array('currentDb' => $db, 'currentTable' => $table);
         $pdf->setAttributes($attr);
         $pdf->mysql_report($sql_query);
 

--- a/libraries/export/php_array.php
+++ b/libraries/export/php_array.php
@@ -15,10 +15,10 @@ if (! defined('PHPMYADMIN')) {
  */
 if (isset($plugin_list)) {
     $plugin_list['php_array'] = array(
-        'text'          => __('PHP array'),
-        'extension'     => 'php',
-        'mime_type'     => 'text/plain',
-        'options'       => array(
+        'text' => __('PHP array'),
+        'extension' => 'php',
+        'mime_type' => 'text/plain',
+        'options' => array(
         array('type' => 'begin_group', 'name' => 'general_opts'),
             array(
                 'type' => 'hidden',
@@ -26,7 +26,7 @@ if (isset($plugin_list)) {
             ),
         array('type' => 'end_group')
         ),
-        'options_text'  => __('Options'),
+        'options_text' => __('Options'),
     );
 } else {
 

--- a/libraries/export/php_array.php
+++ b/libraries/export/php_array.php
@@ -22,7 +22,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['php_array']['options'][] = array(
+    $plugin_list['php_array']['options'] = array(
         array(
             'type' => 'begin_group',
             'name' => 'general_opts'

--- a/libraries/export/php_array.php
+++ b/libraries/export/php_array.php
@@ -19,12 +19,15 @@ if (isset($plugin_list)) {
         'extension' => 'php',
         'mime_type' => 'text/plain',
         'options' => array(
-        array('type' => 'begin_group', 'name' => 'general_opts'),
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
+            ),
             array(
                 'type' => 'hidden',
                 'name' => 'structure_or_data',
             ),
-        array('type' => 'end_group')
+            array('type' => 'end_group')
         ),
         'options_text' => __('Options'),
     );
@@ -76,7 +79,11 @@ if (isset($plugin_list)) {
      */
     function PMA_exportDBHeader($db)
     {
-        PMA_exportOutputHandler('//' . $GLOBALS['crlf'] . '// Database ' . PMA_backquote($db) . $GLOBALS['crlf'] . '//' . $GLOBALS['crlf']);
+        PMA_exportOutputHandler(
+            '//' . $GLOBALS['crlf']
+            . '// Database ' . PMA_backquote($db) . $GLOBALS['crlf']
+            . '//' . $GLOBALS['crlf']
+        );
         return true;
     }
 
@@ -131,8 +138,13 @@ if (isset($plugin_list)) {
         }
         unset($i);
 
-        // fix variable names (based on http://www.php.net/manual/language.variables.basics.php)
-        if (preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $table) == false) {
+        // fix variable names (based on 
+        // http://www.php.net/manual/language.variables.basics.php)
+        if (preg_match(
+            '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/',
+            $table
+        ) == false
+        ) {
             // fix invalid chars in variable names by replacing them with underscores
             $tablefixed = preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '_', $table);
 
@@ -152,7 +164,8 @@ if (isset($plugin_list)) {
 
             // Output table name as comment if this is the first record of the table
             if ($record_cnt == 1) {
-                $buffer .= $crlf . '// ' . PMA_backquote($db) . '.' . PMA_backquote($table) . $crlf;
+                $buffer .= $crlf . '// '. PMA_backquote($db) . '.'
+                    . PMA_backquote($table) . $crlf;
                 $buffer .= '$' . $tablefixed . ' = array(' . $crlf;
                 $buffer .= '  array(';
             } else {
@@ -160,7 +173,9 @@ if (isset($plugin_list)) {
             }
 
             for ($i = 0; $i < $columns_cnt; $i++) {
-                $buffer .= var_export($columns[$i], true) . " => " . var_export($record[$i], true) . (($i + 1 >= $columns_cnt) ? '' : ',');
+                $buffer .= var_export($columns[$i], true)
+                    . " => " . var_export($record[$i], true)
+                    . (($i + 1 >= $columns_cnt) ? '' : ',');
             }
 
             $buffer .= ')';

--- a/libraries/export/php_array.php
+++ b/libraries/export/php_array.php
@@ -44,9 +44,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -56,9 +56,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -77,9 +77,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -96,9 +96,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -110,9 +110,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -128,9 +128,9 @@ if (isset($plugin_list)) {
      * @param string  $error_url  the url to go back in case of error
      * @param string  $sql_query  SQL query for obtaining data
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {

--- a/libraries/export/php_array.php
+++ b/libraries/export/php_array.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build dumps of tables as PHP Arrays
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage PHP
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/php_array.php
+++ b/libraries/export/php_array.php
@@ -18,18 +18,22 @@ if (isset($plugin_list)) {
         'text' => __('PHP array'),
         'extension' => 'php',
         'mime_type' => 'text/plain',
-        'options' => array(
-            array(
-                'type' => 'begin_group',
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'hidden',
-                'name' => 'structure_or_data',
-            ),
-            array('type' => 'end_group')
+        'options' => array(),
+        'options_text' => __('Options')
+    );
+
+    $plugin_list['php_array']['options'][] = array(
+        array(
+            'type' => 'begin_group',
+            'name' => 'general_opts'
         ),
-        'options_text' => __('Options'),
+        array(
+            'type' => 'hidden',
+            'name' => 'structure_or_data',
+        ),
+        array(
+            'type' => 'end_group'
+        )
     );
 } else {
 

--- a/libraries/export/php_array.php
+++ b/libraries/export/php_array.php
@@ -142,7 +142,7 @@ if (isset($plugin_list)) {
         }
         unset($i);
 
-        // fix variable names (based on 
+        // fix variable names (based on
         // http://www.php.net/manual/language.variables.basics.php)
         if (preg_match(
             '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/',

--- a/libraries/export/php_array.php
+++ b/libraries/export/php_array.php
@@ -75,7 +75,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -94,7 +94,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -108,7 +108,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -122,11 +122,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs the content of a table as a fragment of PHP code
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
      *
      * @return bool Whether it succeeded
      *

--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -1132,16 +1132,15 @@ if (isset($plugin_list)) {
                     $sql_constraints .= ';' . $crlf;
                     $sql_constraints_query .= ';';
 
-                    $create_query
-                        = implode(
-                            $crlf,
-                            array_slice($sql_lines, 0, $i)
-                        )
-                        . $crlf
-                        . implode(
-                            $crlf,
-                            array_slice($sql_lines, $j, $sql_count - 1)
-                        );
+                    $create_query = implode(
+                        $crlf,
+                        array_slice($sql_lines, 0, $i)
+                    )
+                    . $crlf
+                    . implode(
+                        $crlf,
+                        array_slice($sql_lines, $j, $sql_count - 1)
+                    );
                     unset($sql_lines);
                 }
             }

--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -1263,6 +1263,9 @@ if (isset($plugin_list)) {
      * @param string $table       table name
      * @param string $crlf        the end of line sequence
      * @param string $error_url   the url to go back in case of error
+     * @param string $export_mode 'create_table','triggers','create_view',
+     *                            'stand_in'
+     * @param string $export_type 'server', 'database', 'table'
      * @param bool   $relation    whether to include relation comments
      * @param bool   $comments    whether to include the pmadb-style column comments
      *                            as comments in the structure; this is deprecated
@@ -1271,8 +1274,6 @@ if (isset($plugin_list)) {
      *                            types which use this parameter
      * @param bool   $mime        whether to include mime comments
      * @param bool   $dates       whether to include creation/update/check dates
-     * @param string $export_mode 'create_table','triggers','create_view','stand_in'
-     * @param string $export_type 'server', 'database', 'table'
      *
      * @return bool Whether it succeeded
      *
@@ -1283,12 +1284,12 @@ if (isset($plugin_list)) {
         $table,
         $crlf,
         $error_url,
+        $export_mode,
+        $export_type,
         $relation = false,
         $comments = false,
         $mime = false,
-        $dates = false,
-        $export_mode,
-        $export_type
+        $dates = false
     ) {
         $formatted_table_name = (isset($GLOBALS['sql_backquotes']))
                               ? PMA_backquote($table)

--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -16,7 +16,9 @@ if (! defined('PHPMYADMIN')) {
 if (isset($plugin_list)) {
     $hide_sql       = false;
     $hide_structure = false;
-    if ($plugin_param['export_type'] == 'table' && ! $plugin_param['single_table']) {
+    if ($plugin_param['export_type'] == 'table'
+        && ! $plugin_param['single_table']
+    ) {
         $hide_structure = true;
         $hide_sql       = true;
     }
@@ -25,11 +27,13 @@ if (isset($plugin_list)) {
             'text' => __('SQL'),
             'extension' => 'sql',
             'mime_type' => 'text/x-sql',
-            'options' => array());
+            'options' => array()
+        );
 
         $plugin_list['sql']['options'][] = array(
             'type' => 'begin_group',
-            'name' => 'general_opts');
+            'name' => 'general_opts'
+        );
 
         /* comments */
         $plugin_list['sql']['options'][] = array(
@@ -37,33 +41,42 @@ if (isset($plugin_list)) {
             'subgroup_header' => array(
                 'type' => 'bool',
                 'name' => 'include_comments',
-                'text' => __('Display comments <i>(includes info such as export timestamp, PHP version, and server version)</i>')
-            ));
+                'text' => __(
+                    'Display comments <i>(includes info such as export timestamp,'
+                    . ' PHP version, and server version)</i>'
+                )
+            )
+        );
         $plugin_list['sql']['options'][] = array(
             'type' => 'text',
             'name' => 'header_comment',
             'text' => __('Additional custom header comment (\n splits lines):')
-            );
+        );
         $plugin_list['sql']['options'][] = array(
             'type' => 'bool',
             'name' => 'dates',
-            'text' => __('Include a timestamp of when databases were created, last updated, and last checked')
-            );
+            'text' => __(
+                'Include a timestamp of when databases were created, last'
+                . ' updated, and last checked'
+            )
+        );
         if (! empty($GLOBALS['cfgRelation']['relation'])) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'relation',
                 'text' => __('Display foreign key relationships')
-                );
+            );
         }
         if (! empty($GLOBALS['cfgRelation']['mimework'])) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'mime',
                 'text' => __('Display MIME types')
-                );
+            );
         }
-        $plugin_list['sql']['options'][] = array('type' => 'end_subgroup');
+        $plugin_list['sql']['options'][] = array(
+            'type' => 'end_subgroup'
+        );
         /* end comments */
 
         /* enclose in a transaction */
@@ -71,8 +84,12 @@ if (isset($plugin_list)) {
             'type' => 'bool',
             'name' => 'use_transaction',
             'text' => __('Enclose export in a transaction'),
-            'doc' => array('programs', 'mysqldump', 'option_mysqldump_single-transaction')
-            );
+            'doc' => array(
+                'programs',
+                'mysqldump',
+                'option_mysqldump_single-transaction'
+            )
+        );
 
         /* disable foreign key checks */
         $plugin_list['sql']['options'][] = array(
@@ -82,8 +99,9 @@ if (isset($plugin_list)) {
             'doc' => array(
                 'manual_MySQL_Database_Administration',
                 'server-system-variables',
-                'sysvar_foreign_key_checks')
-            );
+                'sysvar_foreign_key_checks'
+            )
+        );
 
         $plugin_list['sql']['options_text'] = __('Options');
 
@@ -97,12 +115,16 @@ if (isset($plugin_list)) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'select',
                 'name' => 'compatibility',
-                'text' => __('Database system or older MySQL server to maximize output compatibility with:'),
+                'text' => __(
+                    'Database system or older MySQL server to maximize output'
+                    . ' compatibility with:'
+                ),
                 'values' => $values,
                 'doc' => array(
                     'manual_MySQL_Database_Administration',
-                    'Server_SQL_mode')
-                );
+                    'Server_SQL_mode'
+                )
+            );
             unset($values);
         }
 
@@ -111,8 +133,10 @@ if (isset($plugin_list)) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'drop_database',
-                'text' => sprintf(__('Add %s statement'), '<code>DROP DATABASE</code>')
-                );
+                'text' => sprintf(
+                    __('Add %s statement'), '<code>DROP DATABASE</code>'
+                )
+            );
         }
 
         /* what to dump (structure/data/both) */
@@ -121,7 +145,8 @@ if (isset($plugin_list)) {
             'subgroup_header' => array(
                 'type' => 'message_only',
                 'text' => __('Dump table')
-            ));
+            )
+        );
         $plugin_list['sql']['options'][] = array(
             'type' => 'radio',
             'name' => 'structure_or_data',
@@ -129,10 +154,15 @@ if (isset($plugin_list)) {
                 'structure' => __('structure'),
                 'data' => __('data'),
                 'structure_and_data' => __('structure and data')
-            ));
-        $plugin_list['sql']['options'][] = array('type' => 'end_subgroup');
+            )
+        );
+        $plugin_list['sql']['options'][] = array(
+            'type' => 'end_subgroup'
+        );
 
-        $plugin_list['sql']['options'][] = array('type' => 'end_group');
+        $plugin_list['sql']['options'][] = array(
+            'type' => 'end_group'
+        );
 
         /* begin Structure options */
         if (! $hide_structure) {
@@ -141,7 +171,7 @@ if (isset($plugin_list)) {
                 'name' => 'structure',
                 'text' => __('Object creation options'),
                 'force' => 'data'
-                );
+            );
 
             /* begin SQL Statements */
             $plugin_list['sql']['options'][] = array(
@@ -150,7 +180,8 @@ if (isset($plugin_list)) {
                     'type' => 'message_only',
                     'name' => 'add_statements',
                     'text' => __('Add statements:')
-                ));
+                )
+            );
             if ($plugin_param['export_type'] == 'table') {
                 if (PMA_Table::isView($GLOBALS['db'], $GLOBALS['table'])) {
                     $drop_clause = '<code>DROP VIEW</code>';
@@ -161,7 +192,8 @@ if (isset($plugin_list)) {
                 if (PMA_DRIZZLE) {
                     $drop_clause = '<code>DROP TABLE</code>';
                 } else {
-                    $drop_clause = '<code>DROP TABLE / VIEW / PROCEDURE / FUNCTION</code>';
+                    $drop_clause = '<code>DROP TABLE / VIEW / PROCEDURE'
+                        . ' / FUNCTION</code>';
                     if (PMA_MYSQL_INT_VERSION > 50100) {
                         $drop_clause .= '<code> / EVENT</code>';
                     }
@@ -171,14 +203,18 @@ if (isset($plugin_list)) {
                 'type' => 'bool',
                 'name' => 'drop_table',
                 'text' => sprintf(__('Add %s statement'), $drop_clause)
-                );
+            );
             // Drizzle doesn't support procedures and functions
             if (! PMA_DRIZZLE) {
                 $plugin_list['sql']['options'][] = array(
                     'type' => 'bool',
                     'name' => 'procedure_function',
-                    'text' => sprintf(__('Add %s statement'), '<code>CREATE PROCEDURE / FUNCTION' . (PMA_MYSQL_INT_VERSION > 50100 ? ' / EVENT</code>' : '</code>'))
-                    );
+                    'text' => sprintf(
+                        __('Add %s statement'),
+                        '<code>CREATE PROCEDURE / FUNCTION'
+                        . (PMA_MYSQL_INT_VERSION > 50100
+                        ? ' / EVENT</code>' : '</code>'))
+                );
             }
 
             /* begin CREATE TABLE statements*/
@@ -188,30 +224,41 @@ if (isset($plugin_list)) {
                     'type' => 'bool',
                     'name' => 'create_table_statements',
                     'text' => __('<code>CREATE TABLE</code> options:')
-                ));
+                )
+            );
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'if_not_exists',
                 'text' => '<code>IF NOT EXISTS</code>'
-                );
+            );
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'auto_increment',
                 'text' => '<code>AUTO_INCREMENT</code>'
-                );
-            $plugin_list['sql']['options'][] = array('type' => 'end_subgroup');
+            );
+            $plugin_list['sql']['options'][] = array(
+                'type' => 'end_subgroup'
+            );
             /* end CREATE TABLE statements */
 
-            $plugin_list['sql']['options'][] = array('type' => 'end_subgroup');
+            $plugin_list['sql']['options'][] = array(
+                'type' => 'end_subgroup'
+            );
             /* end SQL statements */
 
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'backquotes',
-                'text' => __('Enclose table and column names with backquotes <i>(Protects column and table names formed with special characters or keywords)</i>')
-                );
+                'text' => __(
+                    'Enclose table and column names with backquotes '
+                    . '<i>(Protects column and table names formed with'
+                    . ' special characters or keywords)</i>'
+                )
+            );
 
-            $plugin_list['sql']['options'][] = array('type' => 'end_group');
+            $plugin_list['sql']['options'][] = array(
+                'type' => 'end_group'
+            );
         }
         /* end Structure options */
 
@@ -221,32 +268,44 @@ if (isset($plugin_list)) {
             'name' => 'data',
             'text' => __('Data dump options'),
             'force' => 'structure'
-            );
-        $plugin_list['sql']['options'][] =
-            array('type' => 'bool', 'name' => 'truncate', 'text' => __('Truncate table before insert'));
+        );
+        $plugin_list['sql']['options'][] = array(
+            'type' => 'bool',
+            'name' => 'truncate',
+            'text' => __('Truncate table before insert')
+        );
         /* begin SQL statements */
         $plugin_list['sql']['options'][] = array(
             'type' => 'begin_subgroup',
             'subgroup_header' => array(
                 'type' => 'message_only',
                 'text' => __('Instead of <code>INSERT</code> statements, use:')
-            ));
+            )
+        );
         // Not supported in Drizzle
         if (! PMA_DRIZZLE) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'delayed',
                 'text' => __('<code>INSERT DELAYED</code> statements'),
-                'doc' => array('manual_MySQL_Database_Administration', 'insert_delayed')
-                );
+                'doc' => array(
+                    'manual_MySQL_Database_Administration',
+                    'insert_delayed'
+                )
+            );
         }
         $plugin_list['sql']['options'][] = array(
             'type' => 'bool',
             'name' => 'ignore',
             'text' => __('<code>INSERT IGNORE</code> statements'),
-            'doc' => array('manual_MySQL_Database_Administration', 'insert')
-            );
-        $plugin_list['sql']['options'][] = array('type' => 'end_subgroup');
+            'doc' => array(
+                'manual_MySQL_Database_Administration',
+                'insert'
+            )
+        );
+        $plugin_list['sql']['options'][] = array(
+            'type' => 'end_subgroup'
+        );
         /* end SQL statements */
 
         /* Function to use when dumping data */
@@ -258,8 +317,8 @@ if (isset($plugin_list)) {
                 'INSERT' => 'INSERT',
                 'UPDATE' => 'UPDATE',
                 'REPLACE' => 'REPLACE'
-                )
-            );
+            )
+        );
 
         /* Syntax to use when inserting data */
         $plugin_list['sql']['options'][] = array(
@@ -267,17 +326,36 @@ if (isset($plugin_list)) {
             'subgroup_header' => array(
                 'type' => 'message_only',
                 'text' => __('Syntax to use when inserting data:')
-            ));
+            )
+        );
         $plugin_list['sql']['options'][] = array(
             'type' => 'radio',
             'name' => 'insert_syntax',
             'values' => array(
-                'complete' => __('include column names in every <code>INSERT</code> statement <br /> &nbsp; &nbsp; &nbsp; Example: <code>INSERT INTO tbl_name (col_A,col_B,col_C) VALUES (1,2,3)</code>'),
-                'extended' => __('insert multiple rows in every <code>INSERT</code> statement<br /> &nbsp; &nbsp; &nbsp; Example: <code>INSERT INTO tbl_name VALUES (1,2,3), (4,5,6), (7,8,9)</code>'),
-                'both' => __('both of the above<br /> &nbsp; &nbsp; &nbsp; Example: <code>INSERT INTO tbl_name (col_A,col_B) VALUES (1,2,3), (4,5,6), (7,8,9)</code>'),
-                'none' => __('neither of the above<br /> &nbsp; &nbsp; &nbsp; Example: <code>INSERT INTO tbl_name VALUES (1,2,3)</code>')
-            ));
-          $plugin_list['sql']['options'][] = array('type' => 'end_subgroup');
+                'complete' => __(
+                    'include column names in every <code>INSERT</code> statement'
+                    . ' <br /> &nbsp; &nbsp; &nbsp; Example: <code>INSERT INTO'
+                    . ' tbl_name (col_A,col_B,col_C) VALUES (1,2,3)</code>'
+                ),
+                'extended' => __(
+                    'insert multiple rows in every <code>INSERT</code> statement'
+                    . '<br /> &nbsp; &nbsp; &nbsp; Example: <code>INSERT INTO'
+                    . ' tbl_name VALUES (1,2,3), (4,5,6), (7,8,9)</code>'
+                ),
+                'both' => __(
+                    'both of the above<br /> &nbsp; &nbsp; &nbsp; Example:'
+                    . ' <code>INSERT INTO tbl_name (col_A,col_B) VALUES (1,2,3),'
+                    . ' (4,5,6), (7,8,9)</code>'
+                ),
+                'none' => __(
+                    'neither of the above<br /> &nbsp; &nbsp; &nbsp; Example:'
+                    . ' <code>INSERT INTO tbl_name VALUES (1,2,3)</code>'
+                )
+            )
+        );
+          $plugin_list['sql']['options'][] = array(
+            'type' => 'end_subgroup'
+          );
 
         /* Max length of query */
         $plugin_list['sql']['options'][] = array(
@@ -290,8 +368,11 @@ if (isset($plugin_list)) {
         $plugin_list['sql']['options'][] = array(
             'type' => 'bool',
             'name' => 'hex_for_blob',
-            'text' => __('Dump binary columns in hexadecimal notation <i>(for example, "abc" becomes 0x616263)</i>')
-            );
+            'text' => __(
+                'Dump binary columns in hexadecimal notation'
+                . ' <i>(for example, "abc" becomes 0x616263)</i>'
+            )
+        );
 
         // Drizzle works only with UTC timezone
         if (! PMA_DRIZZLE) {
@@ -299,11 +380,17 @@ if (isset($plugin_list)) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'utc_time',
-                'text' => __('Dump TIMESTAMP columns in UTC <i>(enables TIMESTAMP columns to be dumped and reloaded between servers in different time zones)</i>')
-                );
+                'text' => __(
+                    'Dump TIMESTAMP columns in UTC <i>(enables TIMESTAMP columns'
+                    . ' to be dumped and reloaded between servers in different'
+                    . ' time zones)</i>'
+                )
+            );
         }
 
-        $plugin_list['sql']['options'][] = array('type' => 'end_group');
+        $plugin_list['sql']['options'][] = array(
+            'type' => 'end_group'
+        );
          /* end Data options */
     }
 } else {
@@ -395,7 +482,9 @@ if (isset($plugin_list)) {
      */
     function PMA_exportComment($text = '')
     {
-        if (isset($GLOBALS['sql_include_comments']) && $GLOBALS['sql_include_comments']) {
+        if (isset($GLOBALS['sql_include_comments'])
+            && $GLOBALS['sql_include_comments']
+        ) {
             // see http://dev.mysql.com/doc/refman/5.0/en/ansi-diff-comments.html
             return '--' . (empty($text) ? '' : ' ') . $text . $GLOBALS['crlf'];
         } else {
@@ -412,7 +501,9 @@ if (isset($plugin_list)) {
      */
     function PMA_possibleCRLF()
     {
-        if (isset($GLOBALS['sql_include_comments']) && $GLOBALS['sql_include_comments']) {
+        if (isset($GLOBALS['sql_include_comments'])
+            && $GLOBALS['sql_include_comments']
+        ) {
             return $GLOBALS['crlf'];
         } else {
             return '';
@@ -442,12 +533,19 @@ if (isset($plugin_list)) {
         }
 
         // restore connection settings
-        $charset_of_file = isset($GLOBALS['charset_of_file']) ? $GLOBALS['charset_of_file'] : '';
-        if (! empty($GLOBALS['asfile']) && isset($mysql_charset_map[$charset_of_file]) && !PMA_DRIZZLE) {
+        $charset_of_file = isset($GLOBALS['charset_of_file'])
+            ? $GLOBALS['charset_of_file'] : '';
+        if (! empty($GLOBALS['asfile'])
+            && isset($mysql_charset_map[$charset_of_file])
+            && ! PMA_DRIZZLE
+        ) {
             $foot .=  $crlf
-                    . '/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;' . $crlf
-                    . '/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;' . $crlf
-                    . '/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;' . $crlf;
+                . '/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;'
+                . $crlf
+                . '/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;'
+                . $crlf
+                . '/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;'
+                . $crlf;
         }
 
         /* Restore timezone */
@@ -488,12 +586,17 @@ if (isset($plugin_list)) {
             $host_string .= ':' . $cfg['Server']['port'];
         }
         $head .= PMA_exportComment($host_string);
-        $head .= PMA_exportComment(__('Generation Time') . ': ' .  PMA_localisedDate())
-              .  PMA_exportComment(__('Server version') . ': ' . PMA_MYSQL_STR_VERSION)
-              .  PMA_exportComment(__('PHP Version') . ': ' . phpversion())
-              .  PMA_possibleCRLF();
+        $head .=
+            PMA_exportComment(
+                __('Generation Time') . ': ' .  PMA_localisedDate()
+            )
+            .  PMA_exportComment(__('Server version') . ': ' . PMA_MYSQL_STR_VERSION)
+            .  PMA_exportComment(__('PHP Version') . ': ' . phpversion())
+            .  PMA_possibleCRLF();
 
-        if (isset($GLOBALS['sql_header_comment']) && ! empty($GLOBALS['sql_header_comment'])) {
+        if (isset($GLOBALS['sql_header_comment'])
+            && ! empty($GLOBALS['sql_header_comment'])
+        ) {
             // '\n' is not a newline (like "\n" would be), it's the characters
             // backslash and n, as explained on the export interface
             $lines = explode('\n', $GLOBALS['sql_header_comment']);
@@ -508,8 +611,10 @@ if (isset($plugin_list)) {
             $head .= 'SET FOREIGN_KEY_CHECKS=0;' . $crlf;
         }
 
-        /* We want exported AUTO_INCREMENT columns to have still same value, do this only for recent MySQL exports */
-        if ((! isset($GLOBALS['sql_compatibility']) || $GLOBALS['sql_compatibility'] == 'NONE')
+        // We want exported AUTO_INCREMENT columns to have still same value, 
+        // do this only for recent MySQL exports
+        if ((! isset($GLOBALS['sql_compatibility'])
+            || $GLOBALS['sql_compatibility'] == 'NONE')
             && ! PMA_DRIZZLE
         ) {
             $head .= 'SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";' . $crlf;
@@ -519,7 +624,6 @@ if (isset($plugin_list)) {
             $head .= 'SET AUTOCOMMIT=0;' . $crlf
                    . 'START TRANSACTION;' . $crlf;
         }
-
 
         /* Change timezone if we should export timestamps in UTC */
         if (isset($GLOBALS['sql_utc_time']) && $GLOBALS['sql_utc_time']) {
@@ -534,7 +638,9 @@ if (isset($plugin_list)) {
             // we are saving as file, therefore we provide charset information
             // so that a utility like the mysql client can interpret
             // the file correctly
-            if (isset($GLOBALS['charset_of_file']) && isset($mysql_charset_map[$GLOBALS['charset_of_file']])) {
+            if (isset($GLOBALS['charset_of_file'])
+                && isset($mysql_charset_map[$GLOBALS['charset_of_file']])
+            ) {
                 // we got a charset from the export dialog
                 $set_names = $mysql_charset_map[$GLOBALS['charset_of_file']];
             } else {
@@ -542,10 +648,13 @@ if (isset($plugin_list)) {
                 $set_names = $mysql_charset_map['utf-8'];
             }
             $head .=  $crlf
-                   . '/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;' . $crlf
-                   . '/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;' . $crlf
-                   . '/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;' . $crlf
-                   . '/*!40101 SET NAMES ' . $set_names . ' */;' . $crlf . $crlf;
+                . '/*!40101 SET @OLD_CHARACTER_SET_CLIENT='
+                . '@@CHARACTER_SET_CLIENT */;' . $crlf
+                . '/*!40101 SET @OLD_CHARACTER_SET_RESULTS='
+                . '@@CHARACTER_SET_RESULTS */;' . $crlf
+                . '/*!40101 SET @OLD_COLLATION_CONNECTION='
+                . '@@COLLATION_CONNECTION */;'. $crlf
+                . '/*!40101 SET NAMES ' . $set_names . ' */;' . $crlf . $crlf;
         }
 
         return PMA_exportOutputHandler($head);
@@ -564,17 +673,25 @@ if (isset($plugin_list)) {
     {
         global $crlf;
         if (isset($GLOBALS['sql_drop_database'])) {
-            if (! PMA_exportOutputHandler('DROP DATABASE ' . (isset($GLOBALS['sql_backquotes']) ? PMA_backquote($db) : $db) . ';' . $crlf)) {
+            if (! PMA_exportOutputHandler(
+                'DROP DATABASE '
+                . (isset($GLOBALS['sql_backquotes'])
+                ? PMA_backquote($db) : $db)
+                . ';' . $crlf
+            )) {
                 return false;
             }
         }
-        $create_query = 'CREATE DATABASE ' . (isset($GLOBALS['sql_backquotes']) ? PMA_backquote($db) : $db);
+        $create_query = 'CREATE DATABASE '
+            . (isset($GLOBALS['sql_backquotes']) ? PMA_backquote($db) : $db);
         $collation = PMA_getDbCollation($db);
         if (PMA_DRIZZLE) {
             $create_query .= ' COLLATE ' . $collation;
         } else {
             if (strpos($collation, '_')) {
-                $create_query .= ' DEFAULT CHARACTER SET ' . substr($collation, 0, strpos($collation, '_')) . ' COLLATE ' . $collation;
+                $create_query .= ' DEFAULT CHARACTER SET '
+                    . substr($collation, 0, strpos($collation, '_'))
+                    . ' COLLATE ' . $collation;
             } else {
                 $create_query .= ' DEFAULT CHARACTER SET ' . $collation;
             }
@@ -584,9 +701,13 @@ if (isset($plugin_list)) {
             return false;
         }
         if (isset($GLOBALS['sql_backquotes'])
-            && ((isset($GLOBALS['sql_compatibility']) && $GLOBALS['sql_compatibility'] == 'NONE') || PMA_DRIZZLE)
+            && ((isset($GLOBALS['sql_compatibility'])
+            && $GLOBALS['sql_compatibility'] == 'NONE')
+            || PMA_DRIZZLE)
         ) {
-            $result = PMA_exportOutputHandler('USE ' . PMA_backquote($db) . ';' . $crlf);
+            $result = PMA_exportOutputHandler(
+                'USE ' . PMA_backquote($db) . ';' . $crlf
+            );
         } else {
             $result = PMA_exportOutputHandler('USE ' . $db . ';' . $crlf);
         }
@@ -606,8 +727,12 @@ if (isset($plugin_list)) {
     function PMA_exportDBHeader($db)
     {
         $head = PMA_exportComment()
-              . PMA_exportComment(__('Database') . ': ' . (isset($GLOBALS['sql_backquotes']) ? PMA_backquote($db) : '\'' . $db . '\''))
-              . PMA_exportComment();
+            . PMA_exportComment(
+                __('Database') . ': '
+                . (isset($GLOBALS['sql_backquotes'])
+                ? PMA_backquote($db) : '\'' . $db . '\'')
+            )
+            . PMA_exportComment();
         return PMA_exportOutputHandler($head);
     }
 
@@ -630,12 +755,18 @@ if (isset($plugin_list)) {
             unset($GLOBALS['sql_constraints']);
         }
 
-        if (($GLOBALS['sql_structure_or_data'] == 'structure' || $GLOBALS['sql_structure_or_data'] == 'structure_and_data') && isset($GLOBALS['sql_procedure_function'])) {
+        if (($GLOBALS['sql_structure_or_data'] == 'structure'
+            || $GLOBALS['sql_structure_or_data'] == 'structure_and_data')
+            && isset($GLOBALS['sql_procedure_function'])
+        ) {
             $text = '';
             $delimiter = '$$';
 
             if (PMA_MYSQL_INT_VERSION > 50100) {
-                $event_names = PMA_DBI_fetch_result('SELECT EVENT_NAME FROM information_schema.EVENTS WHERE EVENT_SCHEMA= \'' . PMA_sqlAddSlashes($db, true) . '\';');
+                $event_names = PMA_DBI_fetch_result(
+                    'SELECT EVENT_NAME FROM information_schema.EVENTS WHERE'
+                    . ' EVENT_SCHEMA= \'' . PMA_sqlAddSlashes($db, true) . '\';'
+                );
             } else {
                 $event_names = array();
             }
@@ -646,14 +777,16 @@ if (isset($plugin_list)) {
 
                 $text .=
                     PMA_exportComment()
-                  . PMA_exportComment(__('Events'))
-                  . PMA_exportComment();
+                    . PMA_exportComment(__('Events'))
+                    . PMA_exportComment();
 
                 foreach ($event_names as $event_name) {
                     if (! empty($GLOBALS['sql_drop_table'])) {
-                        $text .= 'DROP EVENT ' . PMA_backquote($event_name) . $delimiter . $crlf;
+                        $text .= 'DROP EVENT ' . PMA_backquote($event_name)
+                            . $delimiter . $crlf;
                     }
-                    $text .= PMA_DBI_get_definition($db, 'EVENT', $event_name) . $delimiter . $crlf . $crlf;
+                    $text .= PMA_DBI_get_definition($db, 'EVENT', $event_name)
+                        . $delimiter . $crlf . $crlf;
                 }
 
                 $text .= 'DELIMITER ;' . $crlf;
@@ -681,12 +814,15 @@ if (isset($plugin_list)) {
     {
         $create_query = '';
         if (! empty($GLOBALS['sql_drop_table'])) {
-            $create_query .= 'DROP VIEW IF EXISTS ' . PMA_backquote($view) . ';' . $crlf;
+            $create_query .= 'DROP VIEW IF EXISTS ' . PMA_backquote($view)
+                . ';' . $crlf;
         }
 
         $create_query .= 'CREATE TABLE ';
 
-        if (isset($GLOBALS['sql_if_not_exists']) && $GLOBALS['sql_if_not_exists']) {
+        if (isset($GLOBALS['sql_if_not_exists'])
+            && $GLOBALS['sql_if_not_exists']
+        ) {
             $create_query .= 'IF NOT EXISTS ';
         }
         $create_query .= PMA_backquote($view) . ' (' . $crlf;
@@ -707,15 +843,23 @@ if (isset($plugin_list)) {
      * @param string $crlf          the end of line sequence
      * @param string $error_url     the url to go back in case of error
      * @param bool   $show_dates    whether to include creation/update/check dates
-     * @param bool   $add_semicolon whether to add semicolon and end-of-line at the end
+     * @param bool   $add_semicolon whether to add semicolon and end-of-line at
+     *                              the end
      * @param bool   $view          whether we're handling a view
      *
      * @return string resulting schema
      *
      * @access public
      */
-    function PMA_getTableDef($db, $table, $crlf, $error_url, $show_dates = false, $add_semicolon = true, $view = false)
-    {
+    function PMA_getTableDef(
+        $db,
+        $table,
+        $crlf,
+        $error_url,
+        $show_dates = false,
+        $add_semicolon = true,
+        $view = false
+    ) {
         global $sql_drop_table;
         global $sql_backquotes;
         global $sql_constraints;
@@ -728,7 +872,8 @@ if (isset($plugin_list)) {
 
         // need to use PMA_DBI_QUERY_STORE with PMA_DBI_num_rows() in mysqli
         $result = PMA_DBI_query(
-            'SHOW TABLE STATUS FROM ' . PMA_backquote($db) . ' LIKE \'' . PMA_sqlAddSlashes($table, true) . '\'',
+            'SHOW TABLE STATUS FROM ' . PMA_backquote($db) . ' LIKE \''
+                . PMA_sqlAddSlashes($table, true) . '\'',
             null,
             PMA_DBI_QUERY_STORE
         );
@@ -736,7 +881,8 @@ if (isset($plugin_list)) {
             if (PMA_DBI_num_rows($result) > 0) {
                 $tmpres = PMA_DBI_fetch_assoc($result);
                 if (PMA_DRIZZLE && $show_dates) {
-                    // Drizzle doesn't give Create_time and Update_time in SHOW TABLE STATUS, add it
+                    // Drizzle doesn't give Create_time and Update_time in 
+                    // SHOW TABLE STATUS, add it
                     $sql ="SELECT
                             TABLE_CREATION_TIME AS Create_time,
                             TABLE_UPDATE_TIME AS Update_time
@@ -750,22 +896,43 @@ if (isset($plugin_list)) {
                 // in SHOW CREATE TABLE so we'll remove it below
                 // It's required for Drizzle because SHOW CREATE TABLE uses
                 // the value from table's creation time
-                if (isset($GLOBALS['sql_auto_increment']) && ! empty($tmpres['Auto_increment'])) {
-                    $auto_increment .= ' AUTO_INCREMENT=' . $tmpres['Auto_increment'] . ' ';
+                if (isset($GLOBALS['sql_auto_increment'])
+                    && ! empty($tmpres['Auto_increment'])
+                ) {
+                    $auto_increment .= ' AUTO_INCREMENT='
+                        . $tmpres['Auto_increment'] . ' ';
                 }
 
-                if ($show_dates && isset($tmpres['Create_time']) && ! empty($tmpres['Create_time'])) {
-                    $schema_create .= PMA_exportComment(__('Creation') . ': ' . PMA_localisedDate(strtotime($tmpres['Create_time'])));
+                if ($show_dates
+                    && isset($tmpres['Create_time'])
+                    && ! empty($tmpres['Create_time'])
+                ) {
+                    $schema_create .= PMA_exportComment(
+                        __('Creation') . ': '
+                        . PMA_localisedDate(strtotime($tmpres['Create_time']))
+                    );
                     $new_crlf = PMA_exportComment() . $crlf;
                 }
 
-                if ($show_dates && isset($tmpres['Update_time']) && ! empty($tmpres['Update_time'])) {
-                    $schema_create .= PMA_exportComment(__('Last update') . ': ' . PMA_localisedDate(strtotime($tmpres['Update_time'])));
+                if ($show_dates
+                    && isset($tmpres['Update_time'])
+                    && ! empty($tmpres['Update_time'])
+                ) {
+                    $schema_create .= PMA_exportComment(
+                        __('Last update') . ': '
+                        . PMA_localisedDate(strtotime($tmpres['Update_time']))
+                    );
                     $new_crlf = PMA_exportComment() . $crlf;
                 }
 
-                if ($show_dates && isset($tmpres['Check_time']) && ! empty($tmpres['Check_time'])) {
-                    $schema_create .= PMA_exportComment(__('Last check') . ': ' . PMA_localisedDate(strtotime($tmpres['Check_time'])));
+                if ($show_dates
+                    && isset($tmpres['Check_time'])
+                    && ! empty($tmpres['Check_time'])
+                ) {
+                    $schema_create .= PMA_exportComment(
+                        __('Last check') . ': '
+                        . PMA_localisedDate(strtotime($tmpres['Check_time']))
+                    );
                     $new_crlf = PMA_exportComment() . $crlf;
                 }
             }
@@ -776,7 +943,8 @@ if (isset($plugin_list)) {
 
         // no need to generate a DROP VIEW here, it was done earlier
         if (! empty($sql_drop_table) && ! PMA_Table::isView($db, $table)) {
-            $schema_create .= 'DROP TABLE IF EXISTS ' . PMA_backquote($table, $sql_backquotes) . ';' . $crlf;
+            $schema_create .= 'DROP TABLE IF EXISTS '
+                . PMA_backquote($table, $sql_backquotes) . ';' . $crlf;
         }
 
         // Complete table dump,
@@ -793,13 +961,16 @@ if (isset($plugin_list)) {
         // I don't see the reason why this unbuffered query could cause problems,
         // because SHOW CREATE TABLE returns only one row, and we free the
         // results below. Nonetheless, we got 2 user reports about this
-        // (see bug 1562533) so I remove the unbuffered mode.
-        //$result = PMA_DBI_query('SHOW CREATE TABLE ' . PMA_backquote($db) . '.' . PMA_backquote($table), null, PMA_DBI_QUERY_UNBUFFERED);
+        // (see bug 1562533) so I removed the unbuffered mode.
+        // $result = PMA_DBI_query('SHOW CREATE TABLE ' . PMA_backquote($db) 
+        // . '.' . PMA_backquote($table), null, PMA_DBI_QUERY_UNBUFFERED);
         //
         // Note: SHOW CREATE TABLE, at least in MySQL 5.1.23, does not
         // produce a displayable result for the default value of a BIT
         // column, nor does the mysqldump command. See MySQL bug 35796
-        $result = PMA_DBI_try_query('SHOW CREATE TABLE ' . PMA_backquote($db) . '.' . PMA_backquote($table));
+        $result = PMA_DBI_try_query(
+            'SHOW CREATE TABLE ' . PMA_backquote($db) . '.' . PMA_backquote($table)
+        );
         // an error can happen, for example the table is crashed
         $tmp_error = PMA_DBI_getError();
         if ($tmp_error) {
@@ -810,7 +981,8 @@ if (isset($plugin_list)) {
             $create_query = $row[1];
             unset($row);
 
-            // Convert end of line chars to one that we want (note that MySQL doesn't return query it will accept in all cases)
+            // Convert end of line chars to one that we want (note that MySQL
+            // doesn't return query it will accept in all cases)
             if (strpos($create_query, "(\r\n ")) {
                 $create_query = str_replace("\r\n", $crlf, $create_query);
             } elseif (strpos($create_query, "(\n ")) {
@@ -827,29 +999,46 @@ if (isset($plugin_list)) {
              * statement.
              */
             if ($view) {
-                $create_query = preg_replace('/' . PMA_backquote($db) . '\./', '', $create_query);
+                $create_query = preg_replace(
+                    '/' . PMA_backquote($db) . '\./',
+                    '',
+                    $create_query
+                );
             }
 
             // Should we use IF NOT EXISTS?
             if (isset($GLOBALS['sql_if_not_exists'])) {
-                $create_query = preg_replace('/^CREATE TABLE/', 'CREATE TABLE IF NOT EXISTS', $create_query);
+                $create_query = preg_replace(
+                    '/^CREATE TABLE/',
+                    'CREATE TABLE IF NOT EXISTS',
+                    $create_query
+                );
             }
 
-            // Drizzle (checked on 2011.03.13) returns ROW_FORMAT surrounded with quotes, which is not accepted by parser
+            // Drizzle (checked on 2011.03.13) returns ROW_FORMAT surrounded
+            // with quotes, which is not accepted by parser
             if (PMA_DRIZZLE) {
-                $create_query = preg_replace('/ROW_FORMAT=\'(\S+)\'/', 'ROW_FORMAT=$1', $create_query);
+                $create_query = preg_replace(
+                    '/ROW_FORMAT=\'(\S+)\'/',
+                    'ROW_FORMAT=$1',
+                    $create_query
+                );
             }
 
             // are there any constraints to cut out?
             if (preg_match('@CONSTRAINT|FOREIGN[\s]+KEY@', $create_query)) {
 
-                // Split the query into lines, so we can easily handle it. We know lines are separated by $crlf (done few lines above).
+                // Split the query into lines, so we can easily handle it. 
+                // We know lines are separated by $crlf (done few lines above).
                 $sql_lines = explode($crlf, $create_query);
                 $sql_count = count($sql_lines);
 
                 // lets find first line with constraints
                 for ($i = 0; $i < $sql_count; $i++) {
-                    if (preg_match('@^[\s]*(CONSTRAINT|FOREIGN[\s]+KEY)@', $sql_lines[$i])) {
+                    if (preg_match(
+                        '@^[\s]*(CONSTRAINT|FOREIGN[\s]+KEY)@',
+                        $sql_lines[$i]
+                    )) {
                         break;
                     }
                 }
@@ -857,8 +1046,12 @@ if (isset($plugin_list)) {
                 // If we really found a constraint
                 if ($i != $sql_count) {
 
-                    // remove , from the end of create statement
-                    $sql_lines[$i - 1] = preg_replace('@,$@', '', $sql_lines[$i - 1]);
+                    // remove, from the end of create statement
+                    $sql_lines[$i - 1] = preg_replace(
+                        '@,$@',
+                        '',
+                        $sql_lines[$i - 1]
+                    );
 
                     // prepare variable for constraints
                     if (! isset($sql_constraints)) {
@@ -866,44 +1059,69 @@ if (isset($plugin_list)) {
                             $sql_constraints = '';
                         } else {
                             $sql_constraints = $crlf
-                                             . PMA_exportComment()
-                                             . PMA_exportComment(__('Constraints for dumped tables'))
-                                             . PMA_exportComment();
+                                . PMA_exportComment()
+                                . PMA_exportComment(
+                                    __('Constraints for dumped tables')
+                                )
+                                . PMA_exportComment();
                         }
                     }
 
                     // comments for current table
                     if (! isset($GLOBALS['no_constraints_comments'])) {
                         $sql_constraints .= $crlf
-                                          . PMA_exportComment()
-                                          . PMA_exportComment(__('Constraints for table') . ' ' . PMA_backquote($table))
-                                          . PMA_exportComment();
+                        . PMA_exportComment()
+                        . PMA_exportComment(
+                            __('Constraints for table')
+                            . ' '
+                            . PMA_backquote($table)
+                        )
+                        . PMA_exportComment();
                     }
 
                     // let's do the work
-                    $sql_constraints_query .= 'ALTER TABLE ' . PMA_backquote($table) . $crlf;
-                    $sql_constraints .= 'ALTER TABLE ' . PMA_backquote($table) . $crlf;
-                    $sql_drop_foreign_keys .= 'ALTER TABLE ' . PMA_backquote($db) . '.' . PMA_backquote($table) . $crlf;
+                    $sql_constraints_query .= 'ALTER TABLE ' . PMA_backquote($table)
+                        . $crlf;
+                    $sql_constraints .= 'ALTER TABLE ' . PMA_backquote($table)
+                        . $crlf;
+                    $sql_drop_foreign_keys .= 'ALTER TABLE ' . PMA_backquote($db)
+                        . '.' . PMA_backquote($table) . $crlf;
 
                     $first = true;
                     for ($j = $i; $j < $sql_count; $j++) {
-                        if (preg_match('@CONSTRAINT|FOREIGN[\s]+KEY@', $sql_lines[$j])) {
+                        if (preg_match(
+                            '@CONSTRAINT|FOREIGN[\s]+KEY@',
+                            $sql_lines[$j]
+                        )) {
                             if (! $first) {
                                 $sql_constraints .= $crlf;
                             }
                             if (strpos($sql_lines[$j], 'CONSTRAINT') === false) {
-                                $tmp_str = preg_replace('/(FOREIGN[\s]+KEY)/', 'ADD \1', $sql_lines[$j]);
+                                $tmp_str = preg_replace(
+                                    '/(FOREIGN[\s]+KEY)/',
+                                    'ADD \1',
+                                    $sql_lines[$j]
+                                );
                                 $sql_constraints_query .= $tmp_str;
                                 $sql_constraints .= $tmp_str;
                             } else {
-                                $tmp_str = preg_replace('/(CONSTRAINT)/', 'ADD \1', $sql_lines[$j]);
+                                $tmp_str = preg_replace(
+                                    '/(CONSTRAINT)/',
+                                    'ADD \1',
+                                    $sql_lines[$j]
+                                );
                                 $sql_constraints_query .= $tmp_str;
                                 $sql_constraints .= $tmp_str;
-                                preg_match('/(CONSTRAINT)([\s])([\S]*)([\s])/', $sql_lines[$j], $matches);
+                                preg_match(
+                                    '/(CONSTRAINT)([\s])([\S]*)([\s])/',
+                                    $sql_lines[$j],
+                                    $matches
+                                );
                                 if (! $first) {
                                     $sql_drop_foreign_keys .= ', ';
                                 }
-                                $sql_drop_foreign_keys .= 'DROP FOREIGN KEY ' . $matches[3];
+                                $sql_drop_foreign_keys .= 'DROP FOREIGN KEY '
+                                    . $matches[3];
                             }
                             $first = false;
                         } else {
@@ -913,7 +1131,12 @@ if (isset($plugin_list)) {
                     $sql_constraints .= ';' . $crlf;
                     $sql_constraints_query .= ';';
 
-                    $create_query = implode($crlf, array_slice($sql_lines, 0, $i)) . $crlf . implode($crlf, array_slice($sql_lines, $j, $sql_count - 1));
+                    $create_query = implode($crlf, array_slice($sql_lines, 0, $i))
+                    . $crlf
+                    . implode(
+                        $crlf,
+                        array_slice($sql_lines, $j, $sql_count - 1)
+                    );
                     unset($sql_lines);
                 }
             }
@@ -922,8 +1145,13 @@ if (isset($plugin_list)) {
 
         // remove a possible "AUTO_INCREMENT = value" clause
         // that could be there starting with MySQL 5.0.24
-        // in Drizzle it's useless as it contains the value given at table creation time
-        $schema_create = preg_replace('/AUTO_INCREMENT\s*=\s*([0-9])+/', '', $schema_create);
+        // in Drizzle it's useless as it contains the value given at table
+        // creation time
+        $schema_create = preg_replace(
+            '/AUTO_INCREMENT\s*=\s*([0-9])+/',
+            '',
+            $schema_create
+        );
 
         $schema_create .= $auto_increment;
 
@@ -944,7 +1172,13 @@ if (isset($plugin_list)) {
      *
      * @access private
      */
-    function PMA_getTableComments($db, $table, $crlf, $do_relation = false, $do_mime = false)
+    function PMA_getTableComments(
+        $db,
+        $table,
+        $crlf,
+        $do_relation = false,
+        $do_mime = false
+    )
     {
         global $cfgRelation;
         global $sql_backquotes;
@@ -975,26 +1209,46 @@ if (isset($plugin_list)) {
 
         if (isset($mime_map) && count($mime_map) > 0) {
             $schema_create .= PMA_possibleCRLF()
-                           . PMA_exportComment()
-                           . PMA_exportComment(__('MIME TYPES FOR TABLE'). ' ' . PMA_backquote($table, $sql_backquotes) . ':');
+            . PMA_exportComment()
+            . PMA_exportComment(
+                __('MIME TYPES FOR TABLE'). ' '
+                . PMA_backquote($table, $sql_backquotes) . ':'
+            );
             @reset($mime_map);
             foreach ($mime_map AS $mime_field => $mime) {
-                $schema_create .= PMA_exportComment('  ' . PMA_backquote($mime_field, $sql_backquotes))
-                                . PMA_exportComment('      ' . PMA_backquote($mime['mimetype'], $sql_backquotes));
+                $schema_create .=
+                    PMA_exportComment(
+                        '  '
+                        . PMA_backquote($mime_field, $sql_backquotes)
+                    )
+                    . PMA_exportComment(
+                        '      '
+                        . PMA_backquote($mime['mimetype'], $sql_backquotes)
+                    );
             }
             $schema_create .= PMA_exportComment();
         }
 
         if ($have_rel) {
             $schema_create .= PMA_possibleCRLF()
-                           . PMA_exportComment()
-                           . PMA_exportComment(__('RELATIONS FOR TABLE'). ' ' . PMA_backquote($table, $sql_backquotes) . ':');
+                . PMA_exportComment()
+                . PMA_exportComment(
+                    __('RELATIONS FOR TABLE') . ' '
+                    . PMA_backquote($table, $sql_backquotes)
+                    . ':'
+                );
             foreach ($res_rel AS $rel_field => $rel) {
-                $schema_create .= PMA_exportComment('  ' . PMA_backquote($rel_field, $sql_backquotes))
-                               . PMA_exportComment(
-                                   '      ' . PMA_backquote($rel['foreign_table'], $sql_backquotes)
-                                   . ' -> ' . PMA_backquote($rel['foreign_field'], $sql_backquotes)
-                               );
+                $schema_create .= 
+                    PMA_exportComment(
+                        '  '
+                        . PMA_backquote($rel_field, $sql_backquotes)
+                    )
+                    . PMA_exportComment(
+                        '      '
+                        . PMA_backquote($rel['foreign_table'], $sql_backquotes)
+                        . ' -> '
+                        . PMA_backquote($rel['foreign_field'], $sql_backquotes)
+                    );
             }
             $schema_create .= PMA_exportComment();
         }
@@ -1025,19 +1279,31 @@ if (isset($plugin_list)) {
      *
      * @access public
      */
-    function PMA_exportStructure($db, $table, $crlf, $error_url, $relation = false, $comments = false, $mime = false, $dates = false, $export_mode, $export_type)
-    {
+    function PMA_exportStructure(
+        $db,
+        $table,
+        $crlf,
+        $error_url,
+        $relation = false,
+        $comments = false,
+        $mime = false,
+        $dates = false,
+        $export_mode,
+        $export_type
+    ) {
         $formatted_table_name = (isset($GLOBALS['sql_backquotes']))
                               ? PMA_backquote($table)
                               : '\'' . $table . '\'';
         $dump = PMA_possibleCRLF()
-              . PMA_exportComment(str_repeat('-', 56))
-              . PMA_possibleCRLF()
-              . PMA_exportComment();
+            . PMA_exportComment(str_repeat('-', 56))
+            . PMA_possibleCRLF()
+            . PMA_exportComment();
 
         switch($export_mode) {
         case 'create_table':
-            $dump .= PMA_exportComment(__('Table structure for table') . ' ' . $formatted_table_name);
+            $dump .= PMA_exportComment(
+                __('Table structure for table') . ' '. $formatted_table_name
+            );
             $dump .= PMA_exportComment();
             $dump .= PMA_getTableDef($db, $table, $crlf, $error_url, $dates);
             $dump .= PMA_getTableComments($db, $table, $crlf, $relation, $mime);
@@ -1047,9 +1313,11 @@ if (isset($plugin_list)) {
             $triggers = PMA_DBI_get_triggers($db, $table);
             if ($triggers) {
                 $dump .=  PMA_possibleCRLF()
-                        . PMA_exportComment()
-                        . PMA_exportComment(__('Triggers') . ' ' . $formatted_table_name)
-                        . PMA_exportComment();
+                    . PMA_exportComment()
+                    . PMA_exportComment(
+                        __('Triggers') . ' ' . $formatted_table_name
+                    )
+                    . PMA_exportComment();
                 $delimiter = '//';
                 foreach ($triggers as $trigger) {
                     $dump .= $trigger['drop'] . ';' . $crlf;
@@ -1060,17 +1328,25 @@ if (isset($plugin_list)) {
             }
             break;
         case 'create_view':
-            $dump .= PMA_exportComment(__('Structure for view') . ' ' . $formatted_table_name)
-                   . PMA_exportComment();
+            $dump .= PMA_exportComment(__('Structure for view')
+                . ' '
+                . $formatted_table_name)
+                . PMA_exportComment();
             // delete the stand-in table previously created (if any)
             if ($export_type != 'table') {
-                $dump .= 'DROP TABLE IF EXISTS ' . PMA_backquote($table) . ';' . $crlf;
+                $dump .= 'DROP TABLE IF EXISTS ' . PMA_backquote($table)
+                    . ';' . $crlf;
             }
-            $dump .= PMA_getTableDef($db, $table, $crlf, $error_url, $dates, true, true);
+            $dump .= PMA_getTableDef($db, $table, $crlf, $error_url, $dates,
+                true, true
+            );
             break;
         case 'stand_in':
-            $dump .=  PMA_exportComment(__('Stand-in structure for view') . ' ' . $formatted_table_name)
-                    . PMA_exportComment();
+            $dump .=
+                PMA_exportComment(
+                    __('Stand-in structure for view') . ' ' . $formatted_table_name
+                )
+                . PMA_exportComment();
             // export a stand-in definition to resolve view dependencies
             $dump .= PMA_getTableDefStandIn($db, $table, $crlf);
         } // end switch
@@ -1129,7 +1405,11 @@ if (isset($plugin_list)) {
         // a possible error: the table has crashed
         $tmp_error = PMA_DBI_getError();
         if ($tmp_error) {
-            return PMA_exportOutputHandler(PMA_exportComment(__('Error reading data:') . ' (' . $tmp_error . ')'));
+            return PMA_exportOutputHandler(
+                PMA_exportComment(
+                    __('Error reading data:') . ' (' . $tmp_error . ')'
+                )
+            );
         }
 
         if ($result != false) {
@@ -1144,13 +1424,21 @@ if (isset($plugin_list)) {
 
             for ($j = 0; $j < $fields_cnt; $j++) {
                 if (isset($analyzed_sql[0]['select_expr'][$j]['column'])) {
-                    $field_set[$j] = PMA_backquote($analyzed_sql[0]['select_expr'][$j]['column'], $sql_backquotes);
+                    $field_set[$j] = PMA_backquote(
+                        $analyzed_sql[0]['select_expr'][$j]['column'],
+                        $sql_backquotes
+                    );
                 } else {
-                    $field_set[$j] = PMA_backquote($fields_meta[$j]->name, $sql_backquotes);
+                    $field_set[$j] = PMA_backquote(
+                        $fields_meta[$j]->name,
+                        $sql_backquotes
+                    );
                 }
             }
 
-            if (isset($GLOBALS['sql_type']) && $GLOBALS['sql_type'] == 'UPDATE') {
+            if (isset($GLOBALS['sql_type'])
+                && $GLOBALS['sql_type'] == 'UPDATE'
+            ) {
                 // update
                 $schema_insert  = 'UPDATE ';
                 if (isset($GLOBALS['sql_ignore'])) {
@@ -1160,7 +1448,9 @@ if (isset($plugin_list)) {
                 $schema_insert .= PMA_backquote($table, $sql_backquotes) . ' SET';
             } else {
                 // insert or replace
-                if (isset($GLOBALS['sql_type']) && $GLOBALS['sql_type'] == 'REPLACE') {
+                if (isset($GLOBALS['sql_type'])
+                    && $GLOBALS['sql_type'] == 'REPLACE'
+                ) {
                     $sql_command = 'REPLACE';
                 } else {
                     $sql_command = 'INSERT';
@@ -1174,39 +1464,58 @@ if (isset($plugin_list)) {
                 }
 
                 // insert ignore?
-                if (isset($GLOBALS['sql_type']) && $GLOBALS['sql_type'] == 'INSERT' && isset($GLOBALS['sql_ignore'])) {
+                if (isset($GLOBALS['sql_type'])
+                    && $GLOBALS['sql_type'] == 'INSERT'
+                    && isset($GLOBALS['sql_ignore'])
+                ) {
                     $insert_delayed .= ' IGNORE';
                 }
                 //truncate table before insert
-                if (isset($GLOBALS['sql_truncate']) && $GLOBALS['sql_truncate'] && $sql_command == 'INSERT') {
-                    $truncate = 'TRUNCATE TABLE ' . PMA_backquote($table, $sql_backquotes) . ";";
+                if (isset($GLOBALS['sql_truncate'])
+                    && $GLOBALS['sql_truncate']
+                    && $sql_command == 'INSERT'
+                ) {
+                    $truncate = 'TRUNCATE TABLE '
+                        . PMA_backquote($table, $sql_backquotes) . ";";
                     $truncatehead = PMA_possibleCRLF()
-                      . PMA_exportComment()
-                      . PMA_exportComment(__('Truncate table before insert') . ' ' . $formatted_table_name)
-                      . PMA_exportComment()
-                      . $crlf;
+                        . PMA_exportComment()
+                        . PMA_exportComment(
+                            __('Truncate table before insert') . ' '
+                            . $formatted_table_name
+                        )
+                        . PMA_exportComment()
+                        . $crlf;
                     PMA_exportOutputHandler($truncatehead);
                     PMA_exportOutputHandler($truncate);
                 } else {
                     $truncate = '';
                 }
                 // scheme for inserting fields
-                if ($GLOBALS['sql_insert_syntax'] == 'complete' || $GLOBALS['sql_insert_syntax'] == 'both') {
+                if ($GLOBALS['sql_insert_syntax'] == 'complete'
+                    || $GLOBALS['sql_insert_syntax'] == 'both'
+                ) {
                     $fields        = implode(', ', $field_set);
-                    $schema_insert = $sql_command . $insert_delayed .' INTO ' . PMA_backquote($table, $sql_backquotes)
+                    $schema_insert = $sql_command . $insert_delayed .' INTO '
+                        . PMA_backquote($table, $sql_backquotes)
                         // avoid EOL blank
                         . ' (' . $fields . ') VALUES';
                 } else {
-                    $schema_insert = $sql_command . $insert_delayed .' INTO ' . PMA_backquote($table, $sql_backquotes)
-                                   . ' VALUES';
+                    $schema_insert = $sql_command . $insert_delayed .' INTO '
+                        . PMA_backquote($table, $sql_backquotes)
+                        . ' VALUES';
                 }
             }
 
-            $search      = array("\x00", "\x0a", "\x0d", "\x1a"); //\x08\\x09, not required
+            //\x08\\x09, not required
+            $search      = array("\x00", "\x0a", "\x0d", "\x1a");
             $replace     = array('\0', '\n', '\r', '\Z');
             $current_row = 0;
             $query_size  = 0;
-            if (($GLOBALS['sql_insert_syntax'] == 'extended' || $GLOBALS['sql_insert_syntax'] == 'both') && (! isset($GLOBALS['sql_type']) || $GLOBALS['sql_type'] != 'UPDATE')) {
+            if (($GLOBALS['sql_insert_syntax'] == 'extended'
+                || $GLOBALS['sql_insert_syntax'] == 'both')
+                && (! isset($GLOBALS['sql_type'])
+                || $GLOBALS['sql_type'] != 'UPDATE')
+            ) {
                 $separator      = ',';
                 $schema_insert .= $crlf;
             } else {
@@ -1216,10 +1525,13 @@ if (isset($plugin_list)) {
             while ($row = PMA_DBI_fetch_row($result)) {
                 if ($current_row == 0) {
                     $head = PMA_possibleCRLF()
-                          . PMA_exportComment()
-                          . PMA_exportComment(__('Dumping data for table') . ' ' . $formatted_table_name)
-                          . PMA_exportComment()
-                          . $crlf;
+                        . PMA_exportComment()
+                        . PMA_exportComment(
+                            __('Dumping data for table') . ' '
+                            . $formatted_table_name
+                        )
+                        . PMA_exportComment()
+                        . $crlf;
                     if (! PMA_exportOutputHandler($head)) {
                         return false;
                     }
@@ -1230,9 +1542,12 @@ if (isset($plugin_list)) {
                     if (! isset($row[$j]) || is_null($row[$j])) {
                         $values[] = 'NULL';
                     // a number
-                    // timestamp is numeric on some MySQL 4.1, BLOBs are sometimes numeric
-                    } elseif ($fields_meta[$j]->numeric && $fields_meta[$j]->type != 'timestamp'
-                            && ! $fields_meta[$j]->blob) {
+                    // timestamp is numeric on some MySQL 4.1, BLOBs are sometimes
+                    // numeric
+                    } elseif ($fields_meta[$j]->numeric
+                        && $fields_meta[$j]->type != 'timestamp'
+                        && ! $fields_meta[$j]->blob
+                    ) {
                         $values[] = $row[$j];
                     // a true BLOB
                     // - mysqldump only generates hex data when the --hex-blob
@@ -1243,7 +1558,8 @@ if (isset($plugin_list)) {
                     } elseif (stristr($field_flags[$j], 'BINARY')
                             && $fields_meta[$j]->blob
                             && isset($GLOBALS['sql_hex_for_blob'])) {
-                        // empty blobs need to be different, but '0' is also empty :-(
+                        // empty blobs need to be different, but '0' is also empty
+                        // :-(
                         if (empty($row[$j]) && $row[$j] != '0') {
                             $values[] = '\'\'';
                         } else {
@@ -1251,15 +1567,26 @@ if (isset($plugin_list)) {
                         }
                     // detection of 'bit' works only on mysqli extension
                     } elseif ($fields_meta[$j]->type == 'bit') {
-                        $values[] = "b'" . PMA_sqlAddSlashes(PMA_printable_bit_value($row[$j], $fields_meta[$j]->length)) . "'";
+                        $values[] = "b'" . PMA_sqlAddSlashes(
+                            PMA_printable_bit_value(
+                                $row[$j], $fields_meta[$j]->length
+                            )
+                        )
+                            . "'";
                     // something else -> treat as a string
                     } else {
-                        $values[] = '\'' . str_replace($search, $replace, PMA_sqlAddSlashes($row[$j])) . '\'';
+                        $values[] = '\''
+                            . str_replace(
+                                $search, $replace, PMA_sqlAddSlashes($row[$j])
+                            )
+                            . '\'';
                     } // end if
                 } // end for
 
                 // should we make update?
-                if (isset($GLOBALS['sql_type']) && $GLOBALS['sql_type'] == 'UPDATE') {
+                if (isset($GLOBALS['sql_type'])
+                    && $GLOBALS['sql_type'] == 'UPDATE'
+                ) {
 
                     $insert_line = $schema_insert;
                     for ($i = 0; $i < $fields_cnt; $i++) {
@@ -1273,19 +1600,32 @@ if (isset($plugin_list)) {
                         $insert_line .= $field_set[$i] . ' = ' . $values[$i];
                     }
 
-                    list($tmp_unique_condition, $tmp_clause_is_unique) = PMA_getUniqueCondition($result, $fields_cnt, $fields_meta, $row);
+                    list($tmp_unique_condition, $tmp_clause_is_unique) =
+                        PMA_getUniqueCondition(
+                            $result,
+                            $fields_cnt,
+                            $fields_meta,
+                            $row
+                        );
                     $insert_line .= ' WHERE ' . $tmp_unique_condition;
                     unset($tmp_unique_condition, $tmp_clause_is_unique);
 
                 } else {
 
                     // Extended inserts case
-                    if ($GLOBALS['sql_insert_syntax'] == 'extended' || $GLOBALS['sql_insert_syntax'] == 'both') {
+                    if ($GLOBALS['sql_insert_syntax'] == 'extended'
+                        || $GLOBALS['sql_insert_syntax'] == 'both'
+                    ) {
                         if ($current_row == 1) {
-                            $insert_line  = $schema_insert . '(' . implode(', ', $values) . ')';
+                            $insert_line  = $schema_insert . '('
+                                . implode(', ', $values) . ')';
                         } else {
                             $insert_line  = '(' . implode(', ', $values) . ')';
-                            if (isset($GLOBALS['sql_max_query_size']) && $GLOBALS['sql_max_query_size'] > 0 && $query_size + strlen($insert_line) > $GLOBALS['sql_max_query_size']) {
+                            if (isset($GLOBALS['sql_max_query_size'])
+                                && $GLOBALS['sql_max_query_size'] > 0
+                                && $query_size + strlen($insert_line)
+                                > $GLOBALS['sql_max_query_size']
+                            ) {
                                 if (! PMA_exportOutputHandler(';' . $crlf)) {
                                     return false;
                                 }
@@ -1297,12 +1637,15 @@ if (isset($plugin_list)) {
                         $query_size += strlen($insert_line);
                         // Other inserts case
                     } else {
-                        $insert_line = $schema_insert . '(' . implode(', ', $values) . ')';
+                        $insert_line = $schema_insert
+                            . '(' . implode(', ', $values) . ')';
                     }
                 }
                 unset($values);
 
-                if (! PMA_exportOutputHandler(($current_row == 1 ? '' : $separator . $crlf) . $insert_line)) {
+                if (! PMA_exportOutputHandler(
+                    ($current_row == 1 ? '' : $separator . $crlf) . $insert_line)
+                ) {
                     return false;
                 }
 

--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -212,7 +212,8 @@ if (isset($plugin_list)) {
                         __('Add %s statement'),
                         '<code>CREATE PROCEDURE / FUNCTION'
                         . (PMA_MYSQL_INT_VERSION > 50100
-                        ? ' / EVENT</code>' : '</code>'))
+                        ? ' / EVENT</code>' : '</code>')
+                    )
                 );
             }
 
@@ -872,7 +873,7 @@ if (isset($plugin_list)) {
         // need to use PMA_DBI_QUERY_STORE with PMA_DBI_num_rows() in mysqli
         $result = PMA_DBI_query(
             'SHOW TABLE STATUS FROM ' . PMA_backquote($db) . ' LIKE \''
-                . PMA_sqlAddSlashes($table, true) . '\'',
+            . PMA_sqlAddSlashes($table, true) . '\'',
             null,
             PMA_DBI_QUERY_STORE
         );
@@ -1177,8 +1178,7 @@ if (isset($plugin_list)) {
         $crlf,
         $do_relation = false,
         $do_mime = false
-    )
-    {
+    ) {
         global $cfgRelation;
         global $sql_backquotes;
         global $sql_constraints;
@@ -1327,17 +1327,20 @@ if (isset($plugin_list)) {
             }
             break;
         case 'create_view':
-            $dump .= PMA_exportComment(__('Structure for view')
-                . ' '
-                . $formatted_table_name)
+            $dump .=
+                PMA_exportComment(
+                    __('Structure for view')
+                    . ' '
+                    . $formatted_table_name
+                )
                 . PMA_exportComment();
             // delete the stand-in table previously created (if any)
             if ($export_type != 'table') {
                 $dump .= 'DROP TABLE IF EXISTS ' . PMA_backquote($table)
                     . ';' . $crlf;
             }
-            $dump .= PMA_getTableDef($db, $table, $crlf, $error_url, $dates,
-                true, true
+            $dump .= PMA_getTableDef(
+                $db, $table, $crlf, $error_url, $dates, true, true
             );
             break;
         case 'stand_in':
@@ -1540,23 +1543,25 @@ if (isset($plugin_list)) {
                     // NULL
                     if (! isset($row[$j]) || is_null($row[$j])) {
                         $values[] = 'NULL';
-                    // a number
-                    // timestamp is numeric on some MySQL 4.1, BLOBs are sometimes
-                    // numeric
                     } elseif ($fields_meta[$j]->numeric
                         && $fields_meta[$j]->type != 'timestamp'
                         && ! $fields_meta[$j]->blob
                     ) {
+                        // a number
+                        // timestamp is numeric on some MySQL 4.1, BLOBs are
+                        // sometimes numeric
                         $values[] = $row[$j];
-                    // a true BLOB
-                    // - mysqldump only generates hex data when the --hex-blob
-                    //   option is used, for fields having the binary attribute
-                    //   no hex is generated
-                    // - a TEXT field returns type blob but a real blob
-                    //   returns also the 'binary' flag
                     } elseif (stristr($field_flags[$j], 'BINARY')
-                            && $fields_meta[$j]->blob
-                            && isset($GLOBALS['sql_hex_for_blob'])) {
+                        && $fields_meta[$j]->blob
+                        && isset($GLOBALS['sql_hex_for_blob'])
+                    ) {
+                        // a true BLOB
+                        // - mysqldump only generates hex data when the --hex-blob
+                        //   option is used, for fields having the binary attribute
+                        //   no hex is generated
+                        // - a TEXT field returns type blob but a real blob
+                        //   returns also the 'binary' flag
+
                         // empty blobs need to be different, but '0' is also empty
                         // :-(
                         if (empty($row[$j]) && $row[$j] != '0') {
@@ -1564,16 +1569,16 @@ if (isset($plugin_list)) {
                         } else {
                             $values[] = '0x' . bin2hex($row[$j]);
                         }
-                    // detection of 'bit' works only on mysqli extension
                     } elseif ($fields_meta[$j]->type == 'bit') {
+                        // detection of 'bit' works only on mysqli extension
                         $values[] = "b'" . PMA_sqlAddSlashes(
                             PMA_printable_bit_value(
                                 $row[$j], $fields_meta[$j]->length
                             )
                         )
                             . "'";
-                    // something else -> treat as a string
                     } else {
+                        // something else -> treat as a string
                         $values[] = '\''
                             . str_replace(
                                 $search, $replace, PMA_sqlAddSlashes($row[$j])
@@ -1599,8 +1604,8 @@ if (isset($plugin_list)) {
                         $insert_line .= $field_set[$i] . ' = ' . $values[$i];
                     }
 
-                    list($tmp_unique_condition, $tmp_clause_is_unique) =
-                        PMA_getUniqueCondition(
+                    list($tmp_unique_condition, $tmp_clause_is_unique)
+                        = PMA_getUniqueCondition(
                             $result,
                             $fields_cnt,
                             $fields_meta,
@@ -1620,10 +1625,10 @@ if (isset($plugin_list)) {
                                 . implode(', ', $values) . ')';
                         } else {
                             $insert_line  = '(' . implode(', ', $values) . ')';
-                            if (isset($GLOBALS['sql_max_query_size'])
-                                && $GLOBALS['sql_max_query_size'] > 0
-                                && $query_size + strlen($insert_line)
-                                > $GLOBALS['sql_max_query_size']
+                            $sql_max_size = $GLOBALS['sql_max_query_size'];
+                            if (isset($sql_max_size)
+                                && $sql_max_size > 0
+                                && $query_size + strlen($insert_line) > $sql_max_size
                             ) {
                                 if (! PMA_exportOutputHandler(';' . $crlf)) {
                                     return false;
@@ -1643,8 +1648,9 @@ if (isset($plugin_list)) {
                 unset($values);
 
                 if (! PMA_exportOutputHandler(
-                    ($current_row == 1 ? '' : $separator . $crlf) . $insert_line)
-                ) {
+                    ($current_row == 1 ? '' : $separator . $crlf)
+                    . $insert_line
+                )) {
                     return false;
                 }
 

--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build SQL dumps of tables
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage SQL
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -734,7 +734,7 @@ if (isset($plugin_list)) {
         );
         if ($result != false) {
             if (PMA_DBI_num_rows($result) > 0) {
-                $tmpres        = PMA_DBI_fetch_assoc($result);
+                $tmpres = PMA_DBI_fetch_assoc($result);
                 if (PMA_DRIZZLE && $show_dates) {
                     // Drizzle doesn't give Create_time and Update_time in SHOW TABLE STATUS, add it
                     $sql ="SELECT
@@ -832,7 +832,7 @@ if (isset($plugin_list)) {
 
             // Should we use IF NOT EXISTS?
             if (isset($GLOBALS['sql_if_not_exists'])) {
-                $create_query     = preg_replace('/^CREATE TABLE/', 'CREATE TABLE IF NOT EXISTS', $create_query);
+                $create_query = preg_replace('/^CREATE TABLE/', 'CREATE TABLE IF NOT EXISTS', $create_query);
             }
 
             // Drizzle (checked on 2011.03.13) returns ROW_FORMAT surrounded with quotes, which is not accepted by parser
@@ -1207,10 +1207,10 @@ if (isset($plugin_list)) {
             $current_row = 0;
             $query_size  = 0;
             if (($GLOBALS['sql_insert_syntax'] == 'extended' || $GLOBALS['sql_insert_syntax'] == 'both') && (! isset($GLOBALS['sql_type']) || $GLOBALS['sql_type'] != 'UPDATE')) {
-                $separator    = ',';
+                $separator      = ',';
                 $schema_insert .= $crlf;
             } else {
-                $separator    = ';';
+                $separator      = ';';
             }
 
             while ($row = PMA_DBI_fetch_row($result)) {
@@ -1289,7 +1289,7 @@ if (isset($plugin_list)) {
                                 if (! PMA_exportOutputHandler(';' . $crlf)) {
                                     return false;
                                 }
-                                $query_size = 0;
+                                $query_size  = 0;
                                 $current_row = 1;
                                 $insert_line = $schema_insert . $insert_line;
                             }

--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -16,11 +16,11 @@ if (! defined('PHPMYADMIN')) {
 if (isset($plugin_list)) {
     $hide_sql       = false;
     $hide_structure = false;
-    if ($plugin_param['export_type'] == 'table' && !$plugin_param['single_table']) {
+    if ($plugin_param['export_type'] == 'table' && ! $plugin_param['single_table']) {
         $hide_structure = true;
         $hide_sql       = true;
     }
-    if (!$hide_sql) {
+    if (! $hide_sql) {
         $plugin_list['sql'] = array(
             'text' => __('SQL'),
             'extension' => 'sql',
@@ -49,14 +49,14 @@ if (isset($plugin_list)) {
             'name' => 'dates',
             'text' => __('Include a timestamp of when databases were created, last updated, and last checked')
             );
-        if (!empty($GLOBALS['cfgRelation']['relation'])) {
+        if (! empty($GLOBALS['cfgRelation']['relation'])) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'relation',
                 'text' => __('Display foreign key relationships')
                 );
         }
-        if (!empty($GLOBALS['cfgRelation']['mimework'])) {
+        if (! empty($GLOBALS['cfgRelation']['mimework'])) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'mime',
@@ -135,7 +135,7 @@ if (isset($plugin_list)) {
         $plugin_list['sql']['options'][] = array('type' => 'end_group');
 
         /* begin Structure options */
-        if (!$hide_structure) {
+        if (! $hide_structure) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'begin_group',
                 'name' => 'structure',
@@ -173,7 +173,7 @@ if (isset($plugin_list)) {
                 'text' => sprintf(__('Add %s statement'), $drop_clause)
                 );
             // Drizzle doesn't support procedures and functions
-            if (!PMA_DRIZZLE) {
+            if (! PMA_DRIZZLE) {
                 $plugin_list['sql']['options'][] = array(
                     'type' => 'bool',
                     'name' => 'procedure_function',
@@ -232,7 +232,7 @@ if (isset($plugin_list)) {
                 'text' => __('Instead of <code>INSERT</code> statements, use:')
             ));
         // Not supported in Drizzle
-        if (!PMA_DRIZZLE) {
+        if (! PMA_DRIZZLE) {
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
                 'name' => 'delayed',
@@ -294,7 +294,7 @@ if (isset($plugin_list)) {
             );
 
         // Drizzle works only with UTC timezone
-        if (!PMA_DRIZZLE) {
+        if (! PMA_DRIZZLE) {
             /* Dump time in UTC */
             $plugin_list['sql']['options'][] = array(
                 'type' => 'bool',
@@ -443,7 +443,7 @@ if (isset($plugin_list)) {
 
         // restore connection settings
         $charset_of_file = isset($GLOBALS['charset_of_file']) ? $GLOBALS['charset_of_file'] : '';
-        if (!empty($GLOBALS['asfile']) && isset($mysql_charset_map[$charset_of_file]) && !PMA_DRIZZLE) {
+        if (! empty($GLOBALS['asfile']) && isset($mysql_charset_map[$charset_of_file]) && !PMA_DRIZZLE) {
             $foot .=  $crlf
                     . '/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;' . $crlf
                     . '/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;' . $crlf
@@ -484,7 +484,7 @@ if (isset($plugin_list)) {
                .  PMA_exportComment('http://www.phpmyadmin.net')
                .  PMA_exportComment();
         $host_string = __('Host') . ': ' .  $cfg['Server']['host'];
-        if (!empty($cfg['Server']['port'])) {
+        if (! empty($cfg['Server']['port'])) {
             $host_string .= ':' . $cfg['Server']['port'];
         }
         $head .= PMA_exportComment($host_string);
@@ -493,7 +493,7 @@ if (isset($plugin_list)) {
               .  PMA_exportComment(__('PHP Version') . ': ' . phpversion())
               .  PMA_possibleCRLF();
 
-        if (isset($GLOBALS['sql_header_comment']) && !empty($GLOBALS['sql_header_comment'])) {
+        if (isset($GLOBALS['sql_header_comment']) && ! empty($GLOBALS['sql_header_comment'])) {
             // '\n' is not a newline (like "\n" would be), it's the characters
             // backslash and n, as explained on the export interface
             $lines = explode('\n', $GLOBALS['sql_header_comment']);
@@ -509,8 +509,8 @@ if (isset($plugin_list)) {
         }
 
         /* We want exported AUTO_INCREMENT columns to have still same value, do this only for recent MySQL exports */
-        if ((!isset($GLOBALS['sql_compatibility']) || $GLOBALS['sql_compatibility'] == 'NONE')
-            && !PMA_DRIZZLE
+        if ((! isset($GLOBALS['sql_compatibility']) || $GLOBALS['sql_compatibility'] == 'NONE')
+            && ! PMA_DRIZZLE
         ) {
             $head .= 'SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";' . $crlf;
         }
@@ -530,7 +530,7 @@ if (isset($plugin_list)) {
 
         $head .= PMA_possibleCRLF();
 
-        if (! empty($GLOBALS['asfile']) && !PMA_DRIZZLE) {
+        if (! empty($GLOBALS['asfile']) && ! PMA_DRIZZLE) {
             // we are saving as file, therefore we provide charset information
             // so that a utility like the mysql client can interpret
             // the file correctly
@@ -564,7 +564,7 @@ if (isset($plugin_list)) {
     {
         global $crlf;
         if (isset($GLOBALS['sql_drop_database'])) {
-            if (!PMA_exportOutputHandler('DROP DATABASE ' . (isset($GLOBALS['sql_backquotes']) ? PMA_backquote($db) : $db) . ';' . $crlf)) {
+            if (! PMA_exportOutputHandler('DROP DATABASE ' . (isset($GLOBALS['sql_backquotes']) ? PMA_backquote($db) : $db) . ';' . $crlf)) {
                 return false;
             }
         }
@@ -580,7 +580,7 @@ if (isset($plugin_list)) {
             }
         }
         $create_query .= ';' . $crlf;
-        if (!PMA_exportOutputHandler($create_query)) {
+        if (! PMA_exportOutputHandler($create_query)) {
             return false;
         }
         if (isset($GLOBALS['sql_backquotes'])
@@ -750,21 +750,21 @@ if (isset($plugin_list)) {
                 // in SHOW CREATE TABLE so we'll remove it below
                 // It's required for Drizzle because SHOW CREATE TABLE uses
                 // the value from table's creation time
-                if (isset($GLOBALS['sql_auto_increment']) && !empty($tmpres['Auto_increment'])) {
+                if (isset($GLOBALS['sql_auto_increment']) && ! empty($tmpres['Auto_increment'])) {
                     $auto_increment .= ' AUTO_INCREMENT=' . $tmpres['Auto_increment'] . ' ';
                 }
 
-                if ($show_dates && isset($tmpres['Create_time']) && !empty($tmpres['Create_time'])) {
+                if ($show_dates && isset($tmpres['Create_time']) && ! empty($tmpres['Create_time'])) {
                     $schema_create .= PMA_exportComment(__('Creation') . ': ' . PMA_localisedDate(strtotime($tmpres['Create_time'])));
                     $new_crlf = PMA_exportComment() . $crlf;
                 }
 
-                if ($show_dates && isset($tmpres['Update_time']) && !empty($tmpres['Update_time'])) {
+                if ($show_dates && isset($tmpres['Update_time']) && ! empty($tmpres['Update_time'])) {
                     $schema_create .= PMA_exportComment(__('Last update') . ': ' . PMA_localisedDate(strtotime($tmpres['Update_time'])));
                     $new_crlf = PMA_exportComment() . $crlf;
                 }
 
-                if ($show_dates && isset($tmpres['Check_time']) && !empty($tmpres['Check_time'])) {
+                if ($show_dates && isset($tmpres['Check_time']) && ! empty($tmpres['Check_time'])) {
                     $schema_create .= PMA_exportComment(__('Last check') . ': ' . PMA_localisedDate(strtotime($tmpres['Check_time'])));
                     $new_crlf = PMA_exportComment() . $crlf;
                 }
@@ -782,7 +782,7 @@ if (isset($plugin_list)) {
         // Complete table dump,
         // Whether to quote table and column names or not
         // Drizzle always quotes names
-        if (!PMA_DRIZZLE) {
+        if (! PMA_DRIZZLE) {
             if ($sql_backquotes) {
                 PMA_DBI_query('SET SQL_QUOTE_SHOW_CREATE = 1');
             } else {
@@ -861,7 +861,7 @@ if (isset($plugin_list)) {
                     $sql_lines[$i - 1] = preg_replace('@,$@', '', $sql_lines[$i - 1]);
 
                     // prepare variable for constraints
-                    if (!isset($sql_constraints)) {
+                    if (! isset($sql_constraints)) {
                         if (isset($GLOBALS['no_constraints_comments'])) {
                             $sql_constraints = '';
                         } else {
@@ -873,7 +873,7 @@ if (isset($plugin_list)) {
                     }
 
                     // comments for current table
-                    if (!isset($GLOBALS['no_constraints_comments'])) {
+                    if (! isset($GLOBALS['no_constraints_comments'])) {
                         $sql_constraints .= $crlf
                                           . PMA_exportComment()
                                           . PMA_exportComment(__('Constraints for table') . ' ' . PMA_backquote($table))
@@ -888,7 +888,7 @@ if (isset($plugin_list)) {
                     $first = true;
                     for ($j = $i; $j < $sql_count; $j++) {
                         if (preg_match('@CONSTRAINT|FOREIGN[\s]+KEY@', $sql_lines[$j])) {
-                            if (!$first) {
+                            if (! $first) {
                                 $sql_constraints .= $crlf;
                             }
                             if (strpos($sql_lines[$j], 'CONSTRAINT') === false) {
@@ -953,7 +953,7 @@ if (isset($plugin_list)) {
         $schema_create = '';
 
         // Check if we can use Relations
-        if ($do_relation && !empty($cfgRelation['relation'])) {
+        if ($do_relation && ! empty($cfgRelation['relation'])) {
             // Find which tables are related with the current one and write it in
             // an array
             $res_rel = PMA_getForeigners($db, $table);
@@ -968,7 +968,7 @@ if (isset($plugin_list)) {
         } // end if
 
         if ($do_mime && $cfgRelation['mimework']) {
-            if (!($mime_map = PMA_getMIME($db, $table, true))) {
+            if (! ($mime_map = PMA_getMIME($db, $table, true))) {
                 unset($mime_map);
             }
         }
@@ -1206,7 +1206,7 @@ if (isset($plugin_list)) {
             $replace     = array('\0', '\n', '\r', '\Z');
             $current_row = 0;
             $query_size  = 0;
-            if (($GLOBALS['sql_insert_syntax'] == 'extended' || $GLOBALS['sql_insert_syntax'] == 'both') && (!isset($GLOBALS['sql_type']) || $GLOBALS['sql_type'] != 'UPDATE')) {
+            if (($GLOBALS['sql_insert_syntax'] == 'extended' || $GLOBALS['sql_insert_syntax'] == 'both') && (! isset($GLOBALS['sql_type']) || $GLOBALS['sql_type'] != 'UPDATE')) {
                 $separator    = ',';
                 $schema_insert .= $crlf;
             } else {
@@ -1227,7 +1227,7 @@ if (isset($plugin_list)) {
                 $current_row++;
                 for ($j = 0; $j < $fields_cnt; $j++) {
                     // NULL
-                    if (!isset($row[$j]) || is_null($row[$j])) {
+                    if (! isset($row[$j]) || is_null($row[$j])) {
                         $values[] = 'NULL';
                     // a number
                     // timestamp is numeric on some MySQL 4.1, BLOBs are sometimes numeric
@@ -1286,7 +1286,7 @@ if (isset($plugin_list)) {
                         } else {
                             $insert_line  = '(' . implode(', ', $values) . ')';
                             if (isset($GLOBALS['sql_max_query_size']) && $GLOBALS['sql_max_query_size'] > 0 && $query_size + strlen($insert_line) > $GLOBALS['sql_max_query_size']) {
-                                if (!PMA_exportOutputHandler(';' . $crlf)) {
+                                if (! PMA_exportOutputHandler(';' . $crlf)) {
                                     return false;
                                 }
                                 $query_size = 0;
@@ -1302,13 +1302,13 @@ if (isset($plugin_list)) {
                 }
                 unset($values);
 
-                if (!PMA_exportOutputHandler(($current_row == 1 ? '' : $separator . $crlf) . $insert_line)) {
+                if (! PMA_exportOutputHandler(($current_row == 1 ? '' : $separator . $crlf) . $insert_line)) {
                     return false;
                 }
 
             } // end while
             if ($current_row > 0) {
-                if (!PMA_exportOutputHandler(';' . $crlf)) {
+                if (! PMA_exportOutputHandler(';' . $crlf)) {
                     return false;
                 }
             }

--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -611,7 +611,7 @@ if (isset($plugin_list)) {
             $head .= 'SET FOREIGN_KEY_CHECKS=0;' . $crlf;
         }
 
-        // We want exported AUTO_INCREMENT columns to have still same value, 
+        // We want exported AUTO_INCREMENT columns to have still same value,
         // do this only for recent MySQL exports
         if ((! isset($GLOBALS['sql_compatibility'])
             || $GLOBALS['sql_compatibility'] == 'NONE')
@@ -881,7 +881,7 @@ if (isset($plugin_list)) {
             if (PMA_DBI_num_rows($result) > 0) {
                 $tmpres = PMA_DBI_fetch_assoc($result);
                 if (PMA_DRIZZLE && $show_dates) {
-                    // Drizzle doesn't give Create_time and Update_time in 
+                    // Drizzle doesn't give Create_time and Update_time in
                     // SHOW TABLE STATUS, add it
                     $sql ="SELECT
                             TABLE_CREATION_TIME AS Create_time,
@@ -962,7 +962,7 @@ if (isset($plugin_list)) {
         // because SHOW CREATE TABLE returns only one row, and we free the
         // results below. Nonetheless, we got 2 user reports about this
         // (see bug 1562533) so I removed the unbuffered mode.
-        // $result = PMA_DBI_query('SHOW CREATE TABLE ' . PMA_backquote($db) 
+        // $result = PMA_DBI_query('SHOW CREATE TABLE ' . PMA_backquote($db)
         // . '.' . PMA_backquote($table), null, PMA_DBI_QUERY_UNBUFFERED);
         //
         // Note: SHOW CREATE TABLE, at least in MySQL 5.1.23, does not
@@ -1028,7 +1028,7 @@ if (isset($plugin_list)) {
             // are there any constraints to cut out?
             if (preg_match('@CONSTRAINT|FOREIGN[\s]+KEY@', $create_query)) {
 
-                // Split the query into lines, so we can easily handle it. 
+                // Split the query into lines, so we can easily handle it.
                 // We know lines are separated by $crlf (done few lines above).
                 $sql_lines = explode($crlf, $create_query);
                 $sql_count = count($sql_lines);
@@ -1080,12 +1080,13 @@ if (isset($plugin_list)) {
                     }
 
                     // let's do the work
-                    $sql_constraints_query .= 'ALTER TABLE ' . PMA_backquote($table)
-                        . $crlf;
-                    $sql_constraints .= 'ALTER TABLE ' . PMA_backquote($table)
-                        . $crlf;
-                    $sql_drop_foreign_keys .= 'ALTER TABLE ' . PMA_backquote($db)
-                        . '.' . PMA_backquote($table) . $crlf;
+                    $sql_constraints_query .= 'ALTER TABLE '
+                        . PMA_backquote($table) . $crlf;
+                    $sql_constraints .= 'ALTER TABLE '
+                        . PMA_backquote($table) . $crlf;
+                    $sql_drop_foreign_keys .= 'ALTER TABLE '
+                        . PMA_backquote($db) . '.'
+                        . PMA_backquote($table) . $crlf;
 
                     $first = true;
                     for ($j = $i; $j < $sql_count; $j++) {
@@ -1131,12 +1132,16 @@ if (isset($plugin_list)) {
                     $sql_constraints .= ';' . $crlf;
                     $sql_constraints_query .= ';';
 
-                    $create_query = implode($crlf, array_slice($sql_lines, 0, $i))
-                    . $crlf
-                    . implode(
-                        $crlf,
-                        array_slice($sql_lines, $j, $sql_count - 1)
-                    );
+                    $create_query
+                        = implode(
+                            $crlf,
+                            array_slice($sql_lines, 0, $i)
+                        )
+                        . $crlf
+                        . implode(
+                            $crlf,
+                            array_slice($sql_lines, $j, $sql_count - 1)
+                        );
                     unset($sql_lines);
                 }
             }
@@ -1237,7 +1242,7 @@ if (isset($plugin_list)) {
                     . ':'
                 );
             foreach ($res_rel AS $rel_field => $rel) {
-                $schema_create .= 
+                $schema_create .=
                     PMA_exportComment(
                         '  '
                         . PMA_backquote($rel_field, $sql_backquotes)
@@ -1337,8 +1342,8 @@ if (isset($plugin_list)) {
                 . PMA_exportComment();
             // delete the stand-in table previously created (if any)
             if ($export_type != 'table') {
-                $dump .= 'DROP TABLE IF EXISTS ' . PMA_backquote($table)
-                    . ';' . $crlf;
+                $dump .= 'DROP TABLE IF EXISTS '
+                    . PMA_backquote($table) . ';' . $crlf;
             }
             $dump .= PMA_getTableDef(
                 $db, $table, $crlf, $error_url, $dates, true, true
@@ -1643,7 +1648,9 @@ if (isset($plugin_list)) {
                         // Other inserts case
                     } else {
                         $insert_line = $schema_insert
-                            . '(' . implode(', ', $values) . ')';
+                            . '('
+                            . implode(', ', $values)
+                            . ')';
                     }
                 }
                 unset($values);

--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -27,7 +27,8 @@ if (isset($plugin_list)) {
             'text' => __('SQL'),
             'extension' => 'sql',
             'mime_type' => 'text/x-sql',
-            'options' => array()
+            'options' => array(),
+            'options_text' => __('Options')
         );
 
         $plugin_list['sql']['options'][] = array(
@@ -102,8 +103,6 @@ if (isset($plugin_list)) {
                 'sysvar_foreign_key_checks'
             )
         );
-
-        $plugin_list['sql']['options_text'] = __('Options');
 
         /* compatibility maximization */
         $compats = PMA_DBI_getCompatibilities();

--- a/libraries/export/texytext.php
+++ b/libraries/export/texytext.php
@@ -90,7 +90,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -106,7 +106,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -120,7 +120,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -134,11 +134,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs the content of a table in Texy format
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
      *
      * @return bool Whether it succeeded
      *
@@ -149,8 +149,8 @@ if (isset($plugin_list)) {
         global $what;
 
         if (! PMA_exportOutputHandler(
-            '== ' . __('Dumping data for table') . ' ' . $table . "\n\n")
-        ) {
+            '== ' . __('Dumping data for table') . ' ' . $table . "\n\n"
+        )) {
             return false;
         }
 
@@ -393,10 +393,10 @@ if (isset($plugin_list)) {
     /**
      * Outputs triggers
      *
-     * @param string $db     database name
-     * @param string $table  table name
+     * @param string $db    database name
+     * @param string $table table name
      *
-     * @return string        Formatted triggers list
+     * @return string Formatted triggers list
      *
      * @access public
      */
@@ -432,24 +432,24 @@ if (isset($plugin_list)) {
     /**
      * Outputs table's structure
      *
-     * @param string  $db           database name
-     * @param string  $table        table name
-     * @param string  $crlf         the end of line sequence
-     * @param string  $error_url    the url to go back in case of error
-     * @param bool    $do_relation  whether to include relation comments
-     * @param bool    $do_comments  whether to include the pmadb-style column
+     * @param string $db          database name
+     * @param string $table       table name
+     * @param string $crlf        the end of line sequence
+     * @param string $error_url   the url to go back in case of error
+     * @param bool   $do_relation whether to include relation comments
+     * @param bool   $do_comments whether to include the pmadb-style column
      *                                comments as comments in the structure;
      *                                this is deprecated but the parameter is
      *                                left here because export.php calls
      *                                PMA_exportStructure() also for other
      *                                export types which use this parameter
-     * @param bool    $do_mime      whether to include mime comments
-     * @param bool    $dates        whether to include creation/update/check dates
-     * @param string  $export_mode  'create_table', 'triggers', 'create_view',
-     *                              'stand_in'
-     * @param string  $export_type  'server', 'database', 'table'
+     * @param bool   $do_mime     whether to include mime comments
+     * @param bool   $dates       whether to include creation/update/check dates
+     * @param string $export_mode 'create_table', 'triggers', 'create_view',
+     *                            'stand_in'
+     * @param string $export_type 'server', 'database', 'table'
      *
-     * @return bool      Whether it succeeded
+     * @return bool Whether it succeeded
      *
      * @access public
      */
@@ -503,10 +503,10 @@ if (isset($plugin_list)) {
     /**
      * Formats the definition for one column 
      *
-     * @param array $column  info about this column 
-     * @param array $unique_keys  unique keys for this table 
+     * @param array $column      info about this column 
+     * @param array $unique_keys unique keys for this table 
      *
-     * @return string        Formatted column definition
+     * @return string Formatted column definition
      *
      * @access public
      */

--- a/libraries/export/texytext.php
+++ b/libraries/export/texytext.php
@@ -66,9 +66,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -78,9 +78,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -92,9 +92,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -108,9 +108,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -122,9 +122,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -140,9 +140,9 @@ if (isset($plugin_list)) {
      * @param string  $error_url  the url to go back in case of error
      * @param string  $sql_query  SQL query for obtaining data
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {
@@ -451,7 +451,7 @@ if (isset($plugin_list)) {
      *
      * @return bool      Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportStructure(
         $db,

--- a/libraries/export/texytext.php
+++ b/libraries/export/texytext.php
@@ -22,7 +22,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['texytext']['options'][] = array(
+    $plugin_list['texytext']['options'] = array(
         /* what to dump (structure/data/both) */
         array(
             'type' => 'begin_group',

--- a/libraries/export/texytext.php
+++ b/libraries/export/texytext.php
@@ -19,17 +19,46 @@ if (isset($plugin_list)) {
         'extension' => 'txt',
         'mime_type' => 'text/plain',
         'options' => array(
-        /* what to dump (structure/data/both) */
-        array('type' => 'begin_group', 'text' => __('Dump table'), 'name' => 'general_opts'),
-        array('type' => 'radio', 'name' => 'structure_or_data', 'values' => array('structure' => __('structure'), 'data' => __('data'), 'structure_and_data' => __('structure and data'))),
-        array('type' => 'end_group'),
-        array('type' => 'begin_group', 'name' => 'data', 'text' => __('Data dump options'), 'force' => 'structure'),
-        array('type' => 'text', 'name' => 'null', 'text' => __('Replace NULL by')),
-        array('type' => 'bool', 'name' => 'columns', 'text' => __('Put columns names in the first row')),
-        array('type' => 'end_group'),
+            /* what to dump (structure/data/both) */
+            array(
+                'type' => 'begin_group',
+                'text' => __('Dump table'),
+                'name' => 'general_opts'
+            ),
+            array(
+                'type' => 'radio',
+                'name' => 'structure_or_data',
+                'values' => array(
+                    'structure' => __('structure'),
+                    'data' => __('data'),
+                    'structure_and_data' => __('structure and data')
+                )
+            ),
+            array(
+                'type' => 'end_group'
+            ),
+            array(
+                'type' => 'begin_group', 
+                'name' => 'data',
+                'text' => __('Data dump options'),
+                'force' => 'structure'
+            ),
+            array(
+                'type' => 'text',
+                'name' => 'null',
+                'text' => __('Replace NULL by')
+            ),
+            array(
+                'type' => 'bool',
+                'name' => 'columns',
+                'text' => __('Put columns names in the first row')
+            ),
+            array(
+                'type' => 'end_group'
+            ),
         ),
         'options_text' => __('Options'),
-        );
+    );
 } else {
 
     /**
@@ -67,7 +96,9 @@ if (isset($plugin_list)) {
      */
     function PMA_exportDBHeader($db)
     {
-        return PMA_exportOutputHandler('===' . __('Database') . ' ' . $db . "\n\n");
+        return PMA_exportOutputHandler(
+            '===' . __('Database') . ' ' . $db . "\n\n"
+        );
     }
 
     /**
@@ -115,7 +146,9 @@ if (isset($plugin_list)) {
     {
         global $what;
 
-        if (! PMA_exportOutputHandler('== ' . __('Dumping data for table') . ' ' . $table . "\n\n")) {
+        if (! PMA_exportOutputHandler(
+            '== ' . __('Dumping data for table') . ' ' . $table . "\n\n")
+        ) {
             return false;
         }
 
@@ -127,7 +160,10 @@ if (isset($plugin_list)) {
         if (isset($GLOBALS[$what . '_columns'])) {
             $text_output = "|------\n";
             for ($i = 0; $i < $fields_cnt; $i++) {
-                $text_output .= '|' . htmlspecialchars(stripslashes(PMA_DBI_field_name($result, $i)));
+                $text_output .= '|'
+                    . htmlspecialchars(
+                        stripslashes(PMA_DBI_field_name($result, $i))
+                    );
             } // end for
             $text_output .= "\n|------\n";
             if (! PMA_exportOutputHandler($text_output)) {
@@ -146,7 +182,10 @@ if (isset($plugin_list)) {
                 } else {
                     $value = ' ';
                 }
-                $text_output .= '|' . str_replace('|', '&#124;', htmlspecialchars($value));
+                $text_output .= '|'
+                    . str_replace(
+                        '|', '&#124;', htmlspecialchars($value)
+                    );
             } // end for
             $text_output .= "\n";
             if (! PMA_exportOutputHandler($text_output)) {
@@ -219,22 +258,34 @@ if (isset($plugin_list)) {
      * @param string $crlf          the end of line sequence
      * @param string $error_url     the url to go back in case of error
      * @param bool   $do_relation   whether to include relation comments
-     * @param bool   $do_comments   whether to include the pmadb-style column comments
-     *                                as comments in the structure; this is deprecated
-     *                                but the parameter is left here because export.php
-     *                                calls PMA_exportStructure() also for other export
-     *                                types which use this parameter
+     * @param bool   $do_comments   whether to include the pmadb-style column
+     *                                comments as comments in the structure; 
+     *                                this is deprecated but the parameter is
+     *                                left here because export.php calls
+     *                                PMA_exportStructure() also for other
+     *                                export types which use this parameter
      * @param bool   $do_mime       whether to include mime comments
      * @param bool   $show_dates    whether to include creation/update/check dates
-     * @param bool   $add_semicolon whether to add semicolon and end-of-line at the end
+     * @param bool   $add_semicolon whether to add semicolon and end-of-line
+     *                              at the end
      * @param bool   $view          whether we're handling a view
      *
      * @return string resulting schema
      *
      * @access public
      */
-    function PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime, $show_dates = false, $add_semicolon = true, $view = false)
-    {
+    function PMA_getTableDef(
+        $db,
+        $table,
+        $crlf,
+        $error_url,
+        $do_relation,
+        $do_comments,
+        $do_mime,
+        $show_dates = false,
+        $add_semicolon = true,
+        $view = false
+    ) {
         global $cfgRelation;
 
         $text_output = '';
@@ -309,13 +360,26 @@ if (isset($plugin_list)) {
             $field_name = $column['Field'];
 
             if ($do_relation && $have_rel) {
-                $text_output .= '|' . (isset($res_rel[$field_name]) ? htmlspecialchars($res_rel[$field_name]['foreign_table'] . ' (' . $res_rel[$field_name]['foreign_field'] . ')') : '');
+                $text_output .= '|'
+                    . (isset($res_rel[$field_name])
+                    ? htmlspecialchars(
+                        $res_rel[$field_name]['foreign_table']
+                        . ' (' . $res_rel[$field_name]['foreign_field'] . ')'
+                    )
+                    : '');
             }
             if ($do_comments && $cfgRelation['commwork']) {
-                $text_output .= '|' . (isset($comments[$field_name]) ? htmlspecialchars($comments[$field_name]) : '');
+                $text_output .= '|'
+                    . (isset($comments[$field_name])
+                    ? htmlspecialchars($comments[$field_name]) : '');
             }
             if ($do_mime && $cfgRelation['mimework']) {
-                $text_output .= '|' . (isset($mime_map[$field_name]) ? htmlspecialchars(str_replace('_', '/', $mime_map[$field_name]['mimetype'])) : '');
+                $text_output .= '|'
+                    . (isset($mime_map[$field_name])
+                    ? htmlspecialchars(
+                        str_replace('_', '/', $mime_map[$field_name]['mimetype'])
+                    )
+                    : '');
             }
 
             $text_output .= "\n";
@@ -351,7 +415,12 @@ if (isset($plugin_list)) {
             $dump .= '|' . $trigger['name'];
             $dump .= '|' . $trigger['action_timing'];
             $dump .= '|' . $trigger['event_manipulation'];
-            $dump .= '|' . str_replace('|', '&#124;', htmlspecialchars($trigger['definition']));
+            $dump .= '|' .
+                str_replace(
+                    '|',
+                    '&#124;',
+                    htmlspecialchars($trigger['definition'])
+                );
             $dump .= "\n";
         }
 
@@ -366,28 +435,43 @@ if (isset($plugin_list)) {
      * @param string  $crlf         the end of line sequence
      * @param string  $error_url    the url to go back in case of error
      * @param bool    $do_relation  whether to include relation comments
-     * @param bool    $do_comments  whether to include the pmadb-style column comments
-     *                                as comments in the structure; this is deprecated
-     *                                but the parameter is left here because export.php
-     *                                calls PMA_exportStructure() also for other export
-     *                                types which use this parameter
+     * @param bool    $do_comments  whether to include the pmadb-style column
+     *                                comments as comments in the structure;
+     *                                this is deprecated but the parameter is
+     *                                left here because export.php calls
+     *                                PMA_exportStructure() also for other
+     *                                export types which use this parameter
      * @param bool    $do_mime      whether to include mime comments
      * @param bool    $dates        whether to include creation/update/check dates
-     * @param string  $export_mode  'create_table', 'triggers', 'create_view', 'stand_in'
+     * @param string  $export_mode  'create_table', 'triggers', 'create_view',
+     *                              'stand_in'
      * @param string  $export_type  'server', 'database', 'table'
      *
      * @return bool      Whether it succeeded
      *
      * @access  public
      */
-    function PMA_exportStructure($db, $table, $crlf, $error_url, $do_relation = false, $do_comments = false, $do_mime = false, $dates = false, $export_mode, $export_type)
-    {
+    function PMA_exportStructure(
+        $db,
+        $table,
+        $crlf,
+        $error_url,
+        $do_relation = false,
+        $do_comments = false,
+        $do_mime = false,
+        $dates = false,
+        $export_mode,
+        $export_type
+    ) {
         $dump = '';
 
         switch($export_mode) {
         case 'create_table':
             $dump .= '== ' . __('Table structure for table') . ' ' .$table . "\n\n";
-            $dump .= PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime, $dates);
+            $dump .= PMA_getTableDef(
+                $db, $table, $crlf, $error_url, $do_relation, $do_comments,
+                $do_mime, $dates
+            );
             break;
         case 'triggers':
             $dump = '';
@@ -399,10 +483,14 @@ if (isset($plugin_list)) {
             break;
         case 'create_view':
             $dump .= '== ' . __('Structure for view') . ' ' .$table . "\n\n";
-            $dump .= PMA_getTableDef($db, $table, $crlf, $error_url, $do_relation, $do_comments, $do_mime, $dates, true, true);
+            $dump .= PMA_getTableDef(
+                $db, $table, $crlf, $error_url, $do_relation, $do_comments,
+                $do_mime, $dates, true, true
+            );
             break;
         case 'stand_in':
-            $dump .=  '== ' . __('Stand-in structure for view') . ' ' .$table . "\n\n";
+            $dump .=  '== ' . __('Stand-in structure for view')
+                . ' ' .$table . "\n\n";
             // export a stand-in definition to resolve view dependencies
             $dump .= PMA_getTableDefStandIn($db, $table, $crlf);
         } // end switch
@@ -445,10 +533,16 @@ if (isset($plugin_list)) {
             $fmt_pre = '//' . $fmt_pre;
             $fmt_post = $fmt_post . '//';
         }
-        $definition = '|' . $fmt_pre . htmlspecialchars($column['Field']) . $fmt_post;
+        $definition = '|'
+            . $fmt_pre . htmlspecialchars($column['Field']) . $fmt_post;
         $definition .= '|' . htmlspecialchars($type);
-        $definition .= '|' . (($column['Null'] == '' || $column['Null'] == 'NO') ? __('No') : __('Yes'));
-        $definition .= '|' . htmlspecialchars(isset($column['Default']) ? $column['Default'] : '');
+        $definition .= '|'
+            . (($column['Null'] == '' || $column['Null'] == 'NO')
+            ? __('No') : __('Yes'));
+        $definition .= '|'
+            . htmlspecialchars(
+                isset($column['Default']) ? $column['Default'] : ''
+            );
         return $definition;
     }
 }

--- a/libraries/export/texytext.php
+++ b/libraries/export/texytext.php
@@ -436,6 +436,9 @@ if (isset($plugin_list)) {
      * @param string $table       table name
      * @param string $crlf        the end of line sequence
      * @param string $error_url   the url to go back in case of error
+     * @param string $export_mode 'create_table', 'triggers', 'create_view',
+     *                            'stand_in'
+     * @param string $export_type 'server', 'database', 'table'
      * @param bool   $do_relation whether to include relation comments
      * @param bool   $do_comments whether to include the pmadb-style column
      *                                comments as comments in the structure;
@@ -445,9 +448,6 @@ if (isset($plugin_list)) {
      *                                export types which use this parameter
      * @param bool   $do_mime     whether to include mime comments
      * @param bool   $dates       whether to include creation/update/check dates
-     * @param string $export_mode 'create_table', 'triggers', 'create_view',
-     *                            'stand_in'
-     * @param string $export_type 'server', 'database', 'table'
      *
      * @return bool Whether it succeeded
      *
@@ -458,12 +458,12 @@ if (isset($plugin_list)) {
         $table,
         $crlf,
         $error_url,
+        $export_mode,
+        $export_type,
         $do_relation = false,
         $do_comments = false,
         $do_mime = false,
-        $dates = false,
-        $export_mode,
-        $export_type
+        $dates = false
     ) {
         $dump = '';
 

--- a/libraries/export/texytext.php
+++ b/libraries/export/texytext.php
@@ -18,46 +18,48 @@ if (isset($plugin_list)) {
         'text' => __('Texy! text'),
         'extension' => 'txt',
         'mime_type' => 'text/plain',
-        'options' => array(
-            /* what to dump (structure/data/both) */
-            array(
-                'type' => 'begin_group',
-                'text' => __('Dump table'),
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'radio',
-                'name' => 'structure_or_data',
-                'values' => array(
-                    'structure' => __('structure'),
-                    'data' => __('data'),
-                    'structure_and_data' => __('structure and data')
-                )
-            ),
-            array(
-                'type' => 'end_group'
-            ),
-            array(
-                'type' => 'begin_group', 
-                'name' => 'data',
-                'text' => __('Data dump options'),
-                'force' => 'structure'
-            ),
-            array(
-                'type' => 'text',
-                'name' => 'null',
-                'text' => __('Replace NULL by')
-            ),
-            array(
-                'type' => 'bool',
-                'name' => 'columns',
-                'text' => __('Put columns names in the first row')
-            ),
-            array(
-                'type' => 'end_group'
-            ),
+        'options' => array(),
+        'options_text' => __('Options')
+    );
+
+    $plugin_list['texytext']['options'][] = array(
+        /* what to dump (structure/data/both) */
+        array(
+            'type' => 'begin_group',
+            'text' => __('Dump table'),
+            'name' => 'general_opts'
         ),
-        'options_text' => __('Options'),
+        array(
+            'type' => 'radio',
+            'name' => 'structure_or_data',
+            'values' => array(
+                'structure' => __('structure'),
+                'data' => __('data'),
+                'structure_and_data' => __('structure and data')
+            )
+        ),
+        array(
+            'type' => 'end_group'
+        ),
+        array(
+            'type' => 'begin_group', 
+            'name' => 'data',
+            'text' => __('Data dump options'),
+            'force' => 'structure'
+        ),
+        array(
+            'type' => 'text',
+            'name' => 'null',
+            'text' => __('Replace NULL by')
+        ),
+        array(
+            'type' => 'bool',
+            'name' => 'columns',
+            'text' => __('Put columns names in the first row')
+        ),
+        array(
+            'type' => 'end_group'
+        )
     );
 } else {
 

--- a/libraries/export/texytext.php
+++ b/libraries/export/texytext.php
@@ -42,7 +42,7 @@ if (isset($plugin_list)) {
             'type' => 'end_group'
         ),
         array(
-            'type' => 'begin_group', 
+            'type' => 'begin_group',
             'name' => 'data',
             'text' => __('Data dump options'),
             'force' => 'structure'
@@ -261,7 +261,7 @@ if (isset($plugin_list)) {
      * @param string $error_url     the url to go back in case of error
      * @param bool   $do_relation   whether to include relation comments
      * @param bool   $do_comments   whether to include the pmadb-style column
-     *                                comments as comments in the structure; 
+     *                                comments as comments in the structure;
      *                                this is deprecated but the parameter is
      *                                left here because export.php calls
      *                                PMA_exportStructure() also for other
@@ -373,7 +373,8 @@ if (isset($plugin_list)) {
             if ($do_comments && $cfgRelation['commwork']) {
                 $text_output .= '|'
                     . (isset($comments[$field_name])
-                    ? htmlspecialchars($comments[$field_name]) : '');
+                    ? htmlspecialchars($comments[$field_name])
+                    : '');
             }
             if ($do_mime && $cfgRelation['mimework']) {
                 $text_output .= '|'
@@ -503,8 +504,8 @@ if (isset($plugin_list)) {
     /**
      * Formats the definition for one column 
      *
-     * @param array $column      info about this column 
-     * @param array $unique_keys unique keys for this table 
+     * @param array $column      info about this column
+     * @param array $unique_keys unique keys for this table
      *
      * @return string Formatted column definition
      *

--- a/libraries/export/texytext.php
+++ b/libraries/export/texytext.php
@@ -3,7 +3,7 @@
 /**
  * Export to Texy! text.
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage Texy
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/xml.php
+++ b/libraries/export/xml.php
@@ -95,9 +95,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -109,9 +109,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -316,9 +316,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -343,9 +343,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -365,9 +365,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -383,9 +383,9 @@ if (isset($plugin_list)) {
      * @param string  $error_url  the url to go back in case of error
      * @param string  $sql_query  SQL query for obtaining data
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {

--- a/libraries/export/xml.php
+++ b/libraries/export/xml.php
@@ -361,13 +361,13 @@ if (isset($plugin_list)) {
             }
             unset($i);
 
-            $buffer      = '        <!-- ' . __('Table') . ' ' . $table . ' -->' . $crlf;
+            $buffer = '        <!-- ' . __('Table') . ' ' . $table . ' -->' . $crlf;
             if (! PMA_exportOutputHandler($buffer)) {
                 return false;
             }
 
             while ($record = PMA_DBI_fetch_row($result)) {
-                $buffer         = '        <table name="' . htmlspecialchars($table) . '">' . $crlf;
+                $buffer      = '        <table name="' . htmlspecialchars($table) . '">' . $crlf;
                 for ($i = 0; $i < $columns_cnt; $i++) {
                     // If a cell is NULL, still export it to preserve the XML structure
                     if (! isset($record[$i]) || is_null($record[$i])) {
@@ -376,7 +376,7 @@ if (isset($plugin_list)) {
                     $buffer .= '            <column name="' . htmlspecialchars($columns[$i]) . '">' . htmlspecialchars((string)$record[$i])
                             .  '</column>' . $crlf;
                 }
-                $buffer         .= '        </table>' . $crlf;
+                $buffer     .= '        </table>' . $crlf;
 
                 if (! PMA_exportOutputHandler($buffer)) {
                     return false;

--- a/libraries/export/xml.php
+++ b/libraries/export/xml.php
@@ -20,66 +20,74 @@ if (isset($plugin_list)) {
         'extension' => 'xml',
         'mime_type' => 'text/xml',
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
-            array('type' => 'hidden', 'name' => 'structure_or_data'),
-            array('type' => 'end_group')
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
             ),
+            array(
+                'type' => 'hidden',
+                'name' => 'structure_or_data'
+            ),
+            array(
+                'type' => 'end_group'
+            )
+        ),
         'options_text' => __('Options')
-        );
+    );
 
     /* Export structure */
     $plugin_list['xml']['options'][] = array(
         'type' => 'begin_group',
         'name' => 'structure',
         'text' => __('Object creation options (all are recommended)')
-        );
+    );
     if (! PMA_DRIZZLE) {
         $plugin_list['xml']['options'][] = array(
             'type' => 'bool',
             'name' => 'export_functions',
             'text' => __('Functions')
-            );
+        );
         $plugin_list['xml']['options'][] = array(
             'type' => 'bool',
             'name' => 'export_procedures',
             'text' => __('Procedures')
-            );
+        );
     }
     $plugin_list['xml']['options'][] = array(
         'type' => 'bool',
         'name' => 'export_tables',
         'text' => __('Tables')
-        );
+    );
     if (! PMA_DRIZZLE) {
         $plugin_list['xml']['options'][] = array(
             'type' => 'bool',
             'name' => 'export_triggers',
             'text' => __('Triggers')
-            );
+        );
         $plugin_list['xml']['options'][] = array(
             'type' => 'bool',
             'name' => 'export_views',
             'text' => __('Views')
-            );
+        );
     }
     $plugin_list['xml']['options'][] = array(
         'type' => 'end_group'
-        );
+    );
 
     /* Data */
     $plugin_list['xml']['options'][] = array(
         'type' => 'begin_group',
         'name' => 'data',
         'text' => __('Data dump options')
-        );
+    );
     $plugin_list['xml']['options'][] = array(
         'type' => 'bool',
         'name' => 'export_contents',
         'text' => __('Export contents')
-        );
+    );
     $plugin_list['xml']['options'][] = array(
         'type' => 'end_group'
-        );
+    );
 } else {
 
     /**
@@ -111,8 +119,10 @@ if (isset($plugin_list)) {
         global $table;
         global $tables;
 
-        $export_struct = isset($GLOBALS['xml_export_functions']) || isset($GLOBALS['xml_export_procedures'])
-            || isset($GLOBALS['xml_export_tables']) || isset($GLOBALS['xml_export_triggers'])
+        $export_struct = isset($GLOBALS['xml_export_functions'])
+            || isset($GLOBALS['xml_export_procedures'])
+            || isset($GLOBALS['xml_export_tables'])
+            || isset($GLOBALS['xml_export_triggers'])
             || isset($GLOBALS['xml_export_views']);
         $export_data = isset($GLOBALS['xml_export_contents']) ? true : false;
 
@@ -138,7 +148,11 @@ if (isset($plugin_list)) {
                .  '- ' . __('PHP Version') . ': ' . phpversion() . $crlf
                .  '-->' . $crlf . $crlf;
 
-        $head .= '<pma_xml_export version="1.0"' . (($export_struct) ? ' xmlns:pma="http://www.phpmyadmin.net/some_doc_url/"' : '') . '>' . $crlf;
+        $head .= '<pma_xml_export version="1.0"'
+            . (($export_struct)
+            ? ' xmlns:pma="http://www.phpmyadmin.net/some_doc_url/"'
+            : '')
+            . '>' . $crlf;
 
         if ($export_struct) {
             if (PMA_DRIZZLE) {
@@ -150,7 +164,11 @@ if (isset($plugin_list)) {
                     WHERE SCHEMA_NAME = '" . PMA_sqlAddSlashes($db) . "'"
                 );
             } else {
-                $result = PMA_DBI_fetch_result('SELECT `DEFAULT_CHARACTER_SET_NAME`, `DEFAULT_COLLATION_NAME` FROM `information_schema`.`SCHEMATA` WHERE `SCHEMA_NAME` = \''.PMA_sqlAddSlashes($db).'\' LIMIT 1');
+                $result = PMA_DBI_fetch_result(
+                    'SELECT `DEFAULT_CHARACTER_SET_NAME`, `DEFAULT_COLLATION_NAME`'
+                    . ' FROM `information_schema`.`SCHEMATA` WHERE `SCHEMA_NAME`'
+                    . ' = \''.PMA_sqlAddSlashes($db).'\' LIMIT 1'
+                );
             }
             $db_collation = $result[0]['DEFAULT_COLLATION_NAME'];
             $db_charset = $result[0]['DEFAULT_CHARACTER_SET_NAME'];
@@ -159,7 +177,9 @@ if (isset($plugin_list)) {
             $head .= '    - Structure schemas' . $crlf;
             $head .= '    -->' . $crlf;
             $head .= '    <pma:structure_schemas>' . $crlf;
-            $head .= '        <pma:database name="' . htmlspecialchars($db) . '" collation="' . $db_collation . '" charset="' . $db_charset . '">' . $crlf;
+            $head .= '        <pma:database name="' . htmlspecialchars($db)
+                . '" collation="' . $db_collation . '" charset="' . $db_charset
+                . '">' . $crlf;
 
             if (count($tables) == 0) {
                 $tables[] = $table;
@@ -167,7 +187,11 @@ if (isset($plugin_list)) {
 
             foreach ($tables as $table) {
                 // Export tables and views
-                $result = PMA_DBI_fetch_result('SHOW CREATE TABLE ' . PMA_backquote($db) . '.' . PMA_backquote($table), 0);
+                $result = PMA_DBI_fetch_result(
+                    'SHOW CREATE TABLE ' . PMA_backquote($db) . '.'
+                    . PMA_backquote($table),
+                    0
+                );
                 $tbl =  $result[$table][1];
 
                 $is_view = PMA_Table::isView($db, $table);
@@ -186,7 +210,8 @@ if (isset($plugin_list)) {
                     continue;
                 }
 
-                $head .= '            <pma:' . $type . ' name="' . $table . '">' . $crlf;
+                $head .= '            <pma:' . $type . ' name="' . $table . '">'
+                    . $crlf;
 
                 $tbl = "                " . htmlspecialchars($tbl);
                 $tbl = str_replace("\n", "\n                ", $tbl);
@@ -194,13 +219,15 @@ if (isset($plugin_list)) {
                 $head .= $tbl . ';' . $crlf;
                 $head .= '            </pma:' . $type . '>' . $crlf;
 
-                if (isset($GLOBALS['xml_export_triggers']) && $GLOBALS['xml_export_triggers']) {
+                if (isset($GLOBALS['xml_export_triggers'])
+                    && $GLOBALS['xml_export_triggers']) {
                     // Export triggers
                     $triggers = PMA_DBI_get_triggers($db, $table);
                     if ($triggers) {
                         foreach ($triggers as $trigger) {
                             $code = $trigger['create'];
-                            $head .= '            <pma:trigger name="' . $trigger['name'] . '">' . $crlf;
+                            $head .= '            <pma:trigger name="'
+                                . $trigger['name'] . '">' . $crlf;
 
                             // Do some formatting
                             $code = substr(rtrim($code), 0, -3);
@@ -217,12 +244,15 @@ if (isset($plugin_list)) {
                 }
             }
 
-            if (isset($GLOBALS['xml_export_functions']) && $GLOBALS['xml_export_functions']) {
+            if (isset($GLOBALS['xml_export_functions'])
+                && $GLOBALS['xml_export_functions']
+            ) {
                 // Export functions
                 $functions = PMA_DBI_get_procedures_or_functions($db, 'FUNCTION');
                 if ($functions) {
                     foreach ($functions as $function) {
-                        $head .= '            <pma:function name="' . $function . '">' . $crlf;
+                        $head .= '            <pma:function name="'
+                            . $function . '">' . $crlf;
 
                         // Do some formatting
                         $sql = PMA_DBI_get_definition($db, 'FUNCTION', $function);
@@ -240,12 +270,15 @@ if (isset($plugin_list)) {
                 }
             }
 
-            if (isset($GLOBALS['xml_export_procedures']) && $GLOBALS['xml_export_procedures']) {
+            if (isset($GLOBALS['xml_export_procedures'])
+                && $GLOBALS['xml_export_procedures']
+            ) {
                 // Export procedures
                 $procedures = PMA_DBI_get_procedures_or_functions($db, 'PROCEDURE');
                 if ($procedures) {
                     foreach ($procedures as $procedure) {
-                        $head .= '            <pma:procedure name="' . $procedure . '">' . $crlf;
+                        $head .= '            <pma:procedure name="'
+                            . $procedure . '">' . $crlf;
 
                         // Do some formatting
                         $sql = PMA_DBI_get_definition($db, 'PROCEDURE', $procedure);
@@ -289,7 +322,9 @@ if (isset($plugin_list)) {
     {
         global $crlf;
 
-        if (isset($GLOBALS['xml_export_contents']) && $GLOBALS['xml_export_contents']) {
+        if (isset($GLOBALS['xml_export_contents'])
+            && $GLOBALS['xml_export_contents']
+        ) {
             $head = '    <!--' . $crlf
                   . '    - ' . __('Database') . ': ' .  '\'' . $db . '\'' . $crlf
                   . '    -->' . $crlf
@@ -314,7 +349,9 @@ if (isset($plugin_list)) {
     {
         global $crlf;
 
-        if (isset($GLOBALS['xml_export_contents']) && $GLOBALS['xml_export_contents']) {
+        if (isset($GLOBALS['xml_export_contents'])
+            && $GLOBALS['xml_export_contents']
+        ) {
             return PMA_exportOutputHandler('    </database>' . $crlf);
         } else {
             return true;
@@ -351,8 +388,10 @@ if (isset($plugin_list)) {
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {
 
-        if (isset($GLOBALS['xml_export_contents']) && $GLOBALS['xml_export_contents']) {
-            $result      = PMA_DBI_query($sql_query, null, PMA_DBI_QUERY_UNBUFFERED);
+        if (isset($GLOBALS['xml_export_contents'])
+            && $GLOBALS['xml_export_contents']
+        ) {
+            $result = PMA_DBI_query($sql_query, null, PMA_DBI_QUERY_UNBUFFERED);
 
             $columns_cnt = PMA_DBI_num_fields($result);
             $columns = array();
@@ -367,14 +406,18 @@ if (isset($plugin_list)) {
             }
 
             while ($record = PMA_DBI_fetch_row($result)) {
-                $buffer      = '        <table name="' . htmlspecialchars($table) . '">' . $crlf;
+                $buffer = '        <table name="'
+                    . htmlspecialchars($table) . '">' . $crlf;
                 for ($i = 0; $i < $columns_cnt; $i++) {
-                    // If a cell is NULL, still export it to preserve the XML structure
+                    // If a cell is NULL, still export it to preserve
+                    // the XML structure
                     if (! isset($record[$i]) || is_null($record[$i])) {
                         $record[$i] = 'NULL';
                     }
-                    $buffer .= '            <column name="' . htmlspecialchars($columns[$i]) . '">' . htmlspecialchars((string)$record[$i])
-                            .  '</column>' . $crlf;
+                    $buffer .= '            <column name="'
+                        . htmlspecialchars($columns[$i]) . '">'
+                        . htmlspecialchars((string)$record[$i])
+                        .  '</column>' . $crlf;
                 }
                 $buffer     .= '        </table>' . $crlf;
 

--- a/libraries/export/xml.php
+++ b/libraries/export/xml.php
@@ -10,7 +10,7 @@ if (! defined('PHPMYADMIN')) {
     exit;
 }
 
-if (!strlen($GLOBALS['db'])) { /* Can't do server export */
+if (! strlen($GLOBALS['db'])) { /* Can't do server export */
     return;
 }
 
@@ -33,7 +33,7 @@ if (isset($plugin_list)) {
         'name' => 'structure',
         'text' => __('Object creation options (all are recommended)')
         );
-    if (!PMA_DRIZZLE) {
+    if (! PMA_DRIZZLE) {
         $plugin_list['xml']['options'][] = array(
             'type' => 'bool',
             'name' => 'export_functions',
@@ -50,7 +50,7 @@ if (isset($plugin_list)) {
         'name' => 'export_tables',
         'text' => __('Tables')
         );
-    if (!PMA_DRIZZLE) {
+    if (! PMA_DRIZZLE) {
         $plugin_list['xml']['options'][] = array(
             'type' => 'bool',
             'name' => 'export_triggers',
@@ -129,7 +129,7 @@ if (isset($plugin_list)) {
                .  '- http://www.phpmyadmin.net' . $crlf
                .  '-' . $crlf
                .  '- ' . __('Host') . ': ' . $cfg['Server']['host'];
-        if (!empty($cfg['Server']['port'])) {
+        if (! empty($cfg['Server']['port'])) {
              $head .= ':' . $cfg['Server']['port'];
         }
         $head .= $crlf
@@ -362,7 +362,7 @@ if (isset($plugin_list)) {
             unset($i);
 
             $buffer      = '        <!-- ' . __('Table') . ' ' . $table . ' -->' . $crlf;
-            if (!PMA_exportOutputHandler($buffer)) {
+            if (! PMA_exportOutputHandler($buffer)) {
                 return false;
             }
 
@@ -370,7 +370,7 @@ if (isset($plugin_list)) {
                 $buffer         = '        <table name="' . htmlspecialchars($table) . '">' . $crlf;
                 for ($i = 0; $i < $columns_cnt; $i++) {
                     // If a cell is NULL, still export it to preserve the XML structure
-                    if (!isset($record[$i]) || is_null($record[$i])) {
+                    if (! isset($record[$i]) || is_null($record[$i])) {
                         $record[$i] = 'NULL';
                     }
                     $buffer .= '            <column name="' . htmlspecialchars($columns[$i]) . '">' . htmlspecialchars((string)$record[$i])
@@ -378,7 +378,7 @@ if (isset($plugin_list)) {
                 }
                 $buffer         .= '        </table>' . $crlf;
 
-                if (!PMA_exportOutputHandler($buffer)) {
+                if (! PMA_exportOutputHandler($buffer)) {
                     return false;
                 }
             }

--- a/libraries/export/xml.php
+++ b/libraries/export/xml.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build XML dumps of tables
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage XML
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/xml.php
+++ b/libraries/export/xml.php
@@ -23,7 +23,7 @@ if (isset($plugin_list)) {
         'options_text' => __('Options')
     );
 
-    $plugin_list['xml']['options'][] = array(
+    $plugin_list['xml']['options'] = array(
         array(
             'type' => 'begin_group',
             'name' => 'general_opts'

--- a/libraries/export/xml.php
+++ b/libraries/export/xml.php
@@ -19,20 +19,22 @@ if (isset($plugin_list)) {
         'text' => __('XML'),
         'extension' => 'xml',
         'mime_type' => 'text/xml',
-        'options' => array(
-            array(
-                'type' => 'begin_group',
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'hidden',
-                'name' => 'structure_or_data'
-            ),
-            array(
-                'type' => 'end_group'
-            )
-        ),
+        'options' => array(),
         'options_text' => __('Options')
+    );
+
+    $plugin_list['xml']['options'][] = array(
+        array(
+            'type' => 'begin_group',
+            'name' => 'general_opts'
+        ),
+        array(
+            'type' => 'hidden',
+            'name' => 'structure_or_data'
+        ),
+        array(
+            'type' => 'end_group'
+        )
     );
 
     /* Export structure */

--- a/libraries/export/xml.php
+++ b/libraries/export/xml.php
@@ -222,7 +222,8 @@ if (isset($plugin_list)) {
                 $head .= '            </pma:' . $type . '>' . $crlf;
 
                 if (isset($GLOBALS['xml_export_triggers'])
-                    && $GLOBALS['xml_export_triggers']) {
+                    && $GLOBALS['xml_export_triggers']
+                ) {
                     // Export triggers
                     $triggers = PMA_DBI_get_triggers($db, $table);
                     if ($triggers) {
@@ -314,7 +315,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -341,7 +342,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -363,7 +364,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -377,11 +378,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs the content of a table in XML format
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
      *
      * @return bool Whether it succeeded
      *
@@ -389,7 +390,6 @@ if (isset($plugin_list)) {
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {
-
         if (isset($GLOBALS['xml_export_contents'])
             && $GLOBALS['xml_export_contents']
         ) {

--- a/libraries/export/yaml.php
+++ b/libraries/export/yaml.php
@@ -19,20 +19,22 @@ if (isset($plugin_list)) {
         'extension' => 'yml',
         'mime_type' => 'text/yaml',
         'force_file' => true,
-        'options' => array(
-            array(
-                'type' => 'begin_group',
-                'name' => 'general_opts'
-            ),
-            array(
-                'type' => 'hidden',
-                'name' => 'structure_or_data',
-            ),
-            array(
-                'type' => 'end_group'
-            )
+        'options' => array(),
+        'options_text'  => __('Options')
+    );
+
+    $plugin_list['yaml']['options'][] = array(
+        array(
+            'type' => 'begin_group',
+            'name' => 'general_opts'
         ),
-        'options_text'  => __('Options'),
+        array(
+            'type' => 'hidden',
+            'name' => 'structure_or_data',
+        ),
+        array(
+            'type' => 'end_group'
+        )
     );
 } else {
 

--- a/libraries/export/yaml.php
+++ b/libraries/export/yaml.php
@@ -20,12 +20,17 @@ if (isset($plugin_list)) {
         'mime_type' => 'text/yaml',
         'force_file' => true,
         'options' => array(
-            array('type' => 'begin_group', 'name' => 'general_opts'),
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
+            ),
             array(
                 'type' => 'hidden',
                 'name' => 'structure_or_data',
             ),
-            array('type' => 'end_group')
+            array(
+                'type' => 'end_group'
+            )
         ),
         'options_text'  => __('Options'),
     );
@@ -57,7 +62,9 @@ if (isset($plugin_list)) {
      */
     function PMA_exportHeader()
     {
-        PMA_exportOutputHandler('%YAML 1.1' . $GLOBALS['crlf'] . '---' . $GLOBALS['crlf']);
+        PMA_exportOutputHandler(
+            '%YAML 1.1' . $GLOBALS['crlf'] . '---' . $GLOBALS['crlf']
+        );
         return true;
     }
 
@@ -156,7 +163,11 @@ if (isset($plugin_list)) {
                     continue;
                 }
 
-                $record[$i] = str_replace(array('\\', '"', "\n", "\r"), array('\\\\', '\"', '\n', '\r'), $record[$i]);
+                $record[$i] = str_replace(
+                    array('\\', '"', "\n", "\r"),
+                    array('\\\\', '\"', '\n', '\r'),
+                    $record[$i]
+                );
                 $buffer .= '  ' . $column . ': "' . $record[$i] . '"' . $crlf;
             }
 

--- a/libraries/export/yaml.php
+++ b/libraries/export/yaml.php
@@ -15,11 +15,11 @@ if (! defined('PHPMYADMIN')) {
  */
 if (isset($plugin_list)) {
     $plugin_list['yaml'] = array(
-        'text'          => 'YAML',
-        'extension'     => 'yml',
-        'mime_type'     => 'text/yaml',
-        'force_file'    => true,
-        'options'       => array(
+        'text' => 'YAML',
+        'extension' => 'yml',
+        'mime_type' => 'text/yaml',
+        'force_file' => true,
+        'options' => array(
             array('type' => 'begin_group', 'name' => 'general_opts'),
             array(
                 'type' => 'hidden',

--- a/libraries/export/yaml.php
+++ b/libraries/export/yaml.php
@@ -23,7 +23,7 @@ if (isset($plugin_list)) {
         'options_text'  => __('Options')
     );
 
-    $plugin_list['yaml']['options'][] = array(
+    $plugin_list['yaml']['options'] = array(
         array(
             'type' => 'begin_group',
             'name' => 'general_opts'

--- a/libraries/export/yaml.php
+++ b/libraries/export/yaml.php
@@ -45,9 +45,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export footer
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportFooter()
     {
@@ -58,9 +58,9 @@ if (isset($plugin_list)) {
     /**
      * Outputs export header
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportHeader()
     {
@@ -75,9 +75,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBHeader($db)
     {
@@ -89,9 +89,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBFooter($db)
     {
@@ -103,9 +103,9 @@ if (isset($plugin_list)) {
      *
      * @param string  $db Database name
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportDBCreate($db)
     {
@@ -121,9 +121,9 @@ if (isset($plugin_list)) {
      * @param string  $error_url  the url to go back in case of error
      * @param string  $sql_query  SQL query for obtaining data
      *
-     * @return bool        Whether it succeeded
+     * @return bool Whether it succeeded
      *
-     * @access  public
+     * @access public
      */
     function PMA_exportData($db, $table, $crlf, $error_url, $sql_query)
     {

--- a/libraries/export/yaml.php
+++ b/libraries/export/yaml.php
@@ -3,7 +3,7 @@
 /**
  * Set of functions used to build YAML dumps of tables
  *
- * @package PhpMyAdmin-Export
+ * @package    PhpMyAdmin-Export
  * @subpackage YAML
  */
 if (! defined('PHPMYADMIN')) {

--- a/libraries/export/yaml.php
+++ b/libraries/export/yaml.php
@@ -73,7 +73,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database header
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -87,7 +87,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs database footer
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -101,7 +101,7 @@ if (isset($plugin_list)) {
     /**
      * Outputs CREATE DATABASE statement
      *
-     * @param string  $db Database name
+     * @param string $db Database name
      *
      * @return bool Whether it succeeded
      *
@@ -115,11 +115,11 @@ if (isset($plugin_list)) {
     /**
      * Outputs the content of a table in YAML format
      *
-     * @param string  $db         database name
-     * @param string  $table      table name
-     * @param string  $crlf       the end of line sequence
-     * @param string  $error_url  the url to go back in case of error
-     * @param string  $sql_query  SQL query for obtaining data
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
      *
      * @return bool Whether it succeeded
      *


### PR DESCRIPTION
Changes:
- correct spacing of operators;
- wrapping long lines;
- general spacing and indentation    of functions and control structures;
- camel caps;
- move arguments with default value at the end ( PMA_ExportStructure );
- rearranging plugin options ( all specific options are defined after the general structure of $plugin_list['export_type'] );
- other checkstyle warnings;
- remove trailing whitespaces;

The remaining errors are:
- Functions that are not documented at all;
- Method name "PMA_Export_PDF::Header" is not in camel caps format. I did not change that because it overwrites the function in the PMA_PDF class that it extends, which in turn extends the TCPDF class, which implements the Header() method.

I've tested all the plugins` functionalities and they seem not be affected.
