### PR TITLE
Fixed the bug #3827 Table speciffic privileges are not displayed at all.

### DIFF
--- a/server_privileges.php
+++ b/server_privileges.php
@@ -470,7 +470,7 @@ if (empty($_REQUEST['adduser'])
             PMA_getHtmlForDisplayUserProperties(
                 ((isset ($dbname_is_wildcard)) ? $dbname_is_wildcard : ''),
                 $url_dbname, $username, $hostname, $link_edit, $link_revoke,
-                (isset($dbname) ? $dbname : ''),
+                (isset($unescaped_db) ? $unescaped_db : ''),
                 (isset($tablename) ? $tablename : '')
             )
         );


### PR DESCRIPTION
The function PMA_getHtmlForDisplayUserProperties() expects formated dbname  as a parameter, without escaped characters. 
