### PR TITLE
remove unused variable

### DIFF
--- a/libraries/plugins/import/ImportMediawiki.class.php
+++ b/libraries/plugins/import/ImportMediawiki.class.php
@@ -110,8 +110,7 @@ class ImportMediawiki extends ImportPlugin
             $data = PMA_importGetNextChunk();
 
             if ($data === false) {
-                // Subtract data we didn't handle yet and stop processing
-                $offset -= strlen($buffer);
+                // Stop processing
                 break;
             } elseif ($data === true) {
                 // Handle rest of buffer


### PR DESCRIPTION
$offset is not used in the function, so assigning a value is not necessary
