### PR TITLE
Fix 4157: Display error message when using "Change Login Information / Copy User" dialog to update password

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-19 08:15+0200\n"
 "Last-Translator: Gottlieb Gauche <gottlieb@gosurfonline.co.za>\n"
 "Language-Team: Afrikaans <http://l10n.cihar.com/projects/phpmyadmin/master/"
@@ -43,7 +43,7 @@ msgstr "Tabel kommentaar"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Tipe"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -338,7 +338,7 @@ msgid "Updated"
 msgstr "Opgedateer"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -366,7 +366,7 @@ msgid "Delete tracking data for this table"
 msgstr "Verwyder naspeur data vir die tabel"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -567,8 +567,8 @@ msgstr "Voeg geometrie by"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -594,7 +594,7 @@ msgstr "Voeg geometrie by"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Gaan voort"
@@ -961,7 +961,7 @@ msgstr "Indeks"
 msgid "Edit Index"
 msgstr "Indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 msgid "Add %s column(s) to index"
 msgstr "Voeg 'n nuwe veld by"
@@ -1189,7 +1189,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1514,8 +1514,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1758,8 +1758,8 @@ msgstr "SQL-stelling"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1786,7 +1786,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1866,8 +1866,8 @@ msgstr "SQL resultaat"
 msgid "Data point content"
 msgstr "Tabel kommentaar"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignoreer"
 
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2646,8 +2646,8 @@ msgstr[0] "%s resultate binne tabel <i>%s</i>"
 msgstr[1] "%s resultate binne tabel <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2712,16 +2712,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Voeg By/Verwyder Veld Kolomme"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Begin"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2729,8 +2729,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Vorige"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2738,8 +2738,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Volgende"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2931,9 +2931,9 @@ msgstr "Kies Alles"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3124,9 +3124,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3140,32 +3140,32 @@ msgid "Structure"
 msgstr "Struktuur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Soek"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Voeg by"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3174,20 +3174,20 @@ msgid "Privileges"
 msgstr "Regte"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operasies"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3203,73 +3203,73 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Navraag dmv Voorbeeld"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "databasisse"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Gebruiker"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 #, fuzzy
 msgid "Binary log"
 msgstr "Biner"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr ""
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Fout"
@@ -3295,7 +3295,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3522,7 +3522,7 @@ msgid "Operator"
 msgstr "Operasies"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3539,7 +3539,7 @@ msgstr "Soek"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3551,7 +3551,7 @@ msgstr "Voeg by"
 msgid "Select columns (at least one):"
 msgstr "Kies Velde (ten minste een):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Of"
@@ -3674,284 +3674,284 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Bediener weergawe"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Bediener weergawe"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 msgid "A polygon"
 msgstr "Voeg 'n nuwe veld by"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Skep 'n nuwe indeks"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Lyne beeindig deur"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "totaal"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4038,68 +4038,68 @@ msgstr "%B %d, %Y at %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Maak Leeg"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 #, fuzzy
 msgid "Creation"
 msgstr "Skep"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr ""
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr ""
@@ -4474,9 +4474,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Herstel"
 
@@ -4764,7 +4764,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Stoor as leer (file)"
 
@@ -7111,7 +7111,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 #, fuzzy
 msgid "Version information"
 msgstr "Wys PHP informasie"
@@ -7512,58 +7512,58 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Biner - moenie verander nie"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Voeg by as 'n nuwe ry"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Terug na vorige bladsy"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Voeg 'n nuwe ry by"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 #, fuzzy
 msgid "Go back to this page"
 msgstr "Terug na vorige bladsy"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9726,25 +9726,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Die \"%s\" databasis bestaan nie!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Stel asb. die koordinate op van tabel %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12399,7 +12399,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Algemene verwantskap funksies"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12674,7 +12674,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12689,19 +12689,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12732,6 +12732,10 @@ msgstr "Geen databasisse"
 #, fuzzy
 msgid "View dump (schema) of databases"
 msgstr "Sien die storting (skema) van die databasis"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ar.po
+++ b/po/ar.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-03-20 22:10+0200\n"
 "Last-Translator: mohamed amin boubaker <mohamed.amin.02@gmail.com>\n"
 "Language-Team: Arabic <http://l10n.cihar.com/projects/phpmyadmin/master/ar/"
@@ -44,7 +44,7 @@ msgstr "تعليقات الجدول"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -90,7 +90,7 @@ msgid "Type"
 msgstr "نوع"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -349,7 +349,7 @@ msgid "Updated"
 msgstr "محدث"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -377,7 +377,7 @@ msgid "Delete tracking data for this table"
 msgstr "حذف بيانات التتبع لهذا الجدول"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -581,8 +581,8 @@ msgstr "أضف هندسة"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -608,7 +608,7 @@ msgstr "أضف هندسة"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "إنطلق"
@@ -976,7 +976,7 @@ msgstr "إضافة فهرس"
 msgid "Edit Index"
 msgstr "حرّر الفهرس"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %d column(s) to index"
 msgid "Add %s column(s) to index"
@@ -1192,7 +1192,7 @@ msgid "Traffic"
 msgstr "بيانات سير"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "الإعدادات"
 
@@ -1489,8 +1489,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1701,8 +1701,8 @@ msgstr "إظهار صندوق الإستعلام"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1729,7 +1729,7 @@ msgstr "وقت التنفيذ الأقصى"
 msgid "%d is not valid row number."
 msgstr "%d ليس رقم عمود صالح."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1803,8 +1803,8 @@ msgstr "نتائج الاستعلام"
 msgid "Data point content"
 msgstr "محتوى نقطة البيانات"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "تجاهل"
 
@@ -2364,7 +2364,7 @@ msgstr "ملف الإعدادت (%s) غير قابل للقراءة."
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "صلاحيات خاطئة على ملف الإعدادات , لاينبغى أن يكون قابل للكتابة!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "حجم الخط"
 
@@ -2531,8 +2531,8 @@ msgstr[4] "%s مطابقة في الجدول <i>%s</i>"
 msgstr[5] "%s مطابقة في الجدول <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2588,28 +2588,28 @@ msgstr "إحفظ البيانات المعدّلة"
 msgid "Restore column order"
 msgstr "استعادة ترتيب الأعمدة"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "بداية"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "سابق"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "التالي"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "نهاية"
@@ -2791,9 +2791,9 @@ msgstr "تحديد الكل"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2980,9 +2980,9 @@ msgid "View"
 msgstr "عرض"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2996,32 +2996,32 @@ msgid "Structure"
 msgstr "بناء"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "إبحث"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "إدخال"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3030,20 +3030,20 @@ msgid "Privileges"
 msgstr "الإمتيازات"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "عمليات"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "تتبع"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3059,70 +3059,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr "قاعدة البيانات فارغة!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "استعلام بواسطة مثال"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "أحداث"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "المصمم"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "قاعدة بيانات"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "المستخدمون"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "سجل ثنائي"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "إستنساخ"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "متغيرات"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "مجموعات المحارف"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "القوابس"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "محركات"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "خطأ"
@@ -3160,7 +3160,7 @@ msgstr[3] "%1$d صفوف أضيفت"
 msgstr[4] "%1$d صفوف أضيفت"
 msgstr[5] "%1$d صفوف أضيفت"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3380,7 +3380,7 @@ msgid "Operator"
 msgstr "عامل التشغيل"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3395,7 +3395,7 @@ msgstr "بحث في الجدول"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "تحرير/إدخال"
 
@@ -3403,7 +3403,7 @@ msgstr "تحرير/إدخال"
 msgid "Select columns (at least one):"
 msgstr "اختيار الأعمدة (واحد على الأقل):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "أو"
@@ -3527,278 +3527,278 @@ msgstr "مسار المظهر غير موجود للمظهر %s !"
 msgid "Theme:"
 msgstr "مظهر"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "تاريخ ما، إن النطاق المسموح به هو من %1$s إلى %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "تركيبة تاريخ و زمان، النطاق المسموح به هو من %1$s إلى %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "زمن ما، النطاق يكون من %1$s إلى %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "قيمة واحدة مختارة من مجموعة لحد 64 أعضاء"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "نقطة في فضاء ذات أبعاد ثنائية"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "مضلع"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "مجموعة من النقاط"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "مجموعة من المضلعات"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "مجموعة كائنات الهندسة من أي نوع"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "رقمية"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "التاريخ والوقت"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "السلسلة"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "صحيحة أو خاطئة"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3885,67 +3885,67 @@ msgstr "%d %B %Y الساعة %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s يوم، %s ساعة، %s دقيقة و%s ثانية"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "مدخلات مفقودة:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "الذهاب إلى قاعدة البيانات &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "إنّ ال %s الوظيفية هي مصابة بعطل معروف، أنظر إلى %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "إضغط للإختيار"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "تصفح حاسبك:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "إختر مجلد الرفع من الخادم <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "لا يمكن الوصول إلى الدليل اللذي عينته لعمل التحميل"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "لايوجد أي ملفات لرفعها"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "إفراغ"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "تنفيذ"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "طباعة"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "الإنشاء"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "آخر تحديث"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "آخر فحص"
@@ -4304,9 +4304,9 @@ msgstr "السماح للمستخدمين بتخصيص هذه القيمة"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "إعادة تعيين"
 
@@ -4595,7 +4595,7 @@ msgstr "ضع الوقت المحدد لعمل البرنامج ([kbd]0[/kbd]: ل
 msgid "Maximum execution time"
 msgstr "وقت التنفيذ الأقصى"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "حفظ كملف"
 
@@ -6890,7 +6890,7 @@ msgstr "الملف قيد المعالجة, يرجى الانتظار."
 msgid "Language"
 msgstr "لغة"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7289,59 +7289,59 @@ msgstr "بسبب طوله,<br /> فمن المحتمل أن هذا الحقل غ
 msgid "Binary - do not edit"
 msgstr "ثنائي - لاتحرره"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "دليل تحميل الملفات على خادم الشبكة"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "وبعدها"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "إدخال كتسجيل جديد"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "الرجوع إلى الصفحة السابقة"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "إدخال تسجيل جديد"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "ارجع إلى هذه الصفحة"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "عدل الصف التالي"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9622,25 +9622,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "الجدول \"%s\" غير موجود!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "رجاء إعداد الموقع للجدول %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12366,7 +12366,7 @@ msgstr "تم إنشاء الإصدار %s , التتبع نشط لـ %s.%s"
 msgid "Manage your settings"
 msgstr "المزايا العامّة للرابط"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12646,7 +12646,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12661,19 +12661,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12702,6 +12702,10 @@ msgstr "لايوجد قواعد بيانات"
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/az.po
+++ b/po/az.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:33+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Azerbaijani <http://l10n.cihar.com/projects/phpmyadmin/master/"
@@ -43,7 +43,7 @@ msgstr "Cədvəl haqqında izahat"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Tip"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -350,7 +350,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -378,7 +378,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -592,8 +592,8 @@ msgstr "Yeni İstifadeçi elave Et"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -619,7 +619,7 @@ msgstr "Yeni İstifadeçi elave Et"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Davam"
@@ -990,7 +990,7 @@ msgstr "Yeni sahe elave et"
 msgid "Edit Index"
 msgstr "Bir sonrakı setre keç"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 msgid "Add %s column(s) to index"
 msgstr "Yeni sahe elave et"
@@ -1223,7 +1223,7 @@ msgid "Traffic"
 msgstr "Neqliyyat"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1553,8 +1553,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1801,8 +1801,8 @@ msgstr "SQL sorğusu"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1910,8 +1910,8 @@ msgstr "SQL result"
 msgid "Data point content"
 msgstr "İçindekiler Cedveli"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Diqqete Alma"
 
@@ -2528,7 +2528,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2691,8 +2691,8 @@ msgstr[0] "%s uyğunluq tapıldı (<i>%s</i> cedvelinde)"
 msgstr[1] "%s uyğunluq tapıldı (<i>%s</i> cedvelinde)"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2757,16 +2757,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Sahe Sütunlarını Elave Et/Sil"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Başla"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2774,8 +2774,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Evvelki"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2783,8 +2783,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Sonrakı"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2978,9 +2978,9 @@ msgstr "Hamısını Seç"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3172,9 +3172,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3188,32 +3188,32 @@ msgid "Structure"
 msgstr "Quruluş"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Axtarış"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Elave et"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3222,20 +3222,20 @@ msgid "Privileges"
 msgstr "Selahiyyetler"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Emeliyyatlar"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3251,75 +3251,75 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Sorğu"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Me'lumat Bazaları"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "İstifadeçi"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 #, fuzzy
 msgid "Binary log"
 msgstr "Binary"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 #, fuzzy
 msgid "Replication"
 msgstr "Relations"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Deyişenler"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 #, fuzzy
 msgid "Charsets"
 msgstr "Charset"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motorlar"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Xeta"
@@ -3345,7 +3345,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3574,7 +3574,7 @@ msgid "Operator"
 msgstr "Emeliyyatlar"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3591,7 +3591,7 @@ msgstr "Axtarış"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3603,7 +3603,7 @@ msgstr "Elave et"
 msgid "Select columns (at least one):"
 msgstr "Sahe seçin (en az birini):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "ya da"
@@ -3727,285 +3727,285 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Server versiyası"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Server versiyası"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 msgid "A polygon"
 msgstr "Yeni sahe elave et"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Yeni indeks qur"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Setir leğvedicisi (Lines terminated by)"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Cemi"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4094,70 +4094,70 @@ msgstr "%d %B, %Y saat %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s gün, %s saat, %s deqiqe ve %s saniye"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Add new field"
 msgid "Missing parameter:"
 msgstr "Yeni sahe elave et"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "&quot;%s&quot; me'lumat bazasına keç."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "web-server upload direktoriyası"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Upload işleri üçün te'yin etdiyiniz direktoriya tapılmadı."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Boşalt"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Çap et"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Quruluş"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "En son yenilenme"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "En son yoxlama"
@@ -4533,9 +4533,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Yenile"
 
@@ -4829,7 +4829,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Fayl olaraq qeyd et"
 
@@ -7216,7 +7216,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 #, fuzzy
 msgid "Version information"
 msgstr "Sisteme Giriş Me'lumatı"
@@ -7620,59 +7620,59 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Binary - deyişiklik etme"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "web-server upload direktoriyası"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Yeni setir olaraq elave et"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Evvelki sehifeye qayıt"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Teze bir setir daha gir"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Bu sehifeye geri dön"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Bir sonrakı setre keç"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9929,25 +9929,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "\"%s\" cedveli mövcud deyil!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Xahiş edirem, %s cedveli üçün koordinatları yeniden müeyyen et"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12642,7 +12642,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Ümumi elaqe variantları"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12923,7 +12923,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12938,19 +12938,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12980,6 +12980,10 @@ msgstr "Baza seçilmemişdir ve ya mövcud deyildir."
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Me'lumat bazalarının sxemini göster"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/be.po
+++ b/po/be.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:32+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Belarusian <http://l10n.cihar.com/projects/phpmyadmin/master/"
@@ -42,7 +42,7 @@ msgstr "Камэнтар да табліцы"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -90,7 +90,7 @@ msgid "Type"
 msgstr "Тып"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -355,7 +355,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -383,7 +383,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -599,8 +599,8 @@ msgstr "Дадаць новага карыстальніка"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -626,7 +626,7 @@ msgstr "Дадаць новага карыстальніка"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Панеслася"
@@ -1032,7 +1032,7 @@ msgstr "Дадаць новае поле"
 msgid "Edit Index"
 msgstr "Рэдагаваць наступны радок"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1276,7 +1276,7 @@ msgid "Traffic"
 msgstr "Трафік"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1614,8 +1614,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1871,8 +1871,8 @@ msgstr "SQL-запыт"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1899,7 +1899,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr "%d не зьяўляецца карэктным нумарам радка."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1980,8 +1980,8 @@ msgstr "Дзеяньні з вынікамі запытаў"
 msgid "Data point content"
 msgstr "Памер указальніка на дадзеныя"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ігнараваць"
 
@@ -2605,7 +2605,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Памер шрыфта"
 
@@ -2772,8 +2772,8 @@ msgstr[0] "%s супадзеньняў у табліцы <i>%s</i>"
 msgstr[1] "%s супадзеньняў у табліцы <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2839,16 +2839,16 @@ msgstr "Хатняя тэчка дадзеных"
 msgid "Restore column order"
 msgstr "Дадаць/выдаліць калёнку крытэру"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Першая старонка"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2856,8 +2856,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Папярэдняя старонка"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2865,8 +2865,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Наступная старонка"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3060,9 +3060,9 @@ msgstr "Адзначыць усё"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3261,9 +3261,9 @@ msgid "View"
 msgstr "Выгляд"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3277,32 +3277,32 @@ msgid "Structure"
 msgstr "Структура"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Пошук"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Уставіць"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3311,20 +3311,20 @@ msgid "Privileges"
 msgstr "Прывілеі"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Апэрацыі"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3340,72 +3340,72 @@ msgstr "Трыгеры"
 msgid "Database seems to be empty!"
 msgstr "База дадзеных — пустая!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Запыт згодна прыкладу"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Працэдуры"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Падзеі"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Дызайнэр"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Базы дадзеных"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Карыстальнік"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Двайковы лог"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Рэплікацыя"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Зьменныя"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Кадыроўкі"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Машыны"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Памылка"
@@ -3434,7 +3434,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Устаўлена радкоў: %1$d."
 msgstr[1] "Устаўлена радкоў: %1$d."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3669,7 +3669,7 @@ msgid "Operator"
 msgstr "Апэратар"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3686,7 +3686,7 @@ msgstr "Пошук"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3698,7 +3698,7 @@ msgstr "Уставіць"
 msgid "Select columns (at least one):"
 msgstr "Выбраць палі (прынамсі адно):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Або"
@@ -3824,287 +3824,287 @@ msgstr "Ня знойдзены шлях да тэмы %s!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Стварыць сувязь"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Памылка перайменаваньня табліцы %1$s у %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "Дадаць %s новыя палі"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Стварыць новы індэкс"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Радкі падзеленыя"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Колькасьць файлаў логу"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4193,71 +4193,71 @@ msgstr "%d %B %Y, %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s дзён, %s гадзінаў, %s хвілінаў і %s сэкундаў"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Працэдуры"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Перайсьці да базы дадзеных &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 "Існуе вядомая памылка з выкарыстаньнем парамэтра %s, глядзіце апісаньне на %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "тэчка вэб-сэрвэра для загрузкі файлаў"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Немагчыма адкрыць пазначаную вамі тэчку для загрузкі файлаў."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Ачысьціць"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Друк"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Створаная"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Апошняе абнаўленьне"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Апошняя праверка"
@@ -4641,9 +4641,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Скінуць"
 
@@ -4940,7 +4940,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Захаваць як файл"
 
@@ -7400,7 +7400,7 @@ msgstr ""
 msgid "Language"
 msgstr "Мова"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Інфармацыя пра вэрсію"
 
@@ -7848,63 +7848,63 @@ msgstr "З-за вялікай даўжыні,<br /> гэтае поле ня м
 msgid "Binary - do not edit"
 msgstr "Двайковыя дадзеныя — не рэдагуюцца"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "тэчка вэб-сэрвэра для загрузкі файлаў"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Пачаць устаўку зноў з %s-га радку"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "і пасьля"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Уставіць як новы радок"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 #, fuzzy
 msgid "Show insert query"
 msgstr "У выглядзе SQL-запыту"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Перайсьці да папярэдняй старонкі"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Дадаць яшчэ адзін радок"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Вярнуцца да гэтай старонкі"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Рэдагаваць наступны радок"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Выкарыстоўвайце клявішу TAB для перамяшчэньня ад значэньня да значэньня або "
 "CTRL+стрэлкі для перамяшчэньня ў любое іншае месца"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "У выглядзе SQL-запыту"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "ID устаўленага радку: %1$d"
@@ -10241,25 +10241,25 @@ msgid "There are no events to display."
 msgstr "Праверыць табліцу"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Табліцы \"%s\" не існуе!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Калі ласка, сканфігуруйце каардынаты для табліцы %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -13141,7 +13141,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Магчымасьці асноўных сувязяў"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13432,7 +13432,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13447,19 +13447,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13489,6 +13489,10 @@ msgstr "Базы дадзеных адсутнічаюць"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Праглядзець дамп (схему) базаў дадзеных"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/be@latin.po
+++ b/po/be@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:41+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Belarusian (latin) <http://l10n.cihar.com/projects/phpmyadmin/"
@@ -42,7 +42,7 @@ msgstr "Kamentar da tablicy"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -90,7 +90,7 @@ msgid "Type"
 msgstr "Typ"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -353,7 +353,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -381,7 +381,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -593,8 +593,8 @@ msgstr "Dadać novaha karystalnika"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -620,7 +620,7 @@ msgstr "Dadać novaha karystalnika"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Paniesłasia"
@@ -1028,7 +1028,7 @@ msgstr "Dadać novaje pole"
 msgid "Edit Index"
 msgstr "Redagavać nastupny radok"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1273,7 +1273,7 @@ msgid "Traffic"
 msgstr "Trafik"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1616,8 +1616,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1880,8 +1880,8 @@ msgstr "U vyhladzie SQL-zapytu"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr "%d nie źjaŭlajecca karektnym numaram radka."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1993,8 +1993,8 @@ msgstr "Dziejańni z vynikami zapytaŭ"
 msgid "Data point content"
 msgstr "Pamier ukazalnika na dadzienyja"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignaravać"
 
@@ -2618,7 +2618,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Pamier šryfta"
 
@@ -2787,8 +2787,8 @@ msgstr[1] "%s supadzieńniaŭ u tablicy %s"
 msgstr[2] "%s supadzieńniaŭ u tablicy %s"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2853,16 +2853,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Dadać/vydalić kalonku kryteru"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Pieršaja staronka"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2870,8 +2870,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Papiaredniaja staronka"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2879,8 +2879,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Nastupnaja staronka"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3074,9 +3074,9 @@ msgstr "Adznačyć usio"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3275,9 +3275,9 @@ msgid "View"
 msgstr "Vyhlad"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3291,32 +3291,32 @@ msgid "Structure"
 msgstr "Struktura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Pošuk"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Ustavić"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3325,20 +3325,20 @@ msgid "Privileges"
 msgstr "Pryvilei"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Aperacyi"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3354,72 +3354,72 @@ msgstr "Tryhiery"
 msgid "Database seems to be empty!"
 msgstr "Baza dadzienych — pustaja!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Zapyt zhodna prykładu"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Pracedury"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Padziei"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Dyzajner"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Bazy dadzienych"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Karystalnik"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Dvajkovy łog"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikacyja"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Źmiennyja"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Kadyroŭki"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Mašyny"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Pamyłka"
@@ -3448,7 +3448,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Ustaŭlena radkoŭ: %1$d."
 msgstr[1] "Ustaŭlena radkoŭ: %1$d."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3684,7 +3684,7 @@ msgid "Operator"
 msgstr "Aperatar"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3701,7 +3701,7 @@ msgstr "Pošuk"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3713,7 +3713,7 @@ msgstr "Ustavić"
 msgid "Select columns (at least one):"
 msgstr "Vybrać pali (prynamsi adno):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Abo"
@@ -3839,288 +3839,288 @@ msgstr "Nia znojdzieny šlach da temy %s!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "General relation features"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Mahčymaści asnoŭnych suviaziaŭ"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Pamyłka pierajmienavańnia tablicy %1$s u %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "Dadać %s novyja pali"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Stvaryć novy indeks"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Radki padzielenyja"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Kolkaść fajłaŭ łogu"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4209,72 +4209,72 @@ msgstr "%d %B %Y, %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dzion, %s hadzinaŭ, %s chvilinaŭ i %s sekundaŭ"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Pracedury"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Pierajści da bazy dadzienych \"%s\"."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 "Isnuje viadomaja pamyłka z vykarystańniem parametra %s, hladzicie apisańnie "
 "na %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "tečka web-servera dla zahruzki fajłaŭ"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Niemahčyma adkryć paznačanuju vami tečku dla zahruzki fajłaŭ."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Ačyścić"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Druk"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Stvoranaja"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Apošniaje abnaŭleńnie"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Apošniaja pravierka"
@@ -4660,9 +4660,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Skinuć"
 
@@ -4957,7 +4957,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Zachavać jak fajł"
 
@@ -7392,7 +7392,7 @@ msgstr ""
 msgid "Language"
 msgstr "Mova"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Infarmacyja pra versiju"
 
@@ -7845,62 +7845,62 @@ msgstr "Z-za vialikaj daŭžyni, hetaje pole nia moža być adredagavanaje "
 msgid "Binary - do not edit"
 msgstr "Dvajkovyja dadzienyja — nie redagujucca"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "tečka web-servera dla zahruzki fajłaŭ"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Pačać ustaŭku znoŭ z %s-ha radku"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "i paśla"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Ustavić jak novy radok"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Pierajści da papiaredniaj staronki"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Dadać jašče adzin radok"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Viarnucca da hetaj staronki"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Redagavać nastupny radok"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Vykarystoŭvajcie klavišu TAB dla pieramiaščeńnia ad značeńnia da značeńnia "
 "abo CTRL+strełki dla pieramiaščeńnia ŭ luboje inšaje miesca"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "U vyhladzie SQL-zapytu"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "ID ustaŭlenaha radku: %1$d"
@@ -10243,25 +10243,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Tablicy \"%s\" nie isnuje!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Kali łaska, skanfihurujcie kaardynaty dla tablicy %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -13144,7 +13144,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Mahčymaści asnoŭnych suviaziaŭ"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13435,7 +13435,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13450,19 +13450,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13492,6 +13492,10 @@ msgstr "Bazy dadzienych adsutničajuć"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Prahladzieć damp (schiemu) bazaŭ dadzienych"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:40+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Bulgarian <http://l10n.cihar.com/projects/phpmyadmin/master/"
@@ -43,7 +43,7 @@ msgstr "Коментари към таблицата"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Тип"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -344,7 +344,7 @@ msgid "Updated"
 msgstr "Съвременен"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -372,7 +372,7 @@ msgid "Delete tracking data for this table"
 msgstr "Изтриване на проследената информация за таблицата"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -578,8 +578,8 @@ msgstr "Добави геометрия"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -605,7 +605,7 @@ msgstr "Добави геометрия"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Изпълнение"
@@ -987,7 +987,7 @@ msgstr "Добавяне индекс"
 msgid "Edit Index"
 msgstr "Редактиране индекс"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %d column(s) to index"
 msgid "Add %s column(s) to index"
@@ -1205,7 +1205,7 @@ msgid "Traffic"
 msgstr "Трафик"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Настройки"
 
@@ -1517,8 +1517,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1727,8 +1727,8 @@ msgstr "Показване формата за заявки"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1755,7 +1755,7 @@ msgstr "Време за изпълнение на заявката"
 msgid "%d is not valid row number."
 msgstr "%d не е валиден номер на ред."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1831,8 +1831,8 @@ msgstr "Резултати от заявката"
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Игнориране"
 
@@ -2407,7 +2407,7 @@ msgstr ""
 "Неподходящи права на файлът с настройки, в него не трябва да може да пише "
 "всеки!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Размер шрифт"
 
@@ -2566,8 +2566,8 @@ msgstr[0] "%1$s съвпадение в таблица <strong>%2$s</strong>"
 msgstr[1] "%1$s съвпадения в таблица <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2623,28 +2623,28 @@ msgstr "Съхраняване на редактираните данни"
 msgid "Restore column order"
 msgstr "Възстановяване на подредбата на колоните"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Начало"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Предна"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Следваща"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Последна"
@@ -2824,9 +2824,9 @@ msgstr "Маркиране всички"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3017,9 +3017,9 @@ msgid "View"
 msgstr "Изглед"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3033,32 +3033,32 @@ msgid "Structure"
 msgstr "Структура"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Търсене"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Вмъкване"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3067,20 +3067,20 @@ msgid "Privileges"
 msgstr "Права"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Операции"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Проследяване"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3096,70 +3096,70 @@ msgstr "Тригери"
 msgid "Database seems to be empty!"
 msgstr "БД изглежда празна!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Заявка по пример"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Процедури"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Събития"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Строител"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "БД"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Потребители"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Двоичен дневник"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Репликация"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Променливи"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Знакови набори"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Добавки"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Хранилища"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Грешка"
@@ -3185,7 +3185,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d ред добавен."
 msgstr[1] "%1$d реда добавени."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3405,7 +3405,7 @@ msgid "Operator"
 msgstr "Оператор"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3420,7 +3420,7 @@ msgstr "Търсене в таблица"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Редакция/Вмъкване"
 
@@ -3428,7 +3428,7 @@ msgstr "Редакция/Вмъкване"
 msgid "Select columns (at least one):"
 msgstr "Избор на колона (поне една):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Или"
@@ -3552,178 +3552,178 @@ msgstr "Не е открит път към тема %s!"
 msgid "Theme:"
 msgstr "Тема"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Дата, поддържан диапазон е %1$s до %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Комбинация от дата и час, поддържаният диапазон е %1$s до %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Време, диапазонът е %1$s до %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3731,67 +3731,67 @@ msgstr ""
 "Изброяване, избор от списък с до 65535 стойности или специалната стойност за "
 "грешка ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Единична стойност, избрана от списък с до 64 възможни"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Тип, който може да съхранява геометрия от всякакъв вид"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Точка в 2-мерното пространство"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Крива с линейна интерполация между точки"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Многоъгълник"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Набор от точки"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Колекция от криви с линейна интерполация между точки"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Набор от многоъгълници"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Набор от геометрични обекти от всякакъв вид"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Цифров"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Дата и час"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Низ"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Пространствен"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Цяло 4-байтово число с диапазон от -2 147 483 648 до 2 147 483 647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3799,35 +3799,35 @@ msgstr ""
 "Цяло 8-байтово число с диапазон от -9 223 372 036 854 775 808 до 9 223 372 "
 "036 854 775 807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Истина или неистина"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Синоним на BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Съхранява универсално уникален идентификатор (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Изброяване, избор от списък на определените стойности"
 
@@ -3914,67 +3914,67 @@ msgstr "%e %B %Y в %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s дена, %s часа, %s минути и %s секунди"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Липсващ параметър:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Показване БД &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Функционалността %s се влияе от известен дефект, виж %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Щракване за превключване"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Разглеждане на компютъра:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Избор от директорията за качване <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Папката, която сте указали за качване е недостъпна."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Няма файлве за качване"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Изчистване"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Изпълнение"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Печат"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Дата на създаване"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Последно обновление"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Последна проверка"
@@ -4338,9 +4338,9 @@ msgstr "Позволение на потребители да променят �
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Изчистване"
 
@@ -4653,7 +4653,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Максимално време за изпълнение"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Изпращане"
 
@@ -7003,7 +7003,7 @@ msgstr ""
 msgid "Language"
 msgstr "Език"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Весия"
 
@@ -7396,61 +7396,61 @@ msgstr "Поради дължината си,<br />това поле може д
 msgid "Binary - do not edit"
 msgstr "Двоично - не се редактира"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "директорията за upload на web сървъра"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "и след това"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Вмъкване като нов ред"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Показване заявка за вмъкване"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Обратно към предната страница"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Вмъкване нов ред"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Връщане към тази страница"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Редакция на следващия ред"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Използвайте клавиша TAB, за да премествате крурсора от стойност на стойност "
 "или CTRL+стрелка, за да премествате курсора в съответната посока"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9634,24 +9634,24 @@ msgid "There are no events to display."
 msgstr "Няма събития."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Таблицата %s не съществува!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Моля конфигурирайте координатите за таблица %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Схема на БД %s - страница %s"
@@ -12292,7 +12292,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Управление мои настройки"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Конфигурацията е записана"
 
@@ -12552,7 +12552,7 @@ msgstr "Настройки ще бъдат импортирани от лока�
 msgid "You have no saved settings!"
 msgstr "Нямате запазени настройки!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Тази функционалност не се поддържа от вашия браузър"
 
@@ -12569,19 +12569,19 @@ msgstr ""
 "Имате достъп до още настройки, модифицирайки config.inc.php, примерно чрез %"
 "sскрипта за настройки%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Запис в хранилището на браузъра"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Настройките ще бъдат запазени в хранилището на вашия браузър."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Съществуващи настройки ще бъдат презаписани!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "Може да изчистите настройките си до стойностите им по подразбиране."
 
@@ -12611,6 +12611,10 @@ msgstr "Няма БД"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Преглед на схемата (дъмп) на БД"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/bn.po
+++ b/po/bn.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 15:40+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Bengali <http://l10n.cihar.com/projects/phpmyadmin/master/bn/"
@@ -41,7 +41,7 @@ msgstr "টেবিলের মন্তব্য সমূহ"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "ধরণ"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -342,7 +342,7 @@ msgid "Updated"
 msgstr "আধুনিকায়ন হয়েছে"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -370,7 +370,7 @@ msgid "Delete tracking data for this table"
 msgstr "টেবিল থেকে ট্র্যাকিং এর তথ্য মুছে ফেল"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -576,8 +576,8 @@ msgstr "জ্যামিতি যোগ কর"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -603,7 +603,7 @@ msgstr "জ্যামিতি যোগ কর"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "যাও"
@@ -975,7 +975,7 @@ msgstr "ইনডেক্স্ যোগকর"
 msgid "Edit Index"
 msgstr "ইনডেক্স সম্পাদনা"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "%s স্বম্ভ ইনডেক্সে যোগ কর"
@@ -1191,7 +1191,7 @@ msgid "Traffic"
 msgstr "গমনাগমন"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "সেটিংস"
 
@@ -1501,8 +1501,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1711,8 +1711,8 @@ msgstr "অনুসন্ধান বক্সটি দেখাও"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1739,7 +1739,7 @@ msgstr "অনুসন্ধানের সম্পাদনের সময়"
 msgid "%d is not valid row number."
 msgstr "%d বৈধ রো নাম্বার নয়।"
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1815,8 +1815,8 @@ msgstr "অনুসন্ধান ফলাফল"
 msgid "Data point content"
 msgstr "প্রতিটি পয়েন্ট তথ্য"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "উপেক্ষা"
 
@@ -2371,7 +2371,7 @@ msgstr "বর্তমান কনফিগারেশন ফাইল (%s) �
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "কনফিগারেশন ফাইলে ভুল অনুমতি দেয়া, ওটা লেখার মত নয়"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "অক্ষরের আকার"
 
@@ -2529,8 +2529,8 @@ msgstr[0] "<strong>%2$s</strong> মধ্যে %1$s মিল"
 msgstr[1] "<strong>%2$s</strong> মধ্যে %1$s গুলো মিল"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2586,28 +2586,28 @@ msgstr "সম্পাদিত তথ্য সংরক্ষন কর"
 msgid "Restore column order"
 msgstr "স্থম্ভের বিন্যাস ফিরিয়ে আনা"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "আরম্ভ"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "পূর্ববর্তী"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "পরবর্তী"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "শেষ"
@@ -2786,9 +2786,9 @@ msgstr "সবগুলোতে টিক দাও"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2975,9 +2975,9 @@ msgid "View"
 msgstr "দেখা"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2991,32 +2991,32 @@ msgid "Structure"
 msgstr "গঠন"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "এসকিউএল"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "খোঁজা"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "ইনর্সাট"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3025,20 +3025,20 @@ msgid "Privileges"
 msgstr "অধিকারসমূহ"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "কাজসমূহ"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "ট্রেকিং"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3054,70 +3054,70 @@ msgstr "ট্রিগারসমূহ"
 msgid "Database seems to be empty!"
 msgstr "ডাটাবেইজটি খালি মনে হয়!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "অনুসন্ধান"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "রুটিনসমূহ"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "ইভেন্টসমূহ"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "নকশাকারী"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "ডাটাবেইজ"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "ব্যবহারকারী"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "বাইনারী লগ"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "অনুলিপি"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "চলকসমূহ"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "বর্ণরাশী"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "প্লাগইন"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "ব্যবস্থাসমূহ"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "ভুল"
@@ -3143,7 +3143,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d টি রো প্রবেশ করেছে।"
 msgstr[1] "%1$d টি রো প্রবেশ করেছে।"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3366,7 +3366,7 @@ msgid "Operator"
 msgstr "পরিচালক"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3381,7 +3381,7 @@ msgstr "টেবিলে খোজাঁ"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "সম্পাদন/নতুন"
 
@@ -3389,7 +3389,7 @@ msgstr "সম্পাদন/নতুন"
 msgid "Select columns (at least one):"
 msgstr "স্বম্ভ নির্বাচন করুন (একটি হলেও):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "অথবা"
@@ -3510,12 +3510,12 @@ msgstr "থীম %s এর থীম পথ পাওয়া যায়নি!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr "একটি ১ বাইট ইন্টিজার, চিহ্নিত সীমা -১২৮ থেকে ১২৭, অচিহ্নত হলে ০ থেকে ২৫৫"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3523,7 +3523,7 @@ msgstr ""
 "একটি ২ বাইট পুর্ণ সংখ্য, চিহ্নিতের সীমা -৩২,৭৬৮ - ৩২,৭৬৭, অচিহ্নিতের সীমা ০ থেকে "
 "৬৫,৫৩৫"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3531,13 +3531,13 @@ msgstr ""
 "একটি ৩ বাইট পুর্ণ সংখ্য, চিহ্নিতের সীমা -৮,৩৮৮,৬০৮ - ৮,৩৮৮,৬০৭ অচিহ্নিতের সীমা ০ "
 "থেকে ১৬,৭৭৭,২১৫"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3545,7 +3545,7 @@ msgstr ""
 "একটি ৮ বাইট পুর্ণ সংখ্য, চিহ্নিতের সীমা -৯,২২,৩৭২,০৩৬,৮৫৪,৭৭৫,৮০৮ - "
 "৯,২২৩,৩৭২,০৩৬,৮৫৪,৭৭৫,৮০৭ অচিহ্নিতের সীমা ০ থেকে ১৮,৪৪৬,৭৪৪,০৭৩,৭০৯,৫৫১,৬১৫"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3553,7 +3553,7 @@ msgstr ""
 "একটি নির্দিষ্ট-পয়েন্ট নাম্বার ((M, D) -(M) সর্বোচ্চ ৬৫টি সংখ্যা (স্বভাবিক ১০), "
 "দশমিকের সংখ্যা সর্বোচ্চ (D) ৩০ (স্বভাবিক ০)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3561,7 +3561,7 @@ msgstr ""
 "একটি ছোট দশমিক-পয়েন্টের অনুমোদিত মান হল -৩.৪০২৮২৬৪৬৬E+৩৮ থেকে -১.১৭৫৪৯৪৩৫১E-"
 "৩৮, ০ এবং ১.১৭৫৪৯৪৩৫১E-৩৮ থেকে ৩.৪০২৮২৬৪৬৬E+৩৮"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3571,42 +3571,42 @@ msgstr ""
 "২.২২৫০৭৩৮৫৮৫০৭২০১৪E-৩০৮, ০, এবং ২.২২৫০৭৩৮৫৮৫০৭২০১৪E-৩০৮ থেকে "
 "১.৭৯৭৬৯৩১৩৪৮৬২৩১৫৭E+৩০৮"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 "DOUBLE এর সমার্থক নাম (ব্যাতিক্রম:REAL_AS_FLOAT SQL পদ্ধতিতে এর সমার্থত হল FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 "একটি বিট ক্ষেত্র (M), প্রতিটি মানের জন্য বিট মজুদ করে (স্বাভাবিক হল ১, সর্বোচ্চ ৬৪)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 "একটি সমার্থক হল TINYINT(1) এর, ০ মান মিথ্যা এবং মান ০ নাহলে সত্য বলে ধরা হয়"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "একটি উপনাম BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE এর"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "একটি তারিখ, অনুমোদিত সীমা হল %1$s - %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "একটি তারিখ এবং সময়ের মিশ্রণ,অনুমোদিত সীমা হল %1$s - %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3614,12 +3614,12 @@ msgstr ""
 "একটি timestamp, সীমা হল ১৯৭০-০১-১০ ০০:০০:০১ UTC - ২০৩৮-০১-০৯ ০৩:১৪:০৭ UTC, "
 "সেকেন্ডের নাম্বার হিসাবে মজুদ করা হয় ঐতিহাসিক(১৯৭০-০১-১০ ০০:০০:০১)থেকে"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "সময়, সীমা %1$s - %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3627,21 +3627,21 @@ msgstr ""
 "চার সংখ্যায় বৎসর (৪, স্বাভাবিক) বা দুই সংখ্যা (২) গঠনে, গ্রহনযোগ্য মান হল ৭০ "
 "(১৯৭০) - ৬৯ (২০৬৯) বা ১৯০১ থেকে ২১৫৫ এবং ০০০০"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 "নির্দিষ্ট দৈর্ঘ্য (০-২৫৫, স্বাভাবিক ১) লেখাটি যখন মজুদ করা হবে সবসময় ডান দিকে থাকবে"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr "একটি চলক দৈর্ঘ্য (%s)লেখা, কার্যকর সর্বোচ্চ সংখ্যা হল সর্বোচ্চ দৈঘ্যের আকার"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3649,7 +3649,7 @@ msgstr ""
 "একটি TEXT স্তম্ভ সর্বোচ্চ ২৫৫(২^৮ - ১) সংখ্যক অক্ষরের, সন্মুখে একটি বাইট সহ মজুদ করা "
 "হয় যা এর দৈর্ঘ্যের পরিমান রাখে"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3657,7 +3657,7 @@ msgstr ""
 "একটি TEXT স্তম্ভ সর্বোচ্চ ৬৫,৫৩৫*(২^১৬ - ১) সংখ্যক অক্ষরের, সন্মুখে দুইটি বাইট সহ মজুদ "
 "করা হয় যা এর দৈর্ঘ্যের পরিমান রাখে"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3665,7 +3665,7 @@ msgstr ""
 "একটি TEXT স্তম্ভ সর্বোচ্চ ১৬,৭৭৭,২১৫(২^২৪ - ১) সংখ্যক অক্ষর, সন্মুখে তিনটি বাইট সহ "
 "মজুদ করা হয় যা এর দৈর্ঘ্যের পরিমান রাখে"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3674,19 +3674,19 @@ msgstr ""
 "একটি TEXT স্তম্ভ সর্বোচ্চ ৪,২৯৪,৯৬৭,২৯৫ বা ৪জিবা(২^৩২ - ১) সংখ্যক অক্ষরের, সন্মুখে "
 "চারটি বাইট সহ মজুদ করা হয় যা এর দৈর্ঘ্যের পরিমান রাখে"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "CHAR ধরনের মত, কিন্তু বাইনারী লেখা মজুদ করে অ-বাইনারী নয়"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "VARCHAR ধরনের মত, কিন্তু বাইনারী লেখা মজুদ করে অ-বাইনারী নয়"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3694,7 +3694,7 @@ msgstr ""
 "BLOB স্তম্ভ সর্বোচ্চ ২৫৫(২^৮ - ১)বাইট হয়, সন্মুখে একটি বাইট সহ মজুদ করা হয় যা এর "
 "দৈর্ঘ্যের পরিমান রাখে"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3702,7 +3702,7 @@ msgstr ""
 "BLOB স্তম্ভ সর্বোচ্চ ১৬,৭৭৭,২১৫(২^২৪ - ১)বাইট হয়, সন্মুখে তিনটি বাইট সহ মজুদ করা হয় "
 "যা এর দৈর্ঘ্যের পরিমান রাখে"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3710,7 +3710,7 @@ msgstr ""
 "BLOB স্তম্ভ সর্বোচ্চ ৬৫,৫৩৫(২^১৬ - ১)বাইট হয়, সন্মুখে দুইটি বাইট সহ মজুদ করা হয় যা "
 "এর দৈর্ঘ্যের পরিমান এই  বাইটে রাখে"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3718,73 +3718,73 @@ msgstr ""
 "BLOB স্তম্ভ সর্বোচ্চ ৪,২৯৪,৯৬৭,২৯৫,বা ৪জিবি(২^৩২ - ১)বাইট হয়, সন্মুখে চারটি বাইট "
 "সহ মজুদ করা হয় যা এর দৈর্ঘ্যের পরিমান রাখে"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr "একটি গনক, ৬৫,৫৩৫ টি মান থেকে পছন্দ করা হয় বা বিশেষ '' ভুল মান থেকে"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "৬৪টি সদস্যের মান থেকে একটি পছন্দ করা হয়"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "একটি ধরন যা যে কোন জ্যামিতিক ধরন মজুদ করতে পারে"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "২ দশমিক স্থানের একটি জায়গা"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "একটি বাঁক পয়েন্টের মধ্য রৈখিক সংযোগকারী"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "একটি পলিগন"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "পয়েন্টের সম্ভার"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "বিভিন্ন পয়েন্টের রৈখিক বাকেঁর সম্ভার"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "বহুভুজের সম্ভার"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "জ্যামিতিক অবজেক্টের সম্ভার"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "গানিতিক"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "সময় এবং তারিখ"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "স্ট্রিং"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "স্পাটিয়াল"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "৪ বাইটের ইন্টিজার, সীমা -২,১৪৭,৪৮৩,৬৪৮ থেকে ২,১৪৭,৪৮৩,৬৪৭"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3792,23 +3792,23 @@ msgstr ""
 "৮ বাইট ইন্টিজার, সীমা -৯,২২৩,৩৭২,০৩৬,৮৫৪,৭৭৫,৮০৮ থেকে "
 "৯,২২৩,৩৭২,০৩৬,৮৫৪,৭৭৫,৮০৭"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "সিস্টেমের একটি স্বাভাবিক double-precision দশমিক সংখ্যা"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "সত্য বা মিথ্যা"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "একটি উপনাম BIGINT NOT NULL AUTO_INCREMENT UNIQUE এর"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "একটি অনন্য সর্বত্র পরিচয়জ্ঞাপক মজুদ করে (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3816,13 +3816,13 @@ msgstr ""
 "একটি timestamp (সময়কাল), সীমা '০০০১-০১-০১ ০০:০০:০০ UTC থেকে '৯৯৯৯-১২-৩১ "
 "২৩:৫৯:৫৯ UTC; TIMESTAMP(6) মাইক্রো সেকেন্ড মজুদ করতে পারে"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr "একটি চলক-দৈর্ঘ্যের (০-৬৫,৫৩৫)স্ট্রিং, সব তুলনার জন্য বাইনারী ব্যবহার করে"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "একটি গণক, নিধারির্ত মানের তালিকা থেকে পছন্দ করা হয়"
 
@@ -3909,67 +3909,67 @@ msgstr "%B %d, %Y at %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s দিন, %s ঘন্টা, %s মিনিট এবং %s সেকেন্ড"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "parameter নাই:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "ডাটাবেইজ &quot;%s&quot; যাও।"
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s কার্যকারিতা একটি চিহ্নিত সমস্যা, %s দেখুন"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "টোগল ক্লীক করুন"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "আপনার কম্পিউটারে দেখুন:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "ওয়েভ সার্ভারের আপলোড ডিরেক্টরি থেকে নির্বাচন করুন <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "আপলোড করার জন্য নির্ধারিত ডিরেক্টরীটি পাওয়া যাচ্ছে না।"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "আপলোড করার জন্য কোন ফাইল নাই"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "খালি"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "কর"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "প্রিন্ট"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "প্রস্তুত"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "সর্বশেষ আপডেট"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "সর্বশেষ যাচাই"
@@ -4327,9 +4327,9 @@ msgstr "ব্যাবহারকারীদেরকে এই মান প
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "পূর্বাবস্থায়"
 
@@ -4626,7 +4626,7 @@ msgstr "একটি স্ক্রীপট চলার সময় (সেক�
 msgid "Maximum execution time"
 msgstr "সম্পাদনের সর্বোচ্চ সময়"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "ফাইল এর মত সংরক্ষন"
 
@@ -7013,7 +7013,7 @@ msgstr "ফাইলটি প্রক্রিয়াধীন, ধৈয্য
 msgid "Language"
 msgstr "ভাষা"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "সংস্করন সম্পর্কিত তথ্য"
 
@@ -7442,61 +7442,61 @@ msgstr "দৈর্ঘ্যের জন্য এই স্বম্ভ স�
 msgid "Binary - do not edit"
 msgstr "Binary - সম্পাদন করবেন না"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "web server upload directory"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "%s রোতে প্রবেশ করানো চলতে থাকবে"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "এবং তারপর"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "নতুন রো হিসাবে প্রবেশ করাও"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "নতুন রো হিসাবে প্রবেশ করাও এবং ভুলসমূহ উপেক্ষা কর"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "প্রবেশ করানোর অনুসন্ধান দেখাও"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "পূর্ববর্তী পাতায় যাও"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "অন্য আরেকটি নতুন রো প্রবেশ করাও"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "এই পাতাতেই ফিরে আস"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "পরবর্তী রো সম্পাদনা"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "ট্যাব কি দিয়ে মান থেকে মানে যাওয়া যাবে বা CTRL+arrows দিয়ে যে কোন জায়গায় "
 "যাওয়া যাবে।"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "এসকিউএল অনুসন্ধান দেখাচ্ছে"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "প্রবেশকৃত রো আইডি: %1$d"
@@ -9686,24 +9686,24 @@ msgid "There are no events to display."
 msgstr "প্রদর্শনের জন্য কোন ইভেন্ট নাই।"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "%s টেবলটি নাই!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "%s টেবলের coordinate কনফিগার করুন"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "%s ডাটাবেইজের রূপরেখা - পাতা %s"
@@ -12390,7 +12390,7 @@ msgstr "%1$s সংস্করন তৈরী করা হয়েছে, %2$s 
 msgid "Manage your settings"
 msgstr "আপনার সেটিংস রক্ষণাবেক্ষণ করুন"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "কনফিগারেশন সংরক্ষন করা হয়েছে"
 
@@ -12647,7 +12647,7 @@ msgstr "আপনার ব্রাউজার থেকে সেটিংস
 msgid "You have no saved settings!"
 msgstr "আপনার কাছে সংরক্ষিত সেটিংস নাই!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "আপনার ব্রাউজার এটি সর্মথন করে না"
 
@@ -12664,19 +12664,19 @@ msgstr ""
 "আরো সেটিংসের জন্য config.inc.php ব্যবহার করে আপনি সেটিংস পরিবর্তন করতে পারেন, "
 "বা %sSetup script%s ও ব্যবহার করতে পারেন।"
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "ব্রাউজারের স্থানে সংরক্ষন করুন"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "আপনার ব্রাউজারের নিধারীত স্থানে সেটিংস সংরক্ষতিত হবে।"
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "পূর্ববতী সেটিংস এর উপর লেখা হবে!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "আপনি সমস্ত সেটিংস পুর্বাবস্থায় ফিরিয়ে নিতে পারেন এবং স্বাভাবিক অবস্থায় ফিরে যেতে "
@@ -12708,6 +12708,10 @@ msgstr "কোন ডাটাবেইজ নাই"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "ডাটাবেইজের স্তুপ(আকৃতি) দেখাও"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/br.po
+++ b/po/br.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-07-15 11:11+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Breton <http://l10n.cihar.com/projects/phpmyadmin/master/br/"
@@ -47,7 +47,7 @@ msgstr "Evezhiadennoù diwar-benn an daolenn"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -93,7 +93,7 @@ msgid "Type"
 msgstr "Seurt"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -350,7 +350,7 @@ msgid "Updated"
 msgstr "Hizivaet"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -378,7 +378,7 @@ msgid "Delete tracking data for this table"
 msgstr "Diverkañ ar roadennoù heuliañ evit an daolenn-mañ"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -584,8 +584,8 @@ msgstr "Ouzhpennañ mentoniezh"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -611,7 +611,7 @@ msgstr "Ouzhpennañ mentoniezh"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Mont"
@@ -985,7 +985,7 @@ msgstr "Menegerioù"
 msgid "Edit Index"
 msgstr "Mod aozañ"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add/Delete columns"
 msgid "Add %s column(s) to index"
@@ -1201,7 +1201,7 @@ msgid "Traffic"
 msgstr "Tremenerezh"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Arventennoù"
 
@@ -1526,8 +1526,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1758,8 +1758,8 @@ msgstr "Diskouez ar voest rekedoù SQL"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1788,7 +1788,7 @@ msgstr "Pad seveniñ hirañ"
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1867,8 +1867,8 @@ msgstr "Kuzhat disoc'hoù an enklask"
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Na ober van"
 
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Ment an destenn"
 
@@ -2589,8 +2589,8 @@ msgstr[0] "%s glotadenn en daolenn <i>%s</i>"
 msgstr[1] "%s klotadenn en daolenn <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2646,16 +2646,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Kregiñ"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2663,8 +2663,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Kent"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2672,8 +2672,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "War-lerc'h"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2857,9 +2857,9 @@ msgstr "Askañ pep tra"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3053,9 +3053,9 @@ msgid "View"
 msgstr "Gwelet"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3069,32 +3069,32 @@ msgid "Structure"
 msgstr "Framm"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Klask"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Ensoc'hañ"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3103,20 +3103,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Oberiadennoù"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3132,70 +3132,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Diazoù roadennoù"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Eilañ"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Fazi"
@@ -3221,7 +3221,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d linenn ensoc'het."
 msgstr[1] "%1$d linenn ensoc'het."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3443,7 +3443,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3460,7 +3460,7 @@ msgstr "Klask"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3470,7 +3470,7 @@ msgstr "Ensoc'hañ"
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Pe"
@@ -3596,286 +3596,286 @@ msgstr "N'eo ket bet kavet an hent evit an tem  %s !"
 msgid "Theme:"
 msgstr "Tem"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "Other core settings"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Arventennoù pouezus all"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Fazi en ur adenvel %1$s e %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add a polygon"
 msgid "A polygon"
 msgstr "Ouzhpennañ ul lieskorneg"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Krouiñ un argerzh"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Linestring"
 msgctxt "string types"
 msgid "String"
 msgstr "Aradennad linennoù"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3962,67 +3962,67 @@ msgstr "%A %d %B %Y da %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s deiz, %s eur, %s munut ha %s eilenn"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Mont d'an diaz roadennoù &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Direizhet eo an arc'hwel %s gant un draen anavezet, sellit ouzh %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Klikañ evit gwintañ"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Furchal en hoc'h urzhiataer :"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Diuzit e-mesk kavlec'h pellgargañ ar servijer web <b>%s</b> :"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Ar c'havlec'h treuzkas n'hall ket bezañ diraezet."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "N'eus restr ebet da enporzhiañ"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Goullonderiñ"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Seveniñ"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Moullañ"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Krouiñ"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Hizivadenn ziwezhañ"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Gwiriadenn ziwezhañ"
@@ -4391,9 +4391,9 @@ msgstr "Aotren an implijerien da bersonelaat an talvoud-mañ"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Adderaouekaat"
 
@@ -4707,7 +4707,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Pad seveniñ hirañ"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Enrollañ evel restr"
 
@@ -7013,7 +7013,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7408,59 +7408,59 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "Select from the web server upload directory <b>%s</b>:"
 msgid "web server upload directory:"
 msgstr "Diuzit e-mesk kavlec'h pellgargañ ar servijer web <b>%s</b> :"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9608,24 +9608,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -12212,7 +12212,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -12462,7 +12462,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12477,19 +12477,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12518,6 +12518,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/bs.po
+++ b/po/bs.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:31+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Bosnian <http://l10n.cihar.com/projects/phpmyadmin/master/bs/"
@@ -42,7 +42,7 @@ msgstr "Komentari tabele"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Tip"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -343,7 +343,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -371,7 +371,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -583,8 +583,8 @@ msgstr "Dodaj novog korisnika"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -610,7 +610,7 @@ msgstr "Dodaj novog korisnika"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Kreni"
@@ -978,7 +978,7 @@ msgstr "Dodaj novo polje"
 msgid "Edit Index"
 msgstr "Ključ"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 msgid "Add %s column(s) to index"
 msgstr "Dodaj novo polje"
@@ -1211,7 +1211,7 @@ msgid "Traffic"
 msgstr "Saobraćaj"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1542,8 +1542,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1790,8 +1790,8 @@ msgstr "SQL upit"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1899,8 +1899,8 @@ msgstr "SQL rezultat"
 msgid "Data point content"
 msgstr "Sadržaj"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignoriši"
 
@@ -2519,7 +2519,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2682,8 +2682,8 @@ msgstr[0] "%s pogodaka unutar tabele <i>%s</i>"
 msgstr[1] "%s pogodaka unutar tabele <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2748,16 +2748,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Dodaj/obriši kolonu"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Početak"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2765,8 +2765,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Prethodna"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2774,8 +2774,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Slijedeći"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2969,9 +2969,9 @@ msgstr "Označi sve"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3162,9 +3162,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3178,32 +3178,32 @@ msgid "Structure"
 msgstr "Struktura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Pretraživanje"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Novi zapis"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3212,20 +3212,20 @@ msgid "Privileges"
 msgstr "Privilegije"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operacije"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3241,74 +3241,74 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Upit po primeru"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Baze"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Korisnik"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 #, fuzzy
 msgid "Binary log"
 msgstr "Binarni"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 #, fuzzy
 msgid "Replication"
 msgstr "Relacije"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Promjenljive"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Kodne strane"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Greška"
@@ -3334,7 +3334,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3563,7 +3563,7 @@ msgid "Operator"
 msgstr "Operacije"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3580,7 +3580,7 @@ msgstr "Pretraživanje"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3592,7 +3592,7 @@ msgstr "Novi zapis"
 msgid "Select columns (at least one):"
 msgstr "Izaberi polja (najmanje jedno)"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "ili"
@@ -3716,285 +3716,285 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Verzija servera"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Verzija servera"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 msgid "A polygon"
 msgstr "Dodaj novo polje"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Napravi novi ključ"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Linije se završavaju sa"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Ukupno"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4081,70 +4081,70 @@ msgstr "%d. %B %Y. u %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dana, %s sati, %s minuta i %s sekundi"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Add new field"
 msgid "Missing parameter:"
 msgstr "Dodaj novo polje"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Pređi na bazu &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "direkcija za slanje web servera "
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Direkcija koju ste izabrali za slanje nije dostupna."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Isprazni"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Štampaj"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Napravljeno"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Posljednja izmjena"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Posljednja provjera"
@@ -4523,9 +4523,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Resetuj"
 
@@ -4816,7 +4816,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Sačuvaj kao datoteku"
 
@@ -7200,7 +7200,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 #, fuzzy
 msgid "Version information"
 msgstr "Podatci o prijavi"
@@ -7601,60 +7601,60 @@ msgstr "Zbog njehove veličine, polje<br />možda nećete moći da izmenite"
 msgid "Binary - do not edit"
 msgstr "Binarni - ne mijenjaj"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "direkcija za slanje web servera"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Unesi kao novi red"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Nazad na prethodnu stranu"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Dodaj još jedan novi red"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 #, fuzzy
 msgid "Go back to this page"
 msgstr "Nazad na prethodnu stranu"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9913,25 +9913,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Tabela \"%s\" ne postoji!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Podesite koordinate za tabelu %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12635,7 +12635,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Opšte osobine relacija"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12917,7 +12917,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12932,19 +12932,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12974,6 +12974,10 @@ msgstr "Baza ne postoji"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Prikaži sadržaj (shemu) baze"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ca.po
+++ b/po/ca.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:41+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Catalan <http://l10n.cihar.com/projects/phpmyadmin/master/ca/"
@@ -43,7 +43,7 @@ msgstr "Comentaris de la taula"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Tipus"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -344,7 +344,7 @@ msgid "Updated"
 msgstr "Actualitzat"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -372,7 +372,7 @@ msgid "Delete tracking data for this table"
 msgstr "Esborra les dades de seguiment per aquesta taula"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -578,8 +578,8 @@ msgstr "Afegir geometria"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -605,7 +605,7 @@ msgstr "Afegir geometria"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Executa"
@@ -1006,7 +1006,7 @@ msgstr "Afegir Index"
 msgid "Edit Index"
 msgstr "Editar índex"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Afegeix %s columna(es) a l'index"
@@ -1224,7 +1224,7 @@ msgid "Traffic"
 msgstr "Tràfic"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Configuració"
 
@@ -1541,8 +1541,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1752,8 +1752,8 @@ msgstr "Mostrar quadre de consultes"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1780,7 +1780,7 @@ msgstr "Temps d'execució de la consulta"
 msgid "%d is not valid row number."
 msgstr "%d no és un num. vàlid de fila."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1855,8 +1855,8 @@ msgstr "Resultats de consultes"
 msgid "Data point content"
 msgstr "Contingut del punter de dades"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignora"
 
@@ -2423,7 +2423,7 @@ msgstr ""
 "Permisos incorrectes a l'arxiu de configuració, no pot ser modificable per "
 "tothom!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Tamany de lletra"
 
@@ -2582,8 +2582,8 @@ msgstr[0] "%1$s resultat a <strong>%2$s</strong>"
 msgstr[1] "%1$s resultats a <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2639,28 +2639,28 @@ msgstr "Desar dades editades"
 msgid "Restore column order"
 msgstr "Reataurar ordre de columnes"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Inici"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Pàgina anterior"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Pàgina següent"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Darrera pàgina"
@@ -2841,9 +2841,9 @@ msgstr "Marcar-ho tot"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3036,9 +3036,9 @@ msgid "View"
 msgstr "Vista"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3052,32 +3052,32 @@ msgid "Structure"
 msgstr "Estructura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Cerca"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Insereix"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3086,20 +3086,20 @@ msgid "Privileges"
 msgstr "Permisos"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operacions"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Seguiment"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3115,70 +3115,70 @@ msgstr "Disparadors"
 msgid "Database seems to be empty!"
 msgstr "La base de dades sembla buida!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Consulta segons exemple"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutines"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Esdeveniments"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Dissenyador"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Bases de dades"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Usuaris"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Registre binari"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replicació"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variables"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Jocs de caràcters"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Complements"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motors"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Error"
@@ -3204,7 +3204,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d fila inserida."
 msgstr[1] "%1$d files inserides."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3431,7 +3431,7 @@ msgid "Operator"
 msgstr "Operador"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3446,7 +3446,7 @@ msgstr "Cerca de taules"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Edita/Insereix"
 
@@ -3454,7 +3454,7 @@ msgstr "Edita/Insereix"
 msgid "Select columns (at least one):"
 msgstr "Tria les columnes (una com a mínim):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "O"
@@ -3578,14 +3578,14 @@ msgstr "No s'ha trobat el camí de les imatges del tema %s!"
 msgid "Theme:"
 msgstr "Tema"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "El rang d'un enter d'1 byte, amb signe, és de -128 a 127, sense signe és de "
 "0 a 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3593,7 +3593,7 @@ msgstr ""
 "El rang d'un enter de 2 bytes, amb signe, és de -32.768 a 32.767, sense "
 "signe és de 0 a 65.535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3601,7 +3601,7 @@ msgstr ""
 "El rang d'un enter de 3 bytes, amb signe, és de -8.388.608 a 8.388.607, "
 "sense signe és de 0 a 16.777.215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3609,7 +3609,7 @@ msgstr ""
 "El rang d'un enter de 4 bytes, amb signe, és de -2.147.483.648 a "
 "2.147.483.647, sense signe és de 0 a 4.294.967.295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3617,7 +3617,7 @@ msgstr ""
 "El rang d'un enter de 8 bytes, amb signe, és de -9.223.372.036.854.775.808 a "
 "9.223.372.036.854.775.807, sense signe és de 0 a 18.446.744.073.709.551.615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3625,7 +3625,7 @@ msgstr ""
 "Un nombre decimal fix (M,D) - el nombre màxim de dígits (M) és 65 (per "
 "defecte 10), el nombre màxim de decimals (D) és 30 (per defecte 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3633,7 +3633,7 @@ msgstr ""
 "Un nombre de coma flotant petit, els valors permesos són de -3.402823466E+38 "
 "a -1.175494351E-38, 0, i de 1.175494351E-38 a 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3643,7 +3643,7 @@ msgstr ""
 "1.7976931348623157E+308 a -2.2250738585072014E-308, 0, i de "
 "2.2250738585072014E-308 a 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3651,7 +3651,7 @@ msgstr ""
 "Sinònim de DOUBLE (excepció: en el mode SQL REAL_AS_FLOAT és un sinònim de "
 "FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3659,7 +3659,7 @@ msgstr ""
 "Una màscara de bits (M), emmagatzemant M bits per valor (per defecte és 1 i "
 "el màxim és 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3667,21 +3667,21 @@ msgstr ""
 "Un sinònim de TINYINT(1), un valor de zero es considera fals, qualsevol "
 "valor diferent de zero es considera cert"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un sinònim de BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Una data, rang suportat és de %1$s a %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Una combinació de data i hora, rang suportat és de %1$s a %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3690,12 +3690,12 @@ msgstr ""
 "03:14:07 UTC, s'emmagatzema com el nombre de segons des de l'època UNIX "
 "(1970.01.01 00:00:00 UTC )"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Una marca de temps, el rang és de %1$s a %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3703,7 +3703,7 @@ msgstr ""
 "Un any en fotmat de quatre dígits (4 per defecte) o dos dígits (2), els "
 "valors permesos són de 70 (1970) a 69 (2069) o de 1901 a 2155 i 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3711,7 +3711,7 @@ msgstr ""
 "Una cadena de longitud fixa (0-255, per defecte 1) que sempre s'omple amb "
 "espais a la dreta fins a la longitud especificada quan es desa"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3720,7 +3720,7 @@ msgstr ""
 "Una cadena de longitud variable (%s), la longitud efectiva màxima està "
 "subjecta al tamany màxim d'una fila"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3729,7 +3729,7 @@ msgstr ""
 "emmagatzemats amb un prefix d'un byte que indica la longitud del valor en "
 "bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3738,7 +3738,7 @@ msgstr ""
 "emmagatzemats amb un prefix de 2 bytes que indica la longitud del valor en "
 "bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3747,7 +3747,7 @@ msgstr ""
 "emmagatzemats amb un prefix de 3 bytes que indica la longitud del valor en "
 "bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3757,7 +3757,7 @@ msgstr ""
 "caràcters, emmagatzemats amb un prefix de 4 bytes que indica la longitud del "
 "valor en bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3765,7 +3765,7 @@ msgstr ""
 "Similar al tipus CHAR, però emmagatzema cadenes binàries de bytes en lloc "
 "de  cadenes de caràcters no binaris"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3773,7 +3773,7 @@ msgstr ""
 "Similar al tipus VARCHAR, però emmagatzema cadenes binàries de bytes en lloc "
 "de cadenes de caràcters no binaris"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3781,7 +3781,7 @@ msgstr ""
 "Una columna BLOB amb una longitud màxima de 255 (2^8-1) bytes, emmagatzemats "
 "amb un prefix d'un byte que indica la longitud del valor"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3789,7 +3789,7 @@ msgstr ""
 "Una columna BLOB amb una longitud màxima de 16.777.215 (2^24-1) bytes, "
 "emmagatzemats amb un prefix de 3 bytes que indica la longitud del valor"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3797,7 +3797,7 @@ msgstr ""
 "Una columna BLOB amb una longitud màxima de 65.535 (2^16-1) bytes, "
 "emmagatzemats amb un prefix de 2 bytes que indica la longitud del valor"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3806,7 +3806,7 @@ msgstr ""
 "bytes, emmagatzemats amb un prefix de 4 bytes que indica la longitud del "
 "valor"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3814,68 +3814,68 @@ msgstr ""
 "Una enumeració, triada d'una llista de fins a 65.535 valors o el valor "
 "especial d'error ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Un únic valor triat d'un conjunt de fins a 64 membres"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 "Un tipus en el que es pot emmagatzemar una geometria de qualsevol tipus"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Un punt en un espai de 2 dimensions"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Una corba amb interpolació lineal entre punts"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Un polígon"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Una col·lecció de punts"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Una col·lecció de corbes amb interpolació lineal entre punts"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Una col·lecció de polígons"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Una col·lecció d'objectes geomètrics de qualsevol tipus"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numèric"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Data i hora"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Cadena"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Espacial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Un enter de 4 bytes, el rang és de -2.147.483.648 a 2.147.483.647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3883,23 +3883,23 @@ msgstr ""
 "Un enter de 8 bytes, el rang és de -9.223.372.036.854.775.808 a "
 "9.223.372.036.854.775.807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Un nombre de coma flotant de doble precisió per defecte del sistema"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Cert o fals"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un sinònim de BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Emmagatzema identificadors únics universals (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3907,7 +3907,7 @@ msgstr ""
 "Una marca de temps, el rang és de '0001-01-01 00:00:00' UTC a '9999-12-31 "
 "23:59:59' UTC; TIMESTAMP(6) pot emmagatzemar microsegons"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3915,7 +3915,7 @@ msgstr ""
 "Una cadena de longitud variable (0-65.535) que utilitza col·lació binària "
 "per a totes les comparacions"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Una enumeració, triada de la llista de valors definits"
 
@@ -4002,68 +4002,68 @@ msgstr "%d-%m-%Y a les %H:%M:%S"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dies, %s hores, %s minuts i %s segons"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Falta paràmetre:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Vés a la base de dades &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "La funcionalitat %s es veu afectada per un error conegut, veieu %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Prem per canviar"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Navega al teu ordinador:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 "Selecciona des del directori de pujada d'arxius del servidor web <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "No està disponible el directori indicat per pujar arxius."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "No hi ha cap arxiu per pujar"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Buida"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Executar"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Imprimeix"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Creació"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Darrera actualització"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Darrera comprovació"
@@ -4428,9 +4428,9 @@ msgstr "Permet als usuaris configurar aquest valor"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Reinicia"
 
@@ -4740,7 +4740,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Màxim temps d'execució"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Desa com a arxiu"
 
@@ -7229,7 +7229,7 @@ msgstr "L'arxiu s'està processant, per favor, sigues pacient."
 msgid "Language"
 msgstr "Idioma"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informació de versió"
 
@@ -7675,61 +7675,61 @@ msgstr "A causa de la seva longitud,<br /> aquesta columna no pot ser editable"
 msgid "Binary - do not edit"
 msgstr "Binari - no editeu"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "directori de pujada d'arxius del servidor web"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Continua l'inserció amb %s files"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "i llavors"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Insereix com a nova fila"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Insereix com a nova fila i ignora els errors"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Mostra la consulta d'inserció"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Torna"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Insereix un nou registre"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Torna a aquesta pàgina"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Edita el següent registre"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Usa la tecla TAB per moure't de valor en valor, o CTRL+fletxes per moure't "
 "on vulguis"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Mostrant consulta SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Id de la fila inserida: %1$d"
@@ -9952,24 +9952,24 @@ msgid "There are no events to display."
 msgstr "No hi ha esdeveniments per mostrar."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "La taula %s no existeix!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Configura les coordinades per la taula %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Esquema de la base de dades %s - Pàgina %s"
@@ -12761,7 +12761,7 @@ msgstr "S'ha creat la versió %1$s, activat el seguiment per %2$s."
 msgid "Manage your settings"
 msgstr "Gestiona els teus paràmetres"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "S'a desat la configuració"
 
@@ -13023,7 +13023,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "No has desat els paràmetres!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Aquesta característica no està suportada pel teu navegador"
 
@@ -13040,19 +13040,19 @@ msgstr ""
 "Pots establir més paràmetres modificant l'arxiu config.inc.php, ex. by usant "
 "%sSetup script%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Desar a l'emmagatzemament del navegador"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Els paràmetres es desaran al emmagatzemament local del teu navegador."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Els paràmetres existents es sobreescriuran!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "Pots restablir tots els teus paràmetres als valors per defecte."
 
@@ -13082,6 +13082,10 @@ msgstr "No hi ha bases de dades"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Veure volcat (esquema) de les bases de dades"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 15:04+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Kurdish Sorani <http://l10n.cihar.com/projects/phpmyadmin/"
@@ -47,7 +47,7 @@ msgstr "تێبینیەکانی خشتە"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -93,7 +93,7 @@ msgid "Type"
 msgstr "جۆر"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -347,7 +347,7 @@ msgid "Updated"
 msgstr "بارکراوە"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -375,7 +375,7 @@ msgid "Delete tracking data for this table"
 msgstr "سڕینەوە داتا شوێنکەوتووەکان لەم خشتەیەدا"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -581,8 +581,8 @@ msgstr "زیادکردنی ئەندازەگەری"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -608,7 +608,7 @@ msgstr "زیادکردنی ئەندازەگەری"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "بڕۆ"
@@ -969,7 +969,7 @@ msgstr "زیادکردنی نیشاندەر"
 msgid "Edit Index"
 msgstr "چاکردنی نیشاندەر"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %d column(s) to index"
 msgid "Add %s column(s) to index"
@@ -1183,7 +1183,7 @@ msgid "Traffic"
 msgstr "هاتووچوو"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "ڕێکخستنەکان"
 
@@ -1479,8 +1479,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1691,8 +1691,8 @@ msgstr "پێشاندانی سندوقی داواکاری"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1719,7 +1719,7 @@ msgstr "ماوەی جێبەجێکردنی داواکاری"
 msgid "%d is not valid row number."
 msgstr "%d ژمارەی ڕیزی نادروستە."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1792,8 +1792,8 @@ msgstr "ئەنجامەکانی داواکاری"
 msgid "Data point content"
 msgstr "ناوەڕۆکی زانیاری خاڵ"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "فەرامۆشکردن"
 
@@ -2337,7 +2337,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "قەبارەی فۆنت"
 
@@ -2494,8 +2494,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2552,28 +2552,28 @@ msgstr "پاشەکەوتکردنی زانیاری گۆڕاو"
 msgid "Restore column order"
 msgstr "گەڕانەوەی ڕێزبەندی ستون"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "دەسپێکردن"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "پێشتر"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "دواتر"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "کۆتایی"
@@ -2755,9 +2755,9 @@ msgstr "هەڵبژاردنی هەموو"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2944,9 +2944,9 @@ msgid "View"
 msgstr "نیشاندان"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2960,32 +2960,32 @@ msgid "Structure"
 msgstr "پێکهاتە"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "سیكوێڵ"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "گەڕان"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "تێخستن"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2994,20 +2994,20 @@ msgid "Privileges"
 msgstr "تایبەتمەندێتیەکان"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "کارەکان"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3023,70 +3023,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr "پێدەچێت بنکە زانیاریەکە بەتاڵ بێت!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "داواکاری"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "ڕۆتینەکان"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "چالاکیەکان"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "شێوەساز"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "بنکە زانیاریەکان"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "بەکارهێنەرەکان"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "تۆماری دوودانەیی"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "دووپاتکاری"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "گۆڕاوەکان"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "گورزەپیتەکان"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "پێوەکراوەکان"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "بزوێنەرەکان"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "هەڵە"
@@ -3112,7 +3112,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3332,7 +3332,7 @@ msgid "Operator"
 msgstr "كرده‌هێما"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3347,7 +3347,7 @@ msgstr "گەڕانی خشتە"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "گۆڕین/تێخستن"
 
@@ -3355,7 +3355,7 @@ msgstr "گۆڕین/تێخستن"
 msgid "Select columns (at least one):"
 msgstr "ستونەکان هەڵبژێرە (لانی کەم یەک):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "یان"
@@ -3473,278 +3473,278 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "ژمارە"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "بەروار و کات"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "ده‌قه‌ڕیزبه‌ند"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "ڕاست یان چەوت"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3831,67 +3831,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "ڕادەی لەدەستچوو:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "بەتاڵ"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "درووستکردن"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "دواترین نوێکردنەوە"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "دواترین پشکنین"
@@ -4246,9 +4246,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4529,7 +4529,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6762,7 +6762,7 @@ msgstr ""
 msgid "Language"
 msgstr "زمان"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "زانیاری وەشان"
 
@@ -7153,57 +7153,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9275,24 +9275,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11829,7 +11829,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -12079,7 +12079,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12094,19 +12094,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12133,6 +12133,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/cs.po
+++ b/po/cs.po
@@ -5,14 +5,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-26 07:46+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Czech <http://l10n.cihar.com/projects/phpmyadmin/master/cs/>\n"
-"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: cs\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -42,7 +42,7 @@ msgstr "Komentář k tabulce:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Typ"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -338,7 +338,7 @@ msgid "Updated"
 msgstr "Aktualizováno"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -366,7 +366,7 @@ msgid "Delete tracking data for this table"
 msgstr "Odstranit všechny informace o sledování této tabulky"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -564,8 +564,8 @@ msgstr "Přidat geometrii"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -591,7 +591,7 @@ msgstr "Přidat geometrii"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Proveď"
@@ -961,7 +961,7 @@ msgstr "Přidat klíč"
 msgid "Edit Index"
 msgstr "Upravit klíč"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Přidat %s polí do klíče"
@@ -1177,7 +1177,7 @@ msgid "Traffic"
 msgstr "Provoz"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Nastavení"
 
@@ -1492,8 +1492,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1702,8 +1702,8 @@ msgstr "Zobrazit pole pro dotaz"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1730,7 +1730,7 @@ msgstr "Doba běhu dotazu"
 msgid "%d is not valid row number."
 msgstr "%d není platné číslo řádku."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1799,8 +1799,8 @@ msgstr "Výsledky dotazu"
 msgid "Data point content"
 msgstr "Obsah datového bodu"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorovat"
 
@@ -2351,7 +2351,7 @@ msgstr ""
 "Chybná přístupová práva konfiguračního souboru, neměl by být zapisovatelný "
 "pro všechny!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Velikost písma"
 
@@ -2500,8 +2500,8 @@ msgstr[1] "%1$s odpovídající záznamy v <strong>%2$s</strong>"
 msgstr[2] "%1$s odpovídajících záznamů v <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2557,28 +2557,28 @@ msgstr "Uložit upravovaná data"
 msgid "Restore column order"
 msgstr "Obnovit pořadí sloupců"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "První"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Předchozí"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Následující"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Poslední"
@@ -2755,9 +2755,9 @@ msgstr "Zaškrtnout vše"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2948,9 +2948,9 @@ msgid "View"
 msgstr "Pohled"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2964,32 +2964,32 @@ msgid "Structure"
 msgstr "Struktura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Vyhledávání"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Vložit"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2998,20 +2998,20 @@ msgid "Privileges"
 msgstr "Oprávnění"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Úpravy"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Sledování"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3027,70 +3027,70 @@ msgstr "Spouště"
 msgid "Database seems to be empty!"
 msgstr "Databáze se zdá být prázdná!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Dotaz"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutiny"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Události"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Návrhář"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Databáze"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Uživatelé"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binární log"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikace"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Proměnné"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Znakové sady"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Rozšíření"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Úložiště"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Chyba"
@@ -3119,7 +3119,7 @@ msgstr[0] "Vložen %1$d řádek."
 msgstr[1] "Vloženy %1$d řádky."
 msgstr[2] "Vloženo %1$d řádek."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3339,7 +3339,7 @@ msgid "Operator"
 msgstr "Operátor"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3354,7 +3354,7 @@ msgstr "Vyhledávání v tabulce"
 msgid "Find and Replace"
 msgstr "Vyhledat a nahradit"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Upravit/Vložit"
 
@@ -3362,7 +3362,7 @@ msgstr "Upravit/Vložit"
 msgid "Select columns (at least one):"
 msgstr "Zvolte pole (alespoň jedno):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Nebo"
@@ -3473,13 +3473,13 @@ msgstr "Nebyla nalezena platná cesta k vzhledu %s!"
 msgid "Theme:"
 msgstr "Vzhled:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Jednobajtové číslo, se znaménkem v rozsahu -128 až 127, bez znaménka 0 až 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3487,7 +3487,7 @@ msgstr ""
 "Dvoubajtové číslo, se znaménkem v rozsahu -32768 až 32767, bez znaménka 0 až "
 "65535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3495,7 +3495,7 @@ msgstr ""
 "Tříbajtové číslo, se znaménkem v rozsahu -8388608 až 8388607, bez znaménka 0 "
 "až 16777215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3503,7 +3503,7 @@ msgstr ""
 "Čtyřbajtové číslo, se znaménkem v rozsahu -2147483648 až 2147483647, bez "
 "znaménka 0 až 4294967295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3511,7 +3511,7 @@ msgstr ""
 "Osmibajtové číslo, se znaménkem v rozsahu -9223372036854775808 až "
 "9223372036854775807, bez znaménka 0 až 18446744073709551615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3519,7 +3519,7 @@ msgstr ""
 "Číslo s pevnou desetinnou čárkou (M, D) - maximální počet číslic (M) je 65 "
 "(výchozí 10), maximální počet desetinných míst (D) je 30 (výchozí 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3527,7 +3527,7 @@ msgstr ""
 "Číslo s pohyblivou desetinnou čárkou, podporované rozsahy od -3.402823466E"
 "+38 od -1.175494351E-38, 0, a od 1.175494351E-38 do 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3537,20 +3537,20 @@ msgstr ""
 "1.7976931348623157E+308 do -2.2250738585072014E-308, 0, a od "
 "2.2250738585072014E-308 do 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr "Synonymum pro DOUBLE (v případě SQL režimu REAL_AS_FLOAT pro FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 "Bitové pole (M), ukládající M bitů v záznam (výchozí je 1, maximum je 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3558,21 +3558,21 @@ msgstr ""
 "Synonymum pro TINYINT(1), nula je považována ze nepravdu, jakékoliv jiné "
 "hodnoty za pravdu"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Zkratka pro BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Datum, podporovaný rozsah od %1$s do %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Datum a čas, podporovaný rozsah od %1$s do %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3580,12 +3580,12 @@ msgstr ""
 "Časová značka v rozsahu od 1970-01-01 00:00:01 UTC do 2038-01-09 03:14:07 "
 "UTC, ukládaná jako počet sekund od počátku epochy (1970-01-01 00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Čas, podporovaný rozsah od %1$s do %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3593,7 +3593,7 @@ msgstr ""
 "Rok buď ve čtyřciferném (4, výchozí) nebo dvouciferném (2) formátu, povolené "
 "hodnoty jsou 70 (1970) až 69 (2069) nebo 1901 až 2155 a 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3601,7 +3601,7 @@ msgstr ""
 "Řetězec s pevnou délkou (0-255, výchozí je 1), který je vždy při ukládání "
 "zprava doplněn mezerami do požadované délky"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3610,7 +3610,7 @@ msgstr ""
 "Řetězec s proměnlivou délkou (%s), skutečná maximální velikost může být "
 "ovlivněna maximální velikostí řádku"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3618,7 +3618,7 @@ msgstr ""
 "Textový sloupec s maximální délkou 255 (2⁸ - 1) znaků, uložen s "
 "jednobajtovým číslem určujícím jeho délku"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3626,7 +3626,7 @@ msgstr ""
 "Textový sloupec s maximální délkou 65535 (2¹⁶ - 1) znaků, uložen s "
 "dvoubajtovým číslem určujícím jeho délku"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3634,7 +3634,7 @@ msgstr ""
 "Textový sloupec s maximální délkou 16777215 (2²⁴ - 1) znaků, uložen s "
 "tříbajtovým číslem určující jeho délku"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3643,19 +3643,19 @@ msgstr ""
 "Textový sloupec s maximální délkou 4294967295 nebo 4GiB (2³² - 1) znaků, "
 "uložen s čtyřbajtovým číslem určující jeho délku"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "Podobné jako typ CHAR, jen ukládá binární řetězce"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "Podobné jako typ VARCHAR, jen ukládá binární řetězce"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3663,7 +3663,7 @@ msgstr ""
 "Datový sloupec s maximální délkou 255 (2⁸ - 1) znaků, uložen s jednobajtovým "
 "číslem určujícím jeho délku"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3671,7 +3671,7 @@ msgstr ""
 "Datový sloupec s maximální délkou 16777215 (2²⁴ - 1) znaků, uložen s "
 "tříbajtovým číslem určující jeho délku"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3679,7 +3679,7 @@ msgstr ""
 "Datový sloupec s maximální délkou 65535 (2¹⁶ - 1) znaků, uložen s "
 "dvoubajtovým číslem určujícím jeho délku"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3687,7 +3687,7 @@ msgstr ""
 "Datový sloupec s maximální délkou 4294967295 nebo 4GiB (2³² - 1) znaků, "
 "uložen s čtyřbajtovým číslem určující jeho délku"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3695,90 +3695,90 @@ msgstr ""
 "Výčtový typ, umožňující výběr až z 65535 hodnot nebo speciální chybovou "
 "hodnotou ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Jedna hodnota vybraná z množiny až 64 možností"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Geometrický útvar libovolného typu"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Bod v dvourozměrném prostoru"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Křivka s lineární interpolací mezi body"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Mnohoúhelník"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Množina bodů"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Množina křivek s lineární interpolací mezi body"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Množina mnohoúhelníků"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Množina libovolných geometrických útvarů"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Čísla"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Datum a čas"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Řetězce"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Prostorové"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Čtyřbajtové číslo v rozsahu -2147483648 až 2147483647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 "Osmibajtové číslo v rozsahu -9223372036854775808 až 9223372036854775807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Číslo s pohyblivou řádovou čárkou s dvojitou přesností"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "True nebo false"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Zkratka pro BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Univerzální Unikátní Identifikátor (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3786,13 +3786,13 @@ msgstr ""
 "Časová značka v rozsahu '0001-01-01 00:00:00' UTC až '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) může uchovat i mikrosekundy"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr "Řetězec s proměnnou délkou (0 - 65535), požívá binární porovnávání"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Výčtový typ, umožňující výběr ze zadaných hodnot"
 
@@ -3877,67 +3877,67 @@ msgstr "%a %d. %b %Y, %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dnů, %s hodin, %s minut a %s sekund"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Chybějící parametr:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Přejít na databázi „%s“."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Funkčnost %s je omezena známou chybou, viz %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Klikněte pro přepnutí"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Procházet váš počítač:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Zvolte soubor z adresáře pro upload na serveru <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Adresář určený pro upload souborů nemohl být otevřen."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Nebyl zvolen žádný soubor pro nahrání"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Vyprázdnit"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Spustit"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Vytisknout"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Vytvořeno"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Poslední změna"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Poslední kontrola"
@@ -4292,9 +4292,9 @@ msgstr "Povolit uživatelům změnit tuto hodnotu"
 msgid "Apply"
 msgstr "Použít"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Původní"
 
@@ -4598,7 +4598,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Časový limit běhu skriptu"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Uložit jako soubor"
 
@@ -6995,7 +6995,7 @@ msgstr "Soubor je zpracováván, prosím buďte trpěliví."
 msgid "Language"
 msgstr "Jazyk"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informace o verzi"
 
@@ -7429,59 +7429,59 @@ msgstr "Toto pole možná nepůjde <br />kvůli délce upravit"
 msgid "Binary - do not edit"
 msgstr "Binární - neupravujte"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "soubor z adresáře pro upload:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Pokračovat ve vkládání s %s řádky"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "a poté"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Vložit jako nový řádek"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Vložit jako nový řádek a ignorovat chyby"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Zobrazit dotaz pro vložení"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Návrat na předchozí stránku"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Vložit další řádek"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Návrat na tuto stránku"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Upravit následující řádek"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Použijte klávesu TAB pro pohyb mezi hodnotami nebo CTRL+šipky po pohyb všemi "
 "směry"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Zobrazuji SQL dotaz"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "ID vloženého řádku: %1$d"
@@ -7813,7 +7813,6 @@ msgid "Database operations"
 msgstr "Operace s databází"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Zobrazit skryté položky"
 
@@ -9612,24 +9611,24 @@ msgid "There are no events to display."
 msgstr "Nejsou zde žádné události k zobrazení."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Tabulka %s neexistuje!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Prosím, nastavte souřadnice pro tabulku %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Schéma databáze %s - Strana %s"
@@ -12292,7 +12291,7 @@ msgstr "Verze %1$s vytvořena, sledování pro %2$s je zapnuté."
 msgid "Manage your settings"
 msgstr "Spravujte svoje nastavení"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Nastavení bylo uloženo"
 
@@ -12544,7 +12543,7 @@ msgstr "Nastavení bude načteno z lokálního úložiště ve vašem prohlíže
 msgid "You have no saved settings!"
 msgstr "Nemáte žádná uložená nastavení!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Tato funkce není vaším prohlížečem podporována"
 
@@ -12561,19 +12560,19 @@ msgstr ""
 "Více věcí můžete nastavit úpravou config.inc.php, např. použitím %"
 "sNastavovacího skriptu%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Uložit do úložiště prohlížeče"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Nastavení bude uloženo do lokálního úložiště prohlížeče."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Již uložené nastavení bude přepsáno!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "Můžete vymazat vaše nastavení a vrátit se k výchozím hodnotám."
 
@@ -12601,6 +12600,10 @@ msgstr "Žádné databáze"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Export databází"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/cy.po
+++ b/po/cy.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 09:14+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Welsh <http://l10n.cihar.com/projects/phpmyadmin/master/cy/>\n"
@@ -45,7 +45,7 @@ msgstr "Sylwadau tabl"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -91,7 +91,7 @@ msgid "Type"
 msgstr "Math"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -348,7 +348,7 @@ msgid "Updated"
 msgstr "Diweddarwyd"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -376,7 +376,7 @@ msgid "Delete tracking data for this table"
 msgstr "Dilëwch data tracio ar gyfer y tabl hwn"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -587,8 +587,8 @@ msgstr "Ychwanegwch weinydd newydd"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -614,7 +614,7 @@ msgstr "Ychwanegwch weinydd newydd"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Ewch"
@@ -1000,7 +1000,7 @@ msgstr "Indecs"
 msgid "Edit Index"
 msgstr "Golygu'r rhes nesaf"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s column(s)"
 msgid "Add %s column(s) to index"
@@ -1240,7 +1240,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1586,8 +1586,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1847,8 +1847,8 @@ msgstr "Dangos ymholiad mewnosod"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1877,7 +1877,7 @@ msgstr "Gweithrediad SQL"
 msgid "%d is not valid row number."
 msgstr "Dydy %d ddim yn rhif rhes dilys."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1962,8 +1962,8 @@ msgstr "Gweithrediadau canlyniadau ymholiad"
 msgid "Data point content"
 msgstr "Datganiad diffiniad data"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Anwybyddu"
 
@@ -2539,7 +2539,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Maint ffont"
 
@@ -2699,8 +2699,8 @@ msgstr[0] "%s ergyd mewn tabl <i>%s</i>"
 msgstr[1] "%s ergyd mewn tabl <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2762,16 +2762,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Ychwanegu/Dileu colofnau"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Dechrau"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2779,8 +2779,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Cynt"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2788,8 +2788,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Nesaf"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2980,9 +2980,9 @@ msgstr "Dewis Pob"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3175,9 +3175,9 @@ msgid "View"
 msgstr "Dangos"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3191,32 +3191,32 @@ msgid "Structure"
 msgstr "Strwythur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Chwilio"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Mewnosod"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3225,20 +3225,20 @@ msgid "Privileges"
 msgstr "Breintiau"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Gweithrediadau"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Tracio"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3254,72 +3254,72 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr "Mae'r gronfa ddata yn ymddangos yn wag!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Ymholiad"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rheolweithiau"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Digwyddiadau"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Dyluniwr"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Cronfeydd Data"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Defnyddiwr"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Log deuaidd"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Dyblygiad"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Newidynnau"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Setiau nod"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Peiriannau"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Gwall"
@@ -3345,7 +3345,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d rhes wedi'i hychwanegu."
 msgstr[1] "%1$d rhes wedi'u hychwanegu."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3575,7 +3575,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3592,7 +3592,7 @@ msgstr "Chwilio"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3602,7 +3602,7 @@ msgstr "Mewnosod"
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Or"
@@ -3728,286 +3728,286 @@ msgstr "Heb ddarganfod llwybr thema ar gyfer thema %s!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "Create version %s of %s.%s"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Crëwch fersiwn %s o %s.%s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Gwall wrth ailenwi tabl %1$s i %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Crëwch dudalen"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Terfynwyd llinellau gan"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Cyfrif ffeiliau log"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4096,74 +4096,74 @@ msgstr "%B %d, %Y am %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s diwrnod, %s awr, %s munud a %s eiliad"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Rheolweithiau"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Neidio  i gronfa ddata &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 #, fuzzy
 #| msgid "Click to select"
 msgid "Click to toggle"
 msgstr "Pwyso i ddewis"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "cyfeiriadur lanlwytho y gweinydd gwe"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 "Does dim modd cyrraedd y cyfeiriadur a osodoch chi ar gyfer gwaith a "
 "lanwlythwyd."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Gwagu"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Argraffu"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Cread"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Diweddariad diwethaf"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Gwiriad diwethaf"
@@ -4536,9 +4536,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Ailosod"
 
@@ -4839,7 +4839,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Cadw fel ffeil"
 
@@ -7234,7 +7234,7 @@ msgstr "Mae'r ffeil yn cael ei phrosesu. Byddwch yn amyneddgar."
 msgid "Language"
 msgstr "iaith"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Gwybodaeth y fersiwn"
 
@@ -7631,61 +7631,61 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Deuaidd - peidiwch â golygu"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "cyfeiriadur lanlwytho y gweinydd gwe"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "ac yna"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Mewnosod fel rhes newydd"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Dangos ymholiad mewnosod"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Dychwelyd i'r dudalen flaenorol"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Mewnosod rhes newydd arall"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Dychwelyd i'r dudalen hon"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Golygu'r rhes nesaf"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Defnyddiwch y bysell TAB i symud o un gwerth i'r llall, neu CTRL + saethau i "
 "symud unrhyw le"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9903,24 +9903,24 @@ msgid "There are no events to display."
 msgstr "Nid oes unrhyw gweinyddion a ffurfweddwyd"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -12575,7 +12575,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Nodweddion perthynas cyffredinol"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12857,7 +12857,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12872,19 +12872,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12914,6 +12914,10 @@ msgstr "Dim cronfeydd data"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Gwylio dadlwythiad (sgema) cronfeydd data"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/da.po
+++ b/po/da.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-13 02:05+0200\n"
 "Last-Translator: Aputsiaq Niels Janussen <aj@isit.gl>\n"
 "Language-Team: Danish <http://l10n.cihar.com/projects/phpmyadmin/master/da/"
@@ -40,7 +40,7 @@ msgstr "Tabelkommentarer:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -86,7 +86,7 @@ msgid "Type"
 msgstr "Datatype"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -334,7 +334,7 @@ msgid "Updated"
 msgstr "Opdateret"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -362,7 +362,7 @@ msgid "Delete tracking data for this table"
 msgstr "Slet sporingsdata for denne tabel"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -566,8 +566,8 @@ msgstr "Tilføj geometri"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -593,7 +593,7 @@ msgstr "Tilføj geometri"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Udfør"
@@ -967,7 +967,7 @@ msgstr "Tilføj indeks"
 msgid "Edit Index"
 msgstr "Redigér indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Tilføj %s kolonne(r) til indeks"
@@ -1184,7 +1184,7 @@ msgid "Traffic"
 msgstr "Trafik"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Indstillinger"
 
@@ -1499,8 +1499,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1712,8 +1712,8 @@ msgstr "Vis forespørgselsbox"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1740,7 +1740,7 @@ msgstr "Eksekveringstid for forespørgsel"
 msgid "%d is not valid row number."
 msgstr "%d er ikke et gyldigt rækkenummer."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1812,8 +1812,8 @@ msgstr "Forespørgselsresultater"
 msgid "Data point content"
 msgstr "Datapunkt-indhold"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorer"
 
@@ -2366,7 +2366,7 @@ msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 "Forkerte rettigheder på konfigurationsfil. Må ikke være skrivbar af alle!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Skriftstørrelse"
 
@@ -2513,8 +2513,8 @@ msgstr[0] "%1$s sammenfald i <strong>%2$s</strong>"
 msgstr[1] "%1$s sammenfald i <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2570,28 +2570,28 @@ msgstr "Gem redigerede data"
 msgid "Restore column order"
 msgstr "Gendan kolonneorden"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Start"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Forrige"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Næste"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Slut"
@@ -2768,9 +2768,9 @@ msgstr "Vælg alle"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2959,9 +2959,9 @@ msgid "View"
 msgstr "Visning"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2975,32 +2975,32 @@ msgid "Structure"
 msgstr "Struktur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Søg"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Indsæt"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3009,20 +3009,20 @@ msgid "Privileges"
 msgstr "Privilegier"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operationer"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Sporing"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3038,70 +3038,70 @@ msgstr "Triggers/udløsere"
 msgid "Database seems to be empty!"
 msgstr "Database ser ud til at være tom!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Foresp. via eks"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutiner"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Hændelser"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Designer"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Databaser"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Brugere"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binær log"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikation"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variable"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Tegnsæt"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Udvidelsesmoduler"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Lagring"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Fejl"
@@ -3127,7 +3127,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d række sat ind."
 msgstr[1] "%1$d rækker sat ind."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3350,7 +3350,7 @@ msgid "Operator"
 msgstr "Operatør"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3365,7 +3365,7 @@ msgstr "Tabelsøgning"
 msgid "Find and Replace"
 msgstr "Søg og erstat"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Rediger/Indsæt"
 
@@ -3373,7 +3373,7 @@ msgstr "Rediger/Indsæt"
 msgid "Select columns (at least one):"
 msgstr "Vælg kolonner (mindst én):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Eller"
@@ -3485,14 +3485,14 @@ msgstr "Sti til tema ikke fundet for tema %s!"
 msgid "Theme:"
 msgstr "Tema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Et heltal på 1 byte, signeret interval er -128 til 127, usigneret interval "
 "er 0 til 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3500,7 +3500,7 @@ msgstr ""
 "Et heltal på 2 byte, signeret interval er -32.768 til 32.767, usigneret "
 "interval er 0 til 65.535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3508,7 +3508,7 @@ msgstr ""
 "Et heltal på 3 byte, signeret interval er -8.388.608 til 8.388.607, "
 "usigneret interval er 0 til 16.777.215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3516,7 +3516,7 @@ msgstr ""
 "Et heltal på 4 byte, signeret interval er -2.147.483.648 til 2.147.483.647, "
 "usigneret interval er 0 til 4.294.967.295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3525,7 +3525,7 @@ msgstr ""
 "9.223.372.036.854.755.807, usigneret interval er 0 til "
 "18.446.744.073.709.55.615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3533,7 +3533,7 @@ msgstr ""
 "Et fast decimaltal (M, D) - det maksimale antal af tal (M) er 65 (standard "
 "10), det maksimale antal decimaler (D) er 30 (standard 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3541,7 +3541,7 @@ msgstr ""
 "Et lille, flydende decimaltal. Tilladte værdier er -3.402823466E+38 til -"
 "1.175494351E-38, 0, samt 1.175494351E-38 til 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3551,7 +3551,7 @@ msgstr ""
 "1.7976931348623157E+308 til -2.2250738585072014E-308, 0, samt "
 "2.2250738585072014E-308 til 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3559,7 +3559,7 @@ msgstr ""
 "Synonym for DOUBLE (undtagelse: i REAL_AS_FLOAT SQL-tilstanden er det et "
 "synonym for FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3567,7 +3567,7 @@ msgstr ""
 "Et bit-felttype (M), der lagrer M bits per værdi (standard er 1, maksimum er "
 "64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3575,21 +3575,21 @@ msgstr ""
 "Et synonym for TINYINT(1), en værdi på nul anses som falsk, værdier som ikke "
 "er nul anses som sande"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Et alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "En dato, understøttet interval er %1$s til %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "En kombination af dato og tid, understøttet interval er %1$s til %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3598,12 +3598,12 @@ msgstr ""
 "03:14:07 UTC, lagret som antallet af sekunder siden epoken (1970-01-01 "
 "00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Et tidspunkt, interval er %1$s til %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3611,7 +3611,7 @@ msgstr ""
 "Et år med formater på fire cifre (4, standard) eller to cifre (2), hvor "
 "tilladte værdier er 70 (1970) til 69 (2069) eller 1901 til 2155 og 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3619,7 +3619,7 @@ msgstr ""
 "En streng med fast længde (0-255, standard er 1), der altid har mellemrum "
 "til højre i den angivet længde når den lagres"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3628,7 +3628,7 @@ msgstr ""
 "En streng med variabel længde (%s). Den effektive, maksimale længde er "
 "subjektet for din maksimale rækkestørrelse"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3636,7 +3636,7 @@ msgstr ""
 "En TEXT-kolonne med en maksimal længde på 255 (2^8 - 1) tegn, lagret med et "
 "præfiks på én byte, der indikerer længden af værdien i bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3644,7 +3644,7 @@ msgstr ""
 "En TEXT-kolonne med en maksimal længde på 65.535 (2^16 - 1) tegn, lagret med "
 "et præfiks på to bytes, der indikerer længden af værdien i bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3652,7 +3652,7 @@ msgstr ""
 "En TEXT-kolonne med en maksimal længde på 16.777.215 (2^24 - 1) tegn, lagret "
 "med et præfiks på tre bytes, der indikerer længden af værdien i bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3661,7 +3661,7 @@ msgstr ""
 "En TEXT-kolonne med en maksimal længde på 4.294.967.295 (2^32 - 1) tegn, "
 "lagret med et præfiks på fire bytes, der indikerer længden af værdien i bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3669,7 +3669,7 @@ msgstr ""
 "Ligner CHAR-typen, men lagrer binære byte-strenge i stedet for ikkebinære "
 "tegnstrenge"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3677,7 +3677,7 @@ msgstr ""
 "Ligner typen VARCHAR, men lagrer binære byte-strenge frem for ikkebinære "
 "tegn-strenge"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3685,7 +3685,7 @@ msgstr ""
 "En BLOB-kolonne med en maksimal længde på 255 (2^8 - 1) byte, lagret med et "
 "præfiks på én byte som indikerer længden af værdien"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3693,7 +3693,7 @@ msgstr ""
 "En BLOB-kolonne med en maksimal længde på 16.777.215 (2^24 - 1) byte, lagret "
 "med et præfiks på tre byte som indikerer længden af værdien"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3701,7 +3701,7 @@ msgstr ""
 "En BLOB-kolonne med en maksimal længde på 65.535 (2^16 - 1) byte, lagret med "
 "et præfiks på to byte som indikerer længden af værdien"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3709,7 +3709,7 @@ msgstr ""
 "En BLOB-kolonne med en maksimal længde på 4.294.967.295 (2^32 - 1) byte, "
 "lagret med et præfiks på fire byte som indikerer længden af værdien"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3717,67 +3717,67 @@ msgstr ""
 "En optælling, udvalgt fra listen med op til 65.535 værdier eller den særlige "
 "''-fejlværdi"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "En enkelt værdi udvalgt fra et sæt på op til 64 medlemmer"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "En type som kan lagre en hvilken som helst type geometri"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Et punkt i et 2-dimensionelt rum"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "En kurve med lineær interpolering mellem punkterne"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "En polygon"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "En samling af punkter"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "En samling af kurver med lineære interpoleringer mellem punkterne"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "En samling af polygoner"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "En samling af geometriske objekter af enhver type"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numerisk"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Dato og tid"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Streng"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Spatial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Et heltal på 4 byte, intervallet er -2.147.483.648 to 2.147.483.647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3785,23 +3785,23 @@ msgstr ""
 "Et heltal på 8 byte, intervallet er -9.223.372.036.854.775.808 to "
 "9.223.372.036.854.775.807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Et systems standard for flydepunktstal med dobbelt præcision"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Sand eller falsk"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Et alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Lagrer en Universally Unique Identifier (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3809,7 +3809,7 @@ msgstr ""
 "Et tidsstempel, intervallet er '0001-01-01 00:00:00' UTC til '9999-12-31 "
 "23:59:59' UTC; TIMESTAMP(6) kan lagre mikrosekunder"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3817,7 +3817,7 @@ msgstr ""
 "En streng med variabel længde (0-65.535), bruger binær sammenligning for "
 "alle sammenligninger"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "En optælling, udvalgt fra listen med definerede værdier"
 
@@ -3902,69 +3902,69 @@ msgstr "%d. %m %Y kl. %H:%M:%S"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dage, %s timer, %s minutter og %s sekunder"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Manglende parameter:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Hop til database &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Funktionaliteten af %s er påvirket af en kendt fejl, se %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Klik for at skifte"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Gennemse din computer:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Vælg fra <b>%s</b> - webserverens upload-mappe:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Mappen du har sat til upload-arbejde kan ikke findes."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Der er ikke nogen filer at uploade"
 
 # By "Empty", if this is an action, it should translate to "Tøm" but if it's a
 # state it should translate to "Tom".
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Tøm"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Udfør"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Print"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Oprettelse"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Sidste opdatering"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Seneste tjek"
@@ -4324,9 +4324,9 @@ msgstr "Tillad brugerdefinerede indstillinger for værdien"
 msgid "Apply"
 msgstr "Anvend"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Nulstil"
 
@@ -4636,7 +4636,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maksimal eksekveringstid"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Send (download)"
 
@@ -7039,7 +7039,7 @@ msgstr "Filen behandles, vær tålmodig."
 msgid "Language"
 msgstr "Sprog"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Versionsinformation"
 
@@ -7479,59 +7479,59 @@ msgstr "På grund af feltets længde,<br /> kan det muligvis ikke ændres"
 msgid "Binary - do not edit"
 msgstr "Binært - må ikke ændres"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "webserver upload-mappe:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Fortsæt indsættelse med %s rækker"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "og derefter"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Indsæt som ny række"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Indsæt som ny række og ignorer fejl"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Vis indsættelsesforespørgsel"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Tilbage til foregående side"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Indsæt endnu en ny række"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Gå tilbage til denne side"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Rediger næste række"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Brug TAB-tasten for at flytte dig fra værdi til værdi, eller CTRL"
 "+piletasterne til at flytte frit omkring"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Viser SQL-forespørgsel"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Indsatte række id: %1$d"
@@ -9667,24 +9667,24 @@ msgid "There are no events to display."
 msgstr "Der er ingen hændelser at vise."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Tabellen \"%s\" findes ikke!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Konfigurer venligst koordinaterne for tabel %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Skema for databasen \"%s\" - Side %s"
@@ -12378,7 +12378,7 @@ msgstr "Version %1$s blev oprettet, sporing af %2$s er aktiv."
 msgid "Manage your settings"
 msgstr "Administrer dine indstillinger"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Konfigurationen er gemt"
 
@@ -12630,7 +12630,7 @@ msgstr "Indstillinger vil blive importeret fra din browsers lokale lager."
 msgid "You have no saved settings!"
 msgstr "Du har ingen gemte indstillinger!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Denne funktion er ikke understøttet af din browser"
 
@@ -12647,19 +12647,19 @@ msgstr ""
 "Du kan sætte flere indstillinger ved at modificere config.inc.php fx ved at "
 "bruge %sSetup script%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Gem i browserens lager"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Indstillinger vil blive gemt i din browsers lokale lager."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Eksisterende indstillinger vil blive overskrevet!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Du kan nulstille alle dine indstillinger og gendanne dem med standardværdier."
@@ -12688,6 +12688,10 @@ msgstr "Ingen databaser"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Vis dump (skema) for databaser"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/de.po
+++ b/po/de.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin-docs 4.0.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-19 10:34+0200\n"
 "Last-Translator: Ramona Hapke <ramona.hapke@gmail.com>\n"
 "Language-Team: German <http://l10n.cihar.com/projects/phpmyadmin/master/de/"
@@ -41,7 +41,7 @@ msgstr "Tabellenkommentar:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Typ"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr "Aktualisiert"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Lösche die Verlaufsdaten dieser Tabelle"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -568,8 +568,8 @@ msgstr "Geometrie hinzufügen"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -595,7 +595,7 @@ msgstr "Geometrie hinzufügen"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "OK"
@@ -976,7 +976,7 @@ msgstr "Index hinzufügen"
 msgid "Edit Index"
 msgstr "Index bearbeiten"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "%s Spalte(n) zum Index hinzufügen"
@@ -1194,7 +1194,7 @@ msgid "Traffic"
 msgstr "Netzwerkverkehr"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -1513,8 +1513,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1727,8 +1727,8 @@ msgstr "SQL-Querybox anzeigen"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1755,7 +1755,7 @@ msgstr "Ausführungszeit der Abfrage"
 msgid "%d is not valid row number."
 msgstr "%d ist keine gültige Zeilennummer."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1833,8 +1833,8 @@ msgstr "Abfrageergebnisse"
 msgid "Data point content"
 msgstr "Datenpunkt-Inhalt"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorieren"
 
@@ -2406,7 +2406,7 @@ msgstr ""
 "Falsche Zugriffsrechte auf die Konfigurationsdatei. Schreibzugriff sollte "
 "nicht für alle möglich sein!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Schriftgröße"
 
@@ -2567,8 +2567,8 @@ msgstr[0] "%1$s Treffer in <strong>%2$s</strong>"
 msgstr[1] "%1$s Treffer in <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2624,28 +2624,28 @@ msgstr "Speichere bearbeitete Daten"
 msgid "Restore column order"
 msgstr "Spalten-Anordnung wiederherstellen"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Anfang"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Vorherige"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Nächste"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Ende"
@@ -2829,9 +2829,9 @@ msgstr "Alle auswählen"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3026,9 +3026,9 @@ msgid "View"
 msgstr "Ansicht"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3042,32 +3042,32 @@ msgid "Structure"
 msgstr "Struktur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Suche"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Einfügen"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3076,20 +3076,20 @@ msgid "Privileges"
 msgstr "Rechte"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operationen"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Nachverfolgung"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3105,70 +3105,70 @@ msgstr "Trigger"
 msgid "Database seems to be empty!"
 msgstr "Die Datenbank scheint leer zu sein!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Abfrage"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Routinen"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Ereignisse"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Designer"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Datenbanken"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Benutzer"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binäres Protokoll"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikation"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variablen"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Zeichensätze"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Erweiterungen"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Formate"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Fehler"
@@ -3194,7 +3194,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d Datensatz eingefügt."
 msgstr[1] "%1$d Datensätze eingefügt."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3420,7 +3420,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3435,7 +3435,7 @@ msgstr "Tabellensuche"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Bearbeiten/Einfügen"
 
@@ -3443,7 +3443,7 @@ msgstr "Bearbeiten/Einfügen"
 msgid "Select columns (at least one):"
 msgstr "Spalten auswählen (min. eines):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Oder"
@@ -3567,14 +3567,14 @@ msgstr "Pfad für das Oberflächendesign %s nicht gefunden!"
 msgid "Theme:"
 msgstr "Oberflächendesign"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Ein 1-Byte-Integer, Bereich mit Vorzeichen ist -128 bis 127, ohne Vorzeichen "
 "0 bis 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3582,7 +3582,7 @@ msgstr ""
 "Ein 2-Byte-Integer, Bereich mit Vorzeichen ist -32.768 bis 32.767, ohne "
 "Vorzeichen 0 bis 65.535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3590,7 +3590,7 @@ msgstr ""
 "Ein 3-Byte-Integer, Bereich mit Vorzeichen ist -8.388.608 bis 8.388.607, "
 "ohne Vorzeichen 0 bis 16.277.215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3598,7 +3598,7 @@ msgstr ""
 "Ein 4-Byte-Integer, Bereich mit Vorzeichen ist -2.147.483.648 bis "
 "2.147.483.647, ohne Vorzeichen 0 bis 4.294.967.295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3607,7 +3607,7 @@ msgstr ""
 "bis 9.223.372.036.854.775.807, ohne Vorzeichen 0 bis "
 "18.446.744.073.709.551.615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3615,7 +3615,7 @@ msgstr ""
 "Eine Fixkommazahl (M, D) - die maximale Anzahl Ziffern (M) ist 65 (Standard "
 "10), die maximale Anzahl Dezimale (D) ist 30 (Standard 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3623,7 +3623,7 @@ msgstr ""
 "Eine kleine Fließkommazahl, erlaubte Werte sind -3,402823466E+38 bis -"
 "1,175494351E-38, 0, und 1,175494351E-38 bis 3,402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3633,7 +3633,7 @@ msgstr ""
 "1,7976931348623157E+308 bis -2,2250738585072014E-308, 0, und "
 "2,2250738585072014E-308 bis 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3641,7 +3641,7 @@ msgstr ""
 "Synonym für DOUBLE (Ausnahme: im SQL-Modus REAL_AS_FLOAT ein Synonym für "
 "FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3649,7 +3649,7 @@ msgstr ""
 "Ein Bitfeld-Typ (M), der M Bits pro Wert speichert (Standard ist 1, Maximum "
 "ist 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3657,23 +3657,23 @@ msgstr ""
 "Ein Synonym für TINYINT(1), ein Null-Wert wird als falsch angesehen, Nicht-"
 "Null-Werte werden als wahr angesehen"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Ein Alias für BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Ein Datum, unterstützter Bereich ist %1$s bis %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 "Eine Kombination aus Datum und Uhrzeit, unterstützter Bereich ist %1$s bis %2"
 "$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3682,12 +3682,12 @@ msgstr ""
 "UTC, gespeichert als Anzahl Sekunden seit Beginn der UNIX-Epoche (1970-01-01 "
 "00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Eine Uhrzeit, Bereich ist %1$s bis %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3695,7 +3695,7 @@ msgstr ""
 "Ein Jahr im vier- (4, Standard) oder zweistelligen (2) Format, die erlaubten "
 "Werte sind 70 (1970) bis 69 (2069) oder 1901 bis 2155 und 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3703,7 +3703,7 @@ msgstr ""
 "Eine Zeichenkette mit fester Länge (0-255, Standard 1), die rechts beim "
 "Speichern immer mit Leerzeichen auf die angegebene Länge aufgefüllt wird"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3712,7 +3712,7 @@ msgstr ""
 "Eine Zeichenkette mit variabler Länge (%s), die tatsächliche maximale Länge "
 "hängt von der maximalen Anzahl Zeilen ab"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3721,7 +3721,7 @@ msgstr ""
 "gespeichert mit einem Ein-Byte-Präfix, der die Länge des Wertes in Bytes "
 "angibt"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3730,7 +3730,7 @@ msgstr ""
 "gespeichert mit einem Zwei-Byte-Präfix, der die Länge des Wertes in Bytes "
 "angibt"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3739,7 +3739,7 @@ msgstr ""
 "Zeichen, gespeichert mit einem Drei-Byte-Präfix, der die Länge des Wertes in "
 "Bytes angibt"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3749,7 +3749,7 @@ msgstr ""
 "- 1) Zeichen, gespeichert mit einem Vier-Byte-Präfix, der die Länge des "
 "Wertes in Bytes angibt"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3757,7 +3757,7 @@ msgstr ""
 "Ähnlich wie der CHAR-Typ, speichert aber binäre Byte-Zeichenketten anstelle "
 "von nicht-binären Buchstaben-Zeichenketten"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3765,7 +3765,7 @@ msgstr ""
 "Ähnlich wie der VARCHAR-Typ, speichert aber binäre Byte-Zeichenketten "
 "anstelle von nicht-binären Buchstaben-Zeichenketten"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3773,7 +3773,7 @@ msgstr ""
 "Eine BLOB-Spalte mit einer maximalen Länge von 255 (2^8 - 1) Bytes, "
 "gespeichert mit einem Ein-Byte-Präfix, der die Länge des Wertes angibt"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3781,7 +3781,7 @@ msgstr ""
 "Eine BLOB-Spalte mit einer maximalen Länge von 16.777.215 (2^24 - 1) Bytes, "
 "gespeichert mit einem Drei-Byte-Präfix, der die Länge des Wertes angibt"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3789,7 +3789,7 @@ msgstr ""
 "Eine BLOB-Spalte mit einer maximalen Länge von 65.535 (2^16 - 1) Bytes, "
 "gespeichert mit einem Zwei-Byte-Präfix, der die Länge des Wertes angibt"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3798,7 +3798,7 @@ msgstr ""
 "- 1) Bytes, gespeichert mit einem Vier-Byte-Präfix, der die Länge des Wertes "
 "angibt"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3806,67 +3806,67 @@ msgstr ""
 "Eine Aufzählung, gewählt aus der Liste von bis zu 65.535 Werten oder dem "
 "besonderen '' Fehler-Wert"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Ein einzelner Wert gewählt aus einem Satz von bis zu 64 Einträgen"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Ein Typ, der die Geometrie irgendeines Typs speichern kann"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Ein Punkt im 2-dimensionalen Raum"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Eine Kurve mit linearer Interpolation zwischen Punkten"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Ein Vieleck (Polygon)"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Eine Punkte-Sammlung"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Eine Kurven-Sammlung mit linearer Interpolation zwischen Punkten"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Eine Polygon-Sammlung"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Eine Sammlung von Geometrie-Objekten irgendeines Typs"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numerisch"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Datum und Uhrzeit"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Zeichenkette"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Räumlich"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Ein 4-Byte-Integer, Bereich ist -2.147.483.648 bis 2.147.483.647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3874,23 +3874,23 @@ msgstr ""
 "Ein 8-Byte-Integer, Bereich ist -9.223.372.036.854.775.808 bis "
 "9.223.372.036.854.775.807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Eine Systemstandard-Fließkommazahl mit doppelter Genauigkeit"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Wahr oder falsch"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Ein Alias für BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Speichert einen universell eindeutigen Identifizierer (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3898,7 +3898,7 @@ msgstr ""
 "Ein Zeitstempel, Bereich ist '0001-01-01 00:00:00' UTC bis '9999-12-31 "
 "23:59:59' UTC; TIMESTAMP(6) kann Mikrosekunden speichern"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3906,7 +3906,7 @@ msgstr ""
 "Eine Zeichenkette mit variabler Länge (0-65.535), verwendet binäre Kollation "
 "für alle Vergleiche"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Eine Aufzählung, gewählt aus der Liste definierter Werte"
 
@@ -3993,68 +3993,68 @@ msgstr "%d. %B %Y um %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s Tage, %s Stunden, %s Minuten und %s Sekunden"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Fehlende(r) Parameter:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Zur Datenbank &quot;%s&quot; springen."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 "Die Funktion %s wird durch einen bekannten Fehler beeinträchtigt, siehe %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Zum Umschalten anklicken"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Durchsuchen Sie Ihren Computer:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Wählen Sie vom Webserver-Uploadverzeichnis <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Auf das festgelegte Upload-Verzeichnis kann nicht zugegriffen werden."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Es sind keine Dateien zum Upload vorhanden"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Leeren"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Ausführen"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Drucken"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Erzeugt am"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Aktualisiert am"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Letzter Check am"
@@ -4414,9 +4414,9 @@ msgstr "Erlaube den Benutzern diesen Wert anzupassen"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Zurücksetzen"
 
@@ -4728,7 +4728,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maximale Ausführungszeit"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Senden"
 
@@ -7203,7 +7203,7 @@ msgstr "Bitte Geduld, die Datei wird verarbeitet."
 msgid "Language"
 msgstr "Sprache"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Versionsinformationen"
 
@@ -7648,61 +7648,61 @@ msgstr "Wegen seiner Länge ist dieses<br />Feld vielleicht nicht editierbar"
 msgid "Binary - do not edit"
 msgstr "Binär - nicht editierbar"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "Upload-Verzeichnis auf dem Webserver"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Einfügen mit %s Datensätzen fortfahren"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "und dann"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Als neuen Datensatz speichern"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Als neue Zeile einfügen und Fehler ignorieren"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Zeige insert Abfrage"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "zurück"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "anschließend einen weiteren Datensatz einfügen"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Zurück zu dieser Seite"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "nächste Zeile bearbeiten"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Mittels TAB-Taste von Feld zu Feld springen, oder mit STRG+Pfeiltasten "
 "beliebig bewegen"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Ansicht als SQL Abfrage"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "ID der eingefügten Zeile: %1$d"
@@ -9967,24 +9967,24 @@ msgid "There are no events to display."
 msgstr "Es sind keine Ereignisse vorhanden, die angezeigt werden könnten."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Die Tabelle %s existiert nicht!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Bitte konfigurieren Sie die Koordinaten für die Tabelle %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Schema der Datenbank %s - Seite %s"
@@ -12813,7 +12813,7 @@ msgstr "Version %1$s wurde erstellt, Tracking von %2$s ist aktiviert."
 msgid "Manage your settings"
 msgstr "Deine Einstellungen verwalten"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Die Konfiguration wurde gespeichert"
 
@@ -13074,7 +13074,7 @@ msgstr "Einstellungen werden aus Ihrem lokalen Browserspeicher importiert."
 msgid "You have no saved settings!"
 msgstr "Sie haben keine gespeicherten Einstellungen!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Dieses Feature wird von ihrem Webbrowser nicht unterstützt"
 
@@ -13091,19 +13091,19 @@ msgstr ""
 "Weitere Einstellungen können durch das Anpassen der Datei config.inc.php "
 "verändert werden, z.B. durch die Verwendung von %sSetup Script%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Im Browserspeicher speichern"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Einstellungen werden in Ihrem lokalen Browserspeicher gespeichert."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Vorhandene Einstellungen werden überschrieben!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "Sie können alle Einstellungen auf die Standardwerte zurücksetzen."
 
@@ -13135,6 +13135,10 @@ msgstr "Keine Datenbanken"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Dump (Schema) der Datenbanken anzeigen"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/el.po
+++ b/po/el.po
@@ -3,14 +3,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-26 09:40+0200\n"
 "Last-Translator: Panagiotis Papazoglou <papaz_p@yahoo.com>\n"
 "Language-Team: Greek <http://l10n.cihar.com/projects/phpmyadmin/master/el/>\n"
-"Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: el\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -40,7 +40,7 @@ msgstr "Σχόλια πίνακα:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -86,7 +86,7 @@ msgid "Type"
 msgstr "Τύπος"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -335,7 +335,7 @@ msgid "Updated"
 msgstr "Ενημερώθηκε"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -363,7 +363,7 @@ msgid "Delete tracking data for this table"
 msgstr "Διαγραφή δεδομένων παρακολούθησης για αυτόν τον πίνακα"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -565,8 +565,8 @@ msgstr "Προσθήκη γεωμετρίας"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -592,7 +592,7 @@ msgstr "Προσθήκη γεωμετρίας"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Εκτέλεση"
@@ -974,7 +974,7 @@ msgstr "Προσθήκη Ευρετηρίου"
 msgid "Edit Index"
 msgstr "Επεξεργασία ευρετηρίου"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Προσθήκη %s στήλης(ών) στο ευρετήριο"
@@ -1191,7 +1191,7 @@ msgid "Traffic"
 msgstr "Κίνηση"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Ρυθμίσεις"
 
@@ -1513,8 +1513,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1724,8 +1724,8 @@ msgstr "Προβολή παραθύρου ερωτήματος"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1752,7 +1752,7 @@ msgstr "Χρόνος εκτέλεσης ερωτήματος"
 msgid "%d is not valid row number."
 msgstr "Ο αριθμός %d δεν είναι έγκυρος αριθμός γραμμών."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1826,8 +1826,8 @@ msgstr "Ααποτελέσματα ερωτήματος"
 msgid "Data point content"
 msgstr "Περιεχόμενο δείκτη δεδομένων"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Παράληψη"
 
@@ -2384,7 +2384,7 @@ msgstr ""
 "Εσφαλμένα δικαιώματα στο αρχείο ρυθμίσεων, δεν πρέπει να είναι καθολικά "
 "εγγράψιμο!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Μέγεθος γραμματοσειράς"
 
@@ -2531,8 +2531,8 @@ msgstr[0] "%1$s απατέλεσμα στο <strong>%2$s</strong>"
 msgstr[1] "%1$s αποτελέσματα στο <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2588,28 +2588,28 @@ msgstr "Αποθήκευση επεξεργασμένων δεδομένων"
 msgid "Restore column order"
 msgstr "Επαναφορά κατανομής στηλών"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Αρχή"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Προηγούμενη"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Επόμενη"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Τέλος"
@@ -2787,9 +2787,9 @@ msgstr "Επιλογή όλων"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2982,9 +2982,9 @@ msgid "View"
 msgstr "Προβολή"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2998,32 +2998,32 @@ msgid "Structure"
 msgstr "Δομή"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "Κώδικας SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Προσθήκη"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3032,20 +3032,20 @@ msgid "Privileges"
 msgstr "Δικαιώματα"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Λειτουργίες"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Παρακολούθηση"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3061,70 +3061,70 @@ msgstr "Δείκτες"
 msgid "Database seems to be empty!"
 msgstr "Η βάση δεδομένων φαίνεται να είναι άδεια!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Επερώτημα κατά παράδειγμα"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Εργασίες"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Συμβάντα"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Σχεδιαστής"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Βάσεις δεδομένων"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Χρήστες"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Δυαδικό αρχείο καταγραφής"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Αναπαραγωγή"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Μεταβλητές"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Σύνολο χαρακτήρων"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Πρόσθετα"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Μηχανές"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Λάθος"
@@ -3150,7 +3150,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Εισήχθηκε %1$d γραμμή."
 msgstr[1] "Εισήχθηκαν %1$d γραμμές."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3374,7 +3374,7 @@ msgid "Operator"
 msgstr "Τελεστής"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3389,7 +3389,7 @@ msgstr "Αναζήτηση Πίνακα"
 msgid "Find and Replace"
 msgstr "Εύρεση και Αντικατάσταση"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Επεξεργασία/Προσθήκη"
 
@@ -3397,7 +3397,7 @@ msgstr "Επεξεργασία/Προσθήκη"
 msgid "Select columns (at least one):"
 msgstr "Επιλογή πεδίων (τουλάχιστον ένα):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Ενωση"
@@ -3509,14 +3509,14 @@ msgstr "Η διαδρομή θέματος δεν βρέθηκε για το θ�
 msgid "Theme:"
 msgstr "Θέμα:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Ένας ακέραιος 1-byte, εύρος με πρόσημο είναι -128 έως 127, εύρος χωρίς "
 "πρόσημο είναι 0 έως 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3524,7 +3524,7 @@ msgstr ""
 "Ένας ακέραιος 2-byte, εύρος με πρόσημο είναι -32.768 έως 32.767, εύρος χωρίς "
 "πρόσημο είναι 0 έως 65.535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3532,7 +3532,7 @@ msgstr ""
 "Ένας ακέραιος 3-byte, εύρος με πρόσημο είναι -8.388.608 έως 8.388.607, εύρος "
 "χωρίς πρόσημο είναι 0 έως 16.777.215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3540,7 +3540,7 @@ msgstr ""
 "Ένας ακέραιος 4-byte, εύρος με πρόσημο είναι -2.147.483.648 έως "
 "2.147.483.647, εύρος χωρίς πρόσημο είναι 0 έως 4.294.967.295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3549,7 +3549,7 @@ msgstr ""
 "9.223.372.036.854.775.807, εύρος χωρίς πρόσημο είναι 0 έως "
 "18.446.744.073.709.551.615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3558,7 +3558,7 @@ msgstr ""
 "είναι 65 (προεπιλογή 10), ο μέγιστος αριθμός δεκαδικών είναι (Δ) είναι 30 "
 "(προεπιλογή 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3567,7 +3567,7 @@ msgstr ""
 "3.402823466E+38 έως -1.175494351E-38, 0, και 1.175494351E-38 έως 3.402823466E"
 "+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3577,7 +3577,7 @@ msgstr ""
 "1.7976931348623157E+308 έως -2.2250738585072014E-308, 0, και "
 "2.2250738585072014E-308 έως 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3585,7 +3585,7 @@ msgstr ""
 "Συνώνυμο για το DOUBLE (εξαίρεση: στην κατάσταση SQL REAL_AS_FLOAT είναι "
 "συνώνυμο με το FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3593,7 +3593,7 @@ msgstr ""
 "Ένας τύπος πεδίου bit (M), αποθηκεύονται το πλήθος (M) των bits ανά τιμή "
 "(προεπιλογή είναι το 1, μέγιστο είναι το 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3601,23 +3601,23 @@ msgstr ""
 "Ένα συνώνυμο για το TINYINT(1), μια μηδενική τιμή θεωρείτε λάθος, μη "
 "μηδενικές τιμές θεωρούνται σωστές"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Μια ετικέτα για το BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Μια ημερομηνία, υποστηριζόμενο εύρος είναι από %1$s έως %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 "Ένας συνδυασμός ημερομηνίας και ώρας, υποστηριζόμενο εύρος είναι από %1$s "
 "έως %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3626,12 +3626,12 @@ msgstr ""
 "UTC, αποπθηκεύεται ως ο αριθμός των δευτερολέπτων από την αρχή (1970-01-01 "
 "00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Ένας χρόνος, εύρος είναι από %1$s έως %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3639,7 +3639,7 @@ msgstr ""
 "Το έτος με τέσσερα ψηφία (4, προεπιλογή) ή μορφή 2 ψηφίων (2), οι επιτρεπτές "
 "τιμές είναι 70 (1970) έως 69 (2069) ή 1901 έως 2155 και 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3647,7 +3647,7 @@ msgstr ""
 "Ένα κείμενο σταθερού μήκους (0-255, προεπιλογή 1) που είναι πάντα δεξιά "
 "στοιχισμένο με κενά στο ορισμένο μήκος όταν αποθηεκύεται"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3656,7 +3656,7 @@ msgstr ""
 "Ένα κείμενο μεταβλητού μήκους (%s), το δραστικό μέγιστο μήκος είναι σχετικό "
 "με το μέγιστο μέγεθος της εγγραφής"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3664,7 +3664,7 @@ msgstr ""
 "Μια στήλη TEXT με μέγιστο μήκος 255 (2⁸ - 1) χαρακτήρες, αποθηκεύεται με "
 "πρόθεμα 1-byte δείχνοντας το μήκος της τιμής σε bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3672,7 +3672,7 @@ msgstr ""
 "Μια στήλη TEXT με μέγιστο μήκος 65.535 (2¹⁶ - 1) χαρακτήρες, αποθηκεύεται με "
 "πρόθεμα 2-byte δείχνοντας το μήκος της τιμής σε bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3680,7 +3680,7 @@ msgstr ""
 "Μια στήλη TEXT με μέγιστο μήκος 16.777.215 (2²⁴ - 1) χαρακτήρες, "
 "αποθηκεύεται με πρόθεμα 3-byte δείχνοντας το μήκος της τιμής σε bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3689,7 +3689,7 @@ msgstr ""
 "Μια στήλη TEXT με μέγιστο μήκος 4.294.967.295 ή 4GB (2³² - 1) χαρακτήρες, "
 "αποθηκεύεται με πρόθεμα 4-byte δείχνοντας το μήκος της τιμής σε bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3697,7 +3697,7 @@ msgstr ""
 "Παρόμοιο με τον τύπο CHAR, αλλά αποθηκεύει τα κείμενα δυαδικού byte παρά τα "
 "κείμενα με μη δυαδικούς χαρακτήρες"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3705,7 +3705,7 @@ msgstr ""
 "Παρόμοιο με τον τύπο VARCHAR, αλλά αποθηκεύει τα κείμενα δυαδικού byte παρά "
 "τα κείμενα με μη δυαδικούς χαρακτήρες"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3713,7 +3713,7 @@ msgstr ""
 "Μια στήλη BLOB με μέγιστο μήκος 255 (2⁸ - 1) bytes, αποθηκεύεται με πρόθεμα "
 "2-byte δείχνοντας το μήκος της τιμής σε bytes"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3721,7 +3721,7 @@ msgstr ""
 "Μια στήλη BLOB με μέγιστο μήκος 16.777.215 (2²⁴ - 1) χαρακτήρες, "
 "αποθηκεύεται με πρόθεμα 3-byte δείχνοντας το μήκος της τιμής σε bytes"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3729,7 +3729,7 @@ msgstr ""
 "Μια στήλη BLOB με μέγιστο μήκος 65.535 (2¹⁶ - 1) χαρακτήρες, αποθηκεύεται με "
 "πρόθεμα 2-byte δείχνοντας το μήκος της τιμής σε bytes"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3737,7 +3737,7 @@ msgstr ""
 "Μια στήλη BLOB με μέγιστο μήκος 4.294.967.295 ή 4GB (2³² - 1) χαρακτήρες, "
 "αποθηκεύεται με πρόθεμα 4-byte δείχνοντας το μήκος της τιμής σε bytes"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3745,67 +3745,67 @@ msgstr ""
 "Μια απαρίθμηση, η οποία έχει επιλεγεί από τη λίστα των έως και 65.535 τιμές "
 "ή τις ειδικές \" τιμή σφάλματος"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Μία μόνο τιμή που επιλέγεται από ένα σύνολο έως και 64 μέλη"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Ένας τύπος που μπορεί να αποθηκεύσει μια γεωμετρία οποιουδήποτε τύπου"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Ένα σημείο σε δισδιάστατο χώρο"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Μια καμπύλη με γραμμική παρεμβολή μεταξύ σημείων"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Ένα πολύγωνο"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Μια συλλογή από σημεία"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Μια συλλογή καμπυλών με γραμμική παρεμβολή μεταξύ σημείων"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Μια συλλογή πολυγώνων"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Μια συλλογή γεωμετρικών αντικειμένων οποιουδήποτε τύπου"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Αριθμητικό"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Ημερομηνία και ώρα"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Κείμενο"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Χωρική"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Ένας ακέραιος 4-byte, εύρος είναι -2.147.483.648 έως 2.147.483.647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3813,24 +3813,24 @@ msgstr ""
 "Ένας ακέραιος 8-byte, εύρος είναι -9.223.372.036.854.775.808 έως "
 "9.223.372.036.854.775.807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 "Ένας προεπιλεγμένος αριθμός κινητής υποδιαστολής διπλής ακριβείας συστήματος"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Σωστό ή λάθος"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Μια ετικέτα για BIGINT NOT NULL AUTO_INCREMENT ΜΟΝΑΔΙΚΌ"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Αποθηκεύει ένα Καθολικά Μοναδικό Αναγνωριστικό (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3838,7 +3838,7 @@ msgstr ""
 "Μια χρονοσφραγίδα, εύρος είναι από «0001-01-01 00:00:00» UTC έως «9999-12-31 "
 "23:59:59» UTC; TIMESTAMP(6) μπορεί να αποθηκεύσει μικροδευτερόλεπτα"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3846,7 +3846,7 @@ msgstr ""
 "Ένα κείμενο μεταβλητού μήκους (0-65.535), χρησιμοποιεί δυαδική συρραφή για "
 "όλες τις συγκρίσεις"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Μια απαρίθμηση, η οποία έχει επιλεγεί από τη λίστα ορισμένων τιμών"
 
@@ -3931,69 +3931,69 @@ msgstr "%d %B %Y στις %H:%M:%S"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s μέρες, %s ώρες, %s λεπτά %s δευτερόλεπτα"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Απολεσθείσα παράμετρος:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Μεταπήδηση στην βάση «%s»."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 "Η λειτουργία %s έχει επηρρεαστεί από ένα γνωστό σφάλμα, για αυτό δείτε %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Πατήστε για εναλλαγή"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Περιηγηθείτε στον υπολογιστή σας:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Επιλογή από το φάκελο αποστολής του διακομίστή ιστού <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 "Ο φάκελος που ορίσατε για την αποθήκευση αρχείων δεν μπόρεσε να βρεθεί."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Δεν υπάρχουν αρχεία προς αποστολή"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Άδειασμα"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Εκτέλεση"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Εκτύπωση"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Δημιουργία"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Τελευταία ενημέρωση"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Tελευταίος έλεγχος"
@@ -4354,9 +4354,9 @@ msgstr "Επιτρέπεται στους χρήστες να προσαρμόσ
 msgid "Apply"
 msgstr "Εφαρμογή"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Επαναφορά"
 
@@ -4668,7 +4668,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Μέγιστος χρόνος εκτέλεσης"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Αποστολή"
 
@@ -7113,7 +7113,7 @@ msgstr "Η εισαγωγή του αρχείου είναι σε εξέλιξη
 msgid "Language"
 msgstr "Γλώσσα"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Πληροφορίες έκδοσης"
 
@@ -7563,59 +7563,59 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Δυαδικό - χωρίς δυνατότητα επεξεργασίας"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "κατάλογος αποθήκευσης αρχείων διακομιστή:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Συνέχιση εισαγωγής με %s εγγραφές"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "και μετά"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Εισαγωγή ως νέα εγγραφή"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Εισαγωγή ως νέα γραμμή και παράβλεψη σφαλμάτων"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Εμφάνιση ερωτήματος εισαγωγής"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Επιστροφή"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Εισαγωγή νέας εγγραφής"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Επιστροφή σε αυτή τη σελίδα"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Επεξεργασία επόμενης γραμμής"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Χρήση του πλήκτρου TAB για μετακίνηση από τιμή σε τιμή ή CTRL+βέλη για "
 "μετακίνηση παντού"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Εμφάνιση ερωτήματος SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Ταυτότητα εισερχόμενης εγγραφής: %1$d"
@@ -7946,7 +7946,6 @@ msgid "Database operations"
 msgstr "Λειτουργίες βάσης δεδομένων"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Εμφάνιση κρυφών αντικειμένων"
 
@@ -9778,24 +9777,24 @@ msgid "There are no events to display."
 msgstr "Δεν υπάρχουν συμβάντα για εμφάνιση."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Ο πίνακας «%s» δεν υπάρχει!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Παρακαλώ ορίστε τις συντεταγμένες για τον πίνακα %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Σχήμα της βάσης δεδομένων %s - Σελίδα %s"
@@ -12542,7 +12541,7 @@ msgstr "Η έκδοση %1$s δημιουργήθηκε, η παρακολούθ
 msgid "Manage your settings"
 msgstr "Διαχειριστείτε τις ρυθμίσεις σας"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Οι ρυθμίσεις αποθηκεύτηκαν"
 
@@ -12796,7 +12795,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Δεν έχετε αποθηκευμένες ρυθμίσεις!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Αυτό το χαρακτηριστικό δεν υποστηρίζεται από τον φυλλομετρητή σας"
 
@@ -12813,20 +12812,20 @@ msgstr ""
 "Μπορείτε να ορίσετε περισσότερες ρυθμίσεις αλλάζοντας το αρχείο config.inc."
 "php, π.χ. χρησιμοποιώντας τον %sκώδικα Εγκατάστασης%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Αποθήκευση στο χώρο αποθήκευσης του φυλλομετρητή"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 "Οι ρυθμίσεις θα αποθηκευτούν στην τοπική αποθήκευση του φυλλομετρητή σας."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Οι υπάρχουσες ρυθμίσεις θα αντικατασταθούν!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Μπορείτε να επαναφέρεται όλες σας τις ρυθμίσεις στις προεπιλεγμένες τιμές."
@@ -12855,6 +12854,10 @@ msgstr "Δεν υπάρχουν βάσεις δεδομένων"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Εμφάνισης σκαριφήματος (σχήματος) βάσεων δεδομένων"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-09-24 03:42+0200\n"
 "Last-Translator: Robert Readman <robert_readman@hotmail.com>\n"
 "Language-Team: English (United Kingdom) <http://l10n.cihar.com/projects/"
@@ -43,7 +43,7 @@ msgstr "Table comments:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Type"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -338,7 +338,7 @@ msgid "Updated"
 msgstr "Updated"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -366,7 +366,7 @@ msgid "Delete tracking data for this table"
 msgstr "Delete tracking data for this table"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -561,8 +561,8 @@ msgstr "Add geometry"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -588,7 +588,7 @@ msgstr "Add geometry"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Go"
@@ -960,7 +960,7 @@ msgstr "Add Index"
 msgid "Edit Index"
 msgstr "Edit Index"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Add %s column(s) to index"
@@ -1177,7 +1177,7 @@ msgid "Traffic"
 msgstr "Traffic"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Settings"
 
@@ -1488,8 +1488,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1699,8 +1699,8 @@ msgstr "Show query box"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1727,7 +1727,7 @@ msgstr "Query execution time"
 msgid "%d is not valid row number."
 msgstr "%d is not valid row number."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1796,8 +1796,8 @@ msgstr "Query results"
 msgid "Data point content"
 msgstr "Data point content"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignore"
 
@@ -2352,7 +2352,7 @@ msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 "Wrong permissions on configuration file, should not be world writeable!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Font size"
 
@@ -2499,8 +2499,8 @@ msgstr[0] "%1$s match in <strong>%2$s</strong>"
 msgstr[1] "%1$s matches in <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2556,28 +2556,28 @@ msgstr "Save edited data"
 msgid "Restore column order"
 msgstr "Restore column order"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Begin"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Previous"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Next"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "End"
@@ -2755,9 +2755,9 @@ msgstr "Check All"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2947,9 +2947,9 @@ msgid "View"
 msgstr "View"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2963,32 +2963,32 @@ msgid "Structure"
 msgstr "Structure"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Search"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Insert"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2997,20 +2997,20 @@ msgid "Privileges"
 msgstr "Privileges"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operations"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Tracking"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3026,70 +3026,70 @@ msgstr "Triggers"
 msgid "Database seems to be empty!"
 msgstr "Database seems to be empty!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Query"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Routines"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Events"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Designer"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Databases"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Users"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binary log"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replication"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variables"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Charsets"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Engines"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Error"
@@ -3115,7 +3115,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d row inserted."
 msgstr[1] "%1$d rows inserted."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3337,7 +3337,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3352,7 +3352,7 @@ msgstr "Table Search"
 msgid "Find and Replace"
 msgstr "Find and Replace"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Edit/Insert"
 
@@ -3360,7 +3360,7 @@ msgstr "Edit/Insert"
 msgid "Select columns (at least one):"
 msgstr "Select columns (at least one):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Or"
@@ -3470,13 +3470,13 @@ msgstr "Theme path not found for theme %s!"
 msgid "Theme:"
 msgstr "Theme:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3484,7 +3484,7 @@ msgstr ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3492,7 +3492,7 @@ msgstr ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3500,7 +3500,7 @@ msgstr ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3508,7 +3508,7 @@ msgstr ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3516,7 +3516,7 @@ msgstr ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3524,7 +3524,7 @@ msgstr ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3534,7 +3534,7 @@ msgstr ""
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3542,7 +3542,7 @@ msgstr ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3550,7 +3550,7 @@ msgstr ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3558,21 +3558,21 @@ msgstr ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "A date, supported range is %1$s to %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "A date and time combination, supported range is %1$s to %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3580,12 +3580,12 @@ msgstr ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "A time, range is %1$s to %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3593,7 +3593,7 @@ msgstr ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3601,7 +3601,7 @@ msgstr ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3610,7 +3610,7 @@ msgstr ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3618,7 +3618,7 @@ msgstr ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3626,7 +3626,7 @@ msgstr ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3634,7 +3634,7 @@ msgstr ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3644,7 +3644,7 @@ msgstr ""
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3652,7 +3652,7 @@ msgstr ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3660,7 +3660,7 @@ msgstr ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3668,7 +3668,7 @@ msgstr ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3676,7 +3676,7 @@ msgstr ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3684,7 +3684,7 @@ msgstr ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3692,7 +3692,7 @@ msgstr ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3700,67 +3700,67 @@ msgstr ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "A single value chosen from a set of up to 64 members"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "A type that can store a geometry of any type"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "A point in 2-dimensional space"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "A curve with linear interpolation between points"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "A polygon"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "A collection of points"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "A collection of curves with linear interpolation between points"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "A collection of polygons"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "A collection of geometry objects of any type"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numeric"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Date and time"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "String"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Spatial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3768,23 +3768,23 @@ msgstr ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "A system's default double-precision floating-point number"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "True or false"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Stores a Universally Unique Identifier (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3792,7 +3792,7 @@ msgstr ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3800,7 +3800,7 @@ msgstr ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "An enumeration, chosen from the list of defined values"
 
@@ -3885,67 +3885,67 @@ msgstr "%B %d, %Y at %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s days, %s hours, %s minutes and %s seconds"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Missing parameter:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Jump to database &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "The %s functionality is affected by a known bug, see %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Click to toggle"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Browse your computer:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Select from the web server upload directory <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "The directory you set for upload work cannot be reached."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "There are no files to upload"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Empty"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Execute"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Print"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Creation"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Last update"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Last check"
@@ -4301,9 +4301,9 @@ msgstr "Allow users to customise this value"
 msgid "Apply"
 msgstr "Apply"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Reset"
 
@@ -4609,7 +4609,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maximum execution time"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Save as file"
 
@@ -7016,7 +7016,7 @@ msgstr "The file is being processed, please be patient."
 msgid "Language"
 msgstr "Language"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Version information"
 
@@ -7457,58 +7457,58 @@ msgstr "Because of its length,<br /> this column might not be editable"
 msgid "Binary - do not edit"
 msgstr "Binary - do not edit"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "web server upload directory:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Continue insertion with %s rows"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "and then"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Insert as new row"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Insert as new row and ignore errors"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Show insert query"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Go back to previous page"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Insert another new row"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Go back to this page"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Edit next row"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Showing SQL query"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Inserted row id: %1$d"
@@ -9657,24 +9657,24 @@ msgid "There are no events to display."
 msgstr "There are no events to display."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "The %s table doesn't exist!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Please configure the coordinates for table %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Schema of the %s database - Page %s"
@@ -12347,7 +12347,7 @@ msgstr "Version %1$s was created, tracking for %2$s is active."
 msgid "Manage your settings"
 msgstr "Manage your settings"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Configuration has been saved"
 
@@ -12599,7 +12599,7 @@ msgstr "Settings will be imported from your browser's local storage."
 msgid "You have no saved settings!"
 msgstr "You have no saved settings!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "This feature is not supported by your web browser"
 
@@ -12616,19 +12616,19 @@ msgstr ""
 "You can set more settings by modifying config.inc.php, eg. by using %sSetup "
 "script%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Save to browser's storage"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Settings will be saved in your browser's local storage."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Existing settings will be overwritten!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "You can reset all your settings and restore them to default values."
 
@@ -12656,6 +12656,10 @@ msgstr "No databases"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "View dump (schema) of databases"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/es.po
+++ b/po/es.po
@@ -3,15 +3,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-26 13:57+0200\n"
 "Last-Translator: Matías Bellone <matiasbellone+weblate@gmail.com>\n"
-"Language-Team: Spanish "
-"<http://l10n.cihar.com/projects/phpmyadmin/master/es/>\n"
-"Language: es\n"
+"Language-Team: Spanish <http://l10n.cihar.com/projects/phpmyadmin/master/es/"
+">\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -41,7 +41,7 @@ msgstr "Comentarios de la tabla:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Tipo"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -338,7 +338,7 @@ msgid "Updated"
 msgstr "Actualizado"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -366,7 +366,7 @@ msgid "Delete tracking data for this table"
 msgstr "Borrar los datos de seguimiento para esta tabla"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -568,8 +568,8 @@ msgstr "Agregar geometría"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -595,7 +595,7 @@ msgstr "Agregar geometría"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Continuar"
@@ -978,7 +978,7 @@ msgstr "Agregar índice"
 msgid "Edit Index"
 msgstr "Editar índice"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Agregar %s columna(s) al índice"
@@ -1198,7 +1198,7 @@ msgstr "Tráfico"
 
 # This is the text showed in the tab
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Configuración"
 
@@ -1517,8 +1517,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1729,8 +1729,8 @@ msgstr "Mostrar ventana de consultas SQL"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1757,7 +1757,7 @@ msgstr "Tiempo de ejecución de la consulta"
 msgid "%d is not valid row number."
 msgstr "%d no es un número de fila válido."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1828,8 +1828,8 @@ msgstr "Resultados de la consulta"
 msgid "Data point content"
 msgstr "Contenido del punto de datos"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorar"
 
@@ -2390,7 +2390,7 @@ msgstr ""
 "Permisos incorrectos en el archivo de configuración ¡cualquiera no debería "
 "poder modificarlo!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Tamaño de fuente"
 
@@ -2539,8 +2539,8 @@ msgstr[0] "%1$s coincidencia en la tabla <strong>%2$s</strong>"
 msgstr[1] "%1$s coincidencias en la tabla <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2596,28 +2596,28 @@ msgstr "Guardar datos editados"
 msgid "Restore column order"
 msgstr "Restaurar orden de las columnas"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Comenzar"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Anterior"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Siguiente"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Fin"
@@ -2797,9 +2797,9 @@ msgstr "Marcar todos"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2992,9 +2992,9 @@ msgid "View"
 msgstr "Visualizar"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3008,32 +3008,32 @@ msgid "Structure"
 msgstr "Estructura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Buscar"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Insertar"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3042,20 +3042,20 @@ msgid "Privileges"
 msgstr "Privilegios"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operaciones"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Seguimiento"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3071,70 +3071,70 @@ msgstr "Disparadores"
 msgid "Database seems to be empty!"
 msgstr "La base de datos, ¡parece estar vacía!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Generar una consulta"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutinas"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Eventos"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Diseñador"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Bases de datos"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Usuarios"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Registro binario"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replicación"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variables"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Juegos de caracteres"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Complementos"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motores"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Error"
@@ -3160,7 +3160,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d fila insertada."
 msgstr[1] "%1$d filas insertadas."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3385,7 +3385,7 @@ msgid "Operator"
 msgstr "Operador"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3400,7 +3400,7 @@ msgstr "Búsqueda de tablas"
 msgid "Find and Replace"
 msgstr "Buscar y reemplazar"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Editar/Insertar"
 
@@ -3408,7 +3408,7 @@ msgstr "Editar/Insertar"
 msgid "Select columns (at least one):"
 msgstr "Seleccionar campos (al menos uno):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "O"
@@ -3521,14 +3521,14 @@ msgstr "¡No se encontró la ruta del tema %s!"
 msgid "Theme:"
 msgstr "Tema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Un entero de 1 byte; el rango con signo es de -128 a 127, el rango sin signo "
 "es de 0 a 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3536,7 +3536,7 @@ msgstr ""
 "Un entero de 2 bytes; el rango con signo es de -32768 a 32767, el rango sin "
 "signo es de 0 a 65535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3544,7 +3544,7 @@ msgstr ""
 "Un entero de 3 bytes; el rango con signo es de -8388608 a 8388607, el rango "
 "sin signo es de 0 a 16777215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3552,7 +3552,7 @@ msgstr ""
 "Un entero de 4 bytes; el rango con signo es de 2147483648 a 2147483647, el "
 "rango sin signo es de 0 a 4294967295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3560,7 +3560,7 @@ msgstr ""
 "En entero de 8 bytes; el rango con signo es de -9223372036854775808 a "
 "9223372036854775807, el rango sin signo es de 0 a 18446744073709551615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3569,7 +3569,7 @@ msgstr ""
 "(valor predeterminado de 10), el mayor número posible de decimales (D) es 30 "
 "(valor predeterminado de 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3577,7 +3577,7 @@ msgstr ""
 "Un número de coma flotante pequeño; los valores posibles son de -3.402823466E"
 "+38 a -1.175494351E-38, 0 y de 1.175494351E-38 a 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3587,7 +3587,7 @@ msgstr ""
 "-1.7976931348623157E+308 a -2.2250738585072014E-308, 0 y de "
 "2.2250738585072014E-308 a 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3595,7 +3595,7 @@ msgstr ""
 "Sinónimo de DOUBLE (excepción: si el modo SQL «REAL_AS_FLOAT» está activo es "
 "sinónimo de FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3603,7 +3603,7 @@ msgstr ""
 "Una máscara de bits (M), almacenando M bits por valor (valor predeterminado "
 "de 1, máximo de 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3611,23 +3611,23 @@ msgstr ""
 "Sinónimo de TINYINT(1), un valor de cero es considerado falso, cualquier "
 "valor distinto de cero es considerado verdadero"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un sinónimo de BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Una fecha, el rango válido es de «%1$s» a «%2$s»"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 "Una combinación de fecha y marca temporal, el rango válido es de «%1$s» a «%2"
 "$s»"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3636,12 +3636,12 @@ msgstr ""
 "03:14:07» UTC almacenados como la cantidad de segundos desde el «epoch» («01-"
 "Ene-1970 00:00:00» UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Una marca temporal, el rango es de «%1$s» a «%2$s»"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3650,7 +3650,7 @@ msgstr ""
 "dígitos (2); los valores posibles son de 70 (1970) a 69 (2069) ó de 1901 a "
 "2155 y 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3659,7 +3659,7 @@ msgstr ""
 "siempre completada a la derecha con espacios hasta la longitud especificada "
 "al ser almacenada"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3668,7 +3668,7 @@ msgstr ""
 "Una cadena de longitud variable (%s), la longitud máxima está asociada al "
 "tamaño máximo de un registro"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3676,7 +3676,7 @@ msgstr ""
 "Una columna de texto con una longitud máxima de 255 (2^8 - 1) caracteres, "
 "almacenado con un prefijo de 1 byte que indica la longitud del valor en bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3685,7 +3685,7 @@ msgstr ""
 "almacenado con un prefijo de 2 bytes que indica la longitud del valor en "
 "bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3694,7 +3694,7 @@ msgstr ""
 "caracteres, almacenado con un prefijo de 3 bytes que indica la longitud del "
 "valor en bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3704,7 +3704,7 @@ msgstr ""
 "caracteres, almacenado con un prefijo de 4 bytes que indica la longitud del "
 "valor en bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3712,7 +3712,7 @@ msgstr ""
 "Similar al tipo CHAR, pero almacena cadenas binarias de bytes en lugar de "
 "cadenas de caracteres no binarios"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3720,7 +3720,7 @@ msgstr ""
 "Similar al tipo VARCHAR, pero almacena cadenas binarias de bytes en lugar de "
 "cadenas de caracteres no binarios"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3729,7 +3729,7 @@ msgstr ""
 "1) bytes. Cada valor TINYBLOB es almacenado con un prefijo de 1 byte que "
 "indica la cantidad de bytes en el valor"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3738,7 +3738,7 @@ msgstr ""
 "(2^24 - 1) bytes, almacenado con un prefijo de 3 bytes que indica la "
 "longitud del valor"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3747,7 +3747,7 @@ msgstr ""
 "(2^16 - 1) bytes, almacenado con un prefijo de 2 bytes que indica la "
 "longitud del valor"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3756,7 +3756,7 @@ msgstr ""
 "(2^32 - 1) bytes (4GB), almacenado con un prefijo de 4 bytes que indica la "
 "longitud del valor"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3764,67 +3764,67 @@ msgstr ""
 "Una enumeración, elegida de una lista de hasta 65535 valores o el valor "
 "especial de error ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Un único valor elegido de un conjunto de hasta 64 elementos"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Un tipo que puede almacenar una geometría de cualquier tipo"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Un punto en espacio de dos dimensiones"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Una curva con interpolación lineal entre puntos"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Un polígono"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Una colección de puntos"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Una colección de curvas con interpolación lineal entre puntos"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Una colección de polígonos"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Una colección de objetos geométricos de cualquier tipo"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numérico"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Fecha y marca temporal"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Cadena"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Espacial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Un entero de 4 bytes, el rango es de -2147483648 a 2147483647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3832,24 +3832,24 @@ msgstr ""
 "En entero de 8 bytes, el rango es de -9223372036854775808 a "
 "9223372036854775807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 "El número de coma flotante de doble precisión predeterminado del sistema"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Verdadero o falso"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un sinónimo de BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Almacena indentificadores únicos universales («UUID»)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3857,7 +3857,7 @@ msgstr ""
 "Una marca temporal, el rango es de «01-Ene-0001 00:00:00» UTC a «31-Dic-9999 "
 "23:59:59» UTC; TIMESTAMP(6) puede almacena microsegundos"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3865,7 +3865,7 @@ msgstr ""
 "Una cadena de longitud variable (0-65535) que utiliza cotejamiento binario "
 "para las comparaciones"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Una enumeración, elegida de una lista de valores definidos"
 
@@ -3950,69 +3950,69 @@ msgstr "%d-%m-%Y a las %H:%M:%S"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s días, %s horas, %s minutos y %s segundos"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Parámetro faltante:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Saltar a la base de datos &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "La funcionalidad %s está afectada por un fallo conocido, vea %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Pulse para conmutar"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Buscar en su ordenador:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 "Seleccionar directorio en el servidor web para subir los archivos <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 "No se puede acceder al directorio que seleccionó para subir los archivos."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "No hay archivos para subir"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Vaciar"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Ejecutar"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Imprimir"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Creación"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Última actualización"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Última revisión"
@@ -4376,9 +4376,9 @@ msgstr "Permitir a los usuarios personalizar este valor"
 msgid "Apply"
 msgstr "Aplicar"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Reiniciar"
 
@@ -4692,7 +4692,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Tiempo máximo de ejecución"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Guardar como archivo"
 
@@ -7147,7 +7147,7 @@ msgstr "El archivo está siendo procesado, sea paciente."
 msgid "Language"
 msgstr "Idioma"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Acerca de esta versión"
 
@@ -7602,59 +7602,59 @@ msgstr "Debido a su longitud,<br /> esta columna podría no ser editable"
 msgid "Binary - do not edit"
 msgstr "Binario - no editar"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "directorio en el servidor web para subir los archivos:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Continuar inserción con %s filas"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "y luego"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Insertar como una nueva fila"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Agregar como nueva fila e ignorar errores"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Mostrar consulta de inserción"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Volver"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Insertar un nuevo registro"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Volver a esta página"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Editar la siguiente fila"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Use la tecla TAB para saltar de un valor a otro, o CTRL+flechas para moverse "
 "a cualquier parte"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Mostrando la consulta SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "La Id de la fila insertada es: %1$d"
@@ -7988,7 +7988,6 @@ msgid "Database operations"
 msgstr "Opciones de la base de datos"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Mostrar elementos ocultos"
 
@@ -9817,24 +9816,24 @@ msgid "There are no events to display."
 msgstr "No existen eventos para mostrar."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "¡La tabla %s no existe!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Configure las coordenadas para la tabla %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Esquema de la base de datos %s - Página %s"
@@ -12579,7 +12578,7 @@ msgstr "Se ha creado la versión %1$s, se ha activado el seguimiento para %2$s."
 msgid "Manage your settings"
 msgstr "Administrar tu configuración"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Se guardó la configuración"
 
@@ -12834,7 +12833,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "¡No se encontraron configuraciones guardadas!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Esta funcionalidad no está soportada por tu navegador"
 
@@ -12852,20 +12851,20 @@ msgstr ""
 "Se pueden definir más configuraciones modificando config.inc.php. Por "
 "ejemplo, utilizado %sscripts de configuración%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Guardar en almacenamiento del navegador"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 "La configuración será guardada en el almacenamiento local del navegador."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "¡Se reemplazarán las configuraciones existentes!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Se pueden reiniciar todas las configuraciones y devolverlas a sus valores "
@@ -12895,6 +12894,10 @@ msgstr "No hay bases de datos"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Ver el volcado (schema) de la base de datos"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/et.po
+++ b/po/et.po
@@ -5,15 +5,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 22:26+0200\n"
 "Last-Translator: Kristjan Räts <kristjanrats@gmail.com>\n"
-"Language-Team: Estonian "
-"<http://l10n.cihar.com/projects/phpmyadmin/master/et/>\n"
-"Language: et\n"
+"Language-Team: Estonian <http://l10n.cihar.com/projects/phpmyadmin/master/et/"
+">\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: et\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -43,7 +43,7 @@ msgstr "Tabeli kommentaarid:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Tüüp"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -338,7 +338,7 @@ msgid "Updated"
 msgstr "Uuendatud"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -366,7 +366,7 @@ msgid "Delete tracking data for this table"
 msgstr "Kustuta selle tabeli jälgimise andmed"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -564,8 +564,8 @@ msgstr "Lisa geomeetria"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -591,7 +591,7 @@ msgstr "Lisa geomeetria"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Mine"
@@ -963,7 +963,7 @@ msgstr "Lisa indeks"
 msgid "Edit Index"
 msgstr "Muuda indeksit"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Lisa indeksisse %s veerg(u)"
@@ -1180,7 +1180,7 @@ msgid "Traffic"
 msgstr "Liiklus"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Sätted"
 
@@ -1492,8 +1492,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1702,8 +1702,8 @@ msgstr "Näita päringu kasti"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1730,7 +1730,7 @@ msgstr "Päringu sooritamise aeg"
 msgid "%d is not valid row number."
 msgstr "%d ei ole õige reanumber."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1800,8 +1800,8 @@ msgstr "Päringu tulemused"
 msgid "Data point content"
 msgstr "Andmepunkti sisu"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignoreeri"
 
@@ -2349,7 +2349,7 @@ msgstr ""
 "Seadistusfailil on valed õigused. See ei tohiks olla kõikide jaoks "
 "kirjutatav!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Fondi kõrgus"
 
@@ -2495,8 +2495,8 @@ msgstr[0] "%1$s vaste <strong>%2$s</strong> tabelis"
 msgstr[1] "%1$s vastet <strong>%2$s</strong> tabelis"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2552,28 +2552,28 @@ msgstr "Salvesta muudetud andmed"
 msgid "Restore column order"
 msgstr "Taasta veeru järjekord"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Algus"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Eelmine"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Järgmine"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Lõpp"
@@ -2750,9 +2750,9 @@ msgstr "Vali kõik"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2941,9 +2941,9 @@ msgid "View"
 msgstr "Vaade"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2957,32 +2957,32 @@ msgid "Structure"
 msgstr "Struktuur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Otsi"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Lisa"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2991,20 +2991,20 @@ msgid "Privileges"
 msgstr "Õigused"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Tegevused"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Jälgimine"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3020,70 +3020,70 @@ msgstr "Päästikud"
 msgid "Database seems to be empty!"
 msgstr "Andmebaas tundub olevat tühi!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Päring"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Funktsioonid"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Sündmused"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Kujundaja"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Andmebaasid"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Kasutajad"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binaarne logi"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Paljundamine"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Muutujad"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Märgitabelid"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Pluginad"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Mootorid"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Viga"
@@ -3109,7 +3109,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Lisati %1$d rida."
 msgstr[1] "Lisati %1$d rida."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3329,7 +3329,7 @@ msgid "Operator"
 msgstr "Operaator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3344,7 +3344,7 @@ msgstr "Tabeli otsing"
 msgid "Find and Replace"
 msgstr "Leia ja asenda"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Muuda/Lisa"
 
@@ -3352,7 +3352,7 @@ msgstr "Muuda/Lisa"
 msgid "Select columns (at least one):"
 msgstr "Vali veerud (vähemalt üks):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Või"
@@ -3463,14 +3463,14 @@ msgstr "%s välimuse asukohta ei leitud!"
 msgid "Theme:"
 msgstr "Välimus:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Ühebaidine täisarv, märgiga vahemik -128 kuni 127, märgita vahemik on 0 kuni "
 "255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3478,7 +3478,7 @@ msgstr ""
 "Kahebaidine täisarv, märgiga vahemik on -32,768 kuni 32,767, märgita vahemik "
 "is 0 kuni 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3486,7 +3486,7 @@ msgstr ""
 "Kolmebaidine täisarv, märgiga vahemik on -8,388,608 kuni 8,388,607, märgita "
 "vahemik on 0 kuni 16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3494,7 +3494,7 @@ msgstr ""
 "Neljabaidine täisarv, märgiga vahemik on -2,147,483,648 kuni 2,147,483,647, "
 "märgita vahemik on 0 kuni 4,294,967,295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3503,7 +3503,7 @@ msgstr ""
 "9,223,372,036,854,775,807, märgita vahemik on 0 kuni "
 "18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3511,7 +3511,7 @@ msgstr ""
 "Fikseeritud punktiga arv (M, D) - maksimaalne numbrite arv (M) on 65 "
 "(vaikimisi 10), maksimaalne kümnendkohtade arv (D) on 30 (vaikimisi 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3519,7 +3519,7 @@ msgstr ""
 "Väike ujukoma arv, lubatud väärtused on vahemikus -3.402823466E+38 kuni -"
 "1.175494351E-38, 0, ja 1.175494351E-38 kuni 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3529,14 +3529,14 @@ msgstr ""
 "1.7976931348623157E+308 luni -2.2250738585072014E-308, 0, ja "
 "2.2250738585072014E-308 kuni 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 "DOUBLE sünonüüm (erand: REAL_AS_FLOAT SQL režiimis on ta FLOAT'i sünonüüm)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3544,7 +3544,7 @@ msgstr ""
 "Bitivälja tüüp (M), salvestab M bitti informatsiooni väärtuse kohta "
 "(vaikimisi on 1, maksimaalne on 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3552,21 +3552,21 @@ msgstr ""
 "TINYINT(1) sünonüüm, väärtust null tõlgendatakse väärana, mittenullist "
 "väärtust tõesena"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE alias"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Kuupäev, sobiv ulatus on %1$s kuni %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Kuupäeva ja aja kombinatsioon, sobiv ulatus on %1$s kuni %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3575,12 +3575,12 @@ msgstr ""
 "\" UTC, säilitatakse sekundite hulgana alates ajastu algusest (\"1970-01-01 "
 "00:00:00\" UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Aeg, ulatus on %1$s kuni %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3588,7 +3588,7 @@ msgstr ""
 "Neljanumbriline aastaarv (vaikimisi 4) või kahenumbriline (2) formaat. "
 "Lubatud väärtused on 70 (1970) kuni 69 (2069) või 1901 kuni 2155 ja 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3596,7 +3596,7 @@ msgstr ""
 "Fikseeritud pikkusega (0-255, vaikimisi 1) sõne, mis salvestamisel "
 "pikendatakse sobivasse pikkusesse paremal pool asuvate tühikute abil"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3605,7 +3605,7 @@ msgstr ""
 "Muutuva pikkusega (%s) sõne. Parim sobiv maksimaalne pikkus on rea "
 "maksimaalne suurus"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3613,7 +3613,7 @@ msgstr ""
 "TEXT veerg (maksimaalse pikkusega 255 (2^8 - 1) sümbolit) salvestatakse "
 "ühebitise eesliitega, mis märgib väärtuse pikkust baitides"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3621,7 +3621,7 @@ msgstr ""
 "TEXT veerg (maksimaalse pikkusega 65,535 (2^16 - 1) sümbolit) salvestatakse "
 "kahebitise eesliitega, mis märgib väärtuse pikkust baitides"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3629,7 +3629,7 @@ msgstr ""
 "TEXT veerg (maksimaalse pikkusega 16,777,215 (2^24 - 1) sümbolit) "
 "salvestatakse kolmebitise eesliitega, mis märgib väärtuse pikkust baitides"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3638,7 +3638,7 @@ msgstr ""
 "TEXT veerg (maksimaalse pikkusega 4,294,967,295 or 4GiB (2^32 - 1) sümbolit) "
 "salvestatakse neljabitise eesliitega, mis märgib väärtuse pikkust baitides"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3646,7 +3646,7 @@ msgstr ""
 "Sarnane CHAR tüübile, kuid salvestab binaarse baidi sõned pigem "
 "mittebinaarse sümboli sõnedena"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3654,7 +3654,7 @@ msgstr ""
 "Sarnane VARCHAR tüübile, kuid salvestab binaarse baidi sõned pigem "
 "mittebinaarse sümboli sõnedena"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3662,7 +3662,7 @@ msgstr ""
 "BLOB veerg (maksimaalse pikkusega 255 (2^8 - 1) baiti) salvestatakse "
 "ühebaidise eesliitega, mis märgib väärtuse pikkust"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3670,7 +3670,7 @@ msgstr ""
 "BLOB veerg (maksimaalse pikkusega 16,777,215 (2^24 - 1) baiti) salvestatakse "
 "kolmebaidise eesliitega, mis märgib väärtuse pikkust"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3678,7 +3678,7 @@ msgstr ""
 "BLOB veerg (maksimaalse pikkusega 65,535 (2^16 - 1) baiti) salvestatakse "
 "kahebaidise eesliitega, mis märgib väärtuse pikkust"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3686,73 +3686,73 @@ msgstr ""
 "BLOB veerg (maksimaalse pikkusega 4,294,967,295 or 4GiB (2^32 - 1) baiti) "
 "salvestatakse neljabaidise eesliitega, mis märgib väärtuse pikkust"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr "Loend, valitakse kuni 65535 väärtusest või spetsiaalne '' vea tunnus"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Üks väärtus, mis valitakse kuni 64 elemendiga hulgast"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Tüüp, mis suudab salvestada mistahes tüüpi geomeetriat"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Punkt kahemõõtmelises ruumis"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Punktidevaheline kaar koos sirgjoonega"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Hulktahukas"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Punktide kogum"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Punktidevaheliste sirgjoontega kaarte kogum"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Hulktahukate kogum"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Igat tüüpi geomeetriliste objektide kogum"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Arv"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Kuupäev ja aeg"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Sõne"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Ruumiline"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Neljabaidine täisarv ulatusega -2,147,483,648 kuni 2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3760,23 +3760,23 @@ msgstr ""
 "Kaheksabaidine täisarv ulatusega -9,223,372,036,854,775,808 kuni "
 "9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Süsteemi vaikimisi kahekordse täpsusega ujukoma number"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Õige või vale"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT NOT NULL AUTO_INCREMENT UNIQUE alias"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Salvestab universaalselt unikaalse identifikaatori (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3784,7 +3784,7 @@ msgstr ""
 "Ajatempel, ulatus on '0001-01-01 00:00:00' UTC kuni '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) suudab salvestada mikrosekundeid"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3792,7 +3792,7 @@ msgstr ""
 "Muutuva pikkusega (0-65,535) sõne, mis kasutab kõikide võrdluste jaoks "
 "binaarset kõrvutamist"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Loetelu, mis on valitud määratletud väärtuste nimekirjast"
 
@@ -3877,67 +3877,67 @@ msgstr "%B %d, %Y kell %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s päeva, %s tundi, %s minutit ja %s sekundit"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Puudulik parameeter:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Mine &quot;%s&quot; andmebaasi."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Seda %s funktsionaalsust mõjutas tuntud viga, vaata %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Muuda"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Sirvi oma arvutist:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Vali veebiserveri üleslaadimise kataloogist <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Valitud üleslaadimise kataloogile ei pääse ligi."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Seal pole faile, mida üles laadida"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Tühjenda"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Teosta"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Prindi"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Loodud"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Viimati uuendatud"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Viimane kontroll"
@@ -4291,9 +4291,9 @@ msgstr "Luba kasutajatel seda väärtust muuta"
 msgid "Apply"
 msgstr "Rakenda"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Lähtesta"
 
@@ -4598,7 +4598,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Suurim teostamise aeg"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Salvesta failina"
 
@@ -6991,7 +6991,7 @@ msgstr "Faili töödeldakse, palun oota."
 msgid "Language"
 msgstr "Keel"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Versioon"
 
@@ -7427,59 +7427,59 @@ msgstr "Oma pikkuse tõttu<br /> ei pruugi see veerg olla muudetav"
 msgid "Binary - do not edit"
 msgstr "Binaarne - ära muuda"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "veebiserveri üleslaadimiskataloog:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Jätka %s rea lisamist"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "ja siis"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Lisa uue reana"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Lisa uue reana ja ignoreeri vigu"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Näita lisamise päringut"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Mine eelmisele lehele tagasi"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Lisa järgmine uus rida"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Mine tagasi sellele lehele"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Muuda järgmist rida"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Ühelt väärtuselt teisele liikumiseks kasuta TAB-klahvi või mujale "
 "liikumiseks kasuta CTRL + nooled"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Näitan SQL päringut"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Lisatud rea id: %1$d"
@@ -7810,7 +7810,6 @@ msgid "Database operations"
 msgstr "Toimingud andmebaasiga"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Kuva peidetud elemendid"
 
@@ -9604,24 +9603,24 @@ msgid "There are no events to display."
 msgstr "Pole sündmusi, mida näidata."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "%s tabelit pole olemas!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Palun seadista koordinaadid %s tabelile"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "%s andmebaasi skeem - Leht %s"
@@ -12290,7 +12289,7 @@ msgstr "Versioon %1$s on loodud, %2$s jälgimine on aktiveeritud."
 msgid "Manage your settings"
 msgstr "Halda oma sätteid"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Seadistus on salvestatud"
 
@@ -12542,7 +12541,7 @@ msgstr "Sätted imporditakse sinu veebilehitseja kohalikust salvestuskohast."
 msgid "You have no saved settings!"
 msgstr "Sul pole salvestatud sätteid!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Sinu veebilehitseja ei toeta seda võimalust"
 
@@ -12559,19 +12558,19 @@ msgstr ""
 "Saad rakendada rohkem sätteid, kui muudad config.inc.php faili, nt kasutades "
 "%sPaigaldaja skripti%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Salvesta veebilehitseja salvestuskohta"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Sätted salvestatakse sinu veebilehitseja kohalikku salvestuskohta."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Olemasolevad sätted kirjutatakse üle!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "Saad lähtestada kõik sätted ja taastada need vaikimisi väärtustele."
 
@@ -12599,6 +12598,10 @@ msgstr "Andmebaasid puuduvad"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Vaata andmebaaside tõmmist (skeemi)"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:31+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Basque <http://l10n.cihar.com/projects/phpmyadmin/master/eu/"
@@ -43,7 +43,7 @@ msgstr "Taularen iruzkinak"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Mota"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -346,7 +346,7 @@ msgid "Updated"
 msgstr "Eguneratua"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -374,7 +374,7 @@ msgid "Delete tracking data for this table"
 msgstr "Ezabatu taula honetako jarraipen datuak"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -580,8 +580,8 @@ msgstr "Gehitu geometria"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -607,7 +607,7 @@ msgstr "Gehitu geometria"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Joan"
@@ -978,7 +978,7 @@ msgstr "Indizea"
 msgid "Edit Index"
 msgstr "Editatu hurrengo lerroa"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1207,7 +1207,7 @@ msgid "Traffic"
 msgstr "Trafikoa"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1540,8 +1540,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1789,8 +1789,8 @@ msgstr "SQL kontsulta"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1817,7 +1817,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1898,8 +1898,8 @@ msgstr "SQL emaitza"
 msgid "Data point content"
 msgstr "Edukinen taula"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ezikusi"
 
@@ -2517,7 +2517,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2676,8 +2676,8 @@ msgstr[0] "%s emaitza <i>%s</i> taulan"
 msgstr[1] "%s emaitzak <i>%s</i> taulan"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2735,16 +2735,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Gehitu/ezabatu irizpide-zutabea"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Hasi"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2752,8 +2752,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Aurrekoa"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2761,8 +2761,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Hurrengoa"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2958,9 +2958,9 @@ msgstr "Guztiak egiaztatu"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3151,9 +3151,9 @@ msgid "View"
 msgstr "Ikusipegia"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3167,32 +3167,32 @@ msgid "Structure"
 msgstr "Egitura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Bilatu"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Txertatu"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3201,20 +3201,20 @@ msgid "Privileges"
 msgstr "Pribilegioak"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Eragiketak"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3230,73 +3230,73 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Kontsulta"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Datu-baseak"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Erabiltzailea"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 #, fuzzy
 msgid "Binary log"
 msgstr "Binarioa "
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Ihardetsi"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Aldagaiak"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Karaktere-multzoa"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Errorea"
@@ -3322,7 +3322,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3550,7 +3550,7 @@ msgid "Operator"
 msgstr "Eragiketak"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3567,7 +3567,7 @@ msgstr "Bilatu"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3579,7 +3579,7 @@ msgstr "Txertatu"
 msgid "Select columns (at least one):"
 msgstr "Eremuak hautatu (bat gutxienez):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Edo"
@@ -3703,286 +3703,286 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Zerbitzariaren bertsioa"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Zerbitzariaren bertsioa"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add a polygon"
 msgid "A polygon"
 msgstr "Gehitu poligonoa"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Indize berri bat sortu"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Linestring"
 msgctxt "string types"
 msgid "String"
 msgstr "Lerro kateak"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Gutira"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4069,68 +4069,68 @@ msgstr "%Y-%m-%d, %H:%M:%S"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s egun, %s ordu, %s minutu eta %s segundu"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "&quot;%s&quot; datu-basera joan."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Fitxategiak igotzeko web-zerbitzariaren direktorioa"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Igoerentzat ezarri duzun direktorioa ez dago eskuragarri."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Hutsik"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Inprimatu"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Sortzea"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Azken eguneraketa"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Azken egiaztapena"
@@ -4509,9 +4509,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Reset egin"
 
@@ -4804,7 +4804,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Bidali"
 
@@ -7189,7 +7189,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 #, fuzzy
 msgid "Version information"
 msgstr "Saioa hasteko informazioa"
@@ -7590,59 +7590,59 @@ msgstr "Bere luzeragatik,<br /> eremu hau ez da editagarria "
 msgid "Binary - do not edit"
 msgstr "Binarioa - ez editatu"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "Fitxategiak igotzeko web-zerbitzariaren direktorioa"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "eta orduan"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Txertatu errenkada berri batean"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Itzuli"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Erregistro berria gehitu"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Egin atzera orri honetara"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Editatu hurrengo lerroa"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9902,25 +9902,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "\"%s\" taula ez da existitzen!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Mesedez, %s taularentzako koordinatuak konfiguratu"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12649,7 +12649,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Erlazioen ezaaugarri orokorrak"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12931,7 +12931,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12946,19 +12946,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12988,6 +12988,10 @@ msgstr "Datu-baserik ez"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Ikusi datu-baseen iraulketa (eskema)"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/fa.po
+++ b/po/fa.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 15:03+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Persian <http://l10n.cihar.com/projects/phpmyadmin/master/fa/"
@@ -43,7 +43,7 @@ msgstr "توضيحات جدول"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "نوع"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -344,7 +344,7 @@ msgid "Updated"
 msgstr "به روز شده"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -372,7 +372,7 @@ msgid "Delete tracking data for this table"
 msgstr "اطلاعات پیگیری شده برای این جدول را پاک کنید"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -578,8 +578,8 @@ msgstr "اضافه کردن هندسه"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -605,7 +605,7 @@ msgstr "اضافه کردن هندسه"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "تاييد"
@@ -975,7 +975,7 @@ msgstr "افزودن index"
 msgid "Edit Index"
 msgstr "ویرایش کردن ایندکس"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %d column(s) to index"
 msgid "Add %s column(s) to index"
@@ -1194,7 +1194,7 @@ msgid "Traffic"
 msgstr "ترافیک"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "تنظیم"
 
@@ -1504,8 +1504,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1720,8 +1720,8 @@ msgstr "نمایش جعبه پرس و جو"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1748,7 +1748,7 @@ msgstr "زمان اجرای پرس و جو"
 msgid "%d is not valid row number."
 msgstr "%d شماره ردیف معتبر نمی باشد."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1824,8 +1824,8 @@ msgstr "نتایج پرس و جو"
 msgid "Data point content"
 msgstr "محتوای داده ها"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "در نظر نگرفتن"
 
@@ -2393,7 +2393,7 @@ msgstr "فایل تنظیمات فعلی (%s) قابل خواندن نیست."
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "تنظمیات دسترسی اشتباه در فایل تنظیمات ، نباید قابل نوشتن جهانی باشد!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "اندازه فونت"
 
@@ -2550,8 +2550,8 @@ msgstr[0] "%1$s همتا در <strong>%2$s</strong>"
 msgstr[1] "%1$s همتا در <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2609,28 +2609,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr "اضافه يا حذف ستونها"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "شروع"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "قبلی"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "بعدی"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "انتها"
@@ -2818,9 +2818,9 @@ msgstr "انتخاب همه"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3009,9 +3009,9 @@ msgid "View"
 msgstr "نمایه"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3025,32 +3025,32 @@ msgid "Structure"
 msgstr "ساختار"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "جستجو"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "درج"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3059,20 +3059,20 @@ msgid "Privileges"
 msgstr "امتيازات"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "عمليات"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3088,74 +3088,74 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "پرس و جو"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "رویدادها"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "طرّاح"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "پايگاههاي داده"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "كاربر"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 #, fuzzy
 msgid "Binary log"
 msgstr "دودويي"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "تکرار"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 #, fuzzy
 msgid "Variables"
 msgstr "متغییر"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "موتور"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "خطا"
@@ -3181,7 +3181,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3409,7 +3409,7 @@ msgid "Operator"
 msgstr "عمليات"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3426,7 +3426,7 @@ msgstr "جستجو"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3438,7 +3438,7 @@ msgstr "درج"
 msgid "Select columns (at least one):"
 msgstr "ستونها را انتخاب نماييد (حداقل يكي)"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "يا"
@@ -3564,285 +3564,285 @@ msgstr "مسیر برای تم  %s یافت نشد!"
 msgid "Theme:"
 msgstr "تم"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "نسخه سرور"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "نسخه سرور"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 msgid "A polygon"
 msgstr "افزودن ستون جديد"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "ساخت فهرست جديد"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "خطوط منتهي به"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "جمع كل"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3929,69 +3929,69 @@ msgstr "%d %B %Y ساعت %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s روز ، %s ساعت ، %s دقیقه و %s ثانیه"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "پارامتر یافت نشد:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "پرش به پایگاه داده &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 "قابلیت %s به خاطر یک باگ شناخته شده تحت تاثیر قرار گرفته ایست، برای اطلاعات "
 "بیشتر به %s مراجعه کنید"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "برای انتخاب کلیک کنبد"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "رایانه خود را مشاهده نمایید:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "انتخاب از مسیر آپلود در سرور <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "پوشه‌اي را كه براي انتقال فايل انتخاب كرده‌ايد قابل دسترسي نيست"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "فایلی برای آپلود موجود نیست"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "خالي"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "اجرا"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "چاپ"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "ایجاد"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "آخرین به روز رسانی"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "آخرین بازدید"
@@ -4353,9 +4353,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "پاک سازی"
 
@@ -4640,7 +4640,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "ذخيره به صورت پرونده"
 
@@ -6931,7 +6931,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "اطلاعات نسخه"
 
@@ -7330,59 +7330,59 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "Select from the web server upload directory <b>%s</b>:"
 msgid "web server upload directory:"
 msgstr "انتخاب از مسیر آپلود در سرور <b>%s</b>:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "و سپس"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "درج به عنوان يك سطر جديد"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "برو به صفحه قبل"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "درج يك سطر جديد ديگر"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "برگرد به این صفحه"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "ویرایش کردن ردیف بعدی"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9579,25 +9579,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "جدول \"%s\" وجود ندارد!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "لطفا مختصات جدول %s را تنظيم كنيد"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -12262,7 +12262,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12522,7 +12522,7 @@ msgstr "تنظیمات از طریق حافظه مرورگر وارد خواهد
 msgid "You have no saved settings!"
 msgstr "شما تنظیمات ذخیره شده ای ندارید!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "این قابلیت توسط مرورگر وب شما پشتیبانی نمی شود"
 
@@ -12539,19 +12539,19 @@ msgstr ""
 "شما میتوانید تنظیمات بیشتری را از طریق config.inc.php , به طور مثال. با "
 "استفاده از %sSetup script%s ثبت کنید."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "ذخیره کردن در حافظه مرورگر"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "تنظیمات در حافظه مرورگر ذخیره خواهد شد."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "تنظیمات قبلی بازنویسی شدند!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "شما میتوانید تنظیمات خود را به حالت پیش فرض بازگردانید."
 
@@ -12581,6 +12581,10 @@ msgstr ""
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "نمايش الگوي(طرح) پايگاه داده"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:35+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Finnish <http://l10n.cihar.com/projects/phpmyadmin/master/fi/"
@@ -41,7 +41,7 @@ msgstr "Taulun kommentit:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Tyyppi"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr "Päivitetty"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Poista tämän taulun seurantatiedot"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -560,8 +560,8 @@ msgstr "Lisää geometria"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -587,7 +587,7 @@ msgstr "Lisää geometria"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Siirry"
@@ -961,7 +961,7 @@ msgstr "Lisää indeksi"
 msgid "Edit Index"
 msgstr "Muokkaa indeksiä"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Lisää indeksiin %s kolumni(a)"
@@ -1178,7 +1178,7 @@ msgid "Traffic"
 msgstr "Liikenne"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Asetukset"
 
@@ -1491,8 +1491,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1702,8 +1702,8 @@ msgstr "Näytä kyselykenttä"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1730,7 +1730,7 @@ msgstr "Kyselyn suoritusaika"
 msgid "%d is not valid row number."
 msgstr "%d on virheellinen rivinumero."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1799,8 +1799,8 @@ msgstr "Kyselyn tulokset"
 msgid "Data point content"
 msgstr "Tietopisteen sisältö"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Älä huomioi"
 
@@ -2362,7 +2362,7 @@ msgstr ""
 "Väärät pääsyasetukset asetustiedostolla, sen ei kuuluisi olla kaikkien "
 "kirjoitettavissa!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Fonttikoko"
 
@@ -2509,8 +2509,8 @@ msgstr[0] "%1$s hakutulosta taulussa <strong>%2$s</strong>"
 msgstr[1] "%1$s hakutulosta taulussa <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2566,28 +2566,28 @@ msgstr "Tallenna muokatut tiedot"
 msgid "Restore column order"
 msgstr "Palauta sarakkeiden järjestys"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Aloitus"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Edellinen sivu"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Seuraava sivu"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Viimeinen sivu"
@@ -2768,9 +2768,9 @@ msgstr "Valitse kaikki"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2963,9 +2963,9 @@ msgid "View"
 msgstr "Näkymä"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2979,32 +2979,32 @@ msgid "Structure"
 msgstr "Rakenne"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Etsi"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Lisää rivi"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3013,20 +3013,20 @@ msgid "Privileges"
 msgstr "Käyttöoikeudet"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Toiminnot"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Seuranta"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3042,70 +3042,70 @@ msgstr "Herättimet"
 msgid "Database seems to be empty!"
 msgstr "Tietokanta on tyhjä!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Haku"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutiinit"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Tapahtumat"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Suunnittelija"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Tietokannat"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Käyttäjät"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binääriloki"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Kahdennus"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Muuttujat"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Merkistöt"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Liitännäiset"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Moottorit"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Virhe"
@@ -3131,7 +3131,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d rivi lisätty."
 msgstr[1] "%1$d riviä lisätty."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3353,7 +3353,7 @@ msgid "Operator"
 msgstr "Operaattori"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3368,7 +3368,7 @@ msgstr "Taulu haku"
 msgid "Find and Replace"
 msgstr "Etsi ja Korvaa"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Muokkaa/lisää"
 
@@ -3376,7 +3376,7 @@ msgstr "Muokkaa/lisää"
 msgid "Select columns (at least one):"
 msgstr "Valitse sarakkeet (vähintään yksi):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Tai"
@@ -3487,14 +3487,14 @@ msgstr "Teeman %s polkua ei löydy!"
 msgid "Theme:"
 msgstr "Teema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "1-tavuinen kokonaisluku, etumerkillisenä arvot välillä -128 - 127, "
 "etumerkittömänä arvot välillä 0 - 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3502,7 +3502,7 @@ msgstr ""
 "2-tavuinen kokonaisluku, etumerkillisenä arvot olvat -32768 - 32767,  "
 "etumerkittömänä arvot ovat 0 - 65535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3510,7 +3510,7 @@ msgstr ""
 "3-tavuinen kokonaisluku, etumerkillisenä arvot ovat -8388608 - 8388607, "
 "etumerkittömänä arvot ovat 0 - 16777215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3518,7 +3518,7 @@ msgstr ""
 "4-tavuinen kokonaisluku, etumerkillisenä arvot ovat -2147483648 - "
 "2147483647, etumerkittämänä arvot ovat 0 - 4294967295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3526,7 +3526,7 @@ msgstr ""
 "8-tavuinen kokonaisluku, etumerkillisenä arvot ovat -9223372036854775808 - "
 "9223372036854775807, etumerkittämänä arvot ovat 0 - 18446744073709551615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3534,7 +3534,7 @@ msgstr ""
 "Desimaaliluku (M,D) - kokonaislukuosan numeroiden maksimäärä (M) on 65 "
 "(oletuksena 10), desimaaliosan numeroiden maksimäärä (D) on 30 (oletuksena 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3542,7 +3542,7 @@ msgstr ""
 "Pieni liukuluku, mahdolliset arvot ovat välillä -3.402823466E+38 - -"
 "1.175494351E-38, 0 ja 1.175494351E-38 - 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3552,7 +3552,7 @@ msgstr ""
 "1.7976931348623157E+308 - -2.2250738585072014E-308, 0, ja "
 "2.2250738585072014E-308 - 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3560,7 +3560,7 @@ msgstr ""
 "Synonyymi DOUBLE:lle (poikkeus: REAL_AS_FLOAT SQL moodissa se on synonyymi "
 "FLOAT:lle)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3568,7 +3568,7 @@ msgstr ""
 "Bittikenttä tyyppi (M), sisältää M verran bittejä arvoa kohti (oletuksena on "
 "1, maksimi on 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3576,21 +3576,21 @@ msgstr ""
 "Synonyymi TINYINT(1), arvo nolla ilmoitetaan false, muut arvot ilmoitetaan "
 "true"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Alias arvolle BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Päiväys, pitää olla välillä %1$s - %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Päivämäärän ja ajan yhdistelmä, tuettu alue on %1$s - %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3598,12 +3598,12 @@ msgstr ""
 "Aikaleima, alue on 1970-01-01 00:00:01 UTC 01.09.2038 03:14:07 UTC, "
 "tallentaa monta sekunteina, koska aikakausi on (1970-01-01 00:00:00 UTC )"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Aika, mahdollinen välillä %1$s - %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3611,7 +3611,7 @@ msgstr ""
 "Vuosi on nelinumeroinen (4, oletus) tai kaksinumeroinen (2) muodossa, "
 "sallitut arvot ovat 70 (1970), 69 (2069) tai 1901-2155 ja 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3619,7 +3619,7 @@ msgstr ""
 "Pituudeltaan (0-255, oletus 1) merkkijono, johon on lisätty välilyöntejä "
 "määrittämään pituutta tallennettuna"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3627,7 +3627,7 @@ msgid ""
 msgstr ""
 "Vaihtelevan pituinen (%s) merkkijono, tehokas enimmäispituus on enimmäisarvo"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3635,7 +3635,7 @@ msgstr ""
 "A TEXT sarakkeen enimmäispituus 255 (2 ^ 8 - 1) merkkiä, tallennettu "
 "yksitavuisena etuliitteenä, joka osoittaa arvon pituuden tavuina"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3643,7 +3643,7 @@ msgstr ""
 "A TEXT sarakkeen enimmäispituus 65,535 (2^16-1) merkkiä, tallennettu "
 "kaksitavuisena etuliitteenä, joka osoittaa arvon pituuden tavuina"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3651,7 +3651,7 @@ msgstr ""
 "A TEXT sarakkeen enimmäispituus 16,777,215 (2^24-1) merkkiä, tallennettu "
 "kolmen tavun etuliitteenä, joka osoittaa arvon pituuden tavuina"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3660,7 +3660,7 @@ msgstr ""
 "A TEXT sarakkeen enimmäispituus 4,294,967,295 tai 4GiB (2^32-1) merkkiä, "
 "tallennetaan neljän tavun etuliirteenä, joka osoittaa arvon pituuden tavuina"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3668,7 +3668,7 @@ msgstr ""
 "Samanlainen kuin CHAR tyyppi, mutta tallentaa binaariset merkkijonot "
 "mieluummin kuin ei binaariset merkkijonot"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3676,7 +3676,7 @@ msgstr ""
 "Samanlainen kuin VARCHAR tyyppi, mutta tallentaa binaariset merkkijonot "
 "mieluummin ei binaariset merkkijonot"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3684,7 +3684,7 @@ msgstr ""
 "A BLOB sarakkeen enimmäispituus 255 (2^8-1) tavua, tallennettu yksitavuisena "
 "etuliitteenä, joka ilmaisee arvon pituuden"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3692,7 +3692,7 @@ msgstr ""
 "A BLOB sarakkeen enimmäispituus 16,777,215 (2^24-1) tavua, tallennetaan "
 "kolmen tavun etuliiteenä, joka ilmaisee arvon pituuden"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3700,7 +3700,7 @@ msgstr ""
 "A BLOB sarakkeen enimmäispituus 65,535 (2^16-1) tavua, tallennettu "
 "kaksitavuisena etuliiteenä, joka ilmaisee arvon pituuden"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3708,74 +3708,74 @@ msgstr ""
 "A BLOB sarakkeen enimmäispituus 4,294,967,295 tai 4GiB (2^32-1) tavua, "
 "varastoitu nelitavuisena etuliiteenä, joka ilmaisee arvon pituuden"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 "Luettelo, listalta valittu jopa 65,535 arvoa tai erityinen \" virhe arvo"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Yksittäinen arvo, joka on valittu 64 jäsenen joukosta"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Tyyppi, joka voi tallentaa mitä tahansa geometriaa"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Kohta 2-ulotteisessa avaruudessa"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Käyrän pisteiden välisen lineaarinen interpolointi"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Monikulmio"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Kokoelma pisteitä"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Käyrien pisteiden välisen lineaarisen interpolointi kokoelma"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Kokoelma polygoneja"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Kokoelma mitä tahansa geometrisiä objekteja"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Lukuarvo"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Päiväys ja aika"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Merkkijono"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Geometrinen"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "4 tavun kokonaisluku, alue on -2,147,483,648 - 2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3783,23 +3783,23 @@ msgstr ""
 "8 tavun kokonaisluku, alue on -9,223,372,036,854,775,808 - "
 "9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Järjestelmän oletus, kaksinkertaisen tarkkuuden liukuluku"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "True tai false"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Alias arvolle BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Tallentaa maailmanlaajuista yksilöllistä tunnistetta (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3807,7 +3807,7 @@ msgstr ""
 "Aikaleima, alue on '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' UTC; "
 "TIMESTAMP(6) voi tallentaa mikrosekuntia"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3815,7 +3815,7 @@ msgstr ""
 "Vaihteleva pituus (0-65,535) merkkijono, käyttää binaarista lajittelua "
 "kaikissa vertailuissa"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Luettelointi, valittu määritetyt arvot luettelosta"
 
@@ -3900,67 +3900,67 @@ msgstr "%d.%m.%Y klo %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s päivää, %s tuntia, %s minuuttia ja %s sekuntia"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Puuttuva parametri:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Siirry tietokantaan &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Toimintoon %s vaikuttaa tunnettu vika, katso %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Vaihda painamalla"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Selaa tietokonettasi:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Valitse verkkopalvelimen lähetyskansiosta <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Tiedostojen lähetykseen valittua hakemistoa ei voida käyttää."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Lähetettäviä tiedostoja ei ole"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Tyhjennä"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Suorita"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Tulosta"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Luotu"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Viimeksi päivitetty"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Viimeksi tarkistettu"
@@ -4314,9 +4314,9 @@ msgstr "Anna käyttäjien mukauttaa tätä arvoa"
 msgid "Apply"
 msgstr "Käytä"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Palauta"
 
@@ -4623,7 +4623,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Suorituksen enimmäiskesto"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Tallenna tiedostoon"
 
@@ -6983,7 +6983,7 @@ msgstr "Tiedostoa käsitellään, ole kärsivällinen."
 msgid "Language"
 msgstr "Kieli"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Versiotiedot"
 
@@ -7420,63 +7420,63 @@ msgstr "Koska sen pituus, <br/> Tätä saraketta ei ehkä voi muokata"
 msgid "Binary - do not edit"
 msgstr "Binääritietoa - älä muokkaa"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "palvelimen lähetyshakemisto"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Aloita lisäys alusta %s rivillä"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "ja sen jälkeen"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Lisää uutena rivinä"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 #, fuzzy
 msgid "Show insert query"
 msgstr "Näytetään SQL-kysely"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Takaisin"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Lisää uusi rivi"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Palaa tälle sivulle"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Muokkaa seuraavaa riviä"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Sarkaimella voi siirtyä arvosta seuraavaan, Ctrl- ja nuolinäppäimillä pystyy "
 "siirtymään minne suuntaan tahansa."
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Näytetään SQL-kysely"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Lisätyn rivin tunnus: %1$d"
@@ -9820,25 +9820,25 @@ msgid "There are no events to display."
 msgstr "Lähetettäviä tiedostoja ei ole"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Taulua \"%s\" ei ole!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Määrittele koordinaatit taululle %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12743,7 +12743,7 @@ msgstr "Versio %s on luotu, kohteen %s.%s seuranta on käytössä."
 msgid "Manage your settings"
 msgstr "Muut ydinasetukset"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13026,7 +13026,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Muut ydinasetukset"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13043,19 +13043,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13085,6 +13085,10 @@ msgstr "Ei tietokantoja"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Näytä tietokannoista vedos (skeema)"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -3,14 +3,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin-docs 4.0.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 22:30+0200\n"
 "Last-Translator: Marc Delisle <marc@infomarc.info>\n"
-"Language-Team: French <http://l10n.cihar.com/projects/phpmyadmin/master/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <http://l10n.cihar.com/projects/phpmyadmin/master/fr/"
+">\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -40,7 +41,7 @@ msgstr "Commentaires sur la table : "
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -86,7 +87,7 @@ msgid "Type"
 msgstr "Type"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -335,7 +336,7 @@ msgid "Updated"
 msgstr "Mis à jour"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -363,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Supprimer les données de suivi de cette table"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -567,8 +568,8 @@ msgstr "Ajouter géométrie"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -594,7 +595,7 @@ msgstr "Ajouter géométrie"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Exécuter"
@@ -974,7 +975,7 @@ msgstr "Ajouter Index"
 msgid "Edit Index"
 msgstr "Modifier un index"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Ajouter %s colonne(s) à l'index"
@@ -1191,7 +1192,7 @@ msgid "Traffic"
 msgstr "Trafic"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Paramètres"
 
@@ -1508,8 +1509,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1719,8 +1720,8 @@ msgstr "Montrer zone SQL"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1747,7 +1748,7 @@ msgstr "Durée d'exécution de la requête"
 msgid "%d is not valid row number."
 msgstr "%d n'est pas un numéro de ligne valable."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1819,8 +1820,8 @@ msgstr "Opérations sur les résultats"
 msgid "Data point content"
 msgstr "Données reliées à ce point"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorer"
 
@@ -2380,7 +2381,7 @@ msgstr ""
 "Permissions sur le fichier de configuration incorrectes, il ne doit pas être "
 "en écriture pour tout le monde !"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Taille du texte"
 
@@ -2528,8 +2529,8 @@ msgstr[0] "%1$s correspondance dans <strong>%2$s</strong>"
 msgstr[1] "%1$s correspondances dans <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2585,28 +2586,28 @@ msgstr "Sauvegarder les données modifiées"
 msgid "Restore column order"
 msgstr "Restaurer l'ordre des colonnes"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Début"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Précédent"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Suivant"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Fin"
@@ -2784,9 +2785,9 @@ msgstr "Tout cocher"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2980,9 +2981,9 @@ msgid "View"
 msgstr "Vue"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2996,32 +2997,32 @@ msgid "Structure"
 msgstr "Structure"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Rechercher"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Insérer"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3030,20 +3031,20 @@ msgid "Privileges"
 msgstr "Privilèges"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Opérations"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Suivi"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3059,70 +3060,70 @@ msgstr "Déclencheurs"
 msgid "Database seems to be empty!"
 msgstr "La base de données semble vide !"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Requête"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Procédures stockées"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Événements"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Concepteur"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Bases de données"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Utilisateurs"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Log binaire"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Réplication"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variables"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Jeux de caractères"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Moteurs"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Erreur"
@@ -3148,7 +3149,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d ligne insérée."
 msgstr[1] "%1$d lignes insérées."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3371,7 +3372,7 @@ msgid "Operator"
 msgstr "Opérateur"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3386,7 +3387,7 @@ msgstr "Recherche dans la table"
 msgid "Find and Replace"
 msgstr "Chercher et remplacer"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Modifier/Insérer"
 
@@ -3394,7 +3395,7 @@ msgstr "Modifier/Insérer"
 msgid "Select columns (at least one):"
 msgstr "Choisir les colonnes (au moins une) : "
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Ou"
@@ -3506,14 +3507,14 @@ msgstr "Chemin non trouvé pour le thème %s !"
 msgid "Theme:"
 msgstr "Thème : "
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Un nombre entier de 1 octet. La fourchette des nombres avec signe est de -"
 "128 à 127. Pour les nombres sans signe, c'est de 0 à 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3521,7 +3522,7 @@ msgstr ""
 "Un nombre entier de 2 octets. La fourchette des nombres avec signe est de -"
 "32 768 à 32 767. Pour les nombres sans signe, c'est de 0 à 65 535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3529,7 +3530,7 @@ msgstr ""
 "Un nombre entier de 3 octets. La fourchette des nombres avec signe est de -8 "
 "388 608 à 8 388 607. Pour les nombres sans signe, c'est de 0 à 16 777 215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3538,7 +3539,7 @@ msgstr ""
 "147 483 648 à 2 147 483 647. Pour les entiers positifs, c'est de 0 à 4 294 "
 "967 295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3547,7 +3548,7 @@ msgstr ""
 "223 372 036 854 775 808 à 9 223 372 036 854 775 807. Pour les nombres sans "
 "signe, c'est de 0 à 18 446 744 073 709 551 615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3556,7 +3557,7 @@ msgstr ""
 "65 (10 par défaut), le nombre maximum de décimales (D) est de 30 (0 par "
 "défaut)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3564,7 +3565,7 @@ msgstr ""
 "Un petit nombre en virgule flottante, la fourchette des valeurs est -"
 "3.402823466E+38 à -1.175494351E-38, 0, et 1.175494351E-38 à 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3574,7 +3575,7 @@ msgstr ""
 "est -1.7976931348623157E+308 à -2.2250738585072014E-308, 0, et "
 "2.2250738585072014E-308 à 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3582,7 +3583,7 @@ msgstr ""
 "Synonyme de DOUBLE (exception : dans le mode SQL REAL_AS_FLOAT, c'est un "
 "synonyme de FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3590,7 +3591,7 @@ msgstr ""
 "Une colonne contenant des bits (M), stockant M bits par valeur (1 par "
 "défaut, maximum 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3598,21 +3599,21 @@ msgstr ""
 "Un synonyme de TINYINT(1), une valeur de zéro signifie faux, une valeur non-"
 "zéro signifie vrai"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un alias pour BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Une date, la fourchette est de «%1$s» à «%2$s»"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Une combinaison date et heure, la fourchette est de «%1$s» à «%2$s»"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3621,12 +3622,12 @@ msgstr ""
 "01-09 03:14:07» UTC, en nombre de secondes depuis le moment de référence "
 "(«1970-01-01 00:00:00» UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Une heure, la fourchette est de «%1$s» à «%2$s»"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3634,7 +3635,7 @@ msgstr ""
 "Une année à quatre chiffres (4 par défaut) ou à deux chiffres (2), la "
 "fourchette est de 70 (1970) à 69 (2069) ou 1901 à 2155 ainsi que 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3642,7 +3643,7 @@ msgstr ""
 "Une chaîne de longueur fixe (0-255, 1 par défaut) qui est toujours complétée "
 "à droite par des espaces lorsqu'enregistrée"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3651,7 +3652,7 @@ msgstr ""
 "Une chaîne de longueur variable (%s), la longueur effective réelle dépend de "
 "la taille maximum d'une ligne"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3660,7 +3661,7 @@ msgstr ""
 "stockée avec un préfixe d'un octet indiquant la longueur de la valeur en "
 "octets"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3669,7 +3670,7 @@ msgstr ""
 "stockée avec un préfixe de deux octets indiquant la longueur de la valeur en "
 "octets \t"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3678,7 +3679,7 @@ msgstr ""
 "stockée avec un préfixe de trois octets indiquant la longueur de la valeur "
 "en octets"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3688,7 +3689,7 @@ msgstr ""
 "caractères, stockée avec un préfixe de quatre octets indiquant la longueur "
 "de la valeur en octets"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3696,7 +3697,7 @@ msgstr ""
 "Similaire au type CHAR, mais stocke des chaînes binaires au lieu de chaînes "
 "non binaires"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3704,7 +3705,7 @@ msgstr ""
 "Similaire au type VARCHAR, mais stocke des chaînes binaires au lieu de "
 "chaînes non binaires"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3712,7 +3713,7 @@ msgstr ""
 "Une colonne BLOB d'une longueur maximum de 255 (2^8 - 1) octets, stockée "
 "avec un préfixe d'un octet indiquant la longueur de la valeur"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3720,7 +3721,7 @@ msgstr ""
 "Une colonne BLOB d'une longueur maximum de 16 777 215 (2^24 - 1) octets, "
 "stockée avec un préfixe de trois octets indiquant la longueur de la valeur"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3728,7 +3729,7 @@ msgstr ""
 "Une colonne BLOB d'une longueur maximum de 65 535 (2^16 - 1) octets, stockée "
 "avec un préfixe de quatre octets indiquant la longueur de la valeur"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3736,7 +3737,7 @@ msgstr ""
 "Une colonne BLOB d'une longueur maximum de 4 294 967 295 ou 4GiB (2^32 - 1), "
 "stockée avec un préfixe de quatre octets indiquant la longueur de la valeur"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3744,71 +3745,71 @@ msgstr ""
 "Une énumération, choisie parmi une liste comportant jusqu'à 65 535 valeurs "
 "ou la valeur spéciale '' indiquant une erreur"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 "Une valeur unique choisie parmi un ensemble comportant jusqu'à 64 membres"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Un type pouvant stocker une valeur géométrique de tout type"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Un point dans un espace à deux dimensions"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Une courbe avec une interpolation linéaire entre les points"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Un polygone"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Une collection de points"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 "Une collection de courbes avec l'interpolation linéaire entre les points"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Une collection de polygones"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Une collection d'objets de géométrie de tout type"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numérique"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Contient la date et l'heure"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Chaîne de caractères"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Spatial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 "Un nombre entier de 4 octets, avec une fourchette de -2 147 483 648 à 2 147 "
 "483 647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3816,24 +3817,24 @@ msgstr ""
 "Un nombre entier de 8 octets, avec une fourchette de -9 223 372 036 854 775 "
 "808 à 9 223 372 036 854 775 807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 "Une nombre à virgule flottante double précision du type par défaut du système"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Vrai ou faux"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un alias pour BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Contient un identificateur universellement unique (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3841,7 +3842,7 @@ msgstr ""
 "Une colonne d'horodatage, la fourchette est de «0001-01-01 00:00:00» UTC à "
 "«9999-12-31 23:59:59» UTC; TIMESTAMP(6) peut stocker des microsecondes"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3849,7 +3850,7 @@ msgstr ""
 "Une chaîne de longueur variable (0 - 65 535), utilise un interclassement "
 "binaire pour toutes les comparaisons"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Une énumération, choisie parmi la liste de valeurs définies"
 
@@ -3934,68 +3935,68 @@ msgstr "%A %d %B %Y à %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s jours, %s heures, %s minutes et %s secondes"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Paramètre manquant : "
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Aller à la base de données &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "La fonctionnalité %s est affectée par une anomalie connue, voir %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Cliquer pour basculer"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Parcourir : "
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 "Choisissez depuis le répertoire de téléchargement du serveur web <b>%s</b> : "
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Le répertoire de transfert est inaccessible."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Aucun fichier n'est disponible pour le transfert"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Vider"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Exécuter"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Imprimer"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Création"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Dernière modification"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Dernière vérification"
@@ -4356,9 +4357,9 @@ msgstr "Permettre aux utilisateurs de personnaliser cette valeur"
 msgid "Apply"
 msgstr "Appliquer"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Réinitialiser"
 
@@ -4667,7 +4668,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Durée maximum d'exécution"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Transmettre"
 
@@ -7097,7 +7098,7 @@ msgstr "Le fichier est en traitement, veuillez patienter."
 msgid "Language"
 msgstr "Langue"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Version"
 
@@ -7550,59 +7551,59 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Binaire - ne pas éditer"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "répertoire de transfert du serveur web : "
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Continuer l'insertion avec %s lignes"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "et ensuite"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Sauvegarder une nouvelle ligne"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Sauvegarder une nouvelle ligne en ignorant les erreurs"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Afficher l'énoncé d'insertion"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Retourner à la page précédente"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Insérer une nouvelle ligne"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Demeurer sur cette page"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Modifier la ligne suivante"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Utilisez la tabulation pour aller d'une valeur à l'autre, ou CTRL+flèches "
 "pour aller n'importe où"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Affichage de la requête SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Identifiant de la ligne insérée : %1$d"
@@ -7934,7 +7935,6 @@ msgid "Database operations"
 msgstr "Opérations sur base de données"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Montrer les éléments cachés"
 
@@ -9760,24 +9760,24 @@ msgid "There are no events to display."
 msgstr "Aucun évènement à afficher."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "La table %s n'existe pas !"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Les coordonnées de la table %s n'ont pas été configurées"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Schéma de la base %s - Page %s"
@@ -12494,7 +12494,7 @@ msgstr "Version %1$s créée, le suivi pour %2$s est activé."
 msgid "Manage your settings"
 msgstr "Gérer vos paramètres"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "La configuration a été sauvegardée"
 
@@ -12751,7 +12751,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Vous n'avez pas sauvegardé les paramètres !"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Cette fonction n'est pas supportée par votre navigateur"
 
@@ -12768,21 +12768,21 @@ msgstr ""
 "Vous pouvez régler d'autres paramètres en modifiant config.inc.php, par "
 "exemple au moyen du %sscript d'installation%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Sauvegarder dans l'espace de stockage du navigateur"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 "Les paramètres seront sauvegardés dans l'espace de stockage de votre "
 "navigateur."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Les paramètres existants seront écrasés !"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "Vous pouvez ramener tous vos paramètres à leur valeur par défaut."
 
@@ -12810,6 +12810,10 @@ msgstr "Aucune base de données"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Schéma et/ou contenu des bases de données"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -12813,7 +12813,7 @@ msgstr "Schéma et/ou contenu des bases de données"
 
 #: server_privileges.php:142
 msgid "Username and hostname didn't change."
-msgstr ""
+msgstr "Ni le code utilisateur ni le nom du serveur n'ont été modifiés."
 
 #: server_status.php:32
 #, php-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:40+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Galician <http://l10n.cihar.com/projects/phpmyadmin/master/gl/"
@@ -41,7 +41,7 @@ msgstr "Comentarios da táboa:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Tipo"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr "Actualizada"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Eliminar os datos de seguimento desta táboa"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -560,8 +560,8 @@ msgstr "Engadir xeometría"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -587,7 +587,7 @@ msgstr "Engadir xeometría"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Ir"
@@ -972,7 +972,7 @@ msgstr "Engadir un índice"
 msgid "Edit Index"
 msgstr "Editar o índice"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Engadir %s columna(s) ao índice"
@@ -1189,7 +1189,7 @@ msgid "Traffic"
 msgstr "Tráfico"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Configuración"
 
@@ -1506,8 +1506,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1716,8 +1716,8 @@ msgstr "Mostrar a caixa de consultas"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1744,7 +1744,7 @@ msgstr "Tempo de execución da consulta"
 msgid "%d is not valid row number."
 msgstr "%d non é un número de fileira válido."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1814,8 +1814,8 @@ msgstr "Resultados da consulta"
 msgid "Data point content"
 msgstr "Contido do punto de datos"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorar"
 
@@ -2382,7 +2382,7 @@ msgstr ""
 "Os permisos do ficheiro de configuración son incorrectos; non debería poder "
 "escribir nel todo o mundo!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Tamaño da letra"
 
@@ -2529,8 +2529,8 @@ msgstr[0] "%1$s coincidencia en <strong>%2$s</strong>"
 msgstr[1] "%1$s coincidencias en <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2586,28 +2586,28 @@ msgstr "Gardar os datos editados"
 msgid "Restore column order"
 msgstr "Restaurar orde das columnas"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Inicio"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Anterior"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Seguinte"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Fin"
@@ -2788,9 +2788,9 @@ msgstr "Marcalos todos"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2985,9 +2985,9 @@ msgid "View"
 msgstr "Vista"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3001,32 +3001,32 @@ msgid "Structure"
 msgstr "Estrutura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Buscar"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Inserir"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3035,20 +3035,20 @@ msgid "Privileges"
 msgstr "Privilexios"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operacións"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Seguimento"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3064,70 +3064,70 @@ msgstr "Disparadores"
 msgid "Database seems to be empty!"
 msgstr "Parece ser que a táboa está baleira!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Consulta"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutinas"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Acontecementos"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Deseñador"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Bases de datos"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Usuarios"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Rexistro binario"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replicación"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variábeis"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Conxuntos de caracteres"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Engadidos"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motores"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Produciuse un erro"
@@ -3153,7 +3153,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d fila inserida."
 msgstr[1] "%1$d filas inseridas."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3376,7 +3376,7 @@ msgid "Operator"
 msgstr "Operador"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3391,7 +3391,7 @@ msgstr "Busca na táboa"
 msgid "Find and Replace"
 msgstr "Buscar e substituír"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Editar/Inserir"
 
@@ -3399,7 +3399,7 @@ msgstr "Editar/Inserir"
 msgid "Select columns (at least one):"
 msgstr "Escolla os campos (mínimo un):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "ou"
@@ -3511,14 +3511,14 @@ msgstr "Non se atopou a ruta do tema para o tema %s!"
 msgid "Theme:"
 msgstr "Tema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Un enteiro de un byte; o intervalo asinado é desde -128 até 127; o intervalo "
 "sen asinar é desde 0 até 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3526,7 +3526,7 @@ msgstr ""
 "Un enteiro de dous bytes; o intervalo asinado é desde -32.768 até 32.767; o "
 "intervalo sen asinar é desde 0 até 65.535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3534,7 +3534,7 @@ msgstr ""
 "Un enteiro de tres bytes; o intervalo asinado é desde -8.388.608 até "
 "8.388.607; o intervalo sen asinar é desde 0 até 16.777.215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3542,7 +3542,7 @@ msgstr ""
 "Un enteiro de catro bytes; o intervalo asinado é desde -2.147.483.648 até "
 "2.147.483.647; o intervalo sen asinar é desde 0 até 4.294.967.295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3551,7 +3551,7 @@ msgstr ""
 "9.223.372.036.854.775.808 até 9.223.372.036.854.775.807; o intervalo sen "
 "asinar é desde 0 até 18.446.744.073.709.551.615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3559,7 +3559,7 @@ msgstr ""
 "Un número de punto fixo (M, D) - o número máximo de díxitos (M) é 65 (por "
 "omisión, 10); o número máximo de decimais (D) é 30 (por omisión, 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3567,7 +3567,7 @@ msgstr ""
 "Un número de vírgula flutuante pequeno; os valores permitidos son -"
 "3,402823466E+38 até -1,175494351E-38, 0 e 1,175494351E-38 até 3,402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3577,7 +3577,7 @@ msgstr ""
 "1,7976931348623157E+308 até -2,2250738585072014E-308, 0 e2,2250738585072014E-"
 "308 até 1,7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3585,7 +3585,7 @@ msgstr ""
 "Sinónimo de DOUBLE (excepción: no modo de SQL REAL_AS_FLOAT é sinónimo de "
 "FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3593,7 +3593,7 @@ msgstr ""
 "Un tipo de campo de bits (M) que almacena M bits por valor (por omisión é 1; "
 "o máximo é 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3601,22 +3601,22 @@ msgstr ""
 "Un sinónimo de TINYINT(1); o valor cero considérase falso; os valores "
 "diferentes de cero considéranse verdadeiros"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un alias de BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Unha data; o intervalo aceptado é desde %1$s até %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 "Unha combinación de data e hora; o intervalo aceptado é desde %1$s até %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3625,12 +3625,12 @@ msgstr ""
 "09 03:14:07 UTC, almacenado como o número de segundos desde a época (1970-01-"
 "01 00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Unha hora; o intervalo é desde %1$s até %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3638,7 +3638,7 @@ msgstr ""
 "Un ano nos formatos de catro díxitos (4, por omisión) ou dous díxitos (2); "
 "os valores permitidos son 70 (1970) a 69 (2069) ou 1901 a 2155 e 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3646,7 +3646,7 @@ msgstr ""
 "Unha cadea de lonxitude fixa (0-255, 1 por omisión) que sempre se enche á "
 "dereita con espazos até a lonxitude indicada cando se almacena"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3655,7 +3655,7 @@ msgstr ""
 "Unha cadea de lonxitude variábel (%s); a lonxitude efectiva máxima está "
 "suxeita ao tamaño máximo da fileira"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3663,7 +3663,7 @@ msgstr ""
 "Unha columna tipo TEXTO cunha lonxitude máxima de 255 (2^8 - 1) caracteres, "
 "almacenada nun prefixo de un byte que indica a lonxitude do valor en bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3672,7 +3672,7 @@ msgstr ""
 "caracteres, almacenada nun prefixo de un byte que indica a lonxitude do "
 "valor en bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3681,7 +3681,7 @@ msgstr ""
 "caracteres, almacenada nun prefixo de un byte que indica a lonxitude do "
 "valor en bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3691,7 +3691,7 @@ msgstr ""
 "(2^32 - 1) caracteres, almacenada nun prefixo de un byte que indica a "
 "lonxitude do valor en bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3699,7 +3699,7 @@ msgstr ""
 "Semellante ao tipo CHAR, mais almacena cadeas de bytes binarios no canto de "
 "cadeas de caracteres non binarios"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3707,7 +3707,7 @@ msgstr ""
 "Semellante ao tipo VARCHAR, mais almacena cadeas de bytes binarios no canto "
 "de cadeas de caracteres non binarios"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3715,7 +3715,7 @@ msgstr ""
 "Unha columna tipo BLOB cunha lonxitude máxima de 255 (2^8 - 1) bytes, "
 "almacenada nun prefixo de un byte que indica a lonxitude do valor"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3723,7 +3723,7 @@ msgstr ""
 "Unha columna tipo BLOB cunha lonxitude máxima de 16,777,215 (2^24 - 1) "
 "bytes, almacenada nun prefixo de tres bytes que indica a lonxitude do valor"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3731,7 +3731,7 @@ msgstr ""
 "Unha columna tipo BLOB cunha lonxitude máxima de 65,535 (2^16 - 1) bytes, "
 "almacenada nun prefixo de dous bytes que indica a lonxitude do valor"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3740,7 +3740,7 @@ msgstr ""
 "(2^32 - 1)  bytes, almacenada nun prefixo de catro bytes que indica a "
 "lonxitude do valor"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3748,69 +3748,69 @@ msgstr ""
 "Unha enumeración escollida da lista de até 65.535 valores do valor especial "
 "''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Un único valor escollido dun conxunto de até 64 membros"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Un tipo que pode almacenar unha xeometría de calquera tipo"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Un punto nun espacio bidimensonal"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Unha curva con interpolación lineal entre puntos"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Un polígono"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Unha colección de puntos"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Unha colección de curvas con interpolación lineal entre puntos"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Unha colección de polígonos"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Unha colección de obxectos xeométricos de calquera tipo"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numérico"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Data e hora"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Cadea"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Espacial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 "Un enteiro de catro bytes; o intervalo é desde -2,147,483,648 até "
 "2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3818,24 +3818,24 @@ msgstr ""
 "Un enteiro de oito bytes; o intervalo é desde -9,223,372,03,6,854,775,808 "
 "até 9,223,372,03,6,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 "Un número de vírgula flotante de dupla precisión por omisión do sistema"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Verdadeiro ou falso"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un alias de BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Almacena un identificador único universal (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3843,7 +3843,7 @@ msgstr ""
 "Unha marca temporal; o intervalo é desde «0000-01-01 00:00:01» UTC até «9999-"
 "12-31 23:59:59» UTC; TIMESTAMP(6) pode almacenar microsegundos"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3851,7 +3851,7 @@ msgstr ""
 "Unha cadea de lonxitude variábel (0-65.535); emprega colación binaria para "
 "todas as comparacións"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Unha enumeración escollida da lista de valores definidos"
 
@@ -3936,67 +3936,67 @@ msgstr "%d de %B de %Y ás %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s días, %s horas, %s minutos e %s segundos"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Parámetro que falta:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Ir á base de datos &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "A función %s vese afectada por un erro descoñecido; consulte %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Prema para conmutar"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Examinar o computador:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Escoller o directorio de subida do servidor web <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Non é posíbel acceder ao directorio que designou para os envíos."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Non hai ficheiros para subir"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Baleirar"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Executar"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Imprimir"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Creación"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Última actualización"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Última revisión"
@@ -4354,9 +4354,9 @@ msgstr "Permitir que os usuarios personalicen este valor"
 msgid "Apply"
 msgstr "Aplicar"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Reiniciar"
 
@@ -4676,7 +4676,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Tempo máximo de execución"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Enviar <i>(gravar nun ficheiro)</i><br />"
 
@@ -7155,7 +7155,7 @@ msgstr "Estase a procesar o ficheiro; teña paciencia, por favor."
 msgid "Language"
 msgstr "Lingua"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Información sobre a versión"
 
@@ -7602,59 +7602,59 @@ msgstr "Por causa da súa lonxitude,<br /> este campo pode non ser editábel"
 msgid "Binary - do not edit"
 msgstr "Binario - non editar"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "directorio de recepción do servidor web:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Continuar a inserción con %s fileiras"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "e despois"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Inserir unha columna nova"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Inserir como fila nova e ignorar os erros"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Mostrar a consulta de inserción"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Volver para páxina anterior"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Inserir un rexistro novo"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Volver para esta páxina"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Modificar a fileira seguinte"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Use a tecla do tabulador para moverse de valor en valor ou a tecla CONTROL "
 "combinada cunha frecha para moverse a calquera sitio"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Mostrar a consulta de SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Identificador da fileira inserida: %1$d"
@@ -9841,24 +9841,24 @@ msgid "There are no events to display."
 msgstr "Non hai acontecementos que mostrar."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Non existe a táboa %s!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Configure as coordenadas da táboa %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Esquema da base de datos %s - Páxina %s"
@@ -12598,7 +12598,7 @@ msgstr "Creouse a versión %1$s; activouse o seguimento de %2$s."
 msgid "Manage your settings"
 msgstr "Xestionar a configuración"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Gardouse a configuración"
 
@@ -12852,7 +12852,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Non ten opcións gardadas!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Esta característica non está admitida por este navegador"
 
@@ -12869,19 +12869,19 @@ msgstr ""
 "Pode configurar máis opcións modificando config.inc.php, p.ex. usando o %"
 "sScript de configuración%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Gardar no almacenamento do navegador"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "A configuración será gardada no almacenamento do navegador."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "A configuración existente será substituída!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "Pode reiniciar a configuración e restaurar os valores predeterminados."
 
@@ -12909,6 +12909,10 @@ msgstr "Non hai ningunha base de datos"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Ver o  envorcado das bases de datos"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/he.po
+++ b/po/he.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-10-28 14:45+0200\n"
 "Last-Translator: Luz Paz <david.yoga@gmail.com>\n"
 "Language-Team: Hebrew <http://l10n.cihar.com/projects/phpmyadmin/master/he/"
@@ -40,7 +40,7 @@ msgstr "הערות לטבלה:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -86,7 +86,7 @@ msgid "Type"
 msgstr "סוג"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -333,7 +333,7 @@ msgid "Updated"
 msgstr "עודכנה"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -361,7 +361,7 @@ msgid "Delete tracking data for this table"
 msgstr "מחיקת נתוני המעקב לטבלה זו"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -555,8 +555,8 @@ msgstr "הוספת פני שטח"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -582,7 +582,7 @@ msgstr "הוספת פני שטח"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "ביצוע"
@@ -948,7 +948,7 @@ msgstr "הוספת אינדקס"
 msgid "Edit Index"
 msgstr "עריכת האינדקס"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "הוספת %s עמודות לאינדקס"
@@ -1170,7 +1170,7 @@ msgid "Traffic"
 msgstr "תעבורה"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1504,8 +1504,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1757,8 +1757,8 @@ msgstr "שאילתת SQL"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1785,7 +1785,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr "%d הוא לא מספר שורה תקין."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1866,8 +1866,8 @@ msgstr "תוצאת SQL"
 msgid "Data point content"
 msgstr "תוכן עניניים"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "התעלמות"
 
@@ -2484,7 +2484,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2645,8 +2645,8 @@ msgstr[0] "תוצאה אחת (%1$s) בטבלה <i>%2$s</i>"
 msgstr[1] "%1$s תוצאות בטבלה <i>%2$s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2705,16 +2705,16 @@ msgstr "תיקיית בית של נתונים"
 msgid "Restore column order"
 msgstr "הוספת/מחיקת עמודות שדה"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "התחלה"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2722,8 +2722,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "הקודם"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2731,8 +2731,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "הבא"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2924,9 +2924,9 @@ msgstr "סימון הכול"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3119,9 +3119,9 @@ msgid "View"
 msgstr "תצוגה"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3135,32 +3135,32 @@ msgid "Structure"
 msgstr "מבנה"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "חיפוש"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "הכנסה"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3169,20 +3169,20 @@ msgid "Privileges"
 msgstr "הרשאות"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "פעולות"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3198,72 +3198,72 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "שאילתה"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "מאגרי נתונים"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "משתמש"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "דו\"ח בינארי"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "שכפול"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "משתנים"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "קידודים"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "מנועים"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "שגיאה"
@@ -3291,7 +3291,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "לא נבחרו שורות"
 msgstr[1] "לא נבחרו שורות"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3518,7 +3518,7 @@ msgid "Operator"
 msgstr "פעולות"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3535,7 +3535,7 @@ msgstr "חיפוש"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3547,7 +3547,7 @@ msgstr "הכנסה"
 msgid "Select columns (at least one):"
 msgstr "בחירת שדות (לפחות אחד):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "או"
@@ -3671,286 +3671,286 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "גרסת שרת"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "גרסת שרת"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add a polygon"
 msgid "A polygon"
 msgstr "הוספת מצולע"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "יצירת אינדקס חדש"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Linestring"
 msgctxt "string types"
 msgid "String"
 msgstr "מחרוזת שורה"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "סה\"כ"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4040,69 +4040,69 @@ msgstr "%B %d, %Y בזמן %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s ימים, %s שעות, %s דקות ו- %s שניות"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Add new field"
 msgid "Missing parameter:"
 msgstr "הוספת שדה חדש"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "קפיצה אל מאגר נתונים &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "שמירת שרת בתוך תיקיית %s"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "ריקון"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "הדפסה"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "יצירה"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "עדכון אחרון"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "נבדק לאחרונה"
@@ -4470,9 +4470,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "איפוס"
 
@@ -4766,7 +4766,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "שמירה כקובץ"
 
@@ -7153,7 +7153,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "מידע גרסאות"
 
@@ -7552,58 +7552,58 @@ msgstr "משום אורכם, <br /> השדה הזה יכול להיות בלתי
 msgid "Binary - do not edit"
 msgstr "בינארי - אין לערוך"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 msgid "web server upload directory:"
 msgstr "שמירת שרת בתוך תיקיית %s"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "ואז"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "הכנסה כשורה חדשה"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "חזרה לעמוד הקודם"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "הוספה נוספת של שורה חדשה"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "חזרה אחורה לעמוד זה"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "עריכת השורה הבאה"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9816,25 +9816,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "הטבלה \"%s\" לא קיימת!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "אנא הגדר נקודות ציון עבור טבלה %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -12528,7 +12528,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "תכונות קשר כלליות"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12813,7 +12813,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12828,19 +12828,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12870,6 +12870,10 @@ msgstr "אין מאגרי נתונים"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "ראיית הוצאה (תבנית) של מאגרי נתונים"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/hi.po
+++ b/po/hi.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-09-19 23:07+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Hindi <http://l10n.cihar.com/projects/phpmyadmin/master/hi/>\n"
@@ -40,7 +40,7 @@ msgstr "तालिका टिप्पणी:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -86,7 +86,7 @@ msgid "Type"
 msgstr "प्रकार/किस्म"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -337,7 +337,7 @@ msgid "Updated"
 msgstr "अद्यतन"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -365,7 +365,7 @@ msgid "Delete tracking data for this table"
 msgstr "इस टेबल के लिए ट्रैकिंग डेटा हटाएँ"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -560,8 +560,8 @@ msgstr "ज्यामिति जोडें"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -587,7 +587,7 @@ msgstr "ज्यामिति जोडें"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "जाएँ"
@@ -956,7 +956,7 @@ msgstr "अनुक्रमणिका जोड़ें"
 msgid "Edit Index"
 msgstr "अनुक्रमणिका सम्पादित करें"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1175,7 +1175,7 @@ msgid "Traffic"
 msgstr "व्यस्तता"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "सेटिंग्स"
 
@@ -1497,8 +1497,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1713,8 +1713,8 @@ msgstr "क्वॅरी बॉक्स दिखाएँ"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1741,7 +1741,7 @@ msgstr "क्वॅरी क्रियान्वन में लगा �
 msgid "%d is not valid row number."
 msgstr "%d एक वैध पंक्ति संख्या नहीं है।"
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1814,8 +1814,8 @@ msgstr "क्वॅरी परिणाम"
 msgid "Data point content"
 msgstr "डॅटा बिन्दु सामग्री"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "उपेक्षा करें"
 
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "फ़ॉन्ट का आकार"
 
@@ -2541,8 +2541,8 @@ msgstr[0] "<i>%s</i> टेबल के अंदर %s मैच हैं."
 msgstr[1] "<i>%s</i> टेबल के अंदर %s मैच हैं."
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2602,16 +2602,16 @@ msgstr "निर्देशिका बचाना"
 msgid "Restore column order"
 msgstr "पाठ क्षेत्रपाठ क्षेत्र कोलम"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "प्रारंभ"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2619,8 +2619,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "पिछला"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2628,8 +2628,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "अगला"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2813,9 +2813,9 @@ msgstr "सभी को चेक करें"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3008,9 +3008,9 @@ msgid "View"
 msgstr "दृश्य"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3024,32 +3024,32 @@ msgid "Structure"
 msgstr "संरचना"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "ढूंढें"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "इनसर्ट"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3058,20 +3058,20 @@ msgid "Privileges"
 msgstr "प्रिविलेज"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "कार्रवाई"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "नज़र रखना"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3087,72 +3087,72 @@ msgstr "ट्रिगर"
 msgid "Database seems to be empty!"
 msgstr "डाटाबेस खाली लग रहा है!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "क्वरी"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "नियमित कार्य"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "डिजाइनर"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "डाटाबेस"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "यूसर"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "बाइनरी लोग"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "प्रतिकृति"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "प्रक्रियां"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "चरित्र सेट"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "इंजन"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "त्रुटि"
@@ -3178,7 +3178,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "एकवचन %1$d पंक्ति डाली।"
 msgstr[1] "बहुवचन %1$d पंक्तिया डाली।"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3411,7 +3411,7 @@ msgid "Operator"
 msgstr "ऑपरेटर"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3428,7 +3428,7 @@ msgstr "ढूंढें"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3438,7 +3438,7 @@ msgstr "इनसर्ट"
 msgid "Select columns (at least one):"
 msgstr "स्तंभ चुनें (कम से कम एक):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "अथवा"
@@ -3566,288 +3566,288 @@ msgstr "विषय %s के लिए थीम पथ नहीं मिल
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "Create version %s of %s.%s"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "%s संस्करण बनायें %s.%s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "टेबल का नाम %1$s से %2$s में बदलने में त्रुटि."
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add column"
 msgid "A polygon"
 msgstr "नया काँलम जोडें"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "एक नया इन्डेक्स बनाऐं"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "लाईन समाप्त होता है"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "कुल"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3934,71 +3934,71 @@ msgstr "%d %B, %Y को %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s दिन, %s घंटे, %s मिनट and %s सेकंड"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "नियमित कार्य"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "&quot;%s&quot; डेटाबेस पर जायें;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s कार्यक्षमताएक एक बग के द्वारा जनि जाती है| %s पर ध्यान दे"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 #, fuzzy
 #| msgid "Click to select"
 msgid "Click to toggle"
 msgstr "चयन करने के लिए क्लिक करें."
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "अपना कंप्यूटर ब्राउज़ करें:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "अपने वेब सर्वर की अपलोड डिरेक्टरी से चुने <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "आपकी अपलोड दिरेक्टोरी तक पहुंचा नहीं जा सकता"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "अपलोड करने के लिए फाइल उपलब्ध नहीं"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "खाली"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "छापें"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "रचना"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "पिछला नवीनीकरण"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "पिछली जाँच"
@@ -4364,9 +4364,9 @@ msgstr "कर्ता को इस मूल्य को अनुकूल�
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "रीसेट"
 
@@ -4668,7 +4668,7 @@ msgstr "एक स्क्रिप्ट को चलने की अवध�
 msgid "Maximum execution time"
 msgstr "अधिकतम निष्पादन समय"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "फ़ाइल के रूप में सहेजें"
 
@@ -7101,7 +7101,7 @@ msgstr "फाइल संसाधित की जा रही है, क�
 msgid "Language"
 msgstr "भाषा"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "संस्करण जानकारी"
 
@@ -7505,59 +7505,59 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "बइनरी - एडिट मत करिये"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "वेब सर्वर अपलोड निर्देशिका"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "और फिर"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "इसको नया रौ में जोडे"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "पिछले पृष्ट पर वापस जाएँ"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "एक और नई रो इनसर्ट करें"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "इस पृष्ठ पर वापस जाएँ"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "अगली रो को संपादित करें"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "SQL क्वेरी शो"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "इनसर्ट रो id: %1$d"
@@ -9791,25 +9791,25 @@ msgid "There are no events to display."
 msgstr "अपलोड करने के लिए फाइल उपलब्ध नहीं"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "%s table(s)"
 msgid "The %s table doesn't exist!"
 msgstr "%s  टेबल(s) मौजूद नहीं है"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -12516,7 +12516,7 @@ msgstr "संस्करण %s बन चूका है, ट्रैकि�
 msgid "Manage your settings"
 msgstr "सेटिंग्स प्रबंधक"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12796,7 +12796,7 @@ msgstr "सेटिंग्स को अपने ब्राउजर क�
 msgid "You have no saved settings!"
 msgstr "आपके पास कोई बचाई गयीसेटिंग नहीं हैं"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "यह सुविधा आपके ब्राउज़र द्वारा समर्थित नहीं है"
 
@@ -12811,19 +12811,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "ब्राउज़र के भंडारण में बचाएं"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "सेटिंग्स को आपके ब्राउजर के स्थानीय भंडारण में सहेज लिया जाएगा"
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "मौजूदा सेटिंग्स अधिलेखित हो जाएगी"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "आप अपने सभी सेटिंग्स रीसेट और उन मूलभूत मूल्यों को पुनर्स्थापित कर सकते हैं"
 
@@ -12852,6 +12852,10 @@ msgstr "कोइ डाटाबेस नहिं"
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/hr.po
+++ b/po/hr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:39+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Croatian <http://l10n.cihar.com/projects/phpmyadmin/master/hr/"
@@ -42,7 +42,7 @@ msgstr "Komentari tablice:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Vrsta"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -345,7 +345,7 @@ msgid "Updated"
 msgstr "Ažurirano"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -373,7 +373,7 @@ msgid "Delete tracking data for this table"
 msgstr "Obriši podatke o praćenju za ovu tablicu"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -578,8 +578,8 @@ msgstr "Dodaj geometriju"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -605,7 +605,7 @@ msgstr "Dodaj geometriju"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Kreni"
@@ -999,7 +999,7 @@ msgstr "Dodaj Indeks"
 msgid "Edit Index"
 msgstr "Uredi indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1235,7 +1235,7 @@ msgid "Traffic"
 msgstr "Promet"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1573,8 +1573,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1830,8 +1830,8 @@ msgstr "SQL upit"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1858,7 +1858,7 @@ msgstr "Vrijeme izvršavanja upita"
 msgid "%d is not valid row number."
 msgstr "%d nije valjani broj retka."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1939,8 +1939,8 @@ msgstr "Operacije rezultata upita"
 msgid "Data point content"
 msgstr "Veličina pokazatelja podataka"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignoriraj"
 
@@ -2566,7 +2566,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Veličina fonta"
 
@@ -2730,8 +2730,8 @@ msgstr[0] "%s poklapanja unutar tablice <i>%s</i>"
 msgstr[1] "%s poklapanja unutar tablice <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2790,16 +2790,16 @@ msgstr "Osnovna mapa podataka"
 msgid "Restore column order"
 msgstr "Dodaj/Izbriši stupce polja"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Na vrh stranice"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2807,8 +2807,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Prethodni"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2816,8 +2816,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Sljedeće"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3010,9 +3010,9 @@ msgstr "Označi sve"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3210,9 +3210,9 @@ msgid "View"
 msgstr "Prikaz"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3226,32 +3226,32 @@ msgid "Structure"
 msgstr "Strukturu"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Traži"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Umetni"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3260,20 +3260,20 @@ msgid "Privileges"
 msgstr "Privilegije"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operacije"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Praćenje"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3289,72 +3289,72 @@ msgstr "Okidači"
 msgid "Database seems to be empty!"
 msgstr "Baza podataka izgleda praznom!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Upit"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutine"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Događaji"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Kreator"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Baze podataka"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Korisnik"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binarni zapisnik"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikacija"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Varijable"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Tablice znakova"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Dodatci"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Pogoni"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Pogreška"
@@ -3383,7 +3383,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Umetnuto redaka: %1$d."
 msgstr[1] "Umetnuto redaka: %1$d."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3614,7 +3614,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3631,7 +3631,7 @@ msgstr "Traži"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3643,7 +3643,7 @@ msgstr "Umetni"
 msgid "Select columns (at least one):"
 msgstr "Odaberite polja (najmanje jedno):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Ili"
@@ -3771,287 +3771,287 @@ msgstr "Za temu %s nije pronađena putanje tema!"
 msgid "Theme:"
 msgstr "Tema"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Izradi relaciju"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Pogreška tijekom preimenovanja tablice %1$s u %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "Dodaj %s polja"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Izradi novi indeks"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Redovi završeni s"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Najveći broj datoteka zapisnika"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4140,70 +4140,70 @@ msgstr "%B %d, %Y u %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dana, %s sati, %s minuta i %s sekunda"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Rutine"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Skoči do baze podataka \"%s\"."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Na funkcionalnost %s utječe poznati nedostatak. Pogledajte %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Pretraži računalo:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "mapa učitavanja web poslužitelja"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Mapu koju ste odabrali za potrebe učitavanja nije moguće dohvatiti."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Isprazni"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Izvrši"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Ispiši"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Izrada"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Posljednje ažuriranje"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Posljednja provjera"
@@ -4586,9 +4586,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Povrat"
 
@@ -4887,7 +4887,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Spremi kao datoteku"
 
@@ -7340,7 +7340,7 @@ msgstr ""
 msgid "Language"
 msgstr "Jezik"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Podaci o verziji"
 
@@ -7789,63 +7789,63 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Binarno - ne uređuj"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "mapa učitavanja web poslužitelja"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Ponovno pokreni umetanje s %s redaka"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "i potom"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Umetni kao novi redak"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 #, fuzzy
 msgid "Show insert query"
 msgstr "Prikazivanje SQL upita"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Kreni nazad na prethodnu stranicu"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Umetni dodatni novi redak"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Kreni nazad na ovu stranicu"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Uredi sljedeći redak"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Pomoću tipke TAB premještate se od jedne vrijednost do druge vrijednost, "
 "odnosno s tipkama CTRL+Strelice za premještanje bilo kamo"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Prikazivanje SQL upita"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Umetnut ID retka: %1$d"
@@ -10189,25 +10189,25 @@ msgid "There are no events to display."
 msgstr "Provjeri tablicu"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Tablica \"%s\" ne postoji!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Konfigurirajte koordinate tablice %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -13073,7 +13073,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Opće osobine relacija"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13363,7 +13363,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13378,19 +13378,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13420,6 +13420,10 @@ msgstr "Nema baza podataka"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Prikaži ispis (shemu) baza podataka"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:40+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Hungarian <http://l10n.cihar.com/projects/phpmyadmin/master/"
@@ -41,7 +41,7 @@ msgstr "Tábla megjegyzések:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Típus"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr "Frissítve"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Tábla nyomkövetési adatainak törlése"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -560,8 +560,8 @@ msgstr "Geometria hozzáadása"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -587,7 +587,7 @@ msgstr "Geometria hozzáadása"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Indítás"
@@ -970,7 +970,7 @@ msgstr "Index hozzáadása"
 msgid "Edit Index"
 msgstr "Index szerkesztése"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "%s oszlop hozzáadása az indexhez"
@@ -1187,7 +1187,7 @@ msgid "Traffic"
 msgstr "Forgalom"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Beállítások"
 
@@ -1504,8 +1504,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1716,8 +1716,8 @@ msgstr "Lekérdezési doboz megjelenítése"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1744,7 +1744,7 @@ msgstr "A lekérdezés végrehajtási ideje"
 msgid "%d is not valid row number."
 msgstr "A(z) %d érvénytelen sorszám."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1817,8 +1817,8 @@ msgstr "Lekérdezési eredmények"
 msgid "Data point content"
 msgstr "Adatmutató tartalma"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Kihagyás"
 
@@ -2376,7 +2376,7 @@ msgstr "A létező beállító fájl (%s) nem olvasható."
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "A konfigurációs fájl helytelen írási engedéllyel rendelkezik!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Betűméret"
 
@@ -2524,8 +2524,8 @@ msgstr[0] "%1$s találat ebben: <strong>%2$s</strong>"
 msgstr[1] "%1$s találat ebben: <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2581,28 +2581,28 @@ msgstr "A módosított adatok mentése"
 msgid "Restore column order"
 msgstr "Oszlopsorrend visszaállítása"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Kezdet"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Előző"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Következő"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Vége"
@@ -2780,9 +2780,9 @@ msgstr "Mind kijelölése"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2975,9 +2975,9 @@ msgid "View"
 msgstr "Nézet"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2991,32 +2991,32 @@ msgid "Structure"
 msgstr "Szerkezet"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Keresés"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Beszúrás"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3025,20 +3025,20 @@ msgid "Privileges"
 msgstr "Jogok"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Műveletek"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Követés"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3054,70 +3054,70 @@ msgstr "Eseményindítók"
 msgid "Database seems to be empty!"
 msgstr "Üresnek tűnik az adatbázis!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Lekérdezés"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Eljárások"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Események"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Tervező"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Adatbázisok"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Felhasználók"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Bináris napló"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Többszörözés"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Változók"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Karakterkészlet"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Bővítmények"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motorok"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Hiba"
@@ -3143,7 +3143,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "A(z) %1$d sor beszúrása megtörtént."
 msgstr[1] "A(z) %1$d sor beszúrása megtörtént."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3364,7 +3364,7 @@ msgid "Operator"
 msgstr "Operátor"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3379,7 +3379,7 @@ msgstr "Táblakeresés"
 msgid "Find and Replace"
 msgstr "Keresés és csere"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Szerkesztés/Beszúrás"
 
@@ -3387,7 +3387,7 @@ msgstr "Szerkesztés/Beszúrás"
 msgid "Select columns (at least one):"
 msgstr "Válasszon oszlopokat (legalább egyet):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Vagy"
@@ -3500,14 +3500,14 @@ msgstr "Nem található a(z) %s téma elérési útja!"
 msgid "Theme:"
 msgstr "Téma:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "1 bájtos integer, signed tartomány -128 és 127 között, unsigned tartomány 0 "
 "és 255 között"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3515,7 +3515,7 @@ msgstr ""
 "2 bájtos integer, signed tartomány -32 768 és 32 767 között, unsigned "
 "tartomány 0 és 65 535 között"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3523,7 +3523,7 @@ msgstr ""
 "3 bájtos integer, signed tartomány -8 388 608 és 8 388 607 között, unsigned "
 "tartomány 0 és 16 777 215 között"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3531,7 +3531,7 @@ msgstr ""
 "4 bájtos integer, signed tartomány -2 147 483 648 és 2 147 483 647 közt, "
 "unsigned tartomány 0 és 4 294 967 295 közt"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3540,7 +3540,7 @@ msgstr ""
 "036 854 775 807 között, unsigned tartomány 0 és 18 446 744 073 709 551 615 "
 "között"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3548,7 +3548,7 @@ msgstr ""
 "Tizedestört szám - az egész jegyek maximális száma 65 (alapértelmezett a "
 "10), a törtek maximális száma 30 (alapértelmezett a 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3556,7 +3556,7 @@ msgstr ""
 "Small floating-point szám, értéktartománya -3.402823466E+38 és -1.175494351E-"
 "38 között, 0, 1.175494351E-38 és 3.402823466E+38 között"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3566,7 +3566,7 @@ msgstr ""
 "+308 és -2.2250738585072014E-308 között, 0, 2.2250738585072014E-308 és "
 "1.7976931348623157E+308 között"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3574,35 +3574,35 @@ msgstr ""
 "DOUBLE-lal egyenértékű (kivéve: REAL_AS_FLOAT SQL módban a FLAT-tal "
 "egyenértékű)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 "Bit-field típus (M), értékenként M darab bit (alapértelmezett: 1, maximum 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 "TINYINT(1)-gyel egyenértékű, zéró esetén false, nemzéró esetén true érték"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Egy dátum, a támogatott tartomány %1$s és %2$s között van"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Dátum és idő kombináció, értéktartomány %1$s és %2$s között"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3610,12 +3610,12 @@ msgstr ""
 "Időbélyeg, tartomány 1970-01-01 00:00:01 UTC és 2038-01-09 03:14:07 UTC "
 "között, másodpercek számaként tárolva a kezdettől"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Egy idő, a tartomány %1$s és %2$s között van"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3623,7 +3623,7 @@ msgstr ""
 "4 vagy 2 karakteres évszám, megengedett értékei 70 (1970) és 69 (2069), vagy "
 "1901 és 2155 között és 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3631,7 +3631,7 @@ msgstr ""
 "Fix hosszúságú (0-255, alapértelmezett 1) sztring, amely szóközökkel van "
 "jobbról kitöltve a meghatározott hossz eléréséhez"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3640,7 +3640,7 @@ msgstr ""
 "Változó hosszúságú (%s) sztring, a tényleges maximális hossz függ a "
 "maximális sormérettől"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3648,7 +3648,7 @@ msgstr ""
 "TEXT oszlop, maximális hossz 255 karakter, tárolása 1 bájt előtaggal, amely "
 "az érték hosszát tartalmazza bájtokban"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3656,7 +3656,7 @@ msgstr ""
 "TEXT oszlop maximum 65 535 karakterhosszúsággal, 2 bájtos előtaggal tárolva, "
 "amely az érték hosszát tartalmazza bájtokban"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3664,7 +3664,7 @@ msgstr ""
 "TEXT oszlop 16 777 215 maximális hosszúsággal, három bájt előtaggal tárolva, "
 "amely az érték hosszát tartalmazza bájtokban"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3673,7 +3673,7 @@ msgstr ""
 "TEXT oszlop maximum 4 294 967 295 vagy 4 GB hosszal, 4 bájtos előtaggal "
 "tárolva, amely az érték hosszát tartalmazza bájtokban"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3681,7 +3681,7 @@ msgstr ""
 "Hasonló a CHAR típushoz, de bináris bájtláncot tárol nem-bináris "
 "karakterláncok helyett"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3689,7 +3689,7 @@ msgstr ""
 "Hasonló a VARCHAR típushoz, de bináris bájtláncot tárol nem-bináris "
 "karakterláncok helyett"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3697,7 +3697,7 @@ msgstr ""
 "BLOB oszlop maximális hossza 255 (2 ^ 8 - 1) bájt, tárolt érték hosszát "
 "jelző egybájtos előtaggal"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3705,7 +3705,7 @@ msgstr ""
 "BLOB-oszlop 16 777 215 maximális hosszal (2 ^ 24 - 1), tárolt érték hosszát "
 "jelző három byte-os előtaggal"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3713,7 +3713,7 @@ msgstr ""
 "BLOB oszlop maximális hossza a 65 535 (2 ^ 16 - 1) bájt, tárolt érték "
 "hosszát jelző két byte-os előtaggal"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3721,74 +3721,74 @@ msgstr ""
 "BLOB oszlop 4 294 967 295 vagy 4 GB maximális hosszal (2 ^ 32 - 1), tárolt "
 "érték hosszát jelző négybájtos előtaggal"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 "Felsorolás, legfeljebb 65 535 értékkel vagy a speciális '' hibaértékkel"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Egyetlen érték egy 64 tagú készletből"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Típus, amely bármely típus geometriáját tudja tárolni"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Pont 2 dimenziós pozícióban"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Görbe lineáris interpolációval a pontjai között"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Egy sokszög"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Pontok összessége"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Görbék összessége lineáris interpolációval a pontjaik közt"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Sokszögek összessége"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Bármely típusú geometriai tárgyak összessége"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "numerikus"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Dátum és idő"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Karakterlánc"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Térbeli"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "4 bájtos integer, tartomány -2147483648 és 2147483647 között"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3796,23 +3796,23 @@ msgstr ""
 "8 bájtos integer, tartomány -9 223 372 036 854 775 808 és 9 223 372 036 854 "
 "775 807 között"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "A rendszer által alapértelmezett dupla pontosságú lebegőpontos szám"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Igaz vagy Hamis"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Más néven BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Tárolja az univerzálisan egyedi azonosítót (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3820,7 +3820,7 @@ msgstr ""
 "Időbélyeg, tartománya '0001-01-01 00:00:00 \"UTC\" és 9999-12-31 23:59:59' "
 "UTC között; TIMESTAMP(6) tárolhat mikroszekundumot"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3828,7 +3828,7 @@ msgstr ""
 "Változó hosszúságú (0-65 535) karakterlánc, bináris rendezést használ minden "
 "összehasonlításhoz"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Felsorolás, meghatározott értékek listájából kiválasztva"
 
@@ -3913,67 +3913,67 @@ msgstr "%Y. %B %d. %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s nap, %s óra, %s perc, %s másodperc"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Hiányzó paraméter:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Ugrás a(z) &quot;%s&quot; adatbázishoz."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "A(z) %s funkcióra egy ismert hiba van hatással, lásd itt: %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Kattintson a váltáshoz"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Számítógép tallózása:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Válasszon a szerver feltöltési könyvtárából <b> %s </b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Nem elérhető a feltöltésekhez megadott könyvtár."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Nincsenek feltöltendő fájlok"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Kiürítés"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Végrehajtás"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Nyomtatás"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Létrehozás"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Utolsó frissítés"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Utolsó ellenőrzés"
@@ -4329,9 +4329,9 @@ msgstr "Engedélyezi a felhasználóknak az érték módosítását"
 msgid "Apply"
 msgstr "Alkalmaz"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Visszaállítás"
 
@@ -4649,7 +4649,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Végrehajtási idő legfeljebb"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Mentés fájlként"
 
@@ -7090,7 +7090,7 @@ msgstr "Fájl feldolgozása folyamatban, kis türelmet kérünk."
 msgid "Language"
 msgstr "Nyelv"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Verziószám"
 
@@ -7534,59 +7534,59 @@ msgstr "A hossza miatt ez az<br /> oszlop talán nem szerkeszthető"
 msgid "Binary - do not edit"
 msgstr "Bináris - nem szerkeszthető"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "webszerver feltöltési könyvtár:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Beszúrás folytatása a(z) %s sorokkal"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "és utána"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Beszúrás új sorként"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Új sor beillesztése és a hibák figyelmen kívül hagyása"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Beillesztő lekérdezés megjelenítése"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Vissza az előző oldalra"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Új sor beszúrása"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Visszatérés erre az oldalra"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Következő sor szerkesztése"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "A TAB billentyűvel értékről értékre lépkedhet, vagy a CTRL+nyilakkal bárhová "
 "léphet"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Megjelenítés SQL lekérdezésként"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "A beszúrt sor azonosítószáma: %1$d"
@@ -9755,24 +9755,24 @@ msgid "There are no events to display."
 msgstr "Nincsen megjeleníthető esemény."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "A(z) %s tábla nem létezik!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Állítsa be a(z) %s tábla koordinátáit"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "A(z) \"%s\" adatbázis sémája - %s. oldal"
@@ -12487,7 +12487,7 @@ msgstr "%1$s verzió létrejött, a %2$s nyomonkövetése aktív."
 msgid "Manage your settings"
 msgstr "Beállítások kezelése"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "A módosítások mentése megtörtént"
 
@@ -12739,7 +12739,7 @@ msgstr "A beállítások a böngészője helyi tárolójából lesznek importál
 msgid "You have no saved settings!"
 msgstr "Nincsenek elmentett beállításai!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Az ön web böngészője nem támogatja ezt a szolgáltatást"
 
@@ -12756,19 +12756,19 @@ msgstr ""
 "További beállításokat állíthat be a config.inc.php modosításával, pl. %"
 "sBeállító parancsfájl%s használatával."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Mentés a böngésző tárolójába"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "A beállítások a böngészője helyi tárolójába lesznek mentve."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "A meglévő beállítások felülíródnak!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Alaphelyzetbe állíthatja az összes beállítását és visszaállíthatja azokat az "
@@ -12799,6 +12799,10 @@ msgstr "Nincs adatbázis"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Adatbázis kiírás (séma) megtekintése"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/hy.po
+++ b/po/hy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-03-30 12:19+0200\n"
 "Last-Translator: Hamlet Muradyan <contact@hamletmuradyan.com>\n"
 "Language-Team: Armenian <http://l10n.cihar.com/projects/phpmyadmin/master/hy/"
@@ -47,7 +47,7 @@ msgstr "Աղյուսակի մեկնաբանությունը"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -93,7 +93,7 @@ msgid "Type"
 msgstr "Տեսակ"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -347,7 +347,7 @@ msgid "Updated"
 msgstr "Թարմացված է"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -375,7 +375,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -569,8 +569,8 @@ msgstr ""
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -596,7 +596,7 @@ msgstr ""
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "OK"
@@ -928,7 +928,7 @@ msgstr ""
 msgid "Edit Index"
 msgstr ""
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr ""
@@ -1141,7 +1141,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr ""
 
@@ -1435,8 +1435,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1645,8 +1645,8 @@ msgstr ""
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1742,8 +1742,8 @@ msgstr ""
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2279,7 +2279,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2434,8 +2434,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2491,28 +2491,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr ""
@@ -2688,9 +2688,9 @@ msgstr "Նշել բոլորը"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2875,9 +2875,9 @@ msgid "View"
 msgstr "Ներկայացում"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2891,32 +2891,32 @@ msgid "Structure"
 msgstr ""
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr ""
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Որոնում"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2925,20 +2925,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2954,70 +2954,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr ""
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Վերարադրում"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr ""
@@ -3043,7 +3043,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3263,7 +3263,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3278,7 +3278,7 @@ msgstr ""
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3286,7 +3286,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Կամ"
@@ -3402,278 +3402,278 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr ""
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3758,67 +3758,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Դատարկել"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Ստեղծում"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Վերջին թարմացումը"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Վերջին ստուգումը"
@@ -4170,9 +4170,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6675,7 +6675,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7066,57 +7066,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9167,24 +9167,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11673,7 +11673,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -11921,7 +11921,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -11936,19 +11936,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -11975,6 +11975,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/ia.po
+++ b/po/ia.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 23:01+0200\n"
 "Last-Translator: Giovanni Sora <g.sora@tiscali.it>\n"
-"Language-Team: Interlingua "
-"<http://l10n.cihar.com/projects/phpmyadmin/master/ia/>\n"
-"Language: ia\n"
+"Language-Team: Interlingua <http://l10n.cihar.com/projects/phpmyadmin/master/"
+"ia/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ia\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -45,7 +45,7 @@ msgstr "Commentos de tabella:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -91,7 +91,7 @@ msgid "Type"
 msgstr "Typo"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -340,7 +340,7 @@ msgid "Updated"
 msgstr "Actualisate"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -368,7 +368,7 @@ msgid "Delete tracking data for this table"
 msgstr "Dele datos traciante pro iste tabula"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -425,9 +425,6 @@ msgid "You may want to refresh the page."
 msgstr "Tu poterea voler refrescar le pagina."
 
 #: error_report.php:45
-#| msgid ""
-#| "An error has been detected and an error report has been automatically "
-#| "submitted based on your settings."
 msgid ""
 "An error has been detected and an error report has been generated but failed "
 "to be sent."
@@ -571,8 +568,8 @@ msgstr "Adde un geometria"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -598,7 +595,7 @@ msgstr "Adde un geometria"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Vade"
@@ -979,7 +976,7 @@ msgstr "Adde indice"
 msgid "Edit Index"
 msgstr "Modifica indice"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Adde %s columna(s) al indice"
@@ -1197,7 +1194,7 @@ msgid "Traffic"
 msgstr "Traffico"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Preferentias"
 
@@ -1518,8 +1515,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1732,8 +1729,8 @@ msgstr "Monstra quadro de query"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1760,7 +1757,7 @@ msgstr "Tempore de executation del query"
 msgid "%d is not valid row number."
 msgstr "%d non es un valide numero de rangos."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1834,8 +1831,8 @@ msgstr "Exitos del query"
 msgid "Data point content"
 msgstr "Contento del puncto de datos"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignora"
 
@@ -2398,7 +2395,7 @@ msgstr ""
 "Permissiones incorrecte sur le file de configuration, il non deberea esser "
 "scribibile per omnes!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Grandor de font"
 
@@ -2547,8 +2544,8 @@ msgstr[0] "%1$s correspondentia in <strong>%2$s</strong>"
 msgstr[1] "%1$s correspondentias in <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2604,28 +2601,28 @@ msgstr "Salveguarda datos modificate"
 msgid "Restore column order"
 msgstr "Restabili ordine de columna"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Initio"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Previe"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Proxime"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Ultime"
@@ -2803,9 +2800,9 @@ msgstr "Marca omnes"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2996,9 +2993,9 @@ msgid "View"
 msgstr "Vista"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3012,32 +3009,32 @@ msgid "Structure"
 msgstr "Structura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Cerca"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Inserta"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3046,20 +3043,20 @@ msgid "Privileges"
 msgstr "Permissiones"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operationes"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Traciamento"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3075,70 +3072,70 @@ msgstr "Triggers"
 msgid "Database seems to be empty!"
 msgstr "Le base de datos sembla esser vacue!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Query"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Routines"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Eventos"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Designator"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Base de datos"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Usatores"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Registro binari"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replication"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variabiles"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Insimul de characteres"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Plugins"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motores"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Error"
@@ -3164,7 +3161,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d rango insertate."
 msgstr[1] "%1$d rangos insertate."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3387,7 +3384,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3402,7 +3399,7 @@ msgstr "Cerca de tabella"
 msgid "Find and Replace"
 msgstr "Trova e reimplacia"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Modifica/Inserta"
 
@@ -3410,7 +3407,7 @@ msgstr "Modifica/Inserta"
 msgid "Select columns (at least one):"
 msgstr "Selige columnas (al minus uno):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "O"
@@ -3522,14 +3519,14 @@ msgstr "Il non trovava le percurso pro le thema %s!"
 msgid "Theme:"
 msgstr "Thema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Le extension de un integer de 1 byte, signate es ex -128 a 127, si non "
 "signate es ex 0 a 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3537,7 +3534,7 @@ msgstr ""
 "Le extension de un integer de 2 bytes signate es ex -32,768 a 32,767, si non "
 "signate es ex 0 a 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3545,7 +3542,7 @@ msgstr ""
 "Le extension de un integer de 3 bytes signate es ex -8,388,608 a 8,388,607, "
 "si non signate es ex 0 a 16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3553,7 +3550,7 @@ msgstr ""
 "Le extension de un integer de 4 bytes signate es ex -2,147,483,648 a "
 "2,147,483,647, si non signate es ex 0 a 4,294,967,295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3562,7 +3559,7 @@ msgstr ""
 "9,223,372,036,854,775,808 a 9,223,372,036,854,775,807, si non signate es ex "
 "0 a 18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3571,7 +3568,7 @@ msgstr ""
 "es 65 (predefinite 10), le maxime numero de decimales (D) es 30 (predefinite "
 "0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3579,7 +3576,7 @@ msgstr ""
 "Pro un parve numero a virgula/puncto mobile, valores disponibile es ex -"
 "3.402823466E+38 a -1.175494351E-38, 0, e ex 1.175494351E-38 a 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3589,7 +3586,7 @@ msgstr ""
 "disponibile es ex -1.7976931348623157E+308 a -2.2250738585072014E-308, 0, e "
 "ex 2.2250738585072014E-308 a 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3597,7 +3594,7 @@ msgstr ""
 "Synonymo de DOUBLE (exception in modo REAL_AS_FLOAT illo es un synonymo de "
 "FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3605,7 +3602,7 @@ msgstr ""
 "Un typo de campo bit (M), immagazinante M bits per valor (predefinite 1, "
 "maxime es 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3613,22 +3610,22 @@ msgstr ""
 "Un synonymo de TINYINT(1), un valor de zero es considerate false (false), "
 "valores de non zero es considerate ver (true)"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Un data, le extension supportate es ex %1$s a %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 "Un combination de data e tempore, extension supportate es ex %1$s a %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3637,12 +3634,12 @@ msgstr ""
 "03:14:07 UTC, immagazinate como le numero de secundas ex le epocha (1970-01-"
 "01 00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Un tempore, extension es ab %1$s a %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3650,7 +3647,7 @@ msgstr ""
 "Un anno in le formato de quatro cifras (4, per definition) o duo cifras, le "
 "valores permittite es ex 70 (1970) a 69 (2069) o ex 191 a 2155 e 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3658,7 +3655,7 @@ msgstr ""
 "Un catena de longitude fixate (0-255, 1 predefinite) que es sempre plenate a "
 "dextera con spatios al longor specificate quando on immagazinava"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3667,7 +3664,7 @@ msgstr ""
 "Un catena de longitude variabile (%s), le effective maxime longor depende ex "
 "le maxime grandor de rango"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3675,7 +3672,7 @@ msgstr ""
 "Un columna de TEXT con un longor maxime de 255 (2^8 - 1) characteres,  "
 "immagazinate con un prefixo de 1 byte indicante le valores in bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3683,7 +3680,7 @@ msgstr ""
 "Un columna de TEXT con un longor maxime de 65,535 (2^16 - 1)  characteres,  "
 "immagazinate con un prefixo de 2 bytes indicante le valores in bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3692,7 +3689,7 @@ msgstr ""
 "characteres,  immagazinate con un prefixo de 3 bytes indicante le valores in "
 "bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3702,7 +3699,7 @@ msgstr ""
 "characteres,  immagazinate con un prefixo de 4 bytes indicante le valores in "
 "bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3710,7 +3707,7 @@ msgstr ""
 "Como pro le typo CHAR, ma immagazina catenas de byte binari plus tosto que "
 "catenas de character non binari"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3718,7 +3715,7 @@ msgstr ""
 "Como pro le typo VARCHAR, ma immagazina catenas de byte binari plus tosto "
 "que catenas de character non binari"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3726,7 +3723,7 @@ msgstr ""
 "Un columna de BLOB con un longitude maxime de 255 (2^8 - 1) bytes, "
 "immagazinate con un prefixo indicante le longor del valor"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3734,7 +3731,7 @@ msgstr ""
 "Un columna de BLOB con un longitude maxime de 16,777,215 (2^24 - 1) bytes, "
 "immagazinate con un prefixo de 3 bytes indicante le longor del valor"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3742,7 +3739,7 @@ msgstr ""
 "Un columna de BLOB con un longitude maxime de 65,535 (2^16 - 1) bytes, "
 "immagazinate con un prefixo de duo bytes indicante le longor del valor"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3750,7 +3747,7 @@ msgstr ""
 "Un columna de BLOB con un longitude maxime de 4,294,967,295 or 4GiB (2^32 - "
 "1) bytes, immagazinate con un prefixo de 4bytes indicante le longor del valor"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3758,67 +3755,67 @@ msgstr ""
 "Un enumeration,seligite ex le lista usque calores de 65,535  o le valor "
 "special de error \""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Un singule valor, seligite ex un insimul usque 64 membros"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Un typo pote immagazinar un geometria de omne typo"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Un puncto in un spatio a duo dimensiones"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Un curva con interpolation linear inter punctos"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Un polygono"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Un collection de punctos"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Un collection de curvas con interpolation linear inter punctos"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Un collection de polygonos"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Un collection de objectos de geometria de omne typo"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numeric"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Data e tempore"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Catena"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Spatial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Un integer de 4-bytes, extension es ab -2,147,483,648 a 2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3826,26 +3823,26 @@ msgstr ""
 "Un integer de 8-bytes, extension es ab  -9,223,372,036,854,775,808 ab "
 "9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 "Un numero a virgula mobile de duple precision predefinite pro le systema"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Ver o false"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Un alias pro BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 "Immagazina un Identificator Unic Universal -  Universally Unique Identifier "
 "(UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3853,7 +3850,7 @@ msgstr ""
 "Un marca de tempore, extension es ab '0001-01-01 00:00:00' UTC a '9999-12-31 "
 "23:59:59' UTC; TIMESTAMP(6) pote immagazinar microsecundas"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3861,7 +3858,7 @@ msgstr ""
 "Un catena de longitude variabile (0-65,535), usa collation binari pro omne "
 "comparationes"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Un enumeration, seligite ex le lista de valores definite"
 
@@ -3946,70 +3943,70 @@ msgstr "%B %d, %Y a %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dies, %s horas, %s minutas e %s secundas"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Parametro mancante:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Salta al base de datos &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 "Le functionalitate %s es influentiate per un error cognoscite, tu vide %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Pulsa pro alternar"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Cerca in tu computator:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Selige ex le directorio de incargamento de servitor web <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 "Le directorio que tu fixava pro le travalio de incargar non pote esser "
 "attingite."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Il non ha alcun file  de incargar"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Vacua"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Executa"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Imprime"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Creation"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Ultime actualisation"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Ultime controlo"
@@ -4372,9 +4369,9 @@ msgstr "Permitte a usatores personalisar iste valor"
 msgid "Apply"
 msgstr "Applica"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Refixa"
 
@@ -4687,7 +4684,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maxime tempore de execution"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Salveguarda como file"
 
@@ -6909,7 +6906,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Information de version"
 
@@ -7300,57 +7297,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -7681,7 +7678,6 @@ msgid "Database operations"
 msgstr "Operationes de base de datos"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show indexes"
 msgid "Show hidden items"
 msgstr "Monstra elementos celate"
 
@@ -9367,24 +9363,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11855,7 +11851,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -12103,7 +12099,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12118,19 +12114,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12157,6 +12153,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/id.po
+++ b/po/id.po
@@ -3,15 +3,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-26 05:04+0200\n"
 "Last-Translator: Dadan Setia <da2n_s@yahoo.co.id>\n"
-"Language-Team: Indonesian "
-"<http://l10n.cihar.com/projects/phpmyadmin/master/id/>\n"
-"Language: id\n"
+"Language-Team: Indonesian <http://l10n.cihar.com/projects/phpmyadmin/master/"
+"id/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: id\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 1.9-dev\n"
 "X-Poedit-Basepath: ../../..\n"
@@ -42,7 +42,7 @@ msgstr "Komentar tabel:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Jenis"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr "Diperbarui"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Hapus pelacakan data untuk tabel ini"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -565,8 +565,8 @@ msgstr "Tambahkan geometri"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -592,7 +592,7 @@ msgstr "Tambahkan geometri"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Kirim"
@@ -971,7 +971,7 @@ msgstr "Tambah indek"
 msgid "Edit Index"
 msgstr "Mengedit Indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Tambahkan %s kolom ke index"
@@ -1188,7 +1188,7 @@ msgid "Traffic"
 msgstr "Lalu Lintas"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Pengaturan"
 
@@ -1501,8 +1501,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1713,8 +1713,8 @@ msgstr "Tampilkan kotak kueri"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1742,7 +1742,7 @@ msgstr "Waktu eksekusi kueri"
 msgid "%d is not valid row number."
 msgstr "%d bukanlah nomor baris yang berlaku."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1813,8 +1813,8 @@ msgstr "Operasi hasil pertanyaan"
 msgid "Data point content"
 msgstr "Isi titk data"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Abaikan"
 
@@ -2016,7 +2016,6 @@ msgid "Create view"
 msgstr "Buat tampilan"
 
 #: js/messages.php:408
-#| msgid "Server port"
 msgid "Send Error Report"
 msgstr "Kirim laporan kesalahan"
 
@@ -2033,12 +2032,10 @@ msgstr ""
 "kesalahan?"
 
 #: js/messages.php:413
-#| msgid "Change settings"
 msgid "Change Report Settings"
 msgstr "Ubah Pengaturan Pelaporan"
 
 #: js/messages.php:414
-#| msgid "Show open tables"
 msgid "Show Report Details"
 msgstr "Tampilkan Detail Laporan"
 
@@ -2374,7 +2371,7 @@ msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 "Perizinan yang salah pada file konfigurasi, sehingga tidak dapat ditulis!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Ukuran huruf"
 
@@ -2519,8 +2516,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] "%1$s cocok dengan <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2576,28 +2573,28 @@ msgstr "Simpan data yang diedit"
 msgid "Restore column order"
 msgstr "Pulihkan urutan kolom"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Awal"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Sebelumnya"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Berikutnya"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Akhir"
@@ -2775,9 +2772,9 @@ msgstr "Pilih Semua"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2966,9 +2963,9 @@ msgid "View"
 msgstr "Gambarkan"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2982,32 +2979,32 @@ msgid "Structure"
 msgstr "Struktur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Cari"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Tambahkan"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3016,20 +3013,20 @@ msgid "Privileges"
 msgstr "Hak Akses"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operasi"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Pelacakan"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3045,70 +3042,70 @@ msgstr "Trigger"
 msgid "Database seems to be empty!"
 msgstr "Basis data kelihatannya kosong!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Kueri"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Routine"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Event"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Desainer"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Basis data"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Pengguna"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Log biner"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikasi"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variabel"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Set Karakter"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Plugin"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Mesin"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Galat"
@@ -3137,7 +3134,7 @@ msgid "%1$d row inserted."
 msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d baris ditambahkan."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3358,7 +3355,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3373,7 +3370,7 @@ msgstr "Pencarian Tabel"
 msgid "Find and Replace"
 msgstr "Cari dan Gantikan"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Edit/Tambah"
 
@@ -3381,7 +3378,7 @@ msgstr "Edit/Tambah"
 msgid "Select columns (at least one):"
 msgstr "Pilih kolom (paling tidak satu):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Atau"
@@ -3493,14 +3490,14 @@ msgstr "\"Path\" untuk tema tidak ditemukan untuk tema %s!"
 msgid "Theme:"
 msgstr "Tema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "1-byte integer, berkisar antara -128 sampai 127, unsigned berkisar antara 0 "
 "sampai 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3508,7 +3505,7 @@ msgstr ""
 "2-byte integer, berkisar antara -32,768 sampai 32,767, unsigned berkisar "
 "antara 0 sampai 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3516,7 +3513,7 @@ msgstr ""
 "3-byte integer, signed berkisar antara -8,388,608 sampai 8,388,607, unsigned "
 "berkisar antara 0 sampai 16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3524,7 +3521,7 @@ msgstr ""
 "4-byte integer, signed berkisar antara -2,147,483,648 sampai 2,147,483,647, "
 "unsigned berkisar antara 0 sampai 4,294,967,295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3533,7 +3530,7 @@ msgstr ""
 "9,223,372,036,854,775,807, unsigned berkisar antara 0 sampai "
 "18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3541,7 +3538,7 @@ msgstr ""
 "Sebuah Nomor fixed-point (M, D) - Jumlah maksimum digit (M) adalah 65 "
 "(standar 10), nomor maksimal desimal (D) adalah 30 (standar 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3549,7 +3546,7 @@ msgstr ""
 "small floating-point number, mengizinkan nilai dari -3.402823466E+38 sampai -"
 "1.175494351E-38, 0, dan 1.175494351E-38 sampai 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3559,7 +3556,7 @@ msgstr ""
 "1.7976931348623157E+308 sampai -2.2250738585072014E-308, 0, dan "
 "2.2250738585072014E-308 sampai 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3567,7 +3564,7 @@ msgstr ""
 "Sinonim untuk DOUBLE (kecuali: dalam mode REAL_AS_FLOAT SQL adalah sinonim "
 "untuk FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3575,7 +3572,7 @@ msgstr ""
 "Sebuah tipe bit-field (M), menyimpan M dari bit tiap nilai (standar adalah "
 "1, maksimum adalah  64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3583,21 +3580,21 @@ msgstr ""
 "Sinonim untuk TINYINT(1), nilai nol dianggal false, nilai selain nol "
 "dianggap true"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Sebuah alias untuk BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Sebuah Tanggal, Didukung pada kisaran %1$s sampai %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Kombinasi tanggal dan waktu, didukung pada kisaran %1$s sampai %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3606,12 +3603,12 @@ msgstr ""
 "03:14:07 UTC, disimpan sebagai jumlah detik sejak awal waktu (1970-01-01 "
 "00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Waktu, berkisar %1$s sampai %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3619,7 +3616,7 @@ msgstr ""
 "Format tahun dalam 4-digit (4, standar) atau 2 digit (2), mengizinkan nilai "
 "dari 70 (1970) sampai 69 (2069) atau 1901 sampai 2155 dan 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3627,7 +3624,7 @@ msgstr ""
 "Sebuah panjang tetap (0-255, standar 1) string yang selalu benar-diisi "
 "dengan spasi dengan panjang tertentu bila disimpan"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3636,7 +3633,7 @@ msgstr ""
 "Sebuah pangjang-variabel(%s) string, panjang maksimum efektif tunduk pada "
 "ukuran baris"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3644,7 +3641,7 @@ msgstr ""
 "kolom TEXT dengan panjang maksimum karakter 255 (2^8 - 1), disimpan dengan "
 "awalan satu-byte menunjukkan panjang nilai dalam byte"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3652,7 +3649,7 @@ msgstr ""
 "Kolom TEXT dengan panjang maksimum karakter 65,535 (2^16 - 1), disimpan "
 "dengan awalan dua-byte menunjukan panjang nilai dalam byte"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3660,7 +3657,7 @@ msgstr ""
 "Kolom TEXT dengan panjang maksimum karakter 16,777,215 (2^24 - 1), disimpan "
 "awalan tiga-byte menunjukan pajang nilai dalam byte"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3670,7 +3667,7 @@ msgstr ""
 "1) karakter, disimpan dengan awalan empat byte menunjukkan panjang nilai "
 "dalam byte"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3678,7 +3675,7 @@ msgstr ""
 "Serupa dengan tipe CHAR, tetapi string menyimpan karakter string biner byte "
 "daripada non-biner"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3686,7 +3683,7 @@ msgstr ""
 "Serupa dengan tipe VARCHAR, tetapi string menyimpan karakter string biner "
 "byte daripada non-biner"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3694,7 +3691,7 @@ msgstr ""
 "Sebuah kolom BLOB dengan panjang maksimum 255 (2^8 - 1) byte, disimpan "
 "dengan awalan satu-byte menunjukkan panjang nilai"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3702,7 +3699,7 @@ msgstr ""
 "Sebuah kolom BLOB dengan panjang maksimum 16,777,215 (2^24 - 1) byte, "
 "disimpan dengan awalan tiga byte yang menunjukkan panjang nilai"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3710,7 +3707,7 @@ msgstr ""
 "Sebuah kolom BLOB dengan panjang maksimum 65,535 (2^16 - 1) byte, disimpan "
 "dengan awalan dua-byte menunjukkan panjang nilai"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3718,7 +3715,7 @@ msgstr ""
 "Sebuah kolom BLOB dengan panjang maksimum 4,294,967,295 atau 4GiB (2^32 - 1) "
 "byte, disimpan dengan awalan empat byte menunjukkan panjang nilai"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 #, fuzzy
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
@@ -3727,70 +3724,70 @@ msgstr ""
 "Sebuah pencacahan, nilai dipilih dari daftar hingga 65,535 atau nilai khusus "
 "'' error"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Sebuah nilai tunggal dipilih dari satu set hingga 64 anggota"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Suatu jenis yang dapat menyimpan geometri dari jenis apa pun"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Sebuah titik dalam ruang 2-dimensi"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Kurva dengan interpolasi linier antara titik"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Sebuah poligon"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Sebuah koleksi poin"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Sebuah koleksi kurva dengan interpolasi linier antara titik"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Sebuah koleksi poligon"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Sebuah koleksi objek geometri dari jenis apa pun"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numerik"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Tanggal dan waktu"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Linestring"
 msgctxt "string types"
 msgid "String"
 msgstr "String"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Spasial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 "4-byte integer, berada pada kisaran -2,147,483,648 sampai 2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3798,24 +3795,24 @@ msgstr ""
 "8-byte integer, berada pada kisaran -9,223,372,036,854,775,808 sampai "
 "9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Sebuah nomor standar presisi-ganda sistem"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Benar atau salah"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Alias untuk BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 #, fuzzy
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Stores a Universally Unique Identifier (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3823,7 +3820,7 @@ msgstr ""
 "Timestamp, berada pada kisaran '0001-01-01 00:00:00' UTC sampai '9999-12-31 "
 "23:59:59' UTC; TIMESTAMP(6) dapat disimpan dalam mikro detik"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3831,7 +3828,7 @@ msgstr ""
 "Sebuah panjang-variabel string(0-65,535), menggunakan pemeriksaan biner "
 "untuk semua perbandingan"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Sebuah pencacahan, dipilih dari daftar nilai yang ditetapkan"
 
@@ -3916,69 +3913,69 @@ msgstr "%d %B %Y pada %H.%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s hari, %s jam, %s menit dan %s detik"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Parameter yang hilang:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Langsung ke basis data &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Fungsionalitas %s dipengaruhi oleh suatu bug, lihat %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Klik untuk beralih"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Telusuri komputer Anda:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Pilih dari direktori unggah <b>%s</b> pada web server:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 "Direktori yang telah ditetapkan untuk mengunggah tidak dapat dihubungi."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Tidak ada arsip untuk diunggah"
 
 # Imperative menu
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Kosongkan"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Eksekusi"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Cetak"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Pembuatan"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Pembaruan terakhir"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Pemeriksaan terakhir"
@@ -4336,9 +4333,9 @@ msgstr "Izinkan pengguna untuk mengubah nilai ini"
 msgid "Apply"
 msgstr "Terapkan"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Reset"
 
@@ -4643,7 +4640,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Waktu eksekusi maksimum"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Simpan sebagai berkas"
 
@@ -5389,7 +5386,6 @@ msgid "Users cannot set a higher value"
 msgstr "Pengguna tidak dapat menetapkan nilai yang lebih tinggi"
 
 #: libraries/config/messages.inc.php:287
-#| msgid "Maximum number of tables displayed in table list"
 msgid "Maximum number of databases displayed in database list"
 msgstr "Jumlah maksimum database yang ditampilkan dalam daftar database"
 
@@ -5444,15 +5440,14 @@ msgid ""
 "The number of bytes a script is allowed to allocate, eg. [kbd]32M[/kbd] "
 "([kbd]0[/kbd] for no limit)"
 msgstr ""
-"Jumlah bytes script yang diperbolehkan untuk mengalokasikan, misalnya. "
-"[kbd]32M[/kbd] ([kbd]0[/kbd] untuk tak terbatas)."
+"Jumlah bytes script yang diperbolehkan untuk mengalokasikan, misalnya. [kbd]"
+"32M[/kbd] ([kbd]0[/kbd] untuk tak terbatas)."
 
 #: libraries/config/messages.inc.php:299
 msgid "Memory limit"
 msgstr "Limit memori"
 
 #: libraries/config/messages.inc.php:300
-#| msgid "Show logo in left frame"
 msgid "Show logo in navigation panel"
 msgstr "Tampilkan logo di panel navigasi"
 
@@ -5483,7 +5478,6 @@ msgid "Logo link target"
 msgstr "Sasaran tautan logo"
 
 #: libraries/config/messages.inc.php:306
-#| msgid "Display server choice at the top of the left frame"
 msgid "Display server choice at the top of the navigation panel"
 msgstr "Tampilkan pilihan server di bagian atas panel navigasi"
 
@@ -5496,7 +5490,6 @@ msgid "Target for quick access icon"
 msgstr "Target ikon akses cepat"
 
 #: libraries/config/messages.inc.php:309
-#| msgid "Minimum number of tables to display the table filter box"
 msgid ""
 "Defines the minimum number of items (tables, views, routines and events) to "
 "display a filter box."
@@ -5505,25 +5498,19 @@ msgstr ""
 "menampilkan kotak filter."
 
 #: libraries/config/messages.inc.php:310
-#| msgid "Minimum number of tables to display the table filter box"
 msgid "Minimum number of items to display the filter box"
 msgstr "Jumlah minimum item yang ditampilkan di kotak tabel filter"
 
 #: libraries/config/messages.inc.php:311
-#| msgid "Minimum number of tables to display the table filter box"
 msgid "Minimum number of databases to display the database filter box"
 msgstr "Jumlah minimum database yang ditampilkan di kotak tabel filter"
 
 #: libraries/config/messages.inc.php:312
-#| msgid ""
-#| "Only light version; display databases in a tree (determined by the "
-#| "separator defined below)"
 msgid ""
 "Group items in the navigation tree (determined by the separator defined "
 "below)"
 msgstr ""
-"Item Group di pohon navigasi (ditentukan oleh pemisah didefinisikan di "
-"bawah)"
+"Item Group di pohon navigasi (ditentukan oleh pemisah didefinisikan di bawah)"
 
 #: libraries/config/messages.inc.php:313
 msgid "Group items in the tree"
@@ -5589,7 +5576,6 @@ msgid "Use only icons, only text or both"
 msgstr "Gunakan hanya ikon, hanya teks, atau keduanya"
 
 #: libraries/config/messages.inc.php:328
-#| msgid "Iconic navigation bar"
 msgid "Table navigation bar"
 msgstr "Bar tabel navigasi"
 
@@ -7061,7 +7047,7 @@ msgstr ""
 msgid "Language"
 msgstr "Bahasa"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informasi versi"
 
@@ -7478,61 +7464,61 @@ msgstr "Karena panjangnya,<br /> isian ini mungkin tidak dapat diedit"
 msgid "Binary - do not edit"
 msgstr "Biner - jangan diedit"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "direktori unggahan server web"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Lanjutkan penambahan untuk %s baris"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "selanjutnya"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Tambahkan sebagai baris baru"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Tambahkan sebagai baris baru dan abaikan galat"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Tampilkan kueri penambahan"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "kembali"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "tambahkan baris baru berikutnya"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Kembali ke halaman ini"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Edit baris berikut"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Gunakan tombol TAB untuk maju dari angka ke angka atau gunakan CTRL+panah "
 "untuk maju kemana saja"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Menampilkan kueri SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Nomor baris baru: %1$d"
@@ -9719,24 +9705,24 @@ msgid "There are no events to display."
 msgstr "Tidak ada event untuk ditampilkan."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Tabel %s tidak ditemukan!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Harap konfigurasikan koordinasi bagi tabel %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Skema basis data %s - Halaman %s"
@@ -12437,7 +12423,7 @@ msgstr "Versi %s telah dibuat, pelacakan untuk %s.%s diaktifkan."
 msgid "Manage your settings"
 msgstr "Kelola pengaturan Anda"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Konfigurasi telah disimpan"
 
@@ -12693,7 +12679,7 @@ msgstr "Pengaturan akan diimpor dari penyimpanan lokal peramban Anda."
 msgid "You have no saved settings!"
 msgstr "Anda tidak punya pengaturan tersimpan!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Fitur ini tidak didukung oleh peramban web Anda"
 
@@ -12710,19 +12696,19 @@ msgstr ""
 "Anda dapat mengatur pengaturan lain dengan mengubah config.inc.php, mis. "
 "dengan menggunakan %sskrip pengaturan%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Simpan di penyimpanan peramban"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Pengaturan akan disimpan di penyimpanan lokal peramban Anda."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Pengaturan yang ada akan ditimpa!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Anda dapat mengatur ulang semua pengaturan Anda dan memulihkan nilai bawaan."
@@ -12753,6 +12739,10 @@ msgstr "Basis data tidak ditemukan"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Tampilkan dump (skema) basis data"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/it.po
+++ b/po/it.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-10-16 11:02+0200\n"
 "Last-Translator: Marcello Romani <marcello.romani@libero.it>\n"
 "Language-Team: Italian <http://l10n.cihar.com/projects/phpmyadmin/master/it/"
@@ -41,7 +41,7 @@ msgstr "Commenti alla tabella:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Tipo"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr "Aggiornato"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Cancella dati di tracciamento per questa tabella"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -569,8 +569,8 @@ msgstr "Aggiungi una geometria"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -596,7 +596,7 @@ msgstr "Aggiungi una geometria"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Esegui"
@@ -980,7 +980,7 @@ msgstr "Aggiungi Indice"
 msgid "Edit Index"
 msgstr "Modifica Indice"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Aggiungi %s campo/i all'indice"
@@ -1198,7 +1198,7 @@ msgid "Traffic"
 msgstr "Traffico"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Impostazioni"
 
@@ -1516,8 +1516,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1730,8 +1730,8 @@ msgstr "Mostra riquadro query SQL"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1758,7 +1758,7 @@ msgstr "Tempo di esecuzione della query"
 msgid "%d is not valid row number."
 msgstr "%d non è un numero valido di righe."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1832,8 +1832,8 @@ msgstr "Risultati della query"
 msgid "Data point content"
 msgstr "Contenuto del punto"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignora"
 
@@ -2393,7 +2393,7 @@ msgstr ""
 "Permessi incorretti sul file di configurazione, non deve essere scrivibile "
 "da tutti!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Dimensione font"
 
@@ -2540,8 +2540,8 @@ msgstr[0] "%1$s corrispondenza in <strong>%2$s</strong>"
 msgstr[1] "%1$s corrispondenze in <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2597,28 +2597,28 @@ msgstr "Salva i dati modificati"
 msgid "Restore column order"
 msgstr "Ripristina l'ordine dei campi"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Inizio"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Precedente"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Prossima"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Ultima"
@@ -2797,9 +2797,9 @@ msgstr "Seleziona tutti"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2988,9 +2988,9 @@ msgid "View"
 msgstr "Vista"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3004,32 +3004,32 @@ msgid "Structure"
 msgstr "Struttura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Cerca"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Inserisci"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3038,20 +3038,20 @@ msgid "Privileges"
 msgstr "Privilegi"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operazioni"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Monitoraggio"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3067,70 +3067,70 @@ msgstr "Trigger"
 msgid "Database seems to be empty!"
 msgstr "Il database sembra essere vuoto!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Query da esempio"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Routine"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Eventi"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Designer"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Database"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Utenti"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Log binario"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replicazione"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variabili"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Set di caratteri"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Plugin"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motori"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Errore"
@@ -3156,7 +3156,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d riga inserita."
 msgstr[1] "%1$d righe inserite."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3384,7 +3384,7 @@ msgid "Operator"
 msgstr "Operatore"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3399,7 +3399,7 @@ msgstr "Ricerca nella Tabella"
 msgid "Find and Replace"
 msgstr "Trova e sostituisci"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Modifica/Inserisci"
 
@@ -3407,7 +3407,7 @@ msgstr "Modifica/Inserisci"
 msgid "Select columns (at least one):"
 msgstr "Seleziona campi (almeno uno):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Oppure"
@@ -3519,14 +3519,14 @@ msgstr "Percorso per il tema non trovato %s!"
 msgid "Theme:"
 msgstr "Tema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Intero di un byte, con segno l'intervallo va da -128 a 127, senza segno "
 "l'intervallo va da 0 a 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3534,7 +3534,7 @@ msgstr ""
 "Intero di due byte, con segno l'intervallo va da -32.768 a 32767, senza "
 "segno l'intervallo va da 0 a 65.535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3542,7 +3542,7 @@ msgstr ""
 "Intero di 3 byte, con segno l'intervallo va da -8.388.608 a 8.388.607, senza "
 "segno l'intervallo va da 0 a 16.777.215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3550,7 +3550,7 @@ msgstr ""
 "Intero di 4 byte, con segno l'intervallo va da -2.147.483.648 a "
 "2.147.483.647, senza segno l'intervallo va da 0 a 4.294.967.295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3559,7 +3559,7 @@ msgstr ""
 "9.223.372.036.854.775.807, senza segno l'intervallo va da 0 a "
 "18.446.744.073.709.551.615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3567,246 +3567,246 @@ msgstr ""
 "Un numero in virgola fissa (M, D) - il numero massimo di cifre (M) è 65 "
 "(default 10), il numero massimo di decimali (D) è 30 (default 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Una data, l'intervallo supportato va da %1$s a %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 "Una combinazione di data e ora, l'intervallo supportato va da %1$s a %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Un orario, l'intervallo va da %1$s a %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Un poligono"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Data e ora"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Stringa"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Spatial"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Spatial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3891,67 +3891,67 @@ msgstr "%B %d, %Y alle %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s giorni, %s ore, %s minuti e %s secondi"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Parametro mancante:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Passa al database &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "La %s funzionalità è affetta da un bug noto, vedi %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Clicca per alternare"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Cerca sul tuo computer:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Selezionare dalla cartella di upload del server web <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "La directory impostata per l'upload non può essere trovata."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Nessun file da caricare"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Svuota"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Esegui"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Stampa"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Creazione"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Ultimo cambiamento"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Ultimo controllo"
@@ -4312,9 +4312,9 @@ msgstr "Consente agli utenti di personalizzare questo valore"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Riavvia"
 
@@ -4631,7 +4631,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Massimo tempo di esecuzione"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Salva con nome"
 
@@ -7177,7 +7177,7 @@ msgstr "Il file è in fase di elaborazione, vi preghiamo di essere pazienti."
 msgid "Language"
 msgstr "Lingua"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informazioni sulla versione"
 
@@ -7624,61 +7624,61 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Dato binario - non modificare"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "directory di upload del web-server"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Riprendi inserimento con %s righe"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "e quindi"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Inserisci come nuova riga"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Inserisci come nuova riga e ignora gli errori"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Mostra la insert query"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Indietro"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Inserisci un nuovo record"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Torna a questa pagina"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Modifica il record successivo"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Usare il tasto TAB per spostare il cursore di valore in valore, o CTRL"
 "+frecce per spostarlo altrove"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Visualizzo la query SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Inserita riga id: %1$d"
@@ -9939,24 +9939,24 @@ msgid "There are no events to display."
 msgstr "Non ci sono eventi da visualizzare."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "La tabella %s non esiste!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Prego, configurare le coordinate per la tabella %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Schema del database %s - Pagina %s"
@@ -12779,7 +12779,7 @@ msgstr "Versione %1$s creata, monitoraggio attivato per %2$s."
 msgid "Manage your settings"
 msgstr "Gestisci le tue impostazioni"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "La configurazione é stata salvata"
 
@@ -13039,7 +13039,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Non hai alcuna impostazione salvata!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Questa funzionalitá non é supportata dal tuo browser"
 
@@ -13056,19 +13056,19 @@ msgstr ""
 "Puoi impostare ulteriori impostazioni modificando config.inc.php, ad esempio "
 "via %sGli script di setup%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Salva nella memoria del browser"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Le impostazioni verranno salvate nella memoria locale del tuo browser."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "La impostazioni esistenti verranno sovrascritte!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Puoi reimpostare tutte le tue configurazioni e ripristinarle ai valori "
@@ -13100,6 +13100,10 @@ msgstr "Nessun database"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Visualizza il dump (schema) dei databases"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-11 13:31+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Japanese <http://l10n.cihar.com/projects/phpmyadmin/master/ja/"
@@ -41,7 +41,7 @@ msgstr "テーブルのコメント："
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "データ型"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -341,7 +341,7 @@ msgid "Updated"
 msgstr "更新日時"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -369,7 +369,7 @@ msgid "Delete tracking data for this table"
 msgstr "このテーブルに対しての追跡データを削除する"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -575,8 +575,8 @@ msgstr "幾何データを追加する"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -602,7 +602,7 @@ msgstr "幾何データを追加する"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "実行"
@@ -993,7 +993,7 @@ msgstr "インデックスを追加する"
 msgid "Edit Index"
 msgstr "インデックスを編集する"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %d column(s) to index"
 msgid "Add %s column(s) to index"
@@ -1210,7 +1210,7 @@ msgid "Traffic"
 msgstr "トラフィック"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "設定"
 
@@ -1524,8 +1524,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1738,8 +1738,8 @@ msgstr "クエリボックスを表示"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1766,7 +1766,7 @@ msgstr "クエリの実行時間"
 msgid "%d is not valid row number."
 msgstr "%d は不正な行番号です。"
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1841,8 +1841,8 @@ msgstr "クエリの結果"
 msgid "Data point content"
 msgstr "プロット点におけるデータ内容"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "無視"
 
@@ -2413,7 +2413,7 @@ msgstr ""
 "設定ファイルのパーミッションが正しくありません。誰でも書き込み可能になってい"
 "ます！"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "フォントサイズ"
 
@@ -2573,8 +2573,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] "%1$s 件 (テーブル <i>%2$s</i>)"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2630,28 +2630,28 @@ msgstr "変更したデータを保存する"
 msgid "Restore column order"
 msgstr "カラムの順番を元に戻す"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "先頭"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "前へ"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "次へ"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "最後"
@@ -2831,9 +2831,9 @@ msgstr "すべてチェックする"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3028,9 +3028,9 @@ msgid "View"
 msgstr "ビュー"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3044,32 +3044,32 @@ msgid "Structure"
 msgstr "構造"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "検索"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "挿入"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3078,20 +3078,20 @@ msgid "Privileges"
 msgstr "特権"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "操作"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "SQL コマンドの追跡"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3107,70 +3107,70 @@ msgstr "トリガ"
 msgid "Database seems to be empty!"
 msgstr "データベースが空のようです!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "クエリ"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "ルーチン"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "イベント"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "デザイナ"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "データベース"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "ユーザ"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "バイナリログ"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "レプリケーション"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "変数"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "文字セット"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "プラグイン"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "エンジン"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "エラー"
@@ -3193,7 +3193,7 @@ msgid "%1$d row inserted."
 msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d 行挿入しました。"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3417,7 +3417,7 @@ msgid "Operator"
 msgstr "演算子"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3432,7 +3432,7 @@ msgstr "テーブル検索"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "編集／挿入"
 
@@ -3440,7 +3440,7 @@ msgstr "編集／挿入"
 msgid "Select columns (at least one):"
 msgstr "表示するカラム (最低 1 つ):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "または"
@@ -3562,18 +3562,18 @@ msgstr "テーマ %s のテーマパスが見つかりません!"
 msgid "Theme:"
 msgstr "テーマ"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr "1 バイト整数、符号付きは -128 から 127、符号なしは 0 から 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr "2 バイト整数、符号付きは -32,768 から 32,767、符号なしは 0 から 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3581,7 +3581,7 @@ msgstr ""
 "3 バイト整数、符号付きは -8,388,608 から 8,388,607、符号なしは 0 から "
 "16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3589,7 +3589,7 @@ msgstr ""
 "4 バイト整数、符号付きは -2,147,483,648 から 2,147,483,647、符号なしは 0 か"
 "ら 4,294,967,295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3597,7 +3597,7 @@ msgstr ""
 "8 バイト整数、符号付きは -9,223,372,036,854,775,808 から "
 "9,223,372,036,854,775,807、符号なしは 0 から 18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3605,7 +3605,7 @@ msgstr ""
 "固定小数 (M, D) - 整数部の最大桁数 M は 65 (デフォルトは 10)、小数部のの最大"
 "桁数 D は 30 (デフォルトは 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3613,7 +3613,7 @@ msgstr ""
 "単精度浮動小数、有効範囲は -3.402823466E+38 から -1.175494351E-38、0、"
 "1.175494351E-38 から 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3623,7 +3623,7 @@ msgstr ""
 "2.2250738585072014E-308、0、2.2250738585072014E-308 から 1.7976931348623157E"
 "+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3631,35 +3631,35 @@ msgstr ""
 "DOUBLE と同義 (例外：REAL を FLOAT として扱うモード (REAL_AS_FLOAT) では、"
 "FLOAT と 同義になります)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr "TINYINT(1) と同義、0 が FALSE と見なされ、0 以外が TRUE と見なされます"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 "BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE の別名 (BIGINT、符号なし、"
 "NULL なし、AUTO_INCREMENT、ユニークキー)"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "日付、有効範囲は %1$s から %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "日時 (日付と時刻)、有効範囲は %1$s から %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3667,12 +3667,12 @@ msgstr ""
 "タイムスタンプ、範囲は 1970-01-01 00:00:01 UTC から 2038-01-09 03:14:07 UTC "
 "で、1970-01-01 00:00:00 UTC からの経過秒数を示しています"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "時刻、範囲は %1$s から %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3680,7 +3680,7 @@ msgstr ""
 "年、4 桁 (デフォルト) または 2 桁、有効な値は 2 桁が 70 (1970) から 69 "
 "(2069)、4 桁が 1901 から 2155 および 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3688,7 +3688,7 @@ msgstr ""
 "固定長文字列 (長さは 0-255、デフォルトは 1)、満たない分は右側が空白で埋められ"
 "ます"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3696,7 +3696,7 @@ msgid ""
 msgstr ""
 "可変長文字列 (長さは %s)、長さの有効上限は行の最大サイズの制約を受けます"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3704,7 +3704,7 @@ msgstr ""
 "TEXT カラム、最大長 255 (2^8 - 1)、これの長さは単位がバイトで、1 バイト値で表"
 "現できる範囲です"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3712,7 +3712,7 @@ msgstr ""
 "TEXT カラム、最大長 65,535 (2^16 - 1)、これの長さは単位がバイトで、2 バイト値"
 "で表現できる範囲です"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3720,7 +3720,7 @@ msgstr ""
 "TEXT カラム、最大長 16,777,215 (2^24 - 1)、これの長さは単位がバイトで、3 バイ"
 "ト値で表現できる範囲です"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3729,14 +3729,14 @@ msgstr ""
 "TEXT カラム、最大長 4,294,967,295 または 4GiB (2^32 - 1)、これの長さは単位が"
 "バイトで、4 バイト値で表現できる範囲です"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 "CHAR 型と似ていますが、非バイナリ文字列ではなくバイナリ文字列で保存されます"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3744,7 +3744,7 @@ msgstr ""
 "VARCHAR 型と似ていますが、非バイナリ文字列ではなくバイナリ文字列で保存されま"
 "す"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3752,7 +3752,7 @@ msgstr ""
 "BLOB カラム、最大 255 (2^8 - 1) バイト、これの長さは 1 バイト値で表現できる範"
 "囲です"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3760,7 +3760,7 @@ msgstr ""
 "BLOB カラム、最大 16,777,215 (2^24 - 1) バイト、これの長さは 3 バイト値で表現"
 "できる範囲です"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3768,7 +3768,7 @@ msgstr ""
 "BLOB カラム、最大 65,535 (2^16 - 1) バイト、これの長さは 2 バイト値で表現でき"
 "る範囲です"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3776,7 +3776,7 @@ msgstr ""
 "BLOB カラム、最大 4,294,967,295 バイトまたは 4GiB (2^32 - 1)、これの長さは 4 "
 "バイト値で表現できる範囲です"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3784,67 +3784,67 @@ msgstr ""
 "﻿列挙型、最大 65,535 個の列挙値または特殊な値 (エラー値 '') を取ることができま"
 "す"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "最大 64 メンバに対しての有無を一括で扱う単一の値"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "任意の型の幾何データが保存できるデータ型"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "2 次元空間の点"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "多点間の線形補間による曲線"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "ポリゴン"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "座標の集合"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "多点間の線形補間による曲線の集合"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "ポリゴンの集合"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "任意の型の幾何物体の集合"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "数値"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "日付・時刻"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "文字列"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "空間データ"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "4 バイト整数、範囲は -2,147,483,648 から 2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3852,25 +3852,25 @@ msgstr ""
 "8 バイト整数、範囲は -9,223,372,036,854,775,808 から "
 "9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "システムでデフォルトの倍精度浮動小数"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "TRUE または FALSE"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 "BIGINT NOT NULL AUTO_INCREMENT UNIQUE の別名 (BIGINT、NULL なし、"
 "AUTO_INCREMENT、ユニークキー)"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "汎用一意識別子 (UUID) 保存用"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3878,13 +3878,13 @@ msgstr ""
 "タイムスタンプ、範囲は 0001-01-01 00:00:00 UTC から 9999-12-31 23:59:59、"
 "TIMESTAMP(6) でマイクロ秒まで保存できるようになります"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr "可変長文字列 (長さは 0-65,535)、文字列の比較はバイナリで行われます"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "列挙型、定義しておいた列挙リストより値を取ることができます"
 
@@ -3971,67 +3971,67 @@ msgstr "%Y 年 %B %d 日 %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s 日 %s 時間 %s 分 %s 秒"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "パラメータがありません："
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "データベース「%s」に移動します。"
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s の機能には既知のバグがあります。%s をご覧ください"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "クリックでオン／オフ切り替え"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "アップロードファイル:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "ウェブサーバ上のアップロードディレクトリ <b>%s</b> から選択する："
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "指定したアップロードディレクトリが利用できません"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "アップロードファイルがありません"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "空にする"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "実行"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "印刷"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "作成日時"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "最終更新"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "最終検査"
@@ -4393,9 +4393,9 @@ msgstr "この値の変更をユーザに許可する"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "リセット"
 
@@ -4699,7 +4699,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "最大実行時間"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "ファイルに保存する"
 
@@ -7246,7 +7246,7 @@ msgstr "ファイルが処理されています。しばらくお待ちくださ
 msgid "Language"
 msgstr "言語"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "バージョン情報"
 
@@ -7685,61 +7685,61 @@ msgstr "長さによってはこのカラムを<br />編集できなくなる場
 msgid "Binary - do not edit"
 msgstr "バイナリ - 編集不可"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "ウェブサーバ上のアップロードディレクトリ"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "%s 行づつ挿入を行う"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "続いて"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "新しい行として挿入する"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "新しい行として挿入し、エラーは無視する"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "挿入クエリ文を表示する"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "前のページに戻る"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "新しいレコードを追加する"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "このページに戻る"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "次の行を編集する"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "次の値に移動するときは TAB キーを使ってください。CTRL＋カーソルキーを使うと自"
 "由に移動できます"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "SQL クエリを表示"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "id %1$d の行を挿入しました"
@@ -9970,24 +9970,24 @@ msgid "There are no events to display."
 msgstr "表示できるイベントがありません。"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "%s テーブルは存在しません!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "テーブル %s の座標を設定してください"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "データベース %s のスキーマ - ページ %s"
@@ -12742,7 +12742,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "ユーザ環境設定の管理"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "設定を保存しました"
 
@@ -13006,7 +13006,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "保存されている設定はありません！"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "この機能はブラウザよってサポートされていません"
 
@@ -13023,21 +13023,21 @@ msgstr ""
 "%sセットアップスクリプト%sを使用するなどして config.inc.php を変更することに"
 "より、より多くの設定を行うことができます。"
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "ブラウザ (Web Storage) に保存する"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 "設定がブラウザ (Web Storage) に保存されます。ローカルの保存場所ですがクッキー"
 "ではありません。"
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "既に保存してある設定に上書きします！"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "すべての設定をリセットして、デフォルト値に復元します。"
 
@@ -13068,6 +13068,10 @@ msgstr "データベースが存在しません"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "データベースのダンプ (スキーマ) 表示"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ka.po
+++ b/po/ka.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:34+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Georgian <http://l10n.cihar.com/projects/phpmyadmin/master/ka/"
@@ -43,7 +43,7 @@ msgstr "ცხრილის კომენტარები"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "ტიპი"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -344,7 +344,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -372,7 +372,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -570,8 +570,8 @@ msgstr "გეომეტრიის დამატება"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -597,7 +597,7 @@ msgstr "გეომეტრიის დამატება"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "გადასვლა"
@@ -1002,7 +1002,7 @@ msgstr "ახალი ველის დამატება"
 msgid "Edit Index"
 msgstr "რედაქტირების რეჟიმი"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1244,7 +1244,7 @@ msgid "Traffic"
 msgstr "ტრაფიკი"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1586,8 +1586,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1847,8 +1847,8 @@ msgstr "SQL Query box"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1877,7 +1877,7 @@ msgstr "Maximum execution time"
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1962,8 +1962,8 @@ msgstr "Query results operations"
 msgid "Data point content"
 msgstr "Data pointer size"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "იგნორირება"
 
@@ -2590,7 +2590,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "შრიფტის ზომა"
 
@@ -2755,8 +2755,8 @@ msgstr[0] "%s match(es) inside table <i>%s</i>"
 msgstr[1] "%s match(es) inside table <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2820,16 +2820,16 @@ msgstr "დირექტორიის შენახვა"
 msgid "Restore column order"
 msgstr "CHAR textarea columns"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "დასაწყისი"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2837,8 +2837,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "წინა"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2846,8 +2846,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "შემდეგი"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3038,9 +3038,9 @@ msgstr "ყველას შემოწმება"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3229,9 +3229,9 @@ msgid "View"
 msgstr "ხედო"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3245,32 +3245,32 @@ msgid "Structure"
 msgstr "სტრუქტურა"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "ძებნა"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "ჩასმა"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3279,20 +3279,20 @@ msgid "Privileges"
 msgstr "პრივილეგიები"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "მოქმედებები"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3308,72 +3308,72 @@ msgstr "ტრიგერები"
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "მოთხოვნა"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Routines"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "მოვლენები"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "შემქნელი"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "მონაცემთა ბაზები"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "მომხმარებელი"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "ბინარული ჟურნალი"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "რეპლიკაცია"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "ცვლადები"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "სიმბოლოთა ნაკრებები"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "ძრავები"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "შეცდომა"
@@ -3402,7 +3402,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "ჩაისვა %1$d სტრიქონი."
 msgstr[1] "ჩაისვა %1$d სტრიქონი."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3636,7 +3636,7 @@ msgid "Operator"
 msgstr "ოპერატორი"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3653,7 +3653,7 @@ msgstr "ძებნა"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3665,7 +3665,7 @@ msgstr "ჩასმა"
 msgid "Select columns (at least one):"
 msgstr "Select fields (at least one):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "ან"
@@ -3795,284 +3795,284 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Create relation"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Create relation"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "ახალი ინდექსის შექმნა"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Lines terminated by"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Log file count"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4163,70 +4163,70 @@ msgstr "%B %d, %Y, %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s დღე, %s საათი, %s წუთი და %s წამი"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Routines"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "web server upload directory"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "ცარიელი"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "დაბეჭდვა"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "შეიქმნა"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "უკანასკნელი განახლება"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Last check"
@@ -4601,9 +4601,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "დაბრუნება"
 
@@ -4916,7 +4916,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "ფაილის სახის შენახვა"
 
@@ -7465,7 +7465,7 @@ msgstr ""
 msgid "Language"
 msgstr "ენა"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "ინფორმაცია ვერსიის შესახებ"
 
@@ -7866,61 +7866,61 @@ msgstr "Because of its length,<br /> this field might not be editable "
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "web server upload directory"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Restart insertion with %s rows"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "და შემდეგ"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "ახალი სტრიქონის ჩამატება"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 #, fuzzy
 msgid "Show insert query"
 msgstr "Showing SQL query"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "წინა გვერდზე დაბრუნება"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "სხვა ახალი სტრიქონის დამატება"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "ამ გვერდზე დაბრუნება"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "შემდეგი სტრიქონის რედაქტირება"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "ჩამატებული სტრიქონის id: %1$d"
@@ -10244,25 +10244,25 @@ msgid "There are no events to display."
 msgstr "There are no configured servers"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "ცხრილი \"%s\" არ არსებობს!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12965,7 +12965,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Other core settings"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13257,7 +13257,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Other core settings"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13274,19 +13274,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13315,6 +13315,10 @@ msgstr "მონაცემთა ბაზები არაა"
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/kk.po
+++ b/po/kk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-07-15 11:25+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Kazakh <http://l10n.cihar.com/projects/phpmyadmin/master/kk/"
@@ -47,7 +47,7 @@ msgstr "Кестеге түсініктеме:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -93,7 +93,7 @@ msgid "Type"
 msgstr "Типі"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -348,7 +348,7 @@ msgid "Updated"
 msgstr "Жаңартылған"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -376,7 +376,7 @@ msgid "Delete tracking data for this table"
 msgstr "Кесте үшін мәліметтерді бақылауды тоқтату"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -582,8 +582,8 @@ msgstr "Геометрияны қосу"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -609,7 +609,7 @@ msgstr "Геометрияны қосу"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Өту"
@@ -963,7 +963,7 @@ msgstr "Индекс қосу"
 msgid "Edit Index"
 msgstr "Индексті өзгерту"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add columns"
 msgid "Add %s column(s) to index"
@@ -1179,7 +1179,7 @@ msgid "Traffic"
 msgstr "Трафик"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Баптау"
 
@@ -1473,8 +1473,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1683,8 +1683,8 @@ msgstr "Сұраныс өрісін көрсету"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1711,7 +1711,7 @@ msgstr "Сұраныстың орындалу уақыты"
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1784,8 +1784,8 @@ msgstr "Сұраныс нәтижелері"
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Елемеу"
 
@@ -2327,7 +2327,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 #, fuzzy
 msgid "Font size"
 msgstr "Қарiп өлшемi"
@@ -2487,8 +2487,8 @@ msgstr[0] "%1$s кестедегi сәйкестiк <i>%2$s</i>"
 msgstr[1] "%1$s кестедегi сәйкестiктер <i>%2$s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2544,28 +2544,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr ""
@@ -2742,9 +2742,9 @@ msgstr "Барлығын белгілеу"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2929,9 +2929,9 @@ msgid "View"
 msgstr "Түр"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2945,32 +2945,32 @@ msgid "Structure"
 msgstr ""
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr ""
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Іздеу"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2979,20 +2979,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3008,70 +3008,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Дерекқоры"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Репликация"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Қате"
@@ -3097,7 +3097,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3317,7 +3317,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3332,7 +3332,7 @@ msgstr ""
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3340,7 +3340,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Немесе"
@@ -3458,280 +3458,280 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr ""
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Linestring"
 msgctxt "string types"
 msgid "String"
 msgstr "Сызық"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3816,67 +3816,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Тазарту"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Құру"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Соңғы жаңартылым"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Соңғы тексерім"
@@ -4234,9 +4234,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4519,7 +4519,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6753,7 +6753,7 @@ msgstr ""
 msgid "Language"
 msgstr "Тіл"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7144,57 +7144,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9260,24 +9260,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11814,7 +11814,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -12062,7 +12062,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12077,19 +12077,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12116,6 +12116,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/kn.po
+++ b/po/kn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-06-04 15:25+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Kannada <http://l10n.cihar.com/projects/phpmyadmin/master/kn/"
@@ -43,7 +43,7 @@ msgstr ""
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr ""
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -558,8 +558,8 @@ msgstr ""
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -585,7 +585,7 @@ msgstr ""
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr ""
@@ -913,7 +913,7 @@ msgstr ""
 msgid "Edit Index"
 msgstr ""
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr ""
@@ -1126,7 +1126,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr ""
 
@@ -1420,8 +1420,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1630,8 +1630,8 @@ msgstr ""
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1658,7 +1658,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1727,8 +1727,8 @@ msgstr ""
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2409,8 +2409,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2466,28 +2466,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr ""
@@ -2663,9 +2663,9 @@ msgstr ""
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2850,9 +2850,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2866,32 +2866,32 @@ msgid "Structure"
 msgstr ""
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr ""
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr ""
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2900,20 +2900,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2929,70 +2929,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr ""
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr ""
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr ""
@@ -3018,7 +3018,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3234,7 +3234,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3249,7 +3249,7 @@ msgstr ""
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3257,7 +3257,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr ""
@@ -3367,278 +3367,278 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr ""
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3723,67 +3723,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr ""
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr ""
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr ""
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr ""
@@ -4131,9 +4131,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4414,7 +4414,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6630,7 +6630,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7021,57 +7021,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9087,24 +9087,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11573,7 +11573,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -11821,7 +11821,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -11836,19 +11836,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -11875,6 +11875,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/ko.po
+++ b/po/ko.po
@@ -3,14 +3,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-29 11:18+0200\n"
 "Last-Translator: 흥재 신 <xfp.730700@gmail.com>\n"
-"Language-Team: Korean <http://l10n.cihar.com/projects/phpmyadmin/master/ko/>\n"
-"Language: ko\n"
+"Language-Team: Korean <http://l10n.cihar.com/projects/phpmyadmin/master/ko/"
+">\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -40,7 +41,7 @@ msgstr "테이블 설명:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -86,7 +87,7 @@ msgid "Type"
 msgstr "종류"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -334,7 +335,7 @@ msgid "Updated"
 msgstr "수정됨"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -362,7 +363,7 @@ msgid "Delete tracking data for this table"
 msgstr "이 테이블에 대한 추적 데이터를 제거"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -489,7 +490,6 @@ msgstr "SRID:"
 
 #: gis_data_editor.php:186
 #, php-format
-#| msgid "Geometry"
 msgid "Geometry %d:"
 msgstr "기하데이터 %d:"
 
@@ -561,8 +561,8 @@ msgstr "공간 데이터를 추가"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -588,7 +588,7 @@ msgstr "공간 데이터를 추가"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "실행"
@@ -688,7 +688,6 @@ msgid "Back"
 msgstr "뒤로"
 
 #: index.php:115 libraries/Footer.class.php:70
-#| msgid "phpMyAdmin homepage"
 msgid "phpMyAdmin Demo Server"
 msgstr "phpMyAdmin 데모 서버"
 
@@ -699,8 +698,8 @@ msgid ""
 "change root, debian-sys-maint and pma users. More information is available "
 "at %s."
 msgstr ""
-"데모서버를 사용중입니다. 뭐든지 할 수있으나 root, debian-sys-maint, pma사용자는 변경하지 마세요. 추가정보는 %"
-"s에서 있습니다."
+"데모서버를 사용중입니다. 뭐든지 할 수있으나 root, debian-sys-maint, pma사용자"
+"는 변경하지 마세요. 추가정보는 %s에서 있습니다."
 
 #: index.php:129
 msgid "General Settings"
@@ -856,18 +855,15 @@ msgid "The configuration file now needs a secret passphrase (blowfish_secret)."
 msgstr "이제 설정 파일은 암호화 문자열(blowfish_scret) 을 필요로 합니다."
 
 #: index.php:494
-#| msgid ""
-#| "Directory [code]config[/code], which is used by the setup script, still "
-#| "exists in your phpMyAdmin directory. You should remove it once phpMyAdmin "
-#| "has been configured."
 msgid ""
 "Directory [code]config[/code], which is used by the setup script, still "
 "exists in your phpMyAdmin directory. It is strongly recommended to remove it "
 "once phpMyAdmin has been configured. Otherwise the security of your server "
 "may be compromised by unauthorized people downloading your configuration."
 msgstr ""
-"설정 스크립트가 [code]config[/code] 디렉토리를 사용하고 phpMyAdmin디렉토리에도 존재합니다. phpMyAdmin "
-"설정 완료후 꼭 삭제하세요. 그렇지 않으며 보안에 취약해 집니다."
+"설정 스크립트가 [code]config[/code] 디렉토리를 사용하고 phpMyAdmin디렉토리에"
+"도 존재합니다. phpMyAdmin 설정 완료후 꼭 삭제하세요. 그렇지 않으며 보안에 취"
+"약해 집니다."
 
 #: index.php:504
 #, php-format
@@ -935,7 +931,6 @@ msgstr "이 명령은 오랜 시간이 걸릴 수 있습니다. 그래도 실행
 
 #: js/messages.php:44
 #, php-format
-#| msgid "Do you really want to execute \"%s\"?"
 msgid "Do you really want to delete user group \"%s\"?"
 msgstr "\"%s\"그룹을 삭제하시겠습니까?"
 
@@ -944,7 +939,6 @@ msgid "Missing value in the form!"
 msgstr "입력 폼 안에 빠진 값이 있습니다!"
 
 #: js/messages.php:48
-#| msgid "Not a valid port number"
 msgid "Please enter a valid number"
 msgstr "올바른  숫자를 입력하세요"
 
@@ -960,7 +954,7 @@ msgstr "인덱스 추가"
 msgid "Edit Index"
 msgstr "인덱스 수정"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "인덱스에 %s 열 추가"
@@ -1176,7 +1170,7 @@ msgid "Traffic"
 msgstr "소통량"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "설정"
 
@@ -1484,8 +1478,8 @@ msgstr "가져온 설정과 차트 격자를 그리는데 실패했습니다. �
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1545,7 +1539,6 @@ msgstr "취소"
 
 #: js/messages.php:229 libraries/navigation/NavigationHeader.class.php:55
 #: libraries/server_status_monitor.lib.php:164
-#| msgid "Loading"
 msgid "Loading…"
 msgstr "불러오는 중…"
 
@@ -1695,8 +1688,8 @@ msgstr "질의 상자 보이기"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1723,7 +1716,7 @@ msgstr "질의 실행 시간"
 msgid "%d is not valid row number."
 msgstr "%d는 올바른 행번호가 아닙니다."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1741,12 +1734,10 @@ msgid "Show search criteria"
 msgstr "검색 조건 보이기"
 
 #: js/messages.php:296
-#| msgid "Hide search criteria"
 msgid "Hide find and replace criteria"
 msgstr "검색/변경 조건 숨기기"
 
 #: js/messages.php:297
-#| msgid "Show search criteria"
 msgid "Show find and replace criteria"
 msgstr "검색/변경 조건 보이기"
 
@@ -1794,8 +1785,8 @@ msgstr "쿼리 결과"
 msgid "Data point content"
 msgstr "데이터 포인트 내용"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "무시"
 
@@ -1961,7 +1952,6 @@ msgid "Hide Panel"
 msgstr "패널 숨기기"
 
 #: js/messages.php:394
-#| msgid "Show logo in navigation panel"
 msgid "Show hidden navigation tree items"
 msgstr "숨겨진 네비트리의 항목보기"
 
@@ -2003,19 +1993,16 @@ msgid "Submit Error Report"
 msgstr "제출오류 보고서"
 
 #: js/messages.php:411
-#| msgid "An error has occured while loading the navigation tree"
 msgid ""
 "A fatal JavaScript error has occurred. Would you like to send an error "
 "report?"
 msgstr "치명적인 자바스크립트 오류 발생. 오류를 전송할까요?"
 
 #: js/messages.php:413
-#| msgid "Change settings"
 msgid "Change Report Settings"
 msgstr "보고서 설정 변경"
 
 #: js/messages.php:414
-#| msgid "Show open tables"
 msgid "Show Report Details"
 msgstr "보고서 상세 보기"
 
@@ -2349,7 +2336,7 @@ msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 "설정 파일에 잘못된 권한이 지정되어있습니다. 익명 쓰기 권한이면 안됩니다."
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "글꼴 크기"
 
@@ -2496,8 +2483,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] "<strong>%2$s</strong> 에서 %1$s 건 일치"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2553,28 +2540,28 @@ msgstr "수정한 데이터 저장"
 msgid "Restore column order"
 msgstr "컬럼(열) 순서 복구"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "처음"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "이전"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "다음"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "마지막"
@@ -2751,9 +2738,9 @@ msgstr "모두 체크"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2847,7 +2834,6 @@ msgid "Currently running Git revision %1$s from the %2$s branch."
 msgstr "%2$s구분에서 현재 실행중인 Git 리버젼 %1$s."
 
 #: libraries/Footer.class.php:81
-#| msgid "Version information"
 msgid "Git information missing!"
 msgstr "Git정보가 없습니다!"
 
@@ -2943,9 +2929,9 @@ msgid "View"
 msgstr "뷰"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2959,32 +2945,32 @@ msgid "Structure"
 msgstr "구조"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "검색"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "삽입"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2993,20 +2979,20 @@ msgid "Privileges"
 msgstr "사용권한"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "테이블 작업"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "SQL 명령어 트래킹"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3022,70 +3008,70 @@ msgstr "트리거"
 msgid "Database seems to be empty!"
 msgstr "데이터베이스가 비어있는 것 같습니다!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "질의 마법사"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "루틴"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "이벤트"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "디자이너"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "데이터베이스"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "사용자"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "바이너리 로그"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "복제"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "환경설정값"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "문자셋"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "플러그인"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "엔진"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "오류"
@@ -3108,7 +3094,7 @@ msgid "%1$d row inserted."
 msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d 열이 삽입되었습니다."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3329,7 +3315,7 @@ msgid "Operator"
 msgstr "연산자"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3344,7 +3330,7 @@ msgstr "테이블 검색"
 msgid "Find and Replace"
 msgstr "찾기 및 바꾸기"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "편집/삽입"
 
@@ -3352,7 +3338,7 @@ msgstr "편집/삽입"
 msgid "Select columns (at least one):"
 msgstr "컬럼 선택 (하나 이상):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "또는"
@@ -3407,7 +3393,6 @@ msgid "Reset zoom"
 msgstr "줌 초기화"
 
 #: libraries/TableSearch.class.php:1343
-#| msgid "Replace table data with file"
 msgid "Replace with:"
 msgstr "변경:"
 
@@ -3416,22 +3401,18 @@ msgid "Find and replace - preview"
 msgstr "찾기 및 바꾸기 - 미리보기"
 
 #: libraries/TableSearch.class.php:1407
-#| msgid "Column"
 msgid "Count"
 msgstr "개수"
 
 #: libraries/TableSearch.class.php:1408
-#| msgid "Original position"
 msgid "Original string"
 msgstr "원본 문자열"
 
 #: libraries/TableSearch.class.php:1409
-#| msgid "Related Links"
 msgid "Replaced string"
 msgstr "문자열 변경"
 
 #: libraries/TableSearch.class.php:1433
-#| msgid "Replicated"
 msgid "Replace"
 msgstr "변경"
 
@@ -3467,14 +3448,14 @@ msgstr "%s 테마의 경로를 찾을 수 없음!"
 msgid "Theme:"
 msgstr "테마:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "1바이트 정수형의 범위는 부호가 있는 경우 -128 에서 127, 부호가 없는 경우 0 에"
 "서 255 입니다"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3482,7 +3463,7 @@ msgstr ""
 "2바이트 정수형의 범위는 부호가 있는 경우 -32,768 에서 32,767, 부호가 없는 경"
 "우 0 에서 65,355 입니다"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3490,7 +3471,7 @@ msgstr ""
 "3바이트 정수형의 범위는 부호가 있는 경우 -8,388,608 에서 8,388,607, 부호가 없"
 "는 경우 0 에서 16,777,215 입니다"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3498,7 +3479,7 @@ msgstr ""
 "4바이트 정수형의 범위는 부호가 있는 경우 -2,147,483,648 에서 2,147,483,647, "
 "부호가 없는 경우 0 에서 4,294,967,295 입니다."
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3507,7 +3488,7 @@ msgstr ""
 "9,223,372,036,854,775,807, 부호가 없는 경우 0 에서 "
 "18,446,744,073,709,551,615 입니다"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3515,7 +3496,7 @@ msgstr ""
 "고정소수점 숫자 (M, D) - 최대 자릿수(M)는 65이며 (기본값 10), 최대 소수점 자"
 "릿수(D)는 30입니다 (기본값 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3523,7 +3504,7 @@ msgstr ""
 "작은 부동소수점 숫자, 허용 가능한 값은 -3.402823466E+38 에서 -1.175494351E-"
 "38 까지, 0, 그리고 1.175494351E-38 에서 3.402823466E+38 까지입니다"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3533,19 +3514,19 @@ msgstr ""
 "2.2250738585072014E-308 까지, 0, 그리고 2.2250738585072014E-308 에서 "
 "1.7976931348623157E+308 까지입니다"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr "DOUBLE과 동일함. (예외: REAL_AS_FLOAT SQL모드에서는 FLOAT으로 동작함)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3553,21 +3534,21 @@ msgstr ""
 "TINYINT(1)와 동일함. 저장된 값이 0일 경우 거짓으로, 0이 아닐 경우 참값이 저장"
 "된 것으로 간주됨"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE 의 별칭"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "날짜 타입, %1$s 부터 %2$s 까지 지원됨"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "날짜와 시간 조합, %1$s 부터 %2$s 까지 지원됨"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3575,12 +3556,12 @@ msgstr ""
 "타임스탬프 형식, 1970-01-01 00:00:01 UTC 부터 2038-01-09 03:14:07 UTC 까지, "
 "EPOCH (1970-01-01 00:00:00 UTC) 이후 경과된 초 단위 시간을 숫자로 저장함"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "%1$s 에서 %2$s 사이의 범위를 가진 시간값"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3588,7 +3569,7 @@ msgstr ""
 "네 자리(4, 기본값) 또는 두 자리(2)로 표현한 연도, 70(1970) 부터 69(2069) 또"
 "는 1901 부터 2155 까지 및 0000 값이 허용됨"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3596,14 +3577,14 @@ msgstr ""
 "저장시 항상 지정된 길이까지 오른쪽을 공백으로 채우는 고정 길이 (0-255, 기본"
 "값 1) 문자열"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr "가변 길이 (%s) 문자열, 효율적인 최대 길이는 최대 열 크기에 따라 다름"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3611,7 +3592,7 @@ msgstr ""
 "최대 255(2^8-1)글자의 길이를 가지는 TEXT 칼럼, 값의 길이를 바이트 단위로 나타"
 "내는 1바이트 인디케이터를 앞에 붙여서 저장함"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3619,7 +3600,7 @@ msgstr ""
 "최대 65,535(2^16-1)글자의 길이를 가지는 TEXT 칼럼, 값의 길이를 바이트 단위로 "
 "나타내는 2바이트 인디케이터를 앞에 붙여서 저장함"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3627,7 +3608,7 @@ msgstr ""
 "최대 16,777,215(2^24-1)글자의 길이를 가지는 TEXT 칼럼, 값의 길이를 바이트 단"
 "위로 나타내는 3바이트 인디케이터를 앞에 붙여서 저장함"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3636,19 +3617,19 @@ msgstr ""
 "최대 4,294,967,295 또는 4GiB (2^32 - 1) 글자 길이를 가지는 TEXT 칼럼, 값의 길"
 "이를 바이트 단위로 나타내는 4바이트 인디케이터를 앞에 붙여서 저장함"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "CHAR형과 비슷하나, 일반 문자열 대신 바이너리값을 저장할 수 있음"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "VARCHAR형과 비슷하나, 일반 문자열 대신 바이너리 값을 저장할 수 있음"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3656,7 +3637,7 @@ msgstr ""
 "최대 크기가 255 (2^8 - 1) 바이트인 BLOB 컬럼은, 데이터의 현재 크기를 나타내"
 "는 1바이트의 값이 데이터 앞에 붙습니다"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3664,7 +3645,7 @@ msgstr ""
 "최대 크기가 16,777,215 (2^24 - 1) 바이트인 BLOB 컬럼은, 데이터의 현재 크기를 "
 "나타내는 3바이트의 값이 데이터 앞에 붙습니다"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3672,7 +3653,7 @@ msgstr ""
 "최대 크기가 65,535 (2^16 - 1) 바이트인 BLOB 컬럼은, 데이터의 현재 크기를 나타"
 "내는 2 바이트의 값이 데이터 앞에 붙음"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3680,7 +3661,7 @@ msgstr ""
 "최대 크기가 4,294,967,295(2^32 - 1) 바이트(4GiB)인 BLOB 컬럼은, 데이터의 현"
 "재 크기를 나타내는 4바이트의 값이 데이터 앞에 붙습니다"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3688,68 +3669,68 @@ msgstr ""
 "열거형, 최대 65,535개의 지정된 값 또는 특수 오류 값 ('') 중에서 선택될 수 있"
 "음"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "최대 64개의 맴버 집합으로부터 선택되는 단일 값"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "모든 종류의 기하데이터를 저장할 수 있는 타입"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "2차원 공간의 점"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "점들로부터 생성된 하나의 선형 곡선"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "폴리곤"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "포인트들의 집합"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "포인트간의 선형 보간을 거친 커브들의 집합"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "폴리곤들의 집합"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "모든 종류의 기하데이터 객체들의 집합"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "숫자"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "날짜와 시간"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "문자열"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "공간(좌표)형"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 "-2,147,483,648부터 2,147,483,647까지의 값을 저장할 수 있는 4바이트 정수형"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3757,23 +3738,23 @@ msgstr ""
 "-9,223,372,036,854,775,808 에서 9,223,372,036,854,775,807까지의 값을 저장할 "
 "수 있는 8바이트 정수형"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "시스템 기본 배정도 부동소수점 (double-pricision floating point) 숫자"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "참 혹은 거짓"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT NOT NULL AUTO_INCREMENT UNIQUE 에 대한 알리아스"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "범용 고유 식별자(UUID) 저장"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3781,13 +3762,13 @@ msgstr ""
 "타임스탬프, '0001-01-01 00:00:00' UTC 부터 '9999-12-31 23:59:59' UTC 까지의 "
 "범위를 가짐, TIMESTAMP(6)은 마이크로 초를 저장할 수 있음"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr "가변 길이 (0-65,535) 문자열, 비교에 이진(binary) 콜레이션 사용"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "열거형, 정의된 값들의 목록 중에서 선택됨"
 
@@ -3872,67 +3853,67 @@ msgstr "%y-%m-%d %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s일 %s시간 %s분 %s초"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "매개 변수 누락:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "데이터베이스 &quot;%s&quot; 로 이동."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s 기능은 알려진 버그가 있습니다. %s 문서를 참조하십시오"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "토글하려면 클릭"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "업로드 파일:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "웹 서버 업로드 디렉토리중 <b>%s</b>에서 선택:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "업로드 디렉토리에 접근할 수 없습니다"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "업로드할 파일이 없습니다."
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "비우기"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "실행하기"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "인쇄"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "생성"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "마지막 업데이트"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "마지막 검사"
@@ -4180,12 +4161,10 @@ msgid "Custom - like above, but without the quick/custom choice"
 msgstr "커스텀 - 위와 같음. 단, 빠른 보기/커스텀 선택 없음"
 
 #: libraries/config.values.php:177
-#| msgid "Delayed inserts"
 msgid "complete inserts"
 msgstr "완전한 삽입"
 
 #: libraries/config.values.php:178
-#| msgid "Delayed inserts"
 msgid "extended inserts"
 msgstr "확장된 삽입"
 
@@ -4244,13 +4223,11 @@ msgstr "\"%s\"(은)는 확장기능 %s 이 필요합니다"
 
 #: libraries/config/FormDisplay.class.php:791
 #, php-format
-#| msgid "import will not work, missing function (%s)"
 msgid "Compressed import will not work due to missing function %s."
 msgstr "%s 기능이 누락되어 가져올 수 없습니다."
 
 #: libraries/config/FormDisplay.class.php:797
 #, php-format
-#| msgid "export will not work, missing function (%s)"
 msgid "Compressed export will not work due to missing function %s."
 msgstr "%s 기능이 누락되어 내보낼 수 없습니다."
 
@@ -4289,9 +4266,9 @@ msgstr "이 값을 사용자화하기 위한 사용자 허용"
 msgid "Apply"
 msgstr "적용"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "초기화"
 
@@ -4589,7 +4566,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "최대 실행 시간"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "파일로 저장"
 
@@ -4764,7 +4741,6 @@ msgstr "외래 키(foreign key) 체크 사용 안함"
 
 #: libraries/config/messages.inc.php:126
 #: libraries/plugins/export/ExportSql.class.php:155
-#| msgid "Create table on database %s"
 msgid "Export views as tables"
 msgstr "뷰를 테이블로 내보내기"
 
@@ -6912,7 +6888,7 @@ msgstr "파일이 처리되는 중입니다. 잠시 기다려 주십시오."
 msgid "Language"
 msgstr "언어"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "버전 정보"
 
@@ -7318,58 +7294,58 @@ msgstr "컬럼의 길이 때문에,<br />이 컬럼을 편집할 수 없을 수�
 msgid "Binary - do not edit"
 msgstr "바이너리 - 편집 금지"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "이어서"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "새 행을 삽입합니다"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "새 행을 삽입하고 에러를 무시합니다"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "삽입 쿼리 보기"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "이전 페이지로 되돌아가기"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "새 행(레코드) 삽입하기"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 #, fuzzy
 msgid "Go back to this page"
 msgstr "되돌아가기"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "다음 행 수정"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr "TAB 키나 CTRL+화살표로 값 사이를 이동할 수 있습니다"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "SQL 쿼리 보기"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9541,24 +9517,24 @@ msgid "There are no events to display."
 msgstr "표시할 이벤트가 없습니다."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "%s 테이블이 존재하지 않습니다!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12200,7 +12176,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "나만의 설정 관리"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "설정 저장 완료"
 
@@ -12482,7 +12458,7 @@ msgstr "웹 브라우저의 로컬 스토리지로부터 설정을 불러옵니�
 msgid "You have no saved settings!"
 msgstr "저장된 설정이 없습니다!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "현재 웹 브라우저에서 이 기능을 지원하지 않음"
 
@@ -12499,19 +12475,19 @@ msgstr ""
 "%s셋업 스크립트%s를 사용하는 등의 방법으로 config.inc.php를 수정하여 더 많은 "
 "설정을 조정할 수 있습니다."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "브라우저의 저장 공간에 저장"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "설정 내용이 웹 브라우저의 로컬 스토리지에 저장됩니다."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "기존 설정에 덮여쓰여집니다!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "모든 설정을 초기화할 수 있습니다."
 
@@ -12539,6 +12515,10 @@ msgstr "데이터베이스가 없습니다"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "데이터베이스의 덤프(스키마) 데이터 보기"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ky.po
+++ b/po/ky.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-15 05:16+0200\n"
 "Last-Translator: Bahoriddin Dushabayev <bahoriddin@gmail.com>\n"
 "Language-Team: Kyrgyz <http://l10n.cihar.com/projects/phpmyadmin/master/ky/"
@@ -45,7 +45,7 @@ msgstr "Жадыбал жөнүндө маалымат:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -91,7 +91,7 @@ msgid "Type"
 msgstr "Тиби"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -340,7 +340,7 @@ msgid "Updated"
 msgstr "Жаңыланды"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -368,7 +368,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -567,8 +567,8 @@ msgstr ""
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -594,7 +594,7 @@ msgstr ""
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Кет"
@@ -922,7 +922,7 @@ msgstr ""
 msgid "Edit Index"
 msgstr ""
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr ""
@@ -1135,7 +1135,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr ""
 
@@ -1429,8 +1429,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1639,8 +1639,8 @@ msgstr ""
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1667,7 +1667,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1736,8 +1736,8 @@ msgstr ""
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2273,7 +2273,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2418,8 +2418,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2475,28 +2475,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr ""
@@ -2672,9 +2672,9 @@ msgstr ""
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2859,9 +2859,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2875,32 +2875,32 @@ msgid "Structure"
 msgstr ""
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr ""
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr ""
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2909,20 +2909,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2938,70 +2938,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr ""
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr ""
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr ""
@@ -3027,7 +3027,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3243,7 +3243,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3258,7 +3258,7 @@ msgstr ""
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3266,7 +3266,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr ""
@@ -3376,278 +3376,278 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr ""
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3732,67 +3732,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr ""
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr ""
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr ""
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr ""
@@ -4140,9 +4140,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4423,7 +4423,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6639,7 +6639,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7030,57 +7030,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9096,24 +9096,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11582,7 +11582,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -11830,7 +11830,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -11845,19 +11845,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -11884,6 +11884,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/lt.po
+++ b/po/lt.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:40+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Lithuanian <http://l10n.cihar.com/projects/phpmyadmin/master/"
@@ -44,7 +44,7 @@ msgstr "Lentelės komentarai"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -90,7 +90,7 @@ msgid "Type"
 msgstr "Tipas"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -344,7 +344,7 @@ msgid "Updated"
 msgstr "Atnaujinta"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -372,7 +372,7 @@ msgid "Delete tracking data for this table"
 msgstr "Ištrinti šios lentelės sekimo duomenis"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -578,8 +578,8 @@ msgstr "Pridėti geometriją"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -605,7 +605,7 @@ msgstr "Pridėti geometriją"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Vykdyti"
@@ -991,7 +991,7 @@ msgstr "Pridėti indeksą"
 msgid "Edit Index"
 msgstr "Redaguoti indeksą"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Pridėti %s stulpelį(-ius) į indeksą"
@@ -1206,7 +1206,7 @@ msgid "Traffic"
 msgstr "Apkrovimas"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Nustatymai"
 
@@ -1512,8 +1512,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1739,8 +1739,8 @@ msgstr "Rodyti užklausos laukelį"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1767,7 +1767,7 @@ msgstr "Užklausos vykdymo laikas"
 msgid "%d is not valid row number."
 msgstr "%d nėra galimas eilutės numeris."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1844,8 +1844,8 @@ msgstr "Užklausos rezultatai"
 msgid "Data point content"
 msgstr "Duomenų rodyklės dydis"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignoruoti"
 
@@ -2416,7 +2416,7 @@ msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 "Blogos teisės konfigūracinio failo, neturėtų būti įrašymo galimybė visiems!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Šrifto dydis"
 
@@ -2581,8 +2581,8 @@ msgstr[1] "%s atitikmenys lentelėse <i>%s</i>"
 msgstr[2] "%s atitikmenų lentelėse <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2640,16 +2640,16 @@ msgstr "Išsaugoti katalogą"
 msgid "Restore column order"
 msgstr "Atstatyti stulpelių rikiavimą"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Pradžia"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2657,8 +2657,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Ankstesnis"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2666,8 +2666,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Kitas"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2853,9 +2853,9 @@ msgstr "Pažymėti visas"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3047,9 +3047,9 @@ msgid "View"
 msgstr "Rodinys"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3063,32 +3063,32 @@ msgid "Structure"
 msgstr "Struktūra"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Paieška"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Įterpti"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3097,20 +3097,20 @@ msgid "Privileges"
 msgstr "Privilegijos"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Veiksmai"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Sekimas"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3126,70 +3126,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr "Duomenų bazė atrodo tuščia!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "SQL užklausa"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Įvykiai"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Projektavimas"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Duomenų bazės"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Naudotojai"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Dvejetainis log'as"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikavimas"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Kintamieji"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Koduotės"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Varikliai"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Klaida"
@@ -3218,7 +3218,7 @@ msgstr[0] "Įterpta %1$d eilutė."
 msgstr[1] "Įterptos %1$d eilutės."
 msgstr[2] "Įterpta %1$d eilučių."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3442,7 +3442,7 @@ msgid "Operator"
 msgstr "Operatorius"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3459,7 +3459,7 @@ msgstr "Paieška"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3469,7 +3469,7 @@ msgstr "Įterpti"
 msgid "Select columns (at least one):"
 msgstr "Pasirinkite stulpelius (bent vieną):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Arba"
@@ -3601,286 +3601,286 @@ msgstr "Kelias iki temos nerastas temai %s!"
 msgid "Theme:"
 msgstr "Išvaizda"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "Create version"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Sukurti versiją"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Klaida pervadinant lentelę iš %1$s į %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add a polygon"
 msgid "A polygon"
 msgstr "Pridėti daugiakampį"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Sukurti naują indeksą"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Eilutės baigiasi"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3967,67 +3967,67 @@ msgstr "%Y m. %B %d d. %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s d., %s val., %s min. ir %s s"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Trūkstamas parametras:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Pereiti į „%s“ duomenų bazę."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s funkcionalumas paveiktas žinomos klaidos, žiūrėti %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Spustelėkite suskleidimui/atskleidimui"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Naršyti savo kompiuteryje:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Pasirinkti iš saityno serverio atsisiuntimų katalogą <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Aplankas, kuris nurodytas įkeliamiems failams, nepasiekiamas."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Nėra failų išsiuntimui"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Išvalyti"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Vykdyti"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Spausdinti"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Sukurta"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Paskutinis atnaujinimas"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Paskutinis patikrinimas"
@@ -4394,9 +4394,9 @@ msgstr "Leisti naudotojams adaptuoti šią reikšmę"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Atstatyti į pradinę būseną"
 
@@ -4701,7 +4701,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Ilgiausias vykdymo laikas"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Išsaugoti į failą"
 
@@ -7202,7 +7202,7 @@ msgstr "Failas apdorojamas, prašome palaukti."
 msgid "Language"
 msgstr "Kalba"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Versija"
 
@@ -7617,60 +7617,60 @@ msgstr "Dėl jo ilgio,<br /> šis laukelis gali būti neredaguojamas (tinas)"
 msgid "Binary - do not edit"
 msgstr "Dvejetainis - nekeisti"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "web serverio katalogas atsiuntimams"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Tęstį įterpimą su %s eilučių"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "ir tada"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Įterpti kaip naują įrašą"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Įterpti kaip naują eilutę ir ignoruoti klaidas"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Rodyti įterptą užklausą"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Sugrįžti į buvusį puslapį"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Įterpti kitą naują eilutę"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Grįžti atgal į šį puslapį"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Redaguoti kitą įrašą"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Šokinėjimui tarp reikšmių naudokite TAB mygtuką arba naudokite CTRL+rodyklės"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Rodoma SQL užklausa"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Įterpto įrašo id: %1$d"
@@ -9926,24 +9926,24 @@ msgid "There are no events to display."
 msgstr "Nėra įvykių rodymui."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Lentelė %s neegzistuoja!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Nustatykite lentelės %s koordinates"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Duomenų bazės %s schema - %s puslapis"
@@ -12609,7 +12609,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Keiskite savo nustatymus"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Konfigūracija išsaugota"
 
@@ -12874,7 +12874,7 @@ msgstr "Nustatymai bus importuoti iš Jūsų naršyklės vidinės atminties."
 msgid "You have no saved settings!"
 msgstr "Jūs neturite išsaugotų nustatymų!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Šios galimybės Jūsų interneto naršyklė nepalaiko"
 
@@ -12891,19 +12891,19 @@ msgstr ""
 "Jūs galite nustatyti daugiau nuostatų modifikuojant config.inc.php, "
 "pavyzdžiui naudojantis %sDiegimo scenarijumi%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Išsaugoti į naršyklės atmintinę"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Nustatymai bus išsaugoti Jūsų naršyklės vidinėje atmintyje."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Esantys nustatymai bus perrašyti!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "Jūs galite atkurti (nustatyti) pradinius nustatymus."
 
@@ -12933,6 +12933,10 @@ msgstr "Nėra duomenų bazių"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Peržiūrėti duomenų bazių atvaizdį (schemą)"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 12:53+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Latvian <http://l10n.cihar.com/projects/phpmyadmin/master/lv/"
@@ -43,7 +43,7 @@ msgstr "Komentārs tabulai"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Tips"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -348,7 +348,7 @@ msgid "Updated"
 msgstr "Atjaunots"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -376,7 +376,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -587,8 +587,8 @@ msgstr "Pievienot jaunu lietotāju"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -614,7 +614,7 @@ msgstr "Pievienot jaunu lietotāju"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Aiziet"
@@ -978,7 +978,7 @@ msgstr "Pievienot indeksu"
 msgid "Edit Index"
 msgstr "Labot indeksu"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %d column(s) to index"
 msgid "Add %s column(s) to index"
@@ -1197,7 +1197,7 @@ msgid "Traffic"
 msgstr "Datu apmaiņa"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Uzstādījumi"
 
@@ -1505,8 +1505,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1730,8 +1730,8 @@ msgstr "Rādīt pieprasījumu logu"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1758,7 +1758,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1835,8 +1835,8 @@ msgstr "Pieprasījuma rezultāti"
 msgid "Data point content"
 msgstr "Satura rādītājs"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorēt"
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2619,8 +2619,8 @@ msgstr[0] "%s rezultāti tabulā <i>%s</i>"
 msgstr[1] "%s rezultāti tabulā <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2685,16 +2685,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Pievienot/Dzēst laukus (kolonnas)"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Sākums"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2702,8 +2702,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Iepriekšējie"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2711,8 +2711,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Nākamie"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2906,9 +2906,9 @@ msgstr "Iezīmēt visu"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3100,9 +3100,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3116,32 +3116,32 @@ msgid "Structure"
 msgstr "Struktūra"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Meklēt"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Pievienot"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3150,20 +3150,20 @@ msgid "Privileges"
 msgstr "Privilēģijas"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Darbības"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3179,73 +3179,73 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Vaicājums pēc parauga"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Datubāzes"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Lietotājs"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binārais log-fails"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 #, fuzzy
 msgid "Replication"
 msgstr "Relācijas"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Mainīgie"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Rakstzīmju kodējumi"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Kļūda"
@@ -3273,7 +3273,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Rindas nav iezīmētas"
 msgstr[1] "Rindas nav iezīmētas"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3500,7 +3500,7 @@ msgid "Operator"
 msgstr "Operators"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3517,7 +3517,7 @@ msgstr "Meklēt"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3529,7 +3529,7 @@ msgstr "Pievienot"
 msgid "Select columns (at least one):"
 msgstr "Izvēlieties laukus (kaut vienu):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Vai"
@@ -3653,286 +3653,286 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Servera versija"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Servera versija"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "Pievienot %s lauku(s)"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Izveidot jaunu indeksu"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Rindas atdalītas ar"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Kopā"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4019,70 +4019,70 @@ msgstr "%d.%m.%Y %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dienas, %s stundas, %s minūtes un %s sekundes"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Add new field"
 msgid "Missing parameter:"
 msgstr "Pievienot jaunu lauku"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "pāriet pie datubāzes &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "web servera augšupielādes direktorija"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Direktoija, kuru norādijāt augšupielādei, nav pieejama."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Iztukšot"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Drukāt"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Izveidošana"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Pēdējā atjaunošana"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Pēdējā pārbaude"
@@ -4461,9 +4461,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Atcelt"
 
@@ -4755,7 +4755,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Saglabāt kā failu"
 
@@ -7143,7 +7143,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 #, fuzzy
 msgid "Version information"
 msgstr "Piekļuves informācija"
@@ -7544,61 +7544,61 @@ msgstr "Sava garuma dēļ,<br /> šis lauks var būt nerediģējams "
 msgid "Binary - do not edit"
 msgstr "Binārais - netiek labots"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "web servera augšupielādes direktorija"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Ievietot kā jaunu rindu"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Atgriezties atpakaļ iepriekšējā lapā"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Ievietot vēl vienu rindu"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Atgriezties šajā lapā"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Lietojiet TAB taustiņu, lai pārvietotos no vērtības līdz vērtībai, vai CTRL"
 "+bultiņas, lai pārvietotos jebkurā vietā"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9879,25 +9879,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Tabula \"%s\" neeksistē!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Lūdzu konfigurējiet koordinātes tabulai %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12624,7 +12624,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Galvenās relāciju īpašības"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12910,7 +12910,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12925,19 +12925,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12967,6 +12967,10 @@ msgstr "Nav datubāzu"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Apskatīt datubāzu dampu (shēmu)"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/mk.po
+++ b/po/mk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:35+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Macedonian <http://l10n.cihar.com/projects/phpmyadmin/master/"
@@ -41,7 +41,7 @@ msgstr "Коментар на табелата"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Тип"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -351,7 +351,7 @@ msgid "Updated"
 msgstr "Ажурирано"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -379,7 +379,7 @@ msgid "Delete tracking data for this table"
 msgstr "Избришете го податоците за тракирање од табелава"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -595,8 +595,8 @@ msgstr "Додади нов корисник"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -622,7 +622,7 @@ msgstr "Додади нов корисник"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "OK"
@@ -1002,7 +1002,7 @@ msgstr "Додади ново поле"
 msgid "Edit Index"
 msgstr "Ажурирање на следниот запис"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1241,7 +1241,7 @@ msgid "Traffic"
 msgstr "Сообраќај"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1576,8 +1576,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1828,8 +1828,8 @@ msgstr "SQL упит"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1856,7 +1856,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1937,8 +1937,8 @@ msgstr "SQL резултат"
 msgid "Data point content"
 msgstr "Големина на покажувачите на податоци"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Игнорирај"
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2724,8 +2724,8 @@ msgstr[0] "%s погодоци во табелата <i>%s</i>"
 msgstr[1] "%s погодоци во табелата <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2791,16 +2791,16 @@ msgstr "Основен директориум на податоците"
 msgid "Restore column order"
 msgstr "Додади/избриши колона"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Почеток"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2808,8 +2808,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Претходна"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2817,8 +2817,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Следен"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3014,9 +3014,9 @@ msgstr "обележи ги сите"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3211,9 +3211,9 @@ msgid "View"
 msgstr "Поглед"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3227,32 +3227,32 @@ msgid "Structure"
 msgstr "Структура"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Пребарување"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Нов запис"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3261,20 +3261,20 @@ msgid "Privileges"
 msgstr "Привилегии"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Операции"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3290,73 +3290,73 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Упит по пример"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Рутини"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "База на податоци"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Корисник"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Бинарен дневник"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 #, fuzzy
 msgid "Replication"
 msgstr "Релации"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Променливи"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Кодни страници"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Складишта"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Грешка"
@@ -3384,7 +3384,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Нема селектирани записи"
 msgstr[1] "Нема селектирани записи"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3612,7 +3612,7 @@ msgid "Operator"
 msgstr "Оператор"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3629,7 +3629,7 @@ msgstr "Пребарување"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3641,7 +3641,7 @@ msgstr "Нов запис"
 msgid "Select columns (at least one):"
 msgstr "Избери полиња (најмалку едно)"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "или"
@@ -3765,286 +3765,286 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Верзија на серверот"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Верзија на серверот"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "Додади %s полиња"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Креирај нов клуч"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Линиите се завршуваат со"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Вкупно"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4133,70 +4133,70 @@ msgstr "%d. %B %Y. во %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s денови, %s часови, %s минути и %s секунди"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Рутини"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Премин на базата &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "директориум за праќање на веб серверот "
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Директориумот кој го избравте за праќање не е достапен."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Испразни"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Печати"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Направено"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Последна измена"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Последна проверка"
@@ -4576,9 +4576,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Поништи"
 
@@ -4873,7 +4873,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Сочувај како податотека"
 
@@ -7268,7 +7268,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Информации за верзијата"
 
@@ -7692,61 +7692,61 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Бинарен - не менувај"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "директориум за праќање на веб серверот"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Внеси како нов запис"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Назад на претходната страница"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Додади уште еден нов запис"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Врати се на оваа страница"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Ажурирање на следниот запис"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Користете го TAB тастерот за движење од поле во поле, или CTRL+стрелка за "
 "слободно движење"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -10049,25 +10049,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Табелата \"%s\" не постои!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Подесете ги координатите за табелата %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12795,7 +12795,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Општи особини на релациите"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13081,7 +13081,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13096,19 +13096,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13138,6 +13138,10 @@ msgstr "Базата на податоци не постои"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Прикажи содржина (шема) на базите"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ml.po
+++ b/po/ml.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2011-09-27 08:42+0200\n"
 "Last-Translator: <sadik.khalid@gmail.com>\n"
 "Language-Team: Malayalam <ml@li.org>\n"
@@ -42,7 +42,7 @@ msgstr "പട്ടിക അഭിപ്രയങ്ങൾ"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "തരം"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -343,7 +343,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -371,7 +371,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -565,8 +565,8 @@ msgstr ""
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -592,7 +592,7 @@ msgstr ""
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "പോകൂ"
@@ -922,7 +922,7 @@ msgstr ""
 msgid "Edit Index"
 msgstr ""
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr ""
@@ -1137,7 +1137,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr ""
 
@@ -1435,8 +1435,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1645,8 +1645,8 @@ msgstr ""
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1742,8 +1742,8 @@ msgstr ""
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2281,7 +2281,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2438,8 +2438,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2495,28 +2495,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr ""
@@ -2694,9 +2694,9 @@ msgstr ""
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2881,9 +2881,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2897,32 +2897,32 @@ msgid "Structure"
 msgstr ""
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr ""
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "തിരയൂ"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2931,20 +2931,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2960,70 +2960,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr ""
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr ""
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr ""
@@ -3049,7 +3049,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3268,7 +3268,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3283,7 +3283,7 @@ msgstr ""
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3291,7 +3291,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "അല്ലെനങ്കിൽ"
@@ -3403,278 +3403,278 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr ""
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3759,67 +3759,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr ""
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "അച്ചടിക്കുക"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "സൃഷ്‌ടി"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "അവസാനം നവീകരിച്ചത്"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "അന്തിമ പരിശോധന"
@@ -4171,9 +4171,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4456,7 +4456,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6682,7 +6682,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7074,57 +7074,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9166,24 +9166,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11683,7 +11683,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -11931,7 +11931,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -11946,19 +11946,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -11985,6 +11985,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/mn.po
+++ b/po/mn.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-14 10:57+0200\n"
 "Last-Translator: yondonjamts rentsendorj <yontkoo@yahoo.com>\n"
 "Language-Team: Mongolian <http://l10n.cihar.com/projects/phpmyadmin/master/"
@@ -43,7 +43,7 @@ msgstr "Хүснэгтийн тайлбар"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Төрөл"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -344,7 +344,7 @@ msgid "Updated"
 msgstr "Шинэчлэгдсэн"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -372,7 +372,7 @@ msgid "Delete tracking data for this table"
 msgstr "Энэ хүснэгтийн хөөлтийн өгөгдлийг устгах"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -569,8 +569,8 @@ msgstr "Геометр нэмэх"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -596,7 +596,7 @@ msgstr "Геометр нэмэх"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Яв"
@@ -986,7 +986,7 @@ msgstr "Шинэ талбар нэмэх"
 msgid "Edit Index"
 msgstr "Дараагийн мөрийг засах"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1231,7 +1231,7 @@ msgid "Traffic"
 msgstr "Гуйвуулга"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1569,8 +1569,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1831,8 +1831,8 @@ msgstr "SQL асуудал харуулах"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1859,7 +1859,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr "%d нь мөрийн буруу дугаар байна."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1944,8 +1944,8 @@ msgstr "Асуудлын үр дүнгийн үйлдэл"
 msgid "Data point content"
 msgstr "Өгөгдөл заагчийн хэмжээ"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Үл тоох"
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Үсгийн хэмжээ"
 
@@ -2732,8 +2732,8 @@ msgstr[0] "%s олдоц(ууд) хүснэгт <i>%s</i>-д"
 msgstr[1] "%s олдоц(ууд) хүснэгт <i>%s</i>-д"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2798,16 +2798,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Багана нэмэх/устгах"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Эхлэл"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2815,8 +2815,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Өмнөх"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2824,8 +2824,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Цааш"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3017,9 +3017,9 @@ msgstr "Бүгдийг чагтлах"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3210,9 +3210,9 @@ msgid "View"
 msgstr "Харц"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3226,32 +3226,32 @@ msgid "Structure"
 msgstr "Бүтэц"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Хайх"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Оруулах"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3260,20 +3260,20 @@ msgid "Privileges"
 msgstr "Онцгой эрхүүд"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Үйлдлүүд"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3289,72 +3289,72 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr "Өгөгдлийн сан хоосон санагдаж байна!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Асуулт (Query)"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Дизайнч"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Өгөгдлийн сангууд"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Хэрэглэгч"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Хоёртын log"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Олшруулалт"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Утгууд"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Кодлолууд"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Хөдөлгүүрүүд"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Алдаа"
@@ -3382,7 +3382,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Сонгогдсон мөргүй"
 msgstr[1] "Сонгогдсон мөргүй"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3614,7 +3614,7 @@ msgid "Operator"
 msgstr "Оператор"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3631,7 +3631,7 @@ msgstr "Хайх"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3643,7 +3643,7 @@ msgstr "Оруулах"
 msgid "Select columns (at least one):"
 msgstr "Талбар сонгох (ядаж нэгийг):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Эсвэл"
@@ -3769,288 +3769,288 @@ msgstr "Сэдэв %s сэдвийн зам олдохгүй байна!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "General relation features"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Ерөнхий хамаатай онцлог"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "General relation features"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Ерөнхий хамаатай онцлог"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "%s талбар(ууд) нэмэх"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Шинэ индекс үүсгэх"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Шугамыг төгсгөгч"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Нийт"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4139,70 +4139,70 @@ msgstr "%Y оны %B сарын %d., %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s өдөр, %s цаг, %s минут, %s секунд"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Add new field"
 msgid "Missing parameter:"
 msgstr "Шинэ талбар нэмэх"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "&quot;%s&quot; өгөгдлийн сан руу үсрэх."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "web-сервэр түлхэх хавтас"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Таны сонгосон хавтас \"upload\" хийгдэхгүй байна."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Хоосон"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Хэвлэх"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Үүсгэлт"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Сүүлийн шинэчлэл"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Сүүлийн шалгалт"
@@ -4585,9 +4585,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Да.эхлэх"
 
@@ -4882,7 +4882,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Илгээх"
 
@@ -7284,7 +7284,7 @@ msgstr ""
 msgid "Language"
 msgstr "Хэл"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Хувилбарын мэдээлэл"
 
@@ -7700,61 +7700,61 @@ msgstr "Яагаад гэвэл урт нь их,<br /> энэ талбар за
 msgid "Binary - do not edit"
 msgstr "Хоёртын өгөгдөл - засагдахгүй"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "web-сервэр түлхэх хавтас"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "ба тэгээд"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Шинэ мөр оруулаад"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Буцах"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Өөр шинэ мөр оруулах"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Энэ хуудас руу буцах"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Дараагийн мөрийг засах"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "TAB товчийг хэрэглэн утгаас утгын хооронд шилжинэ, эсвэл CTRL+сумууд-аар "
 "зөөгдөнө"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "SQL асуудал харуулах"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -10053,25 +10053,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Хүснэгт \"%s\" байхгүй байна!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "%s хүснэгтийн координатыг тохируулна уу"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12829,7 +12829,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Ерөнхий хамаатай онцлог"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13117,7 +13117,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13132,19 +13132,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13174,6 +13174,10 @@ msgstr "ӨС байхгүй"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "ӨС-ийн схем харах"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ms.po
+++ b/po/ms.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-30 15:47+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Malay <http://l10n.cihar.com/projects/phpmyadmin/master/ms/>\n"
@@ -42,7 +42,7 @@ msgstr "Komen jadual"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Jenis"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -344,7 +344,7 @@ msgid "Updated"
 msgstr "dikemaskini"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -373,7 +373,7 @@ msgid "Delete tracking data for this table"
 msgstr "Padam mengesan data untuk jadual ini"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -580,8 +580,8 @@ msgstr "Tambah geometri"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -607,7 +607,7 @@ msgstr "Tambah geometri"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Pergi"
@@ -978,7 +978,7 @@ msgstr "Indeks"
 msgid "Edit Index"
 msgstr "Indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 msgid "Add %s column(s) to index"
 msgstr "Tambah medan baru"
@@ -1209,7 +1209,7 @@ msgid "Traffic"
 msgstr "Kesibukan"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1536,8 +1536,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1782,8 +1782,8 @@ msgstr "kueri-SQL"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1810,7 +1810,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1891,8 +1891,8 @@ msgstr "Hasil SQL"
 msgid "Data point content"
 msgstr "Kandungan"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Abai"
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2664,8 +2664,8 @@ msgstr[0] "%s padanan di dalam jadual <i>%s</i>"
 msgstr[1] "%s padanan di dalam jadual <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2723,16 +2723,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Tambah/Padam Kolum Medan"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Mula"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2740,8 +2740,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Terdahulu"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2749,8 +2749,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Berikut"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2943,9 +2943,9 @@ msgstr "Tanda Semua"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3136,9 +3136,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3152,32 +3152,32 @@ msgid "Structure"
 msgstr "Struktur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Cari"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Selit"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3186,20 +3186,20 @@ msgid "Privileges"
 msgstr "Privilej"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operasi"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3215,73 +3215,73 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Kueri"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "pangkalan data"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Pengguna"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 #, fuzzy
 msgid "Binary log"
 msgstr "Binari"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikasi"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Pemboleh-pembolehubah"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Ralat"
@@ -3307,7 +3307,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3534,7 +3534,7 @@ msgid "Operator"
 msgstr "Operasi"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3551,7 +3551,7 @@ msgstr "Cari"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3563,7 +3563,7 @@ msgstr "Selit"
 msgid "Select columns (at least one):"
 msgstr "Pilih medan (sekurang-kurangnya satu):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Atau"
@@ -3685,285 +3685,285 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Versi Pelayan"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Versi Pelayan"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 msgid "A polygon"
 msgstr "Tambah medan baru"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Cipta indeks baru"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Baris ditamatkan oleh"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Jumlah"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4050,68 +4050,68 @@ msgstr "%B %d, %Y at %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s hari, %s jam, %s minit dan %s saat"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "direktori muatnaik pelayan-web"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Direktori muatnaik yang telah ditetapkan tidak dapat dicapai."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Kosong"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Cetak"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Mewujudkan"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Kemaskini terakhir"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Semakan Terakhir"
@@ -4489,9 +4489,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Ulangtetap"
 
@@ -4780,7 +4780,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Simpan sebagai fail"
 
@@ -7139,7 +7139,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 #, fuzzy
 msgid "Version information"
 msgstr "Informasi MasaJana"
@@ -7539,60 +7539,60 @@ msgstr "Kerana kepanjangannya, <br />medan ini tidak boleh diedit "
 msgid "Binary - do not edit"
 msgstr "Binari - jgn diubah"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "direktori muatnaik pelayan-web"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Selitkan baris baru"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Kembali ke muka sebelumnya"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Tambah baris yang baru"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 #, fuzzy
 msgid "Go back to this page"
 msgstr "Kembali ke muka sebelumnya"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9771,25 +9771,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Jadual \"%s\" tidak wujud!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Sila konfigurasikan kordinat bagi jadual %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12456,7 +12456,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Ciri-ciri hubungan am"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12731,7 +12731,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12746,19 +12746,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12789,6 +12789,10 @@ msgstr "Tiada pangkalan data"
 #, fuzzy
 msgid "View dump (schema) of databases"
 msgstr "Lihat longgokan (skema) pangkalan data"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/nb.po
+++ b/po/nb.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-10-03 08:49+0200\n"
 "Last-Translator: Yngve Nybakk <yngve.nybakk@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <http://l10n.cihar.com/projects/phpmyadmin/"
@@ -43,7 +43,7 @@ msgstr "Tabellkommentarer"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Type"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -343,7 +343,7 @@ msgid "Updated"
 msgstr "Oppdatert"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -371,7 +371,7 @@ msgid "Delete tracking data for this table"
 msgstr "Slett overvåkningsdata for denne tabellen"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -577,8 +577,8 @@ msgstr "Legg til geometri"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -604,7 +604,7 @@ msgstr "Legg til geometri"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Utfør"
@@ -1000,7 +1000,7 @@ msgstr "Legg til index"
 msgid "Edit Index"
 msgstr "Rediger indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Legg %s kolonne(r) til index"
@@ -1218,7 +1218,7 @@ msgid "Traffic"
 msgstr "Trafikk"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Innstillinger"
 
@@ -1534,8 +1534,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1746,8 +1746,8 @@ msgstr "Vis spørringsboks"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1774,7 +1774,7 @@ msgstr "Spørringens utførelsestid"
 msgid "%d is not valid row number."
 msgstr "%d er ikke et gyldig radnummer."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1850,8 +1850,8 @@ msgstr "Spørringsresultater"
 msgid "Data point content"
 msgstr "Datapunktinnhold"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorer"
 
@@ -2402,7 +2402,7 @@ msgstr "Nåværende konfigurasjonsfil (%s) er ikke lesbar."
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "Gale tillatelser på konfigurasjonsfilen, den burde ikke være skrivbar!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Fontstørrelse"
 
@@ -2561,8 +2561,8 @@ msgstr[0] "%1$s treff i <strong>%2$s</strong>"
 msgstr[1] "%1$s treff i <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2618,28 +2618,28 @@ msgstr "Lagre redigerte data"
 msgid "Restore column order"
 msgstr "Tilbakestill kolonnerekkefølge"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Start"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Forrige"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Neste"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Siste"
@@ -2823,9 +2823,9 @@ msgstr "Merk alle"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3020,9 +3020,9 @@ msgid "View"
 msgstr "Vis"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3036,32 +3036,32 @@ msgid "Structure"
 msgstr "Struktur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Søk"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Sett inn"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3070,20 +3070,20 @@ msgid "Privileges"
 msgstr "Privilegier"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operasjoner"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Overvåkning"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3099,70 +3099,70 @@ msgstr "Triggere"
 msgid "Database seems to be empty!"
 msgstr "Databasen ser ut til å være tom!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Spørring ved eksempel (Query by Example)"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutiner"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Hendelser"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Designer"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Databaser"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Brukere"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binærlogg"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikering"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variabler"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Tegnsett"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Programtillegg"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motorer"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Feil"
@@ -3188,7 +3188,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d rader innsatt."
 msgstr[1] "%1$d rader innsatt."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3415,7 +3415,7 @@ msgid "Operator"
 msgstr "Operatør"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3430,7 +3430,7 @@ msgstr "Tabellsøk"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Rediger/Sett inn"
 
@@ -3438,7 +3438,7 @@ msgstr "Rediger/Sett inn"
 msgid "Select columns (at least one):"
 msgstr "Velg kolonner (minst ett):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Eller"
@@ -3564,283 +3564,283 @@ msgstr "Stilsti ble ikke funnet for stilen %s!"
 msgid "Theme:"
 msgstr "Tema"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "Create version %s of %s.%s"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Opprett versjon %s av %s.%s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Et klokkeslett, rekkevidde er %1$s til %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Et polygon"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "En samling av punkter"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "En samling av polygoner"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "En samling av geometriobjekter av enhver type"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numerisk"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Dato og tid"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Linestring"
 msgctxt "string types"
 msgid "String"
 msgstr "Linjestreng"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Antall loggfiler"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "True eller false"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Et alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Lagrer en Universally Unique Identifier (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3927,67 +3927,67 @@ msgstr "%d. %B, %Y %H:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dager, %s timer, %s minutter og %s sekunder"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Mangler parametere:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Hopp til databasen &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Funksjonaliteten %s er påvirket av en kjent feil, se %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Klikk for å endre"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Bla gjennom datamaskinen:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Merk fra opplastingskatalogen på vevtjeneren <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Katalogen du anga for opplasting kan ikke nåes."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Det er ingen filer å laste opp"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Tøm"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Utfør"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Skriv ut"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Opprettet"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Sist oppdatert"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Sist kontrollert"
@@ -4351,9 +4351,9 @@ msgstr "Tillat brukere å endre denne verdien"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Tilbakestill"
 
@@ -4662,7 +4662,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maks kjøretid"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Lagre som fil"
 
@@ -7191,7 +7191,7 @@ msgstr "Fila er under behandling, venligst vent."
 msgid "Language"
 msgstr "Språk"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Versionsinformasjon"
 
@@ -7644,62 +7644,62 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Binær - må ikke redigeres"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "webtjener opplastingskatalog"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Restarte innsettinga med %s rader"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "og så"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Sett inn som ny rad"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Sett inn som ny rad og ignorer feil"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Viser SQL spørring"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Returner"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Sett inn en ny post"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Tilbake til denne siden"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Rediger neste rad"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Bruk TAB tasten for å flytte fra verdi til verdi, eller CTRL+piltastene for "
 "å bevege deg hvor som helst"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Viser SQL spørring"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Insatt rad id: %1$d"
@@ -10024,24 +10024,24 @@ msgid "There are no events to display."
 msgstr "Det er ingen filer å laste opp"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Tabellen %s eksisterer ikke!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Vennligst konfigurer koordinatene for tabell %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Skjema for %s databasen - Side %s"
@@ -12901,7 +12901,7 @@ msgstr "Versjon %s er opprettet, overvåking av %s.%s er aktivert."
 msgid "Manage your settings"
 msgstr "Endre dine innstillinger"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13193,7 +13193,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Andre hovedinnstillinger"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13210,19 +13210,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13252,6 +13252,10 @@ msgstr "Ingen databaser"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Vis dumpet skjema av databaser"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -3,14 +3,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-26 17:51+0200\n"
 "Last-Translator: Dieter Adriaenssens <ruleant@users.sourceforge.net>\n"
 "Language-Team: Dutch <http://l10n.cihar.com/projects/phpmyadmin/master/nl/>\n"
-"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: nl\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -40,7 +40,7 @@ msgstr "Tabelopmerkingen:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -86,7 +86,7 @@ msgid "Type"
 msgstr "Type"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -335,7 +335,7 @@ msgid "Updated"
 msgstr "Bijgewerkt"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -363,7 +363,7 @@ msgid "Delete tracking data for this table"
 msgstr "Verwijder tracking data voor deze tabel"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -566,8 +566,8 @@ msgstr "Een geometrie toevoegen"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -593,7 +593,7 @@ msgstr "Een geometrie toevoegen"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Start"
@@ -973,7 +973,7 @@ msgstr "Index toevoegen"
 msgid "Edit Index"
 msgstr "Index bewerken"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Voeg %s kolom(men) toe aan index"
@@ -1191,7 +1191,7 @@ msgid "Traffic"
 msgstr "Verkeer"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Instellingen"
 
@@ -1508,8 +1508,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1721,8 +1721,8 @@ msgstr "SQL-queryveld tonen"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1749,7 +1749,7 @@ msgstr "Query-uitvoertijd"
 msgid "%d is not valid row number."
 msgstr "%d is geen geldig rijnummer."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1822,8 +1822,8 @@ msgstr "Queryresultaten"
 msgid "Data point content"
 msgstr "Inhoud gegevenspunt"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Negeren"
 
@@ -2380,7 +2380,7 @@ msgstr ""
 "Verkeerde rechten ingesteld op het configuratiebestand, dit mag niet "
 "leesbaar zijn voor iedereen!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Lettertypegrootte"
 
@@ -2526,8 +2526,8 @@ msgstr[0] "%1$s overeenkomst in <strong>%2$s</strong>"
 msgstr[1] "%1$s overeenkomsten in <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2583,28 +2583,28 @@ msgstr "Sla aangepaste gegevens op"
 msgid "Restore column order"
 msgstr "Kolomvolgorde herstellen"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Begin"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Vorige"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Volgende"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Einde"
@@ -2781,9 +2781,9 @@ msgstr "Selecteer alles"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2976,9 +2976,9 @@ msgid "View"
 msgstr "View"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2992,32 +2992,32 @@ msgid "Structure"
 msgstr "Structuur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Zoeken"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Invoegen"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3026,20 +3026,20 @@ msgid "Privileges"
 msgstr "Rechten"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Handelingen"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Traceren"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3055,70 +3055,70 @@ msgstr "Triggers"
 msgid "Database seems to be empty!"
 msgstr "Databank lijkt leeg te zijn!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Query opbouwen"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Routines"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Gebeurtenissen"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Ontwerper"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Databanken"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Gebruikers"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binaire log"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replicatie"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variabelen"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Karaktersets"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Plug-ins"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Engines"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Fout"
@@ -3144,7 +3144,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d rij toegevoegd."
 msgstr[1] "%1$d rijen toegevoegd."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3367,7 +3367,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3382,7 +3382,7 @@ msgstr "In de tabel zoeken"
 msgid "Find and Replace"
 msgstr "Zoeken en vervangen"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Aanpassen/Invoegen"
 
@@ -3390,7 +3390,7 @@ msgstr "Aanpassen/Invoegen"
 msgid "Select columns (at least one):"
 msgstr "Selecteer kolommen (minstens één):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Of"
@@ -3502,14 +3502,14 @@ msgstr "Themapad niet gevonden voor thema %s!"
 msgid "Theme:"
 msgstr "Thema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Een 1-byte integer, signed range is van -128 tot 127, unsigned range is van "
 "0 tot 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3517,7 +3517,7 @@ msgstr ""
 "Een 2-byte integer, signed range van -32,768 tot 32,767, unsigned range van "
 "0 tot 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3525,7 +3525,7 @@ msgstr ""
 "Een 3-byte integer, signed range van -8,388,608 tot 8,388,607, unsigned "
 "range van 0 tot 16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3533,7 +3533,7 @@ msgstr ""
 "Een 4-byte integer, signed range van -2,147,483,648 tot 2,147,483,647, "
 "unsigned range van 0 tot 4,294,967,295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3542,7 +3542,7 @@ msgstr ""
 "9,223,372,036,854,775,807, unsigned range van 0 tot "
 "18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3550,7 +3550,7 @@ msgstr ""
 "Een getal met vaste kommapositie (M,D) - het maximum aantal cijfers (M) is "
 "65 (standaard 10), het maximum aantal decimalen (D) is 30 (standaard 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3559,7 +3559,7 @@ msgstr ""
 "3,402823466E+38 tot -1,175494351E-38, 0, en 1,175494351E-38 tot 3.402823466E"
 "+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3569,7 +3569,7 @@ msgstr ""
 "waarden zijn -1,7976931348623157E+308 tot -2,2250738585072014E-308, 0, en "
 "2,2250738585072014E-308 tot 1,7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3577,7 +3577,7 @@ msgstr ""
 "Synoniem voor DOUBLE (uitzondering : in REAL_AS_FLOAT SQL mode is dit een "
 "synoniem voor FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3585,7 +3585,7 @@ msgstr ""
 "Een bit-field type (M), slaat M bits per waarde op (standaard is 1, maximum "
 "is 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3593,21 +3593,21 @@ msgstr ""
 "Een synoniem voor TINYINT(1), Een nulwaarde wordt beschouwd als vals, een "
 "niet-nulwaarde wordt beschouwd als waar"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Een alias voor BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Een datum, ondersteund bereik is %1$s tot %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Een dag en tijd combinatie, ondersteunde reeks gaat van %1$s tot %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3615,12 +3615,12 @@ msgstr ""
 "Een tijdstip, van 1970-01-01 00:00:01 UTC tot 2038-01-09 03:14:07 UTC, wordt "
 "opgeslaan als aantal seconden sinds het beginmoment (1970-01-01 00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Een uur, bereik is %1$s tot %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3629,7 +3629,7 @@ msgstr ""
 "toegelaten waarden lopen van 70 (1970) tot 69 (2069) of van 1901 tot 2155 en "
 "0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3637,7 +3637,7 @@ msgstr ""
 "Een string met vaste lengte (0-255, standaard 1) wordt bij opslag met "
 "spaties rechts tot de gespecificeerde lengte aangevuld"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3646,7 +3646,7 @@ msgstr ""
 "Een string met variabele lengte (%s), de effectieve maximale lengte is "
 "afhankelijk van de maximale rij grootte"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3655,7 +3655,7 @@ msgstr ""
 "wordt opgeslagen met een 1-byte voorvoegsel dat de lengte van de waarde in "
 "bytes aangeeft"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3664,7 +3664,7 @@ msgstr ""
 "tekens, wordt opgeslagen met een 2-byte voorvoegsel dat de lengte van de "
 "waarde in bytes aangeeft"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3673,7 +3673,7 @@ msgstr ""
 "1) tekens, wordt opgeslagen met een 3-byte voorvoegsel dat de lengte van de "
 "waarde in bytes aangeeft"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3683,7 +3683,7 @@ msgstr ""
 "4GiB (2^32 - 1) tekens, wordt opgeslagen met een 4-byte voorvoegsel dat de "
 "lengte van de waarde in bytes aangeeft"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3691,7 +3691,7 @@ msgstr ""
 "Vergelijkbaar met het CHAR type, maar opgeslagen in een binaire byte "
 "tekenreeks in plaats van een niet-binaire reeks lettertekens"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3699,7 +3699,7 @@ msgstr ""
 "Vergelijkbaar met het VARCHAR type, maar slaat de waarde op als binaire byte "
 "tekenreeks in plaats van een niet-binaire tekenreeks"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3708,7 +3708,7 @@ msgstr ""
 "wordt opgeslagen met een 1-byte voorvoegsel dat de lengte van de waarde "
 "aangeeft"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3717,7 +3717,7 @@ msgstr ""
 "bytes, wordt opgeslagen met een 3-byte voorvoegsel dat de lengte van de "
 "waarde aangeeft"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3726,7 +3726,7 @@ msgstr ""
 "bytes, wordt opgeslagen met een 2-byte voorvoegsel dat de lengte van de "
 "waarde aangeeft"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3735,7 +3735,7 @@ msgstr ""
 "(2^32 - 1) bytes, wordt opgeslagen met een 4-byte voorvoegsel dat de lengte "
 "van de waarde aangeeft"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3743,67 +3743,67 @@ msgstr ""
 "Een opsomming, geselecteerd uit een lijst met tot 65.535 waarden of de "
 "speciale '' foutwaarde"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Een enkele waarde geselecteerd uit een lijst met tot 64 waarden"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Een type dat een meetkundig object van gelijk welk type op kan slaan"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Een punt in een 2-dimensionale ruimte"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Een kromme met lineaire interpolatie tussen punten"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Een veelhoek"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Een verzameling van punten"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Een verzameling van krommen met lineaire interpolatie tussen punten"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Een verzameling van veelhoeken"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Een verzameling van meetkundige objecten van gelijk welk type"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numeriek"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Datum en tijd"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Tekenreeks"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Ruimtelijk"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Een 4-byte integer, bereik is -2.147.483.648 tot 2.147.483.647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3811,23 +3811,23 @@ msgstr ""
 "Een 8-byte integer, bereik is -9.223.372.036.854.775.808 tot "
 "9.223.372.036.854.775.807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Een systeem standaard dubbele precisie variabele kommapositiegetal"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Waar of vals"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Een alias voor BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Bevat een Universeel Unieke Identifier (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3835,7 +3835,7 @@ msgstr ""
 "Een tijdstip, bereik is '0001-01-01 00:00:00' UTC tot '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) kan microseconden opslaan"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3843,7 +3843,7 @@ msgstr ""
 "Een tekenreeks met variabele lengte (0-65.535), gebruikt binaire controle "
 "voor alle vergelijkingen"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Een opsomming, gekozen uit de lijst van gedefinieerde waarden"
 
@@ -3930,68 +3930,68 @@ msgstr "%d %B %Y om %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dagen, %s uren, %s minuten en %s seconden"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Ontbrekende parameter:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Ga naar databank &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "De %s functionaliteit heeft last van een bekend probleem, zie %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Klik om te wisselen"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Blader op uw eigen pc:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Selecteer uit de web-server upload directory <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 "De folder die u heeft ingesteld om te uploaden kan niet worden bereikt."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Er zijn geen bestanden om te uploaden"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Legen"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Uitvoeren"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Afdrukken"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Gecreëerd"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Laatst bijgewerkt"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Laatst gecontroleerd"
@@ -4348,9 +4348,9 @@ msgstr "Gebruikers toestaan deze waarde aan te passen"
 msgid "Apply"
 msgstr "Toepassen"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Herstellen"
 
@@ -4665,7 +4665,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maximale uitvoertijd"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Opslaan als bestand"
 
@@ -7101,7 +7101,7 @@ msgstr "Het bestand wordt verwerkt, een ogenblik geduld."
 msgid "Language"
 msgstr "Taal"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Versie-informatie"
 
@@ -7552,59 +7552,59 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Binair - niet aanpassen"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "uploadfolder op webserver:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Herstart invoegen met %s rijen"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "en dan"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Toevoegen als nieuwe rij"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Toevoegen als nieuwe rij en foutmeldingen negeren"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Toon insert-query"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Terug"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Een nieuwe rij toevoegen"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Ga terug naar deze pagina"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Volgende rij bewerken"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Gebruik de TAB-toets om van waarde naar waarde te navigeren of CTRL+pijltjes "
 "om vrijuit te navigeren"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Toont SQL-query"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Toegevoegd rijnummer: %1$d"
@@ -7938,7 +7938,6 @@ msgid "Database operations"
 msgstr "Databankbewerkingen"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Toon verborgen onderdelen"
 
@@ -9761,24 +9760,24 @@ msgid "There are no events to display."
 msgstr "Er zijn geen gebeurtenissen om weer te geven."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "De tabel %s bestaat niet!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Configureer de coördinaten voor de tabel %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Schema van de databank %s - Pagina %s"
@@ -12512,7 +12511,7 @@ msgstr "Versie %1$s is aangemaakt, tracking van %2$s is ingeschakeld."
 msgid "Manage your settings"
 msgstr "Uw instellingen beheren"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Configuratie werd opgeslagen"
 
@@ -12770,7 +12769,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Er zijn geen opgeslagen instellingen!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Deze functie wordt niet ondersteund door uw webbrowser"
 
@@ -12787,20 +12786,20 @@ msgstr ""
 "U kan meer instellingen veranderen door config.inc.php aan te passen, bv. "
 "door het %ssetup-script%s te gebruiken."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Opslaan in de browseropslag"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 "De instellingen zullen bewaard worden in de lokale opslag van uw browser."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Bestaande instellingen zullen overschreven worden!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "U kan al uw instellingen terugzetten op de standaardwaarden."
 
@@ -12828,6 +12827,10 @@ msgstr "Geen databanken"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Dump (schema) van de databanken bekijken"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-11 13:38+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Punjabi <http://l10n.cihar.com/projects/phpmyadmin/master/pa/"
@@ -43,7 +43,7 @@ msgstr ""
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr ""
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -558,8 +558,8 @@ msgstr ""
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -585,7 +585,7 @@ msgstr ""
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "ਚੱਲੋ"
@@ -913,7 +913,7 @@ msgstr ""
 msgid "Edit Index"
 msgstr ""
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr ""
@@ -1126,7 +1126,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr ""
 
@@ -1420,8 +1420,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1630,8 +1630,8 @@ msgstr ""
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1658,7 +1658,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1727,8 +1727,8 @@ msgstr ""
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2413,8 +2413,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2470,28 +2470,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr ""
@@ -2667,9 +2667,9 @@ msgstr ""
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2854,9 +2854,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2870,32 +2870,32 @@ msgid "Structure"
 msgstr ""
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr ""
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "ਲੱਭੋ"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2904,20 +2904,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2933,70 +2933,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr ""
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr ""
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr ""
@@ -3022,7 +3022,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3238,7 +3238,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3253,7 +3253,7 @@ msgstr ""
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3261,7 +3261,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr ""
@@ -3371,278 +3371,278 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr ""
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3727,67 +3727,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr ""
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr ""
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr ""
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr ""
@@ -4137,9 +4137,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4420,7 +4420,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6636,7 +6636,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7027,57 +7027,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9095,24 +9095,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11583,7 +11583,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -11831,7 +11831,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -11846,19 +11846,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -11885,6 +11885,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/phpmyadmin.pot
+++ b/po/phpmyadmin.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,7 +41,7 @@ msgstr ""
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr ""
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -334,7 +334,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -362,7 +362,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -556,8 +556,8 @@ msgstr ""
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -583,7 +583,7 @@ msgstr ""
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Edit Index"
 msgstr ""
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, possible-php-format
 msgid "Add %s column(s) to index"
 msgstr ""
@@ -1124,7 +1124,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr ""
 
@@ -1418,8 +1418,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1628,8 +1628,8 @@ msgstr ""
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1656,7 +1656,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1725,8 +1725,8 @@ msgstr ""
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2407,8 +2407,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2464,28 +2464,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr ""
@@ -2661,9 +2661,9 @@ msgstr ""
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2848,9 +2848,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2864,32 +2864,32 @@ msgid "Structure"
 msgstr ""
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr ""
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr ""
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2898,20 +2898,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2927,70 +2927,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr ""
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr ""
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr ""
@@ -3016,7 +3016,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3232,7 +3232,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3247,7 +3247,7 @@ msgstr ""
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3255,7 +3255,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr ""
@@ -3365,278 +3365,278 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, possible-php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, possible-php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, possible-php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, possible-php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr ""
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3721,67 +3721,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, possible-php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, possible-php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, possible-php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr ""
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr ""
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr ""
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr ""
@@ -4129,9 +4129,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4412,7 +4412,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6628,7 +6628,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7019,57 +7019,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, possible-php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, possible-php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9085,24 +9085,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, possible-php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, possible-php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, possible-php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11571,7 +11571,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -11819,7 +11819,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -11834,19 +11834,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -11873,6 +11873,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/pl.po
+++ b/po/pl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-03 12:06+0200\n"
 "Last-Translator: Piotr Przybylski <piotrprz@gmail.com>\n"
 "Language-Team: Polish <http://l10n.cihar.com/projects/phpmyadmin/master/pl/"
@@ -42,7 +42,7 @@ msgstr "Komentarze tabeli:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Typ"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -338,7 +338,7 @@ msgid "Updated"
 msgstr "Zaktualizowana"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -366,7 +366,7 @@ msgid "Delete tracking data for this table"
 msgstr "Usuń dane śledzące tę tabelę"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -570,8 +570,8 @@ msgstr "Dodaj geometrię"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -597,7 +597,7 @@ msgstr "Dodaj geometrię"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Wykonaj"
@@ -996,7 +996,7 @@ msgstr "Dodaj indeks"
 msgid "Edit Index"
 msgstr "Edytuj indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Dodaj %s kolumny do indeksu"
@@ -1213,7 +1213,7 @@ msgid "Traffic"
 msgstr "Ruch"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Ustawienia"
 
@@ -1529,8 +1529,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1739,8 +1739,8 @@ msgstr "Pokaż okno zapytań"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1767,7 +1767,7 @@ msgstr "Czas wykonywania zapytania"
 msgid "%d is not valid row number."
 msgstr "%d nie jest prawidłowym numerem wiersza."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1844,8 +1844,8 @@ msgstr "Wyniki zapytania"
 msgid "Data point content"
 msgstr "Treść punktu danych"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignoruj"
 
@@ -2410,7 +2410,7 @@ msgstr "Istniejący plik konfiguracyjny (%s) nie jest czytelny."
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "Złe uprawnienia pliku konfiguracyjnego, nie powinien być zapisywalny!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Rozmiar czcionki"
 
@@ -2571,8 +2571,8 @@ msgstr[1] "%1$s dopasowania w <strong>%2$s</strong>"
 msgstr[2] "%1$s dopasowań w <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2628,28 +2628,28 @@ msgstr "Zapisz edytowane dane"
 msgid "Restore column order"
 msgstr "Przywrócić porządek w kolumnie"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Początek"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Poprzednie"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Następne"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Koniec"
@@ -2831,9 +2831,9 @@ msgstr "Zaznacz wszystkie"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3027,9 +3027,9 @@ msgid "View"
 msgstr "Widok"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3043,32 +3043,32 @@ msgid "Structure"
 msgstr "Struktura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Szukaj"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Wstaw"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3077,20 +3077,20 @@ msgid "Privileges"
 msgstr "Uprawnienia"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operacje"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Śledzenie"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3106,70 +3106,70 @@ msgstr "Wyzwalacze"
 msgid "Database seems to be empty!"
 msgstr "Baza danych wydaje się pusta!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Zapytanie"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Procedury i funkcje"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Zdarzenia"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Widok projektu"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Bazy danych"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Użytkownicy"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Dziennik binarny"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikacja"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Zmienne"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Kodowania znaków"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Wtyczki"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Mechanizmy"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Błąd"
@@ -3198,7 +3198,7 @@ msgstr[0] "Wstawionych rekordów: %1$d."
 msgstr[1] "Wstawionych rekordów: %1$d."
 msgstr[2] "Wstawionych rekordów: %1$d."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3422,7 +3422,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3437,7 +3437,7 @@ msgstr "Tabela szukania"
 msgid "Find and Replace"
 msgstr "Znajdź i zamień"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Edycja/Wstaw"
 
@@ -3445,7 +3445,7 @@ msgstr "Edycja/Wstaw"
 msgid "Select columns (at least one):"
 msgstr "Wybierz kolumny (przynajmniej jedną):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Lub"
@@ -3568,14 +3568,14 @@ msgstr "Nie znaleziono ścieżki do motywu %s!"
 msgid "Theme:"
 msgstr "Motyw"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "1-Bajtowa liczba całkowita, podpisany zakres jest-128 do 127, niepodpisany "
 "zakres wynosi od 0 do 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3583,7 +3583,7 @@ msgstr ""
 "2-Bajtowa liczba całkowita, podpisany zakres jest-32,768 do 32 767, "
 "niepodpisany zakres wynosi od 0 do 65 535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3591,7 +3591,7 @@ msgstr ""
 "3-Bajtowa liczba całkowita, podpisany zakres jest-8,388,608 do 8,388,607, "
 "jest niepodpisany zakres 0 do 16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3599,7 +3599,7 @@ msgstr ""
 "4-Bajtowa liczba całkowita, podpisany zakres jest-2,147,483,648 do 2 147 483 "
 "647, jest niepodpisany zakres 0 do 4 294 967 295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3608,7 +3608,7 @@ msgstr ""
 "do 9,223,372,036,854,775,807, jest niepodpisany zakres 0 do "
 "18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3617,7 +3617,7 @@ msgstr ""
 "(domyślnie 10), maksymalna liczba miejsc po przecinku (D) wynosi 30 "
 "(domyślnie 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3625,7 +3625,7 @@ msgstr ""
 "Małe wartości zmiennoprzecinkowych numer, dopuszczalne są - 3.402823466E 38 "
 "do - 1.175494351E-38, 0 i 1.175494351E-38 do 3.402823466E 38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3635,7 +3635,7 @@ msgstr ""
 "1.7976931348623157E 308 do - 2.2250738585072014E-308, 0 i "
 "2.2250738585072014E-308 do 1.7976931348623157E 308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3643,7 +3643,7 @@ msgstr ""
 "Synonim dla DOUBLE (wyjątek: w trybie REAL_AS_FLOAT SQL jest synonimem typu "
 "\"float\")"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3651,7 +3651,7 @@ msgstr ""
 "Przechowywanie m bitów na wartość typu pole bitowe (M), (wartością domyślną "
 "jest 1, maksymalnie jest 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3659,21 +3659,21 @@ msgstr ""
 "Synonim TINYINT(1), wartość zero uznaje wartość FAŁSZ, wartości niezerowe — "
 "są uważane za prawdziwe"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Alias unikatowy BIGINT niepodpisane nie NULL AUTO_INCREMENT"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Datę, obsługiwany jest zakres %1$s do %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Data i godzina kombinacja zakresu obsługiwanych jest %1$s %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3682,12 +3682,12 @@ msgstr ""
 "03: 14: 07 UTC, przechowywane jako liczba sekund od epoki (1970-01-01 00: "
 "00: 00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Czas, zakres jest %1$s do %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3695,7 +3695,7 @@ msgstr ""
 "W roku w czterocyfrowym (4, domyślnie) lub (2) formacie dwucyfrowym, "
 "wartości dopuszczalne są 70 (1970)-69 (2069) lub 1901 do 2155 i 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3703,7 +3703,7 @@ msgstr ""
 "O stałej długości (0-255, domyślnie 1) ciąg znaków, który jest zawsze prawo "
 "dopełnione spacjami do podanej długości podczas przechowywania"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3712,7 +3712,7 @@ msgstr ""
 "Ciąg znaków o zmiennej długości (%s) efektywna długość maksymalna jest z "
 "zastrzeżeniem maksymalny rozmiar wiersza"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3720,7 +3720,7 @@ msgstr ""
 "Kolumna tekstu o maksymalnej długości 255 (2 ^ 8 - 1) znaków przechowywanych "
 "z prefiksem jednobajtowych wskazujące długość wartości w bajtach"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3728,7 +3728,7 @@ msgstr ""
 "Kolumna tekstu o maksymalnej długości 65 535 (2 ^ 16 - 1) znaki, "
 "przechowywane prefiksu dwubajtowy, wskazując długość wartości w bajtach"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3736,7 +3736,7 @@ msgstr ""
 "Kolumna tekstu o maksymalnej długości 16,777,215 (2 ^ 24 - 1) znaków "
 "przechowywanych z prefiksem trzybajtowy wskazujące długość wartości w bajtach"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3746,7 +3746,7 @@ msgstr ""
 "znaki, przechowywane prefiksu czwartego bajtu, wskazując długość wartości w "
 "bajtach"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3754,7 +3754,7 @@ msgstr ""
 "Podobne do typu CHAR, ale przechowuje binarna bajtu ciągi zamiast ciągów "
 "znaków nieznakowe"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3762,7 +3762,7 @@ msgstr ""
 "Podobnego typu VARCHAR, ale przechowuje binarna bajtu ciągów, zamiast ciągów "
 "znaków nieznakowe"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3770,7 +3770,7 @@ msgstr ""
 "Kolumna BLOB o maksymalnej długości 255 (2 ^ 8 - 1) bajtów, przechowywane z "
 "prefiksem jednobajtowych wskazujące długość wartości"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3778,7 +3778,7 @@ msgstr ""
 "Kolumna BLOB o maksymalnej długości 16,777,215 (2 ^ 24 - 1) bajtów, "
 "przechowywane z prefiksem trzybajtowy wskazujące długość wartości"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3786,7 +3786,7 @@ msgstr ""
 "Kolumna BLOB o maksymalnej długości 65 535 (2 ^ 16 - 1) bajtów, "
 "przechowywane prefiksu dwubajtowy, wskazując długość wartości"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3794,7 +3794,7 @@ msgstr ""
 "Kolumny obiektu BLOB o maksymalnej długooci 4 294 967 295 lub 4GiB (2 ^ 32 - "
 "1) bajtów, przechowywane prefiksu czwartego bajtu, wskazując długość wartości"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3802,67 +3802,67 @@ msgstr ""
 "Wyliczenie, wybrane z listy wartości maksymalnie 65 535 lub specjalnych '' "
 "wartość błędu"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Pojedyncza wartość wybrana z zestawu maksymalnie 64 członków"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Typy, które mogą przechowywać geometrię dowolnego typu"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Punkt w przestrzeni 2-wymiarowej"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Krzywa z interpolacji liniowej pomiędzy punktami"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Wielokąt"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Zbiór punktów"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Zbiór krzywych z interpolacji liniowej pomiędzy punktami"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Zbiór wielokątów"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Zbiór obiektów geometrycznych dowolnego typu"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numeryczny"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Data i czas"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Ciąg"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Przestrzenny"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "4-Bajtowa liczba całkowita, zakres jest-2,147,483,648 do 2 147 483 647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3870,23 +3870,23 @@ msgstr ""
 "8-Bajtowa liczba całkowita, zakres jest-9,223,372,036,854,775,808 do "
 "9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Liczba zmiennoprzecinkowa podwójnej precyzji domyślnego systemu"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Prawda lub fałsz"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Alias unikatowy dla BIGINT NOT NULL AUTO_INCREMENT"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Przechowuje unikatowego identyfikatora (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3894,7 +3894,7 @@ msgstr ""
 "Sygnatury czasowej, zakres jest ' 0001-01-01 00: 00: 00' UTC do \"9999-12-31 "
 "23: 59: 59' UTC; TimeStamp(6) mogą być przechowywane w mikrosekundach"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3902,7 +3902,7 @@ msgstr ""
 "Ciąg o długości zmiennej (0 do 65 535) używa binarne sortowania dla "
 "wszystkich porównań"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Wyliczenie, wybrane z listy zdefiniowane wartości"
 
@@ -3989,67 +3989,67 @@ msgstr "%d %B %Y, %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dni, %s godzin, %s minut i %s sekund"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Brakuje parametru:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Przejście do bazy danych &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Funkcja %s jest dotknięta przez znany błąd, zobacz %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Kliknij, aby przełączać"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Wyszukaj w komputerze:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Wybierz katalog serwera WWW dla uploadu <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Nie można znaleźć katalogu do zapisu przesyłanych plików."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Brak plików do wysłania"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Opróżnij"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Wykonaj"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Drukuj"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Data utworzenia"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Ostatnia aktualizacja"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Ostatnie sprawdzanie"
@@ -4410,9 +4410,9 @@ msgstr "Zezwól użytkownikom na zmianę tej wartości"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Resetuj"
 
@@ -4729,7 +4729,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maksymalny czas wykonania"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Zapisz jako plik"
 
@@ -7206,7 +7206,7 @@ msgstr "Plik jest przetwarzany. Prosimy o cierpliwość."
 msgid "Language"
 msgstr "Język"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informacja o wersji"
 
@@ -7649,61 +7649,61 @@ msgstr "Ze względu na jego długość, <br /> kolumna ta może nie być edytowa
 msgid "Binary - do not edit"
 msgstr "Binarne - nie do edycji"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "katalog przesyłania serwera web"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Kontynuuj wstawianie %s wierszy"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "i potem"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Wstaw jako nowy wiersz"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Wstaw jko nowy wiersz i ignoruj błędy"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Pokaż wstawiane zapytanie"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Wróć"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Wstaw nowy wiersz"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Powrót do tej strony"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Edytuj następny wiersz"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Użyj TAB, aby przejść z wartości do wartości, lub CTRL+strzałki do "
 "poruszania się w dowolnym miejscu"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Wyświetl zapytanie SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Id wstawionego wiersza: %1$d"
@@ -9925,24 +9925,24 @@ msgid "There are no events to display."
 msgstr "Nie ma żadnych zdarzeń do wyświetlenia."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Tabela '%s' nie istnieje!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Proszę skonfigurować współrzędne dla tabeli %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Schemat bazy danych %s - Strona %s"
@@ -12735,7 +12735,7 @@ msgstr "Wersja %1$s stworzona, śledzenie dla %2$s jest aktywne."
 msgid "Manage your settings"
 msgstr "Zarządzaj ustawieniami"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Konfiguracja została zapamiętana"
 
@@ -12994,7 +12994,7 @@ msgstr "Ustawienia będą zaimportowane z pamięci przeglądarki."
 msgid "You have no saved settings!"
 msgstr "Nie masz żadnych zapisanych ustawień!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Ta funkcja nie jest obsługiwana przez twoją przeglądarkę internetową"
 
@@ -13011,19 +13011,19 @@ msgstr ""
 "Możesz ustawić więcej ustawień poprzez modyfikację config.inc.php, przez "
 "użycie %sSkrypt instalacyjny%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Zapisz w pamięci przeglądarki"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Ustawienia zostaną zapisane w lokalnej pamięci przeglądarki."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Istniejące ustawienia zostaną nadpisane!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Można przywrócić wszystkie ustawienia i przywrócić je do wartości domyślnych."
@@ -13054,6 +13054,10 @@ msgstr "Brak baz danych"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Pokaż zrzut (schemat) bazy danych"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/pt.po
+++ b/po/pt.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 11:12+0200\n"
 "Last-Translator: Edu Rib PT <edurib.pt@gmail.com>\n"
 "Language-Team: Portuguese <http://l10n.cihar.com/projects/phpmyadmin/master/"
@@ -41,7 +41,7 @@ msgstr "Comentários da tabela:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Tipo"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr "Actualizado"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Apagar dados de tracking para esta tabela"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -566,8 +566,8 @@ msgstr "Adicionar geometria"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -593,7 +593,7 @@ msgstr "Adicionar geometria"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Executar"
@@ -972,7 +972,7 @@ msgstr "Adicionar Índice"
 msgid "Edit Index"
 msgstr "Editar Índice"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Adiciona %s coluna(s) ao Índice"
@@ -1189,7 +1189,7 @@ msgid "Traffic"
 msgstr "Tráfego"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Configurações"
 
@@ -1508,8 +1508,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1718,8 +1718,8 @@ msgstr "Mostrar Caixa do query"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1746,7 +1746,7 @@ msgstr "Tempo de execução da consulta"
 msgid "%d is not valid row number."
 msgstr "%d não é um número de linha válido."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1818,8 +1818,8 @@ msgstr "Resultado(s) das(s) consulta(s)"
 msgid "Data point content"
 msgstr "Conteúdo do ponto de dados"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignora"
 
@@ -2376,7 +2376,7 @@ msgstr ""
 "Permissões errada no ficheiro de configuração. Não deve ser editável por "
 "todos!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Tamanho da fonte"
 
@@ -2523,8 +2523,8 @@ msgstr[0] "%1$s resultado em <strong>%2$s</strong>"
 msgstr[1] "%1$s resultados em <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2580,28 +2580,28 @@ msgstr "Guardar dados editados"
 msgid "Restore column order"
 msgstr "Restaurar ordem da coluna"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Início"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Anterior"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Seguinte"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Fim"
@@ -2779,9 +2779,9 @@ msgstr "Todos"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2971,9 +2971,9 @@ msgid "View"
 msgstr "Vista"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2987,32 +2987,32 @@ msgid "Structure"
 msgstr "Estrutura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Pesquisar"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Insere"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3021,20 +3021,20 @@ msgid "Privileges"
 msgstr "Privilégios"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operações"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Rastreando"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3050,70 +3050,70 @@ msgstr "Acionadores"
 msgid "Database seems to be empty!"
 msgstr "A Base de Dados aparenta estar vazia!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Pesquisa por formulário"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rotinas"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Eventos"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Desenhador"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Base de Dados"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Utilizadores"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Registo binário"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replicação"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variáveis"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Mapas de Caracteres"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Plugins"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motores"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Erro"
@@ -3139,7 +3139,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d linha inserida."
 msgstr[1] "%1$d linha(s) inseridas."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3362,7 +3362,7 @@ msgid "Operator"
 msgstr "Operador"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3377,7 +3377,7 @@ msgstr "Pesquisa de tabela"
 msgid "Find and Replace"
 msgstr "Localizar e substituir"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Inserir/Editar"
 
@@ -3385,7 +3385,7 @@ msgstr "Inserir/Editar"
 msgid "Select columns (at least one):"
 msgstr "Seleccione colunas (no mínimo um):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Ou"
@@ -3497,14 +3497,14 @@ msgstr "Encontrado caminho inválido para o tema %s!"
 msgid "Theme:"
 msgstr "Tema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Um inteiro de 1 byte, a gama atribuída é de -128 a 127, a gama não atribuída "
 "é de 0 a 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3512,7 +3512,7 @@ msgstr ""
 "Um inteiro de 2 byte, a gama atribuída é de -32,768 a 32,767, a gama não "
 "atribuída é de 0 a 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3520,7 +3520,7 @@ msgstr ""
 "Um inteiro de 3 byte, a gama atribuída é de -8,388,608 a 8,388,607, a gama "
 "não atribuída é de 0 a 16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3528,7 +3528,7 @@ msgstr ""
 "Um inteiro de 4 byte, a gama atribuída é de -2,147,483,648 a 2,147,483,647, "
 "a gama não atribuída é de 0 a 4,294,967,295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3537,7 +3537,7 @@ msgstr ""
 "9,223,372,036,854,775,807, a gama não atribuída é de 0 a "
 "18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3545,7 +3545,7 @@ msgstr ""
 "Um número de ponto fixo (M, D), o número máximo de dígitos (M) é de 65 (por "
 "defeito 10), o número máximo de decimais (D) é de 30 (por defeito 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3553,7 +3553,7 @@ msgstr ""
 "Um pequeno número de ponto flutuante, os valores permitidos são -3.402823466E"
 "+38 a -1.175494351E-38, 0 e 1.175494351E-38 a 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3563,7 +3563,7 @@ msgstr ""
 "1.7976931348623157E+308 a -2.2250738585072014E-308, 0 e 2.2250738585072014E-"
 "308 a 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3571,7 +3571,7 @@ msgstr ""
 "Sinónimo para DOUBLE (excepção: no modo SQL REAL_AS_FLOAT é sinónimo para "
 "FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3579,7 +3579,7 @@ msgstr ""
 "Um tipo de campo bit (M), armazena M de bits por valor (o padrão é 1 e o "
 "máximo é 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3587,22 +3587,22 @@ msgstr ""
 "Um sinónimo para TINYINT(1), um valor de zero é considerado falso, valores "
 "diferentes de zero são considerados verdadeiros"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 #, fuzzy
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Um alias para BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Uma data, intervalo suportado é %1$s até %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Uma combinação de data e hora, o intervalo suportado é %1$s até %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3611,12 +3611,12 @@ msgstr ""
 "09 03:14:07 UTC, guardado como um número de segundos desde a época (1970-01-"
 "01 00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Uma hora, intervalo é %1$s até %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3624,7 +3624,7 @@ msgstr ""
 "Um ano no formato de quatro dígitos (4, padrão) ou de dois dígitos (2), os "
 "valores permitidos são de 70 (1970) até 69 (2069) ou 1901 até 2155 e 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3632,7 +3632,7 @@ msgstr ""
 "Uma string de comprimento fixo (0-255, padrão 1) que é sempre preenchida à "
 "direita com espaços até o tamanho especificado quando guardada"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3641,7 +3641,7 @@ msgstr ""
 "Uma variável de comprimento (%s) do tipo string, o comprimento máximo "
 "efectivo está sujeito ao tamanho máximo de linha"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3649,7 +3649,7 @@ msgstr ""
 "Uma coluna de texto com um comprimento máximo de 255 (2^8 - 1) caracteres, "
 "guardados com um prefixo de um byte indicando o comprimento do valor em bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3658,7 +3658,7 @@ msgstr ""
 "caracteres, guardada com um prefixo de dois bytes indicando o comprimento do "
 "valor em bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3667,7 +3667,7 @@ msgstr ""
 "caracteres, guardada com um prefixo de três bytes que indica o comprimento "
 "do valor em bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3677,7 +3677,7 @@ msgstr ""
 "- 1) caracteres, guardada com um prefixo de quatro bytes que indica o "
 "comprimento do valor em bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3685,7 +3685,7 @@ msgstr ""
 "Semelhante ao tipo CHAR, mas armazena strings de bytes binários em vez de "
 "strings de caracteres não-binários"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3693,7 +3693,7 @@ msgstr ""
 "Semelhante ao tipo VARCHAR, mas armazena strings de bytes binários em vez de "
 "strings de caracteres não-binários"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3701,7 +3701,7 @@ msgstr ""
 "Uma coluna tipo BLOB com um comprimento máximo de 255 (2^8 - 1) bytes, "
 "armazenada com um prefixo de um byte indicando o comprimento do valor"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3710,7 +3710,7 @@ msgstr ""
 "bytes, armazenada com um prefixo de três bytes que indica o comprimento do "
 "valor"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3718,7 +3718,7 @@ msgstr ""
 "Uma coluna tipo BLOB com um comprimento máximo de 65.535 (2^16 - 1) bytes, "
 "armazenada com um prefixo de dois byte indicando o comprimento do valor"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3727,7 +3727,7 @@ msgstr ""
 "bytes, armazenados com um prefixo de quatro bytes indicando o comprimento do "
 "valor"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3735,69 +3735,69 @@ msgstr ""
 "Uma enumeração, escolhida a partir da lista de até 65.535 valores ou o valor "
 "especial '' do erro"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Um valor único escolhido de um conjunto de até 64 membros"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Um tipo que pode armazenar uma geometria de qualquer tipo"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Um ponto no espaço de 2 dimensões"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Uma curva com uma interpolação linear entre os pontos"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Um polígono"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Uma coleção de pontos"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Uma coleção de curvas com uma interpolação linear entre os pontos"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Uma coleção de polígonos"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Uma coleção de objetos geométricos de qualquer tipo"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numérico"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Data e hora"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Segmento"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Espacial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 "O intervalo de um número inteiro de 4-byte é entre -2,147,483,648 e "
 "2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3805,23 +3805,23 @@ msgstr ""
 "O intervalo de um número inteiro de 8-byte é entre -"
 "9,223,372,036,854,775,808 e 9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Número de dupla precisão padrão de um sistema de ponto flutuante"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Verdadeiro ou falso"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Um alias para BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Guarda um Identificador Universal Único (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3829,7 +3829,7 @@ msgstr ""
 "O intervalo de timestamp é '0001-01-01 00:00:00' UTC e '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) e pode armazenar microssegundos"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3837,7 +3837,7 @@ msgstr ""
 "A string de comprimento variável (0-65,535), usa o agrupamento binário para "
 "todas as comparações"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Uma enumeração, escolhida a partir da lista de valores definidos"
 
@@ -3922,67 +3922,67 @@ msgstr "%d-%B-%Y às %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dias, %s horas, %s minutos e %s segundos"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Parâmetros em falta:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Saltar para a Base de Dados &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "A funcionalidade %s é afectada por um bug conhecido, veja %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Clique para alternar"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Procurar no seu computador:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Selecionar a partir da directoria de upload do servidor <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Não é possivel alcançar a directoria que configurou para fazer upload."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Não existem arquivos para fazer upload"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Limpa"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Executar"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Imprimir"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Criação"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Última actualização"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Última Verificação"
@@ -4341,9 +4341,9 @@ msgstr "Permitir a todos os utilizadores alterarem este valor"
 msgid "Apply"
 msgstr "Aplicar"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Limpa"
 
@@ -4651,7 +4651,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Tempo máximo de execução"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "envia"
 
@@ -7104,7 +7104,7 @@ msgstr ""
 msgid "Language"
 msgstr "Lingua"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informação de Versão"
 
@@ -7504,61 +7504,61 @@ msgstr "Devido ao seu tamanho,<br /> este campo pode não ser editável "
 msgid "Binary - do not edit"
 msgstr "Binário - não editar"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "Directoria no servidor web para fazer upload"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Insere como novo registo"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Voltar atrás"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Inserir novo registo"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 #, fuzzy
 msgid "Go back to this page"
 msgstr "Voltar atrás"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Editar próxima coluna"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 #, fuzzy
 msgid "Showing SQL query"
 msgstr "Mostrar queries completos"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9784,25 +9784,25 @@ msgid "There are no events to display."
 msgstr "Tabelas em tracking"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "A tabela \"%s\" não existe!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Configure as cordenadas para a tabela %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12521,7 +12521,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Características gerais de Relação"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12791,7 +12791,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Não dispõe de configurações guardadas!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Esta funcionalidade não é suportada pelo seu browser"
 
@@ -12806,19 +12806,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Gravar para o armazenamento do seu browser"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "As configurações serão gravadas no armazenamento local do seu browser."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "As configurações existentes serão sobre-escritas!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Pode eliminar todas as definições e restaurá-las para os valores padrão."
@@ -12850,6 +12850,10 @@ msgstr "Sem bases de dados"
 #, fuzzy
 msgid "View dump (schema) of databases"
 msgstr "Ver o esquema da base de dados"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,15 +3,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-28 14:02+0200\n"
 "Last-Translator: Helder Santana <helder.bs.santana@gmail.com>\n"
-"Language-Team: Portuguese (Brazil) "
-"<http://l10n.cihar.com/projects/phpmyadmin/master/pt_BR/>\n"
-"Language: pt_BR\n"
+"Language-Team: Portuguese (Brazil) <http://l10n.cihar.com/projects/"
+"phpmyadmin/master/pt_BR/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -41,7 +41,7 @@ msgstr "Comentários de tabela:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Tipo"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr "Atualizado"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Excluir dados de monitoramento desta tabela"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -566,8 +566,8 @@ msgstr "Adicionar geometria"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -593,7 +593,7 @@ msgstr "Adicionar geometria"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Executar"
@@ -972,7 +972,7 @@ msgstr "Adicionar índice"
 msgid "Edit Index"
 msgstr "Editar índice"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Adicionar %s coluna(s) ao índice"
@@ -1189,7 +1189,7 @@ msgid "Traffic"
 msgstr "Tráfego"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Configurações"
 
@@ -1518,8 +1518,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1730,8 +1730,8 @@ msgstr "Mostrar caixa de consulta"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1758,7 +1758,7 @@ msgstr "Tempo de execução de query"
 msgid "%d is not valid row number."
 msgstr "%d não é um número de linha válido."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1830,8 +1830,8 @@ msgstr "Resultado(s) da(s) consulta(s)"
 msgid "Data point content"
 msgstr "Conteúdo do ponteiro de dados"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorar"
 
@@ -2391,7 +2391,7 @@ msgstr ""
 "Permissões incorretas no arquivo de configuração, não deveria permitir "
 "escrita por qualquer um!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Tamanho da fonte"
 
@@ -2539,8 +2539,8 @@ msgstr[0] "%1$s resultado em <strong>%2$s</strong>"
 msgstr[1] "%1$s resultados em <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2596,28 +2596,28 @@ msgstr "Salvar dados editados"
 msgid "Restore column order"
 msgstr "Restaurar ordem da coluna"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Início"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Anterior"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Próximo"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Fim"
@@ -2795,9 +2795,9 @@ msgstr "Marcar todos"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2988,9 +2988,9 @@ msgid "View"
 msgstr "Visualizar"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3004,32 +3004,32 @@ msgid "Structure"
 msgstr "Estrutura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Procurar"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Inserir"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3038,20 +3038,20 @@ msgid "Privileges"
 msgstr "Privilégios"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operações"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Monitoramento"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3067,70 +3067,70 @@ msgstr "Gatilhos"
 msgid "Database seems to be empty!"
 msgstr "O banco de dados parece estar vazio!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Consulta"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rotinas"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Eventos"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Designer"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Bancos de dados"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Usuários"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Log binário"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replicação"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variáveis"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Charsets"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Plugins"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motores"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Erro"
@@ -3156,7 +3156,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d linha inserida."
 msgstr[1] "%1$d linhas inseridas."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3379,7 +3379,7 @@ msgid "Operator"
 msgstr "Operador"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3394,7 +3394,7 @@ msgstr "Pesquisa de tabela"
 msgid "Find and Replace"
 msgstr "Pesquisar e Substituir"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Inserir/Editar"
 
@@ -3402,7 +3402,7 @@ msgstr "Inserir/Editar"
 msgid "Select columns (at least one):"
 msgstr "Selecionar colunas (no mínimo 1):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Ou"
@@ -3514,14 +3514,14 @@ msgstr "Caminho de tema não encontrado para o tema %s!"
 msgid "Theme:"
 msgstr "Tema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Um inteiro de 1 byte, o limite com sinal vai de -128 a 127, o limite sem "
 "sinal vai de 0 a 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3529,7 +3529,7 @@ msgstr ""
 "Um inteiro de 2 bytes, o limite com sinal vai de -32.768 até 32.767, o "
 "limite sem sinal vai de 0 até 65.535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3537,7 +3537,7 @@ msgstr ""
 "Um inteiro de 3 bytes, o limite com sinal vai de -8.388.608 até 8.388.607, o "
 "limite sem sinal vai de 0 até 16.777.215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3545,7 +3545,7 @@ msgstr ""
 "Um inteiro de 4 bytes, o limite com sinal vai de -2.147.483.648 a "
 "2.147.483.647, o limite sem sinal vai de 0 a 4.294.967.295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3554,7 +3554,7 @@ msgstr ""
 "a 9.223.372.036.854.775.808, o limite sem sinal vai de 0 a "
 "18.446.744.073.709.551.615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3562,7 +3562,7 @@ msgstr ""
 "Um número de ponto fixo (M, D) - o número máximo de dígitos (M) é 65 (10 por "
 "padrão), e o número máximo de decimais (D) é 30 (0 por padrão)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3570,7 +3570,7 @@ msgstr ""
 "Um número curto de ponto flutuante, os valores permitidos são: de -"
 "3,402823466E+38 a -1,175494351E-38, 0 e de 1,175494351E-38 a 3,402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3580,7 +3580,7 @@ msgstr ""
 "permitidos são: de -1,7976931348623157E+308 a  -2,2250738585072014E-308, 0 e "
 "de 2,2250738585072014E-308 até 1,7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3588,7 +3588,7 @@ msgstr ""
 "Sinônimo para DOUBLE (exceção: no modo SQL REAL_AS_FLOAT ele é um sinônimo "
 "para FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3596,7 +3596,7 @@ msgstr ""
 "Em um campo de tipo bit (M), o armazenamento M de bits por valor é de (1 por "
 "padrão, 64 no máximo)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3604,21 +3604,21 @@ msgstr ""
 "Um sinônimo para TINYINT(1), o zero é considerado falso, qualquer valor "
 "diferente de zero é considerado verdadeiro"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Um apelido para BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Uma data, o limite suportado é de %1$s até %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Uma combinação de data e hora, o limite suportado vai de %1$s a %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3627,12 +3627,12 @@ msgstr ""
 "03:14:07 UTC, armazenado como o número de segundos desde a época (1970-01-01 "
 "00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Um horário, o limite suportado é de %1$s até %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3640,7 +3640,7 @@ msgstr ""
 "Um ano no formato de quatro dígitos (4, padrão) ou dois dígitos (2), os "
 "valores permitidos são: de 70 (1970) a 69 (2069) ou de 1901 a 2155, e 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3648,7 +3648,7 @@ msgstr ""
 "Uma string de comprimento fixo (0-255, 1 por padrão) que é sempre acrescida "
 "à direita com espaços para o comprimento especificado quando armazenada"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3657,7 +3657,7 @@ msgstr ""
 "Uma string de comprimento variável (%s), o comprimento máximo efetivo está "
 "sujeito ao tamanho máximo da linha"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3666,7 +3666,7 @@ msgstr ""
 "caracteres, armazenada com um prefixo de um byte indicando o tamanho do "
 "valor em bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3675,7 +3675,7 @@ msgstr ""
 "caracteres, armazenada com um prefixo de dois bytes indicando o comprimento "
 "do valor em bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3684,7 +3684,7 @@ msgstr ""
 "caracteres, armazenada com um prefixo de três bytes indicando o comprimento "
 "do valor em bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3694,7 +3694,7 @@ msgstr ""
 "1) caracteres ou 4GiB, armazenada com um prefixo de quatro bytes indicando o "
 "comprimento do valor em bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3702,7 +3702,7 @@ msgstr ""
 "Similar ao tipo CHAR, mas armazena strings de bytes binários em vez de "
 "strings de caracteres não-binários"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3710,7 +3710,7 @@ msgstr ""
 "Similar ao tipo VARCHAR, mas armazena strings de bytes binários em vez de "
 "strings de caracteres não-binários"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3719,7 +3719,7 @@ msgstr ""
 "armazenada com um prefixo de um byte indicando o comprimento do valor em "
 "bytes"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3728,7 +3728,7 @@ msgstr ""
 "bytes, armazenada com um prefixo de três bytes indicando o comprimento do "
 "valor em bytes"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3737,7 +3737,7 @@ msgstr ""
 "armazenada com um prefixo de dois bytes indicando o comprimento do valor em "
 "bytes"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3746,7 +3746,7 @@ msgstr ""
 "1) bytes ou 4GB, armazenada com um prefixo de quatro bytes indicando o "
 "comprimento do valor em bytes"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3754,68 +3754,68 @@ msgstr ""
 "Uma enumeração, escolhida de uma lista de até 65.535 valores ou o valor "
 "especial de erro ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Um valor único escolhido de um conjunto de até 64 membros"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Um tipo que pode armazenar uma geometria de qualquer tipo"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Um ponto em um espaço bidimensional"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Uma curva com uma interpolação linear entre pontos"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Um polígono"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Uma coleção de pontos"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Uma coleção de curvas com interpolação linear entre pontos"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Uma coleção de polígonos"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Uma coleção de objetos geométricos de qualquer tipo"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numérico"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Data e Tempo"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "String"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Espacial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 "Um inteiro de 4 bytes, com faixa entre -2.147.483.648 até 2.147.483.647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3823,23 +3823,23 @@ msgstr ""
 "Um inteiro de 8 bytes, com faixa entre -9.223.372.036.854.775.808 até "
 "9.223.372.036.854.775.807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Um número de ponto flutuante com precisão dupla padrão do sistema"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Verdadeiro ou falso"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Um alias para BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Armazena o Indicador Único Universal (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3847,7 +3847,7 @@ msgstr ""
 "Uma timestamp, o limite vai de '0001-01-01 00:00:00' UTC até '9999-12-31 "
 "23:59:59' UTC; TIMESTAMP(6) pode armazenar microsegundos"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3855,7 +3855,7 @@ msgstr ""
 "Uma string de comprimento variável (0-65, 535), usa verificação binária para "
 "todas as comparações"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Uma enumeração, escolhida de uma lista de valores definidos"
 
@@ -3940,68 +3940,68 @@ msgstr "%d/%m/%Y às %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dias, %s horas, %s minutos e %s segundos"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Parâmetro ausente:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Ir para o banco de dados '%s'."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "A funcionalidade %s é afetada por um bug conhecido, veja %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Clique para alternar"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Procurar no seu computador:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Selecionar a partir do diretório de upload do servidor <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 "O diretório que você especificou para subir arquivos não foi encontrado."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Não existem arquivos para fazer upload"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Limpar"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Executar"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Imprimir"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Criação"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Última atualização"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Última verificação"
@@ -4360,9 +4360,9 @@ msgstr "Permitir usuários customizar esse valor"
 msgid "Apply"
 msgstr "Aplicar"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Resetar"
 
@@ -4672,7 +4672,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Tempo máximo de execução"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Salvar como arquivo"
 
@@ -7099,7 +7099,7 @@ msgstr "Este arquivo está sendo processado, por favor seja paciente."
 msgid "Language"
 msgstr "Linguagem"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informações da versão"
 
@@ -7546,59 +7546,59 @@ msgstr "Por causa da sua largura,<br/> esta coluna pode não ser editável"
 msgid "Binary - do not edit"
 msgstr "Binário - não edite"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "diretório de upload do servidor web:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Continuar a inserção com %s linhas"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "e então"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Inserir como um novo registro"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Inserir como uma linha nova e ignorar erros"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Exibir consulta insert"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Ir para a página anterior"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Inserir um registro novo"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Voltar para esta página"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Editar o próximo registro"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Usar a tecla TAB para se mover de valor em valor, ou CTRL+setas para mover "
 "em qualquer direção"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Exibindo consulta SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Id da linha inserida: %1$d"
@@ -7931,7 +7931,6 @@ msgid "Database operations"
 msgstr "Operações com banco de dados"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Exibir itens ocultos"
 
@@ -9746,24 +9745,24 @@ msgid "There are no events to display."
 msgstr "Não existem eventos para serem mostrados."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "A tabela \"%s\" não existe!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Configure as coordenadas para a tabela %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Esquema do banco de dados \"%s\" - Página %s"
@@ -12466,7 +12465,7 @@ msgstr "Versão %1$s foi criada, rastreamento para %2$s está ativado(a)."
 msgid "Manage your settings"
 msgstr "Gerencie suas configurações"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "A configuração foi salva"
 
@@ -12719,7 +12718,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Você não tem configurações salvas!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Esta funcionalidade não é suportada pelo seu navegador web"
 
@@ -12736,19 +12735,19 @@ msgstr ""
 "Você pode definir mais configurações modificando config.inc.php, por exemplo "
 "usando %sscript de configuração%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Salvar para o armazenamento do navegador"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Configurações serão salvas no armazenamento local do seu navegador."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Configurações existentes serão sobrescritas!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Você pode reiniciar todas as suas configurações e restaurá-las para valores "
@@ -12778,6 +12777,10 @@ msgstr "Nenhum banco de dados"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Ver dump (esquema) dos bancos de dados"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-10-24 20:31+0200\n"
 "Last-Translator: Sergiu Bivol <sergiu@ase.md>\n"
 "Language-Team: Romanian <http://l10n.cihar.com/projects/phpmyadmin/master/ro/"
@@ -42,7 +42,7 @@ msgstr "Comentarii tabel:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Tip"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -338,7 +338,7 @@ msgid "Updated"
 msgstr "Actualizat"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -366,7 +366,7 @@ msgid "Delete tracking data for this table"
 msgstr "Șterge datele de urmărire pentru acest tabel"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -571,8 +571,8 @@ msgstr "Adaugă geometrie"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -598,7 +598,7 @@ msgstr "Adaugă geometrie"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Execută"
@@ -983,7 +983,7 @@ msgstr "Adaugă index"
 msgid "Edit Index"
 msgstr "Modifică index"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Adaugă %s coloane la index"
@@ -1198,7 +1198,7 @@ msgid "Traffic"
 msgstr "Trafic"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Configurări"
 
@@ -1513,8 +1513,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1727,8 +1727,8 @@ msgstr "Arată caseta de interogare"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1755,7 +1755,7 @@ msgstr "Durata de execuție a interogării"
 msgid "%d is not valid row number."
 msgstr "%d nu este un număr valid de rînduri."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1836,8 +1836,8 @@ msgstr "Rezultatele interogării"
 msgid "Data point content"
 msgstr "Mărime pointer date"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignoră"
 
@@ -2438,7 +2438,7 @@ msgstr ""
 "Permisiuni greșite asupra fișierului de configurare, acesta nu ar trebui să "
 "aibă permisiuni de scriere pentru oricine!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Dimensiune font"
 
@@ -2604,8 +2604,8 @@ msgstr[1] "%s rezultat(e) în interiorul tabelului <i>%s</i>"
 msgstr[2] "%s rezultat(e) în interiorul tabelului <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2664,16 +2664,16 @@ msgstr "Directorul de bază pentru date"
 msgid "Restore column order"
 msgstr "Adaugă/șterge coloane"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Începe"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2681,8 +2681,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Anterior"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2690,8 +2690,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Următorul"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2881,9 +2881,9 @@ msgstr "Marchează toate"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3078,9 +3078,9 @@ msgid "View"
 msgstr "Vizualizare"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3094,32 +3094,32 @@ msgid "Structure"
 msgstr "Structură"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Caută"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Inserare"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3128,21 +3128,21 @@ msgid "Privileges"
 msgstr "Drepturi de acces"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operații"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 #, fuzzy
 msgid "Tracking"
 msgstr "Urmărire"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3158,70 +3158,70 @@ msgstr "Declanșatori"
 msgid "Database seems to be empty!"
 msgstr "Baza de date pare a fi goală!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Interogare prin exemplu"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutine"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Evenimente"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Designer"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Baze de date"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Utilizatori"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Jurnal binar"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replicare"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variabile"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Seturi de caractere"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motoare"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Eroare"
@@ -3250,7 +3250,7 @@ msgstr[0] "%1$d rânduri inserate."
 msgstr[1] "%1$d rând inserat."
 msgstr[2] "%1$d rânduri inserate."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3477,7 +3477,7 @@ msgid "Operator"
 msgstr "Operand"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3494,7 +3494,7 @@ msgstr "Caută"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3506,7 +3506,7 @@ msgstr "Inserare"
 msgid "Select columns (at least one):"
 msgstr "Selectează cîmpurile (cel puțin unul):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Sau"
@@ -3635,287 +3635,287 @@ msgstr "Calea temei nu a fost găsită pentru tema %s!"
 msgid "Theme:"
 msgstr "Temă"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Creare relație"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Eroare la redenumirea tabelului %1$s în %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "Adaugă %s cîmp(uri)"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Creează un nou index"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Linii terminate de"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Număr de fișiere-jurnal"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4005,72 +4005,72 @@ msgstr "%d %B %Y la %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s zile, %s ore, %s minute și %s secunde"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Rutine"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Sari la baza de date &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Funcționalitatea %s este afectată de o eroare cunoscută, vedeți %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 #, fuzzy
 #| msgid "Click to select"
 msgid "Click to toggle"
 msgstr "Click pentru a selecta"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Caută în calculatorul tău:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "director de încărcare al serverului Web"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Directorul stabilit pentru încărcare nu poate fi găsit."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Nu sunt fișiere pentru încărcare"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Golește"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Execută"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Listare"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Creare"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Ultima actualizare"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Ultima verficare"
@@ -4455,9 +4455,9 @@ msgstr "Permite utilizatorilor să customizeze această valoare"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Resetare"
 
@@ -4766,7 +4766,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Timpul maxim de execuție"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Salvează ca fișier"
 
@@ -7449,7 +7449,7 @@ msgstr "Fișierul este procesat, vă rugăm să aveți răbdare."
 msgid "Language"
 msgstr "Limbă"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informații despre versiune"
 
@@ -7888,63 +7888,63 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr "Binar - a nu se edita"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "director de încărcare al serverului Web"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Repornește inserția cu %s rînduri"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "și apoi"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Inserează ca o nouă linie"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 #, fuzzy
 msgid "Show insert query"
 msgstr "Afișare interogare SQL"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Revenire"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Adaugă o nouă înregistrare"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Înapoi la această pagină"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Editează rîndul următor"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Folosiți tasta TAB pentru a trece de la o valoare la alta sau CTRL+săgeți "
 "pentru a merge în oricare direcție"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Afișare interogare SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "ID rînd inserat: %1$d"
@@ -10290,25 +10290,25 @@ msgid "There are no events to display."
 msgstr "Nu există evenimente de afișat."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Tabelul „%s” nu există!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Configureaza coordonatelepentru tabelul %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -13046,7 +13046,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Facilități generale"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13322,7 +13322,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Nu aveți setări salvate!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Această facilitate nu este suportată de browser-ul dumneavoastră web"
 
@@ -13337,19 +13337,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13379,6 +13379,10 @@ msgstr "Nu sînt baze de date"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Vizualizarea schemei bazei de date"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:35+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Russian <http://l10n.cihar.com/projects/phpmyadmin/master/ru/"
@@ -42,7 +42,7 @@ msgstr "Комментарии к таблице:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Тип"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -339,7 +339,7 @@ msgid "Updated"
 msgstr "Обновлён"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -367,7 +367,7 @@ msgid "Delete tracking data for this table"
 msgstr "Удалить данные слежения за таблицей"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -563,8 +563,8 @@ msgstr "Добавить геометрии"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -590,7 +590,7 @@ msgstr "Добавить геометрии"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "OK"
@@ -973,7 +973,7 @@ msgstr "Добавить индекс"
 msgid "Edit Index"
 msgstr "Редактировать индекс"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Добавить %s поле(я) к индексу"
@@ -1190,7 +1190,7 @@ msgid "Traffic"
 msgstr "Трафик"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Настройки"
 
@@ -1507,8 +1507,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1718,8 +1718,8 @@ msgstr "Отобразить поле запроса"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1746,7 +1746,7 @@ msgstr "Время выполнения запроса"
 msgid "%d is not valid row number."
 msgstr "Число %d не является правильным номером строки."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1817,8 +1817,8 @@ msgstr "Результаты запроса"
 msgid "Data point content"
 msgstr "Содержание точки данных"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Игнорировать"
 
@@ -2384,7 +2384,7 @@ msgstr ""
 "На конфигурационный файл выставлены неверные права разрешающие запись для "
 "всех!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Размер шрифта"
 
@@ -2532,8 +2532,8 @@ msgstr[1] "%1$s соответствия в таблице <strong>%2$s</strong>
 msgstr[2] "%1$s соответствий в таблице <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2589,28 +2589,28 @@ msgstr "Сохранить отредактированные данные"
 msgid "Restore column order"
 msgstr "Восстановить порядок столбцов"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Начало"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Предыдущая"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Следующая"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Конец"
@@ -2788,9 +2788,9 @@ msgstr "Отметить все"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2983,9 +2983,9 @@ msgid "View"
 msgstr "Представление"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2999,32 +2999,32 @@ msgid "Structure"
 msgstr "Структура"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Поиск"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Вставить"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3033,20 +3033,20 @@ msgid "Privileges"
 msgstr "Привилегии"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Операции"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Слежение"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3062,70 +3062,70 @@ msgstr "Триггеры"
 msgid "Database seems to be empty!"
 msgstr "Пустая база данных!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Запрос&nbsp;по&nbsp;шаблону"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Процедуры"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "События"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Дизайнер"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Базы данных"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Пользователи"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Бинарный журнал"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Репликация"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Переменные"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Кодировки"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Расширения"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Типы таблиц"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Ошибка"
@@ -3154,7 +3154,7 @@ msgstr[0] "Добавлена %1$d строка."
 msgstr[1] "Добавлено %1$d строки."
 msgstr[2] "Добавлено %1$d строк."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3376,7 +3376,7 @@ msgid "Operator"
 msgstr "Оператор"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3391,7 +3391,7 @@ msgstr "Поиск в таблице"
 msgid "Find and Replace"
 msgstr "Поиск и замена"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Редактировать/Вставить"
 
@@ -3399,7 +3399,7 @@ msgstr "Редактировать/Вставить"
 msgid "Select columns (at least one):"
 msgstr "Выберите поля (не менее одного):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Или"
@@ -3511,14 +3511,14 @@ msgstr "Путь к файлам темы %s не найден!"
 msgid "Theme:"
 msgstr "Тема:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Одно-байтовое целое число, диапазон чисел со знаком от -128 до 127, диапазон "
 "чисел без знака от 0 до 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3526,7 +3526,7 @@ msgstr ""
 "Двух-байтовое целое число, диапазон чисел со знаком от -32,768 до 32,767, "
 "диапазон чисел без знака от 0 до 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3534,7 +3534,7 @@ msgstr ""
 "Трех-байтовое целое число, диапазон чисел со знаком от -8,388,608 до "
 "8,388,607, диапазон чисел без знака от 0 до 16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3542,7 +3542,7 @@ msgstr ""
 "Четырех-байтовое целое число, диапазон чисел со знаком от -2,147,483,648 до "
 "2,147,483,647, диапазон чисел без знака от 0 до 4,294,967,295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3551,7 +3551,7 @@ msgstr ""
 "9,223,372,036,854,775,808 до 9,223,372,036,854,775,807, диапазон чисел без "
 "знака от 0 до 18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3560,7 +3560,7 @@ msgstr ""
 "должно превышать 65 (по умолчанию 10), максимальное количество десятичных "
 "(D) не должно превышать 30 (по умолчанию 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3568,7 +3568,7 @@ msgstr ""
 "Малое число с плавающей точкой, допустимые значения от -3.402823466E+38 до -"
 "1.175494351E-38, 0, и от 1.175494351E-38 до 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3578,7 +3578,7 @@ msgstr ""
 "1.7976931348623157E+308 до -2.2250738585072014E-308, 0, и от "
 "2.2250738585072014E-308 до 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3586,14 +3586,14 @@ msgstr ""
 "Синоним для DOUBLE (исключение: в режиме REAL_AS_FLOAT SQL будет синоним для "
 "FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 "Тип поля-бит (M), сохранит M бит для значения (по умолчанию 1, максимум 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3601,22 +3601,22 @@ msgstr ""
 "Синоним для TINYINT(1), значение нуля предполагает false, ненулевые значения "
 "предполагают true"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Псевдоним для BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Дата, поддерживаемый диапазон от %1$s до %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 "Совмещение даты и времени, поддерживаемый диапазон от \"%1$s\" до \"%2$s\""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3625,12 +3625,12 @@ msgstr ""
 "03:14:07\" UTC, содержит количество секунд прошедших со времени (\"1970-01-"
 "01 00:00:00\" UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Время, диапазон от %1$s до %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3638,7 +3638,7 @@ msgstr ""
 "Год в четырехзначном (4, по умолчанию) или двухзначном (2) формате, "
 "допустимые значения от 70 (1970) до 69 (2069) или от 1901 до 2155 и 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3646,7 +3646,7 @@ msgstr ""
 "Строка фиксированной длинны (0-255, по умолчанию 1), при хранении всегда "
 "дополняется пробелами в конце строки до заданного размера"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3655,7 +3655,7 @@ msgstr ""
 "Строка переменной длинны (%s), эффективная максимальная длинна зависит от "
 "максимального размера строки"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3663,7 +3663,7 @@ msgstr ""
 "Столбец типа TEXT с максимальной длинной 255 (2^8 - 1) символов, сохраняется "
 "с одно-байтовым префиксом указывающим длину значения в байтах"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3671,7 +3671,7 @@ msgstr ""
 "Столбец типа TEXT с максимально длинной 65,535 (2^16 - 1) символов, "
 "сохраняется с двух-байтовым префиксом указывающим длину значения в байтах"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3679,7 +3679,7 @@ msgstr ""
 "Столбец типа TEXT с максимальной длинной 16,777,215 (2^24 - 1) символов, "
 "сохраняется с трех-байтовым префиксом указывающим длину значения в байтах"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3689,7 +3689,7 @@ msgstr ""
 "символов, сохраняется с четырех-байтовым префиксом указывающим длину "
 "значения в байтах"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3697,7 +3697,7 @@ msgstr ""
 "Аналогичен типу CHAR, но предназначен для хранения бинарных байт-строк, "
 "вместо не бинарных символьных строк"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3705,7 +3705,7 @@ msgstr ""
 "Аналогичен типу VARCHAR, но предназначен для хранения бинарных байт-строк, "
 "вместо не бинарных символьных строк"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3713,7 +3713,7 @@ msgstr ""
 "Столбец типа BLOB с максимальной длинной 255 (2^8 - 1) байт, сохраняется с "
 "одно-байтовым префиксом указывающим длину значения"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3721,7 +3721,7 @@ msgstr ""
 "Столбец типа BLOB с максимальной длинной 16,777,215 (2^24 - 1) байт, "
 "сохраняется с трех-байтовым префиксом указывающим длину значения"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3729,7 +3729,7 @@ msgstr ""
 "Столбец типа BLOB с максимальной длинной 65,535 (2^16 - 1) байт, сохраняется "
 "с двух-байтовым префиксом указывающим длину значения"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3737,7 +3737,7 @@ msgstr ""
 "Столбец типа BLOB с максимальной длинной 4,294,967,295 или 4GiB (2^32 - 1) "
 "байт, сохраняется с четырех-байтовым префиксом указывающим длину значения"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3745,68 +3745,68 @@ msgstr ""
 "Перечисляемый тип данных, который может содержать максимум 65,535 различных "
 "величин или специальную величину ошибки ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Единственное значение выбираемое из набора не более 64 членов"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Тип для хранения любого вида геометрических данных"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Точка в двухмерном пространстве"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Кривая с линейной интерполяцией между точек"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Многоугольник"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Набор точек"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Набор кривых с линейной интерполяцией между точек"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Набор многоугольников"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Набор геометрических объектов любого типа"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Числовые"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Дата и время"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Символьные"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Пространственные"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 "Четырех-байтовое целое число, диапазон от -2,147,483,648 до 2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3814,24 +3814,24 @@ msgstr ""
 "Восьми-байтовое целое число, диапазон от -9,223,372,036,854,775,808 до "
 "9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 "Изначальное системное значение двойной точности числа с плавающей точкой"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "True или false"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Псевдоним для BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Сохраняет Уникальный Универсальный Идентификатор (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3839,7 +3839,7 @@ msgstr ""
 "Временная метка, диапазон от '0001-01-01 00:00:00' UTC до '9999-12-31 "
 "23:59:59' UTC; TIMESTAMP(6) может хранить микросекунды"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3847,7 +3847,7 @@ msgstr ""
 "Строка переменной длинны (0-65,535), использует для всех сравнений бинарное "
 "сопоставление"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Перечисление, выбор из списка определенных значений"
 
@@ -3932,68 +3932,68 @@ msgstr "%B %d %Y г., %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s дней, %s часов, %s минут и %s секунд"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Отсутствующий параметр:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Перейти к базе данных &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 "Работа параметра &quot;%s&quot; подвержена ошибке, описание смотрите на %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Кликните для переключения"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Обзор вашего компьютера:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Выберите из каталога загрузки сервера <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Установленный каталог загрузки не доступен."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Файлы для загрузки отсутствуют"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Очистить"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Выполнить"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Печать"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Создание"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Последнее обновление"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Последняя проверка"
@@ -4352,9 +4352,9 @@ msgstr "Разрешить пользователям изменять данн�
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Сбросить"
 
@@ -4672,7 +4672,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Максимальное время выполнения"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Сохранить как файл"
 
@@ -7129,7 +7129,7 @@ msgstr "Пожалуйста, подождите, файл находится в
 msgid "Language"
 msgstr "Язык"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Информация о версии"
 
@@ -7573,59 +7573,59 @@ msgstr "Из-за большого количества данных<br />изм
 msgid "Binary - do not edit"
 msgstr "Двоичные данные - не редактируются"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "Из каталога загрузки:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Продолжить вставку с %s строки"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "и затем"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Вставить запись"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Вставить в виде новой строки и игнорировать появляющиеся ошибки"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Отобразить запрос вставки"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Вернуться на предыдущую страницу"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Добавить новую запись"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Вернуться к данной странице"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Редактировать следующую строку"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Для перемещения между полями значения, используйте клавишу TAB, либо CTRL"
 "+клавиши со стрелками - для свободного перемещения"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Отображает SQL-запрос"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Идентификатор вставленной строки: %1$d"
@@ -9815,24 +9815,24 @@ msgid "There are no events to display."
 msgstr "Отсутствуют события для отображения."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Таблица %s не существует!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Измените координаты таблицы %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Схема базы данных %s - Страница %s"
@@ -12601,7 +12601,7 @@ msgstr "Версия %1$s создана, отслеживание %2$s вклю
 msgid "Manage your settings"
 msgstr "Пользовательские настройки"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Настройки успешно сохранены"
 
@@ -12855,7 +12855,7 @@ msgstr "Настройки будут импортированы из локал
 msgid "You have no saved settings!"
 msgstr "У вас нет сохраненных настроек!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Данная функция не поддерживается вашим браузером"
 
@@ -12872,19 +12872,19 @@ msgstr ""
 "Вы можете установить дополнительные настройки отредактировав config.inc.php, "
 "к примеру, используя %sСкрипт настройки%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Сохранить в хранилище браузера"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Настройки будут сохранены в локальное хранилище вашего браузера."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Текущие настройки будут перезаписаны!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Вы можете сбросить все пользовательские настройки и восстановить их в "
@@ -12914,6 +12914,10 @@ msgstr "Базы данных отсутствуют"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Отобразить дамп (схему) баз данных"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/si.po
+++ b/po/si.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-07-12 14:54+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Sinhala <http://l10n.cihar.com/projects/phpmyadmin/master/si/"
@@ -39,7 +39,7 @@ msgstr "වගු විස්තර:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -85,7 +85,7 @@ msgid "Type"
 msgstr "වර්ගය"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -334,7 +334,7 @@ msgid "Updated"
 msgstr "යාවත්කාලීන කරන ලදි"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -362,7 +362,7 @@ msgid "Delete tracking data for this table"
 msgstr "මෙම වගුවේ අවධානය පිළිබඳ දත්ත ඉවත් කරන්න"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -559,8 +559,8 @@ msgstr "ජ්‍යාමිතියක් එක් කරන්න"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -586,7 +586,7 @@ msgstr "ජ්‍යාමිතියක් එක් කරන්න"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "යන්න"
@@ -957,7 +957,7 @@ msgstr "සුචිය එක් කරන්න"
 msgid "Edit Index"
 msgstr "සුචිය සංස්කරණය කරන්න"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "සුචියට ක්ෂේත්‍ර %s ක් එක් කරන්න"
@@ -1170,7 +1170,7 @@ msgid "Traffic"
 msgstr "තදබදය"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "සිටුවම්"
 
@@ -1476,8 +1476,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1690,8 +1690,8 @@ msgstr "විමසුම් කවුළුව පෙන්වන්න"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1718,7 +1718,7 @@ msgstr "විමසුම ක්‍රියාත්මක කිරීමේ 
 msgid "%d is not valid row number."
 msgstr "%d වලංගු පේළි අංකයක් නොවේ."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1791,8 +1791,8 @@ msgstr "විමසුම් ප්‍රථිඵල"
 msgid "Data point content"
 msgstr "ලක්ෂයට අදාල දත්ත"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "නොසලකන්න"
 
@@ -2345,7 +2345,7 @@ msgstr "වත්මන් වින්‍යාස ගොනුව (%s) කි�
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "වින්‍යාස ගොනුව සඳහා වැරදි අවසර සිටුවා ඇත. සැමටම ඊට ලිවිය හැකි නොවිය යුතුය!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "ෆොන්ටයෙහි ප්‍රමාණය"
 
@@ -2490,8 +2490,8 @@ msgstr[0] "<strong>%2$s</strong> තුල ගැලපීම් %1$s කි"
 msgstr[1] "<strong>%2$s</strong> තුල ගැලපීම් %1$s කි"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2547,28 +2547,28 @@ msgstr "සංස්කරණය කල දත්ත සුරකින්න"
 msgid "Restore column order"
 msgstr "තීර අනුපිලිවල ප්‍රතිෂ්ඨාපනය කරන්න"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "ඇරඹුම"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "පෙර"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "මීලඟ"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "අවසන"
@@ -2747,9 +2747,9 @@ msgstr "සියල්ල කතිර කොටුගත කරන්න"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2936,9 +2936,9 @@ msgid "View"
 msgstr "දසුන"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2952,32 +2952,32 @@ msgid "Structure"
 msgstr "සැකිල්ල"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "සෙවීම"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "ඇතුල් කරන්න"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2986,20 +2986,20 @@ msgid "Privileges"
 msgstr "වරප්‍රසාද"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "මෙහෙයුම්"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "අවධානය"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3015,70 +3015,70 @@ msgstr "ප්‍රේරක"
 msgid "Database seems to be empty!"
 msgstr "දත්තගබඩාව හිස්ය!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "විමසුම"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "නෛත්‍යක"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "සිද්ධි"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "සැලසුම්කරණය"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "දත්තගබඩා"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "භාවිතා කරන්නන්"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "ද්වීමය ලොගය"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "අනුරූකරණය"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "විචල්‍යනයන්"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "අක්ෂර කට්ටලය"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "පේණු"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "යන්ත්‍රයන්"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "දෝෂය"
@@ -3104,7 +3104,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "පේළි %1$d ක් ඇතුල් කෙරුනි."
 msgstr[1] "පේළි %1$d ක් ඇතුල් කෙරුනි."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3325,7 +3325,7 @@ msgid "Operator"
 msgstr "මෙහෙයවනය"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3340,7 +3340,7 @@ msgstr "වගුව තුල සෙවීම"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "සංස්කරණය/ඇතුල් කරන්න"
 
@@ -3348,7 +3348,7 @@ msgstr "සංස්කරණය/ඇතුල් කරන්න"
 msgid "Select columns (at least one):"
 msgstr "පේළි තෝරන්න (අවම වශයෙන් එකක්):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "හෝ"
@@ -3468,19 +3468,19 @@ msgstr "%s තේමාව සඳහා තේමාව ඇති තැන හ�
 msgid "Theme:"
 msgstr "තේමාව:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr "තනි බයිටයේ නිඛිලයකි, සලකුණ සහිත පරාසය -128 සිට 127, සලකුණ රහිත පරාසය 0 සිට 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 "ද්වී බයිට නිඛිලයකි, සලකුණ සහිත පරාසය -32,768 සිට 32,767, සලකුණ රහිත පරාසය 0 සිට 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3488,7 +3488,7 @@ msgstr ""
 "ත්‍රිත්ව බයිට නිඛිලයකි, සලකුණ සහිත පරාසය -8,388,608 සිට 8,388,607, සලකුණ රහිත පරාසය 0 සිට "
 "16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3496,7 +3496,7 @@ msgstr ""
 "සිවු බයිට නිඛිලයකි, සලකුණ සහිත පරාසය -2,147,483,648 සිට 2,147,483,647, සලකුණ රහිත පරාසය "
 "0 සිට 4,294,967,295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3504,7 +3504,7 @@ msgstr ""
 "අෂ්ට බයිට නිඛිලයකි, සලකුණ සහිත පරාසය -9,223,372,036,854,775,808 සිට "
 "9,223,372,036,854,775,807, සලකුණ රහිත පරාසය 0 සිට 18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3512,7 +3512,7 @@ msgstr ""
 "ස්ථිර ලෙස දැක්වූ දශම සංඛ්‍යාවකි (M, D) - උපරිම පූර්නස්ථාන ගණන (M) 65 කි (පෙරනිමි 10), උපරිම "
 "දශමස්ථාන (D) ගණන 30 කි (පෙරනිමි 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3520,7 +3520,7 @@ msgstr ""
 "කුඩා දශම සංඛ්‍යාවකි, ලබා දිය හැකි අගයන් වන්නේ -3.402823466E+38 සිට -1.175494351E-38, "
 "0, හා 1.175494351E-38 සිට 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3530,7 +3530,7 @@ msgstr ""
 "2.2250738585072014E-308, 0, හා 2.2250738585072014E-308 සිට 1.7976931348623157E"
 "+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3538,7 +3538,7 @@ msgstr ""
 "DOUBLE සඳහා සමානාර්ථ පදයකි (REAL_AS_FLOAT SQL ප්‍රකාරයේදී හැර, එහිදී එය FLOAT සඳහා "
 "සමානාර්ථ පදයකි)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3546,7 +3546,7 @@ msgstr ""
 "බිටු (M) ක්ෂේත්‍ර වර්ගයකි, අගයක් සඳහා බිටු M ගණනක් ගබඩා කරයි (පෙරනිමි බිටු ගණන 1 කි, උපරිම 64 "
 "කි)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3554,21 +3554,21 @@ msgstr ""
 "TINYINT(1) සඳහා සමානාර්ථ පදයකි, ශුන්‍ය අගය false ලෙස සැලකෙන අතර ශුන්‍ය නොවන අගයන් "
 "true ලෙස සැලකේ"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE සඳහා අන්වර්ථ නාමයකි"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "දිනයකි, සහයැති පරාසය %1$s සිට %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "දිනය සහ වේලාවේ සංයුක්තයකි, සහයැති පරාසය %1$s සිට %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3576,12 +3576,12 @@ msgstr ""
 "කාල මුද්‍රාවකි, පරාසය 1970-01-01 00:00:01 UTC සිට 2038-01-09 03:14:07 UTC, "
 "කාලරම්භයේ (1970-01-01 00:00:00 UTC) සිට ගත වූ තත්පර ගණන ලෙස ගබඩා කර ඇත"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "වේලාවකි, පරාසය %1$s සිට %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3589,7 +3589,7 @@ msgstr ""
 "අංක හතරකින් (4, පෙරනිමි) හෝ අංක දෙකකින් (2) දැක්වෙන වර්ෂයකි, ගත හැකි අගයන් වන්නේ 70 "
 "(1970) සිට 69 (2069) හෝ 1901 සිට 2155 සහ 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3597,14 +3597,14 @@ msgstr ""
 "ස්ථිර-දිගැති පෙළකි (0-255, පෙරනිමි 1), සෑම විටම නියමිත දිග ලැබෙන තුරු දකුණු පසින් හිස් අවකාශ එක් "
 "කෙරේ"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr "විචල්‍ය-දිගැති පෙළකි (%s), පෙළෙහි උපරිම දිග, පේළියේ උපරිම ප්‍රමාණය මත තීරණය වේ"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3612,7 +3612,7 @@ msgstr ""
 "සලකුණු 255 (2^8 - 1) ක උපරිම දිගක් සහිත පෙළ තීරුවකි, ඉදිරියෙන් යෙදු, අන්තර්ගතයේ දිග සඳහන් "
 "කෙරෙන එක් බයිටයක් සමඟ ගබඩා කෙරේ"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3620,7 +3620,7 @@ msgstr ""
 "සලකුණු 65,535 (2^16 - 1) ක උපරිම දිගක් සහිත පෙළ තීරුවකි, ඉදිරියෙන් යෙදු, අන්තර්ගතයේ දිග සඳහන් "
 "කෙරෙන බයිට දෙකක් සමඟ ගබඩා කෙරේ"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3628,7 +3628,7 @@ msgstr ""
 "සලකුණු 16,777,215 (2^24 - 1) ක උපරිම දිගක් සහිත පෙළ තීරුවකි, ඉදිරියෙන් යෙදු, අන්තර්ගතයේ දිග "
 "සඳහන් කෙරෙන බයිට තුනක් සමඟ ගබඩා කෙරේ"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3637,19 +3637,19 @@ msgstr ""
 "සලකුණු 4,294,967,295 නැතිනම් 4GiB (2^32 - 1) ක උපරිම දිගක් සහිත පෙළ තීරුවකි, ඉදිරියෙන් "
 "යෙදු, අන්තර්ගතයේ දිග සඳහන් කෙරෙන බයිට හතරක් සමඟ ගබඩා කෙරේ"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "CHAR වර්ගයට සමාන මුත් ද්වීමය නොවන සලකුණු පෙළක් වෙනුවට ද්වීමය බයිට පෙළක් ගබඩා කරයි"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "VARCHAR වර්ගයට සමාන මුත් ද්වීමය නොවන සලකුණු පෙළක් වෙනුවට ද්වීමය බයිට පෙළක් ගබඩා කරයි"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3657,7 +3657,7 @@ msgstr ""
 "බයිට 255(2^8 - 1) ක උපරිම දිගක් සහිත බ්ලොබ් තීරුවකි, ඉදිරියෙන් යෙදු, අන්තර්ගතයේ දිග සඳහන් "
 "කෙරෙන එක් බයිටයක් සමඟ ගබඩා කෙරේ"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3665,7 +3665,7 @@ msgstr ""
 "බයිට 16,777,215 (2^24 - 1) ක උපරිම දිගක් සහිත බ්ලොබ් තීරුවකි, ඉදිරියෙන් යෙදු, අන්තර්ගතයේ දිග "
 "සඳහන් කෙරෙන බයිට තුනක් සමඟ ගබඩා කෙරේ"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3673,7 +3673,7 @@ msgstr ""
 "බයිට 65,535 (2^16 - 1) ක උපරිම දිගක් සහිත බ්ලොබ් තීරුවකි, ඉදිරියෙන් යෙදු, අන්තර්ගතයේ දිග සඳහන් "
 "කෙරෙන බයිට දෙකක් සමඟ ගබඩා කෙරේ"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3681,7 +3681,7 @@ msgstr ""
 "බයිට 4,294,967,295 නැතිනම් 4GiB (2^32 - 1) ක උපරිම දිගක් සහිත බ්ලොබ් තීරුවකි, ඉදිරියෙන් "
 "යෙදු, අන්තර්ගතයේ දිග සඳහන් කෙරෙන බයිට හතරක් සමඟ ගබඩා කෙරේ"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3689,90 +3689,90 @@ msgstr ""
 "අගයන් 65535 ක් දක්වා ඇතුලත් කල හැකි ලැයිස්තුවකින් තෝරාගන්නා අගයක් හෝ විශේෂ දෝෂ අගය වන '' "
 "හෝ වේ"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "අගයන් 64 ක් දක්වා අඩංගු විය හැකි කුලකයකින් තෝරාගන්නා අගයකි"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "ඕනෑම වර්ගයක ජ්‍යාමිතියක් ගබඩා කල හැකි වර්ගයකි"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "ද්වීමාන අවකාශයේ ලක්ෂ්‍යයකි"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "ලක්ෂ්‍ය අතර සරල රේඛා අඩංගු වක්‍රයකි"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "බහු අස්‍රයකි"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "ලක්ෂ්‍ය එකතුවකි"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "ලක්ෂ්‍ය අතර සරල රේඛා අඩංගු වක්‍ර එකතුවකි"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "බහු අස්‍ර එකතුවකි"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "ඕනෑම වර්ගයක ජ්‍යාමිතීන් එකතුවකි"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "සංඛ්‍යාත්මක"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "දිනය සහ වේලාව"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "පෙළ"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "අවකාශීය"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "සිවු බයිට නිඛිලයකි, පරාසය -2,147,483,648 සිට 2,147,483,647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 "අෂ්ට බයිට නිඛිලයකි, පරාසය -9,223,372,036,854,775,808 සිට 9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "පද්ධතියේ පෙරනිමි ද්වී-නියත දශම සංඛ්‍යාවකි"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "සත්‍ය හෝ අසත්‍ය"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT NOT NULL AUTO_INCREMENT UNIQUE සඳහා අන්වර්ථ නාමයකි"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "විශ්වීය අනන්‍ය හැඳුනුමක් (UUID) ගබඩා කරයි"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3780,13 +3780,13 @@ msgstr ""
 "කාල මුද්‍රාවකි, පරාසය '0001-01-01 00:00:00' UTC සිට '9999-12-31 23:59:59' UTC; "
 "TIMESTAMP(6) හට මයික්‍රෝ තත්පර ගබඩා කල හැක"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr "විචල්‍ය දිගක් (0-65,535) සහිත, සැසඳීම සඳහා ද්වීමය පරිතුලනය භාවිතා කරන පෙළකි"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "අර්ථදක්වන ලද අගයන් අඩංගු ලැයිස්තුවකින් තෝරාගන්නා අගයකි"
 
@@ -3871,67 +3871,67 @@ msgstr "%B %d, %Y දින %I:%M %p ට"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "දින %s, පැය %s, මිනිත්තු %s සහ තප්පර %s"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "නොමැති පරාමිතිය:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "&quot;%s&quot; දත්තගබඩාව වෙත යන්න."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s විශේෂාංගයෙහි හඳුනාගත් දෝෂයක් ඇත, %s බලන්න"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "මාරු කිරීමට ක්ලික් කරන්න"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "පරිගණකය තුළ පිරික්සන්න:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "වෙබ් සේවාදායකයේ <b>%s</b> උඩුගත කිරීම් ඩිරෙක්ටරියෙන් තෝරන්න:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "අප්ලෝඩ් කිරීම් සඳහා සැකසූ ඩිරෙක්ටරිය වෙත පිවිසිය නොහැක"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "උඩුගත කිරීම සඳහා ගොනු නොමැත"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "හිස් කරන්න"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "ක්‍රියාත්මක කරන්න"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "මුද්‍රණය කරන්න"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "සෑදීම"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "අවසන් යාවත්කාලීන කිරීම"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "අවසන් පරීක්ෂාව"
@@ -4283,9 +4283,9 @@ msgstr "මෙම අගය වෙනස් කිරීමට භවිතා �
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "ප්‍රතිසකසන්න"
 
@@ -4584,7 +4584,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "උපරිම ක්‍රියාත්මක කාලය"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "ගොනුවක් ලෙස තෝරන්න"
 
@@ -6945,7 +6945,7 @@ msgstr "ඔබගේ ගොනුව සැකසෙමින් පවතී. �
 msgid "Language"
 msgstr "භාෂාව"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "අනුවාදය පිළිබඳ තොරතුරු"
 
@@ -7338,57 +7338,57 @@ msgstr "මෙහි දිග නිසා,<br /> මෙම තීරුව ස
 msgid "Binary - do not edit"
 msgstr "ද්වීමය - සංස්කරණය නොකරන්න"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "වෙබ් සේවාදායකයේ උඩුගත ඩිරෙක්ටරිය:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "පේළි %s බැගින් තවදුරටත් ඇතුල් කරන්න"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "අනතුරුව"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "නව පේළියක් ලෙස ඇතුල් කරන්න"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "දෝෂ නොසලකමින් නව පේළියක් ලෙස ඇතුල් කරන්න"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "ඇතුල් කිරීමේ විමසුම පෙන්වන්න"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "පෙර පිටුවට ආපසු යන්න"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "නව පේළියක් එක් කරන්න"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "මෙම පිටුව වෙත ආපසු යන්න"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "මීලඟ පේළිය සංස්කරණය කරන්න"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "SQL විමසුම පෙන්වමින්"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "%1$d පේළිය ඇතුල් කරන ලදි"
@@ -9522,24 +9522,24 @@ msgid "There are no events to display."
 msgstr "පෙන්වීම සඳහා සිද්ධි නොමැත."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "%s නමින් වගුවක් නොපවතියි!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "කරුණාකර %s වගුව සඳහා ඛණ්ඩාංක අගයන් සිටුවන්න"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "%s දත්තගබඩාවේ ක්‍රමානුරූපය - %sවන පිටුව"
@@ -12113,7 +12113,7 @@ msgstr "%1$s වන අනුවාදය සාදන ලදි. %2$s සඳහ
 msgid "Manage your settings"
 msgstr "සිටුවම් පරිපාලනය"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "වෙනස් කිරීම් සුරකින ලදි"
 
@@ -12366,7 +12366,7 @@ msgstr "බ්‍රවුසරයේ ගබඩාවෙන් සිටුව�
 msgid "You have no saved settings!"
 msgstr "සුරැකූ සිටුවම් නොමැත!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12383,19 +12383,19 @@ msgstr ""
 "config.inc.php වෙනස් කිරීම මඟින් ඔබට තවත් සිටුවම් සිටුවිය හැකිය. උදා. %sSetup script%s "
 "භාවිතා කිරීමෙන්."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "බ්‍රවුසරයේ ගබඩාවේ සුරකින්න"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "බ්‍රවුසරයේ ගබඩාවේ සිටුවම් සුරැකෙනු ඇත."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "වත්මන් සිටුවම් උඩින් නව සිටුවම් ලියැවේ!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "ඔබගේ සියලුම සිටුවම් ප්‍රතිසකසා ඒවා පෙරනිමි අගයන් වෙත ප්‍රතිෂ්ඨාපනය කල හැක."
 
@@ -12422,6 +12422,10 @@ msgstr "දත්තගබඩා නොමැත"
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/sk.po
+++ b/po/sk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:32+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Slovak <http://l10n.cihar.com/projects/phpmyadmin/master/sk/"
@@ -43,7 +43,7 @@ msgstr "Komentár k tabuľke"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Typ"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -345,7 +345,7 @@ msgid "Updated"
 msgstr "Aktualizované"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -373,7 +373,7 @@ msgid "Delete tracking data for this table"
 msgstr "Odstrániť všetky informácie o sledovaní tejto tabuľky"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -579,8 +579,8 @@ msgstr "Pridať geometriu"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -606,7 +606,7 @@ msgstr "Pridať geometriu"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Vykonaj"
@@ -1005,7 +1005,7 @@ msgstr "Pridať index"
 msgid "Edit Index"
 msgstr "Upraviť index"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Pridať %s polí do indexu"
@@ -1221,7 +1221,7 @@ msgid "Traffic"
 msgstr "Vyťaženie"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Nastavenia"
 
@@ -1538,8 +1538,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1749,8 +1749,8 @@ msgstr "Zobrazit vyhľadávacie pole"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1777,7 +1777,7 @@ msgstr "Čas behu dopytu"
 msgid "%d is not valid row number."
 msgstr "%d nie je platné číslo riadku."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1850,8 +1850,8 @@ msgstr "Výsledky dopytu"
 msgid "Data point content"
 msgstr "Obsah datového bodu"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorovať"
 
@@ -2405,7 +2405,7 @@ msgstr ""
 "Konfiguračný súbor má zlé prístupové práva, nemal by byť zapisovateľný pre "
 "všetkých!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Veľkosť písma"
 
@@ -2566,8 +2566,8 @@ msgstr[1] "%1$s výskyty v <strong>%2$s</strong>"
 msgstr[2] "%1$s výskytov v <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2623,28 +2623,28 @@ msgstr "Uložiť zmeny"
 msgid "Restore column order"
 msgstr "Obnoviť poradie stĺpcov"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Začiatok"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Predchádzajúci"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Ďalší"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Koniec"
@@ -2825,9 +2825,9 @@ msgstr "Označiť všetko"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3020,9 +3020,9 @@ msgid "View"
 msgstr "Pohľad"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3036,32 +3036,32 @@ msgid "Structure"
 msgstr "Štruktúra"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Hľadať"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Vložiť"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3070,20 +3070,20 @@ msgid "Privileges"
 msgstr "Oprávnenia"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operácie"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Sledovanie"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3099,70 +3099,70 @@ msgstr "Spúšťače"
 msgid "Database seems to be empty!"
 msgstr "Databáza vyzerá prázdna!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Dopyt podľa príkladu"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutiny"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Udalosti"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Dizajnér"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Databázy"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Používatelia"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binárny log"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikácia"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Premenné"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Znakové sady"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Rozšírenia"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Systémy"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Chyba"
@@ -3191,7 +3191,7 @@ msgstr[0] "Bol vložený %1$d riadok."
 msgstr[1] "Boli vložené %1$d riadky."
 msgstr[2] "Bolo vložených %1$d riadkov."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3416,7 +3416,7 @@ msgid "Operator"
 msgstr "Operátor"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3431,7 +3431,7 @@ msgstr "Hľadať v tabuľke"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Upraviť/Vložiť"
 
@@ -3439,7 +3439,7 @@ msgstr "Upraviť/Vložiť"
 msgid "Select columns (at least one):"
 msgstr "Zvoliť stĺpec (najmenej jeden):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Alebo"
@@ -3563,14 +3563,14 @@ msgstr "Nebola nájdená platná cesta ku vzhľadu %s!"
 msgid "Theme:"
 msgstr "Vzhľad"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "1-bytové celé číslo, rozsah: so znamienkom -128 až 127, bez znamienka 0 až "
 "255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3578,7 +3578,7 @@ msgstr ""
 "2-bytové celé číslo, rozsah: so znamienkom -32 768 až 32 767, bez znamienka "
 "0 až 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3586,13 +3586,13 @@ msgstr ""
 "3-bytové celé číslo, rozsah: so znamienkom -8 388 608 až 8 388 607, bez "
 "znamienka 0 až 16 777 215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3600,7 +3600,7 @@ msgstr ""
 "8-bytové celé číslo, rozsah: so znamienkom -9 223 372 036 854 775 808 až 9 "
 "223 372 036 854 775 807, bez znamienka 0 až 18 446 744 073 709 551 615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3608,7 +3608,7 @@ msgstr ""
 "Číslo s pevnou čiarkou (M, D) - maximálny počet číslic (M) je 65 (predvolené "
 "10), maximálny počet desatinných miest (D) 30 (predvolené 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3616,7 +3616,7 @@ msgstr ""
 "Číslo s plávajúcou desatinnou čiarkou, rozsahy: od -3,402823466E+38 do -"
 "1,175494351E-38; 0; od 1,175494351E-38 do 3,402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3626,7 +3626,7 @@ msgstr ""
 "1,7976931348623157E+308 do -2,2250738585072014E-308; 0; od "
 "2,2250738585072014E-308 do 1,7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3634,14 +3634,14 @@ msgstr ""
 "Synonymum pre DOUBLE (výnimka: v SQL režime REAL_AS_FLOAT je to synonymum "
 "pre FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 "Pole bitov (M), ukladá M bitov pre každú hodnotu (predvolené 1, maximum 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3649,21 +3649,21 @@ msgstr ""
 "Synonymum pre TINYINT(1), hodnota 0 znamená NEPRAVDA, nenulové hodnoty "
 "znamenajú PRAVDA"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Alias pre BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Dátum, podporovaný rozsah je od %1$s do %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Dátum a čas, podporovaný rozsah je od %1$s do %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3671,12 +3671,12 @@ msgstr ""
 "Časová značka, rozsah od 1.1.1970 00:00:01 UTC do 1.9.2038 03:14:07 UTC, "
 "ukladá sa ako počet sekúnd od počiatku (1.1.1970 00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Čas, rozsah je od %1$s do %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3684,7 +3684,7 @@ msgstr ""
 "Rok v 4-číslicovom formáte (predvolené 4) alebo 2-číslicovom formáte (2), "
 "povolené hodnoty od 70 (1970) do 69 (2069) alebo 1901 až 2155 a 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3692,7 +3692,7 @@ msgstr ""
 "Text s pevnou dĺžkou (0-255, predvolené 1), zarovnaný sprava s medzerami na "
 "začiatku"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3701,7 +3701,7 @@ msgstr ""
 "Text s premenlivou dĺžkou (%s), skutočná maximálna dĺžka súvisí s maximálnou "
 "dĺžkou riadku"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3709,7 +3709,7 @@ msgstr ""
 "Stĺpec typu TEXT, maximálna dĺžka 255 (2^8 - 1) znakov, ukladá sa s 1-"
 "bytovým prefixom, ktorý obsahuje dĺžku textu v bytoch"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3717,7 +3717,7 @@ msgstr ""
 "Stĺpec typu TEXT, maximálna dĺžka 65 535 (2^16 - 1) znakov, ukladá sa s 2-"
 "bytovým prefixom, ktorý obsahuje dĺžku textu v bytoch"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3725,7 +3725,7 @@ msgstr ""
 "Stĺpec typu TEXT, maximálna dĺžka 16 777 215 (2^24 - 1) znakov, ukladá sa s "
 "3-bytovým prefixom, ktorý obsahuje dĺžku textu v bytoch"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3734,21 +3734,21 @@ msgstr ""
 "Stĺpec typu TEXT, maximálna dĺžka 4 294 967 295 or 4 GB (2^32 - 1) znakov, "
 "ukladá sa s 4-bytovým prefixom, ktorý obsahuje dĺžku textu v bytoch"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 "Podobné typu CHAR, ale ukladá binárne bajty namiesto nebinárnych znakov"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 "Podobné typu VARCHAR, ale ukladá binárne bajty namiesto nebinárnych znakov"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3756,7 +3756,7 @@ msgstr ""
 "Stĺpec BLOB, maximálna dĺžka 255 (2^8 - 1) bytov, ukladá sa sa 1-bytovým "
 "prefixom, ktorý obsahuje dĺžku hodnoty"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3764,7 +3764,7 @@ msgstr ""
 "Stĺpec BLOB, maximálna dĺžka 16 777 (2^24 - 1) bytov, ukladá sa sa 3-bytovým "
 "prefixom, ktorý obsahuje dĺžku hodnoty"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3772,7 +3772,7 @@ msgstr ""
 "Stĺpec BLOB, maximálna dĺžka 65 535 (2^16 - 1) bytov, ukladá sa sa 2-bytovým "
 "prefixom, ktorý obsahuje dĺžku hodnoty"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3780,7 +3780,7 @@ msgstr ""
 "Stĺpec BLOB, maximálna dĺžka 4 294 967 295 alebo 4 GB (2^32 - 1) bytov, "
 "ukladá sa sa 4-bytovým prefixom, ktorý obsahuje dĺžku hodnoty"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3788,67 +3788,67 @@ msgstr ""
 "Vymenovanie hodnôt vybratých zo zoznamu dlhého až 65 535 hodnôt alebo "
 "špeciálna chybová hodnota ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Jediná hodnota vybratá z množiny max. 64 členov"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Tento typ ukladá geometriu akéhokoľvek druhu"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Bod vo dvojrozmernom priestore"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Krivka s lineárnou interpoláciou medzi bodmi"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Polygón"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Množina bodov"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Množina kriviek s lineárnou interpoláciou medzi bodmi"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Množina polygónov"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Množina geometrických objektov akéhokoľvek typu"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Číslo"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Dátum a čas"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Reťazec"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Priestorový objekt"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "4-bytové celé číslo, rozsah od -2 147 483 648 do 2 147 483 647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3856,25 +3856,25 @@ msgstr ""
 "8-bytové celé číslo, rozsah od -9 223 372 036 854 775 808 do 9 223 372 036 "
 "854 775 807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 "Číslo s dvojitou presnosťou a plávajúcou desatinnou čiarkou predvolené "
 "systémom"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Pravda alebo nepravda"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Alias pre BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Ukladá Univerzálny jedinečný identifikátor (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3882,7 +3882,7 @@ msgstr ""
 "Časová značka, rozsah od '1.1.0001 00:00:00' UTC do '31.12.9999 23:59:59' "
 "UTC; TIMESTAMP(6) môže ukladať mikrosekundy"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3890,7 +3890,7 @@ msgstr ""
 "Text s premenlivou dĺžkou (0-65 535), používa binárne zotriedenie pre všetky "
 "porovnávania"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Vymenovanie hodnôt vybratých zo zoznamu definovaných hodnôt"
 
@@ -3977,67 +3977,67 @@ msgstr "%a %d.%B %Y, %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dní, %s hodín, %s minút a %s sekúnd"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Chýbajúci parameter:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Prejsť na databázu &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Funkčnosť %s je ovplyvnená známou chybou, pozri %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Kliknite pre prepnutie"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Prechádzať váš počítač:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Zvoľte súbor z upload adresára <b>%s</b> web servera:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Adresár určený pre upload súborov sa nedá otvoriť."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Žiadny súbor pre nahrávanie"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Vyprázdniť"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Spustiť"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Vytlačiť"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Vytvorenie"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Posledná zmena"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Posledná kontrola"
@@ -4401,9 +4401,9 @@ msgstr "Povoliť užívateľom prispôsobiť túto hodnotu"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Vynulovať"
 
@@ -4712,7 +4712,7 @@ msgstr "Nastavte dĺžku behu skriptu v sekundách ([kbd]0[/kbd] bez obmedzení)
 msgid "Maximum execution time"
 msgstr "Maximálny čas behu"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Uložiť ako súbor"
 
@@ -7162,7 +7162,7 @@ msgstr "Súbor sa spracováva, buďte prosím trpezliví."
 msgid "Language"
 msgstr "Jazyk"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informácie o verzii"
 
@@ -7578,61 +7578,61 @@ msgstr "Kvôli dĺžke poľa,<br /> toto pole sa nemusí dať upraviť"
 msgid "Binary - do not edit"
 msgstr "Binárny - neupravujte"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "upload adresár web serveru"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "a potom"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Vložiť ako nový riadok"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Zobraziť insert dopyt"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Späť"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Vložiť nový záznam"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Späť na túto stránku"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Upraviť nasledujúci riadok"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Pre pohyb medzi hodnotami použite klávesu TAB alebo pre pohyb všetkými "
 "smermi klávesy CTRL+šípky"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Zobrazujem SQL dotaz"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9775,24 +9775,24 @@ msgid "There are no events to display."
 msgstr "Nie sú žiadne udalosti na zobrazenie."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Tabuľka %s neexistuje!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Prosím skonfigurujte koordináty pre tabuľku %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Schéma databázy %s - Strana %s"
@@ -12514,7 +12514,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Spravovať svoje nastavenia"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Nastavenia boli uložené"
 
@@ -12770,7 +12770,7 @@ msgstr "Nastavenia budú načítané z lokálneho úložišťa vášho prehliada
 msgid "You have no saved settings!"
 msgstr "Nemáte uložené žiadne nastavenia!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12787,19 +12787,19 @@ msgstr ""
 "Ďalšie nastavenia môžete urobiť úpravou config.inc.php, napr. použitím %"
 "sNastavovacieho skriptu%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Uložiť do úložiska prehliadača"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Súčasné nastavenia budú prepísané!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Môžete vymazať všetky vaše nastavenia a vrátiť sa k východziím hodnotám."
@@ -12830,6 +12830,10 @@ msgstr "Žiadne databázy"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Export databáz"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -3,17 +3,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 23:08+0200\n"
 "Last-Translator: Domen <mitenem@outlook.com>\n"
-"Language-Team: Slovenian "
-"<http://l10n.cihar.com/projects/phpmyadmin/master/sl/>\n"
-"Language: sl\n"
+"Language-Team: Slovenian <http://l10n.cihar.com/projects/phpmyadmin/master/"
+"sl/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3;\n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%"
+"100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
 #: changelog.php:36 license.php:28
@@ -42,7 +42,7 @@ msgstr "Pripombe tabele:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Vrsta"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -339,7 +339,7 @@ msgid "Updated"
 msgstr "Posodobljeno"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -367,7 +367,7 @@ msgid "Delete tracking data for this table"
 msgstr "Izbriši podatke sledenja te tabele"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -568,8 +568,8 @@ msgstr "Dodaj geometrijo"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -595,7 +595,7 @@ msgstr "Dodaj geometrijo"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Izvedi"
@@ -973,7 +973,7 @@ msgstr "Dodaj indeks"
 msgid "Edit Index"
 msgstr "Uredi indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Dodaj %s stolpec(-cev) k indeksu"
@@ -1190,7 +1190,7 @@ msgid "Traffic"
 msgstr "Promet"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Nastavitve"
 
@@ -1505,8 +1505,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1715,8 +1715,8 @@ msgstr "Prikaži polje poizvedbe"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1743,7 +1743,7 @@ msgstr "Čas izvajanja poizvedbe"
 msgid "%d is not valid row number."
 msgstr "%d ni veljavna številka vrstice."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1813,8 +1813,8 @@ msgstr "Rezultati poizvedbe"
 msgid "Data point content"
 msgstr "Vsebina kazalca podatkov"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Prezri"
 
@@ -2368,7 +2368,7 @@ msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 "Napačna dovoljenja konfiguracijski datoteke; ne sme biti vsem zapisljiva!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Velikost pisave"
 
@@ -2519,8 +2519,8 @@ msgstr[2] "%1$s zadetki v <strong>%2$s</strong>"
 msgstr[3] "%1$s zadetkov v <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2576,28 +2576,28 @@ msgstr "Shrani urejene podatke"
 msgid "Restore column order"
 msgstr "Obnovi vrstni red stolpcev"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Začetek"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Prejšnja"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Naslednja"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Konec"
@@ -2773,9 +2773,9 @@ msgstr "Označi vse"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2965,9 +2965,9 @@ msgid "View"
 msgstr "Pogled"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2981,32 +2981,32 @@ msgid "Structure"
 msgstr "Struktura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Iskanje"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Vstavi"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3015,20 +3015,20 @@ msgid "Privileges"
 msgstr "Privilegiji"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operacije"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Sledenje"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3044,70 +3044,70 @@ msgstr "Sprožilci"
 msgid "Database seems to be empty!"
 msgstr "Zbirka podatkov se zdi prazna!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Poizvedba"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutina"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Dogodki"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Oblikovalnik"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Zbirke podatkov"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Uporabniki"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Dvojiški dnevnik"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Podvojevanje"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Spremenljivke"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Nabori znakov"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Vtičniki"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Pogoni"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Napaka"
@@ -3139,7 +3139,7 @@ msgstr[1] "Vstavil sem %1$d vrstici."
 msgstr[2] "Vstavil sem %1$d vrstice."
 msgstr[3] "Vstavil sem %1$d vrstic."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3361,7 +3361,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3376,7 +3376,7 @@ msgstr "Iskanje po tabeli"
 msgid "Find and Replace"
 msgstr "Najdi in zamenjaj"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Uredi/Vstavi"
 
@@ -3384,7 +3384,7 @@ msgstr "Uredi/Vstavi"
 msgid "Select columns (at least one):"
 msgstr "Izberite stolpce (vsaj enega):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Ali"
@@ -3495,14 +3495,14 @@ msgstr "Pot teme ni bila najdena za temo %s!"
 msgid "Theme:"
 msgstr "Motiv:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "1-bitno celo število; predznačen razpon je -128 do 127, nepredznačen razpon "
 "pa 0 do 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3510,7 +3510,7 @@ msgstr ""
 "2-bitno celo število; predznačen razpon je -32.768 do 32.767, nepredznačen "
 "razpon pa 0 do 65.535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3518,7 +3518,7 @@ msgstr ""
 "3-bitno celo število; predznačen razpon je -8.388.608 do 8.388.607, "
 "nepredznačen razpon pa 0 do 16.777.215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3526,7 +3526,7 @@ msgstr ""
 "4-bitno celo število; predznačeni razpon je od -2.147.483.648 do "
 "2.147.483.647, nepredznačeni razpon pa od 0 do 4.294.967.295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3535,7 +3535,7 @@ msgstr ""
 "9.223.372.036.854.775.807, nepredznačen razpon pa 0 do "
 "18.446.744.073.709.551.615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3543,7 +3543,7 @@ msgstr ""
 "Število s fiksno vejico (M, D) – največje število števk (M) je 65 (privzeto "
 "10), največje število decimalnih mest (D) je 30 (privzeto 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3551,7 +3551,7 @@ msgstr ""
 "Majhno število z decimalno vejico; dovoljene so vrednosti od -3,402823466E"
 "+38 do -1,175494351E-38, 0 in od 1,175494351E-38 do 3,402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3561,7 +3561,7 @@ msgstr ""
 "1,7976931348623157E+308 do -2,2250738585072014E-308, 0 in od "
 "2,2250738585072014E-308 do 1,7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3569,7 +3569,7 @@ msgstr ""
 "Sopomenka za DOUBLE (izjema: v načinu SQL REAL_AS_FLOAT je sopomenka za "
 "FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3577,7 +3577,7 @@ msgstr ""
 "Bitna vrsta polja (M), ki shrani M bitov na vrednost (privzeto je 1, največ "
 "je 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3585,21 +3585,21 @@ msgstr ""
 "Sopomenka za TINYINT(1); ničelna vrednost se obravnava kot ni res, neničelne "
 "vrednosti se obravnavajo kot res"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Vzdevek za BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Datum; podprt je razpon od %1$s do %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Kombinacija datuma in časa; podprt je razpon od %1$s do %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3607,12 +3607,12 @@ msgstr ""
 "Časovni žig; razpon je od 1970-01-01 00:00:01 UTC do 2038-01-09 03:14:07 "
 "UTC, shranjeno kot število sekund od dobe (1970-01-01 00:00:00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Čas; razpon je od %1$s do %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3620,7 +3620,7 @@ msgstr ""
 "Leto v obliki s štirimi (4, privzeto) ali dvema (2) števkama; dovoljene so "
 "vrednosti od 70 (1970) do 69 (2069) ali od 1901 do 2155 in 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3628,7 +3628,7 @@ msgstr ""
 "Niz stalne dolžine (0–255, privzeto 1), ki je ob shranjevanju vedno z desne "
 "zapolnjen s presledki do določene dolžine"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3637,7 +3637,7 @@ msgstr ""
 "Niz spremenljive dolžine (%s); učinkujoča največja dolžina je odvisna od "
 "največje dolžine stolpca"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3645,7 +3645,7 @@ msgstr ""
 "Stolpec TEXT, dolg največ 255 (2^8 - 1) znakov, shranjen z enobajtno "
 "predpono, ki nakazuje dolžino vrednosti v bajtih"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3653,7 +3653,7 @@ msgstr ""
 "Stolpec TEXT, dolg največ 65.535 (2^16 - 1) znakov, shranjen z dvobajtno "
 "predpono, ki nakazuje dolžino vrednosti v bajtih"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3661,7 +3661,7 @@ msgstr ""
 "Stolpec TEXT, dolg največ 16.777.215 (2^24 - 1) znakov, shranjen s tribajtno "
 "predpono, ki nakazuje dolžino vrednosti v bajtih"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3670,7 +3670,7 @@ msgstr ""
 "Stolpec TEXT, dolg največ 4.294.967.295 ali 4 GiB (2^32 - 1) znakov, "
 "shranjen s štiribajtno predpono, ki nakazuje dolžino vrednosti v bajtih"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3678,7 +3678,7 @@ msgstr ""
 "Podobno vrsti CHAR, vendar shranjuje dvojiške nize bajtov namesto "
 "nedvojiških nizov znakov"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3686,7 +3686,7 @@ msgstr ""
 "Podobno vrsti VARCHAR, vendar shranjuje dvojiške nize bajtov namesto "
 "nedvojiških nizov znakov"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3694,7 +3694,7 @@ msgstr ""
 "Stolpec BLOB, dolg največ 255 (2^8 - 1) znakov, shranjen z enobajtno "
 "predpono, ki nakazuje dolžino vrednosti v bajtih"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3702,7 +3702,7 @@ msgstr ""
 "Stolpec BLOB, dolg največ 16.777.215 (2^24 - 1) znakov, shranjen s tribajtno "
 "predpono, ki nakazuje dolžino vrednosti v bajtih"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3710,7 +3710,7 @@ msgstr ""
 "Stolpec BLOB, dolg največ 65.535 (2^16 - 1) znakov, shranjen z dvobajtno "
 "predpono, ki nakazuje dolžino vrednosti v bajtih"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3718,7 +3718,7 @@ msgstr ""
 "Stolpec BLOB, dolg največ 4.294.967.295 ali 4 GiB (2^32 - 1) znakov, "
 "shranjen s štiribajtno predpono, ki nakazuje dolžino vrednosti v bajtih"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3726,67 +3726,67 @@ msgstr ""
 "Naštevanje, izbrano s seznama do 65.535 vrednosti ali posebne vrednosti "
 "napake ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "Ena vrednost, izbrana iz množice z največ 64 člani"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Vrsta, ki lahko shrani katero koli geometrijsko vrsto"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "Točka v dvodimenzionalnem prostoru"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Krivulja z linearno interpolacijo med točkami"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Večkotnik"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Zbirka točk"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Zbirka krivulj z linearno interpolacijo med točkami"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Zbirka večkotnikov"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Zbirka geometrijskih objektov katere koli vrste"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numerično"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Datum in čas"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Niz"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Prostorsko"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "4-bitno celo število; razpon je od -2.147.483.648 do 2.147.483.647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3794,25 +3794,25 @@ msgstr ""
 "8-bitno celo število; razpon je od -9.223.372.036.854.775.808 do "
 "9.223.372.036.854.775.807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Sistemsko privzeto število z decimalno vejico z natančnostjo double"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Res ali ni res"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Vzdevek za BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 "Shrani vsesplošno edinstven označevalnik (Universally Unique Identifier, "
 "UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3820,7 +3820,7 @@ msgstr ""
 "Časovni žig; razpon je od '0001-01-01 00:00:00' UTC do '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) lahko shrani mikrosekunde"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3828,7 +3828,7 @@ msgstr ""
 "Niz spremenljive dolžine (0–65.535); uporablja dvojiško zbirko za vse "
 "primerjave"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Naštevanje, izbrano s seznama določenih vrednosti"
 
@@ -3913,67 +3913,67 @@ msgstr "%d. %B %Y ob %H.%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dni, %s ur, %s minut in %s sekund"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Manjkajoč parameter:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Preskoči na zbirko podatkov &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Na funkcionalnost %s vpliva znan hrošč, glej %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Kliknite za preklop"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Prebrskajte svoj računalnik:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Izberite iz mape za nalaganje na spletnem strežniku <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Imenik, ki ste ga določili za nalaganje, ni dosegljiv."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Nobene datoteke ni za naložiti"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Izprazni"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Izvedi"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Natisni"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Ustvarjeno"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Zadnjič posodobljeno"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Zadnjič pregledano"
@@ -4330,9 +4330,9 @@ msgstr "Dovoli uporabnikom prilagajati to vrednost"
 msgid "Apply"
 msgstr "Uveljavi"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Ponastavi"
 
@@ -4639,7 +4639,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Najdaljši čas izvajanja"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Shrani kot datoteko"
 
@@ -7048,7 +7048,7 @@ msgstr "Datoteka je v obdelavi, prosim, počakajte."
 msgid "Language"
 msgstr "Jezik"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Podatki o različici"
 
@@ -7493,59 +7493,59 @@ msgstr "Zaradi njegove dolžine<br />stolpca morda ne bo mogoče urejati"
 msgid "Binary - do not edit"
 msgstr "Dvojiško - ne urejaj"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "imenik za nalaganje datotek:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Nadaljuj vstavljanje z %s vrsticami"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "in potem"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Vstavi kot novo vrstico"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Vstavi kot novo vrstico in presliši napake"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Prikaži poizvedbo insert"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Pojdi nazaj na prejšnjo stran"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Vstavi še eno novo vrstico"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Pojdi nazaj na stran"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Uredi naslednjo vrstico"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Uporabite tipko TAB za premik od vrednosti do vrednosti ali CTRL+puščice za "
 "premik kamor koli"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Prikazovanje poizvedbe SQL"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Id vstavljene vrstice: %1$d"
@@ -7878,7 +7878,6 @@ msgid "Database operations"
 msgstr "Posegi zbirke podatkov"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Prikaži skrite predmete"
 
@@ -9685,24 +9684,24 @@ msgid "There are no events to display."
 msgstr "Ni dogodkov za prikaz."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Tabela %s ne obstaja!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Prosimo, konfigurirajte koordinate za tabelo %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Shema zbirke podatkov %s - Stran %s"
@@ -12396,7 +12395,7 @@ msgstr "Različica %1$s je ustvarjena, sledenje %2$s je aktivirano."
 msgid "Manage your settings"
 msgstr "Upravljajte svoje nastavitve"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Konfiguracija je shranjena"
 
@@ -12648,7 +12647,7 @@ msgstr "Nastavitve bodo uvožene iz brskalnikove lokalne hrambe."
 msgid "You have no saved settings!"
 msgstr "Nimate shranjenih nastavitev!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Te funkcije vaš spletni brskalnik ne podpira"
 
@@ -12665,19 +12664,19 @@ msgstr ""
 "Več nastavitev lahko nastavite s spreminjanjem config.inc.php, npr. z "
 "uporabo %sNastavitvenega skripta%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Shrani v hrambo brskalnika"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Nastavitve bodo shranjene v lokalno hrambo vašega brskalnika."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Obstoječe nastavitve bodo prepisane!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Ponastavite lahko vse svoje nastavitve in jih obnovite na njihove privzete "
@@ -12707,6 +12706,10 @@ msgstr "Brez zbirk podatkov"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Pokaži povzetek stanja zbirk podatkov"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:35+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Albanian <http://l10n.cihar.com/projects/phpmyadmin/master/sq/"
@@ -41,7 +41,7 @@ msgstr "Kërkim:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Lloji"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr "Përditësuar"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr "Fshij të dhënat e monitorimit për këtë tabelë"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -560,8 +560,8 @@ msgstr "Shto një gjeometri"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -587,7 +587,7 @@ msgstr "Shto një gjeometri"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Zbato"
@@ -970,7 +970,7 @@ msgstr "Shto Indeks"
 msgid "Edit Index"
 msgstr "Modifiko Indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Shtojini %s fushë(a) të re(ja) indeksit"
@@ -1188,7 +1188,7 @@ msgid "Traffic"
 msgstr "Trafiku"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Parametrat"
 
@@ -1482,8 +1482,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1692,8 +1692,8 @@ msgstr "Afisho kutinë e query"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1720,7 +1720,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1793,8 +1793,8 @@ msgstr "Rezultati SQL"
 msgid "Data point content"
 msgstr "Përmbajtja e të dhënave të kësaj pike"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Shpërfill"
 
@@ -2335,7 +2335,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2492,8 +2492,8 @@ msgstr[0] "%1$s korrespondon tek tabela <strong>%2$s</strong>"
 msgstr[1] "%1$s korrespondojnë tek tabela <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2549,28 +2549,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr "Rivendos renditjen e kolonave"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Fillim"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Paraardhësi"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Pasardhëse"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Fundi"
@@ -2758,9 +2758,9 @@ msgstr "Zgjidh gjithçka"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2951,9 +2951,9 @@ msgid "View"
 msgstr "Paraqitje"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2967,32 +2967,32 @@ msgid "Structure"
 msgstr "Struktura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Kërko"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Shto"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3001,20 +3001,20 @@ msgid "Privileges"
 msgstr "Të drejtat"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operacione"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3030,73 +3030,73 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Query nga shembull"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Databazat"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Përdorues"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 #, fuzzy
 msgid "Binary log"
 msgstr "Binar"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikimi"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Të ndryshueshmet"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Familje gërmash"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Gabim"
@@ -3122,7 +3122,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d rresht i shtuar."
 msgstr[1] "%1$d rreshta të shtuar."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3347,7 +3347,7 @@ msgid "Operator"
 msgstr "Operatori"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3364,7 +3364,7 @@ msgstr "Kërko"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3376,7 +3376,7 @@ msgstr "Shto"
 msgid "Select columns (at least one):"
 msgstr "Zgjidh fushat (të paktën një):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Ose"
@@ -3501,285 +3501,285 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Versioni i MySQL"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Versioni i MySQL"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 msgid "A polygon"
 msgstr "Shto një fushë të re"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Krijo një tregues të ri"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Rreshta që mbarojnë me"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Gjithsej"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3866,68 +3866,68 @@ msgstr "%d %B, %Y at %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s ditë, %s orë, %s minuta dhe %s sekonda"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Kalo tek databaza &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "directory e upload të server-it web"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Directory që keni zgjedhur për upload nuk arrin të gjehet."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Zbraz"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Printo"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Krijimi"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Ndryshimi i fundit"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Kontrolli i fundit"
@@ -4305,9 +4305,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Rinis"
 
@@ -4599,7 +4599,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Ruaje skedarin me emër"
 
@@ -6985,7 +6985,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informacione mbi versionin"
 
@@ -7385,59 +7385,59 @@ msgstr "Për shkak të gjatësisë saj,<br /> kjo fushë nuk mund të ndryshohet
 msgid "Binary - do not edit"
 msgstr "Të dhëna të tipit binar - mos ndrysho"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "directory e upload të server-it web"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Shto një rresht të ri"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Mbrapa"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Shto një regjistrim të ri"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Kthehu mbrapa tek kjo faqe"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9708,25 +9708,25 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Tabela \"%s\" nuk ekziston!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Ju lutem, konfiguroni koordinatat për tabelën %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12448,7 +12448,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Karakteristikat e përgjithshme të relacionit"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12734,7 +12734,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12749,19 +12749,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12791,6 +12791,10 @@ msgstr "Asnjë databazë"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Shfaq dump (skema) e databazave"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/sr.po
+++ b/po/sr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:32+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Serbian <http://l10n.cihar.com/projects/phpmyadmin/master/sr/"
@@ -42,7 +42,7 @@ msgstr "Коментари табеле"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Тип"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -354,7 +354,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -382,7 +382,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -599,8 +599,8 @@ msgstr "Додај новог корисника"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -626,7 +626,7 @@ msgstr "Додај новог корисника"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Крени"
@@ -1024,7 +1024,7 @@ msgstr "Додај ново поље"
 msgid "Edit Index"
 msgstr "Уреди следећи ред"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1268,7 +1268,7 @@ msgid "Traffic"
 msgstr "Саобраћај"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1604,8 +1604,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1860,8 +1860,8 @@ msgstr "SQL упит"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr "%d није исправан број реда."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1969,8 +1969,8 @@ msgstr "Операције на резултатима упита"
 msgid "Data point content"
 msgstr "Величина показивача података"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Игнориши"
 
@@ -2592,7 +2592,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Величина фонта"
 
@@ -2757,8 +2757,8 @@ msgstr[1] "%s погодака унутар табеле <i>%s</i>"
 msgstr[2] "%s погодака унутар табеле <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2824,16 +2824,16 @@ msgstr "Основни директоријум података"
 msgid "Restore column order"
 msgstr "Додај/обриши колону"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Почетак"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2841,8 +2841,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Претходна"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2850,8 +2850,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Следећи"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3044,9 +3044,9 @@ msgstr "Означи све"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3243,9 +3243,9 @@ msgid "View"
 msgstr "Поглед"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3259,32 +3259,32 @@ msgid "Structure"
 msgstr "Структура"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Претраживање"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Нови запис"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3293,20 +3293,20 @@ msgid "Privileges"
 msgstr "Привилегије"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Операције"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3322,16 +3322,16 @@ msgstr "Окидачи"
 msgid "Database seems to be empty!"
 msgstr "База је изгледа празна!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Упит по примеру"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Рутине"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
@@ -3339,56 +3339,56 @@ msgstr "Рутине"
 msgid "Events"
 msgstr "Догађаји"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Дизајнер"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Базе"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Корисник"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Бинарни дневник"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Репликација"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Променљиве"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Кодне стране"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Складиштења"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Грешка"
@@ -3416,7 +3416,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Нема одабраних редова"
 msgstr[1] "Нема одабраних редова"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3648,7 +3648,7 @@ msgid "Operator"
 msgstr "Оператор"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3665,7 +3665,7 @@ msgstr "Претраживање"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3677,7 +3677,7 @@ msgstr "Нови запис"
 msgid "Select columns (at least one):"
 msgstr "Изабери поља (најмање једно)"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "или"
@@ -3803,287 +3803,287 @@ msgstr "Није пронађена путања до теме за тему %s!
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Направи релацију"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Грешка при преименовању табеле %1$s у %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "Додај %s поља"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Направи нови кључ"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Линије се завршавају са"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Укупно"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4172,70 +4172,70 @@ msgstr "%d. %B %Y. у %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s дана, %s сати, %s минута и %s секунди"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Рутине"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Пређи на базу &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Ова функционалност %s је погођена познатом грешком, видите %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "директоријум за слање веб сервера "
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Директоријум који сте изабрали за слање није доступан."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Испразни"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Штампај"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Направљено"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Последња измена"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Последња провера"
@@ -4618,9 +4618,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Поништи"
 
@@ -4917,7 +4917,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Сачувај као датотеку"
 
@@ -7367,7 +7367,7 @@ msgstr ""
 msgid "Language"
 msgstr "Језик"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Информације о верзији"
 
@@ -7787,63 +7787,63 @@ msgstr "Због њехове величине, поље<br />можда нећ�
 msgid "Binary - do not edit"
 msgstr "Бинарни - не мењај"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "директоријум за слање веб сервера"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Поново покрени уношење са %s редова"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "и онда"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Унеси као нови ред"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 #, fuzzy
 msgid "Show insert query"
 msgstr "Приказ као SQL упит"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Назад на претходну страну"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Додај још један нови ред"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Врати се на ову страну"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Уреди следећи ред"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Користите TAB тастер за померање од поља до поља, или CTRL+стрелице за "
 "слободно померање"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Приказ као SQL упит"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -10158,25 +10158,25 @@ msgid "There are no events to display."
 msgstr "Провери табелу"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "Табела \"%s\" не постоји!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Подесите координате за табелу %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -13014,7 +13014,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Опште особине релација"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13304,7 +13304,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13319,19 +13319,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13361,6 +13361,10 @@ msgstr "База не постоји"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Прикажи садржај (схему) базе"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:36+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Serbian (latin) <http://l10n.cihar.com/projects/phpmyadmin/"
@@ -44,7 +44,7 @@ msgstr "Komentari tabele"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -90,7 +90,7 @@ msgid "Type"
 msgstr "Tip"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -346,7 +346,7 @@ msgid "Updated"
 msgstr "Ažurirano"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -374,7 +374,7 @@ msgid "Delete tracking data for this table"
 msgstr "Obriši podatke o praćenju za ovu tabelu"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -580,8 +580,8 @@ msgstr "Dodaj geometriju"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -607,7 +607,7 @@ msgstr "Dodaj geometriju"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Kreni"
@@ -989,7 +989,7 @@ msgstr "Dodaj indeks"
 msgid "Edit Index"
 msgstr "Izmeni indeks"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %d column(s) to index"
 msgid "Add %s column(s) to index"
@@ -1208,7 +1208,7 @@ msgid "Traffic"
 msgstr "Saobraćaj"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Podešavanja"
 
@@ -1522,8 +1522,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1734,8 +1734,8 @@ msgstr "Prikažiokvir sa upitima"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1762,7 +1762,7 @@ msgstr "Vreme izvršavanja upita"
 msgid "%d is not valid row number."
 msgstr "%d nije ispravan broj reda."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1838,8 +1838,8 @@ msgstr "Rezultat upita"
 msgid "Data point content"
 msgstr "Sadržaj tačke podataka"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignoriši"
 
@@ -2411,7 +2411,7 @@ msgstr ""
 "Pogrešno podešena prava pristupa na konfiguracionoj datoteci, ne bi trebala "
 "da bude svima dostupna za pisanje!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Veličina fonta"
 
@@ -2573,8 +2573,8 @@ msgstr[1] "%s pogodaka unutar tabele <i>%s</i>"
 msgstr[2] "%s pogodaka unutar tabele <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2630,28 +2630,28 @@ msgstr "Snimi izmenjene podatke"
 msgid "Restore column order"
 msgstr "Vrati redosled kolone"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Početak"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Prethodna"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Sledeća"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Kraj"
@@ -2833,9 +2833,9 @@ msgstr "Označi sve"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3032,9 +3032,9 @@ msgid "View"
 msgstr "Pogled"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3048,32 +3048,32 @@ msgid "Structure"
 msgstr "Struktura"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Pretraživanje"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Novi zapis"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3082,20 +3082,20 @@ msgid "Privileges"
 msgstr "Privilegije"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operacije"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3111,70 +3111,70 @@ msgstr "Okidači"
 msgid "Database seems to be empty!"
 msgstr "Baza je izgleda prazna!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Upit po primeru"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutine"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Događaji"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Dizajner"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Baze"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Korisnici"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binarni dnevnik"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikacija"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Promenljive"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Kodne strane"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Skladištenja"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Greška"
@@ -3203,7 +3203,7 @@ msgstr[0] "%1$d red umetnut."
 msgstr[1] "%1$d redova umetnuto."
 msgstr[2] "%1$d redova umetnuto."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3430,7 +3430,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3445,7 +3445,7 @@ msgstr "Pretraga tabele"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Uredi/Umetni"
 
@@ -3453,7 +3453,7 @@ msgstr "Uredi/Umetni"
 msgid "Select columns (at least one):"
 msgstr "Izaberi kolone (najmanje jednu):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "ili"
@@ -3575,287 +3575,287 @@ msgstr "Nije pronađena putanja do teme za temu %s!"
 msgid "Theme:"
 msgstr "Tema"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Napravi relaciju"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "Greška pri preimenovanju tabele %1$s u %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "Dodaj %s polja"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Napravi novi ključ"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Linije se završavaju sa"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Ukupno"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3942,68 +3942,68 @@ msgstr "%d. %B %Y. u %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dana, %s sati, %s minuta i %s sekundi"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Nedostaje parametar:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Pređi na bazu &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Ova funkcionalnost %s je pogođena poznatom greškom, vidite %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Kliknite da biste zamenili"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Pretražite vaš kompjuter:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 "Izaberi iz direkorijuma otpremljenih datoteka <b>%s</b> na web serveru:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Direktorijum koji ste izabrali za slanje nije dostupan."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Nema datoteka za otpremanje"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Isprazni"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Izvrši"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Štampaj"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Napravljeno"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Poslednja izmena"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Poslednja provera"
@@ -4372,9 +4372,9 @@ msgstr "Dozvoli korisnicima da prilagode ovu vrednost"
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Poništi"
 
@@ -4684,7 +4684,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maksimalno vreme izvršavanja"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Sačuvaj kao datoteku"
 
@@ -7043,7 +7043,7 @@ msgstr ""
 msgid "Language"
 msgstr "Jezik"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Informacije o verziji"
 
@@ -7455,61 +7455,61 @@ msgstr "Zbog njene veličine,<br />ova kolona možda neće moći da se izmeni"
 msgid "Binary - do not edit"
 msgstr "Binarni - ne menjaj"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "direktorijum za slanje veb servera"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Nastavi umetanje sa %s redova"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "i onda"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Unesi kao novi red"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Prikaži insert upit"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Nazad na prethodnu stranu"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Dodaj još jedan novi red"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Vrati se na ovu stranu"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Uredi sledeći red"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Koristite TAB taster za pomeranje od polja do polja, ili CTRL+strelice za "
 "slobodno pomeranje"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Prikaz kao SQL upit"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9666,24 +9666,24 @@ msgid "There are no events to display."
 msgstr "Nema događaja za prikaz."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Tabela %s ne postoji!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Podesite koordinate za tabelu %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Shema baze %s - Strana %s"
@@ -12420,7 +12420,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Upravljanje podešavanjima"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Konfiguracija je sačuvana"
 
@@ -12676,7 +12676,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12691,19 +12691,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12733,6 +12733,10 @@ msgstr "Baza ne postoji"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Prikaži sadržaj (shemu) baze"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:36+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Swedish <http://l10n.cihar.com/projects/phpmyadmin/master/sv/"
@@ -41,7 +41,7 @@ msgstr "Tabellkommentarer:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Typ"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -335,7 +335,7 @@ msgid "Updated"
 msgstr "Uppdaterad"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -363,7 +363,7 @@ msgid "Delete tracking data for this table"
 msgstr "Ta bort spårning för denna tabell"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -559,8 +559,8 @@ msgstr "Addera geometri"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -586,7 +586,7 @@ msgstr "Addera geometri"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Kör"
@@ -962,7 +962,7 @@ msgstr "Addera index"
 msgid "Edit Index"
 msgstr "Redigera index"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Lägg till %s kolumn(er) till index"
@@ -1179,7 +1179,7 @@ msgid "Traffic"
 msgstr "Trafik"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Inställningar"
 
@@ -1491,8 +1491,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1702,8 +1702,8 @@ msgstr "Visa frågerutan"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1730,7 +1730,7 @@ msgstr "Exekveringstid för frågor"
 msgid "%d is not valid row number."
 msgstr "%d är inte ett giltigt radnummer."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1800,8 +1800,8 @@ msgstr "Frågeresultat"
 msgid "Data point content"
 msgstr "Innehåll för datapunkt"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ignorera"
 
@@ -2362,7 +2362,7 @@ msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 "Fel behörigheter på konfigurationsfilen, bör inte vara \"world\" skrivbar!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Teckenstorlek"
 
@@ -2509,8 +2509,8 @@ msgstr[0] "%1$s träff i <strong>%2$s</strong>"
 msgstr[1] "%1$s träffar i <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2566,28 +2566,28 @@ msgstr "Spara editerade data"
 msgid "Restore column order"
 msgstr "Återställ ordningen på kolumner"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Starta"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Föregående"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Nästa"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Slut"
@@ -2763,9 +2763,9 @@ msgstr "Markera alla"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2957,9 +2957,9 @@ msgid "View"
 msgstr "Vy"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2973,32 +2973,32 @@ msgid "Structure"
 msgstr "Struktur"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Sök"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Lägg till"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3007,20 +3007,20 @@ msgid "Privileges"
 msgstr "Privilegier"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operationer"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Spårning"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3036,70 +3036,70 @@ msgstr "Trigger"
 msgid "Database seems to be empty!"
 msgstr "Databasen verkar vara tom!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Fråga"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Rutiner"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Händelser"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Designer"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Databaser"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Användare"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binär logg"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikering"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Variabler"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Teckenuppsättningar"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Insticksprogram"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motorer"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Fel"
@@ -3125,7 +3125,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d rad infogad."
 msgstr[1] "%1$d rader infogade."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3348,7 +3348,7 @@ msgid "Operator"
 msgstr "Aktör"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3363,7 +3363,7 @@ msgstr "Tabellsök"
 msgid "Find and Replace"
 msgstr "Sök och ersätt"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Redigera / Infoga"
 
@@ -3371,7 +3371,7 @@ msgstr "Redigera / Infoga"
 msgid "Select columns (at least one):"
 msgstr "Markera kolumner (minst en):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Eller"
@@ -3482,14 +3482,14 @@ msgstr "Temats sökväg för tema %s hittades inte!"
 msgid "Theme:"
 msgstr "Tema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "En 1-byte heltal, signerat intervall är -128 till 127, osignerad intervall "
 "är 0 till 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3497,7 +3497,7 @@ msgstr ""
 "Ett 2-bytes heltal, signerat inom intervallet -32.768 till 32.767, osignerat "
 "inom intervallet 0 till 65.535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3505,7 +3505,7 @@ msgstr ""
 "Ett 3-bytes heltal, signerat inom intervallet -8.388.608 till 8.388.607, "
 "osignerat inom intervallet 0 till 16.777.215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3513,7 +3513,7 @@ msgstr ""
 "Ett 4-bytes heltal, signerat inom intervallet -2147483648 till 2147483647, "
 "osignerat inom intervallet 0 till 4294967295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3522,7 +3522,7 @@ msgstr ""
 "till 9.223.372.036.854.775.807, osignerat inom intervallet 0 till "
 "18.446.744.073.709.551.615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3530,7 +3530,7 @@ msgstr ""
 "Ett fast-punkt nummer (M, D) - det maximala antalet siffror (M) är 65 "
 "(default 10), det maximala antalet decimaler (D) är 30 (default 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3538,7 +3538,7 @@ msgstr ""
 "Ett litet flyttal. Tillåtna värden är: 3.402823466E+38 till-1.175494351E-38, "
 "0, och 1.175494351E-38 till 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3548,7 +3548,7 @@ msgstr ""
 "till 2.2250738585072014E-308, 0, och 2.2250738585072014E-308 till "
 "1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3556,14 +3556,14 @@ msgstr ""
 "Synonym för DOUBLE (undantag: i REAL_AS_FLOAT SQL läget är det en synonym "
 "för FLOAT)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 "En bit-fälttyp (M), lagrar M bitar per värde default är 1, maximalt är 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3571,21 +3571,21 @@ msgstr ""
 "En synonym för TINYINT (1), ett värde på noll betraktas som falskt, värden "
 "skilda från noll anses sanna"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Ett alias för BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Ett datum, supportat område är %1$s till %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "En datum och tidskombination, supportat område är %1$s till %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3593,12 +3593,12 @@ msgstr ""
 "En tidsstämpel, intervallet är 1970-01-01 00:00:01 UTC till 2038-01-09 "
 "03:14:07 UTC, lagrad som antalet sekunder sedan 1970-01-01 00:00:00 UTC"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "En tid, området är %1$s till %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3606,7 +3606,7 @@ msgstr ""
 "Ett år i fyr-siffrigt (4, default) eller 2-siffrigt (2) format, tillåtna "
 "värden är: 70 (1970) till 69 (2069) eller 1901 till 2155 och 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3614,7 +3614,7 @@ msgstr ""
 "En sträng med fast längd (0-255, standard 1) som alltid är högerfylld med "
 "blankslag till den angivna längden vid lagring"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3623,7 +3623,7 @@ msgstr ""
 "En variabel-längd (%s) sträng, den effektiva maximala längden är "
 "förutsättningen för den maximala radstorleken"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3631,7 +3631,7 @@ msgstr ""
 "En TEXT-kolumn med en maximal längd av 255 (2^8-1) tecken, lagrat med ett en-"
 "bytes prefix vilket anger längden av värdet i bytes"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3639,7 +3639,7 @@ msgstr ""
 "En TEXT-kolumn med en maximal längd av 65.535 (2^16-1) tecken, lagrat med "
 "ett två-bytes prefix vilket anger längden av värdet i bytes"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3647,7 +3647,7 @@ msgstr ""
 "En TEXT-kolumn med en maximal längd av 16.777.215 (2^24-1) tecken, lagrat "
 "med ett tre-bytes prefix vilket anger längden av värdet i bytes"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3657,7 +3657,7 @@ msgstr ""
 "tecken, lagrat med ett fyra-bytes prefix vilket anger längden av värdet i "
 "bytes"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3665,7 +3665,7 @@ msgstr ""
 "Liknande typen CHAR, men lagrar binära bytesträngar snarare än icke-binära "
 "teckensträngar"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3673,7 +3673,7 @@ msgstr ""
 "Liknande typen VARCHAR, men lagrar binära bytesträngar snarare än icke-"
 "binära teckensträngar"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3681,7 +3681,7 @@ msgstr ""
 "En BLOB-kolumn med en maximal längd av 255 (2^8-1) bytes, lagrat med ett en-"
 "bytes prefix vilket anger längden av värdet"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3689,7 +3689,7 @@ msgstr ""
 "En BLOB-kolumn med en maximal längd av 16.777.215 (2^24-1) bytes, lagrat med "
 "ett tre-bytes prefix vilket anger längden av värdet"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3697,7 +3697,7 @@ msgstr ""
 "En BLOB-kolumn med en maximal längd av 65.535 (2^16-1) bytes, lagrad med ett "
 "två bytes prefix vilket anger längden på värdet"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3705,7 +3705,7 @@ msgstr ""
 "En BLOB-kolumn med en maximal längd av 4,294,967,295 och 4GB (2^32-1) byte, "
 "lagrad med ett fyra-bytes prefix som anger längden på värdet"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3713,67 +3713,67 @@ msgstr ""
 "En uppräkning, vald från listan med upp till 65.535 värden eller det "
 "speciella felvärdet ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "En enstaka värde valt från en uppsättning av upp till 64 stycken"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "En typ som kan lagra en geometri av alla typer"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "En punkt i det 2-dimensionella rummet"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "En kurva med linjär interpolering mellan punkter"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "En polygon"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "En samling punkter"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "En samling kurvor med linjär interpolering mellan punkterna"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "En samling polygoner"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "En samling geometriobjekt av valfri typ"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Numeriska"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Datum och tid"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Sträng"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Spatial"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "Ett 4-bytes heltal, intervall -2147483648 till 2147483647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3781,23 +3781,23 @@ msgstr ""
 "Ett 8-bytes heltal, intervallet -9.223.372.036.854.775.808 till "
 "9.223.372.036.854.775.807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Ett systems förvalda flyttal med dubbel precision"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "Sant eller falskt"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "Ett alias för BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Lagrar en universiellt unik identifierare (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3805,7 +3805,7 @@ msgstr ""
 "En tidsstämpel området är 0001-01-01 00:00:00 'UTC till '9999-12-31 "
 "23:59:59' UTC, TIMESTAMP(6) kan lagra mikrosekunder"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3813,7 +3813,7 @@ msgstr ""
 "En sträng av variabel längd (0-65,535), använder binär kollationering för "
 "alla jämförelser"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "En uppräkning, vald från listan av definierade värden"
 
@@ -3898,67 +3898,67 @@ msgstr "%d %B %Y kl %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s dagar, %s timmar, %s minuter och %s sekunder"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Saknade parametrar:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Hoppa till databas &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "Funktionaliteten för %s påverkas av en känd bugg, se %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Klicka för att växla"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Gå igenom din dator:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Välj katalog att ladda upp till från web-server listningen <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Katalogen du ställt in för uppladdning kan inte nås."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Det finns inga filer att ladda upp"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Töm"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Utför"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Skriv ut"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Skapande"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Senaste uppdatering"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Senaste kontroll"
@@ -4315,9 +4315,9 @@ msgstr "Tillåt användare att anpassa detta värde"
 msgid "Apply"
 msgstr "Applicera"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Återställ"
 
@@ -4624,7 +4624,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maximal exekveringstid"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Spara som fil"
 
@@ -7056,7 +7056,7 @@ msgstr "Filen bearbetas, vänligen vänta."
 msgid "Language"
 msgstr "Språk"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Versionsinformation"
 
@@ -7496,59 +7496,59 @@ msgstr "På grund av sin längd,<br /> är denna kolumn kanske inte redigerbar"
 msgid "Binary - do not edit"
 msgstr "Binär - ändra inte"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "Uppladdningskatalog på webbserver:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Fortsätt inmatning med %s rader"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "och sedan"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Lägg till som ny rad"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Infoga som ny rad och ignorera fel"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Visa insert-fråga"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Gå tillbaka till föregående sida"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Lägg till ytterligare en ny rad"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Gå tillbaka till denna sida"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Ändra nästa rad"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Använd TAB-tangenten för att flytta från värde till värde, eller CTRL+pil "
 "för att flytta vart som helst"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Visar SQL-fråga"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Infogade rad-id: %1$d"
@@ -9711,24 +9711,24 @@ msgid "There are no events to display."
 msgstr "Det finns inga händelser att visa."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Tabellen %s existerar inte!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Var god ange koordinaterna för tabellen %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Schema för databasen %s - Sida %s"
@@ -12441,7 +12441,7 @@ msgstr "Version %1$s är skapad, spårning för %2$s är aktiv."
 msgid "Manage your settings"
 msgstr "Hantera dina inställningar"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Konfigurationen har sparats"
 
@@ -12693,7 +12693,7 @@ msgstr "Inställningar kommer att importeras från webbläsaren."
 msgid "You have no saved settings!"
 msgstr "Du har inga sparade inställningar!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Denna funktion stöds inte av din webbläsare"
 
@@ -12710,19 +12710,19 @@ msgstr ""
 "Du kan ställa in fler inställningar genom att ändra config.inc.php, t ex. "
 "genom att använda %sSetup script%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Spara till webbläsaren"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Inställningarna kommer att sparas i din webbläsare."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Befintliga inställningar kommer skrivas över!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Du kan återställa alla inställningar och återföra dem till standardvärdena."
@@ -12751,6 +12751,10 @@ msgstr "Inga databaser"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Visa dump (schema) för databaser"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -6,14 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-26 10:02+0200\n"
 "Last-Translator: Lakshmanan M <send2lakshman@gmail.com>\n"
 "Language-Team: Tamil <http://l10n.cihar.com/projects/phpmyadmin/master/ta/>\n"
-"Language: ta\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: ta\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -41,7 +41,7 @@ msgstr "அட்டவணைக் கருத்துரைகள்:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "வகை"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -273,13 +273,11 @@ msgstr "உருவாக்கம்:"
 
 #: db_printview.php:126 libraries/plugins/export/ExportSql.class.php:1055
 #: libraries/schema/Pdf_Relation_Schema.class.php:1358
-#| msgid "Last update"
 msgid "Last update:"
 msgstr "இறுதி இற்றைப்படுத்தல்:"
 
 #: db_printview.php:135 libraries/plugins/export/ExportSql.class.php:1068
 #: libraries/schema/Pdf_Relation_Schema.class.php:1363
-#| msgid "Last check"
 msgid "Last check:"
 msgstr "கடைசி சோதனை:"
 
@@ -338,7 +336,7 @@ msgid "Updated"
 msgstr "புதுப்பிக்கப்பட்டது"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -366,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -439,7 +437,6 @@ msgid "Unfortunately the submission failed."
 msgstr ""
 
 #: export.php:160
-#| msgid "Index type:"
 msgid "Bad type!"
 msgstr "கெட்ட வகை!"
 
@@ -489,18 +486,15 @@ msgstr ""
 
 #. l10n: Spatial Reference System Identifier
 #: gis_data_editor.php:163
-#| msgid "SRID"
 msgid "SRID:"
 msgstr "SRID:"
 
 #: gis_data_editor.php:186
 #, php-format
-#| msgid "Geometry"
 msgid "Geometry %d:"
 msgstr "கேத்திர கணிதம் %d:"
 
 #: gis_data_editor.php:208
-#| msgid "Point"
 msgid "Point:"
 msgstr "புள்ளி:"
 
@@ -517,7 +511,6 @@ msgstr "Y"
 #: gis_data_editor.php:234 gis_data_editor.php:289 gis_data_editor.php:362
 #: js/messages.php:327
 #, php-format
-#| msgid "Point"
 msgid "Point %d"
 msgstr "புள்ளி %d"
 
@@ -528,23 +521,19 @@ msgstr "ஒரு புள்ளியை சேர்"
 
 #: gis_data_editor.php:264
 #, php-format
-#| msgid "Add constraints"
 msgid "Linestring %d:"
 msgstr "வரி சரம் %d:"
 
 #: gis_data_editor.php:267 gis_data_editor.php:343
-#| msgid "Outer Ring:"
 msgid "Outer ring:"
 msgstr "வெளிப்புற வளையம்:"
 
 #: gis_data_editor.php:269 gis_data_editor.php:345
 #, php-format
-#| msgid "Inner Ring"
 msgid "Inner ring %d:"
 msgstr "உள்ப்புற வளையம் %d:"
 
 #: gis_data_editor.php:305
-#| msgid "Add constraints"
 msgid "Add a linestring"
 msgstr "வரி சரம் சேர்க்க"
 
@@ -554,7 +543,6 @@ msgstr "உள்ப்புற வளையத்தை சேர்"
 
 #: gis_data_editor.php:327
 #, php-format
-#| msgid "Polygon"
 msgid "Polygon %d:"
 msgstr "பல்கோணி %d:"
 
@@ -563,7 +551,6 @@ msgid "Add a polygon"
 msgstr "ஒரு பல்கோணியை சேர்"
 
 #: gis_data_editor.php:392
-#| msgid "Add a new User"
 msgid "Add geometry"
 msgstr "வடிவியல் சேர்க்க"
 
@@ -573,8 +560,8 @@ msgstr "வடிவியல் சேர்க்க"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -600,7 +587,7 @@ msgstr "வடிவியல் சேர்க்க"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "செல்"
@@ -950,7 +937,7 @@ msgstr "சுட்டுகள்"
 msgid "Edit Index"
 msgstr "தொகுப்பு பார்வை"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1166,7 +1153,7 @@ msgid "Traffic"
 msgstr "போக்குவரத்து"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "அமைப்புகள்"
 
@@ -1483,8 +1470,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1705,8 +1692,8 @@ msgstr "வினவல் பெட்டியை காண்பி"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1733,7 +1720,7 @@ msgstr "வினவல் நிறைவேற்றுகை நேரம்"
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1810,8 +1797,8 @@ msgstr "தேடல் முடிவுகளை மறை"
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "புறக்கணி"
 
@@ -2374,7 +2361,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "எழுத்துரு அளவு"
 
@@ -2533,8 +2520,8 @@ msgstr[0] "%s அட்டவணையில் பொருந்தியவ�
 msgstr[1] "%s அட்டவணையில் பொருந்தியவைகள் <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2592,28 +2579,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr "கள நிரல்களை சேர்க்க/ நீக்குக"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "ஆரம்பம்"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "முந்தைய"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "அடுத்து"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "முடிவு"
@@ -2793,9 +2780,9 @@ msgstr "அனைத்தையும் தெரி"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2982,9 +2969,9 @@ msgid "View"
 msgstr "நோக்கு"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2998,32 +2985,32 @@ msgid "Structure"
 msgstr "கட்டமைப்பு"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "தேடு"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "செருகு"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3032,20 +3019,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "செயல்பாடுகள்"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3061,72 +3048,72 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "தரவுத்தளங்கள்"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "Usage"
 msgid "Users"
 msgstr "பாவனையளவு"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "படியெடுத்தல்"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "வலு"
@@ -3152,7 +3139,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d வரிசை சேர்க்கப்பட்டுள்ளது."
 msgstr[1] "%1$d வரிசைகள் சேர்க்கப்பட்டுள்ளன."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3373,7 +3360,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3390,7 +3377,7 @@ msgstr "தேடு"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3398,7 +3385,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "அல்லது"
@@ -3518,286 +3505,286 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "Create version"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "பதிப்பை உருவாக்கு"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Create version"
 msgid "A time, range is %1$s to %2$s"
 msgstr "பதிப்பை உருவாக்கு"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add a polygon"
 msgid "A polygon"
 msgstr "ஒரு பல்கோணியை சேர்"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "புதிய சுட்டை உருவாக்கு"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Add/Delete Field Columns"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "கள நிரல்களை சேர்க்க/ நீக்குக"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3884,67 +3871,67 @@ msgstr "%B %d, %Y இல் %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s நாட்கள் %s மணித்தியாலங்கள் %s நிமிடங்கள் மற்றும் %s நொடிகள்"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "அளவுருக்கள் காணப்படவில்லை:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "தரவுத்தளம் தாவி செல்லவும் &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s செயல்பாடு ஒரு அறியப்படுகிற பிழையால் பாதிக்கப்பட்டுள்ளது, %s பார்க்க"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "மாறுவதற்கு கிளிக் செய்யவும்"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "உனது கணினியை உலாவு:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "வலை சேவையகம் பதிவேற்ற அடைவை <b>%s</b> தேர்ந்தெடுங்கள்:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "நீங்கள் தேர்வு செய்த வலை சேவையகம் பதிவேற்றை அடைய இயலவில்லை."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "பதிவேற்ற எந்த கோப்புகளும் இல்லை"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "வெறுமை"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "நிறைவேற்று"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "அச்சிடு"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "உருவாக்கம்"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "இறுதி இற்றைப்படுத்தல்"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "கடைசி சோதனை"
@@ -4302,9 +4289,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4589,7 +4576,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6843,7 +6830,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7235,57 +7222,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9398,24 +9385,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11997,7 +11984,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -12247,7 +12234,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12262,19 +12249,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12301,6 +12288,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/te.po
+++ b/po/te.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-30 15:46+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Telugu <http://l10n.cihar.com/projects/phpmyadmin/master/te/"
@@ -45,7 +45,7 @@ msgstr "పట్టిక వ్యాఖ్యలు"
 # మొదటి అనువాదము
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -91,7 +91,7 @@ msgid "Type"
 msgstr "రకం"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -350,7 +350,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -379,7 +379,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -585,8 +585,8 @@ msgstr "క్రొత్త వాడుకరిని చేర్చు"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -612,7 +612,7 @@ msgstr "క్రొత్త వాడుకరిని చేర్చు"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "వెళ్ళు"
@@ -966,7 +966,7 @@ msgid "Edit Index"
 msgstr "క్రొత్త వాడుకరిని చేర్చు"
 
 # మొదటి అనువాదము
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add into comments"
 msgid "Add %s column(s) to index"
@@ -1198,7 +1198,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "అమరికలు"
 
@@ -1538,8 +1538,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1789,8 +1789,8 @@ msgstr ""
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1818,7 +1818,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1896,8 +1896,8 @@ msgstr "గణాంకాలను చూపించు"
 msgid "Data point content"
 msgstr "విషయ సూచిక"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2625,8 +2625,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2688,8 +2688,8 @@ msgid "Restore column order"
 msgstr "పట్టిక వ్యాఖ్యలు"
 
 # మొదటి అనువాదము
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
@@ -2697,8 +2697,8 @@ msgid "Begin"
 msgstr "మొదలు"
 
 # మొదటి అనువాదము
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2707,8 +2707,8 @@ msgid "Previous"
 msgstr "క్రితము"
 
 # మొదటి అనువాదము
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2716,8 +2716,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "తదుపరి"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2900,9 +2900,9 @@ msgstr ""
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3092,9 +3092,9 @@ msgid "View"
 msgstr "చూపుము"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3108,9 +3108,9 @@ msgid "Structure"
 msgstr "నిర్మాణాకృతి"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
@@ -3118,23 +3118,23 @@ msgstr ""
 
 # Research అంటే పరిశోధన, అందువల్లన ఇది శోధనైంది
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "శోధించు"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3143,20 +3143,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3172,72 +3172,72 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr ""
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "వాడుకరి"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr ""
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "పొరపాటు"
@@ -3263,7 +3263,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3493,7 +3493,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3511,7 +3511,7 @@ msgstr "శోధించు"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3520,7 +3520,7 @@ msgid "Select columns (at least one):"
 msgstr ""
 
 # మొదటి అనువాదము
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "లేదా"
@@ -3640,287 +3640,287 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "More settings"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "మరిన్ని అమరికలు"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "More settings"
 msgid "A time, range is %1$s to %2$s"
 msgstr "మరిన్ని అమరికలు"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
 # మొదటి అనువాదము
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add into comments"
 msgid "A polygon"
 msgstr "స్పందనలకు చేర్చు"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "పుటని సృష్టించు"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "మొత్తం"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4005,68 +4005,68 @@ msgstr "%B %d, %Y at %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s రోజులు, %s గంటలు, %s నిమిషాలు మరియు %s క్షణాలు"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
 # మొదటి అనువాదము
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "ఖాళీ"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "ముద్రించు"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "సృష్టి"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "చివరి మార్పు"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "చివరి చూపు"
@@ -4428,9 +4428,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4718,7 +4718,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6998,7 +6998,7 @@ msgstr ""
 msgid "Language"
 msgstr "భాష"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "సంచిక సమాచారం"
 
@@ -7396,60 +7396,60 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
 # మొదటి అనువాదము
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "మరియు తరువాత"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
 # మొదటి అనువాదము
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "మునుపటి పుటకు వెళ్ళు"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
 # మొదటి అనువాదము
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "ఈ పుటకు తిరిగి వెళ్ళుము"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9622,24 +9622,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -12267,7 +12267,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "ప్రాధమిక అమరికలు"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Server configuration"
 msgid "Configuration has been saved"
@@ -12540,7 +12540,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12557,19 +12557,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12599,6 +12599,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/th.po
+++ b/po/th.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 15:14+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Thai <http://l10n.cihar.com/projects/phpmyadmin/master/th/>\n"
@@ -40,7 +40,7 @@ msgstr "หมายเหตุของตาราง"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -86,7 +86,7 @@ msgid "Type"
 msgstr "ชนิด"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -338,7 +338,7 @@ msgid "Updated"
 msgstr "ปรับปรุงแล้ว"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -366,7 +366,7 @@ msgid "Delete tracking data for this table"
 msgstr "ลบการติดตามตารางนี้"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -570,8 +570,8 @@ msgstr "เพิ่มเรขาคณิต"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -597,7 +597,7 @@ msgstr "เพิ่มเรขาคณิต"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "ไป"
@@ -965,7 +965,7 @@ msgstr "เพิ่มดัชนีใหม่"
 msgid "Edit Index"
 msgstr "แก้ไขดัชนี"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "เพิ่มคอลัมน์ %s ไปยังดัชนี"
@@ -1182,7 +1182,7 @@ msgid "Traffic"
 msgstr "การจราจร"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "การตั้งค่า"
 
@@ -1485,8 +1485,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1697,8 +1697,8 @@ msgstr "แสดงช่องคำค้น SQL"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1725,7 +1725,7 @@ msgstr "เวลาที่ทำคำสั่ง"
 msgid "%d is not valid row number."
 msgstr "﻿%d ไม่ใช่หมายเลขแถวที่ถูกต้อง"
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1801,8 +1801,8 @@ msgstr "ผลลัพธ์ SQL"
 msgid "Data point content"
 msgstr "สารบัญ"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "ข้าม"
 
@@ -2353,7 +2353,7 @@ msgstr "ไฟล์ตั้งค่า %s ไม่สามารถอ่�
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "สิทธิสำหรับไฟล์ตั้งค่าไม่ถูกต้อง ที่ถูกต้องจะต้องแก้ไขได้เฉพาะ root"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "ขนาดตัวอักษร"
 
@@ -2512,8 +2512,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] "พบ %s ผลลัพธ์ที่ตรงในตาราง <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2571,14 +2571,14 @@ msgstr "บันทึกข้อมูลที่แก้ไข"
 msgid "Restore column order"
 msgstr "เพิ่ม/ลบ คอลัมน์ (ฟิลด์)"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "เริ่มต้น"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2586,15 +2586,15 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "ก่อนหน้า"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "ถัดไป"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "สุดท้าย"
@@ -2784,9 +2784,9 @@ msgstr "เลือกทั้งหมด"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2977,9 +2977,9 @@ msgid "View"
 msgstr "ตารางจำลอง (View)"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2993,32 +2993,32 @@ msgid "Structure"
 msgstr "โครงสร้าง"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "ค้นหา"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "แทรก"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3027,20 +3027,20 @@ msgid "Privileges"
 msgstr "สิทธิ"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "กระบวนการ"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "การติดตาม"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3056,71 +3056,71 @@ msgstr "ทริกเกอร์"
 msgid "Database seems to be empty!"
 msgstr "ดูเหมือนว่าฐานข้อมูลจะว่างเปล่า!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "คำค้นจากตัวอย่าง"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "เหตุการณ์"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "ผู้ออกแบบ"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "ฐานข้อมูล"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "ผู้ใช้"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 #, fuzzy
 msgid "Binary log"
 msgstr "ข้อมูลไบนารี "
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "การจำลองแบบ"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "ตัวแปร"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "ชุดอักขระ"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "ปลั๊กอิน"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "เครื่องมือ"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "ผิดพลาด"
@@ -3143,7 +3143,7 @@ msgid "%1$d row inserted."
 msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d ระเบียนถูกเพิ่ม"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3373,7 +3373,7 @@ msgid "Operator"
 msgstr "กระบวนการ"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3390,7 +3390,7 @@ msgstr "ค้นหา"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3402,7 +3402,7 @@ msgstr "แทรก"
 msgid "Select columns (at least one):"
 msgstr "เลือกฟิลด์ (อย่างน้อยหนึ่งฟิลด์):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "หรือ"
@@ -3529,111 +3529,111 @@ msgstr "﻿เส้นทางของชุดรูปแบบ %s ไม�
 msgid "Theme:"
 msgstr "﻿ชุดรูปแบบ"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "วันเวลา ช่วงที่ได้รับการสนับสนุน %1$s ถึง %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "มีข้อผิดพลาดจากเปลี่ยนชื่อตาราง %1$s เป็น %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, fuzzy, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3642,7 +3642,7 @@ msgstr ""
 "﻿คุณคงไม่ได้สร้างแฟ้มการกำหนดค่า คุณอาจต้องการใช้ %1$ssetup script%2$s "
 "เพื่อสร้างอย่างใดอย่างหนึ่ง"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 #, fuzzy
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
@@ -3652,170 +3652,170 @@ msgstr ""
 "คุณควรตรวจสอบโฮสต์ ชื่อผู้ใช้และรหัสผ่านในการกำหนดค่าของคุณ และให้แน่ใจว่าค่าต่างๆ "
 "สอดคล้องกับข้อมูลที่กำหนดไว้ โดยผู้ดูแลระบบของเซิร์ฟเวอร์ MySQL แล้ว"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add a polygon"
 msgid "A polygon"
 msgstr "เพิ่มรูปหลายเหลี่ยม"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "คอลเลคชั่นของพอยต์"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "คอลเลคชั่นของรูปหลายเหลี่ยม"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "คอลเลคชั่นของวัตถุรูปทรงเรขาคณิตประเภทใดๆ"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "ตัวเลข"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "สร้างดัชนีใหม่"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Linestring"
 msgctxt "string types"
 msgid "String"
 msgstr "แถวข้อความ"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "รวม"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "จริงหรือเท็จ"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3902,70 +3902,70 @@ msgstr "%d %B %Y  %Rน."
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s วัน, %s ชั่วโมง, %s นาที, %s วินาที"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Add new field"
 msgid "Missing parameter:"
 msgstr "เพิ่มฟิลด์ใหม่"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "กระโดดไปที่ฐานข้อมูล &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "คลิกเพื่อสลับ"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "เรียกดูคอมพิวเตอร์ของคุณ:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "ไดเรกทอรีสำหรับอัพโหลด ที่เว็บเซิร์ฟเวอร์"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "ไม่สามารถใช้งาน ไดเรกทอรีที่ตั้งไว้สำหรับอัพโหลดได้"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "ไม่มีไฟล์ที่จะอัพโหลด"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "ลบข้อมูล"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "ดำเนินการ"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "พิมพ์"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "สร้างเมื่อ"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "ปรับปรุงครั้งสุดท้ายเมื่อ"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "ตรวจสอบครั้งสุดท้ายเมื่อ"
@@ -4336,9 +4336,9 @@ msgstr "อนุญาตให้ผู้ใช้แก้ไขค่าน
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "ตั้งค่าใหม่"
 
@@ -4635,7 +4635,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "บันทึกเป็นไฟล์"
 
@@ -6973,7 +6973,7 @@ msgstr ""
 msgid "Language"
 msgstr "ภาษา"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "ข้อมูลเวอร์ชั่น"
 
@@ -7374,60 +7374,60 @@ msgstr "เนื่องจากความยาวของมัน <br /
 msgid "Binary - do not edit"
 msgstr "ข้อมูลไบนารี - ห้ามแก้ไข"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "ไดเรกทอรีสำหรับอัพโหลด ที่เว็บเซิร์ฟเวอร์"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "แทรกเป็นแถวใหม่"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "ส่งกลับ"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "แทรกระเบียนใหม่"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 #, fuzzy
 msgid "Go back to this page"
 msgstr "ส่งกลับ"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9638,25 +9638,25 @@ msgid "There are no events to display."
 msgstr "ไม่มีเหตุการณ์ใดๆ"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "ไม่มีตาราง \"%s\"!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "กรุณาตั้งค่าโคออร์ดิเนตของตาราง %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12341,7 +12341,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "จัดการการตั้งค่าของคุณ"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12625,7 +12625,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "คุณไม่มีการตั้งค่าที่บันทึกไว้!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12642,19 +12642,19 @@ msgstr ""
 "คุณสามารถกำหนดการตั้งค่าเพิ่มเติมได้โดยแก้ไข config.inc.php เช่น โดยการใช้ %sSetup "
 "script%s"
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "บันทึกไปยังที่เก็บข้อมูลของเบราเซอร์"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "การตั้งค่าจะถูกบันทึกไว้ในที่เก็บข้อมูลของเบราเซอร์ภายในเครื่องของคุณ"
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "ถ้ามีการตั้งค่าอยู่แล้วจะถูกเขียนทับ!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "คุณสามารถรีเซ็ตการตั้งค่าทั้งหมดของคุณและเรียกคืนเป็นค่าเริ่มต้น"
 
@@ -12685,6 +12685,10 @@ msgstr "ไม่มีฐานข้อมูล"
 #, fuzzy
 msgid "View dump (schema) of databases"
 msgstr "ดูโครงสร้างของฐานข้อมูล"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/tk.po
+++ b/po/tk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-05-07 17:12+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Turkmen <http://l10n.cihar.com/projects/phpmyadmin/master/tk/"
@@ -45,7 +45,7 @@ msgstr ""
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -91,7 +91,7 @@ msgid "Type"
 msgstr ""
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -340,7 +340,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -368,7 +368,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -562,8 +562,8 @@ msgstr ""
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -589,7 +589,7 @@ msgstr ""
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Git"
@@ -917,7 +917,7 @@ msgstr ""
 msgid "Edit Index"
 msgstr ""
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr ""
@@ -1130,7 +1130,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr ""
 
@@ -1424,8 +1424,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1634,8 +1634,8 @@ msgstr ""
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1662,7 +1662,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1731,8 +1731,8 @@ msgstr ""
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2270,7 +2270,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2417,8 +2417,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2474,28 +2474,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr ""
@@ -2671,9 +2671,9 @@ msgstr ""
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2858,9 +2858,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2874,32 +2874,32 @@ msgid "Structure"
 msgstr ""
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr ""
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Gözle"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2908,20 +2908,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2937,70 +2937,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr ""
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr ""
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr ""
@@ -3026,7 +3026,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3243,7 +3243,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3258,7 +3258,7 @@ msgstr ""
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3266,7 +3266,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr ""
@@ -3376,278 +3376,278 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr ""
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3732,67 +3732,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr ""
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr ""
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr ""
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr ""
@@ -4145,9 +4145,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4428,7 +4428,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6644,7 +6644,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7035,57 +7035,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9103,24 +9103,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11593,7 +11593,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -11841,7 +11841,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -11856,19 +11856,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -11895,6 +11895,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/tr.po
+++ b/po/tr.po
@@ -3,15 +3,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-26 07:43+0200\n"
 "Last-Translator: Burak Yavuz <hitowerdigit@hotmail.com>\n"
-"Language-Team: Turkish "
-"<http://l10n.cihar.com/projects/phpmyadmin/master/tr/>\n"
-"Language: tr\n"
+"Language-Team: Turkish <http://l10n.cihar.com/projects/phpmyadmin/master/tr/"
+">\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: tr\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -41,7 +41,7 @@ msgstr "Tablo yorumları:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -87,7 +87,7 @@ msgid "Type"
 msgstr "Türü"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -335,7 +335,7 @@ msgid "Updated"
 msgstr "Güncellendi"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -363,7 +363,7 @@ msgid "Delete tracking data for this table"
 msgstr "Bu tablo için izleme verisini sil"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -564,8 +564,8 @@ msgstr "Geometri ekle"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -591,7 +591,7 @@ msgstr "Geometri ekle"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Git"
@@ -969,7 +969,7 @@ msgstr "İndeksi ekle"
 msgid "Edit Index"
 msgstr "İndeksi düzenle"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "İndekse %s sütun ekle"
@@ -1186,7 +1186,7 @@ msgid "Traffic"
 msgstr "Trafik"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Ayarlar"
 
@@ -1500,8 +1500,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1712,8 +1712,8 @@ msgstr "Sorgu kutusunu göster"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1740,7 +1740,7 @@ msgstr "Sorgu yürütme süresi"
 msgid "%d is not valid row number."
 msgstr "%d geçerli bir satır sayısı değil."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1814,8 +1814,8 @@ msgstr "Sorgu sonuçları"
 msgid "Data point content"
 msgstr "Veri imleci içeriği"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Yoksay"
 
@@ -2370,7 +2370,7 @@ msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 "Yapılandırma dosyasında yanlış izinler, herkesçe yazılabilir olmamalıdır!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Yazı Tipi boyutu"
 
@@ -2515,8 +2515,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] "<strong>%2$s</strong> tablosu içerisinde %1$s eşleşme"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2572,28 +2572,28 @@ msgstr "Düzenlenen veriyi kaydet"
 msgid "Restore column order"
 msgstr "Sütun düzenini geri yükle"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Başlangıç"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Önceki"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Sonraki"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Son"
@@ -2770,9 +2770,9 @@ msgstr "Tümünü Seç"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2962,9 +2962,9 @@ msgid "View"
 msgstr "Görünüm"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2978,32 +2978,32 @@ msgid "Structure"
 msgstr "Yapı"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Ara"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Ekle"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3012,20 +3012,20 @@ msgid "Privileges"
 msgstr "Yetkiler"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "İşlemler"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "İzleme"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3041,70 +3041,70 @@ msgstr "Tetikleyiciler"
 msgid "Database seems to be empty!"
 msgstr "Veritabanı boş olarak görünüyor!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Sorgu"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Yordamlar"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Olaylar"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Tasarımcı"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Veritabanları"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Kullanıcılar"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binari günlüğü"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Kopya Etme"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Değişkenler"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Karakter Grupları"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Eklentiler"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Motorlar"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Hata"
@@ -3127,7 +3127,7 @@ msgid "%1$d row inserted."
 msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d satır eklendi."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3348,7 +3348,7 @@ msgid "Operator"
 msgstr "İşletici"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3363,7 +3363,7 @@ msgstr "Tablo Arama"
 msgid "Find and Replace"
 msgstr "Bul ve Değiştir"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Düzenle/Ekle"
 
@@ -3371,7 +3371,7 @@ msgstr "Düzenle/Ekle"
 msgid "Select columns (at least one):"
 msgstr "Sütunları seç (en az bir):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Veya"
@@ -3481,14 +3481,14 @@ msgstr "%s teması için tema yolu bulunamadı!"
 msgid "Theme:"
 msgstr "Tema:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "1-bayt'lık bir tamsayı, işaretli aralığı -128'den 127'ye kadardır, işaretsiz "
 "aralığı 0'dan 255'e kadardır"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3496,7 +3496,7 @@ msgstr ""
 "2-bayt'lık bir tamsayı, işaretli aralığı -32,768'den 32,767'ye kadardır, "
 "işaretsiz aralığı 0'dan 65,535'e kadardır"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3504,7 +3504,7 @@ msgstr ""
 "3-bayt'lık bir tamsayı, işaretli aralığı -8,388,608'den 8,388,607'ye "
 "kadardır, işaretsiz aralığı 0'dan 16,777,215'e kadardır"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3512,7 +3512,7 @@ msgstr ""
 "4-bayt'lık bir tamsayı, işaretli aralığı -2,147,483,648'den 2,147,483,647'ye "
 "kadardır, işaretsiz aralığı 0'dan 4,294,967,295'e kadardır"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3521,7 +3521,7 @@ msgstr ""
 "9,223,372,036,854,775,807'ye kadardır, işaretsiz aralığı 0'dan "
 "18,446,744,073,709,551,615'e kadardır"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3529,7 +3529,7 @@ msgstr ""
 "Sabit noktalı bir sayı (M, D) - rakamların (M) en fazla sayısı 65'tir, "
 "ondalıkların (D) en fazla sayısı 30'dur. (varsayılan 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3537,7 +3537,7 @@ msgstr ""
 "Küçük kayan noktalı bir sayı, izin verilebilir değerler -3.402823466E+38'den "
 "-1.175494351E-38'e, 0 ve 1.175494351E-38'den 3.402823466E+38'e kadardır"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3547,7 +3547,7 @@ msgstr ""
 "1.7976931348623157E+308'den -2.2250738585072014E-308'e, 0 ve "
 "2.2250738585072014E-308'den 1.7976931348623157E+308'e kadardır"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
@@ -3555,7 +3555,7 @@ msgstr ""
 "DOUBLE için eş anlamlı (istisna: REAL_AS_FLOAT SQL kipte FLOAT için eş "
 "anlamlıdır)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
@@ -3563,7 +3563,7 @@ msgstr ""
 "Bir bit alanı türü (M), değer (varsayılan 1'dir, en fazla 64'tür) başına "
 "bit'lerin M'sini saklar"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
@@ -3571,21 +3571,21 @@ msgstr ""
 "TINYINT(1) için bir eş anlam, sıfır değeri false sayılır, sıfır olmayan "
 "değerler true sayılır"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE için bir kod adı"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Bir tarih, desteklenen aralık %1$s ile %2$s arası"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Bir tarih ve saat birleşimi, desteklenen aralık %1$s ile %2$s arası"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3594,12 +3594,12 @@ msgstr ""
 "03:14:07\" UTC arası, devirden (\"1970-01-01 00:00:00\" UTC) bu yana saniye "
 "sayısı olarak saklanır"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Bir saat, aralığı %1$s ile %2$s arası"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3608,7 +3608,7 @@ msgstr ""
 "verilebilir değerler 70 (1970) ile 69 (2069) arası ya da 1901 ile 2155 arası "
 "ve 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
@@ -3616,7 +3616,7 @@ msgstr ""
 "Saklandığında belirlenmiş uzunluğa sağdan takviyeli boşluklu sabit uzunluk "
 "(0-255, varsayılan 1) dizgisi"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3625,7 +3625,7 @@ msgstr ""
 "Değişken uzunluk (%s) dizgisi, en fazla satır boyutu etkili en fazla uzunluk "
 "konusudur"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3633,7 +3633,7 @@ msgstr ""
 "En fazla 255 (2^8 - 1) karakter uzunluğunda bir TEXT sütunu, bayt'larda "
 "değerin uzunluğunu gösteren bir-bayt'lık bir ön ek ile saklanır"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3641,7 +3641,7 @@ msgstr ""
 "En fazla 65,535 (2^16 - 1) karakter uzunluğunda bir TEXT sütunu, bayt'larda "
 "değerin uzunluğunu gösteren iki-bayt'lık bir ön ek ile saklanır"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3649,7 +3649,7 @@ msgstr ""
 "En fazla 16,777,215 (2^24 - 1) karakter uzunluğunda bir TEXT sütunu, "
 "bayt'larda değerin uzunluğunu gösteren üç-bayt'lık bir ön ek ile saklanır"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3659,7 +3659,7 @@ msgstr ""
 "sütunu, bayt'larda değerin uzunluğunu gösteren dört-bayt'lık bir ön ek ile "
 "saklanır"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3667,7 +3667,7 @@ msgstr ""
 "CHAR türü benzeridir ama binari olmayan karakter dizgileri yerine binari "
 "bayt dizgilerini saklar"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
@@ -3675,7 +3675,7 @@ msgstr ""
 "VARCHAR türü benzeridir ama binari olmayan karakter dizgileri yerine binari "
 "bayt dizgilerini saklar"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3683,7 +3683,7 @@ msgstr ""
 "En fazla 255 (2^8 - 1) bayt uzunluğunda bir BLOB sütunu, değerin uzunluğunu "
 "gösteren bir-bayt'lık bir ön ek ile saklanır"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3691,7 +3691,7 @@ msgstr ""
 "En fazla 16,777,215 (2^24 - 1) bayt uzunluğunda bir BLOB sütunu, değerin "
 "uzunluğunu gösteren üç-bayt'lık bir ön ek ile saklanır"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3699,7 +3699,7 @@ msgstr ""
 "En fazla 65,535 (2^16 - 1) bayt uzunluğunda bir BLOB sütunu, değerin "
 "uzunluğunu gösteren iki-bayt'lık bir ön ek ile saklanır"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3707,7 +3707,7 @@ msgstr ""
 "En fazla 4,294,967,295 veya 4GiB (2^32 - 1) bayt uzunluğunda bir BLOB "
 "sütunu, değerin uzunluğunu gösteren dört-bayt'lık bir ön ek ile saklanır"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
@@ -3715,68 +3715,68 @@ msgstr ""
 "Bir numaralandırma, 65,535 değerine kadar olan listeden seçilir ya da özel "
 "\" hata değeridir"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "64 üyeye kadar olan bir gruptan seçilen tek bir değerdir"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "Herhangi bir türün geometrisini saklayabilen bir tür"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "2-boyutlu uzayda bir nokta"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "Noktalar arasındaki doğrusal eklentili bir eğri"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Poligon"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "Noktalar topluluğu"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "Noktalar arasındaki doğrusal eklentili bir eğri topluluğu"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "Poligonlar topluluğu"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "Herhangi bir türün geometri nesneleri topluluğu"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "Sayısal"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Tarih ve saat"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Dizgi"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Uzaysal"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 "4-bayt'lık bir tamsayı, aralığı -2,147,483,648'den 2,147,483,647'ye kadardır"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3784,23 +3784,23 @@ msgstr ""
 "8-bayt'lık bir tamsayı, aralığı -9,223,372,036,854,775,808'den "
 "9,223,372,036,854,775,807'ye kadardır"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "Sistemin varsayılan çift duyarlıklı kayan noktalı bir sayısı"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "True veya false"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT NOT NULL AUTO_INCREMENT UNIQUE için bir kod adı"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "Evrensel Benzersiz Tanımlayıcıyı (UUID) saklar"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3808,7 +3808,7 @@ msgstr ""
 "Bir zaman damgası, aralığı \"0001-01-01 00:00:00\" UTC ile \"9999-12-31 "
 "23:59:59\" UTC arası; TIMESTAMP(6) mikro saniyeleri saklayabilir"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
@@ -3816,7 +3816,7 @@ msgstr ""
 "Değişken uzunlukta bir (0-65,535) dizgi, tüm karşılaştırmalar için binari "
 "karşılaştırma kullanır"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "Bir numaralandırma, tanımlanmış değerlerin listesinden seçilir"
 
@@ -3901,67 +3901,67 @@ msgstr "%d %B %Y, %H:%M:%S"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s gün, %s saat, %s dakika ve %s saniye"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Eksik parametreler:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "&quot;%s&quot; veritabanına git."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s işlevselliği bilinen bir hata tarafından zarar görmüş, bakınız %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Değiştirmek için tıklayın"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Bilgisayarınıza gözat:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Web sunucusu gönderme dizininden <b>%s</b> seçin:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Gönderme işi için ayarladığınız dizine ulaşılamıyor."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Göndermek için hiç dosya yok"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Boşalt"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Çalıştır"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Yazdır"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Oluşturma"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Son güncelleme"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Son kontrol"
@@ -4318,9 +4318,9 @@ msgstr "Bu değeri özelleştirmek için kullanıcılara izin ver"
 msgid "Apply"
 msgstr "Uygula"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Sıfırla"
 
@@ -4633,7 +4633,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "En fazla yürütme süresi"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Dosya olarak kaydet"
 
@@ -7061,7 +7061,7 @@ msgstr "Dosya işleme alındı, lütfen sabırlı olun."
 msgid "Language"
 msgstr "Dil"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Sürüm bilgisi"
 
@@ -7507,59 +7507,59 @@ msgstr "Uzunluğu nedeniyle,<br /> bu sütun düzenlenebilir olmayabilir"
 msgid "Binary - do not edit"
 msgstr "Binari - düzenlemeyiniz"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "web sunucusu gönderme dizini:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "%s satırla eklemeye devam et"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "ve ondan sonra"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Yeni satır olarak ekle"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Yeni satır olarak ekle ve hataları yoksay"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Ekleme sorgusunu göster"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Önceki sayfaya geri dön"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Yeni başka bir satır ekle"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Bu sayfaya geri dön"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Sonraki satırı düzenle"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Değerden değere geçmek için TAB tuşunu veya herhangi bir yere gitmek için "
 "CTRL+OK TUŞLARI'nı kullanın"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "SQL sorgusu gösteriliyor"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Eklenen satır id: %1$d"
@@ -7889,7 +7889,6 @@ msgid "Database operations"
 msgstr "Veritabanı işlemleri"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Gizli öğeleri göster"
 
@@ -9700,24 +9699,24 @@ msgid "There are no events to display."
 msgstr "Görüntülemek için olaylar yok."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "%s tablosu yok!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Lütfen %s tablosu için koordinatları yapılandırın"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "%s veritabanının şeması - Sayfa %s"
@@ -12410,7 +12409,7 @@ msgstr "Sürüm %1$s oluşturuldu, %2$s için izleme aktif."
 msgid "Manage your settings"
 msgstr "Ayarlarınızı yönetin"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Yapılandırma kaydedildi"
 
@@ -12662,7 +12661,7 @@ msgstr "Ayarlar tarayıcınızın yerel depolamasından içe aktarılacaktır."
 msgid "You have no saved settings!"
 msgstr "Kaydedilmiş ayarlarınız yok!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Bu özellik web tarayıcınız tarafından desteklenmez"
 
@@ -12679,19 +12678,19 @@ msgstr ""
 "Config.inc.php dosyasını değiştirerek daha fazla ayar yapabilirsiniz, örn. %"
 "sKur programcığı%s kullanarak."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Tarayıcının depolamasına kaydet"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Ayarlar tarayıcının yerel depolamasına kaydedilecektir."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Mevcut ayarlar üzerine yazılacak!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Tüm ayarlarınızı sıfırlayabilir ve varsayılan değerlere geri "
@@ -12721,6 +12720,10 @@ msgstr "Veritabanı yok"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Veritabanlarının dökümünü (şemasını) göster"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/tt.po
+++ b/po/tt.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:43+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Tatar <http://l10n.cihar.com/projects/phpmyadmin/master/tt/>\n"
@@ -40,7 +40,7 @@ msgstr "Tüşämä açıqlaması"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -88,7 +88,7 @@ msgid "Type"
 msgstr "Töre"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -352,7 +352,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -380,7 +380,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -597,8 +597,8 @@ msgstr "Yaña qullanuçı östäw"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -624,7 +624,7 @@ msgstr "Yaña qullanuçı östäw"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Äydä"
@@ -1004,7 +1004,7 @@ msgstr "Tezeş"
 msgid "Edit Index"
 msgstr "Kiläse yazma üzgärtü"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add %s field(s)"
 msgid "Add %s column(s) to index"
@@ -1248,7 +1248,7 @@ msgid "Traffic"
 msgstr "Taşım"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1582,8 +1582,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1836,8 +1836,8 @@ msgstr "SQL-soraw"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1864,7 +1864,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr "%d digäne yazma sanı öçen kileşmi."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1945,8 +1945,8 @@ msgstr "Soraw qaytarmasın eşkärtü"
 msgid "Data point content"
 msgstr "Data pointer olılığı"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Qarama"
 
@@ -2568,7 +2568,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2733,8 +2733,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] "%s kileşü bar, <i>%s</i> atlı tüşämädä"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2800,16 +2800,16 @@ msgstr "Biremnär törgäge"
 msgid "Restore column order"
 msgstr "Add/Delete Field Columns"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Başlawğa"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2817,8 +2817,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Uzğan"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2826,8 +2826,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Kiläse"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3021,9 +3021,9 @@ msgstr "Saylap Beter"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3214,9 +3214,9 @@ msgid "View"
 msgstr "Qaraş"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3230,32 +3230,32 @@ msgid "Structure"
 msgstr "Tözeleş"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Ezläw"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Östäw"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3264,20 +3264,20 @@ msgid "Privileges"
 msgstr "Xoquqlar"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Eşkärtü"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3293,16 +3293,16 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Soraw"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
@@ -3310,57 +3310,57 @@ msgstr ""
 msgid "Events"
 msgstr "Cibärelde"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Biremleklär"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Qullanuçı"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Binar köndälek"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 #, fuzzy
 msgid "Replication"
 msgstr "Bäyläneşlär"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Üzgärmälär"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Bilgelämä"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Engine"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Xata"
@@ -3387,7 +3387,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "Kertemnär sayladı"
 msgstr[1] "Kertemnär sayladı"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3617,7 +3617,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3634,7 +3634,7 @@ msgstr "Ezläw"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3646,7 +3646,7 @@ msgstr "Östäw"
 msgid "Select columns (at least one):"
 msgstr "Alannar saylísı (iñ kimendä ber):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Yä"
@@ -3771,287 +3771,287 @@ msgstr "%s digän tışlaw urınlaşqan yul tabılmadı!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Server söreme"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "%1$s atlı tüşämä adın %2$s itep üzgärtep bulmadı"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add %s field(s)"
 msgid "A polygon"
 msgstr "%s alan östäw"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Yaña tezeş yaratu"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Yul ara bilgese"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Tulayım"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4140,68 +4140,68 @@ msgstr "%Y.%m.%d, %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s kön, %s säğät, %s minut ta %s sekund"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "&quot;%s&quot; biremlegenä küç."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "web-server'neñ yökläw törgäge"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Yökläw öçen bigelängän törgäkne uqıp bulmí."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Buşat"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Bastır"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Yasalışı"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Soñğı yañartılu"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Soñğı tikşerü"
@@ -4577,9 +4577,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Awdar"
 
@@ -4876,7 +4876,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Biremgä saqlıysı"
 
@@ -7299,7 +7299,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Söreme turında"
 
@@ -7716,62 +7716,62 @@ msgstr "Because of its length,<br /> this field might not be editable"
 msgid "Binary - do not edit"
 msgstr "Binar - üzgärtmäslek"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "web-server'neñ yökläw törgäge"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ", şunnan soñ"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Yaña yazma kert tä"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Aldağı bitkä qaytu"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Tağın ber yazma östäw"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Bu bitkä kire qaytası"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Kiläse yazma üzgärtü"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Ber bäyädän ikençegä küçü öçen TAB töymäsen qullanası, başqa cirgä küçü "
 "öçen, CTRL+uq töymäläre bar"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 #, fuzzy
 msgid "Showing SQL query"
 msgstr "Tulı Sorawlar Kürsät"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -10053,25 +10053,25 @@ msgid "There are no events to display."
 msgstr "Tüşämä tikşerü"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "\"%s\" atlı tüşämä yuq äle!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -12788,7 +12788,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Bäyläneşlär buyınça töp mömkinleklär"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13078,7 +13078,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13093,19 +13093,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13135,6 +13135,10 @@ msgstr "Biremleklär yuq"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Biremleklärneñ eçtälegen (tözeleşen) çığaru"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/ug.po
+++ b/po/ug.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 15:29+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Uighur <http://l10n.cihar.com/projects/phpmyadmin/master/ug/"
@@ -44,7 +44,7 @@ msgstr "جەدۋەل ئىزاھى"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -90,7 +90,7 @@ msgid "Type"
 msgstr "تۈرى"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -346,7 +346,7 @@ msgid "Updated"
 msgstr "يېڭلاش"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -374,7 +374,7 @@ msgid "Delete tracking data for this table"
 msgstr "سانلىق مەلۇماتنى ئىزقوغلاپ ئۈچۈرۈش"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -583,8 +583,8 @@ msgstr "مەجبۇرى قوشۇش"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -610,7 +610,7 @@ msgstr "مەجبۇرى قوشۇش"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "ئىجرا قىلىش"
@@ -984,7 +984,7 @@ msgstr "تېزىسلار"
 msgid "Edit Index"
 msgstr "قىستۇرۇش"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add/Delete columns"
 msgid "Add %s column(s) to index"
@@ -1220,7 +1220,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1557,8 +1557,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1808,8 +1808,8 @@ msgstr "SQL سورىقى"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr "%dئۈنۈملۈك قۇر سانى ئەمەس."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1919,8 +1919,8 @@ msgstr "SQL سورىقى"
 msgid "Data point content"
 msgstr "سانلىق مەلۇمات قوللانمىسىنىڭ چوڭ كىچىكلىكى"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "خەتنىڭ چوڭ-كىچىكلىكى"
 
@@ -2655,8 +2655,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] "%s ئۇيغۇنلۇق تىپىلدى، جەدۋىلى <i>%s</i>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2719,16 +2719,16 @@ msgstr ""
 msgid "Restore column order"
 msgstr "سۆزلەم قوشۇش\\ئۆچۈرۈش"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "باشلا"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2736,8 +2736,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "ئالدىنقىسى"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2745,8 +2745,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "كىيىنكى ئاي"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2931,9 +2931,9 @@ msgstr "ھەممىنى تاللاش"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3124,9 +3124,9 @@ msgid "View"
 msgstr "قاراش"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3140,32 +3140,32 @@ msgid "Structure"
 msgstr "تۈزۈلىشى"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "ئىزدەش"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "قىستۇرۇش"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3174,20 +3174,20 @@ msgid "Privileges"
 msgstr "ھۇقۇقى"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "ئىشلەملەر"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "ئىز قۇغلاش"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3203,70 +3203,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr "سانلىق مەلۇمات ئامبىرى قۇرۇق!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "تەكشۈرۈش"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "دائىملىق"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "ھادىسە"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "لايىھەلىگۈچ"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "ساندان"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "كۆچۈرۈش"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "خاتالىق"
@@ -3289,7 +3289,7 @@ msgid "%1$d row inserted."
 msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d قۇر قوشۇلدى."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3517,7 +3517,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3534,7 +3534,7 @@ msgstr "ئىزدەش"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3544,7 +3544,7 @@ msgstr "قىستۇرۇش"
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "ياكى"
@@ -3666,286 +3666,286 @@ msgstr "ماۋزۇ %s تېپىلمىدى!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "Create version"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "نەشىرنى قۇىماق"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "%1$s بۇ جەدۋەل ئىسمىنى %2$s غا ئۆزگەرتىشتە خاتالىق كۆرۈلدى."
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "نەشىرنى قۇىماق"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "قۇر ئالماشۇرۇش بەلگىسى"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "كۈندىلىك ھۆججەت ئۇمۇمىي سانى"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4032,72 +4032,72 @@ msgstr "%يىل %ئاي %كۈن %سائەت:%مىنۇت"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s كۈن, %s سائەت, %s مىنىۇ ۋە %s سېكوند"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "دائىملىق"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "ساندان &quot;%s&quot; .غا ئۆتۈش."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 #, fuzzy
 #| msgid "Click to select"
 msgid "Click to toggle"
 msgstr "بىر چىكىپ تاللاڭ"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "مۇلازىمىتېردىكى يۈكلەش مۇندەرىجىسى"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "كۆرسىتىلگەن مۇندەرىجىگە يۈكلىيەلمىدى."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "تازىلاش"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "يازدۇر"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "قۇرۇش"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "ئاخىرقى يېڭلىنىش"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "ئاخىرقى تەكشۈرۈش"
@@ -4464,9 +4464,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4751,7 +4751,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "ھۆججەتنى باشقا ساقلاش"
 
@@ -7093,7 +7093,7 @@ msgstr "بىتەرەپ قىلىنىۋاتىدۇ، ساقلاڭ."
 msgid "Language"
 msgstr "تىلى"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7488,59 +7488,59 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "مۇلازىمىتېردىكى يۈكلەش مۇندەرىجىسى"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "كېيىن"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9731,24 +9731,24 @@ msgid "There are no events to display."
 msgstr "ئىزلانغان جەدۋەل"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -12357,7 +12357,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "ئاساسىي ئالاقە ۋاريانتلىرى"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12635,7 +12635,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12650,19 +12650,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12691,6 +12691,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/uk.po
+++ b/po/uk.po
@@ -3,15 +3,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-30 13:35+0200\n"
 "Last-Translator: Andriy Bandura <andriykopanytsia@gmail.com>\n"
-"Language-Team: Ukrainian "
-"<http://l10n.cihar.com/projects/phpmyadmin/master/uk/>\n"
-"Language: uk\n"
+"Language-Team: Ukrainian <http://l10n.cihar.com/projects/phpmyadmin/master/"
+"uk/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: uk\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
 "10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 1.9-dev\n"
@@ -37,13 +37,12 @@ msgstr "Коментар бази даних: "
 #: db_datadict.php:159 libraries/schema/Pdf_Relation_Schema.class.php:1348
 #: libraries/tbl_columns_definition_form.lib.php:70
 #: libraries/tbl_printview.lib.php:579
-#| msgid "Table comments"
 msgid "Table comments:"
 msgstr "Коментарі до таблиці:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +88,7 @@ msgid "Type"
 msgstr "Тип"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -270,19 +269,16 @@ msgstr "використовується"
 
 #: db_printview.php:117 libraries/plugins/export/ExportSql.class.php:1042
 #: libraries/schema/Pdf_Relation_Schema.class.php:1353
-#| msgid "Creation"
 msgid "Creation:"
 msgstr "Створення:"
 
 #: db_printview.php:126 libraries/plugins/export/ExportSql.class.php:1055
 #: libraries/schema/Pdf_Relation_Schema.class.php:1358
-#| msgid "Last update"
 msgid "Last update:"
 msgstr "Останнє оновлення:"
 
 #: db_printview.php:135 libraries/plugins/export/ExportSql.class.php:1068
 #: libraries/schema/Pdf_Relation_Schema.class.php:1363
-#| msgid "Last check"
 msgid "Last check:"
 msgstr "Остання перевірка:"
 
@@ -342,7 +338,7 @@ msgid "Updated"
 msgstr "Оновлено"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -370,7 +366,7 @@ msgid "Delete tracking data for this table"
 msgstr "Видалити дані відстеження для цієї таблиці"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -495,18 +491,15 @@ msgstr "Використовуйте OpenStreetMaps як базовий плас
 # Ідентифікатор просторової системи координат
 #. l10n: Spatial Reference System Identifier
 #: gis_data_editor.php:163
-#| msgid "SRID"
 msgid "SRID:"
 msgstr "SRID:"
 
 #: gis_data_editor.php:186
 #, php-format
-#| msgid "Geometry"
 msgid "Geometry %d:"
 msgstr "Геометрія %d:"
 
 #: gis_data_editor.php:208
-#| msgid "Point"
 msgid "Point:"
 msgstr "Точка:"
 
@@ -533,18 +526,15 @@ msgstr "Додати точку"
 
 #: gis_data_editor.php:264
 #, php-format
-#| msgid "Linestring"
 msgid "Linestring %d:"
 msgstr "Ламана %d:"
 
 #: gis_data_editor.php:267 gis_data_editor.php:343
-#| msgid "Outer Ring"
 msgid "Outer ring:"
 msgstr "Зовнішнє кільце:"
 
 #: gis_data_editor.php:269 gis_data_editor.php:345
 #, php-format
-#| msgid "Inner Ring"
 msgid "Inner ring %d:"
 msgstr "Внутрішнє кільце %d:"
 
@@ -558,7 +548,6 @@ msgstr "Додати внутрішнє кільце"
 
 #: gis_data_editor.php:327
 #, php-format
-#| msgid "Polygon"
 msgid "Polygon %d:"
 msgstr "Многокутник %d:"
 
@@ -576,8 +565,8 @@ msgstr "Додати геометрію (geometry)"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -603,7 +592,7 @@ msgstr "Додати геометрію (geometry)"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "Вперед"
@@ -707,7 +696,6 @@ msgid "Back"
 msgstr "Назад"
 
 #: index.php:115 libraries/Footer.class.php:70
-#| msgid "phpMyAdmin homepage"
 msgid "phpMyAdmin Demo Server"
 msgstr "Демо-сервер phpMyAdmin"
 
@@ -749,29 +737,24 @@ msgid "Server:"
 msgstr "Сервер:"
 
 #: index.php:254
-#| msgid "Server port"
 msgid "Server type:"
 msgstr "Тип сервера:"
 
 #: index.php:258 libraries/plugins/export/ExportLatex.class.php:225
 #: libraries/plugins/export/ExportSql.class.php:631
 #: libraries/plugins/export/ExportXml.class.php:198
-#| msgid "Server version"
 msgid "Server version:"
 msgstr "Версія сервера:"
 
 #: index.php:264
-#| msgid "Protocol version"
 msgid "Protocol version:"
 msgstr "Версія протоколу:"
 
 #: index.php:268
-#| msgid "User"
 msgid "User:"
 msgstr "Користувач:"
 
 #: index.php:273
-#| msgid "Server charset"
 msgid "Server charset:"
 msgstr "Кодування символів серверу:"
 
@@ -780,12 +763,10 @@ msgid "Web server"
 msgstr "Веб-сервер"
 
 #: index.php:303
-#| msgid "Database client version"
 msgid "Database client version:"
 msgstr "Версія клієнту бази даних:"
 
 #: index.php:307
-#| msgid "PHP extension"
 msgid "PHP extension:"
 msgstr "PHP розширення:"
 
@@ -794,7 +775,6 @@ msgid "Show PHP information"
 msgstr "Показати інформацію про PHP"
 
 #: index.php:344
-#| msgid "Version information"
 msgid "Version information:"
 msgstr "Відомості про версію:"
 
@@ -884,10 +864,6 @@ msgid "The configuration file now needs a secret passphrase (blowfish_secret)."
 msgstr "Конфігураційний файл потребує секретну фразу (пароль)."
 
 #: index.php:494
-#| msgid ""
-#| "Directory [code]config[/code], which is used by the setup script, still "
-#| "exists in your phpMyAdmin directory. You should remove it once phpMyAdmin "
-#| "has been configured."
 msgid ""
 "Directory [code]config[/code], which is used by the setup script, still "
 "exists in your phpMyAdmin directory. It is strongly recommended to remove it "
@@ -965,7 +941,6 @@ msgstr "Ця операція може зайняти багато часу.  П
 
 #: js/messages.php:44
 #, php-format
-#| msgid "Do you really want to execute \"%s\"?"
 msgid "Do you really want to delete user group \"%s\"?"
 msgstr "Ви дійсно бажаєте видалити групу користувачів \"%s\"?"
 
@@ -974,7 +949,6 @@ msgid "Missing value in the form!"
 msgstr "Не задано значення для форми!"
 
 #: js/messages.php:48
-#| msgid "Not a valid port number"
 msgid "Please enter a valid number"
 msgstr "Введіть вірний номер"
 
@@ -990,7 +964,7 @@ msgstr "Додати Індекс"
 msgid "Edit Index"
 msgstr "Редагувати Індекс"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "Додати до індексу %s стовпчик(ів)"
@@ -1207,7 +1181,7 @@ msgid "Traffic"
 msgstr "Трафік"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "Налаштування"
 
@@ -1519,8 +1493,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1730,8 +1704,8 @@ msgstr "Показати блок запиту"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1758,7 +1732,7 @@ msgstr "Час виконання запиту"
 msgid "%d is not valid row number."
 msgstr "%d неправильний номер рядка."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1776,12 +1750,10 @@ msgid "Show search criteria"
 msgstr "Показати критерії пошуку"
 
 #: js/messages.php:296
-#| msgid "Hide search criteria"
 msgid "Hide find and replace criteria"
 msgstr "Сховати критерії пошуку та заміни"
 
 #: js/messages.php:297
-#| msgid "Show search criteria"
 msgid "Show find and replace criteria"
 msgstr "Показати критерії пошуку та заміни"
 
@@ -1831,8 +1803,8 @@ msgstr "Результати запиту"
 msgid "Data point content"
 msgstr "Вміст точки даних"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Ігнорувати"
 
@@ -2005,7 +1977,6 @@ msgid "Hide Panel"
 msgstr "Приховати панель"
 
 #: js/messages.php:394
-#| msgid "Show logo in left frame"
 msgid "Show hidden navigation tree items"
 msgstr "Показати приховані пункти дерева навігації"
 
@@ -2038,7 +2009,6 @@ msgid "Create view"
 msgstr "Створити подання"
 
 #: js/messages.php:408
-#| msgid "Server port"
 msgid "Send Error Report"
 msgstr "Надіслати звіт про помилку"
 
@@ -2053,12 +2023,10 @@ msgid ""
 msgstr ""
 
 #: js/messages.php:413
-#| msgid "Change settings"
 msgid "Change Report Settings"
 msgstr "Змінити налаштування звіту"
 
 #: js/messages.php:414
-#| msgid "Show open tables"
 msgid "Show Report Details"
 msgstr "Показати подробиці звіту"
 
@@ -2361,7 +2329,6 @@ msgstr "Неочікувані символи в рядку %s."
 
 #: libraries/Advisor.class.php:439
 #, php-format
-#| msgid "Unexpected character on line %1$s. Expected tab, but found \"%2$s\""
 msgid "Unexpected character on line %1$s. Expected tab, but found \"%2$s\"."
 msgstr ""
 "Неочікуваний символ в рядку %1$s. Очікувався tab, але не знайдено \"%2$s\"."
@@ -2395,7 +2362,7 @@ msgstr ""
 "Невірні права доступу до конфігураційного файлу, він не повинен бути "
 "доступним для всіх!"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Розмір шрифту"
 
@@ -2418,22 +2385,18 @@ msgid "Descending"
 msgstr "Спадаючий"
 
 #: libraries/DBQbe.class.php:364 libraries/TableSearch.class.php:1346
-#| msgid "Column"
 msgid "Column:"
 msgstr "Стовпчик:"
 
 #: libraries/DBQbe.class.php:406
-#| msgid "Sort"
 msgid "Sort:"
 msgstr "Посортувати:"
 
 #: libraries/DBQbe.class.php:468
-#| msgid "Show"
 msgid "Show:"
 msgstr "Показати:"
 
 #: libraries/DBQbe.class.php:513
-#| msgid "Criteria"
 msgid "Criteria:"
 msgstr "Критерій:"
 
@@ -2454,7 +2417,6 @@ msgid "Use Tables"
 msgstr "Використовувати таблиці"
 
 #: libraries/DBQbe.class.php:655 libraries/DBQbe.class.php:763
-#| msgid "Or"
 msgid "Or:"
 msgstr "Або:"
 
@@ -2471,7 +2433,6 @@ msgid "Del"
 msgstr "Видалити"
 
 #: libraries/DBQbe.class.php:682
-#| msgid "Modify"
 msgid "Modify:"
 msgstr "Змінити:"
 
@@ -2550,8 +2511,8 @@ msgstr[1] "%1$s співпадіння у <strong>%2$s</strong>"
 msgstr[2] "%1$s співпадінь у <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2607,28 +2568,28 @@ msgstr "Зберегти відредаговані дані"
 msgid "Restore column order"
 msgstr "Відновити порядок стовпців"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "Почати"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "Попередній"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "Вперед"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "Кінець"
@@ -2639,7 +2600,6 @@ msgid "Number of rows:"
 msgstr "Число рядків:"
 
 #: libraries/DisplayResults.class.php:959
-#| msgid "Mode"
 msgid "Mode:"
 msgstr "Режим:"
 
@@ -2766,13 +2726,11 @@ msgstr ""
 
 #: libraries/DisplayResults.class.php:4926
 #, php-format
-#| msgid "Showing rows"
 msgid "Showing rows %1s - %2s"
 msgstr "Показано рядки %1s - %2s"
 
 #: libraries/DisplayResults.class.php:4938
 #, php-format
-#| msgid "total"
 msgid "%d total"
 msgstr "всього %d"
 
@@ -2809,9 +2767,9 @@ msgstr "Відмітити все"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2904,7 +2862,6 @@ msgid "Currently running Git revision %1$s from the %2$s branch."
 msgstr ""
 
 #: libraries/Footer.class.php:81
-#| msgid "Version information"
 msgid "Git information missing!"
 msgstr "Відсутня інформація про Git!"
 
@@ -3001,9 +2958,9 @@ msgid "View"
 msgstr "Подання"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3017,32 +2974,32 @@ msgid "Structure"
 msgstr "Структура"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Пошук"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Вставити"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3051,20 +3008,20 @@ msgid "Privileges"
 msgstr "Привілеї"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Операцій"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Відстеження"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3080,70 +3037,70 @@ msgstr "Тригери"
 msgid "Database seems to be empty!"
 msgstr "Порожня база даних!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Запит згідно прикладу"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Процедури"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Події"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Дизайнер"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Бази Даних"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "Користувачі"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Бінарний журнал"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Реплікація"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Змінні"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Кодування"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "Плагіни"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Типи таблиць"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Помилка"
@@ -3172,7 +3129,7 @@ msgstr[0] "%1$d рядок вставлено."
 msgstr[1] "%1$d рядків вставлено."
 msgstr[2] "%1$d рядків вставлено."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3338,12 +3295,10 @@ msgid "Target database `%s` was not found!"
 msgstr "Цільова база даних \"%s\" не знайдена!"
 
 #: libraries/Table.class.php:1257
-#| msgid "Invalid database"
 msgid "Invalid database:"
 msgstr "Неправильна база даних:"
 
 #: libraries/Table.class.php:1271
-#| msgid "Invalid table name"
 msgid "Invalid table name:"
 msgstr "Неправильна назва таблиці:"
 
@@ -3395,7 +3350,7 @@ msgid "Operator"
 msgstr "Оператор"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3410,7 +3365,7 @@ msgstr "Пошук в таблиці"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "Редагувати/Вставити"
 
@@ -3418,7 +3373,7 @@ msgstr "Редагувати/Вставити"
 msgid "Select columns (at least one):"
 msgstr "Виберіть стовпці (принаймні один):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Або"
@@ -3475,7 +3430,6 @@ msgid "Reset zoom"
 msgstr "Скидання масштабу"
 
 #: libraries/TableSearch.class.php:1343
-#| msgid "Replace NULL with:"
 msgid "Replace with:"
 msgstr "Замінити на:"
 
@@ -3484,22 +3438,18 @@ msgid "Find and replace - preview"
 msgstr ""
 
 #: libraries/TableSearch.class.php:1407
-#| msgid "Column"
 msgid "Count"
 msgstr "Відлік"
 
 #: libraries/TableSearch.class.php:1408
-#| msgid "Original position"
 msgid "Original string"
 msgstr "Початковий рядок"
 
 #: libraries/TableSearch.class.php:1409
-#| msgid "Related Links"
 msgid "Replaced string"
 msgstr "Рядок заміни"
 
 #: libraries/TableSearch.class.php:1433
-#| msgid "Replicated"
 msgid "Replace"
 msgstr "Заміна"
 
@@ -3532,18 +3482,17 @@ msgid "Theme path not found for theme %s!"
 msgstr "Шлях теми не знайдений для теми %s!"
 
 #: libraries/Theme_Manager.class.php:369
-#| msgid "Theme"
 msgid "Theme:"
 msgstr "Тема:"
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 "Однобайтове ціле число, діапазон зі знаком - від -128 до 127, діапазон без "
 "знаку - від 0 до 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
@@ -3551,7 +3500,7 @@ msgstr ""
 "Двобайтове ціле число, діапазон зі знаком від -32768 до 32767, діапазон без "
 "знаку від 0 до 65535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3559,70 +3508,70 @@ msgstr ""
 "Трибайтове ціле число, діапазон зі знаком від -8,388,608 до 8,388,607, "
 "діапазон без знаку від 0 до 16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "Дата, підтримується інтервал від %1$s до %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "Комбінація дати і часу, підтримуваний інтервал від %1$s до %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3630,24 +3579,24 @@ msgstr ""
 "Мітка часу, інтервал від 1970-01-01: 00: 00: 01 UTC до 2038-01-09 03: 14: 07 "
 "UTC у кількості секунд з початку епохи (1970-01-01 00: 00: 00 UTC)"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "Час, інтервал від %1$s до %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
@@ -3656,168 +3605,168 @@ msgstr ""
 "Текстовий рядок змінної довжини (%s), максимальна ефективна довжина "
 "відповідає максимальній довжині рядка таблиці"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "Багатокутник"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Дата і час"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "Рядок"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Просторове"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3827,7 +3776,6 @@ msgid "Max: %s%s"
 msgstr "Максимум: %s%s"
 
 #: libraries/Util.class.php:642 libraries/sql.lib.php:429
-#| msgid "SQL query"
 msgid "SQL query:"
 msgstr "SQL-запит:"
 
@@ -3903,67 +3851,67 @@ msgstr "%B %d %Y р., %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s днів, %s годин, %s хвилин і %s секунд"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "Пропущено параметр:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "Перейти до бази даних &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "На функціональність %s впливає відома помилка, див. %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "Клікніть, щоб змінити"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "Переглянути Ваш комп'ютер:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Виберіть з каталога веб-сервера для відвантаження файлів <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Встановлений Вами каталог для завантаження файлів недоступний."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "Немає файлів для відвантаження"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Очистити"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "Виконати"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Друк"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Створення"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Останнє оновлення"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Остання перевірка"
@@ -3973,7 +3921,6 @@ msgid "shared"
 msgstr "загальні"
 
 #: libraries/browse_foreigners.lib.php:43
-#| msgid "Search"
 msgid "Search:"
 msgstr "Пошук:"
 
@@ -4083,7 +4030,6 @@ msgstr ""
 
 #: libraries/common.inc.php:657
 #, php-format
-#| msgid "Server"
 msgid "Server %d"
 msgstr "Сервер %d"
 
@@ -4114,13 +4060,11 @@ msgstr "виявлено цифровий ключ"
 
 #: libraries/config.values.php:49 libraries/config.values.php:65
 #: libraries/config.values.php:70
-#| msgid "Ins"
 msgid "Icons"
 msgstr "Піктограми"
 
 #: libraries/config.values.php:50 libraries/config.values.php:66
 #: libraries/config.values.php:71
-#| msgid "Test"
 msgid "Text"
 msgstr "Текст"
 
@@ -4280,13 +4224,11 @@ msgstr "\"%s\" потребує додаток %s"
 
 #: libraries/config/FormDisplay.class.php:791
 #, php-format
-#| msgid "import will not work, missing function (%s)"
 msgid "Compressed import will not work due to missing function %s."
 msgstr "Імпорт не буде працювати, бо відсутня функція %s."
 
 #: libraries/config/FormDisplay.class.php:797
 #, php-format
-#| msgid "export will not work, missing function (%s)"
 msgid "Compressed export will not work due to missing function %s."
 msgstr "Експорт не буде працювати, бо відсутня функція %s."
 
@@ -4326,9 +4268,9 @@ msgstr "Дозволити користувачам налаштовувати �
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Перевстановити"
 
@@ -4374,7 +4316,6 @@ msgstr ""
 "phpMyAdmin"
 
 #: libraries/config/Validator.class.php:447
-#| msgid "Incorrect value"
 msgid "Incorrect value:"
 msgstr "Некоректне значення:"
 
@@ -4586,7 +4527,6 @@ msgid "Whether the table structure actions should be hidden"
 msgstr ""
 
 #: libraries/config/messages.inc.php:57
-#| msgid "Propose table structure"
 msgid "Hide table structure actions"
 msgstr "Приховати дії над структурою таблиці"
 
@@ -4642,7 +4582,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Максимальний час виконання"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Зберегти як файл"
 
@@ -4678,14 +4618,12 @@ msgstr "Помістити імена колонок в перший рядок"
 #: libraries/config/messages.inc.php:75 libraries/config/messages.inc.php:246
 #: libraries/config/messages.inc.php:253
 #: libraries/plugins/import/ImportCsv.class.php:150
-#| msgid "Columns enclosed with:"
 msgid "Columns enclosed with"
 msgstr "Стовпчики взято в"
 
 #: libraries/config/messages.inc.php:76 libraries/config/messages.inc.php:247
 #: libraries/config/messages.inc.php:254
 #: libraries/plugins/import/ImportCsv.class.php:157
-#| msgid "Columns escaped with:"
 msgid "Columns escaped with"
 msgstr "Символ екранування"
 
@@ -4694,7 +4632,6 @@ msgstr "Символ екранування"
 #: libraries/config/messages.inc.php:107 libraries/config/messages.inc.php:111
 #: libraries/config/messages.inc.php:143 libraries/config/messages.inc.php:146
 #: libraries/config/messages.inc.php:148
-#| msgid "Replace NULL with:"
 msgid "Replace NULL with"
 msgstr "Замінити значення NULL на"
 
@@ -4705,13 +4642,11 @@ msgstr "Вилучити CRLF символи у стовбцях"
 #: libraries/config/messages.inc.php:79 libraries/config/messages.inc.php:250
 #: libraries/config/messages.inc.php:258
 #: libraries/plugins/import/ImportCsv.class.php:135
-#| msgid "Columns terminated by"
 msgid "Columns terminated with"
 msgstr "Колонки завершуються з"
 
 #: libraries/config/messages.inc.php:80 libraries/config/messages.inc.php:245
 #: libraries/plugins/import/ImportCsv.class.php:164
-#| msgid "Lines terminated with:"
 msgid "Lines terminated with"
 msgstr "Рядки закінчуються з"
 
@@ -4822,7 +4757,6 @@ msgstr "Відключити перевірки зовнішніх ключів"
 
 #: libraries/config/messages.inc.php:126
 #: libraries/plugins/export/ExportSql.class.php:155
-#| msgid "Exporting rows from \"%s\" table"
 msgid "Export views as tables"
 msgstr "Експорт видів як таблиць"
 
@@ -4977,12 +4911,10 @@ msgid "Databases display options"
 msgstr "Параметри відображення баз даних"
 
 #: libraries/config/messages.inc.php:180 setup/frames/menu.inc.php:21
-#| msgid "Navigation frame"
 msgid "Navigation panel"
 msgstr "Оболонка навігації"
 
 #: libraries/config/messages.inc.php:181
-#| msgid "Customize appearance of the navigation frame"
 msgid "Customize appearance of the navigation panel"
 msgstr "Налаштувати вигляд панелі навігації"
 
@@ -5000,7 +4932,6 @@ msgid "Tables display options"
 msgstr "Параметри відображення таблиць"
 
 #: libraries/config/messages.inc.php:186 setup/frames/menu.inc.php:23
-#| msgid "Main frame"
 msgid "Main panel"
 msgstr "Головна панель"
 
@@ -5113,12 +5044,10 @@ msgid "Customize import defaults"
 msgstr "Налаштувати імпорт властивостей по замовчуванню"
 
 #: libraries/config/messages.inc.php:212
-#| msgid "Customize navigation frame"
 msgid "Customize navigation panel"
 msgstr "Налаштувати панель навігації"
 
 #: libraries/config/messages.inc.php:213
-#| msgid "Customize main frame"
 msgid "Customize main panel"
 msgstr "Налаштувати головну панель"
 
@@ -5164,7 +5093,6 @@ msgid "Customize startup page"
 msgstr "Налаштувати початкову сторінку"
 
 #: libraries/config/messages.inc.php:225
-#| msgid "Databases"
 msgid "Database structure"
 msgstr "Структура бази даних"
 
@@ -5173,7 +5101,6 @@ msgid "Choose which details to show in the database structure (list of tables)"
 msgstr ""
 
 #: libraries/config/messages.inc.php:227
-#| msgid "Databases"
 msgid "Table structure"
 msgstr "Структура таблиці"
 
@@ -5406,7 +5333,6 @@ msgid "Users cannot set a higher value"
 msgstr "Користувач не може встановити більше значення"
 
 #: libraries/config/messages.inc.php:287
-#| msgid "Maximum number of tables displayed in table list"
 msgid "Maximum number of databases displayed in database list"
 msgstr ""
 "Максимальна кількість баз даних, які відображатимуться у списку баз даних"
@@ -5471,7 +5397,6 @@ msgid "Memory limit"
 msgstr "Ліміт пам'яті"
 
 #: libraries/config/messages.inc.php:300
-#| msgid "Show logo in left frame"
 msgid "Show logo in navigation panel"
 msgstr "Показати логотип у панелі навігації"
 
@@ -5480,7 +5405,6 @@ msgid "Display logo"
 msgstr "Показати логотип"
 
 #: libraries/config/messages.inc.php:302
-#| msgid "URL where logo in the navigation frame will point to"
 msgid "URL where logo in the navigation panel will point to"
 msgstr "URL, на який веде логотип у панелі навгації"
 
@@ -5501,7 +5425,6 @@ msgid "Logo link target"
 msgstr "Ціль на яку посилається лотип"
 
 #: libraries/config/messages.inc.php:306
-#| msgid "Display server choice at the top of the left frame"
 msgid "Display server choice at the top of the navigation panel"
 msgstr "Показати вибір сервера у верхній частині панелі навігації"
 
@@ -5514,7 +5437,6 @@ msgid "Target for quick access icon"
 msgstr "Ціль іконки швидкого доступу"
 
 #: libraries/config/messages.inc.php:309
-#| msgid "Minimum number of tables to display the table filter box"
 msgid ""
 "Defines the minimum number of items (tables, views, routines and events) to "
 "display a filter box."
@@ -5523,19 +5445,14 @@ msgstr ""
 "відображення вікна фільтру."
 
 #: libraries/config/messages.inc.php:310
-#| msgid "Minimum number of tables to display the table filter box"
 msgid "Minimum number of items to display the filter box"
 msgstr "Мінімальна кількість пунктів для відображення вікна фільтру"
 
 #: libraries/config/messages.inc.php:311
-#| msgid "Minimum number of tables to display the table filter box"
 msgid "Minimum number of databases to display the database filter box"
 msgstr "Мінімальна кількість баз даних для відображення вікна фільтру"
 
 #: libraries/config/messages.inc.php:312
-#| msgid ""
-#| "Only light version; display databases in a tree (determined by the "
-#| "separator defined below)"
 msgid ""
 "Group items in the navigation tree (determined by the separator defined "
 "below)"
@@ -5607,7 +5524,6 @@ msgid "Use only icons, only text or both"
 msgstr "Використовувати тільки піктограми, тільки текст, або обидва"
 
 #: libraries/config/messages.inc.php:328
-#| msgid "Iconic navigation bar"
 msgid "Table navigation bar"
 msgstr "Таблична панель навігації"
 
@@ -5655,9 +5571,6 @@ msgid "Missing phpMyAdmin configuration storage tables"
 msgstr "Відсутня таблиця для збереження конфігурації phpMyAdmin"
 
 #: libraries/config/messages.inc.php:337
-#| msgid ""
-#| "Disable the default warning that is displayed if mcrypt is missing for "
-#| "cookie authentication"
 msgid ""
 "Disable the default warning that is displayed if a difference between the "
 "MySQL library and server is detected"
@@ -5670,10 +5583,6 @@ msgid "Server/library difference warning"
 msgstr ""
 
 #: libraries/config/messages.inc.php:339
-#| msgid ""
-#| "Disable the default warning that is displayed on the database details "
-#| "Structure page if any of the required tables for the phpMyAdmin "
-#| "configuration storage could not be found"
 msgid ""
 "Disable the default warning that is displayed on the Structure page if "
 "column names in a table are reserved MySQL words"
@@ -5686,7 +5595,6 @@ msgid "MySQL reserved word warning"
 msgstr ""
 
 #: libraries/config/messages.inc.php:342
-#| msgid "Allow to display all the rows"
 msgid "How to display the menu tabs"
 msgstr "Як відображати вкладки меню"
 
@@ -5781,7 +5689,6 @@ msgid "Grid editing: trigger action"
 msgstr ""
 
 #: libraries/config/messages.inc.php:366
-#| msgid "Save all edited cells at once"
 msgid "Grid editing: save all edited cells at once"
 msgstr "Редагування сітки: зберегти всі відредаговані комірки зразу"
 
@@ -5911,9 +5818,6 @@ msgid "Control host"
 msgstr "Керування хостом"
 
 #: libraries/config/messages.inc.php:394
-#| msgid ""
-#| "An alternate host to hold the configuration storage; leave blank to use "
-#| "the already defined host"
 msgid ""
 "An alternate port to connect to the host that holds the configuration "
 "storage; leave blank to use the default port, or the already defined port, "
@@ -5924,7 +5828,6 @@ msgstr ""
 "визначеним, якщо контрольний хост ідентичний хосту"
 
 #: libraries/config/messages.inc.php:395
-#| msgid "Control host"
 msgid "Control port"
 msgstr "Контрольний порт"
 
@@ -6001,12 +5904,6 @@ msgid "Connect without password"
 msgstr "З’єднуватись без паролю"
 
 #: libraries/config/messages.inc.php:411
-#| msgid ""
-#| "You can use MySQL wildcard characters (% and _), escape them if you want "
-#| "to use their literal instances, i.e. use [kbd]'my\\_db'[/kbd] and not "
-#| "[kbd]'my_db'[/kbd]. Using this option you can sort database list, just "
-#| "enter their names in order and use [kbd]*[/kbd] at the end to show the "
-#| "rest in alphabetical order."
 msgid ""
 "You can use MySQL wildcard characters (% and _), escape them if you want to "
 "use their literal instances, i.e. use [kbd]'my\\_db'[/kbd] and not "
@@ -6227,9 +6124,6 @@ msgid "User preferences storage table"
 msgstr "Таблиця збереження налаштувань користувача"
 
 #: libraries/config/messages.inc.php:452
-#| msgid ""
-#| "Leave blank for no user preferences storage in database, suggested: [kbd]"
-#| "pma_userconfig[/kbd]"
 msgid ""
 "Leave blank to disable configurable menus feature, suggested: [kbd]pma__users"
 "[/kbd]"
@@ -6238,14 +6132,10 @@ msgstr ""
 "[kbd]pma_userconfig[/kbd]"
 
 #: libraries/config/messages.inc.php:453
-#| msgid "Use Tables"
 msgid "Users table"
 msgstr "Таблиця користувачів"
 
 #: libraries/config/messages.inc.php:454
-#| msgid ""
-#| "Leave blank for no user preferences storage in database, suggested: [kbd]"
-#| "pma_userconfig[/kbd]"
 msgid ""
 "Leave blank to disable configurable menus feature, suggested: [kbd]"
 "pma__usergroups[/kbd]"
@@ -6254,14 +6144,10 @@ msgstr ""
 "[kbd]pma_userconfig[/kbd]"
 
 #: libraries/config/messages.inc.php:455
-#| msgid "Use Host Table"
 msgid "User groups table"
 msgstr "Таблиця груп користувачів"
 
 #: libraries/config/messages.inc.php:456
-#| msgid ""
-#| "Leave blank for no user preferences storage in database, suggested: [kbd]"
-#| "pma_userconfig[/kbd]"
 msgid ""
 "Leave blank to disable the feature to hide and show navigation items, "
 "suggested: [kbd]pma__navigationhiding[/kbd]"
@@ -6318,7 +6204,6 @@ msgid "Show or hide a column displaying the Creation timestamp for all tables"
 msgstr ""
 
 #: libraries/config/messages.inc.php:468
-#| msgid "Show PHP information"
 msgid "Show Creation timestamp"
 msgstr "Показати час створення"
 
@@ -6606,7 +6491,6 @@ msgid ""
 msgstr ""
 
 #: libraries/config/messages.inc.php:531
-#| msgid "Username"
 msgid "Proxy username"
 msgstr "Ім'я користувача проксі"
 
@@ -6615,7 +6499,6 @@ msgid "The password for authenticating with the proxy"
 msgstr ""
 
 #: libraries/config/messages.inc.php:533
-#| msgid "Password"
 msgid "Proxy password"
 msgstr "Пароль проксі"
 
@@ -6652,7 +6535,6 @@ msgid "Choose the default action when sending error reports"
 msgstr ""
 
 #: libraries/config/messages.inc.php:543
-#| msgid "Server port"
 msgid "Send error reports"
 msgstr "Надіслати звіти про помилку"
 
@@ -6680,7 +6562,6 @@ msgstr "CSV, використовуючи LOAD DATA"
 #: libraries/config/setup.forms.php:266 libraries/config/setup.forms.php:360
 #: libraries/config/user_preferences.forms.php:162
 #: libraries/config/user_preferences.forms.php:255
-#| msgid "Open Document Spreadsheet"
 msgid "OpenDocument Spreadsheet"
 msgstr "Відкрити документ електронної таблиці"
 
@@ -6711,7 +6592,6 @@ msgstr "Microsoft Word 2000"
 
 #: libraries/config/setup.forms.php:364
 #: libraries/config/user_preferences.forms.php:259
-#| msgid "Open Document Text"
 msgid "OpenDocument Text"
 msgstr "Текст OpenDocument"
 
@@ -6759,12 +6639,10 @@ msgstr "Пароль:"
 #: libraries/display_change_password.lib.php:67
 #: libraries/replication_gui.lib.php:862
 #: libraries/server_privileges.lib.php:1468
-#| msgid "Re-type"
 msgid "Re-type:"
 msgstr "Підтвердження:"
 
 #: libraries/display_change_password.lib.php:74
-#| msgid "Password Hashing"
 msgid "Password Hashing:"
 msgstr "Хешування паролю:"
 
@@ -6781,7 +6659,6 @@ msgid "Create"
 msgstr "Створити"
 
 #: libraries/display_create_database.lib.php:51
-#| msgid "Create database"
 msgid "Create database:"
 msgstr "Створити базу даних:"
 
@@ -6972,13 +6849,11 @@ msgstr ""
 
 #: libraries/display_git_revision.lib.php:67
 #, php-format
-#| msgid "General relation features"
 msgid "committed on %1$s by %2$s"
 msgstr "вчинено %1$s, %2$s"
 
 #: libraries/display_git_revision.lib.php:75
 #, php-format
-#| msgid "General relation features"
 msgid "authored on %1$s by %2$s"
 msgstr "створено %1$s, %2$s"
 
@@ -7072,7 +6947,6 @@ msgid "%s of %s"
 msgstr ""
 
 #: libraries/display_import.lib.php:454
-#| msgid "Format of imported file"
 msgid "Uploading your import file…"
 msgstr "Вивантаження вашого файлу для імпорту…"
 
@@ -7098,7 +6972,7 @@ msgstr "Файл обробляється, будь ласка, будьте т�
 msgid "Language"
 msgstr "Мова"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Відомості про версію"
 
@@ -7462,7 +7336,6 @@ msgid "Please explain the steps that lead to the error:"
 msgstr ""
 
 #: libraries/error_report.lib.php:301
-#| msgid "Automatically create versions"
 msgid "Automatically send report next time"
 msgstr "Автоматично надсилати звіт наступного разу"
 
@@ -7540,60 +7413,59 @@ msgstr "Через велику довжину,<br /> цей стовпчик н
 msgid "Binary - do not edit"
 msgstr "Двійкові дані - не редагуються"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
-#| msgid "web server upload directory"
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "каталог веб-сервера для відвантаження файлів:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "Продовжити вставку з %s рядка"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "і потім"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Вставити як новий рядок"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Вставити як новий рядок і ігнорувати помилки"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Відображати запит вставлення"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Повернутись"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Вставити новий запис"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Повернутися на цю сторінку"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Редагувати наступний рядок"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Для переходу від значення до значення використовуйте TAB, або CTRL+стрілки - "
 "для переміщення куди завгодно"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "Показ SQL-запиту"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Ідентифікатор доданого рядка: %1$d"
@@ -7614,12 +7486,10 @@ msgid "No change"
 msgstr "Змін немає"
 
 #: libraries/mult_submits.lib.php:329
-#| msgid "Replace table prefix"
 msgid "Replace table prefix:"
 msgstr "Замінити префікс таблиці:"
 
 #: libraries/mult_submits.lib.php:331
-#| msgid "Copy table with prefix"
 msgid "Copy table with prefix:"
 msgstr "Копіювати таблицю з префіксом:"
 
@@ -7637,7 +7507,6 @@ msgid "Submit"
 msgstr "Виконати"
 
 #: libraries/mult_submits.lib.php:371
-#| msgid "Add table prefix"
 msgid "Add table prefix:"
 msgstr "Додати префікс таблиці:"
 
@@ -7646,7 +7515,6 @@ msgid "Add prefix"
 msgstr "Додати префікс"
 
 #: libraries/mult_submits.lib.php:408
-#| msgid "Do you really want to "
 msgid "Do you really want to execute the following query?"
 msgstr "Ви насправді хочете  виконати даний запит?"
 
@@ -7842,27 +7710,22 @@ msgid "An error has occurred while loading the navigation tree"
 msgstr ""
 
 #: libraries/navigation/Navigation.class.php:170
-#| msgid "Events"
 msgid "Events:"
 msgstr "Події:"
 
 #: libraries/navigation/Navigation.class.php:171
-#| msgid "Functions"
 msgid "Functions:"
 msgstr "Функції:"
 
 #: libraries/navigation/Navigation.class.php:172
-#| msgid "Procedures"
 msgid "Procedures:"
 msgstr "Процедури:"
 
 #: libraries/navigation/Navigation.class.php:173
-#| msgid "Tables"
 msgid "Tables:"
 msgstr "Таблиці:"
 
 #: libraries/navigation/Navigation.class.php:174
-#| msgid "Views"
 msgid "Views:"
 msgstr "Подання:"
 
@@ -7879,7 +7742,6 @@ msgid "phpMyAdmin documentation"
 msgstr "Документація по phpMyAdmin"
 
 #: libraries/navigation/NavigationHeader.class.php:250
-#| msgid "Reload navigation frame"
 msgid "Reload navigation panel"
 msgstr "Оновити панель навігації"
 
@@ -7896,18 +7758,15 @@ msgid "Expand/Collapse"
 msgstr ""
 
 #: libraries/navigation/NavigationTree.class.php:1045
-#| msgid "Alter table order by"
 msgid "Filter databases by name or regex"
 msgstr "Фільтрувати бази даних за іменем або регулярним виразом"
 
 #: libraries/navigation/NavigationTree.class.php:1047
 #: libraries/navigation/NavigationTree.class.php:1081
-#| msgid "Clear series"
 msgid "Clear fast filter"
 msgstr "Очистити швидкий фільтр"
 
 #: libraries/navigation/NavigationTree.class.php:1080
-#| msgid "Alter table order by"
 msgid "Filter by name or regex"
 msgstr "Фільтрувати за іменем або регулярним виразом"
 
@@ -7929,29 +7788,24 @@ msgid "Columns"
 msgstr "Колонки"
 
 #: libraries/navigation/Nodes/Node_Column_Container.class.php:38
-#| msgid "New"
 msgctxt "Create new column"
 msgid "New"
 msgstr "Новий"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:34
-#| msgid "Database export options"
 msgid "Database operations"
 msgstr "Операції з базою даних"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "Показувати приховані елементи"
 
 #: libraries/navigation/Nodes/Node_Database_Container.class.php:31
-#| msgid "New"
 msgctxt "Create new database"
 msgid "New"
 msgstr "Нова"
 
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:37
-#| msgid "New"
 msgctxt "Create new event"
 msgid "New"
 msgstr "Нова"
@@ -7964,7 +7818,6 @@ msgid "Functions"
 msgstr "Функції"
 
 #: libraries/navigation/Nodes/Node_Function_Container.class.php:36
-#| msgid "New"
 msgctxt "Create new function"
 msgid "New"
 msgstr "Нова"
@@ -7978,13 +7831,11 @@ msgid "Index"
 msgstr "Індекс"
 
 #: libraries/navigation/Nodes/Node_Index_Container.class.php:38
-#| msgid "New"
 msgctxt "Create new index"
 msgid "New"
 msgstr "Новий"
 
 #: libraries/navigation/Nodes/Node_Procedure.class.php:34
-#| msgid "Procedures"
 msgid "Procedure"
 msgstr "Процедура"
 
@@ -7997,19 +7848,16 @@ msgstr "Процедури"
 
 #: libraries/navigation/Nodes/Node_Procedure_Container.class.php:38
 #: libraries/rte/rte_footer.lib.php:29
-#| msgid "New"
 msgctxt "Create new procedure"
 msgid "New"
 msgstr "Нова"
 
 #: libraries/navigation/Nodes/Node_Table_Container.class.php:45
-#| msgid "New"
 msgctxt "Create new table"
 msgid "New"
 msgstr "Нова"
 
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:37
-#| msgid "New"
 msgctxt "Create new trigger"
 msgid "New"
 msgstr "Новий"
@@ -8021,13 +7869,11 @@ msgid "Views"
 msgstr "Подання"
 
 #: libraries/navigation/Nodes/Node_View_Container.class.php:45
-#| msgid "New"
 msgctxt "Create new view"
 msgid "New"
 msgstr "Нове"
 
 #: libraries/operations.lib.php:75
-#| msgid "Rename database to"
 msgid "Rename database to:"
 msgstr "Перейменувати базу даних на:"
 
@@ -8060,7 +7906,6 @@ msgid "Data only"
 msgstr "Лише дані"
 
 #: libraries/operations.lib.php:175
-#| msgid "Copy database to"
 msgid "Copy database to:"
 msgstr "Копіювати базу даних в:"
 
@@ -8262,7 +8107,6 @@ msgid "Username:"
 msgstr "Ім'я користувача:"
 
 #: libraries/plugins/auth/AuthenticationCookie.class.php:231
-#| msgid "Server Choice"
 msgid "Server Choice:"
 msgstr "Вибір сервера:"
 
@@ -8430,19 +8274,16 @@ msgstr "Параметри створення об'єкта"
 
 #: libraries/plugins/export/ExportLatex.class.php:121
 #: libraries/plugins/export/ExportLatex.class.php:166
-#| msgid "Table caption"
 msgid "Table caption:"
 msgstr "Заголовок таблиці:"
 
 #: libraries/plugins/export/ExportLatex.class.php:126
 #: libraries/plugins/export/ExportLatex.class.php:171
-#| msgid "Table caption (continued)"
 msgid "Table caption (continued):"
 msgstr "Заголовок таблиці (продовження):"
 
 #: libraries/plugins/export/ExportLatex.class.php:131
 #: libraries/plugins/export/ExportLatex.class.php:176
-#| msgid "Label key"
 msgid "Label key:"
 msgstr "Ключ підпису:"
 
@@ -8464,7 +8305,6 @@ msgid "Display MIME types"
 msgstr "Відображати Типи MIME"
 
 #: libraries/plugins/export/ExportLatex.class.php:162
-#| msgid "Put columns names in the first row"
 msgid "Put columns names in the first row:"
 msgstr "Помістити імена стовпців в перший рядок:"
 
@@ -8473,21 +8313,18 @@ msgstr "Помістити імена стовпців в перший рядо�
 #: libraries/plugins/export/ExportXml.class.php:191
 #: libraries/replication_gui.lib.php:411 libraries/replication_gui.lib.php:682
 #: libraries/server_privileges.lib.php:1320 libraries/sql.lib.php:421
-#| msgid "Host"
 msgid "Host:"
 msgstr "Хост:"
 
 #: libraries/plugins/export/ExportLatex.class.php:223
 #: libraries/plugins/export/ExportSql.class.php:627
 #: libraries/plugins/export/ExportXml.class.php:196 libraries/sql.lib.php:425
-#| msgid "Generation Time"
 msgid "Generation Time:"
 msgstr "Час створення:"
 
 #: libraries/plugins/export/ExportLatex.class.php:226
 #: libraries/plugins/export/ExportSql.class.php:633
 #: libraries/plugins/export/ExportXml.class.php:199
-#| msgid "PHP Version"
 msgid "PHP Version:"
 msgstr "Версія PHP:"
 
@@ -8496,28 +8333,23 @@ msgstr "Версія PHP:"
 #: libraries/plugins/export/ExportXml.class.php:398
 #: libraries/plugins/export/PMA_ExportPdf.class.php:115
 #: libraries/sql.lib.php:423
-#| msgid "Database"
 msgid "Database:"
 msgstr "База даних:"
 
 #: libraries/plugins/export/ExportLatex.class.php:303
 #: libraries/plugins/export/ExportSql.class.php:1578
-#| msgid "Data"
 msgid "Data:"
 msgstr "Дані:"
 
 #: libraries/plugins/export/ExportLatex.class.php:487
-#| msgid "Structure"
 msgid "Structure:"
 msgstr "Структура:"
 
 #: libraries/plugins/export/ExportMediawiki.class.php:84
-#| msgid "Invalid table name"
 msgid "Export table names"
 msgstr "Експортувати назви таблиці"
 
 #: libraries/plugins/export/ExportMediawiki.class.php:90
-#| msgid "horizontal (rotated headers)"
 msgid "Export table headers"
 msgstr "Експортувати заголовки таблиці"
 
@@ -8576,7 +8408,6 @@ msgstr ""
 "полів, які містять спеціальні символи або зарезервовані слова)</i>"
 
 #: libraries/plugins/export/ExportSql.class.php:311
-#| msgid "Transformation options"
 msgid "Data creation options"
 msgstr "Параметри створення даних"
 
@@ -8678,7 +8509,6 @@ msgstr "ЗВ'ЯЗКИ ТАБЛИЦІ"
 
 #: libraries/plugins/export/ExportSql.class.php:1513
 #, php-format
-#| msgid "Structure for view"
 msgid "Structure for view %s exported as a table"
 msgstr "Структура для подання %s, експортованого як таблиця"
 
@@ -8695,7 +8525,6 @@ msgid "Export contents"
 msgstr "Експортувати вміст"
 
 #: libraries/plugins/export/PMA_ExportPdf.class.php:116
-#| msgid "Table"
 msgid "Table:"
 msgstr "Таблиця:"
 
@@ -8784,7 +8613,6 @@ msgstr ""
 "спробуйте ще раз."
 
 #: libraries/plugins/import/ImportOds.class.php:183
-#| msgid "Open Document Spreadsheet"
 msgid "Could not parse OpenDocument Spreadsheet!"
 msgstr "Неможливо прочитати електронну таблицю OpenDocument!"
 
@@ -8869,17 +8697,6 @@ msgstr ""
 "порожнього рядка."
 
 #: libraries/plugins/transformations/abstract/ExternalTransformationsPlugin.class.php:31
-#| msgid ""
-#| "UX ONLY: Launches an external application and feeds it the field data  "
-#| "standard input. Returns the standard output of the application. The ault "
-#| "is Tidy, to pretty-print HTML code. For security reasons, you e to "
-#| "manually edit the file libraries/transformations/t_plain__external.inc."
-#| "php and list the tools you want to make ilable. The first option is then "
-#| "the number of the program you want to  and the second option is the "
-#| "parameters for the program. The third ion, if set to 1, will convert the "
-#| "output using htmlspecialchars() fault 1). The fourth option, if set to 1, "
-#| "will prevent wrapping and ure that the output appears all on one line "
-#| "(Default 1)."
 msgid ""
 "LINUX ONLY: Launches an external application and feeds it the column data "
 "via standard input. Returns the standard output of the application. The "
@@ -8895,13 +8712,13 @@ msgstr ""
 "ЛИШЕ LINUX: Запускає зовнішню програму і подає стовпцеві дані через "
 "стандартний ввід. Повертає стандартний вивід програми. Типовою програмою є "
 "Tidy, яка гарно друкує HTML код. З міркувань безпеки Вам потрібно самостійно "
-"відредагувати файл "
-"libraries/plugins/transformations/Text_Plain_External.class.php та вписати "
-"програми дозволені для запуску. У такому випадку, перша опція - кількість "
-"програм, які Ви бажаєте використовувати і друга - параметри для програм. "
-"Третя опція, встановлена в 1, буде конвертувати вивід, використовуючи "
-"htmlspecialchars() (типово: 1). Четверта опція, встановлена в 1, "
-"запобігатиме перенесенню рядка і виведе усі дані одним рядком (типово: 1)."
+"відредагувати файл libraries/plugins/transformations/Text_Plain_External."
+"class.php та вписати програми дозволені для запуску. У такому випадку, перша "
+"опція - кількість програм, які Ви бажаєте використовувати і друга - "
+"параметри для програм. Третя опція, встановлена в 1, буде конвертувати "
+"вивід, використовуючи htmlspecialchars() (типово: 1). Четверта опція, "
+"встановлена в 1, запобігатиме перенесенню рядка і виведе усі дані одним "
+"рядком (типово: 1)."
 
 #: libraries/plugins/transformations/abstract/FormattedTransformationsPlugin.class.php:31
 msgid ""
@@ -8983,7 +8800,6 @@ msgid "not OK"
 msgstr "не OK"
 
 #: libraries/relation.lib.php:92
-#| msgid "OK"
 msgctxt "Correctly working"
 msgid "OK"
 msgstr "Добре"
@@ -9042,12 +8858,10 @@ msgid "User preferences"
 msgstr "Користувацькі настройки"
 
 #: libraries/relation.lib.php:264
-#| msgid "Configuration: %s"
 msgid "Configurable menus"
 msgstr "Налаштовувані меню"
 
 #: libraries/relation.lib.php:275
-#| msgid "Reload navigation frame"
 msgid "Hide/show navigation items"
 msgstr "Приховати/показати пункти навігації"
 
@@ -9265,7 +9079,6 @@ msgstr ""
 
 #: libraries/replication_gui.lib.php:388 libraries/replication_gui.lib.php:772
 #: libraries/server_privileges.lib.php:1259
-#| msgid "User name"
 msgid "User name:"
 msgstr "Ім'я користувача:"
 
@@ -9277,7 +9090,6 @@ msgid "User name"
 msgstr "Ім'я користувача"
 
 #: libraries/replication_gui.lib.php:423
-#| msgid "Port"
 msgid "Port:"
 msgstr "Порт:"
 
@@ -9342,7 +9154,6 @@ msgstr "Довільний користувач"
 #: libraries/replication_gui.lib.php:854
 #: libraries/server_privileges.lib.php:1414
 #: libraries/server_privileges.lib.php:2767
-#| msgid "Use text field"
 msgid "Use text field:"
 msgstr "Використовувати текстове поле:"
 
@@ -9366,7 +9177,6 @@ msgid "Re-type"
 msgstr "Підтвердження"
 
 #: libraries/replication_gui.lib.php:870
-#| msgid "Generate Password"
 msgid "Generate Password:"
 msgstr "Згенерувати пароль:"
 
@@ -9427,10 +9237,9 @@ msgstr "Подія %1$s була створена."
 
 #: libraries/rte/rte_events.lib.php:175 libraries/rte/rte_routines.lib.php:378
 #: libraries/rte/rte_triggers.lib.php:147
-#| msgid ""
-#| "<b>One or more errors have occured while processing your request:</b>"
 msgid "<b>One or more errors have occurred while processing your request:</b>"
-msgstr "<b>Одна або декілька помилок виникли під час обробки вашого запиту:</b>"
+msgstr ""
+"<b>Одна або декілька помилок виникли під час обробки вашого запиту:</b>"
 
 #: libraries/rte/rte_events.lib.php:228
 msgid "Edit event"
@@ -9441,7 +9250,6 @@ msgstr "Редагувати подію"
 #: libraries/rte/rte_routines.lib.php:1501
 #: libraries/rte/rte_routines.lib.php:1541
 #: libraries/rte/rte_triggers.lib.php:230
-#| msgid "Error in processing request"
 msgid "Error in processing request:"
 msgstr "Помилка при обробці запиту:"
 
@@ -9793,24 +9601,24 @@ msgid "There are no events to display."
 msgstr "Немає подій."
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "Таблиця %s не існує!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "Прошу сконфігурувати координати для таблиці %s"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "Схема бази даних %s - Сторінка %s"
@@ -9952,7 +9760,6 @@ msgid "Unknown language: %1$s."
 msgstr "Невідома мова: %1$s."
 
 #: libraries/select_server.lib.php:41 libraries/select_server.lib.php:46
-#| msgid "Current Server"
 msgid "Current Server:"
 msgstr "Поточний сервер:"
 
@@ -10015,7 +9822,6 @@ msgstr "Дозволити статистику"
 
 #: libraries/server_databases.lib.php:493
 #, php-format
-#| msgid "%s databases have been dropped successfully."
 msgid "%1$d database has been dropped successfully."
 msgid_plural "%1$d databases have been dropped successfully."
 msgstr[0] "%1$d базу даних успішно знищено."
@@ -10386,7 +10192,6 @@ msgstr "Користувача було додано."
 
 #: libraries/server_privileges.lib.php:1870
 #: libraries/server_privileges.lib.php:1991
-#| msgid "New"
 msgctxt "Create new user"
 msgid "New"
 msgstr "Новий"
@@ -10410,7 +10215,6 @@ msgid "wildcard"
 msgstr "шаблон"
 
 #: libraries/server_privileges.lib.php:2069
-#| msgid "database-specific"
 msgid "table-specific"
 msgstr "специфічний для таблиці"
 
@@ -10428,7 +10232,6 @@ msgid "Revoke"
 msgstr "Відмінити"
 
 #: libraries/server_privileges.lib.php:2248
-#| msgid "Edit server"
 msgid "Edit user group"
 msgstr "Редагувати групу користувачів"
 
@@ -10466,7 +10269,6 @@ msgid "Column-specific privileges"
 msgstr "Права, які стосуються колонок таблиці"
 
 #: libraries/server_privileges.lib.php:2763
-#| msgid "Add privileges on the following database"
 msgid "Add privileges on the following database:"
 msgstr "Додати права для цієї бази даних:"
 
@@ -10478,7 +10280,6 @@ msgstr ""
 "іншому випадку вони будуть інтерпретовані як групові символи."
 
 #: libraries/server_privileges.lib.php:2808
-#| msgid "Add privileges on the following table"
 msgid "Add privileges on the following table:"
 msgstr "Додати права для цієї таблиці:"
 
@@ -10529,12 +10330,10 @@ msgstr "Користувач %s вже існує!"
 
 #: libraries/server_privileges.lib.php:3624
 #, php-format
-#| msgid "Privileges"
 msgid "Privileges for %s"
 msgstr "Привілеї для %s"
 
 #: libraries/server_privileges.lib.php:3678
-#| msgid "Edit Privileges"
 msgid "Edit Privileges:"
 msgstr "Редагування прав:"
 
@@ -10847,12 +10646,10 @@ msgid "Instructions/Setup"
 msgstr "Інструкції/Налаштування"
 
 #: libraries/server_status_monitor.lib.php:307
-#| msgid "Done rearranging/editing charts"
 msgid "Done dragging (rearranging) charts"
 msgstr "Впорядкування/перетягування діаграм завершено"
 
 #: libraries/server_status_monitor.lib.php:326
-#| msgid "Enable highlighting"
 msgid "Enable charts dragging"
 msgstr "Увімкнути перетягування діаграм"
 
@@ -10886,17 +10683,14 @@ msgid "Questions since startup: %s"
 msgstr "Запитань починаючи із запуску %s"
 
 #: libraries/server_status_queries.lib.php:44
-#| msgid "per hour"
 msgid "per hour:"
 msgstr "за годину:"
 
 #: libraries/server_status_queries.lib.php:47
-#| msgid "per minute"
 msgid "per minute:"
 msgstr "за хвилину:"
 
 #: libraries/server_status_queries.lib.php:54
-#| msgid "per second"
 msgid "per second:"
 msgstr "за секунду:"
 
@@ -11349,7 +11143,6 @@ msgstr ""
 "максимальну кількість блоків, що були одночасно використані."
 
 #: libraries/server_status_variables.lib.php:595
-#| msgid "Character set of the file:"
 msgid "Percentage of used key cache (calculated value)"
 msgstr "Відсоток використаного кешу ключів (обчислене значення)"
 
@@ -11618,7 +11411,6 @@ msgstr ""
 "помітного зростання продуктивності при гарній реалізації потоків.)"
 
 #: libraries/server_status_variables.lib.php:757
-#| msgid "Tracking is not active."
 msgid "Thread cache hit rate (calculated value)"
 msgstr "Відношення звернень до кешу потоку (обчислене значення)"
 
@@ -11636,33 +11428,27 @@ msgid "No users were found belonging to this user group."
 msgstr ""
 
 #: libraries/server_user_groups.lib.php:65 libraries/server_users.lib.php:30
-#| msgid "Users"
 msgid "User groups"
 msgstr "Групи користувачів"
 
 #: libraries/server_user_groups.lib.php:79
-#| msgid "Server version"
 msgid "Server level tabs"
 msgstr "Вкладки рівня сервера"
 
 #: libraries/server_user_groups.lib.php:80
-#| msgid "Database server"
 msgid "Database level tabs"
 msgstr "Вкладки рівня бази даних"
 
 #: libraries/server_user_groups.lib.php:81
-#| msgid "Table comments"
 msgid "Table level tabs"
 msgstr "Вкладки рівня таблиці"
 
 #: libraries/server_user_groups.lib.php:110
-#| msgid "Views"
 msgid "View users"
 msgstr "Переглянути користувачів"
 
 #: libraries/server_user_groups.lib.php:147
 #: libraries/server_user_groups.lib.php:208
-#| msgid "Add user"
 msgid "Add user group"
 msgstr "Додати групу користувачів"
 
@@ -11672,27 +11458,22 @@ msgid "Edit user group: '%s'"
 msgstr ""
 
 #: libraries/server_user_groups.lib.php:227
-#| msgid "No privileges."
 msgid "User group menu assignments"
 msgstr "Призначення меню груп користувачів"
 
 #: libraries/server_user_groups.lib.php:234
-#| msgid "Column names: "
 msgid "Group name:"
 msgstr "Назва групи:"
 
 #: libraries/server_user_groups.lib.php:268
-#| msgid "Server version"
 msgid "Server-level tabs"
 msgstr "Вкладки рівня сервера"
 
 #: libraries/server_user_groups.lib.php:271
-#| msgid "Database server"
 msgid "Database-level tabs"
 msgstr "Вкладки рівня бази даних"
 
 #: libraries/server_user_groups.lib.php:274
-#| msgid "Table comments"
 msgid "Table-level tabs"
 msgstr "Вкладки рівня таблиці"
 
@@ -11714,23 +11495,18 @@ msgid "SQL result"
 msgstr "Результат SQL"
 
 #: libraries/sql.lib.php:427
-#| msgid "Generated by"
 msgid "Generated by:"
 msgstr "Згенеровано:"
 
 #: libraries/sql.lib.php:463
-#| msgid "Data file grow size"
 msgid "Detailed profile"
 msgstr "Детальний профіль"
 
 #: libraries/sql.lib.php:466
-#| msgid "Other"
 msgid "Order"
 msgstr "Порядок"
 
 #: libraries/sql.lib.php:468 libraries/sql.lib.php:484
-#| msgctxt "Start of recurring event"
-#| msgid "Start"
 msgid "State"
 msgstr "Стан"
 
@@ -11739,22 +11515,18 @@ msgid "Summary by state"
 msgstr ""
 
 #: libraries/sql.lib.php:487
-#| msgid "Total time:"
 msgid "Total Time"
 msgstr "Загальний час"
 
 #: libraries/sql.lib.php:489
-#| msgid "Time"
 msgid "% Time"
 msgstr "% Часу"
 
 #: libraries/sql.lib.php:491
-#| msgid "Close"
 msgid "Calls"
 msgstr "Виклики"
 
 #: libraries/sql.lib.php:493
-#| msgid "Time"
 msgid "ø Time"
 msgstr "ø Час"
 
@@ -11763,7 +11535,6 @@ msgid "Bookmark this SQL query"
 msgstr "Закладка на даний SQL запит"
 
 #: libraries/sql.lib.php:765
-#| msgid "Label"
 msgid "Label:"
 msgstr "Мітка:"
 
@@ -11772,7 +11543,6 @@ msgid "Let every user access this bookmark"
 msgstr "Надати всім користувачам доступ до цієї закладки"
 
 #: libraries/sql.lib.php:1025
-#| msgid "Bookmark %s created"
 msgid "Bookmark not created"
 msgstr "Закладка не створена"
 
@@ -11790,9 +11560,6 @@ msgid "Validated SQL"
 msgstr "Перевірений SQL"
 
 #: libraries/sql.lib.php:1912
-#| msgid ""
-#| "This table does not contain a unique column. Features related to the grid "
-#| "edit, checkbox, Edit, Copy and Delete links may not work after saving."
 msgid ""
 "Current selection does not contain a unique column. Grid edit, checkbox, "
 "Edit, Copy and Delete features are not available."
@@ -11820,7 +11587,6 @@ msgid "Clear"
 msgstr "Очистити"
 
 #: libraries/sql_query_form.lib.php:318
-#| msgid "Bookmark this SQL query"
 msgid "Bookmark this SQL query:"
 msgstr "Закласти цей SQL запит:"
 
@@ -11990,7 +11756,6 @@ msgid "Fulltext"
 msgstr "ПовнТекст"
 
 #: libraries/structure.lib.php:1429 libraries/structure.lib.php:1539
-#| msgid "Add columns"
 msgid "Move columns"
 msgstr "Перемістити стовпці"
 
@@ -12039,7 +11804,6 @@ msgid "After %s"
 msgstr "Після %s"
 
 #: libraries/structure.lib.php:1691
-#| msgid "Row Statistics"
 msgid "Row statistics"
 msgstr "Статистика рядка"
 
@@ -12079,7 +11843,6 @@ msgid "A primary key has been added on %s"
 msgstr "Було додано первинний ключ до %s"
 
 #: libraries/structure.lib.php:2024 libraries/structure.lib.php:2095
-#| msgid "Session value"
 msgid "Distinct values"
 msgstr "Окремі значення"
 
@@ -12123,7 +11886,6 @@ msgid "Query error"
 msgstr "Помилка запиту"
 
 #: libraries/structure.lib.php:2532
-#| msgid "The selected users have been deleted successfully."
 msgid "The columns have been moved successfully."
 msgstr "Стовпці успішно переміщено."
 
@@ -12163,7 +11925,6 @@ msgid "Pie"
 msgstr "Пиріг"
 
 #: libraries/tbl_chart.lib.php:58
-#| msgid "Time"
 msgctxt "Chart type"
 msgid "Timeline"
 msgstr "Часова шкала"
@@ -12193,7 +11954,6 @@ msgid "Y-Axis label:"
 msgstr "Мітка вісі Y:"
 
 #: libraries/tbl_chart.lib.php:206
-#| msgid "Start row"
 msgid "Start row:"
 msgstr "Початковий рядок:"
 
@@ -12202,17 +11962,14 @@ msgid "Chart title"
 msgstr "Назва графіку"
 
 #: libraries/tbl_columns_definition_form.lib.php:72
-#| msgid "Storage Engine"
 msgid "Storage Engine:"
 msgstr "Тип таблиць:"
 
 #: libraries/tbl_columns_definition_form.lib.php:76
-#| msgid "Collation"
 msgid "Collation:"
 msgstr "Порівняння:"
 
 #: libraries/tbl_columns_definition_form.lib.php:110
-#| msgid "PARTITION definition"
 msgid "PARTITION definition:"
 msgstr "Визначення розділів:"
 
@@ -12241,7 +11998,6 @@ msgstr ""
 "зворотніх слешів чи лапок, у такому форматі: a"
 
 #: libraries/tbl_columns_definition_form.lib.php:310
-#| msgid "Add into comments"
 msgid "Move column"
 msgstr "Перемістити стовпець"
 
@@ -12276,7 +12032,6 @@ msgstr ""
 
 #: libraries/tbl_columns_definition_form.lib.php:761
 #, php-format
-#| msgid "After %s"
 msgid "after %s"
 msgstr "після %s"
 
@@ -12299,7 +12054,6 @@ msgstr "Як визначено:"
 
 #: libraries/tbl_common.inc.php:54
 #, php-format
-#| msgid "Tracking is active."
 msgid "Tracking of %s is activated."
 msgstr "Відстеження %s - активне."
 
@@ -12358,7 +12112,6 @@ msgid ""
 msgstr "\"PRIMARY\" <b>повинно</b> бути іменем <b>лише</b> первинного ключа!"
 
 #: libraries/tbl_indexes.lib.php:283
-#| msgid "Comment"
 msgid "Comment:"
 msgstr "Коментар:"
 
@@ -12367,22 +12120,18 @@ msgid "Index type:"
 msgstr "Тип індекса&nbsp;:"
 
 #: libraries/tbl_printview.lib.php:30
-#| msgid "Showing tables"
 msgid "Showing tables:"
 msgstr "Показ таблиць:"
 
 #: libraries/tbl_printview.lib.php:174
-#| msgid "Row Statistics"
 msgid "Row Statistics:"
 msgstr "Статистика рядка:"
 
 #: libraries/tbl_printview.lib.php:301
-#| msgid "Space usage"
 msgid "Space usage:"
 msgstr "Використаний простір:"
 
 #: libraries/tbl_relation.lib.php:386
-#| msgid "Choose column to display"
 msgid "Choose column to display:"
 msgstr "Виберіть стовпець для відображення:"
 
@@ -12403,12 +12152,10 @@ msgid "Foreign key constraint"
 msgstr "Обмеження зовнішнього ключа"
 
 #: libraries/tbl_relation.lib.php:553
-#| msgid "Constraints for table"
 msgid "Constraint name"
 msgstr "Обмеження зовнішнього ключа"
 
 #: libraries/tbl_relation.lib.php:584
-#| msgid "No index defined!"
 msgid "No index defined! Create one below"
 msgstr "Індекс не визначено!Створіть внизу індекс"
 
@@ -12419,7 +12166,6 @@ msgstr "Помилка при створенні зовнішнього ключ
 
 #: libraries/tbl_tracking.lib.php:60
 #, php-format
-#| msgid "General relation features"
 msgid "Create version %1$s of %2$s"
 msgstr "Створити версію %1$s із %2$s"
 
@@ -12446,7 +12192,6 @@ msgstr "Активувати зараз"
 
 #: libraries/tbl_tracking.lib.php:148
 #, php-format
-#| msgid "Delete tracking data for this table"
 msgid "Deactivate tracking for %s"
 msgstr "Видалити відстеження для %s"
 
@@ -12549,13 +12294,11 @@ msgstr "Звіт про відстеження для таблиці `%s`"
 
 #: libraries/tbl_tracking.lib.php:1055
 #, php-format
-#| msgid "Tracking is active."
 msgid "Tracking for %1$s was activated at version %2$s."
 msgstr "Відстеження за %1$s було активовано на версії %2$s."
 
 #: libraries/tbl_tracking.lib.php:1077
 #, php-format
-#| msgid "Tracking is active."
 msgid "Tracking for %1$s was deactivated at version %2$s."
 msgstr "Відстеження за %1$s було деактивоване на версії %2$s."
 
@@ -12568,7 +12311,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "Керування налаштуваннями"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "Конфігурація була збережена"
 
@@ -12683,7 +12426,6 @@ msgid "Hide/Show Tables with no relation"
 msgstr "Сховати/Показати Таблиці які не мають зв'язків"
 
 #: pmd_general.php:204
-#| msgid "Number of tables"
 msgid "Number of tables:"
 msgstr "Число таблиць:"
 
@@ -12730,7 +12472,6 @@ msgid "Page creation failed"
 msgstr "Створення сторінки обламалось"
 
 #: pmd_pdf.php:118
-#| msgid "Page"
 msgid "Page:"
 msgstr "Сторінка:"
 
@@ -12751,7 +12492,6 @@ msgid "New page name: "
 msgstr "Нова назва сторінки: "
 
 #: pmd_pdf.php:146
-#| msgid "Export/Import to scale"
 msgid "Export/Import to scale:"
 msgstr "Експорт/Імпорт на шкалу:"
 
@@ -12772,7 +12512,6 @@ msgid "FOREIGN KEY relation added"
 msgstr "FOREIGN KEY зв'язок доданий"
 
 #: pmd_relation_new.php:84
-#| msgid "Error: Relation not added."
 msgid "Error: Relational features are disabled!"
 msgstr "Помилка: реляційні функції вимкнені!"
 
@@ -12824,7 +12563,7 @@ msgstr "Налаштування будуть імпортовані з лока
 msgid "You have no saved settings!"
 msgstr "У вас немає збережених налаштувань!"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "Ця властивість не підтримується вашим веб-браузером"
 
@@ -12841,19 +12580,19 @@ msgstr ""
 "Ви можете встановити більше налаштувань змінюючи файл config.inc.php, "
 "наприклад використовуючи %sSetup script%s."
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "Зберегти у браузері"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "Налаштування будуть збережені у вашому браузері."
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "Існуючі налаштування будуть перезаписані!"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 "Ви можете скинути всі ваші налаштування і відновити їх до значень по "
@@ -12868,7 +12607,6 @@ msgid "All"
 msgstr "Все"
 
 #: querywindow.php:154
-#| msgid "SQL history"
 msgid "SQL history:"
 msgstr "SQL історія:"
 
@@ -12884,6 +12622,10 @@ msgstr "БД відсутні"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Переглянути дамп (схему) баз даних"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format
@@ -13119,10 +12861,6 @@ msgstr ""
 
 #: setup/lib/index.lib.php:246
 #, php-format
-#| msgid ""
-#| "%sLogin cookie validity%s greater than 1440 seconds may cause random "
-#| "session invalidation if %ssession.gc_maxlifetime%s is lower than its "
-#| "value (currently %d)."
 msgid ""
 "%sLogin cookie validity%s greater than %ssession.gc_maxlifetime%s may cause "
 "random session invalidation (currently session.gc_maxlifetime is %d)."
@@ -13227,7 +12965,6 @@ msgid "Wrong data"
 msgstr "Неправильні дані"
 
 #: tbl_chart.php:38
-#| msgid "No databases"
 msgid "No data to display"
 msgstr "Немає даних для відображення"
 
@@ -13280,7 +13017,6 @@ msgid "The table name is empty!"
 msgstr "Порожня назва таблиці!"
 
 #: tbl_structure.php:93
-#| msgid "No rows selected"
 msgid "No column selected."
 msgstr "Жодного стовпчика не вибрано."
 
@@ -13322,7 +13058,6 @@ msgid "Rename view to"
 msgstr "Перейменувати подання на"
 
 #: view_operations.php:133
-#| msgid "Delete the table (DROP)"
 msgid "Delete the view (DROP)"
 msgstr "Видалити подання (DROP)"
 
@@ -13421,9 +13156,6 @@ msgid "Long query time"
 msgstr "Час виконання довгих запитів"
 
 #: libraries/advisory_rules.txt:80
-#| msgid ""
-#| "long_query_time is set to 10 seconds or more, thus only slow queries that "
-#| "take above 10 seconds are logged."
 msgid ""
 "{long_query_time} is set to 10 seconds or more, thus only slow queries that "
 "take above 10 seconds are logged."
@@ -13471,7 +13203,6 @@ msgid ""
 msgstr ""
 
 #: libraries/advisory_rules.txt:96
-#| msgid "long_query_time is set to %d second(s)."
 msgid "slow_query_log is set to 'OFF'"
 msgstr "значення long_query_time встановлено на  'OFF'"
 
@@ -13834,9 +13565,6 @@ msgid "Too many sorts are causing temporary tables."
 msgstr "Забагато сортувань викликають створення тимчасових таблиць."
 
 #: libraries/advisory_rules.txt:215 libraries/advisory_rules.txt:222
-#| msgid ""
-#| "Consider increasing sort_buffer_size and/or read_rnd_buffer_size, "
-#| "depending on your system memory limits"
 msgid ""
 "Consider increasing {sort_buffer_size} and/or {read_rnd_buffer_size}, "
 "depending on your system memory limits"
@@ -14001,7 +13729,6 @@ msgid "tmp_table_size vs. max_heap_table_size"
 msgstr "tmp_table_size проти max_heap_table_size"
 
 #: libraries/advisory_rules.txt:265
-#| msgid "tmp_table_size and max_heap_table_size are not the same."
 msgid "{tmp_table_size} and {max_heap_table_size} are not the same."
 msgstr "{tmp_table_size} і {max_heap_table_size} не одне й те саме."
 
@@ -14201,9 +13928,6 @@ msgstr ""
 "файлів.  Можливо виникнення помилки \"Забагато відкритих файлів\"."
 
 #: libraries/advisory_rules.txt:338 libraries/advisory_rules.txt:345
-#| msgid ""
-#| "Consider increasing {open_files_limit}, and check the error log when "
-#| "restarting after changing open_files_limit."
 msgid ""
 "Consider increasing {open_files_limit}, and check the error log when "
 "restarting after changing {open_files_limit}."
@@ -14333,9 +14057,6 @@ msgid "Slow_launch_threads is above 2s"
 msgstr "Slow_launch_threads перевищує 2с"
 
 #: libraries/advisory_rules.txt:387
-#| msgid ""
-#| "Set slow_launch_time to 1s or 2s to correctly count threads that are slow "
-#| "to launch"
 msgid ""
 "Set {slow_launch_time} to 1s or 2s to correctly count threads that are slow "
 "to launch"
@@ -14353,9 +14074,6 @@ msgid "Percentage of used connections"
 msgstr "Відсоток використаних з'єднань"
 
 #: libraries/advisory_rules.txt:395
-#| msgid ""
-#| "The maximum amount of used connections is getting close to the value of "
-#| "max_connections."
 msgid ""
 "The maximum amount of used connections is getting close to the value of "
 "{max_connections}."
@@ -14364,10 +14082,6 @@ msgstr ""
 "{max_connections}."
 
 #: libraries/advisory_rules.txt:396
-#| msgid ""
-#| "Increase max_connections, or decrease wait_timeout so that connections "
-#| "that do not close database handlers properly get killed sooner. Make sure "
-#| "the code closes database handlers properly."
 msgid ""
 "Increase {max_connections}, or decrease {wait_timeout} so that connections "
 "that do not close database handlers properly get killed sooner. Make sure "
@@ -14587,7 +14301,6 @@ msgid "MyISAM concurrent inserts"
 msgstr "Паралельні вставки MyISAM"
 
 #: libraries/advisory_rules.txt:462
-#| msgid "Enable concurrent_insert by setting it to 1"
 msgid "Enable {concurrent_insert} by setting it to 1"
 msgstr "Включити {concurrent_insert} виставивши його у 1"
 

--- a/po/ur.po
+++ b/po/ur.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 15:25+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Urdu <http://l10n.cihar.com/projects/phpmyadmin/master/ur/>\n"
@@ -46,7 +46,7 @@ msgstr "جدول تبصرے"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -94,7 +94,7 @@ msgid "Type"
 msgstr "قِسم"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -353,7 +353,7 @@ msgid "Updated"
 msgstr "تازہ کی گئی"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -381,7 +381,7 @@ msgid "Delete tracking data for this table"
 msgstr "اس جدول کے لیے کھوج کوائف حذف کریں"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -586,8 +586,8 @@ msgstr "جیومیٹری شامل کریں"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -613,7 +613,7 @@ msgstr "جیومیٹری شامل کریں"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "جائیں"
@@ -980,7 +980,7 @@ msgstr "اشاریے"
 msgid "Edit Index"
 msgstr "تدوین موڈ"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add/Delete Field Columns"
 msgid "Add %s column(s) to index"
@@ -1214,7 +1214,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "General relation features"
 msgid "Settings"
@@ -1554,8 +1554,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1801,8 +1801,8 @@ msgstr "طلب خانہ دکھائیں"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1831,7 +1831,7 @@ msgstr "چلنے کی حد اوقات"
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1910,8 +1910,8 @@ msgstr "طلب نتائج"
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "نظر انداز کریں"
 
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "فانٹ سائز"
 
@@ -2642,8 +2642,8 @@ msgstr[0] "<i>%s</i>جدول کے ساتھ مشابہ%s"
 msgstr[1] "<i>%s</i>جدول کے ساتھ مشابہات%s"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2707,16 +2707,16 @@ msgstr "پوشہ محفوظ کریں"
 msgid "Restore column order"
 msgstr "فیلڈ کالمز شامل یا ختم کریں"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "شروع"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2724,8 +2724,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "پچھلا"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2733,8 +2733,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "اگلا"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -2917,9 +2917,9 @@ msgstr "تمام پڑتال کریں"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3112,9 +3112,9 @@ msgid "View"
 msgstr "نقل جدول"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3128,32 +3128,32 @@ msgid "Structure"
 msgstr "ساخت"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "تلاش"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "داخل کریں"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3162,20 +3162,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "عملیات"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3191,70 +3191,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "کوائفیے"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "چربہ کاری"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "نقص"
@@ -3280,7 +3280,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d صف داخل ہوئی۔"
 msgstr[1] "%1$d صفیں داخل ہوئیں۔"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3508,7 +3508,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3525,7 +3525,7 @@ msgstr "تلاش"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3535,7 +3535,7 @@ msgstr "داخل کریں"
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "یا"
@@ -3663,288 +3663,288 @@ msgstr "خیالیہ راہ اس خیالیہ %s کے لیے نہیں ملا!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "General relation features"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "جنرل ریلیشن فیچرز"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "جدول %1$s کو %2$s نام تبدیل کرتے ہوئے نقص ہے"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add/Delete Field Columns"
 msgid "A polygon"
 msgstr "فیلڈ کالمز شامل یا ختم کریں"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "تخلیق کیا گیا"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "سطریں کے آخر میں"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Total"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "میزان"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4031,69 +4031,69 @@ msgstr "%B %d, %Y پر %I:%M %p"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s دن, %s گھنٹے, %s منٹ اور%s سیکنڈ"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "کوائفیہ میں جائیں &quot;%s&quot;."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s ایک نامعلوم نقص سے کام متاثر ہوا, دیکھیں %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 #, fuzzy
 #| msgid "Click to select"
 msgid "Click to toggle"
 msgstr "انتخاب کے لیے کلک کریں"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "اپنے کمپیوٹر کو براؤز کریں:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "ویب سرور اپ لوڈ پوشہ سے منتخب کریں <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "اپ لوڈ کام کے لیے سیٹ کیا گیا پوشہ قابل رسائی نہیں ہے۔"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "اپ لوڈ کرنے کے لیے کوئی مسل نہیں ہے"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "خالی"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "چھاپیں"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "بنائیں"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "آخری دفعہ کی تازہ کاری"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "آخری دفعہ کی پڑتال"
@@ -4458,9 +4458,9 @@ msgstr "صارفین کو اس قدر کے مخصوص کرنے کی اجازت �
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "دوبارہ سیٹ کریں"
 
@@ -4767,7 +4767,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "چلنے کی حد اوقات"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "بطور مسل محفوظ کریں"
 
@@ -7246,7 +7246,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7643,59 +7643,59 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "Select from the web server upload directory <b>%s</b>:"
 msgid "web server upload directory:"
 msgstr "ویب سرور اپ لوڈ پوشہ سے منتخب کریں <b>%s</b>:"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "اور پھر"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9882,24 +9882,24 @@ msgid "There are no events to display."
 msgstr "اپ لوڈ کرنے کے لیے کوئی مسل نہیں ہے"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -12541,7 +12541,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr "جنرل ریلیشن فیچرز"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -12815,7 +12815,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -12830,19 +12830,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -12871,6 +12871,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/uz.po
+++ b/po/uz.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-25 15:37+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Uzbek <http://l10n.cihar.com/projects/phpmyadmin/master/uz/>\n"
@@ -40,7 +40,7 @@ msgstr "Изоҳлар жадвали:"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -86,7 +86,7 @@ msgid "Type"
 msgstr "Тур"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -334,7 +334,7 @@ msgid "Updated"
 msgstr "Янгиланди"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -362,7 +362,7 @@ msgid "Delete tracking data for this table"
 msgstr "Ушбу жадвал учун кузатув маълумотлари ўчириш"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -574,8 +574,8 @@ msgstr "Янги фойдаланувчи қўшиш"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -601,7 +601,7 @@ msgstr "Янги фойдаланувчи қўшиш"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "OK"
@@ -1041,7 +1041,7 @@ msgstr "Индекс(лар)ни сақлаш"
 msgid "Edit Index"
 msgstr "Таҳрирлаш усули"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add column(s)"
 msgid "Add %s column(s) to index"
@@ -1286,7 +1286,7 @@ msgid "Traffic"
 msgstr "Трафик"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "settings"
 msgid "Settings"
@@ -1631,8 +1631,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1894,8 +1894,8 @@ msgstr "SQL сўровлари қутиси"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1924,7 +1924,7 @@ msgstr "Максимум бажарилиш вақти"
 msgid "%d is not valid row number."
 msgstr "%d сони тўғри қатор рақами эмас."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -2009,8 +2009,8 @@ msgstr "Сўров натижаларини ишлатиш"
 msgid "Data point content"
 msgstr "Маълумотлар файли кўрсатгичи ҳажми"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "Эътибор бермаслик"
 
@@ -2648,7 +2648,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Шрифт ўлчами"
 
@@ -2809,8 +2809,8 @@ msgstr[0] "<i>\"%s\"</i> жадвалида ўхшашликлар сони \"%s
 msgstr[1] "<i>\"%s\"</i> жадвалида ўхшашликлар сони \"%s\" та"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2870,16 +2870,16 @@ msgstr "Сақлаш директорияси"
 msgid "Restore column order"
 msgstr "CHAR майдонидаги устунлар сони"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Боши"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2887,8 +2887,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Орқага"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2896,8 +2896,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Кейинги"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3091,9 +3091,9 @@ msgstr "Барчасини белгилаш"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3290,9 +3290,9 @@ msgid "View"
 msgstr "Намойиш"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3306,32 +3306,32 @@ msgid "Structure"
 msgstr "Тузилиши"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Қидириш"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Қўйиш"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3340,20 +3340,20 @@ msgid "Privileges"
 msgstr "Привилегиялар"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Операциялар"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Кузатиш"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3369,72 +3369,72 @@ msgstr "Триггерлар"
 msgid "Database seems to be empty!"
 msgstr "Маълумотлар базаси бўш!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "Сўров"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Муолажалар"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Ҳодисалар"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Дизайнер"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Маълумотлар базалари"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Фойдаланувчи"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Иккилик журнал"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Репликация (захира нусха кўчириш)"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "Ўзгарувчилар"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Кодировкалар"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Жадвал турлари"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Хатолик"
@@ -3463,7 +3463,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d та қаторлар қўйилди."
 msgstr[1] "%1$d та қаторлар қўйилди."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3700,7 +3700,7 @@ msgid "Operator"
 msgstr "Оператор"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3717,7 +3717,7 @@ msgstr "Қидириш"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3729,7 +3729,7 @@ msgstr "Қўйиш"
 msgid "Select columns (at least one):"
 msgstr "Майдонни танланг (камида битта):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Ёки"
@@ -3859,288 +3859,288 @@ msgstr "\"%s\" мавзуси файлларига йўл топилмади!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "Create version %s of %s.%s"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "\"%s.%s\" жадвалининг %s рақамли версиясини тузиш"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "%1$s жадвалини %2$s деб қайта номлашда хатолик"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add column(s)"
 msgid "A polygon"
 msgstr "Устун(лар) қўшиш"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Янги индекс тузиш"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Қаторлар бўлувчиси"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Журнал файллари сони"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4231,74 +4231,74 @@ msgstr "%d %B %Y й., %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "\"%s\" кун, \"%s\" соат, \"%s\" минут ва \"%s\" секунд"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Муолажалар"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "\"%s\" маълумотлар базасига ўтиш."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 "\"%s\" параметрининг иши маълум хатоликка олиб келиши мумкин, батафсил "
 "маълумот учун қаранг \"%s\""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 #, fuzzy
 #| msgid "Click to select"
 msgid "Click to toggle"
 msgstr "Танлаш учун сичқонча тугмасини босинг"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Юклаш каталогидан"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Кўрсатилган каталокка юклаб бўлмади."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Тозалаш"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Чоп этиш"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Тузиш"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Охирги янгиланиш"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Охирги текширув"
@@ -4687,9 +4687,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Тозалаш"
 
@@ -5028,7 +5028,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Максимум бажарилиш вақти"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Файл каби сақлаш"
 
@@ -7702,7 +7702,7 @@ msgstr "Файл қайта ишланмоқда, илтимос, сабр қи�
 msgid "Language"
 msgstr "Тил"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Версия ҳақида маълумот"
 
@@ -8158,61 +8158,61 @@ msgstr "Маълумотлар кўплиги сабали<br />ўзгартир
 msgid "Binary - do not edit"
 msgstr "Иккилик маълумот - таҳрирлаш мумкин эмас"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "Юклаш каталогидан"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Қўйилаётган қаторлар сони: \"%s\""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "ва сўнг"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Ёзув киритиш"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Янги қатор сифатида қўшиш ва хатоликларга эътибор бермаслик"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Киритилган сўровни кўрсатиш"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Олдинги саҳифага ўтиш"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Янги ёзув киритиш"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Ушбу саҳифага қайтиш"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Кейинги қаторни таҳрирлаш"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Майдонлараро ўтиш учун TAB тугмаси ёки CTRL+стрелка тугмаларидан фойдаланинг"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "SQL-сўровни кўрсатиш"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Киритилган қатор идентификатори: %1$d"
@@ -10608,25 +10608,25 @@ msgid "There are no events to display."
 msgstr "Биронта ҳам конфигурацияланган сервер мавжуд эмас"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "\"%s\" жадвали мавжуд эмас!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "\"%s\" жадвалининг координаталарини ўзгартириш"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -13537,7 +13537,7 @@ msgstr "%s версия тузилди, \"%s.%s\" ни кузатишш фаол
 msgid "Manage your settings"
 msgstr "Бошқа созланишлар"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13831,7 +13831,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Бошқа созланишлар"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13848,19 +13848,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13890,6 +13890,10 @@ msgstr "Маълумотлар базаси мавжуд эмас"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Маълумотлар базалари дампини (схемасини) намойиш этиш"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/uz@latin.po
+++ b/po/uz@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-08-23 11:34+0200\n"
 "Last-Translator: Michal Čihař <michal@cihar.com>\n"
 "Language-Team: Uzbek (latin) <http://l10n.cihar.com/projects/phpmyadmin/"
@@ -41,7 +41,7 @@ msgstr "Jadval izohi"
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr "Tur"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -351,7 +351,7 @@ msgid "Updated"
 msgstr "Yangilandi"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -379,7 +379,7 @@ msgid "Delete tracking data for this table"
 msgstr "Ushbu jadval uchun kuzatuv ma’lumotlari o‘chirish"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -593,8 +593,8 @@ msgstr "Yangi foydalanuvchi qo‘shish"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -620,7 +620,7 @@ msgstr "Yangi foydalanuvchi qo‘shish"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "OK"
@@ -1062,7 +1062,7 @@ msgstr "Indеks(lar)ni saqlash"
 msgid "Edit Index"
 msgstr "Tahrirlash usuli"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, fuzzy, php-format
 #| msgid "Add column(s)"
 msgid "Add %s column(s) to index"
@@ -1307,7 +1307,7 @@ msgid "Traffic"
 msgstr "Trafik"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 #, fuzzy
 #| msgid "settings"
 msgid "Settings"
@@ -1652,8 +1652,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1917,8 +1917,8 @@ msgstr "SQL so‘rovlari qutisi"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1948,7 +1948,7 @@ msgstr "Maksimum bajarilish vaqti"
 msgid "%d is not valid row number."
 msgstr "%d soni to‘g‘ri qator raqami emas."
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -2033,8 +2033,8 @@ msgstr "So‘rov natijalarini ishlatish"
 msgid "Data point content"
 msgstr "Ma`lumotlar fayli ko‘rsatgichi hajmi"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "E`tibor bermaslik"
 
@@ -2674,7 +2674,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "Shrift o‘lchami"
 
@@ -2841,8 +2841,8 @@ msgstr[0] "<i>\"%s\"</i> jadvalida o‘xshashliklar soni \"%s\" ta"
 msgstr[1] "<i>\"%s\"</i> jadvalida o‘xshashliklar soni \"%s\" ta"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2910,16 +2910,16 @@ msgstr "Saqlash direktoriyasi"
 msgid "Restore column order"
 msgstr "CHAR maydonidagi ustunlar soni"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 #, fuzzy
 #| msgid "Begin"
 msgctxt "First page"
 msgid "Begin"
 msgstr "Boshi"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 #, fuzzy
 #| msgid "Previous"
@@ -2927,8 +2927,8 @@ msgctxt "Previous page"
 msgid "Previous"
 msgstr "Orqaga"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 #, fuzzy
 #| msgid "Next"
@@ -2936,8 +2936,8 @@ msgctxt "Next page"
 msgid "Next"
 msgstr "Keyingi"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 #, fuzzy
 #| msgid "End"
 msgctxt "Last page"
@@ -3131,9 +3131,9 @@ msgstr "Barchasini belgilash"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -3330,9 +3330,9 @@ msgid "View"
 msgstr "Namoyish"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -3346,32 +3346,32 @@ msgid "Structure"
 msgstr "Tuzilishi"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "Qidirish"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "Qo‘yish"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -3380,20 +3380,20 @@ msgid "Privileges"
 msgstr "Privilegiyalar"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "Operatsiyalar"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "Kuzatish"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -3409,72 +3409,72 @@ msgstr "Triggerlar"
 msgid "Database seems to be empty!"
 msgstr "Ma`lumotlar bazasi bo‘sh!"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "So‘rov"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "Muolajalar"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "Hodisalar"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "Dizayner"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "Ma`lumotlar bazalari"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 #, fuzzy
 #| msgid "User"
 msgid "Users"
 msgstr "Foydalanuvchi"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "Ikkilik jurnal"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "Replikatsiya (zaxira nusxa ko‘chirish)"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "O‘zgaruvchilar"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "Kodirovkalar"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "Jadval turlari"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "Xatolik"
@@ -3503,7 +3503,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] "%1$d ta qatorlar qo‘yildi."
 msgstr[1] "%1$d ta qatorlar qo‘yildi."
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3740,7 +3740,7 @@ msgid "Operator"
 msgstr "Operator"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3757,7 +3757,7 @@ msgstr "Qidirish"
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 #, fuzzy
 #| msgid "Insert"
 msgid "Edit/Insert"
@@ -3769,7 +3769,7 @@ msgstr "Qo‘yish"
 msgid "Select columns (at least one):"
 msgstr "Maydonni tanlang (kamida bitta):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "Yoki"
@@ -3899,288 +3899,288 @@ msgstr "\"%s\" mavzusi fayllariga yo‘l topilmadi!"
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, fuzzy, php-format
 #| msgid "Create version %s of %s.%s"
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "\"%s.%s\" jadvalining %s raqamli vеrsiyasini tuzish"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, fuzzy, php-format
 #| msgid "Error renaming table %1$s to %2$s"
 msgid "A time, range is %1$s to %2$s"
 msgstr "%1$s jadvalini %2$s deb qayta nomlashda xatolik"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 #, fuzzy
 #| msgid "Add column(s)"
 msgid "A polygon"
 msgstr "Ustun(lar) qo‘shish"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 #, fuzzy
 #| msgid "Create an index"
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "Yangi indeks tuzish"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 #, fuzzy
 #| msgid "Lines terminated by"
 msgctxt "string types"
 msgid "String"
 msgstr "Qatorlar bo‘luvchisi"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 #, fuzzy
 #| msgid "Log file count"
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "Jurnal fayllari soni"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -4271,74 +4271,74 @@ msgstr "%d %B %Y y., %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "\"%s\" kun, \"%s\" soat, \"%s\" minut va \"%s\" sekund"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 #, fuzzy
 #| msgid "Routines"
 msgid "Missing parameter:"
 msgstr "Muolajalar"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "\"%s\" ma`lumotlar bazasiga o‘tish."
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 "\"%s\" parametrining ishi ma`lum xatolikka olib kelishi mumkin, batafsil "
 "ma`lumot uchun qarang \"%s\""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 #, fuzzy
 #| msgid "Click to select"
 msgid "Click to toggle"
 msgstr "Tanlash uchun sichqoncha tugmasini bosing"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, fuzzy, php-format
 #| msgid "web server upload directory"
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "Yuklash katalogidan"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "Ko‘rsatilgan katalokka yuklab bo‘lmadi."
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "Tozalash"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "Chop etish"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "Tuzish"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "Oxirgi yangilanish"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "Oxirgi tekshiruv"
@@ -4729,9 +4729,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "Tozalash"
 
@@ -5071,7 +5071,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr "Maksimum bajarilish vaqti"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "Fayl kabi saqlash"
 
@@ -7754,7 +7754,7 @@ msgstr "Fayl qayta ishlanmoqda, iltimos, sabr qiling."
 msgid "Language"
 msgstr "Til"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "Versiya haqida ma`lumot"
 
@@ -8213,62 +8213,62 @@ msgstr "Ma`lumotlar ko‘pligi sabali<br />o‘zgartirish qiyishlashishi mumkin"
 msgid "Binary - do not edit"
 msgstr "Ikkilik ma`lumot - tahrirlash mumkin emas"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "Yuklash katalogidan"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, fuzzy, php-format
 #| msgid "Restart insertion with %s rows"
 msgid "Continue insertion with %s rows"
 msgstr "Qo‘yilayotgan qatorlar soni: \"%s\""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "va so‘ng"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "Yozuv kiritish"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "Yangi qator sifatida qo‘shish va xatoliklarga e’tibor bеrmaslik"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "Kiritilgan so‘rovni ko‘rsatish"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "Oldingi sahifaga o‘tish"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "Yangi yozuv kiritish"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "Ushbu sahifaga qaytish"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "Keyingi qatorni tahrirlash"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 "Maydonlararo o‘tish uchun TAB tugmasi yoki CTRL+strelka tugmalaridan "
 "foydalaning"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "SQL-so‘rovni ko‘rsatish"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "Kiritilgan qator identifikatori: %1$d"
@@ -10679,25 +10679,25 @@ msgid "There are no events to display."
 msgstr "Bironta ham konfiguratsiyalangan server mavjud emas"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, fuzzy, php-format
 #| msgid "The \"%s\" table doesn't exist!"
 msgid "The %s table doesn't exist!"
 msgstr "\"%s\" jadvali mavjud emas!"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "\"%s\" jadvalining koordinatalarini o‘zgartirish"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, fuzzy, php-format
 #| msgid "Schema of the \"%s\" database - Page %s"
 msgid "Schema of the %s database - Page %s"
@@ -13637,7 +13637,7 @@ msgstr "%s vеrsiya tuzildi, \"%s.%s\" ni kuzatishsh faollashtirilgan."
 msgid "Manage your settings"
 msgstr "Boshqa sozlanishlar"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 #, fuzzy
 #| msgid "Modifications have been saved"
 msgid "Configuration has been saved"
@@ -13932,7 +13932,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr "Boshqa sozlanishlar"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -13949,19 +13949,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -13991,6 +13991,10 @@ msgstr "Ma`lumotlar bazasi mavjud emas"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "Ma`lumotlar bazalari dampini (sxemasini) namoyish etish"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/vls.po
+++ b/po/vls.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-07-25 14:40+0200\n"
 "Last-Translator: saurabh chikate <chikate.saurabh@gmail.com>\n"
 "Language-Team: West Flemish <http://l10n.cihar.com/projects/phpmyadmin/"
@@ -43,7 +43,7 @@ msgstr ""
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -89,7 +89,7 @@ msgid "Type"
 msgstr ""
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -336,7 +336,7 @@ msgid "Updated"
 msgstr ""
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -364,7 +364,7 @@ msgid "Delete tracking data for this table"
 msgstr ""
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -558,8 +558,8 @@ msgstr ""
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -585,7 +585,7 @@ msgstr ""
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr ""
@@ -913,7 +913,7 @@ msgstr ""
 msgid "Edit Index"
 msgstr ""
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr ""
@@ -1126,7 +1126,7 @@ msgid "Traffic"
 msgstr ""
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr ""
 
@@ -1420,8 +1420,8 @@ msgstr ""
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1630,8 +1630,8 @@ msgstr ""
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1658,7 +1658,7 @@ msgstr ""
 msgid "%d is not valid row number."
 msgstr ""
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1727,8 +1727,8 @@ msgstr ""
 msgid "Data point content"
 msgstr ""
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr ""
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr ""
 
@@ -2409,8 +2409,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2466,28 +2466,28 @@ msgstr ""
 msgid "Restore column order"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr ""
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr ""
@@ -2663,9 +2663,9 @@ msgstr ""
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2850,9 +2850,9 @@ msgid "View"
 msgstr ""
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2866,32 +2866,32 @@ msgid "Structure"
 msgstr ""
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr ""
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr ""
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr ""
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2900,20 +2900,20 @@ msgid "Privileges"
 msgstr ""
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr ""
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr ""
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2929,70 +2929,70 @@ msgstr ""
 msgid "Database seems to be empty!"
 msgstr ""
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr ""
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr ""
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr ""
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr ""
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr ""
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr ""
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr ""
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr ""
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr ""
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr ""
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr ""
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr ""
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr ""
@@ -3018,7 +3018,7 @@ msgid_plural "%1$d rows inserted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3234,7 +3234,7 @@ msgid "Operator"
 msgstr ""
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3249,7 +3249,7 @@ msgstr ""
 msgid "Find and Replace"
 msgstr ""
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr ""
 
@@ -3257,7 +3257,7 @@ msgstr ""
 msgid "Select columns (at least one):"
 msgstr ""
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr ""
@@ -3367,278 +3367,278 @@ msgstr ""
 msgid "Theme:"
 msgstr ""
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr ""
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr ""
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
 msgstr ""
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
 msgstr ""
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
 msgstr ""
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
 "2.2250738585072014E-308 to 1.7976931348623157E+308"
 msgstr ""
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr ""
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr ""
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr ""
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
 msgstr ""
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr ""
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
 msgstr ""
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr ""
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr ""
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
 "value in bytes"
 msgstr ""
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr ""
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
 msgstr ""
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr ""
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr ""
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr ""
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr ""
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr ""
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr ""
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr ""
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr ""
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr ""
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr ""
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr ""
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr ""
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr ""
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr ""
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr ""
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr ""
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr ""
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr ""
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr ""
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
 msgstr ""
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr ""
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr ""
 
@@ -3723,67 +3723,67 @@ msgstr ""
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr ""
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr ""
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr ""
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr ""
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr ""
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr ""
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr ""
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr ""
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr ""
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr ""
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr ""
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr ""
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr ""
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr ""
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr ""
@@ -4131,9 +4131,9 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr ""
 
@@ -4414,7 +4414,7 @@ msgstr ""
 msgid "Maximum execution time"
 msgstr ""
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr ""
 
@@ -6630,7 +6630,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr ""
 
@@ -7021,57 +7021,57 @@ msgstr ""
 msgid "Binary - do not edit"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr ""
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr ""
@@ -9087,24 +9087,24 @@ msgid "There are no events to display."
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr ""
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr ""
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr ""
@@ -11573,7 +11573,7 @@ msgstr ""
 msgid "Manage your settings"
 msgstr ""
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr ""
 
@@ -11821,7 +11821,7 @@ msgstr ""
 msgid "You have no saved settings!"
 msgstr ""
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr ""
 
@@ -11836,19 +11836,19 @@ msgid ""
 "script%s."
 msgstr ""
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr ""
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr ""
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr ""
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr ""
 
@@ -11875,6 +11875,10 @@ msgstr ""
 
 #: server_export.php:21
 msgid "View dump (schema) of databases"
+msgstr ""
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
 msgstr ""
 
 #: server_status.php:32

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-09-26 20:35+0200\n"
 "Last-Translator: Hao Luo <haoluo.ca@gmail.com>\n"
 "Language-Team: Simplified Chinese <http://l10n.cihar.com/projects/phpmyadmin/"
@@ -39,7 +39,7 @@ msgstr "表注释："
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -85,7 +85,7 @@ msgid "Type"
 msgstr "类型"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -331,7 +331,7 @@ msgid "Updated"
 msgstr "更新"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -359,7 +359,7 @@ msgid "Delete tracking data for this table"
 msgstr "删除该表的追踪数据"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -553,8 +553,8 @@ msgstr "添加几何体"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -580,7 +580,7 @@ msgstr "添加几何体"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "执行"
@@ -935,7 +935,7 @@ msgstr "添加索引"
 msgid "Edit Index"
 msgstr "编辑索引"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "添加 %s 个字段至索引"
@@ -1150,7 +1150,7 @@ msgid "Traffic"
 msgstr "流量"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "设置"
 
@@ -1452,8 +1452,8 @@ msgstr "使用导入的设置建立图表失败。正在重设为默认设置…
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1664,8 +1664,8 @@ msgstr "显示查询框"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1692,7 +1692,7 @@ msgstr "查询执行时间"
 msgid "%d is not valid row number."
 msgstr "%d 不是有效行数。"
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1761,8 +1761,8 @@ msgstr "查询结果"
 msgid "Data point content"
 msgstr "数据点内容"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "忽略"
 
@@ -2311,7 +2311,7 @@ msgstr "现有的配置文件（%s）是不可读的。"
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "配置文件权限错误，不应任何用户都能修改！"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "字号"
 
@@ -2455,8 +2455,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] "在 <strong>%2$s</strong> 中找到 %1$s 个"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2512,28 +2512,28 @@ msgstr "保存已修改的数据"
 msgid "Restore column order"
 msgstr "恢复字段顺序"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "首页"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "上一页"
 
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "下一页"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "尾页"
@@ -2710,9 +2710,9 @@ msgstr "全选"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2897,9 +2897,9 @@ msgid "View"
 msgstr "视图"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2913,32 +2913,32 @@ msgid "Structure"
 msgstr "结构"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "搜索"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "插入"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2947,20 +2947,20 @@ msgid "Privileges"
 msgstr "权限"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "操作"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "追踪"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2976,70 +2976,70 @@ msgstr "触发器"
 msgid "Database seems to be empty!"
 msgstr "数据库是空的！"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "查询"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "程序"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "事件"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "设计器"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "数据库"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "用户"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "二进制日志"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "复制"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "变量"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "字符集"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "插件"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "引擎"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "错误"
@@ -3062,7 +3062,7 @@ msgid "%1$d row inserted."
 msgid_plural "%1$d rows inserted."
 msgstr[0] "插入了 %1$d 行。"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3279,7 +3279,7 @@ msgid "Operator"
 msgstr "运算符"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3294,7 +3294,7 @@ msgstr "普通搜索"
 msgid "Find and Replace"
 msgstr "查找并替换"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "编辑/插入"
 
@@ -3302,7 +3302,7 @@ msgstr "编辑/插入"
 msgid "Select columns (at least one):"
 msgstr "选择字段（至少一个）："
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "或"
@@ -3413,25 +3413,25 @@ msgstr "找不到主题 %s 的路径！"
 msgid "Theme:"
 msgstr "主题："
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr "1 字节整数，有符号范围从 -128 到 127，无符号范围从 0 到 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr "2 字节整数，有符号范围从 -32768 到 32767，无符号范围从 0 到 65535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
 msgstr ""
 "3 字节整数，有符号范围从 -8388608 到 8388607，无符号范围从 0 到 16777215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3439,7 +3439,7 @@ msgstr ""
 "4 字节整数，有符号范围从 -2147483648 到 2147483647，无符号范围从 0 到 "
 "4294967295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3447,7 +3447,7 @@ msgstr ""
 "8 字节整数，有符号范围从 -9223372036854775808 到 9223372036854775807，无符号"
 "范围从 0 到 18446744073709551615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
@@ -3455,7 +3455,7 @@ msgstr ""
 "定点数（M，D）- 整数部分（M）最大为 65（默认 10），小数部分（D）最大为 30（默"
 "认 0）"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3463,7 +3463,7 @@ msgstr ""
 "单精度浮点数，取值范围从 -3.402823466E+38 到 -1.175494351E-38、0 以及从 "
 "1.175494351E-38 到 3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3472,39 +3472,39 @@ msgstr ""
 "双精度浮点数，取值范围从 -1.7976931348623157E+308 到 -2.2250738585072014E-"
 "308、0 以及从 2.2250738585072014E-308 到 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr "DOUBLE 的别名（例外：REAL_AS_FLOAT SQL 模式时它是 FLOAT 的别名）"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr "位类型（M），每个值存储 M 位（默认为 1，最大为 64）"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr "TINYINT(1) 的别名，零值表示假，非零值表示真"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE 的别名"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "日期，支持的范围从 %1$s 到 %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "日期与时间，支持的范围从 %1$s 到 %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3512,12 +3512,12 @@ msgstr ""
 "时间戳，范围从 1970-01-01 00:00:01 UTC 到 2038-01-09 03:14:07 UTC，存储为自纪"
 "元（1970-01-01 00:00:00 UTC）起的秒数"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "时间，范围从 %1$s 到 %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3525,20 +3525,20 @@ msgstr ""
 "四位数（4，默认）或两位数（2）的年份，取值范围从 70（1970）到 69（2069）或从 "
 "1901 到 2155 以及 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr "定长（0-255，默认 1）字符串，存储时会向右边补足空格到指定长度"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr "变长（%s）字符串，最大有效长度取决于最大行大小"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3546,7 +3546,7 @@ msgstr ""
 "最多存储 255（2^8 - 1）字节的文本字段，存储时在内容前使用 1 字节表示内容的字"
 "节数"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3554,7 +3554,7 @@ msgstr ""
 "最多存储 65535（2^16 - 1）字节的文本字段，存储时在内容前使用 2 字节表示内容的"
 "字节数"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3562,7 +3562,7 @@ msgstr ""
 "最多存储 16777215（2^24 - 1）字节的文本字段，存储时在内容前使用 3 字节表示内"
 "容的字节数"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3571,19 +3571,19 @@ msgstr ""
 "最多存储 4294967295 字节即 4GB（2^32 - 1）的文本字段，存储时在内容前使用 4 字"
 "节表示内容的字节数"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "类似于 CHAR 类型，但其存储的是二进制字节串而不是非二进制字符串"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "类似于 VARCHAR 类型，但其存储的是二进制字节串而不是非二进制字符串"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3591,7 +3591,7 @@ msgstr ""
 "最多存储 255（2^8 - 1）字节的 BLOB 字段，存储时在内容前使用 1 字节表示内容的"
 "字节数"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3599,7 +3599,7 @@ msgstr ""
 "最多存储 16777215（2^24 - 1）字节的 BLOB 字段，存储时在内容前使用 3 字节表示"
 "内容的字节数"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3607,7 +3607,7 @@ msgstr ""
 "最多存储 65535（2^16 - 1）字节的 BLOB 字段，存储时在内容前使用 2 字节表示内容"
 "的字节数"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3615,95 +3615,95 @@ msgstr ""
 "最多存储 4294967295 字节即 4GB（2^32 - 1）的 BLOB 字段，存储时在内容前使用 4 "
 "字节表示内容的字节数"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr "枚举，可从最多 65535 个值的列表中选择或特殊的错误值 ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "可从最多 64 个成员中选择集合为一个值"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "一种能存储任意类型几何体的类型"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "二维空间中的点"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "点之间的线性插值曲线"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "多边形"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "点的集合"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "点之间的线性插值曲线的集合"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "多边形的集合"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "任意类型几何体对象的集合"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "数字"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "日期与时间"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "文本"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "空间"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "4 字节整数，范围从 -2147483648 到 2147483647"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
 msgstr "8 字节整数，范围从 -9223372036854775808 到 9223372036854775807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "系统默认的双精度浮点数"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "真或假"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT NOT NULL AUTO_INCREMENT UNIQUE 的别名"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "存储一个通用唯一识别码（UUID）"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3711,13 +3711,13 @@ msgstr ""
 "时间戳，范围从‘0001-01-01 00:00:00’UTC 到‘9999-12-31 23:59:59’UTC；TIMESTAMP"
 "(6) 可以存储微秒"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr "变长（0-65535）字符串，使用二进制排序规则进行所有比较"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "枚举，从定义好的值中选择"
 
@@ -3802,67 +3802,67 @@ msgstr "%Y-%m-%d %H:%M:%S"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s 天 %s 小时，%s 分 %s 秒"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "缺少参数："
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "转到数据库 &quot;%s&quot;。"
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "功能 %s 受到一个已知缺陷的影响，参见 %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "点击切换"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "从计算机中上传："
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "从网站服务器上传文件夹 <b>%s</b> 中选择："
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "无法访问用于上传的文件夹。"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "没有可上传的文件"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "清空"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "执行"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "打印"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "创建时间"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "最后更新"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "最后检查"
@@ -4212,9 +4212,9 @@ msgstr "允许用户自定义该值"
 msgid "Apply"
 msgstr "应用"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "重置"
 
@@ -4506,7 +4506,7 @@ msgstr "设置脚本运行最长时间（[kbd]0[/kbd] 为无限制）"
 msgid "Maximum execution time"
 msgstr "最长执行时间"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "保存为文件"
 
@@ -6829,7 +6829,7 @@ msgstr "正在处理，请稍候。"
 msgid "Language"
 msgstr "语言"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "版本信息"
 
@@ -7241,59 +7241,59 @@ msgstr "因长度问题，<br /> 该字段可能无法编辑"
 msgid "Binary - do not edit"
 msgstr "二进制 - 无法编辑"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 #, fuzzy
 #| msgid "web server upload directory"
 msgid "web server upload directory:"
 msgstr "网站服务器上传文件夹"
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "继续插入 %s 行"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "然后"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "以新行插入"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "以新行插入 (忽略错误)"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "显示插入语句"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "返回上一页"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "插入新数据"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "返回到本页"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "编辑下一行"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr "按 TAB 键跳到下一个数值，或 CTRL+方向键 作随意移动"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "显示 SQL 查询"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "插入的行 id: %1$d"
@@ -9457,24 +9457,24 @@ msgid "There are no events to display."
 msgstr "没有事件。"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "数据表 %s 不存在！"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "请配置表 %s 的并发"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "数据库 %s 的大纲 - 第 %s 页"
@@ -12128,7 +12128,7 @@ msgstr "已创建版本 %1$s，%2$s 的追踪已启用。"
 msgid "Manage your settings"
 msgstr "管理我的设置"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "设置已保存"
 
@@ -12382,7 +12382,7 @@ msgstr "设置将从浏览器的本地存储中导入。"
 msgid "You have no saved settings!"
 msgstr "你没有已保存的设置！"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "你所使用的浏览器不支持此功能"
 
@@ -12398,19 +12398,19 @@ msgid ""
 msgstr ""
 "你可以通过修改 config.inc.php 文件进行更多设置，如通过使用%s安装脚本%s。"
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "保存到浏览器存储"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "设置将保存到浏览器的本地存储。"
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "现有设置将被覆盖！"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "你可以重置并将所有设置恢复为默认值。"
 
@@ -12440,6 +12440,10 @@ msgstr "无数据库"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "查看数据库的转存(大纲)"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -3,15 +3,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: phpMyAdmin 4.2.0-dev\n"
 "Report-Msgid-Bugs-To: phpmyadmin-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2013-11-25 16:20-0500\n"
+"POT-Creation-Date: 2013-12-01 00:40+0100\n"
 "PO-Revision-Date: 2013-11-29 15:23+0200\n"
 "Last-Translator: Chien Wei Lin <cwlin0416@gmail.com>\n"
-"Language-Team: Traditional Chinese "
-"<http://l10n.cihar.com/projects/phpmyadmin/master/zh_TW/>\n"
-"Language: zh_TW\n"
+"Language-Team: Traditional Chinese <http://l10n.cihar.com/projects/"
+"phpmyadmin/master/zh_TW/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 1.9-dev\n"
 
@@ -39,7 +39,7 @@ msgstr "表註釋："
 
 #: db_datadict.php:168 libraries/Index.class.php:567
 #: libraries/TableSearch.class.php:185 libraries/TableSearch.class.php:1282
-#: libraries/insert_edit.lib.php:1620
+#: libraries/insert_edit.lib.php:1603
 #: libraries/navigation/Nodes/Node_Column.class.php:32
 #: libraries/plugins/export/ExportHtmlword.class.php:278
 #: libraries/plugins/export/ExportHtmlword.class.php:393
@@ -85,7 +85,7 @@ msgid "Type"
 msgstr "型態"
 
 #: db_datadict.php:170 libraries/Index.class.php:570
-#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1629
+#: libraries/TableSearch.class.php:1283 libraries/insert_edit.lib.php:1612
 #: libraries/plugins/export/ExportHtmlword.class.php:284
 #: libraries/plugins/export/ExportHtmlword.class.php:399
 #: libraries/plugins/export/ExportLatex.class.php:512
@@ -331,7 +331,7 @@ msgid "Updated"
 msgstr "更新"
 
 #: db_tracking.php:85 js/messages.php:177 libraries/Menu.class.php:516
-#: libraries/Util.class.php:4106 libraries/rte/rte_events.lib.php:426
+#: libraries/Util.class.php:4115 libraries/rte/rte_events.lib.php:426
 #: libraries/rte/rte_list.lib.php:78 libraries/server_status.lib.php:363
 #: libraries/tbl_tracking.lib.php:200
 msgid "Status"
@@ -359,7 +359,7 @@ msgid "Delete tracking data for this table"
 msgstr "刪除此資料表的追蹤資料"
 
 #: db_tracking.php:103 libraries/Index.class.php:627
-#: libraries/Util.class.php:3410 libraries/Util.class.php:3411
+#: libraries/Util.class.php:3411 libraries/Util.class.php:3412
 #: libraries/server_databases.lib.php:156 libraries/structure.lib.php:307
 #: libraries/structure.lib.php:1384 libraries/structure.lib.php:2071
 #: libraries/structure.lib.php:2073
@@ -414,9 +414,6 @@ msgid "You may want to refresh the page."
 msgstr "您需要重新整理頁面。"
 
 #: error_report.php:45
-#| msgid ""
-#| "An error has been detected and an error report has been automatically "
-#| "submitted based on your settings."
 msgid ""
 "An error has been detected and an error report has been generated but failed "
 "to be sent."
@@ -556,8 +553,8 @@ msgstr "新增幾何形"
 #: libraries/core.lib.php:554 libraries/display_change_password.lib.php:94
 #: libraries/display_create_table.lib.php:71
 #: libraries/display_export.lib.php:294 libraries/display_import.lib.php:368
-#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1601
-#: libraries/insert_edit.lib.php:1636 libraries/operations.lib.php:39
+#: libraries/index.lib.php:40 libraries/insert_edit.lib.php:1584
+#: libraries/insert_edit.lib.php:1619 libraries/operations.lib.php:39
 #: libraries/operations.lib.php:82 libraries/operations.lib.php:210
 #: libraries/operations.lib.php:254 libraries/operations.lib.php:650
 #: libraries/operations.lib.php:703 libraries/operations.lib.php:752
@@ -583,7 +580,7 @@ msgstr "新增幾何形"
 #: libraries/tbl_chart.lib.php:216
 #: libraries/tbl_columns_definition_form.lib.php:174
 #: libraries/tbl_tracking.lib.php:386 libraries/tbl_tracking.lib.php:454
-#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:327
+#: pmd_pdf.php:158 prefs_manage.php:278 prefs_manage.php:336
 #: view_create.php:273 view_operations.php:106
 msgid "Go"
 msgstr "執行"
@@ -943,7 +940,7 @@ msgstr "新增索引"
 msgid "Edit Index"
 msgstr "編輯索引"
 
-#: js/messages.php:52 libraries/tbl_indexes.lib.php:394
+#: js/messages.php:52 libraries/tbl_indexes.lib.php:395
 #, php-format
 msgid "Add %s column(s) to index"
 msgstr "增加 %s 個欄位至索引"
@@ -1158,7 +1155,7 @@ msgid "Traffic"
 msgstr "流量"
 
 #: js/messages.php:119 libraries/Menu.class.php:549
-#: libraries/Util.class.php:4110 libraries/server_status_monitor.lib.php:299
+#: libraries/Util.class.php:4119 libraries/server_status_monitor.lib.php:299
 msgid "Settings"
 msgstr "設定"
 
@@ -1462,8 +1459,8 @@ msgstr "無法使用匯入的設定檔建立圖表，將重設為預設的設定
 
 #: js/messages.php:206 libraries/Menu.class.php:332
 #: libraries/Menu.class.php:431 libraries/Menu.class.php:545
-#: libraries/Util.class.php:4109 libraries/Util.class.php:4124
-#: libraries/Util.class.php:4140 libraries/config/messages.inc.php:171
+#: libraries/Util.class.php:4118 libraries/Util.class.php:4133
+#: libraries/Util.class.php:4149 libraries/config/messages.inc.php:171
 #: libraries/display_import.lib.php:108
 #: libraries/server_status_monitor.lib.php:364 prefs_manage.php:239
 #: setup/frames/menu.inc.php:25
@@ -1672,8 +1669,8 @@ msgstr "顯示查詢框"
 
 #: js/messages.php:282 libraries/DisplayResults.class.php:3352
 #: libraries/Index.class.php:593 libraries/Util.class.php:667
-#: libraries/Util.class.php:1212 libraries/Util.class.php:3414
-#: libraries/Util.class.php:3415 libraries/config/messages.inc.php:492
+#: libraries/Util.class.php:1212 libraries/Util.class.php:3415
+#: libraries/Util.class.php:3416 libraries/config/messages.inc.php:492
 #: libraries/schema/User_Schema.class.php:223
 #: libraries/server_user_groups.lib.php:119
 #: libraries/server_variables.lib.php:154 setup/frames/index.inc.php:176
@@ -1700,7 +1697,7 @@ msgstr "查詢執行時間"
 msgid "%d is not valid row number."
 msgstr "%d 不是有效的資料列編號。"
 
-#: js/messages.php:289 libraries/insert_edit.lib.php:1514
+#: js/messages.php:289 libraries/insert_edit.lib.php:1497
 #: libraries/schema/User_Schema.class.php:390
 #: libraries/server_variables.lib.php:157
 #: libraries/tbl_columns_definition_form.lib.php:141
@@ -1769,8 +1766,8 @@ msgstr "查詢結果"
 msgid "Data point content"
 msgstr "資料點內容"
 
-#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2608
-#: libraries/tbl_indexes.lib.php:333 libraries/tbl_indexes.lib.php:369
+#: js/messages.php:322 js/messages.php:415 libraries/insert_edit.lib.php:2591
+#: libraries/tbl_indexes.lib.php:334 libraries/tbl_indexes.lib.php:370
 msgid "Ignore"
 msgstr "忽略"
 
@@ -1969,7 +1966,6 @@ msgid "Submit Error Report"
 msgstr "送出錯誤報告"
 
 #: js/messages.php:411
-#| msgid "An error has occurred. Do you want to send an error report?"
 msgid ""
 "A fatal JavaScript error has occurred. Would you like to send an error "
 "report?"
@@ -2312,7 +2308,7 @@ msgstr "無法讀取已存在的設定檔 %s。"
 msgid "Wrong permissions on configuration file, should not be world writable!"
 msgstr "設定檔權限錯誤，其他人不應擁有寫入權。"
 
-#: libraries/Config.class.php:1758
+#: libraries/Config.class.php:1759
 msgid "Font size"
 msgstr "字體大小"
 
@@ -2455,8 +2451,8 @@ msgid_plural "%1$s matches in <strong>%2$s</strong>"
 msgstr[0] "%1$s 筆資料符合 <strong>%2$s</strong>"
 
 #: libraries/DbSearch.class.php:350 libraries/Menu.class.php:295
-#: libraries/Util.class.php:3188 libraries/Util.class.php:3403
-#: libraries/Util.class.php:3404 libraries/Util.class.php:4134
+#: libraries/Util.class.php:3189 libraries/Util.class.php:3404
+#: libraries/Util.class.php:3405 libraries/Util.class.php:4143
 #: libraries/navigation/Nodes/Node_Table.class.php:48
 #: libraries/structure.lib.php:1374
 msgid "Browse"
@@ -2512,29 +2508,29 @@ msgstr "儲存"
 msgid "Restore column order"
 msgstr "還原欄位的順序"
 
-#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2483
-#: libraries/Util.class.php:2487
+#: libraries/DisplayResults.class.php:815 libraries/Util.class.php:2484
+#: libraries/Util.class.php:2488
 msgctxt "First page"
 msgid "Begin"
 msgstr "最前頁"
 
-#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2485
-#: libraries/Util.class.php:2488 libraries/server_bin_log.lib.php:171
+#: libraries/DisplayResults.class.php:818 libraries/Util.class.php:2486
+#: libraries/Util.class.php:2489 libraries/server_bin_log.lib.php:171
 #: libraries/server_bin_log.lib.php:173
 msgctxt "Previous page"
 msgid "Previous"
 msgstr "上一頁"
 
 # 這應該使用於選擇日期的小月曆
-#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2520
-#: libraries/Util.class.php:2523 libraries/server_bin_log.lib.php:205
+#: libraries/DisplayResults.class.php:875 libraries/Util.class.php:2521
+#: libraries/Util.class.php:2524 libraries/server_bin_log.lib.php:205
 #: libraries/server_bin_log.lib.php:207
 msgctxt "Next page"
 msgid "Next"
 msgstr "下一頁"
 
-#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2521
-#: libraries/Util.class.php:2524
+#: libraries/DisplayResults.class.php:904 libraries/Util.class.php:2522
+#: libraries/Util.class.php:2525
 msgctxt "Last page"
 msgid "End"
 msgstr "最末頁"
@@ -2710,9 +2706,9 @@ msgstr "全選"
 #: libraries/DisplayResults.class.php:5057
 #: libraries/DisplayResults.class.php:5327 libraries/Menu.class.php:324
 #: libraries/Menu.class.php:422 libraries/Menu.class.php:541
-#: libraries/Util.class.php:3416 libraries/Util.class.php:3417
-#: libraries/Util.class.php:4108 libraries/Util.class.php:4123
-#: libraries/Util.class.php:4139 libraries/config/messages.inc.php:165
+#: libraries/Util.class.php:3417 libraries/Util.class.php:3418
+#: libraries/Util.class.php:4117 libraries/Util.class.php:4132
+#: libraries/Util.class.php:4148 libraries/config/messages.inc.php:165
 #: libraries/display_export.lib.php:163
 #: libraries/server_privileges.lib.php:2231
 #: libraries/server_privileges.lib.php:2906
@@ -2897,9 +2893,9 @@ msgid "View"
 msgstr "檢視表"
 
 #: libraries/Menu.class.php:301 libraries/Menu.class.php:401
-#: libraries/Util.class.php:3184 libraries/Util.class.php:3191
-#: libraries/Util.class.php:3409 libraries/Util.class.php:4119
-#: libraries/Util.class.php:4135 libraries/config/setup.forms.php:303
+#: libraries/Util.class.php:3185 libraries/Util.class.php:3192
+#: libraries/Util.class.php:3410 libraries/Util.class.php:4128
+#: libraries/Util.class.php:4144 libraries/config/setup.forms.php:303
 #: libraries/config/setup.forms.php:340 libraries/config/setup.forms.php:366
 #: libraries/config/user_preferences.forms.php:198
 #: libraries/config/user_preferences.forms.php:235
@@ -2913,32 +2909,32 @@ msgid "Structure"
 msgstr "結構"
 
 #: libraries/Menu.class.php:305 libraries/Menu.class.php:405
-#: libraries/Menu.class.php:512 libraries/Util.class.php:3185
-#: libraries/Util.class.php:3192 libraries/Util.class.php:4105
-#: libraries/Util.class.php:4120 libraries/Util.class.php:4136
+#: libraries/Menu.class.php:512 libraries/Util.class.php:3186
+#: libraries/Util.class.php:3193 libraries/Util.class.php:4114
+#: libraries/Util.class.php:4129 libraries/Util.class.php:4145
 #: libraries/config/messages.inc.php:215
 #: libraries/navigation/Nodes/Node_Table.class.php:45 querywindow.php:59
 msgid "SQL"
 msgstr "SQL"
 
 #: libraries/Menu.class.php:308 libraries/Menu.class.php:408
-#: libraries/Util.class.php:3186 libraries/Util.class.php:3193
-#: libraries/Util.class.php:3405 libraries/Util.class.php:3406
-#: libraries/Util.class.php:4121 libraries/Util.class.php:4137
+#: libraries/Util.class.php:3187 libraries/Util.class.php:3194
+#: libraries/Util.class.php:3406 libraries/Util.class.php:3407
+#: libraries/Util.class.php:4130 libraries/Util.class.php:4146
 #: libraries/navigation/Nodes/Node_Table.class.php:39
 msgid "Search"
 msgstr "搜尋"
 
-#: libraries/Menu.class.php:318 libraries/Util.class.php:3187
-#: libraries/Util.class.php:3407 libraries/Util.class.php:3408
-#: libraries/Util.class.php:4138
+#: libraries/Menu.class.php:318 libraries/Util.class.php:3188
+#: libraries/Util.class.php:3408 libraries/Util.class.php:3409
+#: libraries/Util.class.php:4147
 #: libraries/navigation/Nodes/Node_Table.class.php:42
 #: libraries/sql_query_form.lib.php:301 libraries/sql_query_form.lib.php:304
 msgid "Insert"
 msgstr "新增"
 
 #: libraries/Menu.class.php:340 libraries/Menu.class.php:443
-#: libraries/Util.class.php:4126 libraries/Util.class.php:4141
+#: libraries/Util.class.php:4135 libraries/Util.class.php:4150
 #: libraries/server_common.lib.php:51 libraries/server_privileges.lib.php:1816
 #: libraries/server_privileges.lib.php:1924
 #: libraries/server_privileges.lib.php:2703
@@ -2947,20 +2943,20 @@ msgid "Privileges"
 msgstr "權限"
 
 #: libraries/Menu.class.php:349 libraries/Menu.class.php:376
-#: libraries/Menu.class.php:435 libraries/Util.class.php:3194
-#: libraries/Util.class.php:4125 libraries/Util.class.php:4142
+#: libraries/Menu.class.php:435 libraries/Util.class.php:3195
+#: libraries/Util.class.php:4134 libraries/Util.class.php:4151
 #: view_operations.php:92
 msgid "Operations"
 msgstr "操作"
 
 #: libraries/Menu.class.php:353 libraries/Menu.class.php:469
-#: libraries/Util.class.php:4130 libraries/Util.class.php:4143
+#: libraries/Util.class.php:4139 libraries/Util.class.php:4152
 #: libraries/relation.lib.php:236
 msgid "Tracking"
 msgstr "追蹤"
 
 #: libraries/Menu.class.php:366 libraries/Menu.class.php:463
-#: libraries/Util.class.php:4129 libraries/Util.class.php:4144
+#: libraries/Util.class.php:4138 libraries/Util.class.php:4153
 #: libraries/navigation/Nodes/Node_Trigger_Container.class.php:26
 #: libraries/plugins/export/ExportHtmlword.class.php:565
 #: libraries/plugins/export/ExportOdt.class.php:657
@@ -2976,70 +2972,70 @@ msgstr "觸發器"
 msgid "Database seems to be empty!"
 msgstr "資料庫是空的！"
 
-#: libraries/Menu.class.php:415 libraries/Util.class.php:4122
+#: libraries/Menu.class.php:415 libraries/Util.class.php:4131
 msgid "Query"
 msgstr "查詢"
 
-#: libraries/Menu.class.php:448 libraries/Util.class.php:4127
+#: libraries/Menu.class.php:448 libraries/Util.class.php:4136
 #: libraries/rte/rte_words.lib.php:34
 msgid "Routines"
 msgstr "預存程序"
 
-#: libraries/Menu.class.php:456 libraries/Util.class.php:4128
+#: libraries/Menu.class.php:456 libraries/Util.class.php:4137
 #: libraries/navigation/Nodes/Node_Event_Container.class.php:26
 #: libraries/plugins/export/ExportSql.class.php:833
 #: libraries/rte/rte_words.lib.php:58
 msgid "Events"
 msgstr "事件"
 
-#: libraries/Menu.class.php:475 libraries/Util.class.php:4131
+#: libraries/Menu.class.php:475 libraries/Util.class.php:4140
 #: libraries/relation.lib.php:203
 msgid "Designer"
 msgstr "設計器"
 
-#: libraries/Menu.class.php:508 libraries/Util.class.php:4104
+#: libraries/Menu.class.php:508 libraries/Util.class.php:4113
 #: libraries/config/messages.inc.php:178 libraries/server_common.lib.php:48
 #: libraries/server_privileges.lib.php:3696
 msgid "Databases"
 msgstr "資料庫"
 
-#: libraries/Menu.class.php:531 libraries/Util.class.php:4107
+#: libraries/Menu.class.php:531 libraries/Util.class.php:4116
 msgid "Users"
 msgstr "使用者"
 
 #: libraries/Menu.class.php:558 libraries/ServerStatusData.class.php:194
-#: libraries/Util.class.php:4111 libraries/server_common.lib.php:36
+#: libraries/Util.class.php:4120 libraries/server_common.lib.php:36
 msgid "Binary log"
 msgstr "二進位記錄"
 
 #: libraries/Menu.class.php:564 libraries/ServerStatusData.class.php:199
-#: libraries/Util.class.php:4112 libraries/server_common.lib.php:42
+#: libraries/Util.class.php:4121 libraries/server_common.lib.php:42
 #: libraries/structure.lib.php:182 libraries/structure.lib.php:761
 msgid "Replication"
 msgstr "備援"
 
 #: libraries/Menu.class.php:569 libraries/ServerStatusData.class.php:261
-#: libraries/Util.class.php:4113 libraries/server_engines.lib.php:109
+#: libraries/Util.class.php:4122 libraries/server_engines.lib.php:109
 #: libraries/server_engines.lib.php:113
 msgid "Variables"
 msgstr "變數"
 
-#: libraries/Menu.class.php:573 libraries/Util.class.php:4114
+#: libraries/Menu.class.php:573 libraries/Util.class.php:4123
 msgid "Charsets"
 msgstr "字元編碼"
 
-#: libraries/Menu.class.php:578 libraries/Util.class.php:4115
+#: libraries/Menu.class.php:578 libraries/Util.class.php:4124
 #: libraries/server_common.lib.php:33 libraries/server_plugins.lib.php:31
 msgid "Plugins"
 msgstr "附加元件"
 
-#: libraries/Menu.class.php:582 libraries/Util.class.php:4116
+#: libraries/Menu.class.php:582 libraries/Util.class.php:4125
 msgid "Engines"
 msgstr "引擎"
 
 #: libraries/Message.class.php:199 libraries/Util.class.php:629
 #: libraries/core.lib.php:229 libraries/import.lib.php:174
-#: libraries/insert_edit.lib.php:1232 tbl_chart.php:24 tbl_operations.php:187
+#: libraries/insert_edit.lib.php:1215 tbl_chart.php:24 tbl_operations.php:187
 #: view_operations.php:63
 msgid "Error"
 msgstr "錯誤"
@@ -3062,7 +3058,7 @@ msgid "%1$d row inserted."
 msgid_plural "%1$d rows inserted."
 msgstr[0] "新增了 %1$d 行。"
 
-#: libraries/PDF.class.php:70 libraries/Util.class.php:2475
+#: libraries/PDF.class.php:70 libraries/Util.class.php:2476
 #: libraries/browse_foreigners.lib.php:393
 #: libraries/schema/Pdf_Relation_Schema.class.php:1199
 #: libraries/schema/Pdf_Relation_Schema.class.php:1223
@@ -3282,7 +3278,7 @@ msgid "Operator"
 msgstr "運算子"
 
 #: libraries/TableSearch.class.php:189 libraries/TableSearch.class.php:1284
-#: libraries/insert_edit.lib.php:1630 libraries/replication_gui.lib.php:520
+#: libraries/insert_edit.lib.php:1613 libraries/replication_gui.lib.php:520
 #: libraries/rte/rte_routines.lib.php:1604
 #: libraries/server_status_variables.lib.php:220 pmd_general.php:511
 #: pmd_general.php:570 pmd_general.php:693 pmd_general.php:810
@@ -3297,7 +3293,7 @@ msgstr "資料表搜尋"
 msgid "Find and Replace"
 msgstr "搜尋和替換"
 
-#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1404
+#: libraries/TableSearch.class.php:240 libraries/insert_edit.lib.php:1387
 msgid "Edit/Insert"
 msgstr "修改/新增"
 
@@ -3305,7 +3301,7 @@ msgstr "修改/新增"
 msgid "Select columns (at least one):"
 msgstr "選擇欄位 (至少一個):"
 
-#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1236
+#: libraries/TableSearch.class.php:821 libraries/insert_edit.lib.php:1219
 #: libraries/server_privileges.lib.php:438
 msgid "Or"
 msgstr "或"
@@ -3415,18 +3411,18 @@ msgstr "找不到佈景主題 %s 的路徑！"
 msgid "Theme:"
 msgstr "主題："
 
-#: libraries/Types.class.php:297
+#: libraries/Types.class.php:320
 msgid ""
 "A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255"
 msgstr "1 位元組整數，有號數範圍由 -128 至 127，無號數範圍由 0 至 255"
 
-#: libraries/Types.class.php:299
+#: libraries/Types.class.php:322
 msgid ""
 "A 2-byte integer, signed range is -32,768 to 32,767, unsigned range is 0 to "
 "65,535"
 msgstr "2 位元組整數，有號數範圍由 -32,768 至 32,767，無號數範圍由 0 至 65,535"
 
-#: libraries/Types.class.php:301
+#: libraries/Types.class.php:324
 msgid ""
 "A 3-byte integer, signed range is -8,388,608 to 8,388,607, unsigned range is "
 "0 to 16,777,215"
@@ -3434,7 +3430,7 @@ msgstr ""
 "3 位元組整數，有號數範圍由 -8,388,608 至 8,388,607，無號數範圍由 0 至 "
 "16,777,215"
 
-#: libraries/Types.class.php:303
+#: libraries/Types.class.php:326
 msgid ""
 "A 4-byte integer, signed range is -2,147,483,648 to 2,147,483,647, unsigned "
 "range is 0 to 4,294,967,295"
@@ -3442,7 +3438,7 @@ msgstr ""
 "四個位元組的整數，如果包含負數，範圍將在-2147483648至2147483647，如果不包含負"
 "數，範圍則在0至4294967295"
 
-#: libraries/Types.class.php:305
+#: libraries/Types.class.php:328
 msgid ""
 "An 8-byte integer, signed range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807, unsigned range is 0 to 18,446,744,073,709,551,615"
@@ -3450,14 +3446,14 @@ msgstr ""
 "8 位元組整數，有號數範圍由 -9,223,372,036,854,775,808 至 "
 "9,223,372,036,854,775,807，無號數範圍由 0 至 18,446,744,073,709,551,615"
 
-#: libraries/Types.class.php:307 libraries/Types.class.php:714
+#: libraries/Types.class.php:330 libraries/Types.class.php:779
 msgid ""
 "A fixed-point number (M, D) - the maximum number of digits (M) is 65 "
 "(default 10), the maximum number of decimals (D) is 30 (default 0)"
 msgstr ""
 "定點數 (M, D) - (M) 最大為 65 位數 (預設 10)，(D) 小數位數最大為 30 (預設 0)"
 
-#: libraries/Types.class.php:309
+#: libraries/Types.class.php:332
 msgid ""
 "A small floating-point number, allowable values are -3.402823466E+38 to -"
 "1.175494351E-38, 0, and 1.175494351E-38 to 3.402823466E+38"
@@ -3465,7 +3461,7 @@ msgstr ""
 "浮點數，範圍為 -3.402823466E+38 至 -1.175494351E-38、0 及 1.175494351E-38 至 "
 "3.402823466E+38"
 
-#: libraries/Types.class.php:311
+#: libraries/Types.class.php:334
 msgid ""
 "A double-precision floating-point number, allowable values are -"
 "1.7976931348623157E+308 to -2.2250738585072014E-308, 0, and "
@@ -3474,39 +3470,39 @@ msgstr ""
 "倍準浮點數，範圍為 -1.7976931348623157E+308 至 -2.2250738585072014E-308、0 "
 "及 2.2250738585072014E-308 至 1.7976931348623157E+308"
 
-#: libraries/Types.class.php:313
+#: libraries/Types.class.php:336
 msgid ""
 "Synonym for DOUBLE (exception: in REAL_AS_FLOAT SQL mode it is a synonym for "
 "FLOAT)"
 msgstr "倍準浮點數的別名 (例外: 在 REAL_AS_FLOAT 的模式中為 FLOAT 的別名)"
 
-#: libraries/Types.class.php:315
+#: libraries/Types.class.php:338
 msgid ""
 "A bit-field type (M), storing M of bits per value (default is 1, maximum is "
 "64)"
 msgstr "位元欄型態 (M)，每個值使用 M 個位元 (預設值為 1，最大值為 64)"
 
-#: libraries/Types.class.php:317
+#: libraries/Types.class.php:340
 msgid ""
 "A synonym for TINYINT(1), a value of zero is considered false, nonzero "
 "values are considered true"
 msgstr "TINYINT(1) 的別名，當值為 0 時視為 false，非 0 的值則視為 true"
 
-#: libraries/Types.class.php:319
+#: libraries/Types.class.php:342
 msgid "An alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE 的別名"
 
-#: libraries/Types.class.php:321 libraries/Types.class.php:724
+#: libraries/Types.class.php:344 libraries/Types.class.php:789
 #, php-format
 msgid "A date, supported range is %1$s to %2$s"
 msgstr "日期的有效範圍爲 %1$s 至 %2$s"
 
-#: libraries/Types.class.php:323 libraries/Types.class.php:726
+#: libraries/Types.class.php:346 libraries/Types.class.php:791
 #, php-format
 msgid "A date and time combination, supported range is %1$s to %2$s"
 msgstr "日期與時間組合的有效範圍為 %1$s 至 %2$s"
 
-#: libraries/Types.class.php:325
+#: libraries/Types.class.php:348
 msgid ""
 "A timestamp, range is 1970-01-01 00:00:01 UTC to 2038-01-09 03:14:07 UTC, "
 "stored as the number of seconds since the epoch (1970-01-01 00:00:00 UTC)"
@@ -3514,12 +3510,12 @@ msgstr ""
 "時間戳記的有效範圍為 1970-01-01 00:00:01 UTC 至 2038-01-09 03:14:07 UTC，使用"
 "自 1970-01-01 00:00:00 UTC 計算的秒數儲存"
 
-#: libraries/Types.class.php:327 libraries/Types.class.php:730
+#: libraries/Types.class.php:350 libraries/Types.class.php:795
 #, php-format
 msgid "A time, range is %1$s to %2$s"
 msgstr "時間的有效範圍為 %1$s 至 %2$s"
 
-#: libraries/Types.class.php:329
+#: libraries/Types.class.php:352
 msgid ""
 "A year in four-digit (4, default) or two-digit (2) format, the allowable "
 "values are 70 (1970) to 69 (2069) or 1901 to 2155 and 0000"
@@ -3527,20 +3523,20 @@ msgstr ""
 "以 4 位數或 2 位數的方式表示年份的有效範圍為 70 (1970) 至 69 (2069) 或 1901 "
 "至 2155 和 0000"
 
-#: libraries/Types.class.php:331
+#: libraries/Types.class.php:354
 msgid ""
 "A fixed-length (0-255, default 1) string that is always right-padded with "
 "spaces to the specified length when stored"
 msgstr "固定長度 (0 至 255，預設為 1) 的字串，在儲存長度不足時會自右邊補足空白"
 
-#: libraries/Types.class.php:333 libraries/Types.class.php:732
+#: libraries/Types.class.php:356 libraries/Types.class.php:797
 #, php-format
 msgid ""
 "A variable-length (%s) string, the effective maximum length is subject to "
 "the maximum row size"
 msgstr "可變長度 (%s) 的字串，最大的有效長度需視資料列大小限制而定"
 
-#: libraries/Types.class.php:335
+#: libraries/Types.class.php:358
 msgid ""
 "A TEXT column with a maximum length of 255 (2^8 - 1) characters, stored with "
 "a one-byte prefix indicating the length of the value in bytes"
@@ -3548,7 +3544,7 @@ msgstr ""
 "純文字(TEXT)欄位，最大長度為 255 (2^8 - 1) 個字元，儲存時會附加 1 個位元組在"
 "最前面用來記錄長度"
 
-#: libraries/Types.class.php:337 libraries/Types.class.php:734
+#: libraries/Types.class.php:360 libraries/Types.class.php:799
 msgid ""
 "A TEXT column with a maximum length of 65,535 (2^16 - 1) characters, stored "
 "with a two-byte prefix indicating the length of the value in bytes"
@@ -3556,7 +3552,7 @@ msgstr ""
 "純文字(TEXT)欄位，最大長度為 65,535 (2^16 - 1) 個字元，儲存時會附加 2 個位元"
 "組在最前面用來記錄長度"
 
-#: libraries/Types.class.php:339
+#: libraries/Types.class.php:362
 msgid ""
 "A TEXT column with a maximum length of 16,777,215 (2^24 - 1) characters, "
 "stored with a three-byte prefix indicating the length of the value in bytes"
@@ -3564,7 +3560,7 @@ msgstr ""
 "純文字(TEXT)欄位，最大長度為 16,777,215 (2^24 - 1) 個字元，儲存時會附加 3 個"
 "位元組在最前面用來記錄長度"
 
-#: libraries/Types.class.php:341
+#: libraries/Types.class.php:364
 msgid ""
 "A TEXT column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "characters, stored with a four-byte prefix indicating the length of the "
@@ -3573,19 +3569,19 @@ msgstr ""
 "純文字(TEXT)欄位，最大長度為 4GiB (2^32 - 1) 個字元，儲存時會附加 4 個位元組"
 "在最前面用來記錄長度"
 
-#: libraries/Types.class.php:343
+#: libraries/Types.class.php:366
 msgid ""
 "Similar to the CHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "類似 CHAR 型態，但此類型以二進位的方式儲存字串 而不是字元"
 
-#: libraries/Types.class.php:345
+#: libraries/Types.class.php:368
 msgid ""
 "Similar to the VARCHAR type, but stores binary byte strings rather than non-"
 "binary character strings"
 msgstr "類似 VARCHAR 型態，但此類型以二進位的方式儲存字串 而不是字元"
 
-#: libraries/Types.class.php:347
+#: libraries/Types.class.php:370
 msgid ""
 "A BLOB column with a maximum length of 255 (2^8 - 1) bytes, stored with a "
 "one-byte prefix indicating the length of the value"
@@ -3593,7 +3589,7 @@ msgstr ""
 "大型二進位物件(BLOB)欄位，最大長度為 255 (2^8 - 1) 個位元組，儲存時會附加 1 "
 "個位元組在最前面用來記錄長度"
 
-#: libraries/Types.class.php:349
+#: libraries/Types.class.php:372
 msgid ""
 "A BLOB column with a maximum length of 16,777,215 (2^24 - 1) bytes, stored "
 "with a three-byte prefix indicating the length of the value"
@@ -3601,7 +3597,7 @@ msgstr ""
 "大型二進位物件(BLOB)欄位，最大長度為 16,777,215 (2^24 - 1) 個位元組，儲存時會"
 "附加 3 個位元組在最前面用來記錄長度"
 
-#: libraries/Types.class.php:351 libraries/Types.class.php:738
+#: libraries/Types.class.php:374 libraries/Types.class.php:803
 msgid ""
 "A BLOB column with a maximum length of 65,535 (2^16 - 1) bytes, stored with "
 "a two-byte prefix indicating the length of the value"
@@ -3609,7 +3605,7 @@ msgstr ""
 "大型二進位物件(BLOB)欄位，最大長度為 65,535 (2^16 - 1) 個位元組，儲存時會附"
 "加 2 個位元組在最前面用來記錄長度"
 
-#: libraries/Types.class.php:353
+#: libraries/Types.class.php:376
 msgid ""
 "A BLOB column with a maximum length of 4,294,967,295 or 4GiB (2^32 - 1) "
 "bytes, stored with a four-byte prefix indicating the length of the value"
@@ -3617,73 +3613,73 @@ msgstr ""
 "大型二進位物件(BLOB)欄位，最大長度為 4,294,967,295 or 4GiB (2^32 - 1) 個位元"
 "組，儲存時會附加 4 個位元組在最前面用來記錄長度"
 
-#: libraries/Types.class.php:355
+#: libraries/Types.class.php:378
 msgid ""
 "An enumeration, chosen from the list of up to 65,535 values or the special "
 "'' error value"
 msgstr "列舉型態(ENUM)在清單中最多可有 65,535 個值或錯誤值 ''"
 
-#: libraries/Types.class.php:357
+#: libraries/Types.class.php:380
 msgid "A single value chosen from a set of up to 64 members"
 msgstr "可從最多可 64 個成員中複選組成的一個值"
 
-#: libraries/Types.class.php:359
+#: libraries/Types.class.php:382
 msgid "A type that can store a geometry of any type"
 msgstr "類型可以存儲幾何的任何型態"
 
-#: libraries/Types.class.php:361
+#: libraries/Types.class.php:384
 msgid "A point in 2-dimensional space"
 msgstr "2 維空間的點"
 
-#: libraries/Types.class.php:363
+#: libraries/Types.class.php:386
 msgid "A curve with linear interpolation between points"
 msgstr "點與點之間的線性插值曲線"
 
-#: libraries/Types.class.php:365
+#: libraries/Types.class.php:388
 msgid "A polygon"
 msgstr "一個多邊形"
 
-#: libraries/Types.class.php:367
+#: libraries/Types.class.php:390
 msgid "A collection of points"
 msgstr "一群點的集合"
 
-#: libraries/Types.class.php:369
+#: libraries/Types.class.php:392
 msgid "A collection of curves with linear interpolation between points"
 msgstr "點與點之間線性插值曲線的集合"
 
-#: libraries/Types.class.php:371
+#: libraries/Types.class.php:394
 msgid "A collection of polygons"
 msgstr "一個多邊形的集合"
 
-#: libraries/Types.class.php:373
+#: libraries/Types.class.php:396
 msgid "A collection of geometry objects of any type"
 msgstr "任何類型幾何物件的集合"
 
-#: libraries/Types.class.php:626 libraries/Types.class.php:976
+#: libraries/Types.class.php:649 libraries/Types.class.php:1041
 msgctxt "numeric types"
 msgid "Numeric"
 msgstr "數值"
 
-#: libraries/Types.class.php:645 libraries/Types.class.php:979
+#: libraries/Types.class.php:668 libraries/Types.class.php:1044
 msgctxt "date and time types"
 msgid "Date and time"
 msgstr "日期及時間"
 
-#: libraries/Types.class.php:654 libraries/Types.class.php:982
+#: libraries/Types.class.php:677 libraries/Types.class.php:1047
 msgctxt "string types"
 msgid "String"
 msgstr "字串"
 
-#: libraries/Types.class.php:675
+#: libraries/Types.class.php:698
 msgctxt "spatial types"
 msgid "Spatial"
 msgstr "空間類型"
 
-#: libraries/Types.class.php:710
+#: libraries/Types.class.php:775
 msgid "A 4-byte integer, range is -2,147,483,648 to 2,147,483,647"
 msgstr "4 個位元組整數，範圍是 -2,147,483,648 到 2,147,483,647 之間"
 
-#: libraries/Types.class.php:712
+#: libraries/Types.class.php:777
 msgid ""
 "An 8-byte integer, range is -9,223,372,036,854,775,808 to "
 "9,223,372,036,854,775,807"
@@ -3691,23 +3687,23 @@ msgstr ""
 "8 個位元組整數，範圍是 -9,223,372,036,854,775,808 到 "
 "9,223,372,036,854,775,807"
 
-#: libraries/Types.class.php:716
+#: libraries/Types.class.php:781
 msgid "A system's default double-precision floating-point number"
 msgstr "系統預設為雙精度浮點數"
 
-#: libraries/Types.class.php:718
+#: libraries/Types.class.php:783
 msgid "True or false"
 msgstr "True 或 false"
 
-#: libraries/Types.class.php:720
+#: libraries/Types.class.php:785
 msgid "An alias for BIGINT NOT NULL AUTO_INCREMENT UNIQUE"
 msgstr "為 BIGINT NOT NULL AUTO_INCREMENT UNIQUE 的別名"
 
-#: libraries/Types.class.php:722
+#: libraries/Types.class.php:787
 msgid "Stores a Universally Unique Identifier (UUID)"
 msgstr "存儲一個通用唯一識別碼 (UUID)"
 
-#: libraries/Types.class.php:728
+#: libraries/Types.class.php:793
 msgid ""
 "A timestamp, range is '0001-01-01 00:00:00' UTC to '9999-12-31 23:59:59' "
 "UTC; TIMESTAMP(6) can store microseconds"
@@ -3715,13 +3711,13 @@ msgstr ""
 "時間戳記，範圍由 '0001-01-01 00:00:00' UTC 到 '9999-12-31 23:59:59' UTC；"
 "TIMESTAMP(6) 可以存儲到微秒"
 
-#: libraries/Types.class.php:736
+#: libraries/Types.class.php:801
 msgid ""
 "A variable-length (0-65,535) string, uses binary collation for all "
 "comparisons"
 msgstr "可變長度 (0-65,535) 字串，使用二進位編碼與排序做資料比對"
 
-#: libraries/Types.class.php:740
+#: libraries/Types.class.php:805
 msgid "An enumeration, chosen from the list of defined values"
 msgstr "列舉型態，可從已定義的清單中選擇一個值"
 
@@ -3806,67 +3802,67 @@ msgstr "%Y 年 %m 月 %d 日 %H:%M"
 msgid "%s days, %s hours, %s minutes and %s seconds"
 msgstr "%s 天 %s 小時，%s 分 %s 秒"
 
-#: libraries/Util.class.php:2073
+#: libraries/Util.class.php:2074
 msgid "Missing parameter:"
 msgstr "未填寫必要的參數:"
 
-#: libraries/Util.class.php:2593
+#: libraries/Util.class.php:2594
 #, php-format
 msgid "Jump to database &quot;%s&quot;."
 msgstr "切換到資料庫「%s」。"
 
-#: libraries/Util.class.php:2617
+#: libraries/Util.class.php:2618
 #, php-format
 msgid "The %s functionality is affected by a known bug, see %s"
 msgstr "%s 功能受到一個已知的問題影響，詳情請參考 %s"
 
-#: libraries/Util.class.php:2798
+#: libraries/Util.class.php:2799
 msgid "Click to toggle"
 msgstr "點此切換"
 
-#: libraries/Util.class.php:3322 libraries/sql_query_form.lib.php:477
+#: libraries/Util.class.php:3323 libraries/sql_query_form.lib.php:477
 #: prefs_manage.php:249
 msgid "Browse your computer:"
 msgstr "由電腦上傳:"
 
-#: libraries/Util.class.php:3347
+#: libraries/Util.class.php:3348
 #, php-format
 msgid "Select from the web server upload directory <b>%s</b>:"
 msgstr "由網頁伺服器上傳目錄中選擇 <b>%s</b>:"
 
-#: libraries/Util.class.php:3376 libraries/insert_edit.lib.php:1233
+#: libraries/Util.class.php:3377 libraries/insert_edit.lib.php:1216
 #: libraries/sql_query_form.lib.php:487
 msgid "The directory you set for upload work cannot be reached."
 msgstr "設定之上傳目錄錯誤，無法使用。"
 
-#: libraries/Util.class.php:3387
+#: libraries/Util.class.php:3388
 msgid "There are no files to upload"
 msgstr "目前無可上傳的檔案"
 
-#: libraries/Util.class.php:3412 libraries/Util.class.php:3413
+#: libraries/Util.class.php:3413 libraries/Util.class.php:3414
 #: libraries/structure.lib.php:305
 msgid "Empty"
 msgstr "清空"
 
-#: libraries/Util.class.php:3418 libraries/Util.class.php:3419
+#: libraries/Util.class.php:3419 libraries/Util.class.php:3420
 msgid "Execute"
 msgstr "執行"
 
-#: libraries/Util.class.php:3948
+#: libraries/Util.class.php:3957
 msgid "Print"
 msgstr "列印"
 
-#: libraries/Util.class.php:4049 libraries/structure.lib.php:798
+#: libraries/Util.class.php:4058 libraries/structure.lib.php:798
 #: libraries/structure.lib.php:1775 libraries/tbl_printview.lib.php:239
 msgid "Creation"
 msgstr "建立時間"
 
-#: libraries/Util.class.php:4055 libraries/structure.lib.php:805
+#: libraries/Util.class.php:4064 libraries/structure.lib.php:805
 #: libraries/structure.lib.php:1783 libraries/tbl_printview.lib.php:250
 msgid "Last update"
 msgstr "最後更新"
 
-#: libraries/Util.class.php:4061 libraries/structure.lib.php:812
+#: libraries/Util.class.php:4070 libraries/structure.lib.php:812
 #: libraries/structure.lib.php:1791 libraries/tbl_printview.lib.php:261
 msgid "Last check"
 msgstr "最後檢查"
@@ -4214,9 +4210,9 @@ msgstr "允許使用者自訂此值"
 msgid "Apply"
 msgstr "應用"
 
-#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1603
-#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:332
-#: prefs_manage.php:339
+#: libraries/config/FormDisplay.tpl.php:393 libraries/insert_edit.lib.php:1586
+#: libraries/schema/User_Schema.class.php:567 prefs_manage.php:342
+#: prefs_manage.php:349
 msgid "Reset"
 msgstr "重新設定"
 
@@ -4506,7 +4502,7 @@ msgstr "設定 Script 允許執行的時間限制 (秒，[kbd]0[/kbd] 爲不設�
 msgid "Maximum execution time"
 msgstr "執行時間限制"
 
-#: libraries/config/messages.inc.php:70 prefs_manage.php:310
+#: libraries/config/messages.inc.php:70 prefs_manage.php:313
 msgid "Save as file"
 msgstr "另存新檔"
 
@@ -6793,7 +6789,7 @@ msgstr "檔案正在處理中，請稍候。"
 msgid "Language"
 msgstr "語系"
 
-#: libraries/engines/bdb.lib.php:25
+#: libraries/engines/bdb.lib.php:28
 msgid "Version information"
 msgstr "版本資訊"
 
@@ -7209,57 +7205,57 @@ msgstr "因長度問題，<br /> 該欄位可能無法編輯"
 msgid "Binary - do not edit"
 msgstr "二進位 - 無法編輯"
 
-#: libraries/insert_edit.lib.php:1237 libraries/sql_query_form.lib.php:491
+#: libraries/insert_edit.lib.php:1220 libraries/sql_query_form.lib.php:491
 msgid "web server upload directory:"
 msgstr "網站伺服器上傳資料夾："
 
-#: libraries/insert_edit.lib.php:1454
+#: libraries/insert_edit.lib.php:1437
 #, php-format
 msgid "Continue insertion with %s rows"
 msgstr "繼續新增 %s 列"
 
-#: libraries/insert_edit.lib.php:1484
+#: libraries/insert_edit.lib.php:1467
 msgid "and then"
 msgstr "然後"
 
-#: libraries/insert_edit.lib.php:1517
+#: libraries/insert_edit.lib.php:1500
 msgid "Insert as new row"
 msgstr "以新資料列新增"
 
-#: libraries/insert_edit.lib.php:1520
+#: libraries/insert_edit.lib.php:1503
 msgid "Insert as new row and ignore errors"
 msgstr "以新資料列新增 (忽略錯誤)"
 
-#: libraries/insert_edit.lib.php:1523
+#: libraries/insert_edit.lib.php:1506
 msgid "Show insert query"
 msgstr "顯示新增指令"
 
-#: libraries/insert_edit.lib.php:1543
+#: libraries/insert_edit.lib.php:1526
 msgid "Go back to previous page"
 msgstr "返回上一頁"
 
-#: libraries/insert_edit.lib.php:1546
+#: libraries/insert_edit.lib.php:1529
 msgid "Insert another new row"
 msgstr "新增其他新資料列"
 
-#: libraries/insert_edit.lib.php:1551
+#: libraries/insert_edit.lib.php:1534
 msgid "Go back to this page"
 msgstr "返回到本頁"
 
-#: libraries/insert_edit.lib.php:1573
+#: libraries/insert_edit.lib.php:1556
 msgid "Edit next row"
 msgstr "編輯下一行"
 
-#: libraries/insert_edit.lib.php:1595
+#: libraries/insert_edit.lib.php:1578
 msgid ""
 "Use TAB key to move from value to value, or CTRL+arrows to move anywhere"
 msgstr "按 TAB 鍵跳到下一個數值，或 CTRL+方向鍵 作隨意移動"
 
-#: libraries/insert_edit.lib.php:1978 libraries/sql.lib.php:1632
+#: libraries/insert_edit.lib.php:1961 libraries/sql.lib.php:1632
 msgid "Showing SQL query"
 msgstr "顯示 SQL 查詢"
 
-#: libraries/insert_edit.lib.php:2003 libraries/sql.lib.php:1612
+#: libraries/insert_edit.lib.php:1986 libraries/sql.lib.php:1612
 #, php-format
 msgid "Inserted row id: %1$d"
 msgstr "新增的資料列行 id: %1$d"
@@ -7536,7 +7532,6 @@ msgid "phpMyAdmin documentation"
 msgstr "phpMyAdmin 檔案"
 
 #: libraries/navigation/NavigationHeader.class.php:250
-#| msgid "Reload navigation frame"
 msgid "Reload navigation panel"
 msgstr "重新讀取導覽區"
 
@@ -7590,7 +7585,6 @@ msgid "Database operations"
 msgstr "資料庫操作"
 
 #: libraries/navigation/Nodes/Node_Database.class.php:318
-#| msgid "Show hint"
 msgid "Show hidden items"
 msgstr "顯示隱藏項目"
 
@@ -9343,24 +9337,24 @@ msgid "There are no events to display."
 msgstr "沒有事件可供顯示。"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:237
-#: libraries/schema/Eps_Relation_Schema.class.php:428
+#: libraries/schema/Eps_Relation_Schema.class.php:359
 #: libraries/schema/Pdf_Relation_Schema.class.php:417
-#: libraries/schema/Svg_Relation_Schema.class.php:438
+#: libraries/schema/Svg_Relation_Schema.class.php:330
 #, php-format
 msgid "The %s table doesn't exist!"
 msgstr "資料表 %s 不存在！"
 
 #: libraries/schema/Dia_Relation_Schema.class.php:275
-#: libraries/schema/Eps_Relation_Schema.class.php:479
+#: libraries/schema/Eps_Relation_Schema.class.php:410
 #: libraries/schema/Pdf_Relation_Schema.class.php:459
-#: libraries/schema/Svg_Relation_Schema.class.php:491
+#: libraries/schema/Svg_Relation_Schema.class.php:383
 #, php-format
 msgid "Please configure the coordinates for table %s"
 msgstr "請設定表 %s 的座標"
 
-#: libraries/schema/Eps_Relation_Schema.class.php:834
+#: libraries/schema/Eps_Relation_Schema.class.php:764
 #: libraries/schema/Pdf_Relation_Schema.class.php:872
-#: libraries/schema/Svg_Relation_Schema.class.php:855
+#: libraries/schema/Svg_Relation_Schema.class.php:745
 #, php-format
 msgid "Schema of the %s database - Page %s"
 msgstr "資料庫 %s 的大綱 - 第 %s 頁"
@@ -11931,7 +11925,7 @@ msgstr "已建立版本 %1$s，%2$s 的追蹤已啓用。"
 msgid "Manage your settings"
 msgstr "管理您的設定"
 
-#: libraries/user_preferences.inc.php:46 prefs_manage.php:303
+#: libraries/user_preferences.inc.php:46 prefs_manage.php:304
 msgid "Configuration has been saved"
 msgstr "設定已儲存"
 
@@ -12180,7 +12174,7 @@ msgstr "使用瀏覽器的本地儲存記錄匯入設定。"
 msgid "You have no saved settings!"
 msgstr "您尚未儲存設定！"
 
-#: prefs_manage.php:269 prefs_manage.php:323
+#: prefs_manage.php:269 prefs_manage.php:329
 msgid "This feature is not supported by your web browser"
 msgstr "您所使用的瀏覽器不支援此功能"
 
@@ -12197,19 +12191,19 @@ msgstr ""
 "透過修改 config.inc.php 設定檔您可以調整更多的設定項目，如: 使用 %s安裝程式%"
 "s 。"
 
-#: prefs_manage.php:313
+#: prefs_manage.php:318
 msgid "Save to browser's storage"
 msgstr "儲存到瀏覽器記錄"
 
-#: prefs_manage.php:317
+#: prefs_manage.php:322
 msgid "Settings will be saved in your browser's local storage."
 msgstr "設定將儲存到瀏覽器的本地記錄。"
 
-#: prefs_manage.php:319
+#: prefs_manage.php:324
 msgid "Existing settings will be overwritten!"
 msgstr "現有設定將被覆蓋！"
 
-#: prefs_manage.php:336
+#: prefs_manage.php:346
 msgid "You can reset all your settings and restore them to default values."
 msgstr "您可以重新設定所有設定恢復爲預設值。"
 
@@ -12237,6 +12231,10 @@ msgstr "無資料庫"
 #: server_export.php:21
 msgid "View dump (schema) of databases"
 msgstr "檢視資料庫結構的匯出資料"
+
+#: server_privileges.php:142
+msgid "Username and hostname didn't change."
+msgstr ""
 
 #: server_status.php:32
 #, php-format

--- a/server_privileges.php
+++ b/server_privileges.php
@@ -132,6 +132,19 @@ if (! $is_superuser) {
 }
 
 /**
+ * Checks if the user is using "Change Login Information / Copy User" dialog
+ * only to update the password
+ */
+if (isset($_REQUEST['change_copy']) && $username == $_REQUEST['old_username']
+    && $hostname == $_REQUEST['old_hostname']
+) {
+    $response->addHTML(
+        PMA_Message::error(__('Username and hostname didn\'t change.'))->getDisplay()
+    );
+    exit;
+}
+
+/**
  * Changes / copies a user, part I
  */
 list($queries, $password) = PMA_getDataForChangeOrCopyUser();

--- a/server_privileges.php
+++ b/server_privileges.php
@@ -141,6 +141,7 @@ if (isset($_REQUEST['change_copy']) && $username == $_REQUEST['old_username']
     $response->addHTML(
         PMA_Message::error(__('Username and hostname didn\'t change.'))->getDisplay()
     );
+    $response->isSuccess(false);
     exit;
 }
 


### PR DESCRIPTION
Hi,

I did a bugfix by sending a message error if the user doesn't change username or hostname.
You'll find the modification in the last file of the comparison. (Other are the .po files.)

I added a new translation and also generated .po files and did the French translation.
I ran the generate-mo script, but nothing happened... Maybe something is missing...
