### PR TITLE
Expand the navigation and highlight the current database or table/view

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -78,7 +78,7 @@ var PMA_commonParams = (function () {
                 PMA_querywindow.refresh();
             }
             params[name] = value;
-            if(name == 'db' || name == 'table') {
+            if (name == 'db' || name == 'table') {
                 PMA_showCurrentNavigation();
             }
             return this;
@@ -117,9 +117,7 @@ var PMA_commonActions = {
      */
     setDb: function (new_db) {
         if (new_db != PMA_commonParams.get('db')) {
-            PMA_commonParams.set('db', new_db);
-            PMA_showCurrentNavigation();
-            PMA_querywindow.refresh();
+            PMA_commonParams.setAll({'db': new_db, 'table': ''});
         }
     },
     /**

--- a/js/common.js
+++ b/js/common.js
@@ -37,15 +37,18 @@ var PMA_commonParams = (function () {
          */
         setAll: function (obj) {
             var reload = false;
+            var updateNavigation = false;
             for (var i in obj) {
                 if (params[i] !== undefined && params[i] !== obj[i]) {
                     reload = true;
                 }
-                // To expand the database in use and collapse the previous one
-                if(i == 'db' && obj[i] !== '') {
-                    PMA_autoExpandDatabaseInUse(params['db'], obj[i]);
+                if (i == 'db' || i == 'table') {
+                    updateNavigation = true;
                 }
                 params[i] = obj[i];
+            }
+            if (updateNavigation) {
+                PMA_showCurrentNavigation();
             }
             if (reload) {
                 PMA_querywindow.refresh();
@@ -74,10 +77,10 @@ var PMA_commonParams = (function () {
             if (params[name] !== undefined && params[name] !== value) {
                 PMA_querywindow.refresh();
             }
-            if(name == 'db' && value !== '') {
-                PMA_autoExpandDatabaseInUse(params['db'], value);
-            }
             params[name] = value;
+            if(name == 'db' || name == 'table') {
+                PMA_showCurrentNavigation();
+            }
             return this;
         },
         /**
@@ -114,10 +117,8 @@ var PMA_commonActions = {
      */
     setDb: function (new_db) {
         if (new_db != PMA_commonParams.get('db')) {
-            if(new_db !== '') {
-                PMA_autoExpandDatabaseInUse(PMA_commonParams.get('db'), new_db);
-            }
             PMA_commonParams.set('db', new_db);
+            PMA_showCurrentNavigation();
             PMA_querywindow.refresh();
         }
     },

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -351,6 +351,9 @@ function PMA_showCurrentNavigation()
                if ($li.is('.' + clazz) && $li.children('a').text() == name) {
                    if (doSelect) {
                        $li.addClass('selected');
+                       if (! doOpen) { // if the node will be opened no point scrolling now
+                           scrollToView($li, $('#pma_navigation_tree_content'));
+                       }
                    }
                    if (doOpen) {
                        var $expander = $li.find('div:first').children('a.expander');

--- a/js/sql.js
+++ b/js/sql.js
@@ -296,7 +296,17 @@ AJAX.registerOnload('sql.js', function() {
                 } else if (typeof data.reload != 'undefined') {
                     // this happens if a USE or DROP command was typed
                     PMA_commonActions.setDb(data.db);
-                    PMA_commonActions.refreshMain(false, function () {
+                    var url;
+                    if (data.db) {
+                        if (data.table) {
+                            url = 'table_sql.php';
+                        } else {
+                            url = 'db_sql.php';
+                        }
+                    } else {
+                        url = 'server_sql.php';
+                    }
+                    PMA_commonActions.refreshMain(url, function () {
                         if ($('#result_query').length) {
                             $('#result_query').remove();
                         }
@@ -307,7 +317,7 @@ AJAX.registerOnload('sql.js', function() {
                         }
                     });
                 }
-                
+
                 $sqlqueryresults.show().trigger('makegrid');
                 $('#togglequerybox').show();
                 PMA_init_slider();
@@ -581,7 +591,7 @@ function makeProfilingChart()
     ) {
         return;
     }
-    
+
     var data = [];
     $.each(jQuery.parseJSON($('#profilingChartData').html()),function(key,value) {
         data.push([key,parseFloat(value)]);

--- a/libraries/navigation/NavigationTree.class.php
+++ b/libraries/navigation/NavigationTree.class.php
@@ -881,7 +881,6 @@ class PMA_NavigationTree
                 $retval .= "</div>";
             }
 
-            $dblinkclass = ' class="dbLink"';
             $linkClass = '';
             $haveAjax = array(
                 'functions',
@@ -933,7 +932,7 @@ class PMA_NavigationTree
                     $retval .= htmlspecialchars($node->name);
                     $retval .= "</a>";
                 } else {
-                    $retval .= "<a$dblinkclass$linkClass href='$link'>";
+                    $retval .= "<a$linkClass href='$link'>";
                     $retval .= htmlspecialchars($node->real_name);
                     $retval .= "</a>";
                 }

--- a/libraries/navigation/Nodes/Node_Database.class.php
+++ b/libraries/navigation/Nodes/Node_Database.class.php
@@ -35,6 +35,7 @@ class Node_Database extends Node
             'icon' => 'db_operations.php?server=' . $GLOBALS['server']
                     . '&amp;db=%1$s&amp;token=' . $GLOBALS['token']
         );
+        $this->classes = 'database';
     }
 
     /**

--- a/libraries/navigation/Nodes/Node_Table.class.php
+++ b/libraries/navigation/Nodes/Node_Table.class.php
@@ -38,6 +38,7 @@ class Node_Table extends Node
                     . '?server=' . $GLOBALS['server']
                     . '&amp;db=%2$s&amp;table=%1$s&amp;token=' . $GLOBALS['token']
         );
+        $this->classes = 'table';
     }
 
     /**

--- a/libraries/navigation/Nodes/Node_Table_Container.class.php
+++ b/libraries/navigation/Nodes/Node_Table_Container.class.php
@@ -35,7 +35,8 @@ class Node_Table_Container extends Node
             $this->separator       = $GLOBALS['cfg']['NavigationTreeTableSeparator'];
             $this->separator_depth = (int)($GLOBALS['cfg']['NavigationTreeTableLevel']);
         }
-        $this->real_name       = 'tables';
+        $this->real_name = 'tables';
+        $this->classes   = 'tableContainer';
 
         $new        = PMA_NodeFactory::getInstance('Node', _pgettext('Create new table', 'New'));
         $new->isNew = true;

--- a/libraries/navigation/Nodes/Node_View.class.php
+++ b/libraries/navigation/Nodes/Node_View.class.php
@@ -38,6 +38,7 @@ class Node_View extends Node
                     . '&amp;db=%2$s&amp;table=%1$s'
                     . '&amp;token=' . $GLOBALS['token']
         );
+        $this->classes = 'view';
     }
 }
 

--- a/libraries/navigation/Nodes/Node_View_Container.class.php
+++ b/libraries/navigation/Nodes/Node_View_Container.class.php
@@ -31,6 +31,7 @@ class Node_View_Container extends Node
             'icon' => 'db_structure.php?server=' . $GLOBALS['server']
                     . '&amp;db=%1$s&amp;token=' . $GLOBALS['token'],
         );
+        $this->classes   = 'viewContainer';
         $this->real_name = 'views';
 
         $new        = PMA_NodeFactory::getInstance('Node', _pgettext('Create new view', 'New'));

--- a/themes/original/css/navigation.css.php
+++ b/themes/original/css/navigation.css.php
@@ -128,6 +128,10 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
     color: <?php echo $GLOBALS['cfg']['NaviPointerColor']; ?>;
     background-color: <?php echo $GLOBALS['cfg']['NaviPointerBackground']; ?>;
 }
+#pma_navigation_tree li.selected {
+    color: <?php echo $GLOBALS['cfg']['NaviPointerColor']; ?>;
+    background-color: <?php echo $GLOBALS['cfg']['NaviPointerBackground']; ?>;
+}
 #pma_navigation_tree ul {
     clear: both;
     padding: 0;

--- a/themes/pmahomme/css/navigation.css.php
+++ b/themes/pmahomme/css/navigation.css.php
@@ -113,6 +113,10 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
     color: <?php echo $GLOBALS['cfg']['NaviPointerColor']; ?>;
     background-color: <?php echo $GLOBALS['cfg']['NaviPointerBackground']; ?>;
 }
+#pma_navigation_tree li.selected {
+    color: <?php echo $GLOBALS['cfg']['NaviPointerColor']; ?>;
+    background-color: <?php echo $GLOBALS['cfg']['NaviPointerBackground']; ?>;
+}
 #pma_navigation_tree ul {
     clear: both;
     padding: 0;


### PR DESCRIPTION
I have ported the navigation highlighting improvements to QA_4_0. 

Following are the improvements
1. Improved the 'expand database' functionality to handle database groups grouped according to NavigationTreeDbSeparator.
2. Highlight the current database when the user is in database level.
3. Expand and highlight the current table/view when the user is in table level. (works with table groups grouped according to NavigationTreeTableSeparator)
4. Do database expanding and database/table highlighting when the page is reloaded.
