### PR TITLE
Removed constraints from datetime and timestamp input boxes 

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -209,6 +209,7 @@ function PMA_addDatepicker($this_element, options)
         showButtonPanel: false,
         dateFormat: 'yy-mm-dd', // yy means year with four digits
         timeFormat: 'HH:mm:ss.lc',
+        constrainInput: false,
         altFieldTimeOnly: false,
         showAnim: '',
         beforeShow: function (input, inst) {


### PR DESCRIPTION
added constrainInput:false option to JQueryUI datepicker

https://sourceforge.net/p/phpmyadmin/bugs/4152/

Note that this also removes the constraint form other input boxes for datetimes and timestamps like entering new data.
If the data is not in a valid form the user will receive an error from MySQL. 

There never was validation for this therefore but this would allow the user to enter valid dates in an unsupported format.
Is a profitable trade-off (allowing % searches through the UI vs being able to enter seemingly valid dates) ?
