### PR TITLE
Implementation of feature request 1410. AES_ENCRYPT w/ Salt

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -100,6 +100,7 @@ underscore
 - bug #3840 When exporting to gzip format, the data is compressed 2 times
 + rfe #1319 Permit to create index when creating foreign key
 - bug #3703 Incorrect updating of the list of users
++ rfe #1410 Added support for AES_ENCRYPT for blob fields 
 
 3.5.8.0 (not yet released)
 - bug #3828 MariaDB reported as MySQL

--- a/js/tbl_change.js
+++ b/js/tbl_change.js
@@ -150,7 +150,19 @@ function verificationsAfterFieldChange(urlField, multi_edit, theType)
 {
     var evt = window.event || arguments.callee.caller.arguments[0];
     var target = evt.target || evt.srcElement;
-
+    
+    //TO generate the textbox that can take the salt
+    var new_salt_box = "<br><input type=text name=salt[multi_edit][" + multi_edit + "][" + urlField + "]"
+    +" id=salt_"+evt.srcElement.id+" placeholder='enter Salt'>";
+    
+    //If AES_ENCRYPT is Selected then append the new textbox for salt    
+    if (evt.srcElement.value == "AES_ENCRYPT" && !($("#salt_"+evt.srcElement.id).length)) {
+        $("input[name='fields[multi_edit][" + multi_edit + "][" + urlField + "]']").after(new_salt_box);
+    } else {
+        //The value of the select is no longer AES_ENCRYPT, remove the textbox for salt
+        $("#salt_"+evt.srcElement.id).remove();
+    }
+        
     // Unchecks the corresponding "NULL" control
     $("input[name='fields_null[multi_edit][" + multi_edit + "][" + urlField + "]']").prop('checked', false);
 

--- a/js/tbl_change.js
+++ b/js/tbl_change.js
@@ -153,14 +153,14 @@ function verificationsAfterFieldChange(urlField, multi_edit, theType)
     
     //TO generate the textbox that can take the salt
     var new_salt_box = "<br><input type=text name=salt[multi_edit][" + multi_edit + "][" + urlField + "]"
-    +" id=salt_"+evt.srcElement.id+" placeholder='enter Salt'>";
+    +" id=salt_"+target.id+" placeholder='enter Salt'>";
     
     //If AES_ENCRYPT is Selected then append the new textbox for salt    
-    if (evt.srcElement.value == "AES_ENCRYPT" && !($("#salt_"+evt.srcElement.id).length)) {
+    if (target.value == "AES_ENCRYPT" && !($("#salt_"+target.id).length)) {
         $("input[name='fields[multi_edit][" + multi_edit + "][" + urlField + "]']").after(new_salt_box);
     } else {
         //The value of the select is no longer AES_ENCRYPT, remove the textbox for salt
-        $("#salt_"+evt.srcElement.id).remove();
+        $("#salt_"+target.id).remove();
     }
         
     // Unchecks the corresponding "NULL" control

--- a/libraries/Types.class.php
+++ b/libraries/Types.class.php
@@ -451,6 +451,7 @@ class PMA_Types_MySQL extends PMA_Types
         switch ($class) {
         case 'CHAR':
             return array(
+                'AES_ENCRYPT',
                 'BIN',
                 'CHAR',
                 'COMPRESS',

--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -2125,9 +2125,9 @@ function PMA_transformEditedValues($db, $table,
  * @return array $cur_value
  */
 function PMA_getCurrentValueAsAnArrayForMultipleEdit($multi_edit_colummns,
-    $multi_edit_columns_name, $multi_edit_funcs, $gis_from_text_functions,
-    $current_value, $gis_from_wkb_functions, $func_optional_param,
-    $func_no_param, $key
+    $multi_edit_columns_name, $multi_edit_funcs, $multi_edit_salt, 
+    $gis_from_text_functions, $current_value, $gis_from_wkb_functions, 
+    $func_optional_param, $func_no_param, $key
 ) {
     if (empty($multi_edit_funcs[$key])) {
         return $current_value;
@@ -2148,7 +2148,12 @@ function PMA_getCurrentValueAsAnArrayForMultipleEdit($multi_edit_colummns,
         || ($current_value != "''"
         && in_array($multi_edit_funcs[$key], $func_optional_param))
     ) {
+        if (isset($multi_edit_salt[$key]) && ($multi_edit_funcs[$key] == "AES_ENCRYPT")) {
+            return $multi_edit_funcs[$key] . '(' . $current_value . ",'" 
+                   . PMA_Util::sqlAddSlashes($multi_edit_salt[$key]) . "')";
+        } else { 
         return $multi_edit_funcs[$key] . '(' . $current_value . ')';
+        }
     } else {
         return $multi_edit_funcs[$key] . '()';
     }

--- a/tbl_replace.php
+++ b/tbl_replace.php
@@ -152,6 +152,10 @@ foreach ($loop_array as $rownumber => $where_clause) {
         = isset($_REQUEST['funcs']['multi_edit'][$rownumber])
         ? $_REQUEST['funcs']['multi_edit'][$rownumber]
         : null;
+    $multi_edit_salt
+        = isset($_REQUEST['salt']['multi_edit'][$rownumber])
+        ? $_REQUEST['salt']['multi_edit'][$rownumber]
+        :null;
     $multi_edit_columns_type
         = isset($_REQUEST['fields_type']['multi_edit'][$rownumber])
         ? $_REQUEST['fields_type']['multi_edit'][$rownumber]
@@ -205,9 +209,9 @@ foreach ($loop_array as $rownumber => $where_clause) {
         );
 
         $current_value_as_an_array = PMA_getCurrentValueAsAnArrayForMultipleEdit(
-            $multi_edit_colummns, $multi_edit_columns_name, $multi_edit_funcs,
-            $gis_from_text_functions, $current_value, $gis_from_wkb_functions,
-            $func_optional_param, $func_no_param, $key
+            $multi_edit_colummns, $multi_edit_columns_name, $multi_edit_funcs, 
+            $multi_edit_salt, $gis_from_text_functions, $current_value,
+            $gis_from_wkb_functions, $func_optional_param, $func_no_param, $key
         );
 
         list($query_values, $query_fields)

--- a/test/classes/PMA_Types_MySQL_test.php
+++ b/test/classes/PMA_Types_MySQL_test.php
@@ -302,6 +302,7 @@ class PMA_Types_MySQL_Test extends PHPUnit_Framework_TestCase
             array(
                 'CHAR',
                 array(
+                    'AES_ENCRYPT',
                     'BIN',
                     'CHAR',
                     'COMPRESS',


### PR DESCRIPTION
Implementation of feature request 1410 . Adding AES_ENCRYPTION among the various types of function.

Now when AES_ENCRYPT is selected a new textbox is loaded to take the input for salt which is later used to encrypt the string.

Please review it and guide me if there is some problem or instability in the code. I tried to minimze the GUI cluttering. and to maintain the PEAR standards, however may have left something.

(We were asked to submit a patch for GSoC 2013 before 10th, so submitted this one. Didn't know when to start, so submitted it ASAP)

Thanks
