### PR TITLE
Scroll to view only when the item is not in view

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -294,14 +294,22 @@ function expandTreeNode($expandElem, callback)
  * Auto-scrolls the newly chosen database
  *
  * @param  object   $element    The element to set to view
- * @param  object   $container  The container srollable element
  *
  */
-function scrollToView($element, $container) {
-    var pushToOffset = $element.offset().top - $container.offset().top + $container.scrollTop();
-    $('#pma_navigation_tree_content').stop().animate({
-        scrollTop: pushToOffset
-    });
+function scrollToView($element) {
+    var $container = $('#pma_navigation_tree_content');
+    var elemTop = $element.offset().top - $container.offset().top;
+    var textHeight = 20;
+    var scrollPadding = 20; // extra padding from top of bottom when scrolling to view
+    if (elemTop < 0) {
+        $container.stop().animate({
+            scrollTop: elemTop + $container.scrollTop() - scrollPadding
+        });
+    } else if (elemTop + textHeight > $container.height()) {
+        $container.stop().animate({
+            scrollTop: elemTop + textHeight - $container.height() + $container.scrollTop() + scrollPadding
+        });
+    }
 }
 
 /**
@@ -400,10 +408,10 @@ function PMA_showCurrentNavigation()
             if ($tableContainer.length > 0) {
                 var $expander = $tableContainer.children('div:first').children('a.expander');
                 expandTreeNode($expander, function () {
-                    scrollToView($dbItem, $('#pma_navigation_tree_content'));
+                    scrollToView($dbItem);
                 });
             } else {
-                scrollToView($dbItem, $('#pma_navigation_tree_content'));
+                scrollToView($dbItem);
             }
         }
     }
@@ -473,6 +481,9 @@ function PMA_showCurrentNavigation()
         } else {
             // no containers, highlight the item
             var $tableOrView = findLoadedItem($container, table, null, true);
+            if ($tableOrView){
+                scrollToView($tableOrView);
+            }
         }
     }
 
@@ -489,6 +500,9 @@ function PMA_showCurrentNavigation()
                 $tableContainer.children('div.list_container'),
                 table, 'table', true
             );
+            if ($table) {
+                scrollToView($table);
+            }
         } else if ($viewContainer.length > 0) {
             highlightView($viewContainer, table);
         }
@@ -519,12 +533,18 @@ function PMA_showCurrentNavigation()
                     $viewContainer.children('div.list_container'),
                     view, 'view', true
                 );
+                if ($view) {
+                    scrollToView($view);
+                }
             });
         } else {
             var $view = findLoadedItem(
                 $viewContainer.children('div.list_container'),
                 view, 'view', true
             );
+            if ($view) {
+                scrollToView($view);
+            }
         }
     }
 }

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -294,14 +294,15 @@ function expandTreeNode($expandElem, callback)
  * Auto-scrolls the newly chosen database
  *
  * @param  object   $element    The element to set to view
+ * @param  boolean  $forceToTop Whether to force scroll to top
  *
  */
-function scrollToView($element) {
+function scrollToView($element, $forceToTop) {
     var $container = $('#pma_navigation_tree_content');
     var elemTop = $element.offset().top - $container.offset().top;
     var textHeight = 20;
     var scrollPadding = 20; // extra padding from top of bottom when scrolling to view
-    if (elemTop < 0) {
+    if (elemTop < 0 || $forceToTop) {
         $container.stop().animate({
             scrollTop: elemTop + $container.scrollTop() - scrollPadding
         });
@@ -408,10 +409,10 @@ function PMA_showCurrentNavigation()
             if ($tableContainer.length > 0) {
                 var $expander = $tableContainer.children('div:first').children('a.expander');
                 expandTreeNode($expander, function () {
-                    scrollToView($dbItem);
+                    scrollToView($dbItem, true);
                 });
             } else {
-                scrollToView($dbItem);
+                scrollToView($dbItem, true);
             }
         }
     }
@@ -482,7 +483,7 @@ function PMA_showCurrentNavigation()
             // no containers, highlight the item
             var $tableOrView = findLoadedItem($container, table, null, true);
             if ($tableOrView){
-                scrollToView($tableOrView);
+                scrollToView($tableOrView, false);
             }
         }
     }
@@ -501,7 +502,7 @@ function PMA_showCurrentNavigation()
                 table, 'table', true
             );
             if ($table) {
-                scrollToView($table);
+                scrollToView($table, false);
             }
         } else if ($viewContainer.length > 0) {
             highlightView($viewContainer, table);
@@ -534,7 +535,7 @@ function PMA_showCurrentNavigation()
                     view, 'view', true
                 );
                 if ($view) {
-                    scrollToView($view);
+                    scrollToView($view, false);
                 }
             });
         } else {
@@ -543,7 +544,7 @@ function PMA_showCurrentNavigation()
                 view, 'view', true
             );
             if ($view) {
-                scrollToView($view);
+                scrollToView($view, false);
             }
         }
     }


### PR DESCRIPTION
This is an alternative fix for https://sourceforge.net/p/phpmyadmin/bugs/4169/.
The auto scrolling will not happen if the item is visible in the navigation. So when the user click a link in navigation no auto scrolling will happen.
However if a user selects a database/table from main panel and it is not visible in navigation, auto scrolling will bring it to view, since expanding the highlighting an item that is out of view it not useful.
