### PR TITLE
Drop support for PHP 5.2

### DIFF
--- a/README
+++ b/README
@@ -42,7 +42,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 Requirements
 ------------
 
-* PHP 5.2 or later
+* PHP 5.3 or later
 * MySQL 5.0 or later
 * a web-browser (doh!)
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
         "source": "https://github.com/phpmyadmin/phpmyadmin"
     },
     "require": {
-        "php": ">=5.2.0"
+        "php": ">=5.3.0"
     }
 }

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -395,8 +395,8 @@ MMCache but upgrading MMCache to version 2.3.21 solves the problem.
 
 Yes.
 
-Since release 3.0 only PHP 5.2 and newer. For older PHP versions, use
-phpMyAdmin 2.11.x.
+Since release 4.1 phpMyAdmin supports only PHP 5.3 and newer. For PHP 5.2 you
+can use 4.0.x releases.
 
 .. _faq1_32:
 

--- a/doc/require.rst
+++ b/doc/require.rst
@@ -12,7 +12,7 @@ web server (such as Apache, :term:`IIS`) to install phpMyAdmin's files into.
 PHP
 ---
 
-* You need PHP 5.2.0 or newer, with ``session`` support, the Standard PHP Library 
+* You need PHP 5.3.0 or newer, with ``session`` support, the Standard PHP Library 
   (SPL) extension and JSON support.
 
 * To support uploading of ZIP files, you need the PHP ``zip`` extension.
@@ -31,7 +31,7 @@ PHP
 * To support upload progress bars, see :ref:`faq2_9`.
 
 * To support XML and Open Document Spreadsheet importing, you need PHP
-  5.2.17 or newer and the `libxml <http://www.php.net/libxml>`_
+  with the `libxml <http://www.php.net/libxml>`_
   extension.
 
 .. seealso:: :ref:`faq1_31`, :ref:`authentication_modes`

--- a/libraries/File.class.php
+++ b/libraries/File.class.php
@@ -531,7 +531,7 @@ class PMA_File
          * get registered plugins for file compression
 
         foreach (PMA_getPlugins($type = 'compression') as $plugin) {
-            if (call_user_func_array(array($plugin['classname'], 'canHandle'), array($this->getName()))) {
+            if ($plugin['classname']::canHandle($this->getName())) {
                 $this->setCompressionPlugin($plugin);
                 break;
             }

--- a/libraries/Message.class.php
+++ b/libraries/Message.class.php
@@ -723,12 +723,12 @@ class PMA_Message
 
         return $this->isDisplayed;
     }
-    
+
     /**
      * Returns the message with corresponding image icon
-     * 
+     *
      * @param string $message the message(s)
-     * 
+     *
      * @return string message with icon
      */
     public function getMessageWithIcon($message)
@@ -743,7 +743,7 @@ class PMA_Message
         }
         $message = PMA_Message::notice(PMA_Util::getImage($image)) . " " . $message;
         return $message;
-        
+
     }
 }
 ?>

--- a/libraries/OutputBuffering.class.php
+++ b/libraries/OutputBuffering.class.php
@@ -135,12 +135,9 @@ class PMA_OutputBuffering
     {
         if (ob_get_status() && $this->_mode) {
             ob_flush();
+        } else {
+            flush();
         }
-        /**
-         * previously we had here an "else flush()" but some PHP versions
-         * (at least PHP 5.2.11) have a bug (49816) that produces garbled
-         * data
-         */
     }
 }
 

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -40,13 +40,6 @@ if (version_compare(PHP_VERSION, '5.3.0', 'lt')) {
 }
 
 /**
-  * Backward compatibility for PHP 5.2
-  */
-if (!defined('E_DEPRECATED')) {
-    define('E_DEPRECATED', 8192);
-}
-
-/**
  * the error handler
  */
 require './libraries/Error_Handler.class.php';
@@ -56,17 +49,6 @@ require './libraries/Error_Handler.class.php';
  */
 $GLOBALS['error_handler'] = new PMA_Error_Handler();
 $cfg['Error_Handler']['display'] = true;
-
-/*
- * This setting was removed in PHP 5.3. But at this point PMA_PHP_INT_VERSION
- * is not yet defined so we use another way to find out the PHP version.
- */
-if (version_compare(phpversion(), '5.3', 'lt')) {
-    /**
-     * Avoid object cloning errors
-     */
-    @ini_set('zend.ze1_compatibility_mode', false);
-}
 
 /**
  * This setting was removed in PHP 5.4. But at this point PMA_PHP_INT_VERSION

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -35,8 +35,8 @@
  * Minimum PHP version; can't call PMA_fatalError() which uses a
  * PHP 5 function, so cannot easily localize this message.
  */
