### PR TITLE
Import gettext include to make unit tests friendlier to running independently

### DIFF
--- a/test/classes/navigation/PMA_Node_Column_test.php
+++ b/test/classes/navigation/PMA_Node_Column_test.php
@@ -9,6 +9,7 @@
 require_once 'libraries/navigation/NodeFactory.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
+require_once 'libraries/php-gettext/gettext.inc';
 
 /**
  * Tests for Node_Column class

--- a/test/classes/navigation/PMA_Node_DatabaseChild_test.php
+++ b/test/classes/navigation/PMA_Node_DatabaseChild_test.php
@@ -13,6 +13,7 @@ require_once 'libraries/relation.lib.php';
 require_once 'libraries/navigation/Nodes/Node.class.php';
 require_once 'libraries/navigation/Nodes/Node_DatabaseChild.class.php';
 require_once 'libraries/navigation/NodeFactory.class.php';
+require_once 'libraries/php-gettext/gettext.inc';
 
 /**
  * Tests for Node_DatabaseChild class

--- a/test/classes/navigation/PMA_Node_Database_test.php
+++ b/test/classes/navigation/PMA_Node_Database_test.php
@@ -9,6 +9,7 @@
 require_once 'libraries/navigation/NodeFactory.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
+require_once 'libraries/php-gettext/gettext.inc';
 
 /**
  * Tests for Node_Database class

--- a/test/classes/navigation/PMA_Node_Function_test.php
+++ b/test/classes/navigation/PMA_Node_Function_test.php
@@ -9,6 +9,7 @@
 require_once 'libraries/navigation/NodeFactory.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
+require_once 'libraries/php-gettext/gettext.inc';
 
 /**
  * Tests for Node_Function class

--- a/test/classes/navigation/PMA_Node_Index_test.php
+++ b/test/classes/navigation/PMA_Node_Index_test.php
@@ -9,6 +9,7 @@
 require_once 'libraries/navigation/NodeFactory.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
+require_once 'libraries/php-gettext/gettext.inc';
 
 /**
  * Tests for Node_Index class

--- a/test/classes/navigation/PMA_Node_Procedure_test.php
+++ b/test/classes/navigation/PMA_Node_Procedure_test.php
@@ -9,6 +9,7 @@
 require_once 'libraries/navigation/NodeFactory.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
+require_once 'libraries/php-gettext/gettext.inc';
 
 /**
  * Tests for Node_Procedure class

--- a/test/classes/navigation/PMA_Node_Table_test.php
+++ b/test/classes/navigation/PMA_Node_Table_test.php
@@ -9,6 +9,7 @@
 require_once 'libraries/navigation/NodeFactory.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
+require_once 'libraries/php-gettext/gettext.inc';
 
 /**
  * Tests for Node_Table class

--- a/test/classes/navigation/PMA_Node_View_test.php
+++ b/test/classes/navigation/PMA_Node_View_test.php
@@ -9,6 +9,7 @@
 require_once 'libraries/navigation/NodeFactory.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
+require_once 'libraries/php-gettext/gettext.inc';
 
 /**
  * Tests for Node_View class


### PR DESCRIPTION
The HHVM test runner runs the unit tests in parallel. Currently some tests
fail because not all the dependencies are properly included.

This is similar to this commit 840f7b12150aedca8f8d6d57c0da15dab9f99a07

Signed-off-by: Jeff Chan jefftchan@gmail.com
