### PR TITLE
Fix 4134: After deleting all entries of last page, we should display the new last page

### DIFF
--- a/libraries/mult_submits.lib.php
+++ b/libraries/mult_submits.lib.php
@@ -98,10 +98,12 @@ function PMA_getQueryStrFromSelected(
     }
 
     $selected_cnt   = count($selected);
+    $deletes = false;
 
     for ($i = 0; $i < $selected_cnt; $i++) {
         switch ($query_type) {
         case 'row_delete':
+            $deletes = true;
             $a_query = $selected[$i];
             $run_parts = true;
             break;
@@ -153,6 +155,7 @@ function PMA_getQueryStrFromSelected(
             break;
 
         case 'empty_tbl':
+            $deletes = true;
             $a_query = 'TRUNCATE ';
             $a_query .= PMA_Util::backquote($selected[$i]);
             $run_parts = true;
@@ -267,11 +270,13 @@ function PMA_getQueryStrFromSelected(
                 PMA_clearTransformations($db, $selected[$i]);
             } else if ($query_type == 'drop_fld') {
                 PMA_clearTransformations($db, $table, $selected[$i]);
-            } elseif ($query_type == 'row_delete') {
-                //PMA_updatePos($db, $table);
             }
         } // end if
     } // end for
+
+    if ($deletes) {
+        $_REQUEST['pos'] = PMA_calculatePosForLastPage($db, $table, $_REQUEST['pos']);
+    }
 
     return array(
         $result, $rebuild_database_list, $reload,

--- a/libraries/mult_submits.lib.php
+++ b/libraries/mult_submits.lib.php
@@ -267,6 +267,8 @@ function PMA_getQueryStrFromSelected(
                 PMA_clearTransformations($db, $selected[$i]);
             } else if ($query_type == 'drop_fld') {
                 PMA_clearTransformations($db, $table, $selected[$i]);
+            } elseif ($query_type == 'row_delete') {
+                //PMA_updatePos($db, $table);
             }
         } // end if
     } // end for