-if (version_compare(PHP_VERSION, '5.2.0', 'lt')) {
-    die('PHP 5.2+ is required');
+if (version_compare(PHP_VERSION, '5.3.0', 'lt')) {
+    die('PHP 5.3+ is required');
 }
 
 /**

--- a/libraries/dbi/DBIMysqli.class.php
+++ b/libraries/dbi/DBIMysqli.class.php
@@ -86,12 +86,11 @@ class PMA_DBI_Mysqli implements PMA_DBI_Extension
     ) {
         global $cfg;
 
-        // mysqli persistent connections only on PHP 5.3+
-        if (PMA_PHP_INT_VERSION >= 50300) {
-            if ($cfg['PersistentConnections'] || $persistent) {
-                $host = 'p:' . $host;
-            }
+        // mysqli persistent connections
+        if ($cfg['PersistentConnections'] || $persistent) {
+            $host = 'p:' . $host;
         }
+
         if ($client_flags === null) {
             return @mysqli_real_connect(
                 $link,
@@ -691,10 +690,6 @@ class PMA_DBI_Mysqli implements PMA_DBI_Extension
      */
     public function fieldFlags($result, $i)
     {
-        // This is missing from PHP 5.2.5, see http://bugs.php.net/bug.php?id=44846
-        if (! defined('MYSQLI_ENUM_FLAG')) {
-            define('MYSQLI_ENUM_FLAG', 256); // see MySQL source include/mysql_com.h
-        }
         $f = mysqli_fetch_field_direct($result, $i);
         $type = $f->type;
         $charsetnr = $f->charsetnr;

--- a/libraries/display_import.lib.php
+++ b/libraries/display_import.lib.php
@@ -168,7 +168,7 @@ if ($_SESSION[$SESSION_KEY]["handler"] != "UploadNoplugin") {
 echo ' class="ajax"';
 ?>>
     <input type="hidden" name="<?php
-        echo call_user_func($_SESSION[$SESSION_KEY]['handler'] . '::getIdKey');
+        echo $_SESSION[$SESSION_KEY]['handler']::getIdKey();
     ?>" value="<?php echo $upload_id ; ?>" />
 
     <?php

--- a/libraries/display_import_ajax.lib.php
+++ b/libraries/display_import_ajax.lib.php
@@ -123,10 +123,7 @@ function PMA_importAjaxStatus($id)
 {
     header('Content-type: application/json');
     echo json_encode(
-        call_user_func(
-            $_SESSION[$GLOBALS['SESSION_KEY']]['handler'] . '::getUploadStatus',
-            $id
-        )
+        $_SESSION[$GLOBALS['SESSION_KEY']]['handler']::getUploadStatus($id)
     );
 }
 ?>

--- a/libraries/file_listing.lib.php
+++ b/libraries/file_listing.lib.php
@@ -25,11 +25,7 @@ function PMA_getDirContent($dir, $expression = '')
             $dir .= '/';
         }
         while ($file = @readdir($handle)) {
-            // for PHP < 5.2.4, is_file() gives a warning when using open_basedir
-            // and verifying '..' or '.'
-            if ('.' != $file
-                && '..' != $file
-                && is_file($dir . $file)
+            if (is_file($dir . $file)
                 && ($expression == '' || preg_match($expression, $file))
             ) {
                 $result[] = $file;

--- a/libraries/plugins/PluginObserver.class.php
+++ b/libraries/plugins/PluginObserver.class.php
@@ -43,21 +43,12 @@ abstract class PluginObserver implements SplObserver
      * This method is called when any PluginManager to which the observer
      * is attached calls PluginManager::notify()
      *
-     * TODO Declare this function abstract, removing its body,
-     * as soon as we drop support for PHP 5.2.x.
-     * See bug #3538655.
-     *
      * @param SplSubject $subject The PluginManager notifying the observer
      *                            of an update.
      *
      * @return void
      */
-    public function update (SplSubject $subject)
-    {
-        throw new Exception(
-            'PluginObserver::update must be overridden in child classes.'
-        );
-    }
+    public abstract function update (SplSubject $subject);
 
 
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */

--- a/libraries/plugins/transformations/Application_Octetstream_Download.class.php
+++ b/libraries/plugins/transformations/Application_Octetstream_Download.class.php
@@ -40,25 +40,4 @@ class Application_Octetstream_Download extends DownloadTransformationsPlugin
         return "OctetStream";
     }
 }
-
-/**
- * Function to call Application_Octetstream_Download::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Application_Octetstream_Download_getInfo()
-{
-    return Application_Octetstream_Download::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Application_Octetstream_Hex.class.php
+++ b/libraries/plugins/transformations/Application_Octetstream_Hex.class.php
@@ -41,25 +41,4 @@ class Application_Octetstream_Hex extends HexTransformationsPlugin
         return "OctetStream";
     }
 }
-
-/**
- * Function to call Application_Octetstream_Hex::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Application_Octetstream_Hex_getInfo()
-{
-    return Application_Octetstream_Hex::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Image_JPEG_Inline.class.php
+++ b/libraries/plugins/transformations/Image_JPEG_Inline.class.php
@@ -41,25 +41,4 @@ class Image_JPEG_Inline extends InlineTransformationsPlugin
         return "JPEG";
     }
 }
-
-/**
- * Function to call Image_JPEG_Inline::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Image_JPEG_Inline_getInfo()
-{
-    return Image_JPEG_Inline::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Image_JPEG_Link.class.php
+++ b/libraries/plugins/transformations/Image_JPEG_Link.class.php
@@ -41,25 +41,4 @@ class Image_JPEG_Link extends ImageLinkTransformationsPlugin
         return "JPEG";
     }
 }
-
-/**
- * Function to call Image_JPEG_Link::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Image_JPEG_Link_getInfo()
-{
-    return Image_JPEG_Link::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Image_PNG_Inline.class.php
+++ b/libraries/plugins/transformations/Image_PNG_Inline.class.php
@@ -41,25 +41,4 @@ class Image_PNG_Inline extends InlineTransformationsPlugin
         return "PNG";
     }
 }
-
-/**
- * Function to call Image_PNG_Inline::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Image_PNG_Inline_getInfo()
-{
-    return Image_PNG_Inline::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/TEMPLATE
+++ b/libraries/plugins/transformations/TEMPLATE
@@ -43,26 +43,4 @@ class [MIMEType]_[MIMESubtype]_[TransformationName]
         return "[MIMESubtype]";
     }
 }
-
-/**
- * Function to call [MIMEType]_[MIMESubtype]_[TransformationName]::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-
-function [MIMEType]_[MIMESubtype]_[TransformationName]_getInfo()
-{
-    return [MIMEType]_[MIMESubtype]_[TransformationName]::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Text_Plain_Append.class.php
+++ b/libraries/plugins/transformations/Text_Plain_Append.class.php
@@ -42,25 +42,4 @@ class Text_Plain_Append extends AppendTransformationsPlugin
         return "Plain";
     }
 }
-
-/**
- * Function to call Text_Plain_Append::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Text_Plain_Append_getInfo()
-{
-    return Text_Plain_Append::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Text_Plain_Dateformat.class.php
+++ b/libraries/plugins/transformations/Text_Plain_Dateformat.class.php
@@ -41,25 +41,4 @@ class Text_Plain_Dateformat extends DateFormatTransformationsPlugin
         return "Plain";
     }
 }
-
-/**
- * Function to call Text_Plain_Dateformat::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Text_Plain_Dateformat_getInfo()
-{
-    return Text_Plain_Dateformat::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Text_Plain_External.class.php
+++ b/libraries/plugins/transformations/Text_Plain_External.class.php
@@ -41,25 +41,4 @@ class Text_Plain_External extends ExternalTransformationsPlugin
         return "Plain";
     }
 }
-
-/**
- * Function to call Text_Plain_External::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Text_Plain_External_getInfo()
-{
-    return Text_Plain_External::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Text_Plain_Formatted.class.php
+++ b/libraries/plugins/transformations/Text_Plain_Formatted.class.php
@@ -41,25 +41,4 @@ class Text_Plain_Formatted extends FormattedTransformationsPlugin
         return "Plain";
     }
 }
-
-/**
- * Function to call Text_Plain_Formatted::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Text_Plain_Formatted_getInfo()
-{
-    return Text_Plain_Formatted::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Text_Plain_Imagelink.class.php
+++ b/libraries/plugins/transformations/Text_Plain_Imagelink.class.php
@@ -41,25 +41,4 @@ class Text_Plain_Imagelink extends TextImageLinkTransformationsPlugin
         return "Plain";
     }
 }
-
-/**
- * Function to call Text_Plain_Imagelink::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Text_Plain_Imagelink_getInfo()
-{
-    return Text_Plain_Imagelink::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Text_Plain_Link.class.php
+++ b/libraries/plugins/transformations/Text_Plain_Link.class.php
@@ -41,25 +41,4 @@ class Text_Plain_Link extends TextLinkTransformationsPlugin
         return "Plain";
     }
 }
-
-/**
- * Function to call Text_Plain_Link::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Text_Plain_Link_getInfo()
-{
-    return Text_Plain_Link::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Text_Plain_Longtoipv4.class.php
+++ b/libraries/plugins/transformations/Text_Plain_Longtoipv4.class.php
@@ -41,25 +41,4 @@ class Text_Plain_Longtoipv4 extends LongToIPv4TransformationsPlugin
         return "Plain";
     }
 }
-
-/**
- * Function to call Text_Plain_Longtoipv4::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Text_Plain_Longtoipv4_getInfo()
-{
-    return Text_Plain_Longtoipv4::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Text_Plain_Sql.class.php
+++ b/libraries/plugins/transformations/Text_Plain_Sql.class.php
@@ -41,25 +41,4 @@ class Text_Plain_Sql extends SQLTransformationsPlugin
         return "Plain";
     }
 }
-
-/**
- * Function to call Text_Plain_Sql::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Text_Plain_Sql_getInfo()
-{
-    return Text_Plain_Sql::getInfo();
-}
 ?>

--- a/libraries/plugins/transformations/Text_Plain_Substring.class.php
+++ b/libraries/plugins/transformations/Text_Plain_Substring.class.php
@@ -41,25 +41,4 @@ class Text_Plain_Substring extends SubstringTransformationsPlugin
         return "Plain";
     }
 }
-
-/**
- * Function to call Text_Plain_Substring::getInfo();
- *
- * Temporary workaround for bug #3783 :
- * Calling a method from a variable class is not possible before PHP 5.3.
- *
- * This function is called by PMA_getTransformationDescription()
- * in libraries/transformations.lib.php using a variable to construct it's name.
- * This function then calls the static method.
- *
- * Don't use this function unless you are affected by the same issue.
- * Call the static method directly instead.
- *
- * @deprecated
- * @return string Info about transformation class
- */
-function Text_Plain_Substring_getInfo()
-{
-    return Text_Plain_Substring::getInfo();
-}
 ?>

--- a/libraries/properties/options/OptionsPropertyGroup.class.php
+++ b/libraries/properties/options/OptionsPropertyGroup.class.php
@@ -59,11 +59,9 @@ abstract class OptionsPropertyGroup extends OptionsPropertyItem
         $this->_properties = array_udiff(
             $this->getProperties(),
             array($property),
-            // for PHP 5.2 compability 
-            create_function(
-                '$a, $b',
-                'return ($a === $b ) ? 0 : 1'
-            )
+            function ($a, $b) {
+                return ($a === $b ) ? 0 : 1;
+            }
         );
     }
 

--- a/libraries/transformations.lib.php
+++ b/libraries/transformations.lib.php
@@ -279,7 +279,7 @@ function PMA_setMIME($db, $table, $key, $mimetype, $transformation,
           WHERE `db_name`     = \'' . PMA_Util::sqlAddSlashes($db) . '\'
             AND `table_name`  = \'' . PMA_Util::sqlAddSlashes($table) . '\'
             AND `column_name` = \'' . PMA_Util::sqlAddSlashes($key) . '\'';
-    
+
     $test_rs   = PMA_queryAsControlUser(
         $test_qry, true, PMA_DatabaseInterface::QUERY_STORE
     );
@@ -391,24 +391,24 @@ function PMA_clearTransformations($db, $table = '', $column = '')
         . PMA_Util::backquote($cfgRelation['db']) . '.'
         . PMA_Util::backquote($cfgRelation['column_info'])
         . ' WHERE ';
-    
+
     if (($column != '') && ($table != '')) {
-        
+
         $delete_sql .= '`db_name` = \'' . $db . '\' AND '
             . '`table_name` = \'' . $table . '\' AND '
             . '`column_name` = \'' . $column . '\' ';
-        
+
     } else if ($table != '') {
-        
+
         $delete_sql .= '`db_name` = \'' . $db . '\' AND '
             . '`table_name` = \'' . $table . '\' ';
-        
+
     } else {
         $delete_sql .= '`db_name` = \'' . $db . '\' ';
     }
-    
+
     return $GLOBALS['dbi']->tryQuery($delete_sql);
-    
+
 }
 
 ?>

--- a/libraries/transformations.lib.php
+++ b/libraries/transformations.lib.php
@@ -147,10 +147,7 @@ function PMA_getTransformationDescription($file, $html_formatted = true)
 
     // include and instantiate the class
     include_once 'libraries/plugins/transformations/' . $file;
-    /* Temporary workaround for bug #3783 :
-       Calling a method from a variable class is not possible before PHP 5.3. */
-    $functionGetInfo = $class_name . "_getInfo";
-    return $functionGetInfo();
+    return $class_name->getInfo();
 }
 
 /**

--- a/test/Environment_test.php
+++ b/test/Environment_test.php
@@ -26,8 +26,8 @@ class Environment_Test extends PHPUnit_Framework_TestCase
     public function testPhpVersion()
     {
         $this->assertTrue(
-            version_compare('5.2', phpversion(), '<='),
-            'phpMyAdmin requires PHP 5.2 or above'
+            version_compare('5.3', phpversion(), '<='),
+            'phpMyAdmin requires PHP 5.3 or above'
         );
     }
 


### PR DESCRIPTION
This patch raises requirements to PHP 5.3 and drops many code which was written just for PHP 5.2 compatibility.
