### PR TITLE
Selenium fixes and BrowserStack configuration

### DIFF
--- a/test/AllSeleniumTests.php
+++ b/test/AllSeleniumTests.php
@@ -8,7 +8,6 @@
  */
 
 require_once 'PHPUnit/TextUI/TestRunner.php';
-require_once __DIR__ . '/selenium/PmaSeleniumTestCase.php';
 require_once __DIR__ . '/selenium/PmaSeleniumLoginTest.php';
 require_once __DIR__ . '/selenium/PmaSeleniumXssTest.php';
 require_once __DIR__ . '/selenium/PmaSeleniumPrivilegesTest.php';

--- a/test/bootstrap-dist.php
+++ b/test/bootstrap-dist.php
@@ -19,6 +19,15 @@ define('PHPMYADMIN', 1);
 define('TESTSUITE', 1);
 define('PMA_MYSQL_INT_VERSION', 55000);
 
+$bs_uname = getenv('BS_UNAME');
+$bs_key = getenv('BS_KEY');
+
+if ($bs_uname && $bs_key) {
+    define('PHPUNIT_HOST', $bs_uname . ":" . $bs_key . "@hub.browserstack.com");
+} else {
+    define('PHPUNIT_HOST', "127.0.0.1");
+}
+
 require_once 'libraries/core.lib.php';
 require_once 'libraries/Config.class.php';
 $CFG = new PMA_Config();

--- a/test/selenium/PmaSeleniumLoginTest.php
+++ b/test/selenium/PmaSeleniumLoginTest.php
@@ -31,6 +31,7 @@ class PmaSeleniumLoginTest extends PHPUnit_Extensions_Selenium2TestCase
     public function setUp()
     {
         $this->_helper = new Helper($this);
+        $this->setHost(PHPUNIT_HOST);
         $this->setBrowser($this->_helper->getBrowserString());
         $this->setBrowserUrl(TESTSUITE_PHPMYADMIN_HOST . TESTSUITE_PHPMYADMIN_URL);
     }

--- a/test/selenium/PmaSeleniumPrivilegesTest.php
+++ b/test/selenium/PmaSeleniumPrivilegesTest.php
@@ -71,6 +71,8 @@ class PmaSeleniumPrivilegesTest extends PHPUnit_Extensions_Selenium2TestCase
         $this->assertNotEquals("", $this->byId("generated_pw")->value());
 
         if (TESTSUITE_PASSWORD != "") {
+            $this->byId("text_pma_pw")->clear();
+            $this->byId("text_pma_pw2")->clear();
             $this->byId("text_pma_pw")->value(TESTSUITE_PASSWORD);
             $this->byId("text_pma_pw2")->value(TESTSUITE_PASSWORD);
         } else {


### PR DESCRIPTION
This pull request enables PHPUnit Selenium tests to be run on BrowserStack instances. Some points to be noted:
- We need to provide BrowserStack credentials via Environment variables which can be done via Jenkins by following the steps given here: http://www.browserstack.com/automate/continuous-integration#ci-jenkins
- In phpunit.xml, the URLs and credentials need to be adjusted so that the tests run on the demo server and not on the localhost (which in any case won't be accessible from BrowserStack instances)
- Currently, I have only modified one selenium test to run on BrowserStack: test/selenium/PmaSeleniumLoginTest. The others still run on local Selenium instances. Once we have successfully configured Jenkins and tested this one test, we can configure all other tests too.
