### PR TITLE
Automatic counting of lines for error reporting

### DIFF
--- a/error_report.php
+++ b/error_report.php
@@ -10,29 +10,6 @@ require_once 'libraries/error_report.lib.php';
 
 $response = PMA_Response::getInstance();
 
-// Fail gracefully if this is not a release version of phpMyAdmin
-if(!$GLOBALS['PMA_Config']->isGitRevision()) {
-    $response->addJSON('message', PMA_Message::error(
-        __('An error has been detected, however, you seem to be running on a git '
-            . 'version of phpMyAdmin.')
-            . __('Automatic report submission cannot be used. Please submit a '
-            . 'manual error report on the bug tracker.')
-        . '<br />'
-        . __('You may want to refresh the page.')));
-    $response->isSuccess(false);
-    exit;
-} elseif (!defined('LINE_COUNTS')) {
-    $response->addJSON('message', PMA_Message::error(
-        __('An error has been detected, however, the JavaScript line count file '
-            . 'does not seem to exist in this phpMyAdmin installation.')
-        . __('Automatic report submission cannot be used. Please submit a '
-            . 'manual error report on the bug tracker.')
-        . '<br />'
-        . __('You may want to refresh the page.')));
-    $response->isSuccess(false);
-    exit;
-}
-
 if ($_REQUEST['send_error_report'] == true) {
     if ($_REQUEST['automatic'] === "true") {
         $response->addJSON('message', PMA_Message::error(

--- a/libraries/error_report.lib.php
+++ b/libraries/error_report.lib.php
@@ -155,6 +155,19 @@ function PMA_sendErrorReport($report) {
 }
 
 /**
+ * Returns number of lines in given javascript file.
+ *
+ * @param string $filename javascript filename
+ *
+ * @return Number of lines
+ */
+function PMA_countLines($filename)
+{
+    global $LINE_COUNT;
+    return $LINE_COUNT[$filename];
+}
+
+/**
  * returns the translated linenumber and the file name from the cumulative line
  * number and an array of files
  *
@@ -171,10 +184,9 @@ function PMA_sendErrorReport($report) {
  * - Integer $linenumber the translated line number in the returned file
  */
 function PMA_getLineNumber($filenames, $cumulative_number) {
-  global $LINE_COUNT;
   $cumulative_sum = 0;
   foreach($filenames as $filename) {
-    $filecount = $LINE_COUNT[$filename];
+    $filecount = PMA_countLines($filename);
     if ($cumulative_number <= $cumulative_sum + $filecount + 2) {
       $linenumber = $cumulative_number - $cumulative_sum;
       break;

--- a/libraries/error_report.lib.php
+++ b/libraries/error_report.lib.php
@@ -219,10 +219,6 @@ function PMA_getLineNumber($filenames, $cumulative_number) {
  * @return Array $stack the modified stacktrace
  */
 function PMA_translateStacktrace($stack) {
-    if(!defined('LINE_COUNTS')) {
-        return $stack;
-    }
-
     foreach ($stack as &$level) {
         foreach ($level["context"] as &$line) {
             if (strlen($line) > 80) {

--- a/libraries/error_report.lib.php
+++ b/libraries/error_report.lib.php
@@ -164,7 +164,21 @@ function PMA_sendErrorReport($report) {
 function PMA_countLines($filename)
 {
     global $LINE_COUNT;
-    return $LINE_COUNT[$filename];
+    if (!defined('LINE_COUNTS')) {
+        $linecount = 0;
+        $handle = fopen('./js/' . $filename, 'r');
+        while (!feof($handle)){
+            $line = fgets($handle);
+            if ($line === false) {
+                break;
+            }
+            $linecount++;
+        }
+        fclose($handle);
+        return $linecount;
+    } else {
+        return $LINE_COUNT[$filename];
+    }
 }
 
 /**


### PR DESCRIPTION
Counting lines in a file is not that expensive operation, so do that on the fly in case precalculated counts are not available.
