### PR TITLE
bug fix #4040:

### DIFF
--- a/prefs_manage.php
+++ b/prefs_manage.php
@@ -194,18 +194,6 @@ if (isset($_POST['submit_export'])
     $result = PMA_saveUserprefs(array());
     if ($result === true) {
         $params = array();
-        /*Since we are not resetting theme on reset settings, we dont need below block of code.
-         * for now just commenting out the code so that if we need in future we can reuse
-        */
-       /* 
-        * if ($_SESSION['PMA_Theme_Manager']->theme->getId() != 'original') {
-            $GLOBALS['PMA_Config']->removeCookie(
-                $_SESSION['PMA_Theme_Manager']->getThemeCookieName()
-            );
-            unset($_SESSION['PMA_Theme_Manager']);
-            unset($_SESSION['PMA_Theme']);
-        }
-        */
         if ($GLOBALS['PMA_Config']->get('fontsize') != '82%') {
             $GLOBALS['PMA_Config']->removeCookie('pma_fontsize');
         }

--- a/prefs_manage.php
+++ b/prefs_manage.php
@@ -194,13 +194,18 @@ if (isset($_POST['submit_export'])
     $result = PMA_saveUserprefs(array());
     if ($result === true) {
         $params = array();
-        if ($_SESSION['PMA_Theme_Manager']->theme->getId() != 'original') {
+        /*Since we are not resetting theme on reset settings, we dont need below block of code.
+         * for now just commenting out the code so that if we need in future we can reuse
+        */
+       /* 
+        * if ($_SESSION['PMA_Theme_Manager']->theme->getId() != 'original') {
             $GLOBALS['PMA_Config']->removeCookie(
                 $_SESSION['PMA_Theme_Manager']->getThemeCookieName()
             );
             unset($_SESSION['PMA_Theme_Manager']);
             unset($_SESSION['PMA_Theme']);
         }
+        */
         if ($GLOBALS['PMA_Config']->get('fontsize') != '82%') {
             $GLOBALS['PMA_Config']->removeCookie('pma_fontsize');
         }


### PR DESCRIPTION
Since we are not resetting theme on reset settings, commented out unset theme from session variable. That's what was causing the error because here we are unsetting the theme session variables and then again trying to use the same variables later on causing fatal error.

Signed-off-by: Smita Kumari kumarismita62@gmail.com
