### PR TITLE
bug #3540922 [edit] Error searching table with many fields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,7 @@ VerboseMultiSubmit, ReplaceHelpImg
 + Add Ajax support to Fast filter in order to search the term in all database tables
 - bug #3535015 [navi] DbFilter, TableFilter clear button hidden on Chrome
 + rfe #3528994 [interface] Allow wrapping possibly long values in replication-status table
+- bug #3540922 [edit] Error searching table with many fields
 
 3.5.3.0 (not yet released)
 - bug #3539044 [interface] Browse mode "Show" button gives blank page if no results anymore

--- a/js/tbl_select.js
+++ b/js/tbl_select.js
@@ -52,7 +52,39 @@ $(function() {
 
         PMA_prepareForAjaxRequest($search_form);
 
-        $.post($search_form.attr('action'), $search_form.serialize(), function(data) {
+        var values = {};
+        $search_form.find(':input').each(function() {
+            var $input = $(this);
+            if ($input.attr('type') == 'checkbox') {
+                if ($input.is(':checked')) {
+                    values[this.name] = $input.val();
+                }
+            } else {
+                values[this.name] = $input.val();
+            }
+        });
+        var columnCount = $('select[name="columnsToDisplay[]"] option').length;
+        // Submit values only for the columns that have a search criteria
+        for (var a = 0; a < columnCount; a++) {
+            if (values['criteriaValues[' + a + ']'] == '') {
+                delete values['criteriaValues[' + a + ']'];
+                delete values['criteriaColumnOperators[' + a + ']'];
+                delete values['criteriaColumnNames[' + a + ']'];
+                delete values['criteriaColumnTypes[' + a + ']'];
+                delete values['criteriaColumnCollations[' + a + ']'];
+            }
+        }
+        // If all columns are selected, use a single parameter to indicate that
+        if (values['columnsToDisplay[]'] != null) {
+            if (values['columnsToDisplay[]'].length == columnCount) {
+                delete values['columnsToDisplay[]'];
+                values['displayAllColumns'] = true;
+            }
+        } else {
+            values['displayAllColumns'] = true;
+        }
+
+        $.post($search_form.attr('action'), values, function(data) {
             PMA_ajaxRemoveMessage($msgbox);
             if (data.success == true) {
                 // found results

--- a/libraries/TableSearch.class.php
+++ b/libraries/TableSearch.class.php
@@ -639,10 +639,9 @@ EOT;
         if (isset($_POST['zoom_submit'])) {
             $sql_query .= '* ';
         } else {
-            $sql_query .= (count($_POST['columnsToDisplay'])
-                == count($_POST['criteriaColumnNames'])
+            $sql_query .= ! empty($_POST['displayAllColumns'])
                 ? '* '
-                : implode(', ', $this->getCommonFunctions()->backquote($_POST['columnsToDisplay'])));
+                : implode(', ', $this->getCommonFunctions()->backquote($_POST['columnsToDisplay']));
         } // end if
 
         $sql_query .= ' FROM ' . $this->getCommonFunctions()->backquote($_POST['table']);

--- a/tbl_select.php
+++ b/tbl_select.php
@@ -41,7 +41,7 @@ $table_search = new PMA_TableSearch($db, $table, "normal");
 /**
  * Not selection yet required -> displays the selection form
  */
-if (! isset($_POST['columnsToDisplay']) || $_POST['columnsToDisplay'][0] == '') {
+if (! isset($_POST['columnsToDisplay']) && ! isset($_POST['displayAllColumns'])) {
     // Gets some core libraries
     include_once 'libraries/tbl_common.inc.php';
     //$err_url   = 'tbl_select.php' . $err_url;


### PR DESCRIPTION
The rationale here is that, although a table may have hundreds of columns, one would usually use few fields to enter the search criteria. So if we are submitting only those fields, bug #3540922 can be avoided.
