### PR TITLE
Fix the Bug#4237 [ https://sourceforge.net/p/phpmyadmin/bugs/4237/ ]

### DIFF
--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -485,7 +485,9 @@ if ($token_mismatch) {
         /* Needed to send the correct reply */
         'ajax_request',
         /* Permit to log out even if there is a token mismatch */
-        'old_usr'
+        'old_usr',
+        /* Permit redirection with token-mismatch in url.php */
+        'url'
     );
     /**
      * Allow changing themes in test/theme.php

--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -802,7 +802,15 @@ function PMA_linkURL($url)
     }
     $params = array();
     $params['url'] = $url;
-    return './url.php' . PMA_URL_getCommon($params);
+
+    $url=PMA_URL_getCommon($params);
+    //strp off token and such sensitive information. Just keep url.
+    $arr=parse_url($url);
+    parse_str($arr["query"],$vars);
+    $query = http_build_query(array("url"=>$vars["url"]));
+    $url='./url.php?' . $query;
+    
+    return $url;
 }
 
 /**

--- a/url.php
+++ b/url.php
@@ -17,7 +17,13 @@ if (! PMA_isValid($_GET['url'])
 ) {
     header('Location: ' . $cfg['PmaAbsoluteUri']);
 } else {
-    header('Location: ' . $_GET['url']);
+    // header('Location: ' . $_GET['url']);
+    // JavaScript redirection is necessary. Because if header() is used then web browser sometimes does not change the HTTP_REFERER field and so with old URL as Referer, token also goes to external site.
+    echo "<script type='text/javascript'>
+    window.onload=function(){
+    	window.location='".$_GET['url']."';
+    }
+    </script>";
 }
 die();
 ?>


### PR DESCRIPTION
Now with these changes, sensitive information like token and others do not go with outgoing HTTP Requests.

Also the [Bug Report](https://sourceforge.net/p/phpmyadmin/bugs/4237/) only mentioned URLs associated with SQL queries, but as I found out, token was present in almost all outgoing links (like Wiki, Documentation, etc..). That problem is also solved in these changes.

Travis-CI build fails because, it is comparing the new results with some old result which has token in all its outgoing URLs, and so string comparisons fails on those URLs. See [build log](https://travis-ci.org/dhananjay92/phpmyadmin/jobs/18263846#L270).
