### PR TITLE
Bug #3918 Greyed out tabs when there are no rows fixed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,7 +17,8 @@ phpMyAdmin - ChangeLog
 - bug #3905 [export] Custom Exporting exports all databases
 - bug #3909 [import] Import of CSV FIle to selected table doesn't work
 - bug #3904 Browsing an empty table should not display its Structure
-- bug #3908 Calendar widget improperly redirects to home 
+- bug #3908 Calendar widget improperly redirects to home
+- bug #3918 Greyed out tabs when there are no rows fixed
 
 4.0.0.0 (2013-05-03)
 + Patch #3481047 for rfe #3480477 Insert as new row enhancement

--- a/libraries/Menu.class.php
+++ b/libraries/Menu.class.php
@@ -315,10 +315,6 @@ class PMA_Menu
             $tabs['operation']['text'] = __('Operations');
         }
 
-        if ($table_info_num_rows == 0 && ! $tbl_is_view) {
-            $tabs['browse']['warning'] = __('Table seems to be empty!');
-            $tabs['search']['warning'] = __('Table seems to be empty!');
-        }
         return $tabs;
     }
 

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -1765,15 +1765,9 @@ class PMA_Util
             ) {
                 $tab['class'] = 'active';
             } elseif (is_null($tab['active']) && empty($GLOBALS['active_page'])
-              && (basename($GLOBALS['PMA_PHP_SELF']) == $tab['link'])
-              && empty($tab['warning'])) {
+              && (basename($GLOBALS['PMA_PHP_SELF']) == $tab['link'])) {
                 $tab['class'] = 'active';
             }
-        }
-
-        if (! empty($tab['warning'])) {
-            $tab['class'] .= ' error';
-            $tab['attr'] .= ' title="' . htmlspecialchars($tab['warning']) . '"';
         }
 
         // If there are any tab specific URL parameters, merge those with

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -772,12 +772,6 @@ ul#topmenu2 a.tabactive {
 ul#topmenu > li.active {
      border-bottom:      1pt solid <?php echo $GLOBALS['cfg']['MainBackground']; ?>;
 }
-
-/* disabled tabs */
-ul#topmenu span.tab,
-a.error {
-    cursor:             url(<?php echo $_SESSION['PMA_Theme']->getImgPath('error.ico');?>), default;
-}
 /* end topmenu */
 
 /* zoom search */


### PR DESCRIPTION
The tabs corresponding to empty tables are no longer greyed and no warning message is shown when hover over the tab.
