### PR TITLE
Reserved word warning configuration directive

### DIFF
--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -70,6 +70,13 @@ $cfg['McryptDisableWarning'] = false;
 $cfg['ServerLibraryDifference_DisableWarning'] = false;
 
 /**
+ * Show warning about MySQL reserved words in column names
+ *
+ * @global boolean $cfg['ReservedWordWarning']
+ */
+$cfg['ReservedWordWarning'] = false;
+
+/**
  * Show warning about incomplete translations on certain threshold.
  *
  * @global boolean $cfg['TranslationWarningThreshold']

--- a/sql.php
+++ b/sql.php
@@ -1203,20 +1203,6 @@ if ((0 == $num_rows && 0 == $unlim_num_rows) || $is_affected) {
         echo '</fieldset>' . "\n";
     }
 
-    
-    // Check column names for MySQL reserved words
-    $pma_table = new PMA_Table($table, $db);
-    $columns = $pma_table->getReservedColumnNames();
-    if (! empty($columns)) {
-        foreach ($columns as $column) {
-            $msg = PMA_message::notice(
-                __('The column name \'%s\' is a MySQL reserved keyword.')
-            );
-            $msg->addParam($column);
-            $msg->display();
-        }
-    }
-    
     // Displays the results in a table
     if (empty($disp_mode)) {
         // see the "PMA_setDisplayMode()" function in

--- a/tbl_structure.php
+++ b/tbl_structure.php
@@ -134,15 +134,17 @@ $url_params['goto'] = 'tbl_structure.php';
 $url_params['back'] = 'tbl_structure.php';
 
 // Check column names for MySQL reserved words
-$pma_table = new PMA_Table($table, $db);
-$columns = $pma_table->getReservedColumnNames();
-if (! empty($columns)) {
-    foreach ($columns as $column) {
-        $msg = PMA_message::notice(
-            __('The column name \'%s\' is a MySQL reserved keyword.')
-        );
-        $msg->addParam($column);
-        $response->addHTML($msg);
+if ($cfg['ReservedWordWarning'] === true) {
+    $pma_table = new PMA_Table($table, $db);
+    $columns = $pma_table->getReservedColumnNames();
+    if (! empty($columns)) {
+        foreach ($columns as $column) {
+            $msg = PMA_message::notice(
+                __('The column name \'%s\' is a MySQL reserved keyword.')
+            );
+            $msg->addParam($column);
+            $response->addHTML($msg);
+        }
     }
 }
 


### PR DESCRIPTION
This commit removes reserved word warning from the Browse pages and the
warning on structure page can be switched on/off using the config
variable $cfg['ReservedWordWarning']
