### PR TITLE
Cache the version information obtained from phpmyadmin.net

### DIFF
--- a/version_check.php
+++ b/version_check.php
@@ -1,16 +1,47 @@
 <?php
 /* vim: set expandtab sw=4 ts=4 sts=4: */
 /**
- * Proxy for retrieving version information from phpmyadmin.net
+ * A caching proxy for retrieving version information from phpmyadmin.net
  *
  * @package PhpMyAdmin
  */
 
-$file = 'http://www.phpmyadmin.net/home_page/version.json';
-if (ini_get('allow_url_fopen')) {
-    echo file_get_contents($file);
-} else if (function_exists('curl_init')) {
-    curl_exec(curl_init($file));
+// Sets up the session
+define('PMA_MINIMUM_COMMON', true);
+require_once 'libraries/common.inc.php';
+
+// Get response text from phpmyadmin.net or from the session
+// Update cache every 6 hours
+if (isset($_SESSION['cache']['version_check'])
+    && time() < $_SESSION['cache']['version_check']['timestamp'] + 3600 * 6
+) {
+    $save = false;
+    $response = $_SESSION['cache']['version_check']['response'];
+} else {
+    $save = true;
+    $file = 'http://www.phpmyadmin.net/home_page/version.json';
+    if (ini_get('allow_url_fopen')) {
+        $response = file_get_contents($file);
+    } else if (function_exists('curl_init')) {
+        $curl_handle = curl_init($file);
+        curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, 1);
+        $response = curl_exec();
+    }
+}
+
+// Always send the correct headers
+header('Content-type: application/json; charset=UTF-8');
+
+// Save and forward the response only if in valid format
+$data = json_decode($response);
+if (is_object($data) && strlen($data->version) && strlen($data->date)) {
+    if ($save) {
+        $_SESSION['cache']['version_check'] = array(
+            'response' => $response,
+            'timestamp' => time()
+        );
+    }
+    echo $response;
 }
 
 ?>


### PR DESCRIPTION
With this patch, we can store a cached copy of the version information that we received from phpmyadmin.net in the session. The cache is invalidate every 6 hours.

The benefits include less load on phpmyadmin.net servers and a faster reloading of index.php, especially for local installations.
