### PR TITLE
Small improvement to make the export look more consistent

### DIFF
--- a/libraries/export/sql.php
+++ b/libraries/export/sql.php
@@ -512,11 +512,11 @@ if (isset($plugin_list)) {
         if ((!isset($GLOBALS['sql_compatibility']) || $GLOBALS['sql_compatibility'] == 'NONE')
             && !PMA_DRIZZLE
         ) {
-            $head .= 'SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";' . $crlf;
+            $head .= 'SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";' . $crlf;
         }
 
         if (isset($GLOBALS['sql_use_transaction'])) {
-            $head .= 'SET AUTOCOMMIT=0;' . $crlf
+            $head .= 'SET AUTOCOMMIT = 0;' . $crlf
                    . 'START TRANSACTION;' . $crlf;
         }
 


### PR DESCRIPTION
Added a few spaces in the head of the SQL export

Before:
    SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
    SET time_zone = "+00:00";

Now:
    SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
    SET time_zone = "+00:00";
