### PR TITLE
When importing a CSV file force a trailing new line at EOF (bug #4133)

### DIFF
--- a/libraries/plugins/import/ImportCsv.class.php
+++ b/libraries/plugins/import/ImportCsv.class.php
@@ -259,6 +259,22 @@ class ImportCsv extends AbstractImportCsv
                 // Append new data to buffer
                 $buffer .= $data;
                 unset($data);
+                
+                // Force a trailing new line at EOF to prevent parsing problems
+                if ($finished && $buffer) {
+                    $finalch = substr($buffer, -1);
+                    if ($csv_new_line == 'auto'
+                        && $finalch != "\r"
+                        && $finalch != "\n"
+                    ) {
+                        $buffer .= "\n";
+                    } elseif ($csv_new_line != 'auto' 
+                        && $finalch != $csv_new_line
+                    ) {
+                        $buffer .= $csv_new_line;
+                    }
+                }
+                
                 // Do not parse string when we're not at the end
                 // and don't have new line inside
                 if (($csv_new_line == 'auto'


### PR DESCRIPTION
Fix for bug #4133.  
https://sourceforge.net/p/phpmyadmin/bugs/4133/

When importing a CSV file this new code adds a trailing new line at end-of-file if one does not exist.  Otherwise you can run into a condition where the last line of the file is skipped by the parser or an error occurs stating, "Invalid format of CSV input on line XX"
