### PR TITLE
Add StatsCache* config options for caching TABLE STATUS output in APC (if available)

### DIFF
--- a/Documentation.html
+++ b/Documentation.html
@@ -1349,7 +1349,15 @@ CREATE DATABASE,ALTER DATABASE,DROP DATABASE</pre>
     redirected after logout (doesn't affect config authentication method).
     Should be absolute including protocol.
     </dd>
-
+    <dt><span id="cfg_Servers_StatusCacheDatabases">$cfg['Servers'][$i]['StatusCacheDatabases']</span> array of strings</dt>
+    <dd>Enables caching of <code>TABLE STATUS</code> outputs for specific databases on this server (in some cases <code>TABLE STATUS</code> can be very slow, so you may want to cache it). APC is used (if the PHP extension is available, if not, this setting is ignored silently). You have to provide <a href="#cfg_Servers_StatusCacheLifetime" class="configrule">StatusCacheLifetime</a>.<br />
+    Takes effect only if
+    <a href="#cfg_Servers_DisableIS" class="configrule">DisableIS</a>
+    is <code>true</code>.
+    </dd>
+    <dt><span id="cfg_Servers_StatusCacheLifetime">$cfg['Servers'][$i]['StatusCacheLifetime']</span> integer</dt>
+    <dd>Lifetime in seconds of the <code>TABLE STATUS</code> cache if <a href="#cfg_Servers_StatusCacheDatabases" class="configrule">StatusCacheDatabases</a> is used.
+    </dd>
     <dt id="cfg_ServerDefault">$cfg['ServerDefault'] integer</dt>
     <dd>If you have more than one server configured, you can set
         <code>$cfg['ServerDefault']</code> to any one of them to autoconnect to

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -518,6 +518,24 @@ $cfg['Servers'][$i]['tracking_add_drop_table'] = true;
 $cfg['Servers'][$i]['tracking_add_drop_database'] = true;
 
 /**
+ * Enables caching of TABLE STATUS outputs for specific databases on this server 
+ * (in some cases TABLE STATUS can be very slow, so you may want to cache it). 
+ * APC is used (if the PHP extension is available, if not, this setting is ignored 
+ * silently). You have to provide StatusCacheLifetime.
+ * Takes effect only if DisableIS is true.
+ *
+ * @global array $cfg['Servers'][$i]['StatusCacheDatabases']
+ */
+$cfg['Servers'][$i]['StatusCacheDatabases'] = array();
+
+/**
+ * Lifetime in seconds of the TABLE STATUS cache if StatusCacheDatabases is used
+ *
+ * @global integer $cfg['Servers'][$i]['StatusCacheLifetime']
+ */
+$cfg['Servers'][$i]['StatusCacheLifetime'] = 0;
+
+/**
  * Default server (0 = no default server)
  *
  * If you have more than one server configured, you can set $cfg['ServerDefault']

--- a/libraries/database_interface.lib.php
+++ b/libraries/database_interface.lib.php
@@ -515,7 +515,35 @@ function PMA_DBI_get_tables_full($database, $table = false,
                     . PMA_backquote($each_database);
             }
 
-            $each_tables = PMA_DBI_fetch_result($sql, 'Name', null, $link);
+            $useStatusCache = false;
+
+            if (isset($GLOBALS['cfg']['Server']['StatusCacheDatabases'])) {
+                if (!empty($GLOBALS['cfg']['Server']['StatusCacheLifetime'])) {
+                    if (extension_loaded('apc')) {
+                        $statusCacheDatabases = (array) $GLOBALS['cfg']['Server']['StatusCacheDatabases'];
+
+                        if (in_array($each_database, $statusCacheDatabases)) {
+                            $useStatusCache = true;
+                        }
+                    }
+                }
+            }
+
+            $each_tables = null;
+
+            if ($useStatusCache) {
+                $cacheKey = 'phpMyAdmin_tableStatus_' . md5($GLOBALS['cfg']['Server']['host'] . '_' . $sql);
+
+                $each_tables = apc_fetch($cacheKey);
+            }
+
+            if (!$each_tables) {
+                $each_tables = PMA_DBI_fetch_result($sql, 'Name', null, $link);
+            }
+
+            if ($useStatusCache) {
+                apc_store($cacheKey, $each_tables, $GLOBALS['cfg']['Server']['StatusCacheLifetime']);
+            }
 
             // Sort naturally if the config allows it and we're sorting
             // the Name column.

--- a/libraries/database_interface.lib.php
+++ b/libraries/database_interface.lib.php
@@ -517,22 +517,19 @@ function PMA_DBI_get_tables_full($database, $table = false,
 
             $useStatusCache = false;
 
-            if (isset($GLOBALS['cfg']['Server']['StatusCacheDatabases'])) {
-                if (!empty($GLOBALS['cfg']['Server']['StatusCacheLifetime'])) {
-                    if (extension_loaded('apc')) {
-                        $statusCacheDatabases = (array) $GLOBALS['cfg']['Server']['StatusCacheDatabases'];
-
-                        if (in_array($each_database, $statusCacheDatabases)) {
-                            $useStatusCache = true;
-                        }
-                    }
+            if (extension_loaded('apc')
+                && isset($GLOBALS['cfg']['Server']['StatusCacheDatabases'])
+                && ! empty($GLOBALS['cfg']['Server']['StatusCacheLifetime'])) {
+                $statusCacheDatabases = (array) $GLOBALS['cfg']['Server']['StatusCacheDatabases'];
+                if (in_array($each_database, $statusCacheDatabases)) {
+                    $useStatusCache = true;
                 }
             }
 
             $each_tables = null;
 
             if ($useStatusCache) {
-                $cacheKey = 'phpMyAdmin_tableStatus_' . md5($GLOBALS['cfg']['Server']['host'] . '_' . $sql);
+                $cacheKey = 'phpMyAdmin_tableStatus_' . sha1($GLOBALS['cfg']['Server']['host'] . '_' . $sql);
 
                 $each_tables = apc_fetch($cacheKey);
             }


### PR DESCRIPTION
In some cases `SHOW TABLE STATUS` can be very slow, so you may want to cache it.

This patch adds the config options `StatusCacheDatabases` and `StatusCacheLifetime` to allow caching of the table status for specific databases of a server in PHP's APC (if available).

If APC is not enabled, nothing is cached.
