### PR TITLE
Extended MSSQL compatibility features.

### DIFF
--- a/libraries/CommonFunctions.class.php
+++ b/libraries/CommonFunctions.class.php
@@ -977,7 +977,7 @@ class PMA_CommonFunctions
      * 
      * example:
      * <code>
-     * echo backquote('owner`s db'); // `owner``s db`
+     * echo backquote_compat('owner`s db'); // `owner``s db`
      *
      * </code>
      *

--- a/libraries/CommonFunctions.class.php
+++ b/libraries/CommonFunctions.class.php
@@ -971,6 +971,57 @@ class PMA_CommonFunctions
 
     } // end of the 'backquote()' function
 
+    /**
+     * Adds quotes on both sides of a database, table or field name.
+     * in compatibility mode
+     * 
+     * example:
+     * <code>
+     * echo backquote('owner`s db'); // `owner``s db`
+     *
+     * </code>
+     *
+     * @param mixed   $a_name the database, table or field name to "backquote"
+     *                        or array of it
+     * @param boolean $do_it  a flag to bypass this function (used by dump
+     *                        functions)
+     *
+     * @return mixed    the "backquoted" database, table or field name
+     *
+     * @access  public
+     */
+    public function backquote_compat($a_name, $do_it = true)
+    {
+
+        if (is_array($a_name)) {
+            foreach ($a_name as &$data) {
+                $data = $this->backquote_compat($data, $do_it);
+            }
+            return $a_name;
+        }
+
+        if (! $do_it) {
+            global $PMA_SQPdata_forbidden_word;
+
+            if (! in_array(strtoupper($a_name), $PMA_SQPdata_forbidden_word)) {
+                return $a_name;
+            }
+        }
+    
+        // @todo add more compatibility cases (ORACLE for example)
+        switch ($GLOBALS['sql_compatibility']) {
+            case 'MSSQL': $quote = '"'; break;
+            default: (isset($GLOBALS['sql_backquotes'])) ? $quote = "`" : $quote = ''; break;
+        }
+
+        // '0' is also empty for php :-(
+        if (strlen($a_name) && $a_name !== '*') {
+            return $quote . $a_name . $quote;
+        } else {
+            return $a_name;
+        }
+
+    } // end of the 'backquote_compat()' function    
 
     /**
      * Defines the <CR><LF> value depending on the user OS.

--- a/libraries/CommonFunctions.class.php
+++ b/libraries/CommonFunctions.class.php
@@ -977,7 +977,7 @@ class PMA_CommonFunctions
      * 
      * example:
      * <code>
-     * echo backquote_compat('owner`s db'); // `owner``s db`
+     * echo backquote('owner`s db'); // `owner``s db`
      *
      * </code>
      *
@@ -985,12 +985,13 @@ class PMA_CommonFunctions
      *                        or array of it
      * @param boolean $do_it  a flag to bypass this function (used by dump
      *                        functions)
-     *
+     * @param string  $compatibility string compatibility mode (used by dump
+     *                        functions)
      * @return mixed    the "backquoted" database, table or field name
      *
      * @access  public
      */
