### PR TITLE
Update config.default.php

### DIFF
--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -705,13 +705,13 @@ $cfg['ExecTimeLimit'] = 300;
 $cfg['SessionSavePath'] = '';
 
 /**
- * maximum allocated bytes ('0' for no limit)
+ * maximum allocated bytes ('-1' for no limit)
  * this is a string because '16M' is a valid value; we must put here
  * a string as the default value so that /setup accepts strings
  *
  * @global string $cfg['MemoryLimit']
  */
-$cfg['MemoryLimit'] = '0';
+$cfg['MemoryLimit'] = '-1';
 
 /**
  * mark used tables, make possible to show locked tables (since MySQL 3.23.30)


### PR DESCRIPTION
Since 2010 (at least) 0 has been used for unlimited in maxmem

However, unlimited is actually -1 and using 0 can cause issues in certain environments.
