### PR TITLE
Fixed #3902: Cannot browse when table name contains keyword 'call'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ phpMyAdmin - ChangeLog
 ======================
 
 4.0.2.0 (not yet released)
+- bug #3902 Cannot browse when table name contains keyword "call"
 + center loading indicator for navigation refresh, related to bug #3920
 - bug #3925 Table sorting in navigation panel is case-sensitive
 - bug #3915 Import of CSV file (Replace table data with file) with duplicate

--- a/sql.php
+++ b/sql.php
@@ -646,7 +646,13 @@ if (isset($GLOBALS['show_as_php']) || ! empty($GLOBALS['validatequery'])) {
     } while (PMA_DBI_next_result());
 
     $is_procedure = false;
-    if (stripos($full_sql_query, 'call') !== false) {
+    
+    // Since multpile query execution is anyway handled,
+    // ignore the where clause of the first sql statement
+    // which might contain a phrase like 'call '
+    if (preg_match("/\bcall\b/i", $full_sql_query)
+        && empty($analyzed_sql[0]['where_clause'])
+    ) {
         $is_procedure = true;
     }
 


### PR DESCRIPTION
Display table contents though SQL contains non key word phrase 'CALL ' might presented in where clause or inside table name or column name.
