### PR TITLE
New feature, Navigation hover show full name

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -242,13 +242,6 @@ $(function () {
         });
     });
 
-    /** Show full name when cursor hover .hover_show_full elements and name not fully shown */
-    $('body').append('<div id="full_name_layer" class="hide"></div>');
-    $('#full_name_layer').mouseleave(function() {
-        /** mouseleave */
-        $(this).addClass('hide');
-    });
-
     PMA_showCurrentNavigation();
 });
 
@@ -1206,7 +1199,7 @@ PMA_fastFilter.filter.prototype.restore = function (focus) {
 };
 
 /**
- * Show full name when cursor hover and name not fully shown
+ * Show full name when cursor hover and name not shown completely
  *
  * @param object $containerELem Container element
  *
@@ -1225,6 +1218,15 @@ function PMA_showFullName($containerELem) {
            < (thisOffset.left + $this.outerWidth()))
         {
             var $fullNameLayer = $('#full_name_layer');
+            if($fullNameLayer.length == 0)
+            {
+                $('body').append('<div id="full_name_layer" class="hide"></div>');
+                $('#full_name_layer').mouseleave(function() {
+                    /** mouseleave */
+                    $(this).addClass('hide');
+                });
+                $fullNameLayer = $('#full_name_layer');
+            }
             $fullNameLayer.removeClass('hide');
             $fullNameLayer.css({left: thisOffset.left, top: thisOffset.top});
             $fullNameLayer.html($this.clone());

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -242,6 +242,14 @@ $(function () {
         });
     });
 
+    /** Show full name when cursor hover .hover_show_full elements and name not fully shown */
+    $('body').append('<div id="full_name_layer" class="hide"></div>');
+    $('#full_name_layer').mouseleave(function() {
+        /** mouseleave */
+        $(this).addClass('hide');
+    });
+    PMA_showFullName($('#pma_navigation_tree_content'));
+
     PMA_showCurrentNavigation();
 });
 
@@ -288,6 +296,7 @@ function expandTreeNode($expandElem, callback) {
                 if (callback && typeof callback == 'function') {
                     callback.call();
                 }
+                PMA_showFullName($destination);
             } else {
                 PMA_ajaxShowMessage(data.error, false);
             }
@@ -1195,3 +1204,30 @@ PMA_fastFilter.filter.prototype.restore = function (focus) {
     this.$this.find('div.pageselector').show();
     this.$this.find('div.throbber').remove();
 };
+
+/**
+ * Show full name when cursor hover and name not fully shown
+ *
+ * @param object $containerELem Container element
+ *
+ * @return void
+ */
+function PMA_showFullName($containerELem) {
+
+    $containerELem.find('.hover_show_full').mouseenter(function() {
+        /** mouseenter */
+        var $this = $(this);
+        var thisOffset = $this.offset();
+        if($this.text() == '')
+            return;
+        var $parent = $this.parent();
+        if(  ($parent.offset().left + $parent.outerWidth())
+           < (thisOffset.left + $this.outerWidth()))
+        {
+            var $fullNameLayer = $('#full_name_layer');
+            $fullNameLayer.removeClass('hide');
+            $fullNameLayer.css({left: thisOffset.left, top: thisOffset.top});
+            $fullNameLayer.html($this.clone());
+        }
+    });
+}

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -248,7 +248,6 @@ $(function () {
         /** mouseleave */
         $(this).addClass('hide');
     });
-    PMA_showFullName($('#pma_navigation_tree_content'));
 
     PMA_showCurrentNavigation();
 });
@@ -415,6 +414,7 @@ function PMA_showCurrentNavigation() {
             }
         }
     }
+    PMA_showFullName($('#pma_navigation_tree_content'));
 
     function handleTableOrDb(table, $dbItem) {
         if (table) {

--- a/libraries/navigation/NavigationTree.class.php
+++ b/libraries/navigation/NavigationTree.class.php
@@ -913,7 +913,7 @@ class PMA_NavigationTree
             if ($parent[0]->type == Node::CONTAINER
                 && (in_array($parent[0]->real_name, $haveAjax) || $isNewView)
             ) {
-                $linkClass = ' class="ajax"';
+                $linkClass = ' ajax';
             }
 
             if ($node->type == Node::CONTAINER) {
@@ -927,7 +927,10 @@ class PMA_NavigationTree
                         $args[] = urlencode($parent->real_name);
                     }
                     $link = vsprintf($node->links['icon'], $args);
-                    $retval .= "<a$linkClass href='$link'>{$node->icon}</a>";
+                    if($linkClass != '')
+                        $retval .= "<a class='$linkClass' href='$link'>{$node->icon}</a>";
+                    else
+                        $retval .= "<a href='$link'>{$node->icon}</a>";
                 } else {
                     $retval .= "<u>{$node->icon}</u>";
                 }
@@ -940,11 +943,11 @@ class PMA_NavigationTree
                 }
                 $link = vsprintf($node->links['text'], $args);
                 if ($node->type == Node::CONTAINER) {
-                    $retval .= "<a href='$link'>";
+                    $retval .= "<a class='hover_show_full' href='$link'>";
                     $retval .= htmlspecialchars($node->name);
                     $retval .= "</a>";
                 } else {
-                    $retval .= "<a$linkClass href='$link'>";
+                    $retval .= "<a class='hover_show_full$linkClass' href='$link'>";
                     $retval .= htmlspecialchars($node->real_name);
                     $retval .= "</a>";
                 }

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -775,7 +775,7 @@ div#tablestatistics table {
     margin-<?php echo $right; ?>: 0.5em;
     min-width: 16em;
 }
