### PR TITLE
Proxy ajax calls to pma.net to avoid browser notices

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -130,23 +130,29 @@ function parseVersionString (str)
  */
 function PMA_current_version(data)
 {
-    var current = parseVersionString(pmaversion);
-    var latest = parseVersionString(data['version']);
-    var version_information_message = PMA_messages['strLatestAvailable'] + ' ' + escapeHtml(data['version']);
-    if (latest > current) {
-        var message = $.sprintf(PMA_messages['strNewerVersion'], escapeHtml(data['version']), escapeHtml(data['date']));
-        if (Math.floor(latest / 10000) == Math.floor(current / 10000)) {
-            /* Security update */
-            klass = 'error';
-        } else {
-            klass = 'notice';
+    if (data && data.version && data.date) {
+        var current = parseVersionString(pmaversion);
+        var latest = parseVersionString(data['version']);
+        var version_information_message = PMA_messages['strLatestAvailable'] + ' ' + escapeHtml(data['version']);
+        if (latest > current) {
+            var message = $.sprintf(
+                PMA_messages['strNewerVersion'],
+                escapeHtml(data['version']),
+                escapeHtml(data['date'])
+            );
+            if (Math.floor(latest / 10000) === Math.floor(current / 10000)) {
+                /* Security update */
+                klass = 'error';
+            } else {
+                klass = 'notice';
+            }
+            $('#maincontainer').after('<div class="' + klass + '">' + message + '</div>');
         }
-        $('#maincontainer').after('<div class="' + klass + '">' + message + '</div>');
+        if (latest === current) {
+            version_information_message = ' (' + PMA_messages['strUpToDate'] + ')';
+        }
+        $('#li_pma_version').append(version_information_message);
     }
-    if (latest == current) {
-        version_information_message = ' (' + PMA_messages['strUpToDate'] + ')';
-    }
-    $('#li_pma_version').append(version_information_message);
 }
 
 /**
@@ -3034,7 +3040,7 @@ $(document).ready(function() {
      * Load version information asynchronously.
      */
     if ($('.jsversioncheck').length > 0) {
-        $.getJSON('http://www.phpmyadmin.net/home_page/version.json', {}, PMA_current_version);
+        $.getJSON('version_check.php', {}, PMA_current_version);
     }
 
     /**

--- a/version_check.php
+++ b/version_check.php
@@ -1,0 +1,16 @@
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * Proxy for retrieving version information from phpmyadmin.net
+ *
+ * @package PhpMyAdmin
+ */
+
+$file = 'http://www.phpmyadmin.net/home_page/version.json';
+if (ini_get('allow_url_fopen')) {
+    echo file_get_contents($file);
+} else if (function_exists('curl_init')) {
+    curl_exec(curl_init($file));
+}
+
+?>


### PR DESCRIPTION
I read somewhere that the issue of browsers spitting out notices about insecure connections is still present. This patch should fix it once and for all.
