### PR TITLE
Fixes the action panel problem when editing rows in chrome(Bug 4228)

### DIFF
--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -2902,7 +2902,8 @@ function PMA_getHtmlForInsertEditRow($url_params, $table_columns,
     } // end for
     $o_rows++;
     $html_output .= '  </tbody>'
-        . '</table><br />';
+        . '</table><br />'
+        . '<div class="clearfloat"></div>';
 
     return $html_output;
 }


### PR DESCRIPTION
The action panel which is a fieldset is rendered differently in chrome.
Also the rows are listed in a random fashion unlike in firefox where
they are sorted by the primary key. I fixed this problem by enclosing the
rows in a div tag with float left and clear both styles.

Signed-off-by: Aditya Sastry ganeshaditya1@gmail.com
