### PR TITLE
Remove 1px border of server info

### DIFF
--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -1104,7 +1104,6 @@ div#tablestatistics table {
 }
 
 #serverinfo {
-    border-bottom: 1px solid #fff;
     background: #888;
     padding: .3em .9em;
     padding-<?php echo $left; ?>: 2.2em;


### PR DESCRIPTION
I have removed the White 1px border from above the Navigation. Now it looks more like a unit. I find this little thing makes it look rounder.

Maybe you merge it :-)

Signed-off-by: Marvin Wegener mw197@web.de
