### PR TITLE
unescaped extra backslahes while displaying the list of database names in database specific privilidges  

### DIFF
--- a/js/tbl_structure.js
+++ b/js/tbl_structure.js
@@ -35,7 +35,7 @@ AJAX.registerOnload('tbl_structure.js', function() {
     /**
      *Ajax action for submitting the "Column Change" and "Add Column" form
      */
-    $(".append_fields_form.ajax").bind('submit', function(event) {
+    $(".append_fields_form.ajax").live('submit', function(event) {
         event.preventDefault();
         /**
          * @var    the_form    object referring to the export form

--- a/js/tbl_structure.js
+++ b/js/tbl_structure.js
@@ -35,7 +35,7 @@ AJAX.registerOnload('tbl_structure.js', function() {
     /**
      *Ajax action for submitting the "Column Change" and "Add Column" form
      */
-    $(".append_fields_form.ajax").live('submit', function(event) {
+    $(".append_fields_form.ajax").bind('submit', function(event) {
         event.preventDefault();
         /**
          * @var    the_form    object referring to the export form

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -2280,7 +2280,7 @@ function PMA_getHTmlForDisplaySelectDbInEditPrivs($found_rows)
             // contrary to the output of SHOW DATABASES
             if (empty($found_rows) || ! in_array($current_db, $found_rows)) {
                 $html_output .= '<option value="' . htmlspecialchars($current_db) . '">'
-                    . htmlspecialchars($current_db) . '</option>' . "\n";
+                    . htmlspecialchars(PMA_Util::unescapeMysqlWildcards($current_db)) . '</option>' . "\n";
             }
         }
         $html_output .= '</select>' . "\n";


### PR DESCRIPTION
while i was browsing through this page, i saw the database name as information\_schema, though the page was working all right but the extra slash didn't looked friendly 

so to correct it, i used

htmlspecialchars(PMA_Util::unescapeMysqlWildcards($current_db)) instead of just htmlspecialchars($current_db) in the option tag
# mapped in function PMA_getHTmlForDisplaySelectDbInEditPrivs($found_rows) in server_privileges.lib.php
