### PR TITLE
Simplify CSP policy code

### DIFF
--- a/libraries/header_http.inc.php
+++ b/libraries/header_http.inc.php
@@ -22,12 +22,12 @@ $GLOBALS['now'] = gmdate('D, d M Y H:i:s') . ' GMT';
 /* Prevent against ClickJacking by allowing frames only from same origin */
 if (!$GLOBALS['cfg']['AllowThirdPartyFraming']) {
     header('X-Frame-Options: SAMEORIGIN');
-    header("X-Content-Security-Policy: allow 'self' ; options inline-script eval-script; frame-ancestors 'self'; img-src 'self' data:");
-    if (PMA_USR_BROWSER_AGENT == 'SAFARI') {
-        header("X-WebKit-CSP: allow 'self'; options inline-script eval-script");
-    } else {
-        header("X-WebKit-CSP: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'");
-    }
+    $csp_policy = "allow 'self' ; "
+        . "options inline-script eval-script; "
+        . "frame-ancestors 'self'; "
+        . "img-src 'self' data:";
+    header('X-Content-Security-Policy: ' . $csp_policy);
+    header('X-WebKit-CSP: ' . $csp_policy);
 }
 PMA_no_cache_header();
 if (!defined('IS_TRANSFORMATION_WRAPPER')) {


### PR DESCRIPTION
Currently X-WebKit-CSP should use same syntax as
X-Content-Security-Policy - both have converged to same standard.
Sending old syntax for other WebKit based browsers is wrong as they have
also migrated to new WebKit core using new CSP syntax.
