### PR TITLE
Hide login data in backtrace

### DIFF
--- a/libraries/Error.class.php
+++ b/libraries/Error.class.php
@@ -300,9 +300,20 @@ class PMA_Error extends PMA_Message
             'require',
             'require_once',
         );
+        $connect_functions = array(
+            'mysql_connect',
+            'mysql_pconnect',
+            'mysqli_connect',
+            'mysqli_real_connect',
+            'PMA_DBI_connect',
+            'PMA_DBI_real_connect',
+        );
 
         if (in_array($function, $include_functions)) {
             $retval .= PMA_Error::relPath($arg);
+        } elseif (in_array($function, $connect_functions)
+            && getType($arg) === 'string') {
+            $retval .= getType($arg) . ' ********';
         } elseif (is_scalar($arg)) {
             $retval .= getType($arg) . ' ' . htmlspecialchars($arg);
         } else {

--- a/libraries/Error.class.php
+++ b/libraries/Error.class.php
@@ -312,7 +312,8 @@ class PMA_Error extends PMA_Message
         if (in_array($function, $include_functions)) {
             $retval .= PMA_Error::relPath($arg);
         } elseif (in_array($function, $connect_functions)
-            && getType($arg) === 'string') {
+            && getType($arg) === 'string'
+        ) {
             $retval .= getType($arg) . ' ********';
         } elseif (is_scalar($arg)) {
             $retval .= getType($arg) . ' ' . htmlspecialchars($arg);


### PR DESCRIPTION
Hide hosts, usernames and passwords when displaying calls to *_connect functions in the backtrace. Otherwise sensitive login data may get exposed to people connecting to PMA after the configured MySQL server goes back online after being offline. Minor, as backtraces are hidden per default.

![backtrace-hide-password](https://f.cloud.github.com/assets/157944/427296/a1a350f6-ade1-11e2-9a71-44a31515ab0e.png)
