### PR TITLE
Fixed fatal JS error when changing insert action

### DIFF
--- a/js/tbl_change.js
+++ b/js/tbl_change.js
@@ -286,10 +286,9 @@ $(function() {
     $('select[name="submit_type"]').bind('change', function (e) {
         var $table = $('table.insertRowTable');
         var auto_increment_column = $table.find('input[name^="auto_increment"]').attr('name');
-        var prev_value_field = $table.find('input[name="' + auto_increment_column.replace('auto_increment', 'fields_prev') + '"]');
-        var value_field = $table.find('input[name="' + auto_increment_column.replace('auto_increment', 'fields') + '"]');
-
         if (auto_increment_column) {
+            var prev_value_field = $table.find('input[name="' + auto_increment_column.replace('auto_increment', 'fields_prev') + '"]');
+            var value_field = $table.find('input[name="' + auto_increment_column.replace('auto_increment', 'fields') + '"]');
             var previous_value = $(prev_value_field).val();
             if (previous_value !== undefined) {
                 if ($(this).val() == 'insert' || $(this).val() == 'insertignore' || $(this).val() == 'showinsert' ) {
@@ -299,7 +298,6 @@ $(function() {
                 }
             }
         }
-
     });
 
 


### PR DESCRIPTION
Fixes error introduced in e61a0a5dc6408816b8933e7a867b8a7ad8eb0fa9.

To reproduce, select a table, click the insert tab, change the value of the select box that is displaying "Insert as new row", watch the error pop up in your firebug console.

Only the master branch is affected, hence no bug report on the tracker.
