### PR TITLE
Error reporting improvements

### DIFF
--- a/js/error_report.js
+++ b/js/error_report.js
@@ -113,22 +113,26 @@ var ErrorReport = {
         ErrorReport._removeErrorNotification();
 
         $div = $(
-            '<div style="position:fixed;bottom:0px;left:5px;right:5px;' +
+            '<div style="position:fixed;bottom:0;left:0;right:0;margin:0;' +
             'z-index:1000" class="error" id="error_notification"></div>'
+        ).append(
+            PMA_getImage("s_error.png") + PMA_messages.strErrorOccurred
         );
-        html = '';
-        html += '<img src="themes/dot.gif" title="" alt="" class="icon ic_s_error">';
-        html += PMA_messages.strErrorOccurred;
-        $div.html(html);
 
         $buttons = $('<div style="float:right"></div>');
-        button_html = '';
-        button_html += '<button id="change_error_settings">' +
-                        PMA_messages.strChangeReportSettings + '</button>';
-        button_html += '<button id="show_error_report">' +
-                        PMA_messages.strShowReportDetails + '</button>';
-        button_html += '<button id="ignore_error">' +
-                        PMA_messages.strIgnore + '</button>';
+
+        button_html  = '<button id="show_error_report">';
+        button_html += PMA_messages.strShowReportDetails;
+        button_html += '</button>';
+
+        button_html += '<a id="change_error_settings">';
+        button_html += PMA_getImage('s_cog.png', PMA_messages.strChangeReportSettings);
+        button_html += '</a>';
+
+        button_html += '<a href="#" id="ignore_error">';
+        button_html += PMA_getImage('b_close.png', PMA_messages.strIgnore);
+        button_html += '</a>';
+
         $buttons.html(button_html);
 
         $div.append($buttons);

--- a/js/messages.php
+++ b/js/messages.php
@@ -408,7 +408,7 @@ $js_messages['strCreateView'] = __('Create view');
 $js_messages['strSendErrorReport'] = __("Send Error Report");
 $js_messages['strSubmitErrorReport'] = __("Submit Error Report");
 $js_messages['strErrorOccurred'] = __(
-    "An error has occurred. Do you want to send an error report?"
+    "A fatal JavaScript error has occurred. Would you like to send an error report?"
 );
 $js_messages['strChangeReportSettings'] = __("Change Report Settings");
 $js_messages['strShowReportDetails'] = __("Show Report Details");

--- a/libraries/error_report.lib.php
+++ b/libraries/error_report.lib.php
@@ -292,9 +292,9 @@ function PMA_getErrorReportForm()
 
     $html .= '<input type="checkbox" name="always_send"'
             .' id="always_send_checkbox"/>'
-            .'<span>'
+            .'<label for="always_send_checkbox">'
             . __('Automatically send report next time')
-            .'</span>';
+            .'</label>';
 
     $html .= '</fieldset>';
 


### PR DESCRIPTION
These are mostly usability improvements. First, I've made the label near the checkbox in the error details dialog clickable. Also, I've made the error notification a bit more user friendly by swapping some buttons for clickable images. This way, more attention is drawn towards the only remaining button, which will actually help the user to proceed to submitting the report.

Screenshot: http://placella.com/temp/Screenshot.png
