### PR TITLE
Added a test and fixed webos test for Darwin

### DIFF
--- a/libraries/Config.class.php
+++ b/libraries/Config.class.php
@@ -313,7 +313,7 @@ class PMA_Config
         $this->set('PMA_IS_WINDOWS', 0);
         // If PHP_OS is defined then continue
         if (defined('PHP_OS')) {
-            if (stristr(PHP_OS, 'win')) {
+            if (stristr(PHP_OS, 'win') && !stristr(PHP_OS, 'darwin')) {
                 // Is it some version of Windows
                 $this->set('PMA_IS_WINDOWS', 1);
             } elseif (stristr(PHP_OS, 'OS/2')) {

--- a/test/classes/PMA_Config_test.php
+++ b/test/classes/PMA_Config_test.php
@@ -13,6 +13,7 @@
 require_once 'libraries/core.lib.php';
 require_once 'libraries/Config.class.php';
 require_once 'libraries/relation.lib.php';
+require_once 'libraries/Theme.class.php';
 
 class PMA_ConfigTest extends PHPUnit_Framework_TestCase
 {
@@ -732,10 +733,27 @@ class PMA_ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function testGetThemeUniqueValue()
     {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
+
+        $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
+
+        $partial_sum = (
+            PHPUnit_Framework_Assert::readAttribute($this->object, 'source_mtime') +
+            PHPUnit_Framework_Assert::readAttribute($this->object, 'default_source_mtime') +
+            $this->object->get('user_preferences_mtime') +
+            $_SESSION['PMA_Theme']->mtime_info +
+            $_SESSION['PMA_Theme']->filesize_info
         );
+
+        $this->object->set('fontsize', 10);
+        $this->assertEquals(10 + $partial_sum, $this->object->getThemeUniqueValue());
+        $this->object->set('fontsize', NULL);
+        
+        $_COOKIE['pma_fontsize'] = 20;
+        $this->assertEquals(20 + $partial_sum, $this->object->getThemeUniqueValue());
+        unset($_COOKIE['pma_fontsize']);
+
+        $this->assertEquals($partial_sum, $this->object->getThemeUniqueValue());
+
     }
 
     /**

--- a/test/classes/PMA_Config_test.php
+++ b/test/classes/PMA_Config_test.php
@@ -269,7 +269,9 @@ class PMA_ConfigTest extends PHPUnit_Framework_TestCase
         $this->object->checkWebServerOs();
 
         if (defined('PHP_OS')) {
-            if (stristr(PHP_OS, 'win')) {
+            if (stristr(PHP_OS, 'darwin')) {
+                $this->assertEquals(0, $this->object->get('PMA_IS_WINDOWS'));
+            } elseif (stristr(PHP_OS, 'win')) {
                 $this->assertEquals(1, $this->object->get('PMA_IS_WINDOWS'));
             } elseif (stristr(PHP_OS, 'OS/2')) {
                 $this->assertEquals(1, $this->object->get('PMA_IS_WINDOWS'));


### PR DESCRIPTION
Added testGetThemeUniqueValue and fixed webServerOs for Mac OS X where
the PHP OS is defined as 'Darwin' and was being picked up as a windows
equivalent
