### PR TITLE
#3991 bug fix

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -3838,6 +3838,8 @@ AJAX.registerOnload('functions.js', function () {
     $('#createViewDialog').find('input, select').live('keydown', function (e) {
         if (e.which === 13) { // 13 is the ENTER key
             e.preventDefault();
+            $(this).blur();//as by preventing default, selection by <select> tag is also prevented in IE
+            //Signed-off-by: Aayush Anand <aayushism12@gmail.com>
             $(this).closest('.ui-dialog').find('.ui-button:first').click();
         }
     }); // end $.live()


### PR DESCRIPTION
by preventing default using "preventDefault()", default funtion of tag like action of enter key for choosing any option is also prevented. That's why enter key was not working.
Using ".blur()" select tag looses focus on enter key hit which by default selects the option on focus

Signed-off-by: Aayush Anand aayushism12@gmail.com
