### PR TITLE
Fix replication pages to use correct mysql config syntax

### DIFF
--- a/js/replication.js
+++ b/js/replication.js
@@ -5,23 +5,26 @@
  */
 
 var random_server_id = Math.floor(Math.random() * 10000000);
-var conf_prefix = "server-id=" + random_server_id + "\nlog-bin=mysql-bin\nlog-error=mysql-bin.err\n";
+var conf_prefix = "server-id=" + random_server_id + "\nlog_bin=mysql-bin\nlog_error=mysql-bin.err\n";
 
 function update_config()
 {
     var conf_ignore = "binlog_ignore_db=";
     var conf_do = "binlog_do_db=";
-    var database_list = $('#db_select option:selected:first').val();
-    $('#db_select option:selected:not(:first)').each(function() {
-        database_list += ',' + $(this).val();
-    });
+    var database_list = '';
 
     if ($('#db_select option:selected').size() == 0) {
         $('#rep').text(conf_prefix);
     } else if ($('#db_type option:selected').val() == 'all') {
-        $('#rep').text(conf_prefix + conf_ignore + database_list);
+		$('#db_select option:selected').each(function() {
+			database_list += conf_ignore + $(this).val() + "\n";
+		});
+		$('#rep').text(conf_prefix + database_list);
     } else {
-        $('#rep').text(conf_prefix + conf_do + database_list);
+		$('#db_select option:selected').each(function() {
+			database_list += conf_do + $(this).val() + "\n";
+		});
+        $('#rep').text(conf_prefix + database_list);
     }
 }
 


### PR DESCRIPTION
As specified by http://dev.mysql.com/doc/refman/5.1/en/replication-options-binary-log.html#option_mysqld_binlog-do-db
The binlog-do-db and binlog-ignore-db do not accept commas for multiple databases.
phpmyadmin however does suggest using commas, which is wrong.
This fix will make sure every database has his own line which is how it should be done.
