### PR TITLE
Chart Page Bug[Fixed]

### DIFF
--- a/tbl_chart.php
+++ b/tbl_chart.php
@@ -94,7 +94,7 @@ if (strlen($GLOBALS['table'])) {
 }
 
 $data = array();
-
+$sql_query="SELECT * FROM ".$_GLOBAL['table'];
 $result = PMA_DBI_try_query($sql_query);
 $fields_meta = PMA_DBI_get_fields_meta($result);
 while ($row = PMA_DBI_fetch_assoc($result)) {


### PR DESCRIPTION
![Untitled](https://f.cloud.github.com/assets/1112049/100641/d52f16e8-6841-11e2-860a-d717ec1aa2a4.png)
Bug Description:
The Chart is not displayed whenever you refresh the tbl_chart.php
How to Produce:
1. Go to any "Display Chart" of a table that can generate chart
2. After the AJAX request get loaded, click on refresh.

Results:
Bunch Of Errors are displayed[1] and the rows_meta select option get disappeared.

[1]:
Warning in ./libraries/dbi/mysqli.dbi.lib.php#267
mysqli_query(): Empty query[...]

Warning in ./libraries/dbi/mysqli.dbi.lib.php#599
mysqli_fetch_fields() expects parameter 1 to be mysqli_result, boolean given[...]

Warning in ./libraries/dbi/mysqli.dbi.lib.php#304
mysqli_fetch_array() expects parameter 1 to be mysqli_result, boolean given[...]

Notice in ./tbl_chart.php#160
Undefined offset: 0[...]

Warning in ./tbl_chart.php#160
array_keys() expects parameter 1 to be array, null given[...]

This bug can be reproduced on demo server too.
Reason: When we refresh the page the "$sql_query" variable is not set causing all the errors
So, its mandatory to declare it before we can use it.
