### PR TITLE
Fix bug #3879 Import broken for CSV using LOAD DATA

### DIFF
--- a/import.php
+++ b/import.php
@@ -77,7 +77,7 @@ if (! empty($sql_query)) {
         $ajax_reload['table_name'] = PMA_Util::unQuote($rename_table_names[2]);
         $ajax_reload['reload'] = true;
     }
-    
+
     $sql_query = '';
 } elseif (! empty($sql_localfile)) {
     // run SQL file on server
@@ -474,7 +474,8 @@ if (! $error) {
     $import_plugin = PMA_getPlugin(
         "import",
         $format,
-        'libraries/plugins/import/'
+        'libraries/plugins/import/',
+        $import_type
     );
     if ($import_plugin == null) {
         $error = true;

--- a/libraries/plugins/import/AbstractImportCsv.class.php
+++ b/libraries/plugins/import/AbstractImportCsv.class.php
@@ -1,0 +1,67 @@
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * Super class of CSV import plugins for phpMyAdmin
+ *
+ * @package    PhpMyAdmin-Import
+ * @subpackage CSV
+ */
+if (! defined('PHPMYADMIN')) {
+    exit;
+}
+
+/* Get the import interface */
+require_once 'libraries/plugins/ImportPlugin.class.php';
+
+/**
+ * Super class of the import plugins for the CSV format
+ *
+ * @package    PhpMyAdmin-Import
+ * @subpackage CSV
+ */
+abstract class AbstractImportCsv extends ImportPlugin
+{
+    /**
+     * Populates the passed OptionsPropertyMainGroup object with options common to
+     * CSV type imports.
+     *
+     * @param object $generalOptions main group of format specific options
+     *
+     * @return object main group of format specific options populated
+     *                with common options
+     */
+    protected function populateCommonOptions($generalOptions)
+    {
+        // create common items and add them to the group
+        $leaf = new BoolPropertyItem();
+        $leaf->setName("replace");
+        $leaf->setText(__('Replace table data with file'));
+        $generalOptions->addProperty($leaf);
+        $leaf = new TextPropertyItem();
+        $leaf->setName("terminated");
+        $leaf->setText(__('Columns separated with:'));
+        $leaf->setSize(2);
+        $leaf->setLen(2);
+        $generalOptions->addProperty($leaf);
+        $leaf = new TextPropertyItem();
+        $leaf->setName("enclosed");
+        $leaf->setText(__('Columns enclosed with:'));
+        $leaf->setSize(2);
+        $leaf->setLen(2);
+        $generalOptions->addProperty($leaf);
+        $leaf = new TextPropertyItem();
+        $leaf->setName("escaped");
+        $leaf->setText(__('Columns escaped with:'));
+        $leaf->setSize(2);
+        $leaf->setLen(2);
+        $generalOptions->addProperty($leaf);
+        $leaf = new TextPropertyItem();
+        $leaf->setName("new_line");
+        $leaf->setText(__('Lines terminated with:'));
+        $leaf->setSize(2);
+        $generalOptions->addProperty($leaf);
+
+        return $generalOptions;
+    }
+}
+?>

--- a/libraries/plugins/import/AbstractImportCsv.class.php
+++ b/libraries/plugins/import/AbstractImportCsv.class.php
@@ -22,16 +22,33 @@ require_once 'libraries/plugins/ImportPlugin.class.php';
 abstract class AbstractImportCsv extends ImportPlugin
 {
     /**
-     * Populates the passed OptionsPropertyMainGroup object with options common to
-     * CSV type imports.
+     * Sets the import plugin properties.
+     * Called in the constructor.
      *
-     * @param object $generalOptions main group of format specific options
-     *
-     * @return object main group of format specific options populated
-     *                with common options
+     * @return object OptionsPropertyMainGroup object of the plugin
      */
-    protected function populateCommonOptions($generalOptions)
+    protected function setProperties()
     {
+        $props = 'libraries/properties/';
+        include_once "$props/plugins/ImportPluginProperties.class.php";
+        include_once "$props/options/groups/OptionsPropertyRootGroup.class.php";
+        include_once "$props/options/groups/OptionsPropertyMainGroup.class.php";
+        include_once "$props/options/items/BoolPropertyItem.class.php";
+        include_once "$props/options/items/TextPropertyItem.class.php";
+
+        $importPluginProperties = new ImportPluginProperties();
+        $importPluginProperties->setOptionsText(__('Options'));
+
+        // create the root group that will be the options field for
+        // $importPluginProperties
+        // this will be shown as "Format specific options"
+        $importSpecificOptions = new OptionsPropertyRootGroup();
+        $importSpecificOptions->setName("Format Specific Options");
+
+        // general options main group
+        $generalOptions = new OptionsPropertyMainGroup();
+        $generalOptions->setName("general_opts");
+
         // create common items and add them to the group
         $leaf = new BoolPropertyItem();
         $leaf->setName("replace");
@@ -60,6 +77,13 @@ abstract class AbstractImportCsv extends ImportPlugin
         $leaf->setText(__('Lines terminated with:'));
         $leaf->setSize(2);
         $generalOptions->addProperty($leaf);
+
+        // add the main group to the root group
+        $importSpecificOptions->addProperty($generalOptions);
+
+        // set the options for the import plugin property item
+        $importPluginProperties->setOptions($importSpecificOptions);
+        $this->properties = $importPluginProperties;
 
         return $generalOptions;
     }

--- a/libraries/plugins/import/ImportCsv.class.php
+++ b/libraries/plugins/import/ImportCsv.class.php
@@ -158,7 +158,7 @@ class ImportCsv extends ImportPlugin
      */
     public function doImport()
     {
-        global $db, $csv_terminated, $csv_enclosed, $csv_escaped, $csv_new_line;
+        global $db, $table, $csv_terminated, $csv_enclosed, $csv_escaped, $csv_new_line;
         global $error, $timeout_passed, $finished;
 
         $replacements = array(

--- a/libraries/plugins/import/ImportCsv.class.php
+++ b/libraries/plugins/import/ImportCsv.class.php
@@ -12,7 +12,7 @@ if (! defined('PHPMYADMIN')) {
 }
 
 /* Get the import interface */
-require_once 'libraries/plugins/ImportPlugin.class.php';
+require_once 'libraries/plugins/import/AbstractImportCsv.class.php';
 
 /**
  * Handles the import for the CSV format
@@ -20,7 +20,7 @@ require_once 'libraries/plugins/ImportPlugin.class.php';
  * @package    PhpMyAdmin-Import
  * @subpackage CSV
  */
-class ImportCsv extends ImportPlugin
+class ImportCsv extends AbstractImportCsv
 {
     /**
      * Whether to analyze tables
@@ -72,34 +72,7 @@ class ImportCsv extends ImportPlugin
         // general options main group
         $generalOptions = new OptionsPropertyMainGroup();
         $generalOptions->setName("general_opts");
-        // create primary items and add them to the group
-        $leaf = new BoolPropertyItem();
-        $leaf->setName("replace");
-        $leaf->setText(__('Replace table data with file'));
-        $generalOptions->addProperty($leaf);
-        $leaf = new TextPropertyItem();
-        $leaf->setName("terminated");
-        $leaf->setText(__('Columns separated with:'));
-        $leaf->setSize(2);
-        $leaf->setLen(2);
-        $generalOptions->addProperty($leaf);
-        $leaf = new TextPropertyItem();
-        $leaf->setName("enclosed");
-        $leaf->setText(__('Columns enclosed with:'));
-        $leaf->setSize(2);
-        $leaf->setLen(2);
-        $generalOptions->addProperty($leaf);
-        $leaf = new TextPropertyItem();
-        $leaf->setName("escaped");
-        $leaf->setText(__('Columns escaped with:'));
-        $leaf->setSize(2);
-        $leaf->setLen(2);
-        $generalOptions->addProperty($leaf);
-        $leaf = new TextPropertyItem();
-        $leaf->setName("new_line");
-        $leaf->setText(__('Lines terminated with:'));
-        $leaf->setSize(2);
-        $generalOptions->addProperty($leaf);
+        $generalOptions = $this->populateCommonOptions($generalOptions);
 
         if ($GLOBALS['plugin_param'] !== 'table') {
             $leaf = new BoolPropertyItem();

--- a/libraries/plugins/import/ImportCsv.class.php
+++ b/libraries/plugins/import/ImportCsv.class.php
@@ -51,28 +51,9 @@ class ImportCsv extends AbstractImportCsv
             $this->_setAnalyze(true);
         }
 
-        $props = 'libraries/properties/';
-        include_once "$props/plugins/ImportPluginProperties.class.php";
-        include_once "$props/options/groups/OptionsPropertyRootGroup.class.php";
-        include_once "$props/options/groups/OptionsPropertyMainGroup.class.php";
-        include_once "$props/options/items/BoolPropertyItem.class.php";
-        include_once "$props/options/items/TextPropertyItem.class.php";
-
-        $importPluginProperties = new ImportPluginProperties();
-        $importPluginProperties->setText('CSV');
-        $importPluginProperties->setExtension('csv');
-        $importPluginProperties->setOptionsText(__('Options'));
-
-        // create the root group that will be the options field for
-        // $importPluginProperties
-        // this will be shown as "Format specific options"
-        $importSpecificOptions = new OptionsPropertyRootGroup();
-        $importSpecificOptions->setName("Format Specific Options");
-
-        // general options main group
-        $generalOptions = new OptionsPropertyMainGroup();
-        $generalOptions->setName("general_opts");
-        $generalOptions = $this->populateCommonOptions($generalOptions);
+        $generalOptions = parent::setProperties();
+        $this->properties->setText('CSV');
+        $this->properties->setExtension('csv');
 
         if ($GLOBALS['plugin_param'] !== 'table') {
             $leaf = new BoolPropertyItem();
@@ -102,13 +83,6 @@ class ImportCsv extends AbstractImportCsv
             );
             $generalOptions->addProperty($leaf);
         }
-
-        // add the main group to the root group
-        $importSpecificOptions->addProperty($generalOptions);
-
-        // set the options for the import plugin property item
-        $importPluginProperties->setOptions($importSpecificOptions);
-        $this->properties = $importPluginProperties;
     }
 
     /**

--- a/libraries/plugins/import/ImportLdi.class.php
+++ b/libraries/plugins/import/ImportLdi.class.php
@@ -11,7 +11,7 @@ if (! defined('PHPMYADMIN')) {
 }
 
 /* Get the import interface */
-require_once 'libraries/plugins/ImportPlugin.class.php';
+require_once 'libraries/plugins/import/AbstractImportCsv.class.php';
 
 // We need relations enabled and we work only on database
 if ($GLOBALS['plugin_param'] !== 'table') {
@@ -25,7 +25,7 @@ if ($GLOBALS['plugin_param'] !== 'table') {
  * @package    PhpMyAdmin-Import
  * @subpackage LDI
  */
-class ImportLdi extends ImportPlugin
+class ImportLdi extends AbstractImportCsv
 {
     /**
      * Constructor
@@ -78,10 +78,22 @@ class ImportLdi extends ImportPlugin
         // general options main group
         $generalOptions = new OptionsPropertyMainGroup();
         $generalOptions->setName("general_opts");
-        // create primary items and add them to the group
+
         $leaf = new BoolPropertyItem();
-        $leaf->setName("replace");
-        $leaf->setText(__('Replace table data with file'));
+        $leaf->setName("ignore");
+        $leaf->setText(__('Do not abort on INSERT error'));
+        $generalOptions->addProperty($leaf);
+
+        $generalOptions = $this->populateCommonOptions($generalOptions);
+
+        $leaf = new TextPropertyItem();
+        $leaf->setName("columns");
+        $leaf->setText(__('Column names: '));
+        $generalOptions->addProperty($leaf);
+
+        $leaf = new BoolPropertyItem();
+        $leaf->setName("local_option");
+        $leaf->setText(__('Use LOCAL keyword'));
         $generalOptions->addProperty($leaf);
 
         // add the main group to the root group

--- a/libraries/plugins/import/ImportLdi.class.php
+++ b/libraries/plugins/import/ImportLdi.class.php
@@ -57,34 +57,9 @@ class ImportLdi extends AbstractImportCsv
             unset($result);
         }
 
-        $props = 'libraries/properties/';
-        include_once "$props/plugins/ImportPluginProperties.class.php";
-        include_once "$props/options/groups/OptionsPropertyRootGroup.class.php";
-        include_once "$props/options/groups/OptionsPropertyMainGroup.class.php";
-        include_once "$props/options/items/BoolPropertyItem.class.php";
-        include_once "$props/options/items/TextPropertyItem.class.php";
-
-        $importPluginProperties = new ImportPluginProperties();
-        $importPluginProperties->setText('CSV using LOAD DATA');
-        $importPluginProperties->setExtension('ldi');
-        $importPluginProperties->setOptionsText(__('Options'));
-
-        // create the root group that will be the options field for
-        // $importPluginProperties
-        // this will be shown as "Format specific options"
-        $importSpecificOptions = new OptionsPropertyRootGroup();
-        $importSpecificOptions->setName("Format Specific Options");
-
-        // general options main group
-        $generalOptions = new OptionsPropertyMainGroup();
-        $generalOptions->setName("general_opts");
-
-        $leaf = new BoolPropertyItem();
-        $leaf->setName("ignore");
-        $leaf->setText(__('Do not abort on INSERT error'));
-        $generalOptions->addProperty($leaf);
-
-        $generalOptions = $this->populateCommonOptions($generalOptions);
+        $generalOptions = parent::setProperties();
+        $this->properties->setText('CSV using LOAD DATA');
+        $this->properties->setExtension('ldi');
 
         $leaf = new TextPropertyItem();
         $leaf->setName("columns");
@@ -92,16 +67,14 @@ class ImportLdi extends AbstractImportCsv
         $generalOptions->addProperty($leaf);
 
         $leaf = new BoolPropertyItem();
+        $leaf->setName("ignore");
+        $leaf->setText(__('Do not abort on INSERT error'));
+        $generalOptions->addProperty($leaf);
+
+        $leaf = new BoolPropertyItem();
         $leaf->setName("local_option");
         $leaf->setText(__('Use LOCAL keyword'));
         $generalOptions->addProperty($leaf);
-
-        // add the main group to the root group
-        $importSpecificOptions->addProperty($generalOptions);
-
-        // set the options for the import plugin property item
-        $importPluginProperties->setOptions($importSpecificOptions);
-        $this->properties = $importPluginProperties;
     }
 
     /**

--- a/libraries/plugins/import/ImportLdi.class.php
+++ b/libraries/plugins/import/ImportLdi.class.php
@@ -112,7 +112,7 @@ class ImportLdi extends ImportPlugin
      */
     public function doImport()
     {
-        global $finished, $error, $import_file, $compression, $charset_conversion;
+        global $finished, $error, $import_file, $compression, $charset_conversion, $table;
         global $ldi_local_option, $ldi_replace, $ldi_terminated, $ldi_enclosed,
             $ldi_escaped, $ldi_new_line, $skip_queries, $ldi_columns;
 


### PR DESCRIPTION
The bug was due to two issues:
1. Not providing the $import_type, and ImportLdi.class.php not being included as it only included when $import_type === 'table' --> Fixed by providing the required parameter.
   2 Trying to access out of scope variable $table --> Fixes by importing it with global keyword

I found the that a similar issue is causing problems in importing content to an already existing table with CSV. Fixed in a separate commit,  4477494  
