### PR TITLE
Autoselect username input on cookie login page

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,7 @@ VerboseMultiSubmit, ReplaceHelpImg
 + Add Ajax support to Fast filter in order to search the term in all database tables
 - bug #3535015 [navi] DbFilter, TableFilter clear button hidden on Chrome
 + rfe #3528994 [interface] Allow wrapping possibly long values in replication-status table
++ [interface] Autoselect username input on cookie login page
 
 3.5.3.0 (not yet released)
 - bug #3539044 [interface] Browse mode "Show" button gives blank page if no results anymore

--- a/js/functions.js
+++ b/js/functions.js
@@ -3867,6 +3867,7 @@ $(function () {
  * Reveal the login form to users with JS enabled
  */
 $(function () {
-    $('.js-show').show();
-    $('#loginform #input_username').select();
+    var $loginform = $('#loginform');
+    $loginform.find('.js-show').show();
+    $loginform.find('#input_username').select();
 });

--- a/js/functions.js
+++ b/js/functions.js
@@ -3868,4 +3868,5 @@ $(function () {
  */
 $(function () {
     $('.js-show').show();
+    $('#loginform #input_username').select();
 });


### PR DESCRIPTION
This is pretty straightforward, the idea is to focus the username input field on the cookie login page automatically, so that the user doesn't have to click on it.