-/* END table stats */
+/* end table stats */
 
 
 /* server privileges */
@@ -784,7 +784,7 @@ div#tablestatistics table {
 #tabledatabases td {
     vertical-align: middle;
 }
-/* END server privileges */
+/* end server privileges */
 
 
 
@@ -920,7 +920,7 @@ div#tablestatistics table {
 #fieldset_user_global_rights legend input {
     margin-<?php echo $left; ?>: 2em;
 }
-/* END user privileges */
+/* end user privileges */
 
 
 /* serverstatus */
@@ -1141,7 +1141,7 @@ div#querywindowcontainer {
 div#querywindowcontainer fieldset {
     margin-top: 0;
 }
-/* END querywindow */
+/* end querywindow */
 
 /* profiling */
 
@@ -1179,7 +1179,7 @@ div#profilingchart {
     background-image: url(<?php echo $_SESSION['PMA_Theme']->getImgPath('s_asc.png');?>);
 }
 
-/* END profiling */
+/* end profiling */
 
 /* querybox */
 
@@ -1235,7 +1235,18 @@ div#queryboxcontainer div#bookmarkoptions {
 #maincontainer li {
     margin:  0.2em 0em;
 }
-/* END main page */
+
+#full_name_layer {
+    position: absolute;
+    padding: 2px;
+    margin-top: -3px;
+    z-index: 801;
+
+    border: solid 1px #888;
+    background: #fff;
+
+}
+/* end main page */
 
 /* iconic view for ul items */
 
@@ -1244,7 +1255,7 @@ li.no_bullets {
     margin-left: -25px !important;      //align with other list items which have bullets
 }
 
-/* END iconic view for ul items */
+/* end iconic view for ul items */
 
 #body_browse_foreigners {
     background:         <?php echo $GLOBALS['cfg']['NaviBackground']; ?>;

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -1074,7 +1074,7 @@ div#tablestatistics table {
     min-width: 16em;
 }
 
-/* END table stats */
+/* end table stats */
 
 
 /* server privileges */
@@ -1083,7 +1083,7 @@ div#tablestatistics table {
 #tabledatabases td {
     vertical-align: middle;
 }
-/* END server privileges */
+/* end server privileges */
 
 
 /* Heading */
@@ -1221,7 +1221,7 @@ div#tablestatistics table {
 #fieldset_user_global_rights legend input {
     margin-<?php echo $left; ?>: 2em;
 }
-/* END user privileges */
+/* end user privileges */
 
 
 /* serverstatus */
@@ -1492,7 +1492,7 @@ div#querywindowcontainer {
 div#querywindowcontainer fieldset {
     margin-top: 0;
 }
-/* END querywindow */
+/* end querywindow */
 
 /* profiling */
 
@@ -1530,7 +1530,7 @@ div#profilingchart {
     background-image: url(<?php echo $_SESSION['PMA_Theme']->getImgPath('s_asc.png');?>);
 }
 
-/* END profiling */
+/* end profiling */
 
 /* table charting */
 
@@ -1541,7 +1541,7 @@ div#profilingchart {
     padding: 10px;
 }
 
-/* END table charting */
+/* end table charting */
 
 /* querybox */
 
@@ -1657,7 +1657,19 @@ div#queryboxcontainer div#bookmarkoptions {
 #maincontainer li {
     margin-bottom: .3em;
 }
-/* END main page */
+
+#full_name_layer {
+    position: absolute;
+    padding: 2px;
+    margin-top: -3px;
+    z-index: 801;
+
+    border-radius: 3px;
+    border: solid 1px #888;
+    background: #fff;
+
+}
+/* end main page */
 
 
 /* iconic view for ul items */
@@ -1667,7 +1679,7 @@ li.no_bullets {
     margin-left: -25px !important;      //align with other list items which have bullets
 }
 
-/* END iconic view for ul items */
+/* end iconic view for ul items */
 
 #body_browse_foreigners {
     background: <?php echo $GLOBALS['cfg']['NaviBackground']; ?>;


### PR DESCRIPTION
Some datebase/table/column names are just so long that can't be shown completely,
Instead of adjusting the Navigation's width, hovering upon it to show it fully would be better

![original](https://f.cloud.github.com/assets/5505691/2136096/93fe7228-930a-11e3-8bdd-3cf7495ae403.png)
![pmahomme](https://f.cloud.github.com/assets/5505691/2136097/94016564-930a-11e3-86af-bcb81aa87a3c.png)

BTW，some end-sign notes where "end" are uppercase while others are lowercase, i unified them into lowercase

Signed-off-by: Edward Cheng &lt;c4150221@gmail.com>
