### PR TITLE
Update navigation.js to allow regex based search in quick filter (client side)

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -994,7 +994,8 @@ var PMA_fastFilter = {
                 str = $(this).val().toLowerCase();
             }
             $obj.find('li > a').not('.container').each(function () {
-                if ($(this).text().toLowerCase().indexOf(str) != -1) {
+                var regex = new RegExp(str, 'i')
+                if (regex.test($(this).text().toLowerCase())) {
                     $(this).parent().show().removeClass('hidden');
                 } else {
                     $(this).parent().hide().addClass('hidden');

--- a/libraries/navigation/NavigationTree.class.php
+++ b/libraries/navigation/NavigationTree.class.php
@@ -1073,7 +1073,7 @@ class PMA_NavigationTree
             ) {
                 $placeholder_key = 'placeholder';
             }
-            $retval .= " $placeholder_key='" . __('filter items by name') . "' />";
+            $retval .= " $placeholder_key='" . __('filter items by name or regex') . "' />";
             $retval .= "<span title='" . __('Clear Fast Filter') . "'>X</span>";
             $retval .= "</form>";
             $retval .= "</li>";


### PR DESCRIPTION
Allow regex based search in quick filter (client side) (based on feature request here: http://sourceforge.net/p/phpmyadmin/feature-requests/1463/)

I will work on the server side regex based results as another pull request.
