### PR TITLE
fix get extensions for import plugins

### DIFF
--- a/libraries/CommonFunctions.class.php
+++ b/libraries/CommonFunctions.class.php
@@ -3515,7 +3515,7 @@ class PMA_CommonFunctions
      * Prepare the form used to select a file to import from the server upload
      * directory
      *
-     * @param array  $import_list array of import types
+     * @param array  $import_list array of import plugins
      * @param string $uploaddir   upload directory
      *
      * @return void
@@ -3533,11 +3533,12 @@ class PMA_CommonFunctions
             . '</label>';
 
         $extensions = '';
-        foreach ($import_list as $val) {
+        foreach ($import_list as $import_plugin) {
             if (! empty($extensions)) {
                 $extensions .= '|';
             }
-            $extensions .= $val['extension'];
+            $properties = $import_plugin->getProperties();
+            $extensions .= $properties['extension'];
         }
 
         $matcher = '@\.(' . $extensions . ')(\.('

--- a/libraries/plugins/export/ExportJson.class.php
+++ b/libraries/plugins/export/ExportJson.class.php
@@ -135,7 +135,7 @@ class ExportJson extends ExportPlugin
     }
 
     /**
-     * Outputs the content of a table in CSV format
+     * Outputs the content of a table in JSON format
      *
      * @param string $db        database name
      * @param string $table     table name

--- a/libraries/plugins/export/README
+++ b/libraries/plugins/export/README
@@ -1,0 +1,252 @@
+This directory holds export plugins for phpMyAdmin. Any new plugin should
+basically follow the structure presented here. Official plugins need to
+have str* messages with their definition in language files, but if you build
+some plugins for your use, you can directly use texts in plugin.
+
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * [Name] export plugin for phpMyAdmin
+ *
+ * @package    PhpMyAdmin-Export
+ * @subpackage [Name]
+ */
+if (! defined('PHPMYADMIN')) {
+    exit;
+}
+
+/* Get the export interface */
+require_once "libraries/plugins/ExportPlugin.class.php";
+
+/**
+ * Handles the export for the [Name] format
+ *
+ * @package PhpMyAdmin-Export
+ */
+class Export[Name] extends ExportPlugin
+{
+    /**
+     * optional - declare variables and descriptions
+     *
+     * @var type
+     */
+    private $_myOptionalVariable;
+
+    /**
+     * optional - declare global variables and descriptions
+     *
+     * @var type
+     */
+    private $_globalVariableName;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->setProperties();
+    }
+
+    // optional - declare global variables and use getters later
+    /**
+     * Initialize the local variables that are used specific for export SQL
+     *
+     * @global type $global_variable_name
+     * [..]
+     *
+     * @return void
+     */
+    protected function initSpecificVariables()
+    {
+        global $global_variable_name;
+        $this->_setGlobalVariableName($global_variable_name);
+    }
+
+    /**
+     * Sets the export plugin properties.
+     * Called in the constructor.
+     *
+     * @return void
+     */
+    protected function setProperties()
+    {
+        // optional - get globals
+
+        // set properties
+        $this->properties = array(  // set name of your plugin
+            'text' => __('[Name]'), // text to be displayed as choice
+            'extension' => '[ext]', // extension this plugin can handle
+            'options' => array(),   // array of options
+            'options_text' => __('Options')
+        );
+
+        // optional :
+        // type - bool or text, or begin/end group_subgroup
+        // name - form element name
+        // text - description in GUI
+        // size - size of text element (optional)
+        // len  - maximal size of input (optional)
+        $this->properties['options'] = array(
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
+            ),
+            [..],
+            array(
+                'type' => 'end_group'
+            )
+        );
+    }
+
+    /**
+     * This method is called when any PluginManager to which the observer
+     * is attached calls PluginManager::notify()
+     *
+     * @param SplSubject $subject The PluginManager notifying the observer
+     *                            of an update.
+     *
+     * @return void
+     */
+    public function update (SplSubject $subject)
+    {
+    }
+
+    /**
+     * Outputs export header
+     *
+     * @return bool Whether it succeeded
+     */
+    public function exportHeader ()
+    {
+        // implementation
+        return true;
+    }
+
+    /**
+     * Outputs export footer
+     *
+     * @return bool Whether it succeeded
+     */
+    public function exportFooter ()
+    {
+        // implementation
+        return true;
+    }
+
+    /**
+     * Outputs database header
+     *
+     * @param string $db Database name
+     *
+     * @return bool Whether it succeeded
+     */
+    public function exportDBHeader ($db)
+    {
+        // implementation
+        return true;
+    }
+
+    /**
+     * Outputs database footer
+     *
+     * @param string $db Database name
+     *
+     * @return bool Whether it succeeded
+     */
+    public function exportDBFooter ($db)
+    {
+        // implementation
+        return true;
+    }
+
+    /**
+     * Outputs CREATE DATABASE statement
+     *
+     * @param string $db Database name
+     *
+     * @return bool Whether it succeeded
+     */
+    public function exportDBCreate($db)
+    {
+        // implementation
+        return true;
+    }
+
+    /**
+     * Outputs the content of a table in [Name] format
+     *
+     * @param string $db        database name
+     * @param string $table     table name
+     * @param string $crlf      the end of line sequence
+     * @param string $error_url the url to go back in case of error
+     * @param string $sql_query SQL query for obtaining data
+     *
+     * @return bool Whether it succeeded
+     */
+    public function exportData($db, $table, $crlf, $error_url, $sql_query)
+    {
+        // implementation;
+        return true;
+    }
+
+    // optional - implement other methods defined in ExportPlugin.class.php:
+    //  - exportRoutines()
+    //  - exportStructure()
+    //  - getTableDefStandIn()
+    //  - getTriggers()
+
+    // optional - implement other private methods in order to avoid
+    // having huge methods or avoid duplicate code. Make use of them
+    // as well as of the getters and setters declared both here
+    // and in the ExportPlugin class
+
+
+    // optional:
+    /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */
+
+
+    /**
+     * Getter description
+     *
+     * @return type
+     */
+    private function _getMyOptionalVariable()
+    {
+        return $this->_myOptionalVariable;
+    }
+
+    /**
+     * Setter description
+     *
+     * @param type $my_optional_variable description
+     *
+     * @return void
+     */
+    private function _setMyOptionalVariable($my_optional_variable)
+    {
+        $this->_myOptionalVariable = $my_optional_variable;
+    }
+
+    /**
+     * Getter description
+     *
+     * @return type
+     */
+    private function _getGlobalVariableName()
+    {
+        return $this->_globalVariableName;
+    }
+
+    /**
+     * Setter description
+     *
+     * @param type $global_variable_name description
+     *
+     * @return void
+     */
+    private function _setGlobalVariableName($global_variable_name)
+    {
+        $this->_globalVariableName = $global_variable_name;
+    }
+}
+?>

