### PR TITLE
synchronizing message(query) with the table ordering

### DIFF
--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -1012,7 +1012,18 @@ class PMA_Util
                 $sql_query = '';
             }
         }
-
+        
+        // Parse and analyze the query
+        require 'libraries/parse_analyze.inc.php';
+        
+        /**
+         *Synchronizing message(query) with table
+         */
+        if (PMA_isRememberSortingOrder($analyzed_sql_results) && 
+          !isset($analyzed_sql_results['analyzed_sql'][0]['queryflags']['union'])) {
+            PMA_handleSortOrder($db, $table, $analyzed_sql_results, $sql_query);
+        }
+        
         if (isset($GLOBALS['using_bookmark_message'])) {
             $retval .= $GLOBALS['using_bookmark_message']->getDisplay();
             unset($GLOBALS['using_bookmark_message']);


### PR DESCRIPTION
bug fix for #4245 initial "Browse" query does not match sorting order.
http://sourceforge.net/p/phpmyadmin/bugs/4245/

Even though remembered sorting order was considered when rendering a table, it wasn't considered when displaying the query related to the table. Added some code to consider it when displaying the query if sorting order is remembered. 
