### PR TITLE
Contest-1: Bug#3813 Removed use of htmlentities() while parsing enum/set values in libraries...

### DIFF
--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -3983,7 +3983,7 @@ class PMA_Util
      */
     public static function parseEnumSetValues($definition, $escapeHtml = true)
     {
-        $values_string = htmlentities($definition);
+        $values_string = $definition;
         // There is a JS port of the below parser in functions.js
         // If you are fixing something here,
         // you need to also update the JS port.


### PR DESCRIPTION
.../Util.class.php

Description : To fix Bug#3813, in function parseEnumSetValues() in
libraries/Util.class.php : removed use of htmlentities() for parsing set/enum
values.
