### PR TITLE
Solved Bug #3837

### DIFF
--- a/tbl_addfield.php
+++ b/tbl_addfield.php
@@ -199,6 +199,7 @@ if (isset($_REQUEST['do_save_data'])) {
         }
 
         $active_page = 'tbl_structure.php';
+        $abort = true;
         include 'tbl_structure.php';
     } else {
         PMA_Util::mysqlDie('', '', '', $err_url, false);


### PR DESCRIPTION
I have updated tbl_addfield.php file since it contained a bug, bug has been removed, a very small change was to be done. 

value of $abort variable is changed in the if loop such that once the page reloads after adding column details user will not see the structure once again.

https://sourceforge.net/p/phpmyadmin/bugs/3837/
