### PR TITLE
Allow loading map tiles when HTTPS is not used

### DIFF
--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -439,6 +439,9 @@ class PMA_Header
      */
     public function sendHttpHeaders()
     {
+        $https = $GLOBALS['PMA_Config']->isHttps();
+        $mapTilesUrls = ' *.tile.openstreetmap.org *.tile.opencyclemap.org';
+
         /**
          * Sends http headers
          */
@@ -447,7 +450,9 @@ class PMA_Header
             header(
                 "X-Content-Security-Policy: allow 'self';"
                 . "options inline-script eval-script;"
-                . "img-src 'self' data:; "
+                . "img-src 'self' data:"
+                . ($https ? "" : $mapTilesUrls)
+                . ";"
             );
             if (PMA_USR_BROWSER_AGENT == 'SAFARI'
                 && PMA_USR_BROWSER_VER < '6.0.0'
@@ -455,13 +460,18 @@ class PMA_Header
                 header(
                     "X-WebKit-CSP: allow 'self';"
                     . "options inline-script eval-script;"
-                    . "img-src 'self' data:; "
+                    . "img-src 'self' data:"
+                    . ($https ? "" : $mapTilesUrls)
+                    . ";"
                 );
             } else {
                 header(
                     "X-WebKit-CSP: default-src 'self';"
                     . "script-src 'self' 'unsafe-inline' 'unsafe-eval';"
-                    . "style-src 'self' 'unsafe-inline'"
+                    . "style-src 'self' 'unsafe-inline';"
+                    . "img-src 'self' data:"
+                    . ($https ? "" : $mapTilesUrls)
+                    . ";"
                 );
             }
         }


### PR DESCRIPTION
I noticed that the recent changes to CSP in order to avoid notices when using HTTPS, blocks map tiles from loading. So now the map tile URLs are added conditionally. 
Pls, note that this is untested under HTTPS; I do not have an environment with HTTPS.
