### PR TITLE
Bug fix

### DIFF
--- a/themes/original/css/navigation.css.php
+++ b/themes/original/css/navigation.css.php
@@ -165,6 +165,9 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
 #pma_navigation_tree img {
     margin: 0;
 }
+#pma_navigation_tree i {
+    display: block;
+}
 #pma_navigation_tree div.block {
     position: relative;
     width:1.5em;

--- a/themes/pmahomme/css/navigation.css.php
+++ b/themes/pmahomme/css/navigation.css.php
@@ -152,6 +152,9 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
 #pma_navigation_tree img {
     margin: 0;
 }
+#pma_navigation_tree i {
+    display: block;
+}
 #pma_navigation_tree div.block {
     position: relative;
     width: 1.5em;


### PR DESCRIPTION
Because a commit i've submitted,
that add clear-fix div after navigation &lt;a> elements,
![third-level-nodes-bug](https://f.cloud.github.com/assets/5505691/2214827/f7fe7f6e-99dd-11e3-9de3-a4e04e87560d.png)
third level nodes &lt;i> tags will have wrong height.

Signed-off-by: Edward Cheng &lt;c4150221@gmail.com>
