### PR TITLE
Prevent fatal PHP error when filtering tables in the navigation tree

### DIFF
--- a/libraries/navigation/NavigationTree.class.php
+++ b/libraries/navigation/NavigationTree.class.php
@@ -692,11 +692,14 @@ class PMA_NavigationTree
         }
 
         if (! empty($this->_searchClause) || ! empty($this->_searchClause2)) {
+            $results = 0;
             if (! empty($this->_searchClause2)) {
-                $results = $node->realParent()->getPresence(
-                    $node->real_name,
-                    $this->_searchClause2
-                );
+                if (is_object($node->realParent())) {
+                    $results = $node->realParent()->getPresence(
+                        $node->real_name,
+                        $this->_searchClause2
+                    );
+                }
             } else {
                 $results = $this->_tree->getPresence(
                     'databases',


### PR DESCRIPTION
This is a fix for bug #4159
https://sourceforge.net/p/phpmyadmin/bugs/4159/
