### PR TITLE
Fix database-level permission bug by escaping slashes in db names

### DIFF
--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -3858,7 +3858,7 @@ class PMA_Util
              * Also, we need to double the inner % to please sprintf().
              */
             $query .= " AND '%s' REGEXP"
-                . " REPLACE(REPLACE(TABLE_SCHEMA, '_', '.'), '%%', '.*')";
+                . " REPLACE(REPLACE(REPLACE(TABLE_SCHEMA, '_', '.'), '%%', '.*'), '\\\\', '\\\\\\\')";
             $schema_privileges = $GLOBALS['dbi']->fetchValue(
                 sprintf(
                     $query,


### PR DESCRIPTION
Hi,
my INFORMATION_SCHEMA.SCHEMA_PRIVILEGES table contains entries with table names such as 

```
usr\_web121\_7
```

However, db-level permissions won't work for me unless I ensure that slashes get escaped before passing the database name (TABLE_SCHEMA column) to REGEXP.

I'm not sure whether this is a phpMyAdmin bug or even a MySQL bug itself.

Server version: 5.5.31-0+wheezy1 - (Debian)
phpMyAdmin Version: 4.1.6
