### PR TITLE
Fix bug #3842 Query is not shown when altering a table

### DIFF
--- a/tbl_sql.php
+++ b/tbl_sql.php
@@ -14,10 +14,8 @@ require_once 'libraries/common.inc.php';
  * Runs common work
  */
 $response = PMA_Response::getInstance();
-$header   = $response->getHeader();
-$scripts  = $header->getScripts();
-$scripts->addFile('makegrid.js');
-$scripts->addFile('sql.js');
+$GLOBALS['js_include'][] = 'makegrid.js';
+$GLOBALS['js_include'][] = 'sql.js';
 
 require 'libraries/tbl_common.inc.php';
 $url_query .= '&amp;goto=tbl_sql.php&amp;back=tbl_sql.php';


### PR DESCRIPTION
Hi,

I have solved the bug, which was related to tbl_sql.php page which was not showing up the queries when user was altering table.

ex.
alter table table_name rename to table_new_name

All alter queries were being fired and the page automatically use to get refresh..and the query was not shown in the query box even after selecting the check box.

I have fixed all the errors, and Now tbl_sql works completly fine..:) 
Thanks
