### PR TITLE
Implemented rfe #1416 config.inc.php proxy settings for version_check.ph...

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1013,6 +1013,33 @@ Generic settings
 
         This setting can be adjusted by your vendor.
 
+.. config:option:: $cfg['VersionCheckProxyUrl']
+
+    :type: string
+    :default: ""
+
+    The url of the proxy to be used when retrieving the information about
+    the latest version of phpMyAdmin. You need this if the server where
+    phpMyAdmin is installed does not have direct access to the internet.
+    The format is: "hostname:portnumber"
+
+.. config:option:: $cfg['VersionCheckProxyUser']
+
+    :type: string
+    :default: ""
+
+    The username for authenticating with the proxy. By default, no
+    authentication is performed. If a username is supplied, Basic
+    Authentication will be performed. No other types of authentication
+    are currently supported.
+
+.. config:option:: $cfg['VersionCheckProxyPass']
+
+    :type: string
+    :default: ""
+
+    The password for authenticating with the proxy.
+
 .. config:option:: $cfg['MaxDbList']
 
     :type: integer

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -567,6 +567,33 @@ $cfg['ServerDefault'] = 1;
 $cfg['VersionCheck'] = VERSION_CHECK_DEFAULT;
 
 /**
+ * The url of the proxy to be used when retrieving the information about
+ * the latest version of phpMyAdmin. You need this if the server where
+ * phpMyAdmin is installed does not have direct access to the internet.
+ * The format is: "hostname:portnumber"
+ *
+ * @global string $cfg['VersionCheckProxyUrl']
+ */
+$cfg['VersionCheckProxyUrl'] = "";
+
+/**
+ * The username for authenticating with the proxy. By default, no
+ * authentication is performed. If a username is supplied, Basic
+ * Authentication will be performed. No other types of authentication
+ * are currently supported.
+ *
+ * @global string $cfg['VersionCheckProxyUser']
+ */
+$cfg['VersionCheckProxyUser'] = "";
+
+/**
+ * The password for authenticating with the proxy.
+ *
+ * @global string $cfg['VersionCheckProxyPass']
+ */
+$cfg['VersionCheckProxyPass'] = "";
+
+/**
  * maximum number of db's displayed in database list
  *
  * @global integer $cfg['MaxDbList']

--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -519,6 +519,13 @@ $strConfigUserprefsDeveloperTab_name = __('Enable the Developer tab in settings'
 $strConfigVersionCheckLink = __('Check for latest version');
 $strConfigVersionCheck_desc = __('Enables check for latest version on main phpMyAdmin page');
 $strConfigVersionCheck_name = __('Version check');
+$strConfigVersionCheckProxyUrl_desc = __('The url of the proxy to be used when retrieving the information about the latest version of phpMyAdmin. You need this if the server where phpMyAdmin is installed does not have direct access to the internet. The format is: "hostname:portnumber"');
+$strConfigVersionCheckProxyUrl_name = __('Version check proxy url');
+$strConfigVersionCheckProxyUser_desc = __('The username for authenticating with the proxy. By default, no authentication is performed. If a username is supplied, Basic Authentication will be performed. No other types of authentication are currently supported.');
+$strConfigVersionCheckProxyUser_name = __('Version check proxy username');
+$strConfigVersionCheckProxyPass_desc = __('The password for authenticating with the proxy');
+$strConfigVersionCheckProxyPass_name = __('Version check proxy password');
+
 $strConfigZipDump_desc = __('Enable [a@http://en.wikipedia.org/wiki/ZIP_(file_format)]ZIP[/a] compression for import and export operations');
 $strConfigZipDump_name = __('ZIP');
 

--- a/libraries/config/setup.forms.php
+++ b/libraries/config/setup.forms.php
@@ -124,7 +124,6 @@ $forms['Features']['Developer'] = array(
     'Error_Handler/gather',
     'DBG/sql');
 $forms['Features']['Other_core_settings'] = array(
-    'VersionCheck',
     'NaturalOrder',
     'InitialSlidersState',
     'MaxDbList',
@@ -137,7 +136,12 @@ $forms['Features']['Other_core_settings'] = array(
     'MemoryLimit',
     'SkipLockedTables',
     'DisableMultiTableMaintenance',
-    'UseDbSearch');
+    'UseDbSearch',
+    'VersionCheck',
+    'VersionCheckProxyUrl',
+    'VersionCheckProxyUser',
+    'VersionCheckProxyPass'
+);
 $forms['Sql_queries']['Sql_queries'] = array(
     'ShowSQL',
     'Confirm',

--- a/version_check.php
+++ b/version_check.php
@@ -21,9 +21,39 @@ if (isset($_SESSION['cache']['version_check'])
     $save = true;
     $file = 'http://www.phpmyadmin.net/home_page/version.json';
     if (ini_get('allow_url_fopen')) {
-        $response = file_get_contents($file);
+        if (strlen($cfg['VersionCheckProxyUrl'])) {
+            $context = array(
+                'http' => array(
+                    'proxy' => $cfg['VersionCheckProxyUrl'],
+                    'request_fulluri' => true
+                )
+            );
+            if (strlen($cfg['VersionCheckProxyUser'])) {
+                $auth = base64_encode(
+                    $cfg['VersionCheckProxyUser'] . ':' . $cfg['VersionCheckProxyPass']
+                );
+                $context['http']['header'] = 'Proxy-Authorization: Basic ' . $auth;
+            }
+            $response = file_get_contents(
+                $file,
+                false,
+                stream_context_create($context)
+            );
+        } else {
+            $response = file_get_contents($file);
+        }
     } else if (function_exists('curl_init')) {
         $curl_handle = curl_init($file);
+        if (strlen($cfg['VersionCheckProxyUrl'])) {
+            curl_setopt($curl_handle, CURLOPT_PROXY, $cfg['VersionCheckProxyUrl']);
+            if (strlen($cfg['VersionCheckProxyUser'])) {
+                curl_setopt(
+                    $curl_handle,
+                    CURLOPT_PROXYUSERPWD,
+                    $cfg['VersionCheckProxyUser'] . ':' . $cfg['VersionCheckProxyPass']
+                );
+            }
+        }
         curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, 1);
         $response = curl_exec($curl_handle);
     }


### PR DESCRIPTION
In this pull request I attempted to implement the possibility to add proxy settings for the version check feature, as requested in rfe #1416.

I did not add the proxy settings to the user preferences, but I only included them in the setup script, since these should be server-wide.

Theoretically, the implementation allows to, optionally, specify a user name and a password to be used for basic authentication with the proxy. However I was unable to test this scenario. I only managed to test with transparent proxies.

And lastly, my server (apache2/ubuntu) seems to hang when the url of the proxy server is invalid. I wonder though, if it's a setting on my server that is causing this. Can someone confirm the behaviour after applying the patch, logging in and refreshing the main page?
