### PR TITLE
Added a test and fixed webos test for Darwin

### DIFF
--- a/libraries/Config.class.php
+++ b/libraries/Config.class.php
@@ -301,7 +301,7 @@ class PMA_Config
         $this->set('PMA_IS_WINDOWS', 0);
         // If PHP_OS is defined then continue
         if (defined('PHP_OS')) {
-            if (stristr(PHP_OS, 'win')) {
+            if (stristr(PHP_OS, 'win') && !stristr(PHP_OS, 'darwin')) {
                 // Is it some version of Windows
                 $this->set('PMA_IS_WINDOWS', 1);
             } elseif (stristr(PHP_OS, 'OS/2')) {


### PR DESCRIPTION
Added testGetThemeUniqueValue and fixed webServerOs for Mac OS X where
the PHP OS is defined as 'Darwin' and was being picked up as a windows
equivalent
