### PR TITLE
Increase default maximal number of navigation items

### DIFF
--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -583,7 +583,7 @@ $cfg['MaxDbList'] = 100;
  *
  * @global integer $cfg['MaxDbList']
  */
-$cfg['MaxNavigationItems'] = 25;
+$cfg['MaxNavigationItems'] = 250;
 
 /**
  * maximum number of tables displayed in table list


### PR DESCRIPTION
The load times should not be that big issue with 250 items and it helps
loading all tables/databases for most users.
