### PR TITLE
Import improvements

### DIFF
--- a/import.php
+++ b/import.php
@@ -407,6 +407,19 @@ if ($import_file != 'none' && ! $error) {
             }
 
             $size = filesize($import_file);
+        } else {
+
+            // If the php.ini is misconfigured (eg. there is no /tmp access defined
+            // with open_basedir), $tmp_subdir won't be writable and the user gets 
+            // a 'File could not be read!' error (at PMA_detectCompression), which 
+            // is not too meaningful. Show a meaningful error message to the user 
+            // instead.
+
+            $message = PMA_Message::error(
+                __('Uploaded file cannot be moved, because the server has open_basedir enabled without access to the %s directory (for temporary files).')
+            );
+            $message->addParam($tmp_subdir);
+            _pma_stop_import($message);
         }
     }
 

--- a/import.php
+++ b/import.php
@@ -548,7 +548,7 @@ if (! $error) {
     }
 }
 
-if (! $error && false !== $import_handle && null !== $import_handle) {
+if (false !== $import_handle && null !== $import_handle) {
     fclose($import_handle);
 }
 

--- a/import.php
+++ b/import.php
@@ -389,15 +389,16 @@ if ($import_file != 'none' && ! $error) {
     $open_basedir = @ini_get('open_basedir');
 
     // If we are on a server with open_basedir, we must move the file
-    // before opening it. The doc explains how to create the "./tmp"
-    // directory
+    // before opening it.
 
     if (! empty($open_basedir)) {
 
-        $tmp_subdir = (PMA_IS_WINDOWS ? '.\\tmp\\' : 'tmp/');
+        /**
+         * @todo make use of the config's temp dir with fallback to the system's tmp dir
+         */
+        $tmp_subdir = sys_get_temp_dir();
 
         if (is_writable($tmp_subdir)) {
-
 
             $import_file_new = $tmp_subdir . basename($import_file) . uniqid();
             if (move_uploaded_file($import_file, $import_file_new)) {


### PR DESCRIPTION
The current version of import.php happily runs absolutely unnecessary parts of the code (the ones without a !$error check) upon error. This patch introduces a small local helper, _pma_stop_import() which closes opened file handles, sets the response attributes and immediately exits the code when called.
This patch changes open_basedir handling too: it replaces the current hard-coded tmp directory name to a system-provided one (the correct way would be using $cfg['TempDir'] in the first place) and adds an error message to handle cases when the tmp directory isn't available in open_basedir.
