### PR TITLE
Fixes the action panel problem when editing rows in chrome(Bug 4228)

### DIFF
--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -1605,8 +1605,7 @@ function PMA_getSumbitAndResetButtonForActionsPanel($tabindex, $tabindex_for_val
  */
 function PMA_getHeadAndFootOfInsertRowTable($url_params)
 {
-    $html_output = '<div class="clearfloat">'
-        . '<table class="insertRowTable">'
+    $html_output .= '<table class="insertRowTable">'
         . '<thead>'
         . '<tr>'
         . '<th>' . __('Column') . '</th>';
@@ -2904,7 +2903,7 @@ function PMA_getHtmlForInsertEditRow($url_params, $table_columns,
     $o_rows++;
     $html_output .= '  </tbody>'
         . '</table><br />'
-        . '</div>';
+        . '<div class="clearfloat"></div>';
 
     return $html_output;
 }

--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -1605,7 +1605,8 @@ function PMA_getSumbitAndResetButtonForActionsPanel($tabindex, $tabindex_for_val
  */
 function PMA_getHeadAndFootOfInsertRowTable($url_params)
 {
-    $html_output = '<table class="insertRowTable">'
+    $html_output = '<div id = "edit_row">'
+        . '<table class="insertRowTable">'
         . '<thead>'
         . '<tr>'
         . '<th>' . __('Column') . '</th>';
@@ -2902,7 +2903,8 @@ function PMA_getHtmlForInsertEditRow($url_params, $table_columns,
     } // end for
     $o_rows++;
     $html_output .= '  </tbody>'
-        . '</table><br />';
+        . '</table><br />'
+        . '</div>';
 
     return $html_output;
 }

--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -1605,7 +1605,7 @@ function PMA_getSumbitAndResetButtonForActionsPanel($tabindex, $tabindex_for_val
  */
 function PMA_getHeadAndFootOfInsertRowTable($url_params)
 {
-    $html_output = '<div id="clearfloat">'
+    $html_output = '<div class="clearfloat">'
         . '<table class="insertRowTable">'
         . '<thead>'
         . '<tr>'

--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -1605,7 +1605,7 @@ function PMA_getSumbitAndResetButtonForActionsPanel($tabindex, $tabindex_for_val
  */
 function PMA_getHeadAndFootOfInsertRowTable($url_params)
 {
-    $html_output = '<div id = "edit_row">'
+    $html_output = '<div id="clearfloat">'
         . '<table class="insertRowTable">'
         . '<thead>'
         . '<tr>'

--- a/tbl_change.php
+++ b/tbl_change.php
@@ -187,7 +187,6 @@ $html_output .= PMA_getHtmlForGisEditor();
 if (! isset($after_insert)) {
     $after_insert = 'back';
 }
-$html_output .= '</form>';
 
 //action panel
 $html_output .= PMA_getActionsPanel(

--- a/tbl_change.php
+++ b/tbl_change.php
@@ -187,6 +187,7 @@ $html_output .= PMA_getHtmlForGisEditor();
 if (! isset($after_insert)) {
     $after_insert = 'back';
 }
+$html_output .= '</form>';
 
 //action panel
 $html_output .= PMA_getActionsPanel(

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -2626,3 +2626,8 @@ div#page_content form#db_search_form.ajax fieldset {
 div#page_content div#tableslistcontainer, div#page_content div.notice, div#page_content div#result_query {
     margin-top: 1em;
 }
+
+div#edit_row {
+    float: left;
+    clear: both;
+}

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -2627,7 +2627,3 @@ div#page_content div#tableslistcontainer, div#page_content div.notice, div#page_
     margin-top: 1em;
 }
 
-div#edit_row {
-    float: left;
-    clear: both;
-}

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2921,7 +2921,3 @@ div#page_content div#tableslistcontainer, div#page_content div.notice, div#page_
     margin-top: 1em;
 }
 
-div#edit_row {
-    float: left;
-    clear: both;
-}

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2920,3 +2920,8 @@ div#page_content form#db_search_form.ajax fieldset {
 div#page_content div#tableslistcontainer, div#page_content div.notice, div#page_content div#result_query {
     margin-top: 1em;
 }
+
+div#edit_row {
+    float: left;
+    clear: both;
+}


### PR DESCRIPTION
The action panel which is a fieldset is rendered differently in chrome.
Also the rows are listed in a random fashion unlike in firefox where
they are sorted by the primary key. I fixed this problem by enclosing the
rows in a div tag with float left and clear both styles.

Signed-off-by: Aditya Sastry ganeshaditya1@gmail.com