--- a/libraries/plugins/import/README
+++ b/libraries/plugins/import/README
@@ -30,7 +30,7 @@ class Import[Name] extends ImportPlugin
      *
      * @var type
      */
-    private $_my_optional_variable;
+    private $_myOptionalVariable;
 
     /**
      * Constructor
@@ -131,7 +131,7 @@ class Import[Name] extends ImportPlugin
      */
     private function _getMyOptionalVariable()
     {
-        return $this->_my_optional_variable;
+        return $this->_myOptionalVariable;
     }
 
     /**
@@ -143,7 +143,7 @@ class Import[Name] extends ImportPlugin
      */
     private function _setMyOptionalVariable($my_optional_variable)
     {
-        $this->_my_optional_variable = $my_optional_variable;
+        $this->_myOptionalVariable = $my_optional_variable;
     }
 }
 ?>

--- a/libraries/plugins/import/README
+++ b/libraries/plugins/import/README
@@ -1,43 +1,149 @@
-Todo: Rewrite!
-
-This directory holds import plugins for phpMyAdmin. Plugin should
-basically look like following code. Official plugins need to have str*
-messages with their definition in language files, if you build some
-plugins for your use, you can use directly texts in plugin.
+This directory holds import plugins for phpMyAdmin. Any new plugin should
+basically follow the structure presented here. Official plugins need to
+have str* messages with their definition in language files, but if you build
+some plugins for your use, you can directly use texts in plugin.
 
 <?php
-// vim: expandtab sw=4 ts=4 sts=4 ft=php:
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * [Name] import plugin for phpMyAdmin
+ *
+ * @package    PhpMyAdmin-Import
+ * @subpackage [Name]
+ */
+if (! defined('PHPMYADMIN')) {
+    exit;
+}
 
-/* Demo import plugin for phpMyAdmin */
+/* Get the import interface */
+require_once "libraries/plugins/ImportPlugin.class.php";
 
