### PR TITLE
 Fixed #3789 Erroneous LIMIT clause in prettyprinted SQL

### DIFF
--- a/sql.php
+++ b/sql.php
@@ -560,9 +560,6 @@ if ($GLOBALS['cfg']['RememberSorting']
     PMA_handleSortOrder($db, $table, $analyzed_sql, $full_sql_query);
 }
 
-$sql_limit_to_append = ' LIMIT ' . $_SESSION['tmp_user_values']['pos']
-        . ', ' . $_SESSION['tmp_user_values']['max_rows'] . " ";
-
 // Do append a "LIMIT" clause?
 if (($_SESSION['tmp_user_values']['max_rows'] != 'all')
     && ! ($is_count || $is_export || $is_func || $is_analyse)
@@ -570,6 +567,8 @@ if (($_SESSION['tmp_user_values']['max_rows'] != 'all')
     && ! isset($analyzed_sql[0]['queryflags']['offset'])
     && empty($analyzed_sql[0]['limit_clause'])
 ) {
+    $sql_limit_to_append = ' LIMIT ' . $_SESSION['tmp_user_values']['pos']
+        . ', ' . $_SESSION['tmp_user_values']['max_rows'] . " ";
     $full_sql_query = PMA_getSqlWithLimitClause(
         $full_sql_query,
         $analyzed_sql,
@@ -1517,6 +1516,8 @@ function getTableHtmlForMultipleQueries(
                 && ! isset($analyzed_sql[0]['queryflags']['offset'])
                 && empty($analyzed_sql[0]['limit_clause'])
             ) {
+                $sql_limit_to_append = ' LIMIT ' . $_SESSION['tmp_user_values']['pos']
+        . ', ' . $_SESSION['tmp_user_values']['max_rows'] . " ";
                 $sql_data['valid_sql'][$sql_no] = PMA_getSqlWithLimitClause(
                     $sql_data['valid_sql'][$sql_no],
                     $analyzed_sql,


### PR DESCRIPTION
$sql_limit_to_append will only get append with the default limit value according to the session , if the limit is not added to the sql query explicitly.
