### PR TITLE
Bug #3918 Greyed out tabs when there are no rows fixed

### DIFF
--- a/libraries/Menu.class.php
+++ b/libraries/Menu.class.php
@@ -315,10 +315,6 @@ class PMA_Menu
             $tabs['operation']['text'] = __('Operations');
         }
 
-        if ($table_info_num_rows == 0 && ! $tbl_is_view) {
-            $tabs['browse']['warning'] = __('Table seems to be empty!');
-            $tabs['search']['warning'] = __('Table seems to be empty!');
-        }
         return $tabs;
     }
 

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -1765,15 +1765,9 @@ class PMA_Util
             ) {
                 $tab['class'] = 'active';
             } elseif (is_null($tab['active']) && empty($GLOBALS['active_page'])
-              && (basename($GLOBALS['PMA_PHP_SELF']) == $tab['link'])
-              && empty($tab['warning'])) {
+              && (basename($GLOBALS['PMA_PHP_SELF']) == $tab['link'])) {
                 $tab['class'] = 'active';
             }
-        }
-
-        if (! empty($tab['warning'])) {
-            $tab['class'] .= ' error';
-            $tab['attr'] .= ' title="' . htmlspecialchars($tab['warning']) . '"';
         }
 
         // If there are any tab specific URL parameters, merge those with

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -695,11 +695,6 @@ ul#topmenu2 a {
     white-space:        nowrap;
 }
 
-/* disabled tabs */
-ul#topmenu span.tab {
-    color:              #666666;
-}
-
 fieldset.caution a {
     color:              #FF0000;
 }
@@ -771,12 +766,6 @@ ul#topmenu2 a.tabactive {
 /* to be able to cancel the bottom border, use <li class="active"> */
 ul#topmenu > li.active {
      border-bottom:      1pt solid <?php echo $GLOBALS['cfg']['MainBackground']; ?>;
-}
-
-/* disabled tabs */
-ul#topmenu span.tab,
-a.error {
-    cursor:             url(<?php echo $_SESSION['PMA_Theme']->getImgPath('error.ico');?>), default;
 }
 /* end topmenu */
 

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -942,11 +942,6 @@ ul#topmenu2 a {
 
 }
 
-/* disabled tabs */
-ul#topmenu span.tab {
-    color: #666;
-}
-
 fieldset.caution a {
     color: #FF0000;
 }
@@ -1021,13 +1016,6 @@ ul#topmenu2 a.tabactive {
 ul#topmenu > li.active {
     /* border-bottom: 0pt solid <?php echo $GLOBALS['cfg']['MainBackground']; ?>; */
     border-right: 0;
-}
-
-/* disabled tabs */
-ul#topmenu span.tab,
-a.error {
-    cursor: url(<?php echo $_SESSION['PMA_Theme']->getImgPath('error.ico');?>), default;
-    color: #ccc;
 }
 /* end topmenu */
 


### PR DESCRIPTION
The tabs corresponding to empty tables are no longer greyed and no warning message is shown when hover over the tab.
