### PR TITLE
Fixed test failures and errors caused in tests using the runkit extension

### DIFF
--- a/test/libraries/common/PMA_whichCrlf_test.php
+++ b/test/libraries/common/PMA_whichCrlf_test.php
@@ -44,7 +44,11 @@ class PMA_whichCrlf_test extends PHPUnit_Framework_TestCase
         } else {
 
             if ($runkit) {
-                define('PMA_USR_OS', 'Linux');
+                if (!defined('PMA_USR_OS'))
+                    define('PMA_USR_OS', 'Linux');
+                else
+                    runkit_constant_redefine('PMA_USR_OS', 'Linux');
+                
                 $this->assertEquals(
                     "\n", PMA_Util::whichCrlf()
                 );

--- a/test/libraries/core/PMA_headerLocation_test.php
+++ b/test/libraries/core/PMA_headerLocation_test.php
@@ -112,7 +112,8 @@ class PMA_headerLocation_test extends PHPUnit_Framework_TestCase
 
             $this->oldIISvalue = 'non-defined';
 
-            if (defined('PMA_IS_IIS')) {
+            $user_defined_constants = get_defined_constants(true)['user'];
+            if (array_key_exists('PMA_IS_IIS', $user_defined_constants)) {
                 $this->oldIISvalue = PMA_IS_IIS;
                 runkit_constant_redefine('PMA_IS_IIS', null);
             } else {
@@ -122,7 +123,7 @@ class PMA_headerLocation_test extends PHPUnit_Framework_TestCase
 
             $this->oldSIDvalue = 'non-defined';
 
-            if (defined('SID')) {
+            if (array_key_exists('SID', $user_defined_constants)) {
                 $this->oldSIDvalue = SID;
                 runkit_constant_redefine('SID', null);
             } else {
@@ -214,7 +215,7 @@ class PMA_headerLocation_test extends PHPUnit_Framework_TestCase
             $testUri = 'http://testurl.com/test.php';
             $separator = PMA_get_arg_separator();
 
-            $header = 'Refresh: 0; ' . $testUri;
+            $header = 'Location: ' . $testUri;
 
             PMA_sendHeaderLocation($testUri);            // sets $GLOBALS['header']
 

--- a/test/libraries/core/PMA_headerLocation_test.php
+++ b/test/libraries/core/PMA_headerLocation_test.php
@@ -112,7 +112,8 @@ class PMA_headerLocation_test extends PHPUnit_Framework_TestCase
 
             $this->oldIISvalue = 'non-defined';
 
-            $user_defined_constants = get_defined_constants(true)['user'];
+            $defined_constants = get_defined_constants(true);
+            $user_defined_constants = $defined_constants['user'];
             if (array_key_exists('PMA_IS_IIS', $user_defined_constants)) {
                 $this->oldIISvalue = PMA_IS_IIS;
                 runkit_constant_redefine('PMA_IS_IIS', null);
@@ -216,9 +217,14 @@ class PMA_headerLocation_test extends PHPUnit_Framework_TestCase
             $separator = PMA_get_arg_separator();
 
             $header = 'Location: ' . $testUri;
-
             PMA_sendHeaderLocation($testUri);            // sets $GLOBALS['header']
+            $this->assertEquals($header, $GLOBALS['header']);
 
+            //reset $GLOBALS['header'] for the next assertion
+            unset($GLOBALS['header']);
+
+            $header = 'Refresh: 0; ' . $testUri;
+            PMA_sendHeaderLocation($testUri, true);            // sets $GLOBALS['header']
             $this->assertEquals($header, $GLOBALS['header']);
 
         } else {


### PR DESCRIPTION
...n

Fixed:
1. errors pertaining to runkit extension in tests under
   PMA_headerLocation_test.php
2. errors pertaining to runkit extension in tests under
   PMA_whichCrlf_test.php
3. failed test: testSendHeaderLocationWithoutSidWithIis()
