### PR TITLE
Update sysinfo to support DragonFly BSD

### DIFF
--- a/libraries/sysinfo.lib.php
+++ b/libraries/sysinfo.lib.php
@@ -30,7 +30,7 @@ function PMA_getSysInfoOs($php_os = PHP_OS)
 {
 
     // look for common UNIX-like systems
-    $unix_like = array('FreeBSD');
+    $unix_like = array('FreeBSD', 'DragonFly');
     if (in_array($php_os, $unix_like)) {
         $php_os = 'Linux';
     }


### PR DESCRIPTION
DragonFly is very similar to FreeBSD, so this change should (hopefully) be self-explanatory.
