### PR TITLE
Fixed config tests and static variable issue

### DIFF
--- a/libraries/Config.class.php
+++ b/libraries/Config.class.php
@@ -91,7 +91,7 @@ class PMA_Config
         // other settings, independent from config file, comes in
         $this->checkSystem();
 
-        $this->checkIsHttps();
+        $this->isHttps();
     }
 
     /**
@@ -1474,16 +1474,6 @@ class PMA_Config
     }
 
     /**
-     * check for https
-     *
-     * @return void
-     */
-    function checkIsHttps()
-    {
-        $this->set('is_https', $this->isHttps());
-    }
-
-    /**
      * Checks if protocol is https
      *
      * This function checks if the https protocol is used in the PmaAbsoluteUri
@@ -1494,19 +1484,21 @@ class PMA_Config
      */
     public function isHttps()
     {
-        static $is_https = null;
 
-        if (null !== $is_https) {
-            return $is_https;
+        if (null !== $this->get('is_https')) {
+            return $this->get('is_https');
         }
 
         $url = parse_url($this->get('PmaAbsoluteUri'));
+        $is_https = null;
 
         if (isset($url['scheme']) && $url['scheme'] == 'https') {
             $is_https = true;
         } else {
             $is_https = false;
         }
+
+        $this->set('is_https', $is_https);
 
         return $is_https;
     }

--- a/libraries/Config.class.php
+++ b/libraries/Config.class.php
@@ -1178,7 +1178,7 @@ class PMA_Config
     function set($setting, $value)
     {
         if (! isset($this->settings[$setting])
-            || $this->settings[$setting] != $value
+            || $this->settings[$setting] !== $value
         ) {
             $this->settings[$setting] = $value;
             $this->set_mtime = time();

--- a/test/classes/PMA_Config_test.php
+++ b/test/classes/PMA_Config_test.php
@@ -72,7 +72,7 @@ class PMA_ConfigTest extends PHPUnit_Framework_TestCase
         $this->object->set('PMA_USR_BROWSER_AGENT', 'MOZILLA');
         $this->object->set('PMA_USR_BROWSER_VER', 5);
         $this->object->checkOutputCompression();
-        $this->assertEquals('auto', $this->object->get("OBGzip"));
+        $this->assertTrue($this->object->get("OBGzip"));
     }
 
     /**
@@ -549,11 +549,13 @@ class PMA_ConfigTest extends PHPUnit_Framework_TestCase
 
     public function testIsHttps()
     {
+        $this->object->set('is_https', null);
         $this->object->set('PmaAbsoluteUri', 'http://some_host.com/phpMyAdmin');
         $this->assertFalse($this->object->isHttps());
-
+        
+        $this->object->set('is_https', null);
         $this->object->set('PmaAbsoluteUri', 'https://some_host.com/phpMyAdmin');
-        $this->assertFalse($this->object->isHttps());
+        $this->assertTrue($this->object->isHttps());
     }
 
     public function testDetectHttps()
@@ -629,21 +631,6 @@ class PMA_ConfigTest extends PHPUnit_Framework_TestCase
             $this->assertTrue(defined($define));
             $this->assertEquals(constant($define), $this->object->get($define));
         }
-    }
-
-    /**
-     * Should check for https detection
-     *
-     * @return void
-     *
-     * @todo Implement testCheckIsHttps().
-     */
-    public function testCheckIsHttps()
-    {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
     }
 
     /**


### PR DESCRIPTION
1. Removed checkIsHttps()
2. Used settings['is_https'] instead of static is_https in isHttps()
3. Added type checking (===) in the set function
4. Fixed relevant tests after the above changes
