### PR TITLE
Fix regression: Missing removeCRLF option in ExportCsv and ExportExcel plugins

### DIFF
--- a/export.php
+++ b/export.php
@@ -54,6 +54,7 @@ $post_params = array(
         'codegen_structure_or_data',
         'codegen_format',
         'excel_null',
+        'excel_removeCRLF',
         'excel_columns',
         'excel_edition',
         'excel_structure_or_data',
@@ -101,6 +102,7 @@ $post_params = array(
         'csv_escaped',
         'csv_terminated',
         'csv_null',
+        'csv_removeCRLF',
         'csv_columns',
         'csv_structure_or_data',
         // csv_replace should have been here but we use it directly from $_POST

--- a/libraries/plugins/export/ExportCsv.class.php
+++ b/libraries/plugins/export/ExportCsv.class.php
@@ -113,6 +113,7 @@ class ExportCsv extends ExportPlugin
         $leaf->setText(
             __('Remove carriage return/line feed characters within columns')
         );
+        $generalOptions->addProperty($leaf);
         $leaf = new BoolPropertyItem();
         $leaf->setName('columns');
         $leaf->setText(__('Put columns names in the first row'));

--- a/libraries/plugins/export/ExportExcel.class.php
+++ b/libraries/plugins/export/ExportExcel.class.php
@@ -62,6 +62,7 @@ class ExportExcel extends ExportCsv
         $leaf->setText(
             __('Remove carriage return/line feed characters within columns')
         );
+        $generalOptions->addProperty($leaf);
         $leaf = new BoolPropertyItem();
         $leaf->setName('columns');
         $leaf->setText(__('Put columns names in the first row'));


### PR DESCRIPTION
Fix regression: Missing removeCRLF option in ExportCsv and ExportExcel plugins

Regressions were introduced in commits 12e5c6f5c996757d4ba8b3cf4de84489793a0882 and 94ea719b4de8dd696e93d13220b3a1d1ea7c807b
