### PR TITLE
Fixes the problem with the breadcrumb navigation(Bug 4306)

### DIFF
--- a/tbl_create.php
+++ b/tbl_create.php
@@ -86,6 +86,9 @@ if (isset($_REQUEST['do_save_data'])) {
     exit;
 } // end do create table
 
+//This global variable needs to be reset for the headerclass to function properly
+$GLOBAL['table'] = '';
+
 /**
  * Displays the form used to define the structure of the table
  */


### PR DESCRIPTION
The global variable table is used by both breadcrumb navigation as
well as the tbl_create.php hence it needs to be set back to zero
after use.

Signed-off-by: Aditya Sastry ganeshaditya1@gmail.com
