### PR TITLE
Pull request for bugs:#3802 Datepicker displayed just the first time

### DIFF
--- a/js/jquery/jquery-ui-1.9.2.custom.js
+++ b/js/jquery/jquery-ui-1.9.2.custom.js
@@ -8253,7 +8253,7 @@ $.fn.datepicker = function(options){
 	/* Initialise the date picker. */
 	if (!$.datepicker.initialized) {
 		$(document).mousedown($.datepicker._checkExternalClick).
-                find(document.body).append($.datepicker.dpDiv);
+         find(document.body).append($.datepicker.dpDiv);
 		$.datepicker.initialized = true;
 	}
 

--- a/js/jquery/jquery-ui-1.9.2.custom.js
+++ b/js/jquery/jquery-ui-1.9.2.custom.js
@@ -8253,7 +8253,7 @@ $.fn.datepicker = function(options){
 	/* Initialise the date picker. */
 	if (!$.datepicker.initialized) {
 		$(document).mousedown($.datepicker._checkExternalClick).
-			find(document.body).append($.datepicker.dpDiv);
+                find(document.body).append($.datepicker.dpDiv);
 		$.datepicker.initialized = true;
 	}
 

--- a/js/tbl_change.js
+++ b/js/tbl_change.js
@@ -236,6 +236,7 @@ AJAX.registerTeardown('tbl_change.js', function() {
  * Restart insertion with 'N' rows.
  */
 AJAX.registerOnload('tbl_change.js', function() {
+    $.datepicker.initialized = false;
 
     $('span.open_gis_editor').live('click', function(event) {
         event.preventDefault();


### PR DESCRIPTION
Fixed the bug that was preventing the datepicker from displaying after
ajax call. datepicker remained initialized while its content was
replaced by the ajax response. tbl_change.js now reinitializes
datepicker everytime its loaded.
