### PR TITLE
Display session expiry msg after auto-redirect.

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -339,8 +339,10 @@ var AJAX = {
             PMA_ajaxShowMessage(data.error, false);
             AJAX.active = false;
             AJAX.xhr = null;
-            if (data.redirect_url) {
-                window.location.href=data.redirect_url;
+            if (parseInt(data.redirect_flag) == 1) {
+                // add one more GET param to display session expiry msg
+                window.location.href += '&session_expired=1';
+                window.location.reload();
             }
         }
     },

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -487,7 +487,9 @@ if ($token_mismatch) {
         /* Permit to log out even if there is a token mismatch */
         'old_usr',
         /* Permit redirection with token-mismatch in url.php */
-        'url'
+        'url',
+        /* Permit session expiry flag */
+        'session_expired'
     );
     /**
      * Allow changing themes in test/theme.php

--- a/libraries/plugins/auth/AuthenticationCookie.class.php
+++ b/libraries/plugins/auth/AuthenticationCookie.class.php
@@ -76,8 +76,8 @@ class AuthenticationCookie extends AuthenticationPlugin
             $response->isSuccess(false);
 
             $response->addJSON(
-                'redirect_url',
-                $GLOBALS['cfg']['PmaAbsoluteUri']
+                'redirect_flag',
+                '1'
             );
             if (defined('TESTSUITE')) {
                 return true;
@@ -148,6 +148,9 @@ class AuthenticationCookie extends AuthenticationPlugin
         // Show error message
         if (! empty($conn_error)) {
             PMA_Message::rawError($conn_error)->display();
+        }
+        elseif (isset($_GET['session_expired']) && intval($_GET['session_expired'])==1) {
+            PMA_Message::rawError(__('Your session has expired. Please log in again.'))->display();
         }
 
         echo "<noscript>\n";

--- a/test/classes/plugin/auth/PMA_AuthenticationCookie_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationCookie_test.php
@@ -77,8 +77,8 @@ class PMA_AuthenticationCookie_Test extends PHPUnit_Framework_TestCase
         $mockResponse->expects($this->once())
             ->method('addJSON')
             ->with(
-                'redirect_url',
-                'https://phpmyadmin.net/'
+                'redirect_flag',
+                '1'
             );
 
         $attrInstance = new ReflectionProperty('PMA_Response', '_instance');
@@ -89,11 +89,8 @@ class PMA_AuthenticationCookie_Test extends PHPUnit_Framework_TestCase
         $this->assertTrue(
             $this->object->auth()
         );
+
         // Case 2
-
-
-
-        // case 3
 
         $mockResponse = $this->getMockBuilder('PMA_Response')
             ->disableOriginalConstructor()
@@ -278,7 +275,7 @@ class PMA_AuthenticationCookie_Test extends PHPUnit_Framework_TestCase
 
         @unlink('testlogo_right.png');
 
-        // case 4
+        // case 3
 
         $mockResponse = $this->getMockBuilder('PMA_Response')
             ->disableOriginalConstructor()


### PR DESCRIPTION
Signed-off-by: Dhananjay Nakrani dhananjaynakrani@gmail.com

In the implementation of [feature-request#1460](http://sourceforge.net/p/phpmyadmin/feature-requests/1460/), there were some issues that I have tried to resolve.
1. After auto-redirection on session expiry, there was no msg shown to user. Now with these changes appropriate msg will be displayed on log-in form.
2. After re-login, user was taken to home page because `$GLOBALS['cfg']['PmaAbsoluteUri']` was used. Now user is taken to where he left off. This is similar to [feature-request#1426](http://sourceforge.net/p/phpmyadmin/feature-requests/1426/)
3. I've also renumbered the test cases in `testAuth()`.
