### PR TITLE
allow to set by config.php default charset database

### DIFF
--- a/config.sample.inc.php
+++ b/config.sample.inc.php
@@ -32,6 +32,8 @@ $cfg['Servers'][$i]['host'] = 'localhost';
 $cfg['Servers'][$i]['connect_type'] = 'tcp';
 $cfg['Servers'][$i]['compress'] = false;
 $cfg['Servers'][$i]['AllowNoPassword'] = false;
+$cfg['Servers'][$i]['cbe_utf8_char'] = 'utf8';
+$cfg['Servers'][$i]['cbe_utf8_coll'] = 'utf8_general_ci';
 
 /*
  * phpMyAdmin configuration storage settings.

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -4153,10 +4153,7 @@ function PMA_addUserAndCreateDatabase($_error, $real_sql_query, $sql_query,
 
     if (isset($_REQUEST['createdb-1'])) {
         // Create database with same name and grant all privileges
-        $q = 'CREATE DATABASE IF NOT EXISTS '
-            . PMA_Util::backquote(
-                PMA_Util::sqlAddSlashes($username)
-            ) . ';';
+        $q = 'CREATE DATABASE IF NOT EXISTS ' . PMA_Util::backquote ( PMA_Util::sqlAddSlashes($username) ) . 'DEFAULT CHARACTER SET ' . PMA_Util::backquote($GLOBALS['cfg']['Server']['cbe_utf8_char']) .' COLLATE ' . PMA_Util::backquote($GLOBALS['cfg']['Server']['cbe_utf8_coll']) . ';';
         $sql_query .= $q;
         if (! $GLOBALS['dbi']->tryQuery($q)) {
             $message = PMA_Message::rawError($GLOBALS['dbi']->getError());


### PR DESCRIPTION
i've been doing since 4.x i thought this should be much easier to be implemented in config.php
i have no experience using phpmyadmin custom classes nor functions so i used the easiest method i could think of.