-if (isset($plugin_list)) {
-    $plugin_list['name'] = array(           // set name of your plugin
-        'text' => 'strName',                // text to be displayed as choice
-        'extension' => '',                  // extension this plugin can handle
-        'options' => array(                 // array of options for your plugin (optional)
-            array('type' => '', 'name' => '', 'text' => ''), // type: bool or text, name: form element name, text: description in GUI, size: size of text element (optional). len: maximal size of input (optional)
-        ),
-        'options_text' => 'strNameImportOptions', // text to describe plugin options (must be set if options are used)
+/**
+ * Handles the import for the [Name] format
+ *
+ * @package PhpMyAdmin-Import
+ */
+class Import[Name] extends ImportPlugin
+{
+    /**
+     * optional - declare variables and descriptions
+     *
+     * @var type
+     */
+    private $_my_optional_variable;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->setProperties();
+    }
+
+    /**
+     * Sets the import plugin properties.
+     * Called in the constructor.
+     *
+     * @return void
+     */
+    protected function setProperties()
+    {
+        // optional - get globals
+
+        // set properties
+        $this->properties = array(  // set name of your plugin
+            'text' => __('[Name]'), // text to be displayed as choice
+            'extension' => '[ext]', // extension this plugin can handle
+            'options' => array(),   // array of options
+            'options_text' => __('Options')
         );
-} else {
-/* We do not define function when plugin is just queried for information above */
-    $buffer = '';
-    while (!($finished && $i >= $len) && !$error && !$timeout_passed) {
-        $data = PMA_importGetNextChunk();
-        if ($data === false) {
-            // subtract data we didn't handle yet and stop processing
-            $offset -= strlen($buffer);
-            break;
-        } elseif ($data === true) {
-            // Handle rest of buffer
-        } else {
-            // Append new data to buffer
-            $buffer .= $data;
-        }
-        // PARSE $buffer here, post sql queries using:
-        PMA_importRunQuery($sql, $verbose_sql_with_comments);
-    } // End of import loop
-    // Commit any possible data in buffers
-    PMA_importRunQuery();
+
+        // optional :
+        // type - bool or text, or begin/end group_subgroup
+        // name - form element name
+        // text - description in GUI
+        // size - size of text element (optional)
+        // len  - maximal size of input (optional)
+        $this->properties['options'] = array(
+            array(
+                'type' => 'begin_group',
+                'name' => 'general_opts'
+            ),
+            [..],
+            array(
+                'type' => 'end_group'
+            )
+        );
+    }
+
+    /**
+     * This method is called when any PluginManager to which the observer
+     * is attached calls PluginManager::notify()
+     *
+     * @param SplSubject $subject The PluginManager notifying the observer
+     *                            of an update.
+     *
+     * @return void
+     */
+    public function update (SplSubject $subject)
+    {
+    }
+
+    /**
+     * Handles the whole import logic
+     *
+     * @return void
+     */
+    public function doImport()
+    {
+        // get globals (others are optional)
+        global $error, $timeout_passed, $finished;
+
+        $buffer = '';
+        while (! ($finished && $i >= $len) && ! $error && ! $timeout_passed) {
+            $data = PMA_importGetNextChunk();
+            if ($data === false) {
+                // subtract data we didn't handle yet and stop processing
+                $offset -= strlen($buffer);
+                break;
+            } elseif ($data === true) {
+                // Handle rest of buffer
+            } else {
+                // Append new data to buffer
+                $buffer .= $data;
+            }
+            // PARSE $buffer here, post sql queries using:
+            PMA_importRunQuery($sql, $verbose_sql_with_comments);
+        } // End of import loop
+        // Commit any possible data in buffers
+        PMA_importRunQuery();
+    }
+
+
+    // optional:
+    /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */
+
+
+    /**
+     * Getter description
+     *
+     * @return type
+     */
+    private function _getMyOptionalVariable()
+    {
+        return $this->_my_optional_variable;
+    }
+
+    /**
+     * Setter description
+     *
+     * @param type $my_optional_variable description
+     *
+     * @return void
+     */
+    private function _setMyOptionalVariable($my_optional_variable)
+    {
+        $this->_my_optional_variable = $my_optional_variable;
+    }
 }
 ?>


### PR DESCRIPTION
$import_list was actually a list of import objects, not of strings and arrays (previous format).

Marc,
I corrected this after your notice, but I did not manage to reproduce the error you mentioned. Therefore, I think it would be good if you could check whether that error is actually solved.
