### PR TITLE
creating database while exporting at database level

### DIFF
--- a/export.php
+++ b/export.php
@@ -720,6 +720,9 @@ do {
         if (! $export_plugin->exportDBHeader($db)) {
             break;
         }
+        if (! $export_plugin->exportDBCreate($db)) {
+            break;
+        }
 
         if (method_exists($export_plugin, 'exportRoutines')
             && strpos($GLOBALS['sql_structure_or_data'], 'structure') !== false

--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -706,7 +706,7 @@ class ExportSql extends ExportPlugin
                 return false;
             }
         }
-        $create_query = 'CREATE DATABASE '
+        $create_query = 'CREATE DATABASE IF NOT EXISTS '
             . (isset($GLOBALS['sql_backquotes'])
             ? PMA_Util::backquoteCompat($db, $compat) : $db);
         $collation = PMA_getDbCollation($db);


### PR DESCRIPTION
These isn't a bug fix or a feature request implementation. It's just a small change so as to improve user experience of phpmyadmin. 

While exporting database, I found that although all the data were being exported, but the actual database creation was not happening. Considering the case that user just want to export one database and he has already at its browse tab. He clicks on export and exports the database, but we actually exported tables and no CREATE DATABASE statement.
   So in case the user just import this .sql file, he manually have to create that database, then select it and then import, otherwise there will be no database selected error.

To get rid of that problem and make user task a bit less bothersome, a create database statement should be added in .sql file while exporting it.

Changes:
1) Called exportDBCreate() function to add the line CREATE DATABASE in the SQL script
2) updated the normal CREATE DATABASE query in exportDBCreate to CREATE DATABASE IF NOT EXISTS  to handle those can't create database

Please review it. Thanks :)
