### PR TITLE
Added custom recursive stripslashes function

### DIFF
--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -253,10 +253,10 @@ if (isset($_POST['usesubform'])) {
 if (version_compare(phpversion(), '5.4', 'lt')) {
     // remove quotes added by PHP
     if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
-        PMA_arrayWalkRecursive($_GET, 'stripslashes', true);
-        PMA_arrayWalkRecursive($_POST, 'stripslashes', true);
-        PMA_arrayWalkRecursive($_COOKIE, 'stripslashes', true);
-        PMA_arrayWalkRecursive($_REQUEST, 'stripslashes', true);
+        PMA_arrayWalkRecursive($_GET, 'PMA_stripAllSlashes', true);
+        PMA_arrayWalkRecursive($_POST, 'PMA_stripAllSlashes', true);
+        PMA_arrayWalkRecursive($_COOKIE, 'PMA_stripAllSlashes', true);
+        PMA_arrayWalkRecursive($_REQUEST, 'PMA_stripAllSlashes', true);
     }
 }
 

--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -880,4 +880,17 @@ function PMA_addJSVar($key, $value, $escape = true)
     PMA_addJSCode(PMA_getJsValue($key, $value, $escape));
 }
 
+/**
+ * Strips all slashes from a string.
+ *
+ * @param string $str String to strip
+ *
+ * @return string New string with all slashes removed
+ */
+function PMA_stripAllSlashes($str) {
+    while (strchr($str, "\\")) {
+        $str = stripslashes($str);
+    }
+    return $str;
+}
 ?>

--- a/test/libraries/core/PMA_array_test.php
+++ b/test/libraries/core/PMA_array_test.php
@@ -374,7 +374,7 @@ class PMA_Array_Test extends PHPUnit_Framework_TestCase
             'key3'=>'val3'
         );
 
-        PMA_arrayWalkRecursive($arr, 'stripslashes', true);
+        PMA_arrayWalkRecursive($arr, 'PMA_stripAllSlashes', true);
         $this->assertEquals($arr, $target);
     }
 
@@ -421,5 +421,15 @@ class PMA_Array_Test extends PHPUnit_Framework_TestCase
             array(false, 'k1/k3', array('k1' => array('k2' => array()))),
             array(false, 'k2', array('k1' => array('k2' => array()))),
         );
+    }
+
+    /**
+     * Test for PMA_stripAllSlashes
+     *
+     * @return void
+     */
+    function testStripAllSlashes() {
+        $this->assertEquals("gone", PMA_stripAllSlashes("\\\\g\\o\\\\\\\\ne"));
+        $this->assertEquals("gone", PMA_stripAllSlashes("gone"));
     }
 }


### PR DESCRIPTION
The previous use of `PMA_arrayWalkRecursive` with `stripslashes` required multiple
passes through the array if keys/values had more than 1 slash. To make it more
performant, I added a recursive `stripslashes` function `PMA_stripAllSlashes`
that strips all slashes from keys/values on the first pass.

Signed-off-by: Jeff Chan jefftchan@gmail.com
