### PR TITLE
Fix #3931: Use multiple selection for [NOT] IN/BETWEEN searches.

### DIFF
--- a/js/tbl_change.js
+++ b/js/tbl_change.js
@@ -505,3 +505,23 @@ AJAX.registerOnload('tbl_change.js', function () {
         }
     });
 });
+
+function changeValueFieldType(elem, searchIndex)
+{
+    var fieldsValue = $("select#fieldID_" + searchIndex);
+    if (0 == fieldsValue.size()) {
+        return;
+    }
+
+    var type = $(elem).val();
+    if (
+        'IN (...)' == type
+        || 'NOT IN (...)' == type
+        || 'BETWEEN' == type
+        || 'NOT BETWEEN' == type
+    ) {
+        $("#fieldID_" + searchIndex).attr('multiple', '');
+    } else {
+        $("#fieldID_" + searchIndex).removeAttr('multiple');
+    }
+}

--- a/libraries/TableSearch.class.php
+++ b/libraries/TableSearch.class.php
@@ -586,8 +586,14 @@ EOT;
             ) {
                 $func_type = str_replace(' (...)', '', $func_type);
 
+                //Don't explode if this is already an array
+                //(Case for (NOT) IN/BETWEEN.)
+                if (is_array($criteriaValues)) {
+                    $values = $criteriaValues;
+                } else {
+                    $values = explode(',', $criteriaValues);
+                }
                 // quote values one by one
-                $values = explode(',', $criteriaValues);
                 foreach ($values as &$value) {
                     $value = $quot . PMA_Util::sqlAddSlashes(trim($value))
                         . $quot;
@@ -909,7 +915,7 @@ EOT;
         $type = $this->_columnTypes[$column_index];
         $collation = $this->_columnCollations[$column_index];
         //Gets column's comparison operators depending on column type
-        $func = '<select name="criteriaColumnOperators[' . $search_index . ']">';
+        $func = '<select name="criteriaColumnOperators[' . $search_index . ']" onchange="changeValueFieldType(this, ' . $search_index . ')">';
         $func .= $GLOBALS['PMA_Types']->getTypeOperatorsHtml(
             preg_replace('@\(.*@s', '', $this->_columnTypes[$column_index]),
             $this->_columnNullFlags[$column_index], $selected_operator

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -309,10 +309,6 @@ class PMA_Util
             $a_string = str_replace('\'', '\'\'', $a_string);
         }
 
-        if ('' === $a_string) {
-            $a_string = 'NULL';
-        }
-
         return $a_string;
     } // end of the 'sqlAddSlashes()' function
 

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -309,6 +309,10 @@ class PMA_Util
             $a_string = str_replace('\'', '\'\'', $a_string);
         }
 
+        if ('' === $a_string) {
+            $a_string = 'NULL';
+        }
+
         return $a_string;
     } // end of the 'sqlAddSlashes()' function
 


### PR DESCRIPTION
Hi,

This contribution is a fix for #3931: https://sourceforge.net/p/phpmyadmin/bugs/3931/

In this contribution, I allow the user to select many lines for [NOT] IN/BETWEEN searches on fields with a FK.
