### PR TITLE
Export odt bugs

### DIFF
--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -455,6 +455,7 @@ if (isset($plugin_list)) {
 
         $columns = PMA_DBI_get_columns($db, $table);
         foreach ($columns as $column) {
+            $field_name = $column['Field'];
             $GLOBALS['odt_buffer'] .= PMA_formatOneColumnDefinition($column);
 
             if ($do_relation && $have_rel) {

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -655,7 +655,7 @@ if (isset($plugin_list)) {
             PMA_getTableDefStandIn($db, $table, $crlf);
         } // end switch
 
-        return PMA_exportOutputHandler($dump);
+        return true;
     } // end of the 'PMA_exportStructure' function
 
     /**

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -222,12 +222,10 @@ if (isset($plugin_list)) {
             '<text:h text:outline-level="2" text:style-name="Heading_2"'
                 . ' text:is-list-header="true">'
             . __('Dumping data for table') . ' ' . htmlspecialchars($table)
-            . '</text:h>';
-        $GLOBALS['odt_buffer'] .=
-            '<table:table'
-            . ' table:name="' . htmlspecialchars($table) . '_structure">';
-        $GLOBALS['odt_buffer'] .=
-            '<table:table-column'
+            . '</text:h>'
+            . '<table:table'
+            . ' table:name="' . htmlspecialchars($table) . '_structure">'
+            . '<table:table-column'
             . ' table:number-columns-repeated="' . $fields_cnt . '"/>';
 
         // If required, get fields name at the first line
@@ -323,20 +321,20 @@ if (isset($plugin_list)) {
             '<table:table-column'
             . ' table:number-columns-repeated="' . $columns_cnt . '"/>';
         /* Header */
-        $GLOBALS['odt_buffer'] .= '<table:table-row>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+        $GLOBALS['odt_buffer'] .= '<table:table-row>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Column') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . '</table:table-cell>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Type') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . '</table:table-cell>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Null') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . '</table:table-cell>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Default') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '</table:table-row>';
+            . '</table:table-cell>'
+            . '</table:table-row>';
 
         $columns = PMA_DBI_get_columns($db, $view);
         foreach ($columns as $column) {
@@ -423,17 +421,17 @@ if (isset($plugin_list)) {
         $GLOBALS['odt_buffer'] .= '<table:table-column'
             . ' table:number-columns-repeated="' . $columns_cnt . '"/>';
         /* Header */
-        $GLOBALS['odt_buffer'] .= '<table:table-row>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+        $GLOBALS['odt_buffer'] .= '<table:table-row>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Column') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . '</table:table-cell>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Type') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . '</table:table-cell>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Null') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . '</table:table-cell>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Default') . '</text:p>'
             . '</table:table-cell>';
         if ($do_relation && $have_rel) {
@@ -524,23 +522,23 @@ if (isset($plugin_list)) {
     function PMA_getTriggers($db, $table)
     {
         $GLOBALS['odt_buffer'] .= '<table:table'
-            . ' table:name="' . htmlspecialchars($table) . '_triggers">';
-        $GLOBALS['odt_buffer'] .= '<table:table-column'
-            . ' table:number-columns-repeated="4"/>';
-        $GLOBALS['odt_buffer'] .= '<table:table-row>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . ' table:name="' . htmlspecialchars($table) . '_triggers">'
+            . '<table:table-column'
+            . ' table:number-columns-repeated="4"/>'
+            . '<table:table-row>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Name') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . '</table:table-cell>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Time') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . '</table:table-cell>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Event') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
+            . '</table:table-cell>'
+            . '<table:table-cell office:value-type="string">'
             . '<text:p>' . __('Definition') . '</text:p>'
-            . '</table:table-cell>';
-        $GLOBALS['odt_buffer'] .= '</table:table-row>';
+            . '</table:table-cell>'
+            . '</table:table-row>';
 
         $triggers = PMA_DBI_get_triggers($db, $table);
 
@@ -625,12 +623,12 @@ if (isset($plugin_list)) {
             $triggers = PMA_DBI_get_triggers($db, $table);
             if ($triggers) {
                 $GLOBALS['odt_buffer'] .=
-                '<text:h text:outline-level="2" text:style-name="Heading_2"'
-                . ' text:is-list-header="true">'
-                . __('Triggers') . ' '
-                . htmlspecialchars($table)
-                . '</text:h>';
-                PMA_getTriggers($db, $table);
+                    '<text:h text:outline-level="2" text:style-name="Heading_2"'
+                    . ' text:is-list-header="true">'
+                    . __('Triggers') . ' '
+                    . htmlspecialchars($table)
+                    . '</text:h>';
+                    PMA_getTriggers($db, $table);
             }
             break;
         case 'create_view':
@@ -683,8 +681,8 @@ if (isset($plugin_list)) {
         }
 
         $definition .= '<table:table-cell office:value-type="string">'
-                . '<text:p>' . htmlspecialchars($type) . '</text:p>'
-                . '</table:table-cell>';
+            . '<text:p>' . htmlspecialchars($type) . '</text:p>'
+            . '</table:table-cell>';
         if (! isset($column['Default'])) {
             if ($column['Null'] != 'NO') {
                 $column['Default'] = 'NULL';

--- a/libraries/export/odt.php
+++ b/libraries/export/odt.php
@@ -340,7 +340,7 @@ if (isset($plugin_list)) {
         foreach ($columns as $column) {
             $GLOBALS['odt_buffer'] .= PMA_formatOneColumnDefinition($column);
             $GLOBALS['odt_buffer'] .= '</table:table-row>';
-        } // end foreach 
+        } // end foreach
 
         $GLOBALS['odt_buffer'] .= '</table:table>';
         return true;
@@ -504,7 +504,7 @@ if (isset($plugin_list)) {
                 }
             }
             $GLOBALS['odt_buffer'] .= '</table:table-row>';
-        } // end foreach 
+        } // end foreach
 
         $GLOBALS['odt_buffer'] .= '</table:table>';
         return true;
@@ -659,7 +659,7 @@ if (isset($plugin_list)) {
     } // end of the 'PMA_exportStructure' function
 
     /**
-     * Formats the definition for one column 
+     * Formats the definition for one column
      *
      * @param array $column info about this column
      *
@@ -694,10 +694,10 @@ if (isset($plugin_list)) {
             $column['Default'] = $column['Default'];
         }
         $definition .= '<table:table-cell office:value-type="string">'
-            . '<text:p>' 
-            . (($column['Null'] == '' || $column['Null'] == 'NO') 
-                ? __('No') 
-                : __('Yes')) 
+            . '<text:p>'
+            . (($column['Null'] == '' || $column['Null'] == 'NO')
+                ? __('No')
+                : __('Yes'))
             . '</text:p>'
             . '</table:table-cell>';
         $definition .= '<table:table-cell office:value-type="string">'


### PR DESCRIPTION
If you export a table or database in ODT, and then press the Export button in the navigation again, you will receive the following output:

<code>Notice in ./libraries/export/odt.php#491
Undefined variable: field_name
[Backtrace]</code>

<code>Notice in ./libraries/export/odt.php#659
Undefined variable: dump
[Backtrace]</code>

$field_name was removed in 35c725515b049d816497a3491c108792ffb2b22e
$dump was introduced in 01e8418470ca2e6c50f7c200b8343aee40727bfd
