### PR TITLE
Adds AUTO_INCREMENT value while copying table. Fixes bug 4079

### DIFF
--- a/libraries/Table.class.php
+++ b/libraries/Table.class.php
@@ -836,6 +836,10 @@ class PMA_Table
 
             $no_constraints_comments = true;
             $GLOBALS['sql_constraints_query'] = '';
+            // set the value of global sql_auto_increment variable
+            if( isset($_POST['sql_auto_increment']) ) {
+                $GLOBALS['sql_auto_increment'] = $_POST['sql_auto_increment'];
+            }
 
             $sql_structure = $export_sql_plugin->getTableDef(
                 $source_db, $source_table, "\n", $err_url, false, false


### PR DESCRIPTION
The `$GLOBALS['sql_auto_increment']` was not being set to the appropriate value during the **copy table** procedure.
- Modified `Table.class.php` to set this global variable from the superglobal `$_POST` variable.
