### PR TITLE
Bug #3784 Disabling "Confirm DROP queries" in user preferences does not ...

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -1890,6 +1890,17 @@ function PMA_SQLPrettyPrint(string)
  */
 
 jQuery.fn.PMA_confirm = function(question, url, callbackFn) {
+    var confirmState = PMA_commonParams.get('confirm');
+    // when the Confirm directive is set to false in config.inc.php 
+    // and not changed in user prefs, confirmState is "" 
+    // when it's unticked in user prefs, confirmState is 1
+    if (confirmState === "" || confirmState === "1") {
+        // user does not want to confirm
+        if ($.isFunction(callbackFn)) {
+            callbackFn.call(this, url);
+            return true;
+        }
+    }
     if (PMA_messages['strDoYouReally'] == '') {
         return true;
     }

--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -219,7 +219,8 @@ class PMA_Header
             ),
             'pma_text_left_default_tab' => PMA_Util::getTitleForTarget(
                 $GLOBALS['cfg']['NavigationTreeDefaultTabTable']
-            )
+            ),
+            'confirm' => $GLOBALS['cfg']['Confirm']
         );
     }
 


### PR DESCRIPTION
...make the confirmations go away
