### PR TITLE
Import dependencies to make unit tests friendlier to running independently

### DIFF
--- a/test/classes/PMA_Error_Handler_test.php
+++ b/test/classes/PMA_Error_Handler_test.php
@@ -12,6 +12,7 @@
 require_once 'libraries/Error_Handler.class.php';
 require_once 'libraries/sanitizing.lib.php';
 require_once 'libraries/Util.class.php';
+require_once 'libraries/Theme.class.php';
 
 /**
  * Test for PMA_Error_Handler class.
@@ -36,6 +37,9 @@ class PMA_Error_Handler_Test extends PHPUnit_Framework_TestCase
     {
         $this->object = new PMA_Error_Handler();
 
+        $GLOBALS['pmaThemeImage'] = 'image';
+        $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
+        $_SESSION['PMA_Theme'] = new PMA_Theme();
     }
 
     /**
@@ -273,6 +277,7 @@ class PMA_Error_Handler_Test extends PHPUnit_Framework_TestCase
      */
     public function testHasDisplayErrors()
     {
+        $GLOBALS['cfg']['Error_Handler']['display'] = false;
         $this->assertFalse($this->object->hasDisplayErrors());
     }
 }

--- a/test/classes/PMA_Error_test.php
+++ b/test/classes/PMA_Error_test.php
@@ -14,6 +14,7 @@ require_once 'libraries/Error.class.php';
 require_once 'libraries/Message.class.php';
 require_once 'libraries/sanitizing.lib.php';
 require_once 'libraries/Util.class.php';
+require_once 'libraries/Theme.class.php';
 
 /**
  * Erorr class testing.
@@ -37,6 +38,10 @@ class PMA_Error_Test extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->object = new PMA_Error('2', 'Compile Error', 'error.txt', 15);
+
+        $GLOBALS['pmaThemeImage'] = 'image';
+        $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
+        $_SESSION['PMA_Theme'] = new PMA_Theme();
     }
 
     /**

--- a/test/classes/PMA_Footer_test.php
+++ b/test/classes/PMA_Footer_test.php
@@ -55,6 +55,7 @@ class PMA_Footer_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['db'] = '';
         $GLOBALS['table'] = '';
         $GLOBALS['text_dir'] = 'ltr';
+        $GLOBALS['pmaThemeImage'] = 'image';
         $GLOBALS['PMA_Config'] = new PMA_Config();
         $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['collation_connection'] = 'utf8_general_ci';
@@ -70,6 +71,9 @@ class PMA_Footer_Test extends PHPUnit_Framework_TestCase
         unset($GLOBALS['sql_query']);
         $GLOBALS['error_handler'] = new PMA_Error_Handler();
         unset($_POST);
+
+        $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
+        $_SESSION['PMA_Theme'] = new PMA_Theme();
     }
 
     /**

--- a/test/classes/PMA_Menu_test.php
+++ b/test/classes/PMA_Menu_test.php
@@ -51,6 +51,8 @@ class PMA_Menu_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['DefaultTabTable'] = 'sql.php';
         $GLOBALS['cfg']['OBGzip'] = false;
         $GLOBALS['cfg']['NaturalOrder'] = true;
+        $GLOBALS['cfg']['TabsMode'] = 'both';
+        $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['PMA_PHP_SELF'] = PMA_getenv('PHP_SELF');
         $GLOBALS['server'] = 'server';
         $GLOBALS['db'] = 'pma_test';

--- a/test/classes/PMA_TableReplaceSearch_test.php
+++ b/test/classes/PMA_TableReplaceSearch_test.php
@@ -13,6 +13,7 @@ require_once 'libraries/Util.class.php';
 require_once 'libraries/TableSearch.class.php';
 require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'libraries/url_generating.lib.php';
 
 /**
  * Tests for libraries/TableSearch.class.php with search type replace

--- a/test/classes/PMA_TableSearch_test.php
+++ b/test/classes/PMA_TableSearch_test.php
@@ -21,6 +21,7 @@ require_once 'libraries/Theme.class.php';
 require_once 'libraries/Tracker.class.php';
 require_once 'libraries/Types.class.php';
 require_once 'libraries/relation.lib.php';
+require_once 'libraries/url_generating.lib.php';
 
 /**
  * Tests for PMA_TableSearch

--- a/test/classes/PMA_Util_test.php
+++ b/test/classes/PMA_Util_test.php
@@ -107,6 +107,7 @@ class PMA_Util_Test extends PHPUnit_Framework_TestCase
      */
     public function testGetLatestVersion()
     {
+        $GLOBALS['cfg']['ProxyUrl'] = '';
         $GLOBALS['cfg']['VersionCheckProxyUrl'] = '';
         $version = PMA_Util::getLatestVersion();
         $this->assertNotEmpty($version->version);

--- a/test/classes/navigation/PMA_Node_Database_test.php
+++ b/test/classes/navigation/PMA_Node_Database_test.php
@@ -27,6 +27,8 @@ class Node_Database_Test extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['token'] = 'token';
+        $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
+        $GLOBALS['cfg']['MaxNavigationItems'] = 250;
         $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
     }
 

