### PR TITLE
Fix popup message on build SQL of import

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ phpMyAdmin - ChangeLog
 - bug #3521016 [edit] NOW() function incorrectly selected
 - bug [GUI] Invalid HTML code on transformation_overview.php
 - bug #3522930 [browse] Missing validation in Ajax mode
+- bug Fix popup message on build SQL of import
 
 3.5.1.0 (2012-05-03)
 - bug #3510784 [edit] Limit clause ignored when sort order is remembered

--- a/libraries/import.lib.php
+++ b/libraries/import.lib.php
@@ -1129,7 +1129,7 @@ function PMA_buildSQL($db_name, &$tables, &$analyses = null, &$additional_sql = 
                                 $tbl_struct_url,
                                 sprintf(__('Structure of %s'), htmlspecialchars(PMA_backquote($tables[$i][TBL_NAME]))),
                                 $tbl_ops_url,
-                                sprintf(__('Edit settings for %s'), htmlspecialchars(PMA_backquote($db_name))));
+                                sprintf(__('Edit settings for %s'), htmlspecialchars(PMA_backquote($tables[$i][TBL_NAME]))));
         } else {
             $message .= sprintf('<li><a href="%s" title="%s">%s</a></li>',
                                 $tbl_url,


### PR DESCRIPTION
The popup is seen in success messages when data such as CSV is imported into a database.
This bug may be made by 654228e09104f92b318d60bf511b0050cb9f3b6c.
