### PR TITLE
bug fix #4040

### DIFF
--- a/prefs_manage.php
+++ b/prefs_manage.php
@@ -194,13 +194,6 @@ if (isset($_POST['submit_export'])
     $result = PMA_saveUserprefs(array());
     if ($result === true) {
         $params = array();
-        if ($_SESSION['PMA_Theme_Manager']->theme->getId() != 'original') {
-            $GLOBALS['PMA_Config']->removeCookie(
-                $_SESSION['PMA_Theme_Manager']->getThemeCookieName()
-            );
-            unset($_SESSION['PMA_Theme_Manager']);
-            unset($_SESSION['PMA_Theme']);
-        }
         if ($GLOBALS['PMA_Config']->get('fontsize') != '82%') {
             $GLOBALS['PMA_Config']->removeCookie('pma_fontsize');
         }


### PR DESCRIPTION
Since we are not resetting theme on reset settings, so removed the block that were unsetting theme variables in session

Signed-off-by: Smita Kumari kumarismita62@gmail.com
