### PR TITLE
Fix for Bug#4237 

### DIFF
--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -485,7 +485,9 @@ if ($token_mismatch) {
         /* Needed to send the correct reply */
         'ajax_request',
         /* Permit to log out even if there is a token mismatch */
-        'old_usr'
+        'old_usr',
+        /* Permit redirection with token-mismatch in url.php */
+        'url'
     );
     /**
      * Allow changing themes in test/theme.php

--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -804,7 +804,7 @@ function PMA_linkURL($url)
     $params['url'] = $url;
 
     $url=PMA_URL_getCommon($params);
-    //strp off token and such sensitive information. Just keep url.
+    //strip off token and such sensitive information. Just keep url.
     $arr=parse_url($url);
     parse_str($arr["query"],$vars);
     $query = http_build_query(array("url"=>$vars["url"]));
@@ -812,6 +812,39 @@ function PMA_linkURL($url)
     
     return $url;
 }
+
+/**
+ * Checks whether domain of URL is whitelisted domain or not. Use only for URLs of external sites.
+ *
+ * @param string $url URL of external site.
+ *
+ * @return boolean.True:if domain of $url is allowed domain, False:otherwise.
+ */
+function PMA_isAllowedDomain($url)
+{
+    $arr=parse_url($url);
+    $domain=$arr["host"];
+    $domainWhiteList=array(
+                    /* Include current domain */
+                    $_SERVER['SERVER_NAME'],  
+                    /* phpMyAdmin domains */  
+                    'wiki.phpmyadmin.net', 'www.phpMyAdmin.net','phpmyadmin.net', 'docs.phpmyadmin.net',
+                    /* mysql.com domains */
+                    'dev.mysql.com','bugs.mysql.com',
+                    /* php.net domains */
+                    'php.net',
+                    /* Github domains*/
+                    'github.com','www.github.com',
+                    /* Following are doubtful ones. */
+                    'www.primebase.com','pbxt.blogspot.com'
+                    );
+    if(in_array($domain,$domainWhiteList)){
+        return true;
+    }
+    
+    return false;
+}
+
 
 /**
  * Adds JS code snippets to be displayed by the PMA_Response class.

--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -802,7 +802,15 @@ function PMA_linkURL($url)
     }
     $params = array();
     $params['url'] = $url;
-    return './url.php' . PMA_URL_getCommon($params);
+
+    $url=PMA_URL_getCommon($params);
+    //strp off token and such sensitive information. Just keep url.
+    $arr=parse_url($url);
+    parse_str($arr["query"],$vars);
+    $query = http_build_query(array("url"=>$vars["url"]));
+    $url='./url.php?' . $query;
+    
+    return $url;
 }
 
 /**

--- a/test/classes/PMA_Advisor_test.php
+++ b/test/classes/PMA_Advisor_test.php
@@ -250,7 +250,7 @@ class Advisor_Test extends PHPUnit_Framework_TestCase
                     'name' => 'Distribution',
                     'issue' => 'official MySQL binaries.',
                     'recommendation' => 'See <a href="./url.php?url=http%3A%2F%2F' .
-                        'phpma.org%2F&amp;lang=en&amp;token=token">web</a>',
+                        'phpma.org%2F">web</a>',
                     'id' => 'Distribution'
                 ),
                 null,

--- a/test/classes/PMA_DbSearch_test.php
+++ b/test/classes/PMA_DbSearch_test.php
@@ -210,7 +210,7 @@ class PMA_DbSearch_Test extends PHPUnit_Framework_TestCase
             . 'SearchType_4" value="4" />' . "\n"
             . '<label for="criteriaSearchType_4">as regular expression <a href='
             . '"./url.php?url=http%3A%2F%2Fdev.mysql.com%2Fdoc%2Frefman%2F5.6%2Fen'
-            . '%2Fregexp.html&amp;server=0&amp;lang=en&amp;token=token" target='
+            . '%2Fregexp.html" target='
             . '"mysql_doc"><img src="themes/dot.gifb_help.png" title="Documentation"'
             . ' alt="Documentation" /></a></label><br />' . "\n"
             . '</td></tr><tr><td class="right vtop">Inside tables:</td>'

--- a/test/classes/PMA_Message_test.php
+++ b/test/classes/PMA_Message_test.php
@@ -354,8 +354,8 @@ class PMA_Message_Test extends PHPUnit_Framework_TestCase
             ),
             array(
                 '[a@http://foo.bar/@Documentation]link[/a]',
-                '<a href="./url.php?url=http%3A%2F%2Ffoo.bar%2F&amp;lang=en&amp;'
-                . 'token=token" target="Documentation">link</a>'
+                '<a href="./url.php?url=http%3A%2F%2Ffoo.bar%2F"'
+                . ' target="Documentation">link</a>'
             ),
             array(
                 '[a@./non-existing@Documentation]link[/a]',
@@ -364,7 +364,7 @@ class PMA_Message_Test extends PHPUnit_Framework_TestCase
             array(
                 '[doc@foo]link[/doc]',
                 '<a href="./url.php?url=http%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2F'
-                . 'latest%2Fsetup.html%23foo&amp;lang=en&amp;token=token" '
+                . 'latest%2Fsetup.html%23foo" '
                 . 'target="documentation">link</a>'
             ),
         );
@@ -490,8 +490,8 @@ class PMA_Message_Test extends PHPUnit_Framework_TestCase
         $this->object->setMessage('[kbd]test[/kbd] [doc@cfg_Example]test[/doc]');
         $this->assertEquals(
             '<kbd>test</kbd> <a href="./url.php?url=http%3A%2F%2Fdocs.phpmyadmin.'
-            . 'net%2Fen%2Flatest%2Fcfg.html%23cfg_Example&amp;lang=en&amp;token='
-            . 'token" target="documentation">test</a>',
+            . 'net%2Fen%2Flatest%2Fcfg.html%23cfg_Example"'
+            . ' target="documentation">test</a>',
             $this->object->getMessage()
         );
     }

--- a/test/classes/config/PMA_FormDisplay_test.php
+++ b/test/classes/config/PMA_FormDisplay_test.php
@@ -334,8 +334,7 @@ class PMA_FormDisplay_Test extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             "./url.php?url=http%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2F" .
-            "config.html%23cfg_Servers_3_test_2_&amp;server=0&amp;lang=en&amp" .
-            ";token=token",
+            "config.html%23cfg_Servers_3_test_2_",
             $this->object->getDocLink("Servers/3/test/2/")
         );
 

--- a/test/classes/plugin/auth/PMA_AuthenticationConfig_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationConfig_test.php
@@ -118,8 +118,8 @@ class PMA_AuthenticationConfig_Test extends PHPUnit_Framework_TestCase
 
         $this->assertContains(
             '<strong>MySQL said: </strong><a href="./url.php?url=http%3A%2F%2F' .
-            'dev.mysql.com%2Fdoc%2Frefman%2F5.6%2Fen%2Ferror-messages-server.html' .
-            '&amp;server=0&amp;lang=en&amp;token=token" target="mysql_doc">' .
+            'dev.mysql.com%2Fdoc%2Frefman%2F5.6%2Fen%2Ferror-messages-server.html"' .
+            ' target="mysql_doc">' .
             '<img src="themes/dot.gif" title="Documentation" alt="Documentation" ' .
             'class="icon ic_b_help" /></a>',
             $html

--- a/test/libraries/PMA_sanitize_test.php
+++ b/test/libraries/PMA_sanitize_test.php
@@ -49,7 +49,7 @@ class PMA_Sanitize_Test extends PHPUnit_Framework_TestCase
         unset($GLOBALS['lang']);
         unset($GLOBALS['collation_connection']);
         $this->assertEquals(
-            '<a href="./url.php?url=http%3A%2F%2Fwww.phpmyadmin.net%2F&amp;token=token" target="target">link</a>',
+            '<a href="./url.php?url=http%3A%2F%2Fwww.phpmyadmin.net%2F" target="target">link</a>',
             PMA_sanitize('[a@http://www.phpmyadmin.net/@target]link[/a]')
         );
     }
@@ -62,7 +62,7 @@ class PMA_Sanitize_Test extends PHPUnit_Framework_TestCase
     public function testDoc()
     {
         $this->assertEquals(
-            '<a href="./url.php?url=http%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2Fsetup.html%23foo&amp;token=token" target="documentation">doclink</a>',
+            '<a href="./url.php?url=http%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2Fsetup.html%23foo" target="documentation">doclink</a>',
             PMA_sanitize('[doc@foo]doclink[/doc]')
         );
     }
@@ -101,7 +101,7 @@ class PMA_Sanitize_Test extends PHPUnit_Framework_TestCase
     public function testLinkAndXssInHref()
     {
         $this->assertEquals(
-            '<a href="./url.php?url=http%3A%2F%2Fdocs.phpmyadmin.net%2F&amp;token=token">doc</a>[a@javascript:alert(\'XSS\');@target]link</a>',
+            '<a href="./url.php?url=http%3A%2F%2Fdocs.phpmyadmin.net%2F">doc</a>[a@javascript:alert(\'XSS\');@target]link</a>',
             PMA_sanitize('[a@http://docs.phpmyadmin.net/]doc[/a][a@javascript:alert(\'XSS\');@target]link[/a]')
         );
     }

--- a/test/libraries/common/PMA_showDocu_test.php
+++ b/test/libraries/common/PMA_showDocu_test.php
@@ -26,7 +26,7 @@ class PMA_ShowDocu_Test extends PHPUnit_Framework_TestCase
     function testShowDocu()
     {
         $this->assertEquals(
-            '<a href="./url.php?url=http%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2Fpage.html%23anchor&amp;server=99&amp;lang=en&amp;token=token" target="documentation"><img src="themes/dot.gif" title="Documentation" alt="Documentation" class="icon ic_b_help" /></a>',
+            '<a href="./url.php?url=http%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2Flatest%2Fpage.html%23anchor" target="documentation"><img src="themes/dot.gif" title="Documentation" alt="Documentation" class="icon ic_b_help" /></a>',
             PMA_Util::showDocu('page', 'anchor')
         );
 

--- a/test/libraries/common/PMA_showPHPDocu_test.php
+++ b/test/libraries/common/PMA_showPHPDocu_test.php
@@ -29,8 +29,7 @@ class PMA_ShowPHPDocu_Test extends PHPUnit_Framework_TestCase
         $target = "docu";
         $lang = _pgettext('PHP documentation language', 'en');
         $expected = '<a href="./url.php?url=http%3A%2F%2Fphp.net%2Fmanual%2F' . $lang
-            . '%2F' . $target . '&amp;server=99&amp;lang=en&amp;token=token'
-            . '" target="documentation"><img src="themes/dot.gif" title="'
+            . '%2F' . $target . '" target="documentation"><img src="themes/dot.gif" title="'
             . __('Documentation') . '" alt="' . __('Documentation') . '" class="icon ic_b_help" /></a>';
 
         $this->assertEquals(

--- a/test/libraries/core/PMA_getLinks_test.php
+++ b/test/libraries/core/PMA_getLinks_test.php
@@ -27,7 +27,7 @@ class PMA_GetLinks_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             PMA_getPHPDocLink('function'),
             './url.php?url=http%3A%2F%2Fphp.net%2Fmanual%2F'
-            . $lang . '%2Ffunction&amp;server=99&amp;lang=en&amp;token=token'
+            . $lang . '%2Ffunction'
         );
     }
 
@@ -35,11 +35,9 @@ class PMA_GetLinks_Test extends PHPUnit_Framework_TestCase
     {
         return array(
             array('http://wiki.phpmyadmin.net',
-             './url.php?url=http%3A%2F%2Fwiki.phpmyadmin.net&amp;server=99'
-            . '&amp;lang=en&amp;token=token'),
+             './url.php?url=http%3A%2F%2Fwiki.phpmyadmin.net'),
             array('https://wiki.phpmyadmin.net',
-             './url.php?url=https%3A%2F%2Fwiki.phpmyadmin.net&amp;server=99'
-            . '&amp;lang=en&amp;token=token'),
+             './url.php?url=https%3A%2F%2Fwiki.phpmyadmin.net'),
             array('wiki.phpmyadmin.net', 'wiki.phpmyadmin.net'),
             array('index.php?db=phpmyadmin', 'index.php?db=phpmyadmin')
         );

--- a/url.php
+++ b/url.php
@@ -18,12 +18,21 @@ if (! PMA_isValid($_GET['url'])
     header('Location: ' . $cfg['PmaAbsoluteUri']);
 } else {
     // header('Location: ' . $_GET['url']);
-    // JavaScript redirection is necessary. Because if header() is used then web browser sometimes does not change the HTTP_REFERER field and so with old URL as Referer, token also goes to external site.
-    echo "<script type='text/javascript'>
-    window.onload=function(){
-    	window.location='".$_GET['url']."';
+    
+    // domain whitelist check
+    if (PMA_isAllowedDomain($_GET['url'])) {
+    	// JavaScript redirection is necessary. Because if header() is used then web browser sometimes does not change the HTTP_REFERER field and so with old URL as Referer, token also goes to external site.
+	    echo "<script type='text/javascript'>
+		    	window.onload=function(){
+		    		window.location='".$_GET['url']."';
+	    	}
+	    	</script>";
+        echo 'Taking you to '.($_GET['url']); // Display redirecting msg on screen.
     }
-    </script>";
+    else
+    {
+    	header('Location: ' . $cfg['PmaAbsoluteUri']);
+    }
 }
 die();
 ?>

--- a/url.php
+++ b/url.php
@@ -17,7 +17,13 @@ if (! PMA_isValid($_GET['url'])
 ) {
     header('Location: ' . $cfg['PmaAbsoluteUri']);
 } else {
-    header('Location: ' . $_GET['url']);
+    // header('Location: ' . $_GET['url']);
+    // JavaScript redirection is necessary. Because if header() is used then web browser sometimes does not change the HTTP_REFERER field and so with old URL as Referer, token also goes to external site.
+    echo "<script type='text/javascript'>
+    window.onload=function(){
+    	window.location='".$_GET['url']."';
+    }
+    </script>";
 }
 die();
 ?>


### PR DESCRIPTION
In continuation with [Pull Request#893](https://github.com/phpmyadmin/phpmyadmin/pull/893)...

Whitelist check for domains in url.php has been added. I've tried to add as many valid domains into the [Whitelist](https://github.com/dhananjay92/phpmyadmin/blob/54813d8ddd34e3362ca64e3c56f67c2a4ca6064a/libraries/core.lib.php#L828) as I could. <b>Please point out if any domains have been missed.</b>

Travis-CI build fails because, it is comparing the new results with some old result which has token in all its outgoing URLs, and so string comparisons fails on those URLs.  See [build log](https://travis-ci.org/dhananjay92/phpmyadmin/jobs/18323350).
