### PR TITLE
Repaired autofocus on sql tab & submitting the textbox with ctrl-enter

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -1423,12 +1423,6 @@ AJAX.registerOnload('functions.js', function() {
         }
     });
 
-    $('#sqlquery').focus().keydown(function (e) {
-        if (e.ctrlKey && e.keyCode == 13) {
-            $("#sqlqueryform").submit();
-        }
-    });
-
     if ($('#input_username')) {
         if ($('#input_username').val() == '') {
             $('#input_username').focus();
@@ -3385,8 +3379,15 @@ AJAX.registerOnload('functions.js', function() {
             matchBrackets: true,
             indentUnit: 4,
             mode: "text/x-mysql",
-            lineWrapping: true
+            lineWrapping: true,
+            onKeyEvent: function (inst, e) {
+                if (e.type == 'keydown' && e.ctrlKey && (e.keyCode == 13 || e.keyCode == 10)) {
+                    $("#button_submit_query").submit();
+                    return false;
+                }
+            }
         });
+        codemirror_editor.focus();
     }
 });
 AJAX.registerTeardown('functions.js', function() {

--- a/js/functions.js
+++ b/js/functions.js
@@ -1438,7 +1438,7 @@ AJAX.registerOnload('functions.js', function() {
 function bindCodeMirrorToInlineEditor() {
     var $inline_editor = $('#sql_query_edit');
     if ($inline_editor.length > 0) {
-		if (typeof CodeMirror !== 'undefined') {
+        if (typeof CodeMirror !== 'undefined') {
             var height = $('#sql_query_edit').css('height');
             codemirror_inline_editor = CodeMirror.fromTextArea($inline_editor[0], {
                 lineNumbers: true,
@@ -1450,20 +1450,20 @@ function bindCodeMirrorToInlineEditor() {
             codemirror_inline_editor.getScrollerElement().style.height = height;
             codemirror_inline_editor.refresh();
             codemirror_inline_editor.focus();
-            $(codemirror_inline_editor.getWrapperElement()).bind('keypress', catch_keypresses_from_sql_textboxes);
+            $(codemirror_inline_editor.getWrapperElement()).bind('keypress', catchKeypressesFromSqlTextboxes);
         } else {
-            $($inline_editor).bind('keypress', catch_keypresses_from_sql_textboxes);
+            $inline_editor.focus();
+            $inline_editor.bind('keypress', catchKeypressesFromSqlTextboxes);
         }
-        $inline_editor.focus();
     }
 }
 
-function catch_keypresses_from_sql_textboxes(event) {
+function catchKeypressesFromSqlTextboxes(event) {
     // ctrl-enter is 10 in chrome and ie, but 13 in ff
     if (event.ctrlKey && (event.keyCode == 13 || event.keyCode == 10)) { 
         if ($('#sql_query_edit').length > 0) {
             $("#sql_query_edit_save").trigger('click');
-		} else if ($('#sqlquery').length > 0) {
+        } else if ($('#sqlquery').length > 0) {
             $("#button_submit_query").trigger('click');
         }
     }
@@ -3402,12 +3402,12 @@ AJAX.registerOnload('functions.js', function() {
                 lineWrapping: true
             });
             codemirror_editor.focus();
-            $(codemirror_editor.getWrapperElement()).bind('keypress', catch_keypresses_from_sql_textboxes);
-			return false;
+            $(codemirror_editor.getWrapperElement()).bind('keypress', catchKeypressesFromSqlTextboxes);
+            return false;
         // without codemirror
         } else {
             $elm.focus();
-            $($elm).bind('keypress', catch_keypresses_from_sql_textboxes);
+            $($elm).bind('keypress', catchKeypressesFromSqlTextboxes);
         }
     }
 });

--- a/js/functions.js
+++ b/js/functions.js
@@ -1315,12 +1315,17 @@ AJAX.registerTeardown('functions.js', function() {
     $('input.sqlbutton').unbind('click');
     $("#export_type").unbind('change');
     $('#sqlquery').unbind('keydown');
+    $('#sql_query_edit').unbind('keydown');
 
     if (codemirror_inline_editor) {
         // Copy the sql query to the text area to preserve it.
         $('#sql_query_edit').text(codemirror_inline_editor.getValue());
         codemirror_inline_editor.toTextArea();
         codemirror_inline_editor = false;
+        $(codemirror_inline_editor.getWrapperElement()).unbind('keydown');
+    }
+    if (codemirror_editor) {
+        $(codemirror_editor.getWrapperElement()).unbind('keydown');
     }
 });
 
@@ -1450,10 +1455,10 @@ function bindCodeMirrorToInlineEditor() {
             codemirror_inline_editor.getScrollerElement().style.height = height;
             codemirror_inline_editor.refresh();
             codemirror_inline_editor.focus();
-            $(codemirror_inline_editor.getWrapperElement()).bind('keypress', catchKeypressesFromSqlTextboxes);
+            $(codemirror_inline_editor.getWrapperElement()).bind('keydown', catchKeypressesFromSqlTextboxes);
         } else {
             $inline_editor.focus();
-            $inline_editor.bind('keypress', catchKeypressesFromSqlTextboxes);
+            $inline_editor.bind('keydown', catchKeypressesFromSqlTextboxes);
         }
     }
 }
@@ -3402,18 +3407,15 @@ AJAX.registerOnload('functions.js', function() {
                 lineWrapping: true
             });
             codemirror_editor.focus();
-            $(codemirror_editor.getWrapperElement()).bind('keypress', catchKeypressesFromSqlTextboxes);
+            $(codemirror_editor.getWrapperElement()).bind('keydown', catchKeypressesFromSqlTextboxes);
             return false;
         // without codemirror
         } else {
             $elm.focus();
-            $($elm).bind('keypress', catchKeypressesFromSqlTextboxes);
+            $($elm).bind('keydown', catchKeypressesFromSqlTextboxes);
         }
     }
 });
