### PR TITLE
synchronizing message(query) with the table ordering

### DIFF
--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -1012,7 +1012,18 @@ class PMA_Util
                 $sql_query = '';
             }
         }
-
+        
+        // Parse and analyze the query
+        require 'libraries/parse_analyze.inc.php';
+        
+        /**
+         *Synchronizing message(query) with table
+         */
+        if (PMA_isRememberSortingOrder($analyzed_sql_results) && 
+          !isset($analyzed_sql_results['analyzed_sql'][0]['queryflags']['union'])) {
+            PMA_handleSortOrder($db, $table, $analyzed_sql_results, $sql_query);
+        }
+        
         if (isset($GLOBALS['using_bookmark_message'])) {
             $retval .= $GLOBALS['using_bookmark_message']->getDisplay();
             unset($GLOBALS['using_bookmark_message']);

--- a/libraries/navigation/Nodes/Node_Table.class.php
+++ b/libraries/navigation/Nodes/Node_Table.class.php
@@ -52,10 +52,11 @@ class Node_Table extends Node_DatabaseChild
             'text' => $GLOBALS['cfg']['DefaultTabTable']
                     . '?server=' . $GLOBALS['server']
                     . '&amp;db=%2$s&amp;table=%1$s'
-                    . '&amp;pos=0&amp;token=' . $GLOBALS['token'],
+                    . '&amp;pos=0&amp;token=' . $GLOBALS['token']
+                    . '&amp;recall_order=1',
             'icon' => $GLOBALS['cfg']['NavigationTreeDefaultTabTable']
                     . '?server=' . $GLOBALS['server']
-                    . '&amp;db=%2$s&amp;table=%1$s&amp;token=' . $GLOBALS['token']
+                    . '&amp;db=%2$s&amp;table=%1$s&amp;token=' . $GLOBALS['token'],
         );
         $this->classes = 'table';
     }

--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -227,7 +227,8 @@ function PMA_getTableHtmlForMultipleQueries(
 function PMA_handleSortOrder($db, $table, &$analyzed_sql_results, &$full_sql_query)
 {
     $pmatable = new PMA_Table($table, $db);
-    if (empty($analyzed_sql_results['analyzed_sql'][0]['order_by_clause'])) {
+    if (empty($analyzed_sql_results['analyzed_sql'][0]['order_by_clause'])
+            && isset($_REQUEST['recall_order'])) {
         $sorted_col = $pmatable->getUiProp(PMA_Table::PROP_SORTED_COLUMN);
         if ($sorted_col) {
             //remove the tablename from retrieved preference


### PR DESCRIPTION
Bug fix #4245 (http://sourceforge.net/p/phpmyadmin/bugs/4245/)

synchronizing message(query) with the table sorting order

Now remembered sorting order is displayed only if the user browse tables from the navigation tree. Otherwise (Eg: when executing sql query directly from "sql" tab) , order is remembered, but not displayed. 
