### PR TITLE
small workaround for #3878 Doubleclicking for open tree displays "loading" icon

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -21,9 +21,19 @@ $(function() {
      * opens/closes (hides/shows) tree elements
      * loads data via ajax
      */
+   var click=0;
     $('#pma_navigation_tree a.expander').live('click', function(event) {
         event.preventDefault();
         event.stopImmediatePropagation();
+        //small workaround to solve double click problem
+        click++;
+        if(click==1)
+            setTimeout(function(){click=0;},300);
+        if(click==2){
+             click=0;
+             return false;
+         }
+        //Remaining code continues 
         var $this = $(this);
         var $children = $this.closest('li').children('div.list_container');
         var $icon = $this.find('img');

--- a/js/tbl_structure.js
+++ b/js/tbl_structure.js
@@ -35,7 +35,7 @@ AJAX.registerOnload('tbl_structure.js', function() {
     /**
      *Ajax action for submitting the "Column Change" and "Add Column" form
      */
-    $(".append_fields_form.ajax").bind('submit', function(event) {
+    $(".append_fields_form.ajax").live('submit', function(event) {
         event.preventDefault();
         /**
          * @var    the_form    object referring to the export form

--- a/js/tbl_structure.js
+++ b/js/tbl_structure.js
@@ -35,7 +35,7 @@ AJAX.registerOnload('tbl_structure.js', function() {
     /**
      *Ajax action for submitting the "Column Change" and "Add Column" form
      */
-    $(".append_fields_form.ajax").live('submit', function(event) {
+    $(".append_fields_form.ajax").bind('submit', function(event) {
         event.preventDefault();
         /**
          * @var    the_form    object referring to the export form

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -2280,7 +2280,7 @@ function PMA_getHTmlForDisplaySelectDbInEditPrivs($found_rows)
             // contrary to the output of SHOW DATABASES
             if (empty($found_rows) || ! in_array($current_db, $found_rows)) {
                 $html_output .= '<option value="' . htmlspecialchars($current_db) . '">'
-                    . htmlspecialchars($current_db) . '</option>' . "\n";
+                    . htmlspecialchars(PMA_Util::unescapeMysqlWildcards($current_db)) . '</option>' . "\n";
             }
         }
         $html_output .= '</select>' . "\n";


### PR DESCRIPTION
For every double click a click event was also fired. So made some workaround, so that if second click fires then it will be stopped and only first click will continue, Though the script has to wait for 300 ms but then it differentiates between the click and the double click.
# new code mapped in js/navigation.js
