### PR TITLE
For generating PmaAbsoluteUri $GLOBALS['PMA_PHP_SELF'] should be replaced with PMA_getenv('REQUEST_URI...

### DIFF
--- a/libraries/Config.class.php
+++ b/libraries/Config.class.php
@@ -1287,7 +1287,7 @@ class PMA_Config
 
                 // And finally the path could be already set from REQUEST_URI
                 if (empty($url['path'])) {
-                    $path = parse_url($GLOBALS['PMA_PHP_SELF']);
+                    $path = parse_url(PMA_getenv('REQUEST_URI'));
                     $url['path'] = $path['path'];
                 }
             }


### PR DESCRIPTION
...')

REQUEST_URI is never parsed when generating PmaAbsoluteUri, but $GLOBALS['PMA_PHP_SELF'] is. I'm not sure using PMA_PHP_SELF is the best and most correct way to set the URI, so I changed it to use REQUEST_URI.
