### PR TITLE
Using the whole url with all get parameters

### DIFF
--- a/libraries/sql_query_form.lib.php
+++ b/libraries/sql_query_form.lib.php
@@ -85,7 +85,7 @@ function PMA_getHtmlForSqlQueryForm(
     // start output
     if ($is_querywindow) {
         $html .= '<form method="post" id="sqlqueryform"';
-        $html .= ' action="import.php" ' . $enctype . ' name="sqlform"';
+        $html .= ' action="import.php?' . PMA_URL_getCommon($db, $table) . '" ' . $enctype . ' name="sqlform"';
     } else {
         $html .= '<form method="post" action="import.php" ' . $enctype;
         $html .= ' class="ajax"';


### PR DESCRIPTION
Signed-off-by: Umair Khan omerjerk@gmail.com

This code isn't causing any bug but we should use the whole URL instead of just import.php while executing the statement from querywindow.
