### PR TITLE
fix #3797: Split not only on where, also on group by, having and order by.

### DIFF
--- a/tbl_export.php
+++ b/tbl_export.php
@@ -47,6 +47,18 @@ if (! empty($sql_query)) {
         //  ( SELECT id FROM companies WHERE name LIKE '%u%')"
         $sql_query = $temp_sql_array[0];
 
+        //Explode again on "group by"
+        $temp_sql_array = explode("group by", strtolower($sql_query));
+        $sql_query = $temp_sql_array[0];
+
+        //Explode again on "having"
+        $temp_sql_array = explode("having", strtolower($sql_query));
+        $sql_query = $temp_sql_array[0];
+
+        //Explode again on "order by"
+        $temp_sql_array = explode("order by", strtolower($sql_query));
+        $sql_query = $temp_sql_array[0];
+
         // Append the where clause using the primary key of each row
         if (is_array($where_clause) && (count($where_clause) > 0)) {
             $sql_query .= ' WHERE (' . implode(') OR (', $where_clause) . ')';


### PR DESCRIPTION
Hi,

I tried to fix this bug: https://sourceforge.net/p/phpmyadmin/bugs/3797/

The fix isn't very difficult: the query were split on "where". But if there is no "where"? We should split on "group by"? And if there is no... etc, with "having" and "order by".

I'm not sure from which branch I should create my fix-branch... So I checked out QA_3_5 and created my fix-branch from this branch. Is this good please?
If it's not, please let me know, so I could train and create the good fix.
(Oh... I've just seen that I hadn't the "Able to merge", so I edited the pull request to link it to QA_3_5. I hope it's ok.)

Thanks.
