### PR TITLE
Add space after table columns name, to prevent misuse when you want to m...

### DIFF
--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2615,6 +2615,10 @@ fieldset .disabled-field td {
     overflow: hidden;
 }
 
+.pma_table th.draggable span {
+    margin-<?php echo $right; ?>: 10px;
+}
+
 .modal-copy input {
     display: block;
     width: 100%;


### PR DESCRIPTION
Add space after table columns name, to prevent misuse when you want to mark it.

Sometimes there's not any space for user to click.

Signed-off-by: Edward Cheng &lt;c4150221@gmail.com>
