### PR TITLE
No longer package Travis config when creating a release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -92,6 +92,7 @@ VerboseMultiSubmit, ReplaceHelpImg
 - bug #3827 Table specific privileges not displayed for db name containing
 underscore 
 - rfe #1386 Add IF NOT EXISTS clause when copying database
+- No longer package .travis.yml configuration file when creating a release.
 
 3.5.8.0 (not yet released)
 - bug #3828 MariaDB reported as MySQL

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -145,7 +145,7 @@ rm -rf test
 rm -rf PMAStandard
 
 # Testsuite setup
-rm -f build.xml phpunit.xml.dist
+rm -f build.xml phpunit.xml.dist .travis.yml
 
 # Remove readme for github
 rm -f README.rst


### PR DESCRIPTION
The .travis.yml file is included in the official releases, and I don't see a need for that. Am I missing something?

Thanks to Alex Santos for pointing it out.
