### PR TITLE
fix collation query error when switching from 5.5 server to 5.0

### DIFF
--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -1563,6 +1563,8 @@ class PMA_DatabaseInterface
                         $GLOBALS['collation_connection'],
                         5
                     );
+                } else {
+                   $GLOBALS['collation_connection'] = $default_collation;
                 }
                 $this->query(
                     "SET collation_connection = '"


### PR DESCRIPTION
First pull request included merge with my changes. Here's a clean PR.

When your default server has mysql 5.5 your collation (in GLOBALS) is set to mb4. When you try to change to mysql 5.1 server, you will get error as on this image:

http://codeone.pl/ss/ss-2014-03-10_12-54-41-001.png
