### PR TITLE
improve grammar

### DIFF
--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -127,8 +127,8 @@ function PMA_getTableDropQueryAndMessage($table_is_view, $current_table)
         );
     $drop_message = sprintf(
         (($table_is_view || $current_table['ENGINE'] == null)
-            ? __('View %s has been dropped.')
-            : __('Table %s has been dropped.')),
+            ? __('View %s was dropped.')
+            : __('Table %s was dropped.')),
         str_replace(
             ' ',
             '&nbsp;',

--- a/tbl_operations.php
+++ b/tbl_operations.php
@@ -355,8 +355,8 @@ if (! (isset($db_is_system_schema) && $db_is_system_schema)) {
                 'purge' => '1',
                 'message_to_show' => sprintf(
                     ($tbl_is_view
-                        ? __('View %s has been dropped.')
-                        : __('Table %s has been dropped.')
+                        ? __('View %s was dropped.')
+                        : __('Table %s was dropped.')
                     ),
                     htmlspecialchars($table)
                 ),

--- a/view_operations.php
+++ b/view_operations.php
@@ -116,7 +116,7 @@ $drop_view_url_params = array_merge(
         'reload' => '1',
         'purge' => '1',
         'message_to_show' => sprintf(
-            __('View %s has been dropped.'),
+            __('View %s was dropped.'),
             htmlspecialchars($GLOBALS['table'])
         ),
         'table' => $GLOBALS['table']


### PR DESCRIPTION
I'm not a native speaker, but this proposed change 'has been dropped' -> 'was dropped' seems more natural.
