### PR TITLE
When importing a SQL file convert \r line-endings to \n

### DIFF
--- a/libraries/plugins/import/ImportSql.class.php
+++ b/libraries/plugins/import/ImportSql.class.php
@@ -189,6 +189,11 @@ class ImportSql extends ImportPlugin
                     continue;
                 }
             }
+
+            // Convert CR (but not CRLF) to LF otherwise all queries
+            // may not get executed on some platforms
+            $buffer = preg_replace("/\r($|[^\n])/", "\n$1", $buffer);
+
             // Current length of our buffer
             $len = strlen($buffer);
 


### PR DESCRIPTION
This is a proposed fix for bug #4153
https://sourceforge.net/p/phpmyadmin/bugs/4153/

When importing a SQL file convert carriage return (\r) line-endings to line feeds (\n) otherwise all queries in the file may not get executed on some platforms (e.g. Linux).
