### PR TITLE
Fix For Wildcard-containing only_db failure in sidebar

### DIFF
--- a/libraries/navigation/Nodes/Node.class.php
+++ b/libraries/navigation/Nodes/Node.class.php
@@ -359,29 +359,13 @@ class Node
      */
     public function getData($type, $pos, $searchClause = '')
     {
-        if ($type == 'databases' 
-            && ! empty($GLOBALS['cfg']['Server']['only_db'])
-        ) {
-            $db_list = $GLOBALS['cfg']['Server']['only_db'];
-            $query = "SELECT * FROM ( SELECT '";
-
-            if (is_string($db_list)) {
-                $db_list = array($db_list);
-            }
-
-            if (count($db_list)) {
-                $query .= implode("' UNION ALL SELECT '", $db_list);
-                $query .= "' ";
-            }
-            return $GLOBALS['dbi']->fetchResult($query . ") as alias");
-        } else {
-            $query  = "SELECT `SCHEMA_NAME` ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`SCHEMATA` ";
-            $query .= $this->_getWhereClause($searchClause);
-            $query .= "ORDER BY `SCHEMA_NAME` ASC ";
-            $query .= "LIMIT $pos, {$GLOBALS['cfg']['MaxNavigationItems']}";
-            return $GLOBALS['dbi']->fetchResult($query);
-        }
+        $query  = "SELECT `SCHEMA_NAME` ";
+        $query .= "FROM `INFORMATION_SCHEMA`.`SCHEMATA` ";
+        $query .= $this->_getWhereClause($searchClause);
+        $query .= "ORDER BY `SCHEMA_NAME` ASC ";
+        $query .= "LIMIT $pos, {$GLOBALS['cfg']['MaxNavigationItems']}";
+        return $GLOBALS['dbi']->fetchResult($query);
+        
     }
 
     /**


### PR DESCRIPTION
This commit fixes the Bug #4242. The "only_db"directive  now accepts
MySQL LIKE wildcards without errors.Changes have been made to the
function getData() in phpmyadmin/libraries/navigation/Nodes/Node.class.php .
The if-else clause has been removed. The checking of the "only_db"
directive is now performed solely by the function
getWhereClause()in the same class.

Signed-off-by: Vasu Bhardwaj voodoorapter014@gmail.com
