### PR TITLE
Correction to composer.json mysql dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "source": "https://github.com/phpmyadmin/phpmyadmin"
     },
     "require": {
-        "php": ">=5.2.0",
-        "mysql": ">=5.0"
+        "php": ">=5.2.0"
     }
 }


### PR DESCRIPTION
Mysql dependency is not valid according to discussion on #composer channel. It prevents installation giving this error: phpmyadmin/phpmyadmin dev-master requires mysql >=5.0 -> no matching package found.
