### PR TITLE
Import DatabaseInterface to make unit tests friendlier to running independently

### DIFF
--- a/test/classes/PMA_StorageEngine_test.php
+++ b/test/classes/PMA_StorageEngine_test.php
@@ -12,6 +12,8 @@
 require_once 'libraries/StorageEngine.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/Util.class.php';
+require_once 'libraries/Config.class.php';
+require_once 'libraries/config.default.php';
 require_once 'libraries/database_interface.inc.php';
 require_once 'libraries/Tracker.class.php';
 

--- a/test/classes/PMA_TableReplaceSearch_test.php
+++ b/test/classes/PMA_TableReplaceSearch_test.php
@@ -11,6 +11,7 @@ require_once 'libraries/Util.class.php';
  * Include to test.
  */
 require_once 'libraries/TableSearch.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 
 /**

--- a/test/classes/PMA_TableSearch_test.php
+++ b/test/classes/PMA_TableSearch_test.php
@@ -10,6 +10,7 @@
  * Include to test.
  */
 require_once 'libraries/url_generating.lib.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/TableSearch.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/php-gettext/gettext.inc';

--- a/test/classes/plugin/auth/PMA_AuthenticationHttp_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationHttp_test.php
@@ -7,6 +7,7 @@
  */
 
 require_once 'libraries/plugins/auth/AuthenticationHttp.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Message.class.php';
 require_once 'libraries/Theme.class.php';

--- a/test/classes/plugin/auth/PMA_AuthenticationSignon_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationSignon_test.php
@@ -7,6 +7,7 @@
  */
 
 require_once 'libraries/plugins/auth/AuthenticationSignon.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Message.class.php';
 require_once 'libraries/Theme.class.php';

--- a/test/classes/plugin/export/PMA_ExportCodegen_test.php
+++ b/test/classes/plugin/export/PMA_ExportCodegen_test.php
@@ -7,6 +7,7 @@
  */
 require_once 'libraries/export.lib.php';
 require_once 'libraries/plugins/export/ExportCodegen.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportCsv_test.php
+++ b/test/classes/plugin/export/PMA_ExportCsv_test.php
@@ -7,11 +7,13 @@
  */
 require_once 'libraries/plugins/export/ExportCsv.class.php';
 require_once 'libraries/export.lib.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';
 require_once 'libraries/config.default.php';
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'libraries/Message.class.php';
 require_once 'export.php';
 /**
  * tests for ExportCsv class

--- a/test/classes/plugin/export/PMA_ExportJson_test.php
+++ b/test/classes/plugin/export/PMA_ExportJson_test.php
@@ -10,6 +10,7 @@ require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
 require_once 'export.php';

--- a/test/classes/plugin/export/PMA_ExportLatex_test.php
+++ b/test/classes/plugin/export/PMA_ExportLatex_test.php
@@ -10,8 +10,10 @@ require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
+require_once 'libraries/relation.lib.php';
 require_once 'export.php';
 /**
  * tests for ExportLatex class

--- a/test/classes/plugin/export/PMA_ExportMediawiki_test.php
+++ b/test/classes/plugin/export/PMA_ExportMediawiki_test.php
@@ -6,6 +6,8 @@
  * @package PhpMyAdmin-test
  */
 require_once 'libraries/plugins/export/ExportMediawiki.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';

--- a/test/classes/plugin/export/PMA_ExportPdf_test.php
+++ b/test/classes/plugin/export/PMA_ExportPdf_test.php
@@ -13,6 +13,7 @@ require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
+require_once 'libraries/properties/options/items/MessageOnlyPropertyItem.class.php';
 require_once 'export.php';
 /**
  * tests for ExportPdf class

--- a/test/classes/plugin/export/PMA_ExportSql_test.php
+++ b/test/classes/plugin/export/PMA_ExportSql_test.php
@@ -6,11 +6,15 @@
  * @package PhpMyAdmin-test
  */
 require_once 'libraries/plugins/export/ExportSql.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
+require_once 'libraries/mysql_charsets.lib.php';
+require_once 'libraries/relation.lib.php';
 require_once 'export.php';
 /**
  * tests for ExportSql class

--- a/test/classes/plugin/transformations/Text_Plain_Sql_test.php
+++ b/test/classes/plugin/transformations/Text_Plain_Sql_test.php
@@ -10,6 +10,7 @@
  */
 
 /* Each PluginObserver instance contains a PluginManager instance */
+require_once 'libraries/Util.class.php';
 require_once 'libraries/plugins/PluginManager.class.php';
 require_once 'libraries/plugins/transformations/Text_Plain_Sql.class.php';
 require_once 'libraries/php-gettext/gettext.inc';

--- a/test/libraries/PMA_Tracker_test.php
+++ b/test/libraries/PMA_Tracker_test.php
@@ -10,6 +10,7 @@
  * Include to test.
  */
 require_once 'libraries/Tracker.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/relation.lib.php';

--- a/test/libraries/PMA_tbl_columns_definition_form_test.php
+++ b/test/libraries/PMA_tbl_columns_definition_form_test.php
@@ -11,9 +11,12 @@
  */
 require_once 'libraries/Util.class.php';
 require_once 'libraries/tbl_columns_definition_form.lib.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/Partition.class.php';
 require_once 'libraries/Types.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'libraries/transformations.lib.php';
+require_once 'libraries/mysql_charsets.lib.php';
 
 /**
  * Tests for libraries/tbl_columns_definition_form.lib.php

--- a/test/libraries/PMA_user_preferences_test.php
+++ b/test/libraries/PMA_user_preferences_test.php
@@ -10,11 +10,13 @@
  * Include to test
  */
 require_once 'libraries/user_preferences.lib.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/config/ConfigFile.class.php';
 require_once 'libraries/core.lib.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/relation.lib.php';
+require_once 'libraries/url_generating.lib.php';
 
 /**
  * tests for methods under user_preferences libarary


### PR DESCRIPTION
The HHVM test runner runs the unit tests in parallel. Currently some tests
fail because not all the dependencies are properly included.

This is similar to 840f7b12150aedca8f8d6d57c0da15dab9f99a07

Signed-off-by: Jeff Chan jefftchan@gmail.com
