### PR TITLE
Fix #4030: Fix sort on columns which uses function with column between back quotes.

### DIFF
--- a/libraries/DisplayResults.class.php
+++ b/libraries/DisplayResults.class.php
@@ -1979,6 +1979,10 @@ class PMA_DisplayResults
                 $new_sort_expression_nodirection = $sort_expression_nodirection;
             }
 
+            //Back quotes are removed in next comparison, so remove them from value
+            //to compare.
+            $name_to_use_in_sort = str_replace('`', '', $name_to_use_in_sort);
+
             $is_in_sort = false;
             $sort_name = str_replace('`', '', $sort_tbl) . $name_to_use_in_sort;
 


### PR DESCRIPTION
Hi,

I here removed back quotes from "name to use in sort" to be comparable with "sort name".