--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -2338,15 +2338,17 @@ function PMA_executeQueryAndSendQueryResponse($analyzed_sql_results,
  * Function to define pos to display a row
  *
  * @param Int $number_of_line Number of the line to display
+ * @param Int $max_rows Number of rows by page
  *
  * @return Int Start position to display the line
  */
-function PMA_getStartPosToDisplayRow($number_of_line)
+function PMA_getStartPosToDisplayRow($number_of_line, $max_rows = null)
 {
-    return @(
-        (ceil($number_of_line / $_SESSION['tmpval']['max_rows']) - 1)
-        * $_SESSION['tmpval']['max_rows']
-    );
+    if (null === $max_rows) {
+        $max_rows = $_SESSION['tmpval']['max_rows'];
+    }
+
+    return @((ceil($number_of_line / $max_rows) - 1) * $max_rows);
 }
 
 /**
@@ -2358,11 +2360,15 @@ function PMA_getStartPosToDisplayRow($number_of_line)
  *
  * @return Int Number of pos to display last page
  */
-function PMA_calculatePosForLastPage($db, $table, $pos = 0)
+function PMA_calculatePosForLastPage($db, $table, $pos)
 {
+    if (null === $pos) {
+        $pos = $_SESSION['tmpval']['pos'];
+    }
+
     $unlim_num_rows = PMA_Table::countRecords($db, $table, true);
     //If position is higher than number of rows
-    if ($unlim_num_rows <= $_SESSION['tmpval']['pos']) {
+    if ($unlim_num_rows <= $pos && 0 != $pos) {
         $pos = PMA_getStartPosToDisplayRow($unlim_num_rows);
     }
 

--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -1050,9 +1050,7 @@ function PMA_addBookmark($pmaAbsoluteUri, $goto)
 function PMA_findRealEndOfRows($db, $table)
 {
     $unlim_num_rows = PMA_Table::countRecords($db, $table, true);
-    $_SESSION['tmpval']['pos'] = @((ceil(
-        $unlim_num_rows / $_SESSION['tmpval']['max_rows']
-    ) - 1) * $_SESSION['tmpval']['max_rows']);
+    $_SESSION['tmpval']['pos'] = PMA_getStartPosToDisplayRow($unlim_num_rows);
 
     return $unlim_num_rows;
 }
@@ -2337,22 +2335,38 @@ function PMA_executeQueryAndSendQueryResponse($analyzed_sql_results,
 }
 
 /**
- * Update pos if pos is higher than number of rows of displayed table
+ * Function to define pos to display a row
+ *
+ * @param Int $number_of_line Number of the line to display
+ *
+ * @return Int Start position to display the line
+ */
+function PMA_getStartPosToDisplayRow($number_of_line)
+{
+    return @(
+        (ceil($number_of_line / $_SESSION['tmpval']['max_rows']) - 1)
+        * $_SESSION['tmpval']['max_rows']
+    );
+}
+
+/**
+ * Function to calculate new pos if pos is higher than number of rows of displayed table
  *
  * @param String $db    Database name
  * @param String $table Table name
+ * @param Int    $pos   Initial position
  *
- * @return Int Number of rows
+ * @return Int Number of pos to display last page
  */
-function PMA_updatePos($db, $table)
+function PMA_calculatePosForLastPage($db, $table, $pos = 0)
 {
     $unlim_num_rows = PMA_Table::countRecords($db, $table, true);
     //If position is higher than number of rows
     if ($unlim_num_rows <= $_SESSION['tmpval']['pos']) {
-        PMA_findRealEndOfRows($db, $table);
+        $pos = PMA_getStartPosToDisplayRow($unlim_num_rows);
     }
 
-    return $unlim_num_rows;
+    return $pos;
 }
 
 ?>

--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -1222,7 +1222,7 @@ function PMA_handleQueryExecuteError($is_gotofile, $error, $full_sql_query)
  *
  * @param String  $db                     the current database
  * @param String  $bkm_user               the bookmarking user
- * @param String  $sql_query_for_bookmark the query to be stored in bookmark 
+ * @param String  $sql_query_for_bookmark the query to be stored in bookmark
  * @param String  $bkm_label              bookmark label
  * @param boolean $bkm_replace            whether to replace existing bookmarks
  *
@@ -2232,7 +2232,7 @@ function PMA_sendQueryResponse($num_rows, $unlim_num_rows, $is_affected,
  * @param string $db                   current database
  * @param string $table                current table
  * @param bool   $find_real_end        whether to find real end or not
- * @param string $sql_query_for_bookmark the sql query to be stored as bookmark 
+ * @param string $sql_query_for_bookmark the sql query to be stored as bookmark
  * @param array  $extra_data           extra data
  * @param bool   $is_affected          whether affected or not
  * @param string $message_to_show      message to show
@@ -2335,4 +2335,24 @@ function PMA_executeQueryAndSendQueryResponse($analyzed_sql_results,
         isset($complete_query) ? $complete_query : null
     );
 }
+
+/**
+ * Update pos if pos is higher than number of rows of displayed table
+ *
+ * @param String $db    Database name
+ * @param String $table Table name
+ *
+ * @return Int Number of rows
+ */
+function PMA_updatePos($db, $table)
+{
+    $unlim_num_rows = PMA_Table::countRecords($db, $table, true);
+    //If position is higher than number of rows
+    if ($unlim_num_rows <= $_SESSION['tmpval']['pos']) {
+        PMA_findRealEndOfRows($db, $table);
+    }
+
+    return $unlim_num_rows;
+}
+
 ?>

--- a/test/libraries/PMA_mult_submits_test.php
+++ b/test/libraries/PMA_mult_submits_test.php
@@ -22,6 +22,8 @@ require_once 'libraries/sqlparser.lib.php';
 require_once 'libraries/js_escape.lib.php';
 require_once 'libraries/relation_cleanup.lib.php';
 require_once 'libraries/relation.lib.php';
+require_once 'libraries/sql.lib.php';
+require_once 'libraries/Table.class.php';
 
 /**
  * class PMA_MultSubmits_Test
@@ -48,6 +50,7 @@ class PMA_MultSubmits_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['ShowSQL'] = true;
         $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
         $GLOBALS['cfg']['LimitChars'] = 100;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['ActionLinksMode'] = "both";
         $GLOBALS['pmaThemeImage'] = 'image';
@@ -277,6 +280,10 @@ class PMA_MultSubmits_Test extends PHPUnit_Framework_TestCase
         $primary = null;
         $from_prefix = "from_prefix";
         $to_prefix = "to_prefix";
+
+        $_REQUEST['pos'] = 1000;
+        $_SESSION['tmpval']['pos'] = 1000;
+        $_SESSION['tmpval']['max_rows'] = 25;
 
         list(
             $result, $rebuild_database_list, $reload_ret,


### PR DESCRIPTION
Hi,

I tried to fix this bug: http://sourceforge.net/p/phpmyadmin/bugs/4134/

I added a control after a multi delete. We check if position is higher than number of rows. If this is true, the position is updated to display the lines of the last page.

I'm open to any comment.

Thanks,
H.
