### PR TITLE
Use stable sort for OptionsPropertyGroup removeProperty.

### DIFF
--- a/libraries/properties/options/OptionsPropertyGroup.class.php
+++ b/libraries/properties/options/OptionsPropertyGroup.class.php
@@ -56,12 +56,9 @@ abstract class OptionsPropertyGroup extends OptionsPropertyItem
      */
     public function removeProperty($property)
     {
-        $this->_properties = array_udiff(
+        $this->_properties = array_diff(
             $this->getProperties(),
-            array($property),
-            function ($a, $b) {
-                return ($a === $b ) ? 0 : 1;
-            }
+            array($property)
         );
     }
 

--- a/test/classes/properties/options/PMA_OptionsPropertyGroup_test.php
+++ b/test/classes/properties/options/PMA_OptionsPropertyGroup_test.php
@@ -71,15 +71,6 @@ class PMA_OptionsPropertyGroup_Test extends PHPUnit_Framework_TestCase
         $properties = new \ReflectionProperty('OptionsPropertyGroup', '_properties');
         $properties->setAccessible(true);
 
-        $properties->setValue($this->stub, array(1, 2, 3, 'test'));
-
-        $this->stub->removeProperty('test');
-
-        $this->assertEquals(
-            array(1, 2, 3, 'test'),
-            $properties->getValue($this->stub)
-        );
-
         $properties->setValue($this->stub, array(1, 2, 'test', 3));
         $this->stub->removeProperty('test');
 


### PR DESCRIPTION
The original custom sort function is not stable, which causes different
results on HHVM. It now uses the default array_diff function which is
stable. I also removed a test that I believe is incorrected.

Signed-off-by: Jeff Chan jefftchan@gmail.com