-
-
-
 AJAX.registerTeardown('functions.js', function() {
     if (codemirror_editor) {
         $('#sqlquery').text(codemirror_editor.getValue());

--- a/js/functions.js
+++ b/js/functions.js
@@ -1320,9 +1320,9 @@ AJAX.registerTeardown('functions.js', function() {
     if (codemirror_inline_editor) {
         // Copy the sql query to the text area to preserve it.
         $('#sql_query_edit').text(codemirror_inline_editor.getValue());
+        $(codemirror_inline_editor.getWrapperElement()).unbind('keydown');
         codemirror_inline_editor.toTextArea();
         codemirror_inline_editor = false;
-        $(codemirror_inline_editor.getWrapperElement()).unbind('keydown');
     }
     if (codemirror_editor) {
         $(codemirror_editor.getWrapperElement()).unbind('keydown');

--- a/js/functions.js
+++ b/js/functions.js
@@ -3383,7 +3383,8 @@ AJAX.registerOnload('functions.js', function() {
         });
         codemirror_wrapper_element = codemirror_editor.getWrapperElement();
         $(codemirror_wrapper_element).bind('keypress', function (e) {
-            if (e.ctrlKey && (e.keyCode == 13 || e.keyCode == 10)) { // ctrl-enter is 10 in chrome and ie, but 13 in ff
+            // ctrl-enter is 10 in chrome and ie, but 13 in ff
+            if (e.ctrlKey && (e.keyCode == 13 || e.keyCode == 10)) { 
                 $("#button_submit_query").submit();
                 return false;
             }

--- a/js/functions.js
+++ b/js/functions.js
@@ -1436,18 +1436,36 @@ AJAX.registerOnload('functions.js', function() {
  * Binds the CodeMirror to the text area used to inline edit a query.
  */
 function bindCodeMirrorToInlineEditor() {
-    var $inline_editor = $('textarea[name="sql_query_edit"]');
-    if ($inline_editor.length > 0 && typeof CodeMirror !== 'undefined') {
-        var height = $('#sql_query_edit').css('height');
-        codemirror_inline_editor = CodeMirror.fromTextArea($inline_editor[0], {
-            lineNumbers: true,
-            matchBrackets: true,
-            indentUnit: 4,
-            mode: "text/x-mysql",
-            lineWrapping: true
-        });
-        codemirror_inline_editor.getScrollerElement().style.height = height;
-        codemirror_inline_editor.refresh();
+    var $inline_editor = $('#sql_query_edit');
+    if ($inline_editor.length > 0) {
+		if (typeof CodeMirror !== 'undefined') {
+            var height = $('#sql_query_edit').css('height');
+            codemirror_inline_editor = CodeMirror.fromTextArea($inline_editor[0], {
+                lineNumbers: true,
+                matchBrackets: true,
+                indentUnit: 4,
+                mode: "text/x-mysql",
+                lineWrapping: true
+            });
+            codemirror_inline_editor.getScrollerElement().style.height = height;
+            codemirror_inline_editor.refresh();
+            codemirror_inline_editor.focus();
+            $(codemirror_inline_editor.getWrapperElement()).bind('keypress', catch_keypresses_from_sql_textboxes);
+        } else {
+            $($inline_editor).bind('keypress', catch_keypresses_from_sql_textboxes);
+        }
+        $inline_editor.focus();
+    }
+}
+
+function catch_keypresses_from_sql_textboxes(event) {
+    // ctrl-enter is 10 in chrome and ie, but 13 in ff
+    if (event.ctrlKey && (event.keyCode == 13 || event.keyCode == 10)) { 
+        if ($('#sql_query_edit').length > 0) {
+            $("#sql_query_edit_save").trigger('click');
+		} else if ($('#sqlquery').length > 0) {
+            $("#button_submit_query").trigger('click');
+        }
     }
 }
 
@@ -3373,24 +3391,29 @@ AJAX.registerOnload('functions.js', function() {
  */
 AJAX.registerOnload('functions.js', function() {
     var $elm = $('#sqlquery');
-    if ($elm.length > 0 && typeof CodeMirror != 'undefined') {
-        codemirror_editor = CodeMirror.fromTextArea($elm[0], {
-            lineNumbers: true,
-            matchBrackets: true,
-            indentUnit: 4,
-            mode: "text/x-mysql",
-            lineWrapping: true
-        });
-        codemirror_wrapper_element = codemirror_editor.getWrapperElement();
-        $(codemirror_wrapper_element).bind('keypress', function (e) {
-            // ctrl-enter is 10 in chrome and ie, but 13 in ff
-            if (e.ctrlKey && (e.keyCode == 13 || e.keyCode == 10)) { 
-                $("#button_submit_query").submit();
-            }
-        });
-        codemirror_editor.focus();
+    if ($elm.length > 0) {
+        // for codemirror
+        if (typeof CodeMirror != 'undefined') {
+            codemirror_editor = CodeMirror.fromTextArea($elm[0], {
+                lineNumbers: true,
+                matchBrackets: true,
+                indentUnit: 4,
+                mode: "text/x-mysql",
+                lineWrapping: true
+            });
+            codemirror_editor.focus();
+            $(codemirror_editor.getWrapperElement()).bind('keypress', catch_keypresses_from_sql_textboxes);
+			return false;
+        // without codemirror
+        } else {
+            $elm.focus();
+            $($elm).bind('keypress', catch_keypresses_from_sql_textboxes);
+        }
     }
 });
+
+
+
 AJAX.registerTeardown('functions.js', function() {
     if (codemirror_editor) {
         $('#sqlquery').text(codemirror_editor.getValue());

--- a/js/functions.js
+++ b/js/functions.js
@@ -3379,12 +3379,13 @@ AJAX.registerOnload('functions.js', function() {
             matchBrackets: true,
             indentUnit: 4,
             mode: "text/x-mysql",
-            lineWrapping: true,
-            onKeyEvent: function (inst, e) {
-                if (e.type == 'keydown' && e.ctrlKey && (e.keyCode == 13 || e.keyCode == 10)) {
-                    $("#button_submit_query").submit();
-                    return false;
-                }
+            lineWrapping: true
+        });
+        codemirror_wrapper_element = codemirror_editor.getWrapperElement();
+        $(codemirror_wrapper_element).bind('keypress', function (e) {
+            if (e.ctrlKey && (e.keyCode == 13 || e.keyCode == 10)) { // ctrl-enter is 10 in chrome and ie, but 13 in ff
+                $("#button_submit_query").submit();
+                return false;
             }
         });
         codemirror_editor.focus();

--- a/js/functions.js
+++ b/js/functions.js
@@ -3386,7 +3386,6 @@ AJAX.registerOnload('functions.js', function() {
             // ctrl-enter is 10 in chrome and ie, but 13 in ff
             if (e.ctrlKey && (e.keyCode == 13 || e.keyCode == 10)) { 
                 $("#button_submit_query").submit();
-                return false;
             }
         });
         codemirror_editor.focus();


### PR DESCRIPTION
Howdy!

Today, while running some queries in phpmyadmin, I ran into some trouble. On the rightmost frame, in the sql tab, the cursor didn't automatically go to the textarea. This was bit of a downer, but I carried merrily on with my life for a few passing seconds until I remembered that the tabulator did not function as before (I am quite used to hit it a couple of times to guide the focus to the "Go" button before pressing enter). Oh silly me. 

Sooo.... A couple of hours later while trying to kill the tab-eating feature I found out that there was a legitimate way of submitting the form with keyboard! Oh joy! Too bad it wasn't working (Firefox 17.0.1 on W7). Same thing with the autofocus. The textbox focusing code seemed a bit old, because removing codemirror initialization would throw the cursor nicely inside the textbox. 

Sorry for a bit hackish way of binding the keypress, but I didn't find a better way for the current codemirror.js v.2.18

Juuso
