### PR TITLE
Check that an array index is defined before accessing it to prevent an E_NOTICE

### DIFF
--- a/libraries/Config.class.php
+++ b/libraries/Config.class.php
@@ -1868,7 +1868,7 @@ class PMA_Config
  */
 function PMA_Config_fatalErrorHandler()
 {
-    if ($GLOBALS['pma_config_loading']) {
+    if (isset($GLOBALS['pma_config_loading']) && $GLOBALS['pma_config_loading']) {
         $error = error_get_last();
         if ($error !== null) {
             PMA_fatalError(


### PR DESCRIPTION
The following E_NOTICE message appears when accessing the /setup page to create a new config.inc.php file:
Notice: Undefined index: pma_config_loading in /var/www/phpmyadmingit/libraries/Config.class.php on line 1871

This fix checks that the array index is defined before accessing it.