-    public function backquote_compat($a_name, $do_it = true)
+    public function backquote_compat($a_name, $do_it = true, $compatibility = 'MSSQL')
     {
 
         if (is_array($a_name)) {
@@ -1009,7 +1010,7 @@ class PMA_CommonFunctions
         }
     
         // @todo add more compatibility cases (ORACLE for example)
-        switch ($GLOBALS['sql_compatibility']) {
+        switch ($compatibility) {
             case 'MSSQL': $quote = '"'; break;
             default: (isset($GLOBALS['sql_backquotes'])) ? $quote = "`" : $quote = ''; break;
         }

--- a/libraries/CommonFunctions.class.php
+++ b/libraries/CommonFunctions.class.php
@@ -974,7 +974,7 @@ class PMA_CommonFunctions
     /**
      * Adds quotes on both sides of a database, table or field name.
      * in compatibility mode
-     * 
+     *
      * example:
      * <code>
      * echo backquote('owner`s db'); // `owner``s db`
@@ -983,20 +983,20 @@ class PMA_CommonFunctions
      *
      * @param mixed   $a_name the database, table or field name to "backquote"
      *                        or array of it
-     * @param boolean $do_it  a flag to bypass this function (used by dump
-     *                        functions)
      * @param string  $compatibility string compatibility mode (used by dump
+     *                        functions)
+     * @param boolean $do_it  a flag to bypass this function (used by dump
      *                        functions)
      * @return mixed    the "backquoted" database, table or field name
      *
      * @access  public
      */
-    public function backquote_compat($a_name, $do_it = true, $compatibility = 'MSSQL')
+    public function backquote_compat($a_name, $compatibility = 'MSSQL', $do_it = true)
     {
 
         if (is_array($a_name)) {
             foreach ($a_name as &$data) {
-                $data = $this->backquote_compat($data, $do_it);
+                $data = $this->backquote_compat($data, $compatibility, $do_it);
             }
             return $a_name;
         }
@@ -1008,7 +1008,7 @@ class PMA_CommonFunctions
                 return $a_name;
             }
         }
-    
+
         // @todo add more compatibility cases (ORACLE for example)
         switch ($compatibility) {
             case 'MSSQL': $quote = '"'; break;
@@ -1022,7 +1022,7 @@ class PMA_CommonFunctions
             return $a_name;
         }
 
-    } // end of the 'backquote_compat()' function    
+    } // end of the 'backquote_compat()' function
 
     /**
      * Defines the <CR><LF> value depending on the user OS.

--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1055,7 +1055,7 @@ class ExportSql extends ExportPlugin
             // In MSSQL
             // 1. DATE field doesn't exist, we will use datetime instead
             // 2. UNSIGNED attribute doesn't exist
-            // 3. No length on INT, TINYINT and FLOAT fields
+            // 3. No length on INT, TINYINT, SMALLINT, BIGINT and no precision on FLOAT fields
             // 4. No KEY and INDEX inside CREATE TABLE
             if ($compat == 'MSSQL') {
                 //first we need  to replace all lines ended with '" DATE ...,\n'
@@ -1072,17 +1072,17 @@ class ExportSql extends ExportPlugin
                 
                 // we need to replace all lines ended with '" INT|TINYINT([0-9]{1,}) ...,'
                 //last preg_replace preserve us from situation with int([0-9]{1,}) text inside DEFAULT field value
-                $create_query = preg_replace( '/" (int|tinyint)\([0-9]+\) DEFAULT NULL(,)?\n/', '" $1 DEFAULT NULL$2'."\n", $create_query);
-                $create_query = preg_replace( '/" (int|tinyint)\([0-9]+\) NOT NULL(,)?\n/', '" $1 NOT NULL$2'."\n", $create_query);
-                $create_query = preg_replace( '/" (int|tinyint)\([0-9]+\) NOT NULL DEFAULT \'([^\'])/', '" $1 NOT NULL DEFAULT \'$2', $create_query);
+                $create_query = preg_replace( '/" (int|tinyint|smallint|bigint)\([0-9]+\) DEFAULT NULL(,)?\n/', '" $1 DEFAULT NULL$2'."\n", $create_query);
+                $create_query = preg_replace( '/" (int|tinyint|smallint|bigint)\([0-9]+\) NOT NULL(,)?\n/', '" $1 NOT NULL$2'."\n", $create_query);
+                $create_query = preg_replace( '/" (int|tinyint|smallint|bigint)\([0-9]+\) NOT NULL DEFAULT \'([^\'])/', '" $1 NOT NULL DEFAULT \'$2', $create_query);
                 
                 // we need to replace all lines ended with '" FLOAT([0-9,]{1,}) ...,'
                 //last preg_replace preserve us from situation with float([0-9,]{1,}) text inside DEFAULT field value
-                $create_query = preg_replace( '/" float\([0-9,]+\) DEFAULT NULL(,)?\n/', '" float DEFAULT NULL$1'."\n", $create_query);
-                $create_query = preg_replace( '/" float\([0-9,]+\) NOT NULL(,)?\n/', '" float NOT NULL$1'."\n", $create_query);
-                $create_query = preg_replace( '/" float\([0-9,]+\) NOT NULL DEFAULT \'([^\'])/', '" float NOT NULL DEFAULT \'$1', $create_query);
+                $create_query = preg_replace( '/" float\([0-9]+,[0-9,]+\) DEFAULT NULL(,)?\n/', '" float DEFAULT NULL$1'."\n", $create_query);
+                $create_query = preg_replace( '/" float\([0-9,]+,[0-9,]+\) NOT NULL(,)?\n/', '" float NOT NULL$1'."\n", $create_query);
+                $create_query = preg_replace( '/" float\([0-9,]+,[0-9,]+\) NOT NULL DEFAULT \'([^\'])/', '" float NOT NULL DEFAULT \'$1', $create_query);
                 
-                // @todo remove indexes from CREATE TABLE
+                // @todo remove indexes from CREATE TABLE 
             }
 
             // Drizzle (checked on 2011.03.13) returns ROW_FORMAT surrounded

--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1079,12 +1079,9 @@ class ExportSql extends ExportPlugin
                 
                 // we need to replace all lines ended with '" FLOAT|DOUBLE([0-9,]{1,}) ...,'
                 //last preg_replace preserve us from situation with float([0-9,]{1,}) text inside DEFAULT field value
-                $create_query = preg_replace( '/" float\([0-9]+,[0-9,]+\) DEFAULT NULL(,)?\n/', '" float DEFAULT NULL$1'."\n", $create_query);
-                $create_query = preg_replace( '/" float\([0-9,]+,[0-9,]+\) NOT NULL(,)?\n/', '" float NOT NULL$1'."\n", $create_query);
-                $create_query = preg_replace( '/" float\([0-9,]+,[0-9,]+\) NOT NULL DEFAULT \'([^\'])/', '" float NOT NULL DEFAULT \'$1', $create_query);
-                $create_query = preg_replace( '/" double DEFAULT NULL(,)?\n/', '" float DEFAULT NULL$1'."\n", $create_query);
-                $create_query = preg_replace( '/" double NOT NULL(,)?\n/', '" float NOT NULL$1'."\n", $create_query);
-                $create_query = preg_replace( '/" double NOT NULL DEFAULT \'([^\'])/', '" float NOT NULL DEFAULT \'$1', $create_query);
+                $create_query = preg_replace( '/" (float|double)(\([0-9]+,[0-9,]+\))? DEFAULT NULL(,)?\n/', '" float DEFAULT NULL$3'."\n", $create_query);
+                $create_query = preg_replace( '/" (float|double)(\([0-9,]+,[0-9,]+\))? NOT NULL(,)?\n/', '" float NOT NULL$3'."\n", $create_query);
+                $create_query = preg_replace( '/" (float|double)(\([0-9,]+,[0-9,]+\))? NOT NULL DEFAULT \'([^\'])/', '" float NOT NULL DEFAULT \'$3', $create_query);
                 
                 // @todo remove indexes from CREATE TABLE 
             }

--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1738,7 +1738,7 @@ class ExportSql extends ExportPlugin
                 }
             }
         
-        // We need to SET IDENTITY_INSERT ON for MSSQL 
+        // We need to SET IDENTITY_INSERT OFF for MSSQL 
         if (isset($GLOBALS['sql_compatibility'])
              && $GLOBALS['sql_compatibility'] == 'MSSQL')
         if (! PMA_exportOutputHandler(

--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -698,15 +698,15 @@ class ExportSql extends ExportPlugin
             if (! PMA_exportOutputHandler(
                 'DROP DATABASE '
                 . (isset($GLOBALS['sql_backquotes'])
-                ? $common_functions->backquote_compat($db, true, $compat) : $db)
+                ? $common_functions->backquote_compat($db, $compat) : $db)
                 . ';' . $crlf
             )) {
                 return false;
             }
         }
         $create_query = 'CREATE DATABASE '
-            . (isset($GLOBALS['sql_backquotes']) 
-            ? $common_functions->backquote_compat($db, true, $compat) : $db);
+            . (isset($GLOBALS['sql_backquotes'])
+            ? $common_functions->backquote_compat($db, $compat) : $db);
         $collation = PMA_getDbCollation($db);
         if (PMA_DRIZZLE) {
             $create_query .= ' COLLATE ' . $collation;
@@ -729,7 +729,7 @@ class ExportSql extends ExportPlugin
             || PMA_DRIZZLE)
         ) {
             $result = PMA_exportOutputHandler(
-                'USE ' . $common_functions->backquote_compat($db, true, $compat) . ';' . $crlf
+                'USE ' . $common_functions->backquote_compat($db, $compat) . ';' . $crlf
             );
         } else {
             $result = PMA_exportOutputHandler('USE ' . $db . ';' . $crlf);
@@ -752,7 +752,7 @@ class ExportSql extends ExportPlugin
             . $this->_exportComment(
                 __('Database') . ': '
                 . (isset($GLOBALS['sql_backquotes'])
-                ? PMA_CommonFunctions::getInstance()->backquote_compat($db, true, $compat)
+                ? PMA_CommonFunctions::getInstance()->backquote_compat($db, $compat)
                 : '\'' . $db . '\'')
             )
             . $this->_exportComment();
@@ -893,7 +893,7 @@ class ExportSql extends ExportPlugin
         $schema_create = '';
         $auto_increment = '';
         $new_crlf = $crlf;
-    
+
         $compat = (isset($GLOBALS['sql_compatibility'])) ? $GLOBALS['sql_compatibility'] : 'NONE';
 
         // need to use PMA_DBI_QUERY_STORE with PMA_DBI_num_rows() in mysqli
@@ -1051,8 +1051,8 @@ class ExportSql extends ExportPlugin
                     $create_query
                 );
             }
-        
-            // In MSSQL 
+
+            // In MSSQL
             // 1. DATE field doesn't exist, we will use datetime instead
             // 2. UNSIGNED attribute doesn't exist
             // 3. No length on int fields
@@ -1063,8 +1063,8 @@ class ExportSql extends ExportPlugin
                     '/ int\([0-9]*\) /',
                     ' int ',
                     $create_query
-                );        
-            }        
+                );
+            }
 
             // Drizzle (checked on 2011.03.13) returns ROW_FORMAT surrounded
             // with quotes, which is not accepted by parser
@@ -1125,19 +1125,19 @@ class ExportSql extends ExportPlugin
                         . $this->_exportComment(
                             __('Constraints for table')
                             . ' '
-                            . $common_functions->backquote_compat($table, true, $compat)
+                            . $common_functions->backquote_compat($table, $compat)
                         )
                         . $this->_exportComment();
                     }
 
                     // let's do the work
                     $sql_constraints_query .= 'ALTER TABLE '
-                        . $common_functions->backquote_compat($table, true, $compat) . $crlf;
+                        . $common_functions->backquote_compat($table, $compat) . $crlf;
                     $sql_constraints .= 'ALTER TABLE '
-                        . $common_functions->backquote_compat($table, true, $compat) . $crlf;
+                        . $common_functions->backquote_compat($table,  $compat) . $crlf;
                     $sql_drop_foreign_keys .= 'ALTER TABLE '
-                        . $common_functions->backquote_compat($db, true, $compat) . '.'
-                        . $common_functions->backquote_compat($table, true, $compat) . $crlf;
+                        . $common_functions->backquote_compat($db, $compat) . '.'
+                        . $common_functions->backquote_compat($table, $compat) . $crlf;
 
                     $first = true;
                     for ($j = $i; $j < $sql_count; $j++) {
@@ -1354,9 +1354,9 @@ class ExportSql extends ExportPlugin
 
         $common_functions = PMA_CommonFunctions::getInstance();
         $compat = (isset($GLOBALS['sql_compatibility'])) ? $GLOBALS['sql_compatibility'] : 'NONE';
-        
+
         $formatted_table_name = (isset($GLOBALS['sql_backquotes']))
-            ? $common_functions->backquote_compat($table, true, $compat) : '\'' . $table . '\'';
+            ? $common_functions->backquote_compat($table, $compat) : '\'' . $table . '\'';
         $dump = $this->_possibleCRLF()
             . $this->_exportComment(str_repeat('-', 56))
             . $this->_possibleCRLF()
@@ -1438,12 +1438,12 @@ class ExportSql extends ExportPlugin
     public function exportData($db, $table, $crlf, $error_url, $sql_query)
     {
         global $current_row, $sql_backquotes;
-        
+
         $compat = (isset($GLOBALS['sql_compatibility'])) ? $GLOBALS['sql_compatibility'] : 'NONE';
-        
+
         $common_functions = PMA_CommonFunctions::getInstance();
         $formatted_table_name = (isset($GLOBALS['sql_backquotes']))
-            ? $common_functions->backquote_compat($table, true, $compat)
+            ? $common_functions->backquote_compat($table, $compat)
             : '\'' . $table . '\'';
 
         // Do not export data for a VIEW
@@ -1492,14 +1492,14 @@ class ExportSql extends ExportPlugin
                 if (isset($analyzed_sql[0]['select_expr'][$j]['column'])) {
                     $field_set[$j] = $common_functions->backquote_compat(
                         $analyzed_sql[0]['select_expr'][$j]['column'],
-                        $sql_backquotes, 
-                        $compat
+                        $compat,
+                        $sql_backquotes
                     );
                 } else {
                     $field_set[$j] = $common_functions->backquote_compat(
                         $fields_meta[$j]->name,
-                        $sql_backquotes,
-                        $compat
+                        $compat,
+                        $sql_backquotes
                     );
                 }
             }
@@ -1515,8 +1515,8 @@ class ExportSql extends ExportPlugin
                 // avoid EOL blank
                 $schema_insert .= $common_functions->backquote_compat(
                     $table,
-                    $sql_backquotes,
-                    $compat
+                    $compat,
+                    $sql_backquotes
                 ) . ' SET';
             } else {
                 // insert or replace
@@ -1550,8 +1550,8 @@ class ExportSql extends ExportPlugin
                     $truncate = 'TRUNCATE TABLE '
                         . $common_functions->backquote_compat(
                             $table,
-                            $sql_backquotes,
-                            $compat
+                            $compat,
+                            $sql_backquotes
                         ) . ";";
                     $truncatehead = $this->_possibleCRLF()
                         . $this->_exportComment()
@@ -1566,25 +1566,19 @@ class ExportSql extends ExportPlugin
                 } else {
                     $truncate = '';
                 }
-        
-                // We need to SET IDENTITY_INSERT ON for MSSQL
-                if (isset($GLOBALS['sql_compatibility'])
-                    && $GLOBALS['sql_compatibility'] == 'MSSQL') {
-                    $sql_command = 'SET IDENTITY_INSERT '. $common_functions->backquote_compat($table, true, $compat). ' ON ;'.$crlf.$sql_command;
-                }
-                
+
                 // scheme for inserting fields
                 if ($GLOBALS['sql_insert_syntax'] == 'complete'
                     || $GLOBALS['sql_insert_syntax'] == 'both'
                 ) {
                     $fields        = implode(', ', $field_set);
                     $schema_insert = $sql_command . $insert_delayed .' INTO '
-                        . $common_functions->backquote_compat($table, $sql_backquotes, $compat)
+                        . $common_functions->backquote_compat($table, $compat, $sql_backquotes)
                         // avoid EOL blank
                         . ' (' . $fields . ') VALUES';
                 } else {
                     $schema_insert = $sql_command . $insert_delayed .' INTO '
-                        . $common_functions->backquote_compat($table, $sql_backquotes, $compat)
+                        . $common_functions->backquote_compat($table, $compat, $sql_backquotes)
                         . ' VALUES';
                 }
             }
@@ -1616,6 +1610,14 @@ class ExportSql extends ExportPlugin
                         . $this->_exportComment()
                         . $crlf;
                     if (! PMA_exportOutputHandler($head)) {
+                        return false;
+                    }
+                }
+                 // We need to SET IDENTITY_INSERT ON for MSSQL
+                if (isset($GLOBALS['sql_compatibility'])
+                    && $GLOBALS['sql_compatibility'] == 'MSSQL'
+                    && $current_row == 0) {
+                    if (! PMA_exportOutputHandler('SET IDENTITY_INSERT '. $common_functions->backquote_compat($table, $compat). ' ON ;'.$crlf)) {
                         return false;
                     }
                 }
@@ -1739,22 +1741,23 @@ class ExportSql extends ExportPlugin
                 }
 
             } // end while
-        
+
             if ($current_row > 0) {
                 if (! PMA_exportOutputHandler(';' . $crlf)) {
                     return false;
                 }
             }
-        
-        // We need to SET IDENTITY_INSERT ON for MSSQL 
+
+        // We need to SET IDENTITY_INSERT ON for MSSQL
         if (isset($GLOBALS['sql_compatibility'])
-             && $GLOBALS['sql_compatibility'] == 'MSSQL')
+             && $GLOBALS['sql_compatibility'] == 'MSSQL'
+             && $current_row > 0)
         if (! PMA_exportOutputHandler(
-            $crlf . 'SET IDENTITY_INSERT ' . $common_functions->backquote_compat($table, true, $compat) . ' OFF;' . $crlf
+            $crlf . 'SET IDENTITY_INSERT ' . $common_functions->backquote_compat($table, $compat) . ' OFF;' . $crlf
             )) {
             return false;
         }
-        
+
         } // end if ($result != false)
         PMA_DBI_free_result($result);
 

--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1055,31 +1055,31 @@ class ExportSql extends ExportPlugin
             // In MSSQL
             // 1. DATE field doesn't exist, we will use datetime instead
             // 2. UNSIGNED attribute doesn't exist
-            // 3. No length on INT and FLOAT fields
+            // 3. No length on INT, TINYINT and FLOAT fields
             // 4. No KEY and INDEX inside CREATE TABLE
             if ($compat == 'MSSQL') {
-                //first we need  to replace all lines ended with '" date ...,\n'
+                //first we need  to replace all lines ended with '" DATE ...,\n'
                 //last preg_replace preserve us from situation with date text inside DEFAULT field value
-                $create_query = str_ireplace( "\" date DEFAULT NULL,\n", '" datetime DEFAULT NULL,'."\n", $create_query);
-                $create_query = str_ireplace( "\" date NOT NULL,\n", '" datetime NOT NULL,'."\n", $create_query);
+                $create_query = preg_replace( "/\" date DEFAULT NULL(,)?\n/", '" datetime DEFAULT NULL$1'."\n", $create_query);
+                $create_query = preg_replace( "/\" date NOT NULL(,)?\n/", '" datetime NOT NULL$1'."\n", $create_query);
                 $create_query = preg_replace( '/" date NOT NULL DEFAULT \'([^\'])/', '" datetime NOT NULL DEFAULT \'$1', $create_query);
                 
-                //next we need to replace all lines ended with ') unsigned ...,"
+                //next we need to replace all lines ended with ') UNSIGNED ...,'
                 //last preg_replace preserve us from situation with unsigned text inside DEFAULT field value
-                $create_query = str_ireplace( ") unsigned NOT NULL,\n", ') NOT NULL,'."\n", $create_query);
-                $create_query = str_ireplace( ") unsigned DEFAULT NULL,\n", ') DEFAULT NULL,'."\n", $create_query);
+                $create_query = preg_replace( "/\) unsigned NOT NULL(,)?\n/", ') NOT NULL$1'."\n", $create_query);
+                $create_query = preg_replace( "/\) unsigned DEFAULT NULL(,)?\n/", ') DEFAULT NULL$1'."\n", $create_query);
                 $create_query = preg_replace( '/\) unsigned NOT NULL DEFAULT \'([^\'])/', ') NOT NULL DEFAULT \'$1', $create_query);
                 
-                // we need to replace all lines ended with '" int([0-9]{1,}) ...,"
+                // we need to replace all lines ended with '" INT|TINYINT([0-9]{1,}) ...,'
                 //last preg_replace preserve us from situation with int([0-9]{1,}) text inside DEFAULT field value
-                $create_query = preg_replace( '/" int\([0-9]+\) DEFAULT NULL,\n/', '" int DEFAULT NULL,'."\n", $create_query);
-                $create_query = preg_replace( '/" int\([0-9]+\) NOT NULL,\n/', '" int NOT NULL,'."\n", $create_query);
-                $create_query = preg_replace( '/" int\([0-9]+\) NOT NULL DEFAULT \'([^\'])/', '" int NOT NULL DEFAULT \'$1', $create_query);
+                $create_query = preg_replace( '/" (int|tinyint)\([0-9]+\) DEFAULT NULL(,)?\n/', '" $1 DEFAULT NULL$2'."\n", $create_query);
+                $create_query = preg_replace( '/" (int|tinyint)\([0-9]+\) NOT NULL(,)?\n/', '" $1 NOT NULL$2'."\n", $create_query);
+                $create_query = preg_replace( '/" (int|tinyint)\([0-9]+\) NOT NULL DEFAULT \'([^\'])/', '" $1 NOT NULL DEFAULT \'$2', $create_query);
                 
-                // we need to replace all lines ended with '" float([0-9,]{1,}) ...,"
+                // we need to replace all lines ended with '" FLOAT([0-9,]{1,}) ...,'
                 //last preg_replace preserve us from situation with float([0-9,]{1,}) text inside DEFAULT field value
-                $create_query = preg_replace( '/" float\([0-9,]+\) DEFAULT NULL,\n/', '" float DEFAULT NULL,'."\n", $create_query);
-                $create_query = preg_replace( '/" float\([0-9,]+\) NOT NULL,\n/', '" float NOT NULL,'."\n", $create_query);
+                $create_query = preg_replace( '/" float\([0-9,]+\) DEFAULT NULL(,)?\n/', '" float DEFAULT NULL$1'."\n", $create_query);
+                $create_query = preg_replace( '/" float\([0-9,]+\) NOT NULL(,)?\n/', '" float NOT NULL$1'."\n", $create_query);
                 $create_query = preg_replace( '/" float\([0-9,]+\) NOT NULL DEFAULT \'([^\'])/', '" float NOT NULL DEFAULT \'$1', $create_query);
                 
                 // @todo remove indexes from CREATE TABLE

--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1057,13 +1057,17 @@ class ExportSql extends ExportPlugin
             // 2. UNSIGNED attribute doesn't exist
             // 3. No length on int fields
             if ($compat == 'MSSQL') {
-                $create_query = str_ireplace(' date ', ' datetime ', $create_query);
-                $create_query = str_ireplace(' unsigned ', ' ', $create_query);
-                $create_query = preg_replace(
-                    '/ int\([0-9]*\) /',
-                    ' int ',
-                    $create_query
-                );
+                $create_query = str_ireplace( "\" date DEFAULT NULL,\n", '" datetime DEFAULT NULL,'."\n", $create_query);
+                $create_query = str_ireplace( "\" date NOT NULL,\n", '" datetime NOT NULL,'."\n", $create_query);
+                $create_query = preg_replace( '/" date NOT NULL DEFAULT \'([^\'])/', '" datetime NOT NULL DEFAULT \'$1', $create_query);
+                
+                $create_query = str_ireplace( ") unsigned NOT NULL,\n", ') NOT NULL,'."\n", $create_query);
+                $create_query = str_ireplace( ") unsigned DEFAULT NULL,\n", ') DEFAULT NULL,'."\n", $create_query);
+                $create_query = preg_replace( '/\) unsigned NOT NULL DEFAULT \'([^\'])/', ') NOT NULL DEFAULT \'$1', $create_query);
+                
+                $create_query = preg_replace( '/" int\([0-9]*\) DEFAULT NULL,\n/', '" int DEFAULT NULL,'."\n", $create_query);
+                $create_query = preg_replace( '/" int\([0-9]*\) NOT NULL,\n/', '" int NOT NULL,'."\n", $create_query);
+                $create_query = preg_replace( '/" int\([0-9]*\) NOT NULL DEFAULT \'([^\'])/', '" int NOT NULL DEFAULT \'$1', $create_query);
             }
 
             // Drizzle (checked on 2011.03.13) returns ROW_FORMAT surrounded

--- a/test/libraries/common/PMA_quoting_slashing_test.php
+++ b/test/libraries/common/PMA_quoting_slashing_test.php
@@ -114,6 +114,41 @@ class PMA_quoting_slashing_test extends PHPUnit_Framework_TestCase
         $this->assertEquals($b, PMA_CommonFunctions::getInstance()->backquote($a));
     }
 
+    /**
+     * data provider for backquote_compat test
+     *
+     * @return array
+     */
+    public function backquote_compatDataProvider()
+    {
+        return array(
+            array('0', '"0"'),
+            array('test', '"test"'),
+            array('te`st', '"te`st"'),
+            array(array('test', 'te`st', '', '*'), array('"test"', '"te`st"', '', '*'))
+        );
+    }
+
+    /**
+     * backquote_compat test with different param $compatibility (NONE, MSSQL)
+     * @dataProvider backquote_compatDataProvider
+     */
+    public function testBackquote_compat($a, $b)
+    {
+        // Test bypass quoting (used by dump functions)
+        $this->assertEquals($a, PMA_CommonFunctions::getInstance()->backquote_compat($a, 'NONE', false));
+
+        // Test backquote (backquoting will be enabled only if isset $GLOBALS['sql_backquotes']
+        $this->assertEquals($a, PMA_CommonFunctions::getInstance()->backquote_compat($a, 'NONE'));
+
+        // Run tests in MSSQL compatibility mode
+        // Test bypass quoting (used by dump functions)
+        $this->assertEquals($a, PMA_CommonFunctions::getInstance()->backquote_compat($a, 'MSSQL', false));
+
+        // Test backquote
+        $this->assertEquals($b, PMA_CommonFunctions::getInstance()->backquote_compat($a, 'MSSQL'));
+    }
+
     public function testBackquoteForbidenWords()
     {
         global $PMA_SQPdata_forbidden_word;


### PR DESCRIPTION
In order to ensure compatibility to export in MSSQL compat mode I suppose some features:
1. MSSQL doesn't support backquotes(which are default for pma export options). I replace them with ".
2. MSSQL doesn't have DATE and DOUBLE types. I replaced them with DATETIME and FLOAT.
3. MSSQL doesn't have unsigned attribute. So I removed them from exported text.
4. MSSQL doesn't support direct ID inserting which are IDENTITY fields (AUTO_INCREMENT). So we need to ON and OFF IDENTITY_INSERT query for each table.
5. MSSQL doesn't support length for any INT fields and precision for FLOAT fields. I removed them.

All this work helps me to convert real working mysql db to mssql one only without INDEXES, because of MSSQL have another syntax.

@todo - rewrite KEY (CREATE INDEX in MSSQL) and UNIQUE (CREATE CONSTRAINT in MSSQL).
