### PR TITLE
Killing queries on RDS

### DIFF
--- a/server_status.php
+++ b/server_status.php
@@ -34,7 +34,7 @@ if (! empty($_REQUEST['kill'])) {
     if ($res) {
         $retval = PMA_DBI_fetch_single_row($res);
         
-        if ($info['basedir'] == '/rdsdbbin/mysql/') {
+        if ($retval['basedir'] == '/rdsdbbin/mysql/') {
             $kill_query = sprintf('CALL mysql.rds_kill(%d);', $_REQUEST['kill']);
         }
     }


### PR DESCRIPTION
This patch lets PHPMyAdmin kill queries through the UI on Amazon RDS, using:

```
CALL mysql.rds_kill(99);
```
