### PR TITLE
Implementation of feature request 1412. Creating view for empty resultset

### DIFF
--- a/libraries/DisplayResults.class.php
+++ b/libraries/DisplayResults.class.php
@@ -5156,6 +5156,50 @@ class PMA_DisplayResults
 
     } // end of the '_getPlacedTableNavigatoins()' function
 
+    //A function which generates <span> tag for view
+    //called by _getResultsOperation and getCreateViewQueryResultOp
+    private function getViewLinkForQuery($analyzed_sql,$url_query){
+        $results_operations_html = '';
+        if (!PMA_DRIZZLE && !isset($analyzed_sql[0]['queryflags']['procedure'])) {
+
+            $ajax_class = ' ajax';
+
+            $results_operations_html .= '<span>'
+                . PMA_Util::linkOrButton(
+                    'view_create.php' . $url_query,
+                    PMA_Util::getIcon(
+                        'b_views.png', __('Create view'), true
+                    ),
+                    array('class' => 'create_view' . $ajax_class), true, true, ''
+                )
+                . '</span>' . "\n";
+        }
+        return $results_operations_html;
+    
+    }
+    
+    /**
+        A function used to generate the DOM's for query result operation
+        if query return 0 rows
+        gets called from sql.php 
+    */
+    public function getCreateViewQueryResultOp($analyzed_sql){
+    
+        $results_operations_html = '';
+        $_url_params = array(
+                    'db'        => $this->__get('db'),
+                    'table'     => $this->__get('table'),
+                    'printview' => '1',
+                    'sql_query' => $this->__get('sql_query'),
+                );
+        $url_query = PMA_generate_common_url($_url_params);
+        
+        $results_operations_html .= '<fieldset><legend>' . __('Query results operations')
+                        . '</legend>';
+        $results_operations_html .= $this->getViewLinkForQuery($analyzed_sql,$url_query);
+        $results_operations_html .= '</fieldset>';
+        return $results_operations_html;
+   }
 
     /**
      * Get operations that are available on results.
@@ -5337,20 +5381,7 @@ class PMA_DisplayResults
             $header_shown = true;
         }
 
-        if (!PMA_DRIZZLE && !isset($analyzed_sql[0]['queryflags']['procedure'])) {
-
-            $ajax_class = ' ajax';
-
-            $results_operations_html .= '<span>'
-                . PMA_Util::linkOrButton(
-                    'view_create.php' . $url_query,
-                    PMA_Util::getIcon(
-                        'b_views.png', __('Create view'), true
-                    ),
-                    array('class' => 'create_view' . $ajax_class), true, true, ''
-                )
-                . '</span>' . "\n";
-        }
+        $results_operations_html .= $this->getViewLinkForQuery($analyzed_sql,$url_query);
 
         if ($header_shown) {
             $results_operations_html .= '</fieldset><br />';

--- a/sql.php
+++ b/sql.php
@@ -962,6 +962,11 @@ if ((0 == $num_rows && 0 == $unlim_num_rows) || $is_affected) {
         $response->isSuccess($message->isSuccess());
         // No need to manually send the message
         // The Response class will handle that automatically
+        if($analyzed_sql[0]['querytype'] == PMA_DisplayResults::QUERY_TYPE_SELECT) {
+            $response->addHTML($displayResultsObject->getCreateViewQueryResultOp($analyzed_sql).'<br />');
+            
+        }
+        
         $response->addJSON(isset($extra_data) ? $extra_data : array());
         if (empty($_REQUEST['ajax_page_request'])) {
             $response->addJSON('message', $message);


### PR DESCRIPTION
Refactored work of pull request 226. 

I created two functions 

getViewLinkForQuery whose work is to generate span tag for View. The function was used in _getResultOperation also. It's purpose was to reduce code duplication

The second function was getCreateViewQueryResultOp() whose purpose is to display create view link in case empty resultset is produced. It calls getViewLinkForQuery() to generate span tag and it is called from sql.php

If function names are not appropriate, then please suggest one, because i feel like they are not right.
