### PR TITLE
 Added SQL_MODE for copy and move operations to prevent import errors 

### DIFF
--- a/libraries/operations.lib.php
+++ b/libraries/operations.lib.php
@@ -377,6 +377,11 @@ function PMA_getSqlQueryAndCreateDbBeforeCopy()
     $GLOBALS['dbi']->query($local_query);
     $GLOBALS['db'] = $original_db;
 
+    // Set the SQL mode to NO_AUTO_VALUE_ON_ZERO to prevent MySQL from creating
+    // export statements it cannot import
+    $sql_set_mode = "SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO'";
+    PMA_DBI_query($sql_set_mode);
+
     // rebuild the database list because PMA_Table::moveCopy
     // checks in this list if the target db exists
     $GLOBALS['pma']->databases->build();


### PR DESCRIPTION
When SQL_MODE is not set, the mode might be MYSQL40 which creates export statements for tables that it cannot import. This causes errors when moving or copying databases.
