### PR TITLE
Explicitly cast int to float in PMA_Util::formatByteDown()

### DIFF
--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -1399,7 +1399,9 @@ class PMA_Util
         $unit = $byteUnits[0];
 
         for ($d = 6, $ex = 15; $d >= 1; $d--, $ex-=3) {
-            if (isset($byteUnits[$d]) && ($value >= $li * self::pow(10, $ex))) {
+            // cast to float to avoid overflow
+            $unitSize = (float) $li * self::pow(10, $ex);
+            if (isset($byteUnits[$d]) && $value >= $unitSize) {
                 // use 1024.0 to avoid integer overflow on 64-bit machines
                 $value = round($value / (self::pow(1024, $d) / $dh)) /$dh;
                 $unit = $byteUnits[$d];

--- a/test/libraries/common/PMA_formatNumberByteDown_test.php
+++ b/test/libraries/common/PMA_formatNumberByteDown_test.php
@@ -92,7 +92,8 @@ class PMA_FormatNumberByteDown_Test extends PHPUnit_Framework_TestCase
             array(100, 2, 2, array('0.10', __('KiB'))),
             array(1034, 3, 2, array('1.01', __('KiB'))),
             array(100233, 3, 3, array('97.884', __('KiB'))),
-            array(2206451, 1, 2, array('2.10', __('MiB')))
+            array(2206451, 1, 2, array('2.10', __('MiB'))),
+            array(21474836480, 4, 0, array('20', __('GiB')))
         );
     }
 


### PR DESCRIPTION
**Problem:** Zend PHP interprets integers as floats if it encounters an integer overflow. HHVM, however, does not, and thus causes an overflow.

**The Fix:** Explicitly convert integer into float
