### PR TITLE
Fix PMA_convertString which use a wrong variable.

### DIFF
--- a/libraries/charset_conversion.lib.php
+++ b/libraries/charset_conversion.lib.php
@@ -104,7 +104,7 @@ function PMA_convertString($src_charset, $dest_charset, $what)
         );
     case PMA_CHARSET_MB:
         return mb_convert_encoding(
-            $message, $dest_charset, $src_charset
+            $what, $dest_charset, $src_charset
         );
     default:
         return $what;


### PR DESCRIPTION
Hi,

I saw that the function PMA_convertString (file : libraries\charset_conversion.lib.php) used an unexisting variable "$message" to convert instead of "$what".

This is a minor correction.

H.
