### PR TITLE
Contest-5 Bug#4276.

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,10 +33,20 @@ foreach ($drops as $each_drop) {
 }
 unset($drops, $each_drop);
 
+/* 
+ * Black list of all scripts to which front-end must submit data.
+ * Such scripts must not be loaded on home page.
+ *
+ */
+ $target_blacklist = array (
+    'import.php', 'export.php'
+    );
+
 // If we have a valid target, let's load that script instead
 if (! empty($_REQUEST['target'])
     && is_string($_REQUEST['target'])
     && ! preg_match('/^index/', $_REQUEST['target'])
+    && ! in_array($_REQUEST['target'], $target_blacklist )      // Check if target is not in blacklist.
     && in_array($_REQUEST['target'], $goto_whitelist)
 ) {
     include $_REQUEST['target'];


### PR DESCRIPTION
Signed-off-by: Dhananjay Nakrani dhananjaynakrani@gmail.com

The problem was that the script `import.php` is loaded on [ index.php L#42 ](https://github.com/phpmyadmin/phpmyadmin/blob/QA_4_1/index.php#L42) without posted data which it expects and so it runs into an error.
Added a blacklist check. Now the scripts which expects data from front-end are not loaded on index page.

By the way it was first proposed [here](https://github.com/phpmyadmin/phpmyadmin/pull/903).
Hope this time it satisfies the required community standards..:smiley: 
