### PR TITLE
Feature #569 Load/Save Query By Example

### DIFF
--- a/config.sample.inc.php
+++ b/config.sample.inc.php
@@ -60,6 +60,7 @@ $cfg['Servers'][$i]['AllowNoPassword'] = false;
 // $cfg['Servers'][$i]['users'] = 'pma__users';
 // $cfg['Servers'][$i]['usergroups'] = 'pma__usergroups';
 // $cfg['Servers'][$i]['navigationhiding'] = 'pma__navigationhiding';
+// $cfg['Servers'][$i]['savedsearches'] = 'pma__savedsearches';
 /* Contrib / Swekey authentication */
 // $cfg['Servers'][$i]['auth_swekey_config'] = '/etc/swekey-pma.conf';
 
@@ -145,7 +146,7 @@ $cfg['SaveDir'] = '';
 /**
  * Should error reporting be enabled for JavaScript errors
  *
- * default = 'ask' 
+ * default = 'ask'
  */
 //$cfg['SendErrorReports'] = 'ask';
 

--- a/db_qbe.php
+++ b/db_qbe.php
@@ -21,6 +21,7 @@ $cfgRelation = PMA_getRelationsParam();
 
 $savedSearchList = array();
 $currentSearchId = null;
+$displayUpdateSearchHint = false;
 if ($cfgRelation['savedsearcheswork']) {
     include 'libraries/SavedSearches.php';
     $header = $response->getHeader();
@@ -39,6 +40,7 @@ if ($cfgRelation['savedsearcheswork']) {
         if ('save' === $_REQUEST['action']) {
             $saveResult = $savedSearch->setCriterias($_REQUEST)
                 ->save();
+            $displayUpdateSearchHint = true;
             /*if (!$saveResult) {
                 $response->addHTML('raté');
                 exit();
@@ -52,6 +54,7 @@ if ($cfgRelation['savedsearcheswork']) {
             $_REQUEST = array();
         } elseif ('load' === $_REQUEST['action']) {
             $loadResult = $savedSearch->load();
+            $displayUpdateSearchHint = true;
         }
         //Else, it's an "update query"
     }
@@ -111,6 +114,16 @@ if ($cfgRelation['designerwork']) {
                 __('Switch to %svisual builder%s'),
                 '<a href="' . $url . '">',
                 '</a>'
+            )
+        )
+    );
+}
+if ($displayUpdateSearchHint) {
+    $response->addHTML(
+        PMA_Message::notice(
+            __(
+                'After saving or loading a search, you can rename it and save the '
+                . 'new criterias.'
             )
         )
     );

--- a/db_qbe.php
+++ b/db_qbe.php
@@ -33,30 +33,35 @@ if ($cfgRelation['savedsearcheswork']) {
     $savedSearch->setUsername($GLOBALS['cfg']['Server']['user'])
         ->setDbname($_REQUEST['db']);
 
-    //Criterias field is filled only when clicking on "Save search".
-    if (!empty($_REQUEST['action'])) {
+    if (isset($_REQUEST['action'])) {
         $savedSearch->setId($_REQUEST['searchId'])
             ->setSearchName($_REQUEST['searchName']);
-        if ('save' === $_REQUEST['action']) {
-            $saveResult = $savedSearch->setCriterias($_REQUEST)
-                ->save();
-            $displayUpdateSearchHint = true;
-            /*if (!$saveResult) {
-                $response->addHTML('raté');
-                exit();
-            }*/
-        } elseif ('delete' === $_REQUEST['action']) {
-            $deleteResult = $savedSearch->delete();
-            //After deletion, reset search.
-            $savedSearch = new PMA_SavedSearches($GLOBALS);
-            $savedSearch->setUsername($GLOBALS['cfg']['Server']['user'])
-                ->setDbname($_REQUEST['db']);
-            $_REQUEST = array();
-        } elseif ('load' === $_REQUEST['action']) {
-            $loadResult = $savedSearch->load();
+
+        //Criterias field is filled only when clicking on "Save search".
+        if (!empty($_REQUEST['action'])) {
+            if ('save' === $_REQUEST['action']) {
+                $saveResult = $savedSearch->setCriterias($_REQUEST)
+                    ->save();
+                $displayUpdateSearchHint = true;
+                /*if (!$saveResult) {
+                    $response->addHTML('raté');
+                    exit();
+                }*/
+            } elseif ('delete' === $_REQUEST['action']) {
+                $deleteResult = $savedSearch->delete();
+                //After deletion, reset search.
+                $savedSearch = new PMA_SavedSearches($GLOBALS);
+                $savedSearch->setUsername($GLOBALS['cfg']['Server']['user'])
+                    ->setDbname($_REQUEST['db']);
+                $_REQUEST = array();
+            } elseif ('load' === $_REQUEST['action']) {
+                $loadResult = $savedSearch->load();
+                $displayUpdateSearchHint = true;
+            }
+            //Else, it's an "update query"
+        } elseif (!empty($_REQUEST['searchName'])) {
             $displayUpdateSearchHint = true;
         }
-        //Else, it's an "update query"
     }
 
     $savedSearchList = $savedSearch->getList();

--- a/db_qbe.php
+++ b/db_qbe.php
@@ -29,13 +29,13 @@ if ($cfgRelation['savedsearcheswork']) {
 
     //Get saved search list.
     $savedSearch = new PMA_SavedSearches($GLOBALS);
-    $savedSearch->setId($_REQUEST['searchId'])
-        ->setUsername($GLOBALS['cfg']['Server']['user'])
-        ->setDbname($_REQUEST['db'])
-        ->setSearchName($_REQUEST['searchName']);
+    $savedSearch->setUsername($GLOBALS['cfg']['Server']['user'])
+        ->setDbname($_REQUEST['db']);
 
     //Criterias field is filled only when clicking on "Save search".
     if (!empty($_REQUEST['action'])) {
+        $savedSearch->setId($_REQUEST['searchId'])
+            ->setSearchName($_REQUEST['searchName']);
         if ('save' === $_REQUEST['action']) {
             $saveResult = $savedSearch->setCriterias($_REQUEST)
                 ->save();

--- a/examples/config.manyhosts.inc.php
+++ b/examples/config.manyhosts.inc.php
@@ -47,4 +47,5 @@ foreach ($hosts as $host) {
     $cfg['Servers'][$i]['users'] = 'pma__users';
     $cfg['Servers'][$i]['usergroups'] = 'pma__usergroups';
     $cfg['Servers'][$i]['navigationhiding'] = 'pma__navigationhiding';
+    $cfg['Servers'][$i]['savedsearches'] = 'pma__savedsearches';
 }

--- a/examples/create_tables.sql
+++ b/examples/create_tables.sql
@@ -1,40 +1,40 @@
 -- --------------------------------------------------------
 -- SQL Commands to set up the pmadb as described in the documentation.
--- 
+--
 -- This file is meant for use with MySQL 5 and above!
--- 
+--
 -- This script expects the user pma to already be existing. If we would put a
 -- line here to create him too many users might just use this script and end
 -- up with having the same password for the controluser.
---                                                     
--- This user "pma" must be defined in config.inc.php (controluser/controlpass)                         
---                                                  
--- Please don't forget to set up the tablenames in config.inc.php                                 
--- 
+--
+-- This user "pma" must be defined in config.inc.php (controluser/controlpass)
+--
+-- Please don't forget to set up the tablenames in config.inc.php
+--
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Database : `phpmyadmin`
--- 
+--
 CREATE DATABASE IF NOT EXISTS `phpmyadmin`
   DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
 USE phpmyadmin;
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Privileges
--- 
+--
 -- (activate this statement if necessary)
 -- GRANT SELECT, INSERT, DELETE, UPDATE ON `phpmyadmin`.* TO
 --    'pma'@localhost;
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__bookmark`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__bookmark` (
   `id` int(11) NOT NULL auto_increment,
@@ -49,9 +49,9 @@ CREATE TABLE IF NOT EXISTS `pma__bookmark` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__column_info`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__column_info` (
   `id` int(5) unsigned NOT NULL auto_increment,
@@ -70,9 +70,9 @@ CREATE TABLE IF NOT EXISTS `pma__column_info` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__history`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__history` (
   `id` bigint(20) unsigned NOT NULL auto_increment,
@@ -89,9 +89,9 @@ CREATE TABLE IF NOT EXISTS `pma__history` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__pdf_pages`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__pdf_pages` (
   `db_name` varchar(64) NOT NULL default '',
@@ -136,9 +136,9 @@ CREATE TABLE IF NOT EXISTS `pma__table_uiprefs` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__relation`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__relation` (
   `master_db` varchar(64) NOT NULL default '',
@@ -155,9 +155,9 @@ CREATE TABLE IF NOT EXISTS `pma__relation` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__table_coords`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__table_coords` (
   `db_name` varchar(64) NOT NULL default '',
@@ -172,9 +172,9 @@ CREATE TABLE IF NOT EXISTS `pma__table_coords` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__table_info`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__table_info` (
   `db_name` varchar(64) NOT NULL default '',
@@ -187,9 +187,9 @@ CREATE TABLE IF NOT EXISTS `pma__table_info` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__designer_coords`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__designer_coords` (
   `db_name` varchar(64) NOT NULL default '',
@@ -205,9 +205,9 @@ CREATE TABLE IF NOT EXISTS `pma__designer_coords` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__tracking`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__tracking` (
   `db_name` varchar(64) NOT NULL,
@@ -250,7 +250,7 @@ CREATE TABLE IF NOT EXISTS `pma__users` (
   `username` varchar(64) NOT NULL,
   `usergroup` varchar(64) NOT NULL,
   PRIMARY KEY (`username`,`usergroup`)
-) 
+)
   COMMENT='Users and their assignments to user groups'
   DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
 
@@ -265,10 +265,10 @@ CREATE TABLE IF NOT EXISTS `pma__usergroups` (
   `tab` varchar(64) NOT NULL,
   `allowed` enum('Y','N') NOT NULL DEFAULT 'N',
   PRIMARY KEY (`usergroup`,`tab`,`allowed`)
-) 
+)
   COMMENT='User groups with configured menu items'
   DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
-  
+
 -- --------------------------------------------------------
 
 --
@@ -282,6 +282,24 @@ CREATE TABLE IF NOT EXISTS `pma__navigationhiding` (
   `db_name` varchar(64) NOT NULL,
   `table_name` varchar(64) NOT NULL,
   PRIMARY KEY (`username`,`item_name`,`item_type`,`db_name`,`table_name`)
-) 
+)
   COMMENT='Hidden items of navigation tree'
+  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `pma__savedsearches`
+--
+
+CREATE TABLE IF NOT EXISTS `pma__savedsearches` (
+  `id` int(5) unsigned NOT NULL auto_increment,
+  `username` varchar(64) NOT NULL default '',
+  `db_name` varchar(64) NOT NULL default '',
+  `search_name` varchar(64) NOT NULL default '',
+  `search_data` text NOT NULL,
+  PRIMARY KEY  (`id`),
+  UNIQUE KEY `u_savedsearches_username_dbname` (`username`,`db_name`,`search_name`)
+)
+  COMMENT='Saved searches'
   DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;

--- a/examples/create_tables_drizzle.sql
+++ b/examples/create_tables_drizzle.sql
@@ -1,27 +1,27 @@
 -- --------------------------------------------------------
 -- SQL Commands to set up the pmadb as described in the documentation.
--- 
+--
 -- This file is meant for use with Drizzle 2011.03.13 and above!
--- 
+--
 -- This script expects that you take care of database permissions.
 --
 -- Please don't forget to set up the tablenames in config.inc.php
--- 
+--
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Database : `phpmyadmin`
--- 
+--
 CREATE DATABASE IF NOT EXISTS `phpmyadmin`
   COLLATE utf8_bin;
 USE phpmyadmin;
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__bookmark`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__bookmark` (
   `id` int(11) NOT NULL auto_increment,
@@ -36,9 +36,9 @@ CREATE TABLE IF NOT EXISTS `pma__bookmark` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__column_info`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__column_info` (
   `id` int(5) NOT NULL auto_increment,
@@ -57,9 +57,9 @@ CREATE TABLE IF NOT EXISTS `pma__column_info` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__history`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__history` (
   `id` bigint(20) NOT NULL auto_increment,
@@ -76,9 +76,9 @@ CREATE TABLE IF NOT EXISTS `pma__history` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__pdf_pages`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__pdf_pages` (
   `db_name` varchar(64) NOT NULL default '',
@@ -123,9 +123,9 @@ CREATE TABLE IF NOT EXISTS `pma__table_uiprefs` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__relation`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__relation` (
   `master_db` varchar(64) NOT NULL default '',
@@ -142,9 +142,9 @@ CREATE TABLE IF NOT EXISTS `pma__relation` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__table_coords`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__table_coords` (
   `db_name` varchar(64) NOT NULL default '',
@@ -159,9 +159,9 @@ CREATE TABLE IF NOT EXISTS `pma__table_coords` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__table_info`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__table_info` (
   `db_name` varchar(64) NOT NULL default '',
@@ -174,9 +174,9 @@ CREATE TABLE IF NOT EXISTS `pma__table_info` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__designer_coords`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__designer_coords` (
   `db_name` varchar(64) NOT NULL default '',
@@ -192,9 +192,9 @@ CREATE TABLE IF NOT EXISTS `pma__designer_coords` (
 
 -- --------------------------------------------------------
 
--- 
+--
 -- Table structure for table `pma__tracking`
--- 
+--
 
 CREATE TABLE IF NOT EXISTS `pma__tracking` (
   `db_name` varchar(64) NOT NULL,
@@ -236,7 +236,7 @@ CREATE TABLE IF NOT EXISTS `pma__users` (
   `username` varchar(64) NOT NULL,
   `usergroup` varchar(64) NOT NULL,
   PRIMARY KEY (`username`,`usergroup`)
-) 
+)
   COMMENT='Users and their assignments to user groups'
   COLLATE utf8_bin;
 
@@ -251,10 +251,10 @@ CREATE TABLE IF NOT EXISTS `pma__usergroups` (
   `tab` varchar(64) NOT NULL,
   `allowed` enum('Y','N') NOT NULL DEFAULT 'N',
   PRIMARY KEY (`usergroup`,`tab`,`allowed`)
-) 
+)
   COMMENT='User groups with configured menu items'
   COLLATE utf8_bin;
-  
+
 -- --------------------------------------------------------
 
 --
@@ -268,6 +268,24 @@ CREATE TABLE IF NOT EXISTS `pma__navigationhiding` (
   `db_name` varchar(64) NOT NULL,
   `table_name` varchar(64) NOT NULL,
   PRIMARY KEY (`username`,`item_name`,`item_type`,`db_name`,`table_name`)
-) 
+)
   COMMENT='Hidden items of navigation tree'
   COLLATE utf8_bin;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `pma__savedsearches`
+--
+
+CREATE TABLE IF NOT EXISTS `pma__savedsearches` (
+  `id` int(5) unsigned NOT NULL auto_increment,
+  `username` varchar(64) NOT NULL default '',
+  `db_name` varchar(64) NOT NULL default '',
+  `search_name` varchar(64) NOT NULL default '',
+  `search_data` text NOT NULL,
+  PRIMARY KEY  (`id`),
+  UNIQUE KEY `u_savedsearches_username_dbname` (`username`,`db_name`,`search_name`)
+)
+  COMMENT='Saved searches'
+  DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;

--- a/js/db_qbe.js
+++ b/js/db_qbe.js
@@ -50,6 +50,11 @@ AJAX.registerOnload('db_qbe.js', function () {
      * Ajax event handlers for 'Delete search'
      */
     $("#deleteSearch").live('click', function (event) {
+        var question = $.sprintf(PMA_messages.strConfirmDeleteQBESearch, $("#searchId option:selected").text());
+        if (!confirm(question)) {
+            return false;
+        }
+
         $('#action').val('delete');
     });
 });

--- a/js/db_qbe.js
+++ b/js/db_qbe.js
@@ -1,0 +1,55 @@
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * @fileoverview    function used in QBE for DB
+ * @name            Database Operations
+ *
+ * @requires    jQuery
+ * @requires    jQueryUI
+ * @requires    js/functions.js
+ *
+ */
+
+/**
+ * Ajax event handlers here for db_qbe.php
+ *
+ * Actions Ajaxified here:
+ * Select saved search
+ */
+
+/**
+ * Unbind all event handlers before tearing down a page
+ */
+AJAX.registerTeardown('db_qbe.js', function () {
+    $("#searchId").die('change');
+    $("#saveSearch").die('click');
+    $("#deleteSearch").die('click');
+});
+
+AJAX.registerOnload('db_qbe.js', function () {
+
+    /**
+     * Ajax event handlers for 'Select saved search'
+     */
+    $("#searchId").live('change', function (event) {
+        if ('' == $(this).val()) {
+            return false;
+        }
+
+        $('#action').val('load');
+        $('#formQBE').submit();
+    });
+
+    /**
+     * Ajax event handlers for 'Save search'
+     */
+    $("#saveSearch").live('click', function (event) {
+        $('#action').val('save');
+    });
+
+    /**
+     * Ajax event handlers for 'Delete search'
+     */
+    $("#deleteSearch").live('click', function (event) {
+        $('#action').val('delete');
+    });
+});

--- a/js/messages.php
+++ b/js/messages.php
@@ -42,6 +42,7 @@ $js_messages['strDeletingTrackingData'] = __('Deleting tracking data');
 $js_messages['strDroppingPrimaryKeyIndex'] = __('Dropping Primary Key/Index');
 $js_messages['strOperationTakesLongTime'] = __('This operation could take a long time. Proceed anyway?');
 $js_messages['strDropUserGroupWarning'] = __('Do you really want to delete user group "%s"?');
+$js_messages['strConfirmDeleteQBESearch'] = __('Do you really want to delete the search "%s"?');
 
 /* For indexes */
 $js_messages['strFormEmpty'] = __('Missing value in the form!');

--- a/libraries/DBQbe.class.php
+++ b/libraries/DBQbe.class.php
@@ -871,8 +871,8 @@ class PMA_DbQbe
                 continue;
             }
             $or = 'Or' . $new_row_index;
-            if (! empty($_POST[$or]) && isset($_POST[$or][$column_index])) {
-                $tmp_or = $_POST[$or][$column_index];
+            if (! empty($_REQUEST[$or]) && isset($_REQUEST[$or][$column_index])) {
+                $tmp_or = $_REQUEST[$or][$column_index];
             } else {
                 $tmp_or     = '';
             }

--- a/libraries/SavedSearches.php
+++ b/libraries/SavedSearches.php
@@ -1,0 +1,397 @@
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * Saved searches managing
+ *
+ * @package PhpMyAdmin
+ */
+
+if (! defined('PHPMYADMIN')) {
+    exit;
+}
+
+/**
+ * Saved searches managing
+ *
+ * @package PhpMyAdmin
+ */
+class PMA_SavedSearches
+{
+    /**
+     * Global configuration
+     * @var array
+     */
+    private $_config = null;
+
+    /**
+     * Id
+     * @var int|null
+     */
+    private $_id = null;
+
+    /**
+     * Username
+     * @var string
+     */
+    private $_username = null;
+
+    /**
+     * DB name
+     * @var string
+     */
+    private $_dbname = null;
+
+    /**
+     * Saved search name
+     * @var string
+     */
+    private $_searchName = null;
+
+    /**
+     * Setter of id
+     *
+     * @param int|null $searchId Id of search
+     *
+     * @return static
+     */
+    public function setId($searchId)
+    {
+        $searchId = (int)$searchId;
+        if (empty($searchId)) {
+            $searchId = null;
+        }
+
+        $this->_id = $searchId;
+        return $this;
+    }
+
+    /**
+     * Getter of id
+     *
+     * @return int|null
+     */
+    public function getId()
+    {
+        return $this->_id;
+    }
+
+    /**
+     * Setter of searchName
+     *
+     * @param string $searchName Saved search name
+     *
+     * @return static
+     */
+    public function setSearchName($searchName)
+    {
+        $this->_searchName = $searchName;
+        return $this;
+    }
+
+    /**
+     * Getter of searchName
+     *
+     * @return string
+     */
+    public function getSearchName()
+    {
+        return $this->_searchName;
+    }
+
+    /**
+     * Criterias
+     * @var array
+     */
+    private $_criterias = null;
+
+    /**
+     * Setter of config
+     *
+     * @param array $config Global configuration
+     *
+     * @return static
+     */
+    public function setConfig($config)
+    {
+        $this->_config = $config;
+        return $this;
+    }
+
+    /**
+     * Getter of config
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        return $this->_config;
+    }
+
+    /**
+     * Setter for criterias
+     *
+     * @param array $criterias Criterias of saved searches
+     * @param bool  $json      Criterias are in JSON format
+     *
+     * @return static
+     */
+    public function setCriterias($criterias, $json = false)
+    {
+        if (true === $json) {
+            $this->_criterias = json_decode($criterias, true);
+            return $this;
+        }
+
+        $aListFieldsToGet = array(
+            'criteriaColumn',
+            'criteriaSort',
+            'criteriaShow',
+            'criteria',
+            'criteriaAndOrRow',
+            'criteriaAndOrColumn',
+            'rows'
+        );
+
+        $data = array();
+
+        $data['criteriaColumnCount'] = count($criterias['criteriaColumn']);
+
+        foreach ($aListFieldsToGet as $field) {
+            $data[$field] = $criterias[$field];
+        }
+
+        for ($i = 0; $i <= $data['rows']; $i++) {
+            $data['Or' . $i] = $criterias['Or' . $i];
+        }
+
+        $this->_criterias = $data;
+        return $this;
+    }
+
+    /**
+     * Getter for criterias
+     *
+     * @return array
+     */
+    public function getCriterias()
+    {
+        return $this->_criterias;
+    }
+
+    /**
+     * Setter for username
+     *
+     * @param string $username Username
+     *
+     * @return static
+     */
+    public function setUsername($username)
+    {
+        $this->_username = $username;
+        return $this;
+    }
+
+    /**
+     * Getter for username
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->_username;
+    }
+
+    /**
+     * Setter for DB name
+     *
+     * @param string $dbname DB name
+     *
+     * @return static
+     */
+    public function setDbname($dbname)
+    {
+        $this->_dbname = $dbname;
+        return $this;
+    }
+
+    /**
+     * Getter for DB name
+     *
+     * @return string
+     */
+    public function getDbname()
+    {
+        return $this->_dbname;
+    }
+
+    /**
+     * Public constructor
+     *
+     * @param array $config Global configuration
+     */
+    public function __construct($config)
+    {
+        $this->setConfig($config);
+    }
+
+    /**
+     * Save the search
+     *
+     * @return boolean
+     */
+    public function save()
+    {
+        if (null == $this->getUsername()
+            || null == $this->getDbname()
+            || null == $this->getSearchName()
+            || null == $this->getCriterias()
+        ) {
+            PMA_Util::mysqlDie(__('Missing information to save the search.'));
+        }
+
+        $savedSearchesTbl
+            = PMA_Util::backquote($this->_config['cfgRelation']['db']) . "."
+            . PMA_Util::backquote($this->_config['cfgRelation']['savedsearches']);
+
+        //If it's an insert.
+        if (null === $this->getId()) {
+            $wheres = array(
+                "search_name = '" . PMA_Util::sqlAddSlashes($this->getSearchName())
+                . "'"
+            );
+            $existingSearches = $this->getList($wheres);
+
+            if (!empty($existingSearches)) {
+                PMA_Util::mysqlDie(__('An entry with this name already exists.'));
+            }
+
+            $sqlQuery = "INSERT INTO " . $savedSearchesTbl
+                . "(`username`, `db_name`, `search_name`, `search_data`)"
+                . " VALUES ("
+                . "'" . PMA_Util::sqlAddSlashes($this->getUsername()) . "',"
+                . "'" . PMA_Util::sqlAddSlashes($this->getDbname()) . "',"
+                . "'" . PMA_Util::sqlAddSlashes($this->getSearchName()) . "',"
+                . "'" . PMA_Util::sqlAddSlashes(json_encode($this->getCriterias()))
+                . "')";
+
+            $result = (bool)PMA_queryAsControlUser($sqlQuery);
+            if (!$result) {
+                return false;
+            }
+
+            $this->setId($GLOBALS['dbi']->insertId());
+
+            return true;
+        }
+
+        //Else, it's an update.
+        $wheres = array(
+            "id != " . $this->getId(),
+            "search_name = '" . PMA_Util::sqlAddSlashes($this->getSearchName()) . "'"
+        );
+        $existingSearches = $this->getList($wheres);
+
+        if (!empty($existingSearches)) {
+            PMA_Util::mysqlDie(__('An entry with this name already exists.'));
+        }
+
+        $sqlQuery = "UPDATE " . $savedSearchesTbl
+            . "SET `search_name` = '"
+            . PMA_Util::sqlAddSlashes($this->getSearchName()) . "', "
+            . "`search_data` = '"
+            . PMA_Util::sqlAddSlashes(json_encode($this->getCriterias())) . "' "
+            . "WHERE id = " . $this->getId();
+        return (bool)PMA_queryAsControlUser($sqlQuery);
+    }
+
+    /**
+     * Delete the search
+     *
+     * @return boolean
+     */
+    public function delete()
+    {
+        if (null == $this->getId()) {
+            PMA_Util::mysqlDie(__('Missing information to delete the search.'));
+        }
+
+        $savedSearchesTbl
+            = PMA_Util::backquote($this->_config['cfgRelation']['db']) . "."
+            . PMA_Util::backquote($this->_config['cfgRelation']['savedsearches']);
+
+        $sqlQuery = "DELETE FROM " . $savedSearchesTbl
+            . "WHERE id = '" . PMA_Util::sqlAddSlashes($this->getId()) . "'";
+
+        return (bool)PMA_queryAsControlUser($sqlQuery);
+    }
+
+    /**
+     * Load the current search from an id.
+     *
+     * @return bool Success
+     */
+    public function load()
+    {
+        if (null == $this->getId()) {
+            PMA_Util::mysqlDie(__('Missing information to load the search.'));
+        }
+
+        $savedSearchesTbl = PMA_Util::backquote($this->_config['cfgRelation']['db'])
+            . "."
+            . PMA_Util::backquote($this->_config['cfgRelation']['savedsearches']);
+        $sqlQuery = "SELECT id, search_name, search_data "
+            . "FROM " . $savedSearchesTbl . " "
+            . "WHERE id = '" . PMA_Util::sqlAddSlashes($this->getId()) . "' ";
+
+        $resList = PMA_queryAsControlUser($sqlQuery);
+
+        if (false === ($oneResult = $GLOBALS['dbi']->fetchArray($resList))) {
+            PMA_Util::mysqlDie(__('Error while loading the search.'));
+        }
+
+        $this->setSearchName($oneResult['search_name'])
+            ->setCriterias($oneResult['search_data'], true);
+
+        return true;
+    }
+
+    /**
+     * Get the list of saved search of a user on a DB
+     *
+     * @param array $wheres List of filters
+     *
+     * @return array|bool List of saved search or false on failure
+     */
+    public function getList(array $wheres = array())
+    {
+        if (null == $this->getUsername()
+            || null == $this->getDbname()
+        ) {
+            return false;
+        }
+
+        $savedSearchesTbl = PMA_Util::backquote($this->_config['cfgRelation']['db'])
+            . "."
+            . PMA_Util::backquote($this->_config['cfgRelation']['savedsearches']);
+        $sqlQuery = "SELECT id, search_name "
+            . "FROM " . $savedSearchesTbl . " "
+            . "WHERE "
+            . "username = '" . PMA_Util::sqlAddSlashes($this->getUsername()) . "' "
+            . "AND db_name = '" . PMA_Util::sqlAddSlashes($this->getDbname()) . "' ";
+
+        foreach ($wheres as $where) {
+            $sqlQuery .= "AND " . $where . " ";
+        }
+
+        $sqlQuery .= "order by search_name ASC ";
+
+        $resList = PMA_queryAsControlUser($sqlQuery);
+
+        $list = array();
+        while ($oneResult = $GLOBALS['dbi']->fetchArray($resList)) {
+            $list[$oneResult['id']] = $oneResult['search_name'];
+        }
+
+        return $list;
+    }
+}

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -466,6 +466,15 @@ $cfg['Servers'][$i]['usergroups'] = '';
 $cfg['Servers'][$i]['navigationhiding'] = '';
 
 /**
+ * table to store information about saved searches from query-by-example on a db
+ *   - leave blank to disable saved searches feature
+ *     SUGGESTED: 'pma__savedsearches'
+ *
+ * @global string $cfg['Servers'][$i]['savedsearches']
+ */
+$cfg['Servers'][$i]['savedsearches'] = '';
+
+/**
  * Maximum number of records saved in $cfg['Servers'][$i]['table_uiprefs'] table.
  *
  * In case where tables in databases is modified (e.g. dropped or renamed),

--- a/libraries/config/setup.forms.php
+++ b/libraries/config/setup.forms.php
@@ -79,6 +79,7 @@ $forms['Servers']['Server_pmadb'] = array('Servers' => array(1 => array(
     'table_coords' => 'pma__table_coords',
     'pdf_pages' => 'pma__pdf_pages',
     'designer_coords' => 'pma__designer_coords',
+    'saved_searches' => 'pma__savedsearches',
     'MaxTableUiprefs' => 100)));
 $forms['Servers']['Server_tracking'] = array('Servers' => array(1 => array(
     'tracking_version_auto_create',

--- a/libraries/relation.lib.php
+++ b/libraries/relation.lib.php
@@ -395,6 +395,7 @@ function PMA_checkRelationsParam()
     $cfgRelation['menuswork']      = false;
     $cfgRelation['navwork']        = false;
     $cfgRelation['allworks']       = false;
+    $cfgRelation['savedsearcheswork'] = false;
     $cfgRelation['user']           = null;
     $cfgRelation['db']             = null;
 
@@ -463,6 +464,8 @@ function PMA_checkRelationsParam()
             $cfgRelation['usergroups']      = $curr_table[0];
         } elseif ($curr_table[0] == $GLOBALS['cfg']['Server']['navigationhiding']) {
             $cfgRelation['navigationhiding']      = $curr_table[0];
+        } elseif ($curr_table[0] == $GLOBALS['cfg']['Server']['savedsearches']) {
+            $cfgRelation['savedsearches']    = $curr_table[0];
         }
     } // end while
     $GLOBALS['dbi']->freeResult($tab_rs);
@@ -521,6 +524,10 @@ function PMA_checkRelationsParam()
         $cfgRelation['navwork']          = true;
     }
 
+    if (isset($cfgRelation['savedsearches'])) {
+        $cfgRelation['savedsearcheswork']      = true;
+    }
+
     if ($cfgRelation['relwork'] && $cfgRelation['displaywork']
         && $cfgRelation['pdfwork'] && $cfgRelation['commwork']
         && $cfgRelation['mimework'] && $cfgRelation['historywork']
@@ -528,6 +535,7 @@ function PMA_checkRelationsParam()
         && $cfgRelation['trackingwork'] && $cfgRelation['userconfigwork']
         && $cfgRelation['bookmarkwork'] && $cfgRelation['designerwork']
         && $cfgRelation['menuswork'] && $cfgRelation['navwork']
+        && $cfgRelation['savedsearcheswork']
     ) {
         $cfgRelation['allworks'] = true;
     }

--- a/test/libraries/PMA_relation_cleanup_test.php
+++ b/test/libraries/PMA_relation_cleanup_test.php
@@ -52,6 +52,7 @@ class PMA_Relation_Cleanup_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['Server']['users'] = 'users';
         $GLOBALS['cfg']['Server']['usergroups'] = 'usergroups';
         $GLOBALS['cfg']['Server']['navigationhiding'] = 'navigationhiding';
+        $GLOBALS['cfg']['Server']['savedsearches'] = 'savedsearches';
 
         $this->redefineRelation();
     }


### PR DESCRIPTION
Hi,

I tried to implement this feature: https://sourceforge.net/p/phpmyadmin/feature-requests/569/
The aim is to be able to save/load (and delete) a QBE on a DB and so you'll be able to run the same query easily.

A new table had been created: pma_savedsearches
I'm not sure about all the things to do to add a table, so fell free to tell me if I forgot something.

The po files had not been updated as advised on the wiki (http://wiki.phpmyadmin.net/pma/Gettext_for_developers#Updating_.po_files).

Thanks for your feedback.
