### PR TITLE
Ajax support in Navigation Fast Filter

### DIFF
--- a/db_tables_search.php
+++ b/db_tables_search.php
@@ -1,0 +1,51 @@
+<?php
+
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+
+require_once 'libraries/common.inc.php';
+require_once 'libraries/common.lib.php';
+
+$db = $_GET['db'];
+$table_term = $_GET['table'];
+$common_url_query = PMA_generate_common_url($GLOBALS['db']);
+$tables_full = PMA_getTableList($db);
+$tables_response = array();
+
+foreach ($tables_full as $key => $table) {
+    if (strpos($key, $table_term) !== FALSE) {
+        $link = '<li class="ajax_table"><a class="tableicon" title="'
+                . htmlspecialchars($link_title)
+                . ': ' . htmlspecialchars($table['Comment'])
+                . ' (' . PMA_formatNumber($table['Rows'], 0) . ' ' . __('Rows') . ')"'
+                . ' id="quick_' . htmlspecialchars($table_db . '.' . $table['Name']) . '"'
+                . ' href="' . $GLOBALS['cfg']['LeftDefaultTabTable'] . '?'
+                . $common_url_query
+                . '&amp;table=' . urlencode($table['Name'])
+                . '&amp;goto=' . $GLOBALS['cfg']['LeftDefaultTabTable']
+                . '" >';
+        $attr = array('id' => 'icon_' . htmlspecialchars($table_db . '.' . $table['Name']));
+        if (PMA_Table::isView($table_db, $table['Name'])) {
+            $link .= PMA_getImage('s_views.png', htmlspecialchars($link_title), $attr);
+        } else {
+            $link .= PMA_getImage('b_browse.png', htmlspecialchars($link_title), $attr);
+        }
+        $link .= '</a>';
+        // link for the table name itself
+        $href = $GLOBALS['cfg']['DefaultTabTable'] . '?'
+                . $common_url_query . '&amp;table='
+                . urlencode($table['Name']) . '&amp;pos=0';
+        $link .= '<a href="' . $href . '" title="'
+                . htmlspecialchars(
+                        PMA_getTitleForTarget($GLOBALS['cfg']['DefaultTabTable']) . ': ' . $table['Comment']
+                        . ' (' . PMA_formatNumber($table['Rows'], 0) . ' ' . __('Rows') . ')'
+                )
+                . '" id="' . htmlspecialchars($table_db . '.' . $table['Name']) . '">'
+                // preserve spaces in table name
+                . str_replace(' ', '&nbsp;', htmlspecialchars($table['disp_name'])) . '</a>';
+        $link .= '</li>' . "\n";
+        $table['line'] = $link;
+        $tables_response[] = $table;
+    }
+}
+
+PMA_ajaxResponse('', true, array('tables' => $tables_response));


### PR DESCRIPTION
I folks, I've added support in fast filter to search with ajax in all database tables instead of search only in the current navigation page.

This is very helpful when you have a lot of tables, (like in my case more than 3000).

It will only search with Ajax if the table wasn't found in the current page.

Let me know what you think.
