### PR TITLE
server_databases.php ajax fixes

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -2495,49 +2495,6 @@ $(function() {
 }); // end of $() for Drop Database
 
 /**
- * Attach Ajax event handlers for 'Create Database'.  Used wherever libraries/
- * display_create_database.lib.php is used, ie main.php and server_databases.php
- *
- * @see $cfg['AjaxEnable']
- */
-$(function() {
-
-    $('#create_database_form.ajax').live('submit', function(event) {
-        event.preventDefault();
-
-        $form = $(this);
-
-        PMA_ajaxShowMessage(PMA_messages['strProcessingRequest']);
-        PMA_prepareForAjaxRequest($form);
-
-        $.post($form.attr('action'), $form.serialize(), function(data) {
-            if (data.success == true) {
-                PMA_ajaxShowMessage(data.message);
-
-                //Append database's row to table
-                $("#tabledatabases")
-                .find('tbody')
-                .append(data.new_db_string)
-                .PMA_sort_table('.name')
-                .find('#db_summary_row')
-                .appendTo('#tabledatabases tbody')
-                .removeClass('odd even');
-
-                var $databases_count_object = $('#databases_count');
-                var databases_count = parseInt($databases_count_object.text()) + 1;
-                $databases_count_object.text(databases_count);
-                //Refresh navigation frame as a new database has been added
-                if (window.parent && window.parent.frame_navigation) {
-                    window.parent.frame_navigation.location.reload();
-                }
-            } else {
-                PMA_ajaxShowMessage(data.error, false);
-            }
-        }); // end $.post()
-    }); // end $().live()
-});  // end $() for Create Database
-
-/**
  * Validates the password field in a form
  *
  * @see    PMA_messages['strPasswordEmpty']

--- a/js/server_databases.js
+++ b/js/server_databases.js
@@ -31,6 +31,7 @@ $(function() {
          */
         var selected_dbs = [];
         $form.find('input:checkbox:checked').each(function () {
+            $(this).closest('tr').addClass('removeMe');
             selected_dbs[selected_dbs.length] = 'DROP DATABASE `' + escapeHtml($(this).val()) + '`;';
         });
         if (! selected_dbs.length) {
@@ -55,12 +56,20 @@ $(function() {
                 $.post(url, function(data) {
                     if(data.success == true) {
                         PMA_ajaxShowMessage(data.message);
+
+                        var $rowsToRemove = $form.find('tr.removeMe');
+                        var $databasesCount = $('#databases_count');
+                        var newCount = parseInt($databasesCount.text()) - $rowsToRemove.length;
+                        $databasesCount.text(newCount);
+
+                        $rowsToRemove.remove();
+                        $form.find('tbody').PMA_sort_table('.name');
                         if (window.parent && window.parent.frame_navigation) {
                             window.parent.frame_navigation.location.reload();
                         }
-                        $('#tableslistcontainer').load('server_databases.php form#dbStatsForm');
                     } else {
-                        PMA_ajaxShowMessage(PMA_messages.strErrorProcessingRequest + ": " + data.error, false);
+                        $form.find('tr.removeMe').removeClass('removeMe');
+                        PMA_ajaxShowMessage(data.error, false);
                     }
                 }); // end $.post()
         }); // end $.PMA_confirm()

--- a/js/server_databases.js
+++ b/js/server_databases.js
@@ -74,4 +74,43 @@ $(function() {
                 }); // end $.post()
         }); // end $.PMA_confirm()
     }) ; //end of Drop Database action
+
+    /**
+     * Attach Ajax event handlers for 'Create Database'.
+     *
+     * @see $cfg['AjaxEnable']
+     */
+    $('#create_database_form.ajax').live('submit', function(event) {
+        event.preventDefault();
+
+        $form = $(this);
+
+        PMA_ajaxShowMessage(PMA_messages['strProcessingRequest']);
+        PMA_prepareForAjaxRequest($form);
+
+        $.post($form.attr('action'), $form.serialize(), function(data) {
+            if (data.success == true) {
+                PMA_ajaxShowMessage(data.message);
+
+                //Append database's row to table
+                $("#tabledatabases")
+                .find('tbody')
+                .append(data.new_db_string)
+                .PMA_sort_table('.name')
+                .find('#db_summary_row')
+                .appendTo('#tabledatabases tbody')
+                .removeClass('odd even');
+
+                var $databases_count_object = $('#databases_count');
+                var databases_count = parseInt($databases_count_object.text()) + 1;
+                $databases_count_object.text(databases_count);
+                //Refresh navigation frame as a new database has been added
+                if (window.parent && window.parent.frame_navigation) {
+                    window.parent.frame_navigation.location.reload();
+                }
+            } else {
+                PMA_ajaxShowMessage(data.error, false);
+            }
+        }); // end $.post()
+    }); // end $().live()
 }); // end $()

--- a/js/server_databases.js
+++ b/js/server_databases.js
@@ -85,6 +85,13 @@ $(function() {
 
         $form = $(this);
 
+        var newDbNameInput = $form.find('input[name=new_db]');
+        if (newDbNameInput.val() === '') {
+            newDbNameInput.focus();
+            alert(PMA_messages['strFormEmpty']);
+            return;
+        }
+
         PMA_ajaxShowMessage(PMA_messages['strProcessingRequest']);
         PMA_prepareForAjaxRequest($form);
 

--- a/js/server_databases.js
+++ b/js/server_databases.js
@@ -103,10 +103,7 @@ $(function() {
                 $("#tabledatabases")
                 .find('tbody')
                 .append(data.new_db_string)
-                .PMA_sort_table('.name')
-                .find('#db_summary_row')
-                .appendTo('#tabledatabases tbody')
-                .removeClass('odd even');
+                .PMA_sort_table('.name');
 
                 var $databases_count_object = $('#databases_count');
                 var databases_count = parseInt($databases_count_object.text()) + 1;

--- a/server_databases.php
+++ b/server_databases.php
@@ -246,7 +246,7 @@ if ($databases_count > 0) {
     } // end foreach ($databases as $key => $current)
     unset($current, $odd_row);
 
-    echo '<tr id="db_summary_row">' . "\n";
+    echo '</tbody><tfoot><tr id="db_summary_row">' . "\n";
     if ($is_superuser || $cfg['AllowUserDropDatabase']) {
         echo '    <th></th>' . "\n";
     }
@@ -285,7 +285,7 @@ if ($databases_count > 0) {
         echo '    <th></th>' . "\n";
     }
     echo '</tr>' . "\n";
-    echo '</tbody>' . "\n"
+    echo '</tfoot>' . "\n"
         .'</table>' . "\n";
     unset($column_order, $stat_name, $stat, $databases, $table_columns);
 

--- a/server_databases.php
+++ b/server_databases.php
@@ -246,7 +246,7 @@ if ($databases_count > 0) {
     } // end foreach ($databases as $key => $current)
     unset($current, $odd_row);
 
-    echo '</tbody><tfoot><tr id="db_summary_row">' . "\n";
+    echo '</tbody><tfoot><tr>' . "\n";
     if ($is_superuser || $cfg['AllowUserDropDatabase']) {
         echo '    <th></th>' . "\n";
     }


### PR DESCRIPTION
This pull request implements the following:
- Client-side validation for "name" input when creating a database
- Removed an unnecessary ajax request when dropping databases
- Moved the event handler of "drop database" from function.js back to server_databases.js, since this is no longer required on main.php as the create database form has been removed from there.
