### PR TITLE
 Fixed #3830 Can't export custom query because it lowercases table names - Latestgit 

### DIFF
--- a/tbl_export.php
+++ b/tbl_export.php
@@ -37,7 +37,7 @@ if (! empty($sql_query)) {
     // Need to generate WHERE clause?
     if (isset($where_clause)) {
 
-        $temp_sql_array = explode("where", $sql_query);
+        $temp_sql_array = preg_split("/\bwhere\b/i", $sql_query);
 
         // The part "SELECT `id`, `name` FROM `customers`"
         // is not modified by the next code segment, when exporting 

--- a/tbl_export.php
+++ b/tbl_export.php
@@ -37,7 +37,7 @@ if (! empty($sql_query)) {
     // Need to generate WHERE clause?
     if (isset($where_clause)) {
 
-        $temp_sql_array = explode("where", strtolower($sql_query));
+        $temp_sql_array = explode("where", $sql_query);
 
         // The part "SELECT `id`, `name` FROM `customers`"
         // is not modified by the next code segment, when exporting 


### PR DESCRIPTION
The problem is when exporting some selected rows of an uppercase table, the exported dump doesn't contain insert statement for those selected rows. The problem caused because inside the code it transform the sql statement to lowercase and in-turn it will make the table name to lowercase. 