--- a/test/classes/navigation/PMA_Node_Table_Container_test.php
+++ b/test/classes/navigation/PMA_Node_Table_Container_test.php
@@ -27,6 +27,10 @@ class Node_Table_Container_Test extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['token'] = 'token';
+        $GLOBALS['cfg']['NavigationTreeEnableGrouping'] = true;
+        $GLOBALS['cfg']['NavigationTreeDbSeparator'] = '_';
+        $GLOBALS['cfg']['NavigationTreeTableSeparator'] = '__';
+        $GLOBALS['cfg']['NavigationTreeTableLevel'] = 1;
         $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
     }
 

--- a/test/classes/navigation/PMA_Node_Table_test.php
+++ b/test/classes/navigation/PMA_Node_Table_test.php
@@ -27,6 +27,13 @@ class Node_Table_Test extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['token'] = 'token';
+        $GLOBALS['cfg']['NavigationTreeDefaultTabTable'] = 'b_browse';
+        $GLOBALS['cfg']['DefaultTabTable'] = 'sql.php';
+        $GLOBALS['cfg']['MaxNavigationItems'] = 250;
+        $GLOBALS['cfg']['NavigationTreeEnableGrouping'] = true;
+        $GLOBALS['cfg']['NavigationTreeDbSeparator'] = '_';
+        $GLOBALS['cfg']['NavigationTreeTableSeparator'] = '__';
+        $GLOBALS['cfg']['NavigationTreeTableLevel'] = 1;
         $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
     }
 

--- a/test/classes/navigation/PMA_Node_View_Container_test.php
+++ b/test/classes/navigation/PMA_Node_View_Container_test.php
@@ -27,6 +27,10 @@ class Node_View_Container_Test extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['token'] = 'token';
+        $GLOBALS['cfg']['NavigationTreeEnableGrouping'] = true;
+        $GLOBALS['cfg']['NavigationTreeDbSeparator'] = '_';
+        $GLOBALS['cfg']['NavigationTreeTableSeparator'] = '__';
+        $GLOBALS['cfg']['NavigationTreeTableLevel'] = 1;
         $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
     }
 

--- a/test/classes/plugin/auth/PMA_AuthenticationCookie_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationCookie_test.php
@@ -18,6 +18,7 @@ require_once 'libraries/config.default.php';
 require_once 'libraries/Error_Handler.class.php';
 require_once 'libraries/Response.class.php';
 require_once 'libraries/js_escape.lib.php';
