### PR TITLE
Adds AUTO_INCREMENT value while copying table. Fixes bug #4079

### DIFF
--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -2656,7 +2656,7 @@ class PMA_Util
      * @param boolean $escape_label    whether to use htmlspecialchars() on label
      * @param string  $class           enclose each choice with a div of this class
      *
-     * @return string                  set of html radio fiels
+     * @return string                  set of html radio fields
      */
     public static function getRadioFields(
         $html_field_name, $choices, $checked_choice = '',

--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1027,7 +1027,7 @@ class ExportSql extends ExportPlugin
                 // in SHOW CREATE TABLE so we'll remove it below
                 // It's required for Drizzle because SHOW CREATE TABLE uses
                 // the value from table's creation time
-                if (isset($GLOBALS['sql_auto_increment'])
+                if (isset($_POST['sql_auto_increment'])
                     && ! empty($tmpres['Auto_increment'])
                 ) {
                     $auto_increment .= ' AUTO_INCREMENT='


### PR DESCRIPTION
The `$GLOBALS['sql_auto_increment']` was not set to the appropriate value during the **copy table** procedure.
Replaced it with `$_POST['sql_auto_increment']`.

Let me know if this is the correct way to access the value of `sql_auto_increment`, so that I can modify the code accordingly if required.
