### PR TITLE
Import export.lib.php to make unit tests friendlier to running independently

### DIFF
--- a/test/classes/plugin/export/PMA_ExportCsv_test.php
+++ b/test/classes/plugin/export/PMA_ExportCsv_test.php
@@ -6,6 +6,7 @@
  * @package PhpMyAdmin-test
  */
 require_once 'libraries/plugins/export/ExportCsv.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportExcel_test.php
+++ b/test/classes/plugin/export/PMA_ExportExcel_test.php
@@ -6,6 +6,7 @@
  * @package PhpMyAdmin-test
  */
 require_once 'libraries/plugins/export/ExportExcel.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportHtmlword_test.php
+++ b/test/classes/plugin/export/PMA_ExportHtmlword_test.php
@@ -7,6 +7,7 @@
  */
 require_once 'libraries/plugins/export/ExportHtmlword.class.php';
 require_once 'libraries/DatabaseInterface.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportJson_test.php
+++ b/test/classes/plugin/export/PMA_ExportJson_test.php
@@ -6,6 +6,7 @@
  * @package PhpMyAdmin-test
  */
 require_once 'libraries/plugins/export/ExportJson.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportLatex_test.php
+++ b/test/classes/plugin/export/PMA_ExportLatex_test.php
@@ -6,6 +6,7 @@
  * @package PhpMyAdmin-test
  */
 require_once 'libraries/plugins/export/ExportLatex.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportOds_test.php
+++ b/test/classes/plugin/export/PMA_ExportOds_test.php
@@ -7,6 +7,7 @@
  */
 require_once 'libraries/plugins/export/ExportOds.class.php';
 require_once 'libraries/DatabaseInterface.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportOdt_test.php
+++ b/test/classes/plugin/export/PMA_ExportOdt_test.php
@@ -6,6 +6,7 @@
  * @package PhpMyAdmin-test
  */
 require_once 'libraries/plugins/export/ExportOdt.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportPdf_test.php
+++ b/test/classes/plugin/export/PMA_ExportPdf_test.php
@@ -7,6 +7,7 @@
  */
 require_once 'libraries/plugins/export/ExportPdf.class.php';
 require_once 'libraries/plugins/export/PMA_ExportPdf.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportPhparray_test.php
+++ b/test/classes/plugin/export/PMA_ExportPhparray_test.php
@@ -7,6 +7,7 @@
  */
 require_once 'libraries/plugins/export/ExportPhparray.class.php';
 require_once 'libraries/DatabaseInterface.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportTexytext_test.php
+++ b/test/classes/plugin/export/PMA_ExportTexytext_test.php
@@ -6,6 +6,7 @@
  * @package PhpMyAdmin-test
  */
 require_once 'libraries/plugins/export/ExportTexytext.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportYaml_test.php
+++ b/test/classes/plugin/export/PMA_ExportYaml_test.php
@@ -6,6 +6,7 @@
  * @package PhpMyAdmin-test
  */
 require_once 'libraries/plugins/export/ExportYaml.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';


### PR DESCRIPTION
The HHVM test runner runs the unit tests in parallel. Currently some tests
fail because not all the dependencies are properly included.

This is similar to 1d58392622592d9a2cd6b64b797017d5ba95a113

Signed-off-by: Jeff Chan jefftchan@gmail.com