+require_once 'libraries/sanitizing.lib.php';
 
 /**
  * tests for AuthenticationCookie class
@@ -38,6 +39,9 @@ class PMA_AuthenticationCookie_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['server'] = 0;
         $this->object = new AuthenticationCookie(null);
+
+        $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
+        $_SESSION['PMA_Theme'] = new PMA_Theme();
     }
 
     /**

--- a/test/classes/plugin/auth/PMA_AuthenticationHttp_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationHttp_test.php
@@ -15,6 +15,7 @@ require_once 'libraries/Config.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
 require_once 'libraries/Error_Handler.class.php';
+require_once 'libraries/sanitizing.lib.php';
 
 /**
  * tests for AuthenticationHttp class
@@ -38,6 +39,11 @@ class PMA_AuthenticationHttp_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['PMA_Config'] = new PMA_Config;
         $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['server'] = 0;
+        $GLOBALS['lang'] = "en";
+        $GLOBALS['available_languages'] = array(
+            "en" => array("English", "US-ENGLISH"),
+            "ch" => array("Chinese", "TW-Chinese")
+        );
         $this->object = new AuthenticationHttp(null);
     }
 

--- a/test/classes/plugin/auth/PMA_AuthenticationSignon_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationSignon_test.php
@@ -14,6 +14,7 @@ require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
+require_once 'libraries/sanitizing.lib.php';
 require_once 'libraries/Error_Handler.class.php';
 
 /**

--- a/test/classes/plugin/export/PMA_ExportSql_test.php
+++ b/test/classes/plugin/export/PMA_ExportSql_test.php
@@ -15,6 +15,8 @@ require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
 require_once 'libraries/mysql_charsets.lib.php';
 require_once 'libraries/relation.lib.php';
+require_once 'libraries/Table.class.php';
+require_once 'libraries/sqlparser.lib.php';
 require_once 'export.php';
 /**
  * tests for ExportSql class

--- a/test/libraries/PMA_ConfigGenerator_test.php
+++ b/test/libraries/PMA_ConfigGenerator_test.php
@@ -13,6 +13,7 @@ require_once 'setup/lib/ConfigGenerator.class.php';
 require_once 'libraries/config/ConfigFile.class.php';
 require_once 'libraries/core.lib.php';
 require_once 'libraries/Util.class.php';
+require_once 'libraries/php-gettext/gettext.inc';
 
 /**
  * tests for methods under Config file generator

--- a/test/libraries/PMA_SetupIndex_test.php
+++ b/test/libraries/PMA_SetupIndex_test.php
@@ -28,6 +28,16 @@ require_once 'libraries/sanitizing.lib.php';
 class PMA_SetupIndex_Test extends PHPUnit_Framework_TestCase
 {
     /**
+     * SetUp for test cases
+     *
+     * @return void
+     */
+    public function setup()
+    {
+        $GLOBALS['cfg']['ProxyUrl'] = '';
+    }
+
+    /**
      * Test for PMA_messagesBegin()
      *
      * @return void

--- a/test/libraries/PMA_display_export_test.php
+++ b/test/libraries/PMA_display_export_test.php
@@ -44,6 +44,7 @@ class PMA_DisplayExport_Test extends PHPUnit_Framework_TestCase
     {
         //$GLOBALS
         $GLOBALS['cfg']['MaxRows'] = 10;
+        $GLOBALS['cfg']['ExecTimeLimit'] = 300;
         $GLOBALS['cfg']['ServerDefault'] = "PMA_server";
         $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
         $GLOBALS['cfg']['LimitChars'] = 100;

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -45,6 +45,7 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
 
         //$GLOBALS
         $GLOBALS['cfg']['MaxRows'] = 10;
+        $GLOBALS['cfg']['SendErrorReports'] = "never";
         $GLOBALS['cfg']['ServerDefault'] = "server";
         $GLOBALS['cfg']['RememberSorting'] = true;
         $GLOBALS['cfg']['SQP'] = array();

--- a/test/libraries/PMA_server_user_groups_test.php
+++ b/test/libraries/PMA_server_user_groups_test.php
@@ -28,6 +28,8 @@ class PMA_ServerUserGroupsTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        $GLOBALS['cfg']['ServerDefault'] = 1;
+        $GLOBALS['cfg']['ActionLinksMode'] = 'both';
         $GLOBALS['cfg']['Server']['pmadb'] = 'pmadb';
         $GLOBALS['cfg']['Server']['users'] = 'users';
         $GLOBALS['cfg']['Server']['usergroups'] = 'usergroups';

--- a/test/libraries/PMA_tbl_columns_definition_form_test.php
+++ b/test/libraries/PMA_tbl_columns_definition_form_test.php
@@ -14,9 +14,11 @@ require_once 'libraries/tbl_columns_definition_form.lib.php';
 require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/Partition.class.php';
 require_once 'libraries/Types.class.php';
+require_once 'libraries/Theme.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/transformations.lib.php';
 require_once 'libraries/mysql_charsets.lib.php';
+require_once 'libraries/StorageEngine.class.php';
 
 /**
  * Tests for libraries/tbl_columns_definition_form.lib.php
@@ -36,6 +38,10 @@ class PMA_TblColumnsDefinitionFormTest extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['DBG'] = null;
         $GLOBALS['cfg']['TextareaCols'] = 10;
         $GLOBALS['cfg']['TextareaRows'] = 15;
+        $GLOBALS['pmaThemeImage'] = 'image';
+
+        $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
+        $_SESSION['PMA_Theme'] = new PMA_Theme();
     }
 
     /**

--- a/test/libraries/PMA_user_preferences_test.php
+++ b/test/libraries/PMA_user_preferences_test.php
@@ -17,6 +17,8 @@ require_once 'libraries/Util.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/relation.lib.php';
 require_once 'libraries/url_generating.lib.php';
+require_once 'libraries/sanitizing.lib.php';
+require_once 'libraries/Message.class.php';
 
 /**
  * tests for methods under user_preferences libarary


### PR DESCRIPTION
The HHVM test runner runs the unit tests in parallel. Currently some tests
fail because not all the dependencies are properly included.

This is similar to 659efe1a88e8cc553bfa965aec2069bee897d4b4

Signed-off-by: Jeff Chan jefftchan@gmail.com
