### PR TITLE
bugfix for #3881. "Escaped html in error message"

### DIFF
--- a/import.php
+++ b/import.php
@@ -41,11 +41,16 @@ foreach ($post_params as $one_post_param) {
     }
 }
 
-//lets check if this page has been redirected from index
-//if redirected then load the lastpage stored in SESSION
-if($_SESSION['redirected']){
+// lets check if this page has been redirected from index
+// if redirected then load the lastpage stored in SESSION
+if ($_SESSION['redirected']) {
+    $GLOBALS['db'] = $_SESSION['dbase'];
+    $GLOBALS['table'] = $_SESSION['table'];
+    $sql_query = $_SESSION['sql_query'];
+    $import_type = $_SESSION['import_type'];
+    $format = $_SESSION['format'];
     include $_SESSION['last_import_url'];
-    $_SESSION['redirected'] = false; //Reset session value for redirected
+    $_SESSION['redirected'] = false; // Reset session value for redirected
     exit;
 }
 // reset import messages for ajax request
@@ -587,13 +592,18 @@ if (! empty($last_query_with_results)) {
     $sql_query = $last_query_with_results;
     $go_sql = true;
 }
-
+// store the values in session
+$_SESSION['sql_query'] = $sql_query;
+$_SESSION['last_import_url'] = $goto;
+$_SESSION['format'] = $format;
+$_SESSION['import_type'] = $import_type;
+$_SESSION['dbase'] = $GLOBALS['db'];
+$_SESSION['table'] = $GLOBALS['table'];
 if ($go_sql) {
+    $_SESSION['last_import_url'] = "sql.php";
     include 'sql.php';
 } else {
     $active_page = $goto;
     include '' . $goto;
-    //To remember the last URL, put it into session
-    $_SESSION['last_import_url'] = $goto; 
 }
 ?>

--- a/import.php
+++ b/import.php
@@ -41,6 +41,13 @@ foreach ($post_params as $one_post_param) {
     }
 }
 
+//lets check if this page has been redirected from index
+//if redirected then load the lastpage stored in SESSION
+if($_SESSION['redirected']){
+    include $_SESSION['last_import_url'];
+    $_SESSION['redirected'] = false; //Reset session value for redirected
+    exit;
+}
 // reset import messages for ajax request
 $_SESSION['Import_message']['message'] = null;
 $_SESSION['Import_message']['go_back_url'] = null;
@@ -586,5 +593,7 @@ if ($go_sql) {
 } else {
     $active_page = $goto;
     include '' . $goto;
+    //To remember the last URL, put it into session
+    $_SESSION['last_import_url'] = $goto; 
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -31,15 +31,18 @@ foreach ($drops as $each_drop) {
     }
 }
 unset($drops, $each_drop);
-
+unset($_SESSION['redirected']);
 // If we have a valid target, let's load that script instead
 if (! empty($_REQUEST['target'])
     && is_string($_REQUEST['target'])
     && ! preg_match('/^index/', $_REQUEST['target'])
     && in_array($_REQUEST['target'], $goto_whitelist)
 ) {
-    if($_REQUEST['target'] == "import.php")
-         $_SESSION['redirected'] = true;  //let's store that we have redirected from index
+    if ($_REQUEST['target'] == "import.php") {
+        $_SESSION['redirected'] = true;  // let's store that we have redirected from index
+        $GLOBALS['db'] = $_SESSION['dbase'];
+        $GLOBALS['table'] = $_SESSION['table'];
+    }
     include $_REQUEST['target'];
     exit;
 }

--- a/index.php
+++ b/index.php
@@ -38,6 +38,8 @@ if (! empty($_REQUEST['target'])
     && ! preg_match('/^index/', $_REQUEST['target'])
     && in_array($_REQUEST['target'], $goto_whitelist)
 ) {
+    if($_REQUEST['target'] == "import.php")
+         $_SESSION['redirected'] = true;  //let's store that we have redirected from index
     include $_REQUEST['target'];
     exit;
 }


### PR DESCRIPTION
The reason for the bug is the post request for "import.php" by *_import.php files. So, in this case after logging in, the target variable in the GET REQUEST was always set to import.php and thus PMA was redirected to import.php. But import the php used two parameters import_type and format which when checked in the checkparameters function resulted in fatal error.

The changes that i made were, before redirecting if the request was for import.php in the code of index.php, if true i used session variable to state that i am doing some redirection(this variable can be pretty helpful if in future we have some more legacy submissions like for import.php) and in session variable i check it if it's true or not,

If true then just redirect the code to the last url where we were(which is also stored in session, could have used $GLOBALS but the seems to be reloaded by the common.inc.php, so used sessions)
