### PR TITLE
Import config to make unit tests friendlier to running independently

### DIFF
--- a/test/classes/plugin/auth/PMA_AuthenticationConfig_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationConfig_test.php
@@ -7,12 +7,15 @@
  */
 
 require_once 'libraries/plugins/auth/AuthenticationConfig.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
+require_once 'libraries/js_escape.lib.php';
 require_once 'libraries/Error_Handler.class.php';
+require_once 'libraries/Response.class.php';
 /**
  * tests for AuthenticationConfig class
  *
@@ -101,6 +104,11 @@ class PMA_AuthenticationConfig_Test extends PHPUnit_Framework_TestCase
                 $this->markTestSkipped('Cannot remove constant');
             }
         }
+
+        $dbi = $this->getMockBuilder('PMA_DatabaseInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $GLOBALS['dbi'] = $dbi;
 
         ob_start();
         $result = $this->object->authFails();

--- a/test/classes/plugin/export/PMA_ExportHtmlword_test.php
+++ b/test/classes/plugin/export/PMA_ExportHtmlword_test.php
@@ -14,6 +14,7 @@ require_once 'libraries/Config.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
 require_once 'libraries/relation.lib.php';
+require_once 'libraries/transformations.lib.php';
 require_once 'export.php';
 /**
  * tests for ExportHtmlword class
@@ -31,6 +32,10 @@ class PMA_ExportHtmlword_Test extends PHPUnit_Framework_TestCase
      */
     function setup()
     {
+        if (!defined("PMA_DRIZZLE")) {
+            define("PMA_DRIZZLE", false);
+        }
+
         $GLOBALS['server'] = 0;
         $this->object = new ExportHtmlword();
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/plugin/export/PMA_ExportLatex_test.php
+++ b/test/classes/plugin/export/PMA_ExportLatex_test.php
@@ -14,6 +14,7 @@ require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
 require_once 'libraries/relation.lib.php';
+require_once 'libraries/transformations.lib.php';
 require_once 'export.php';
 /**
  * tests for ExportLatex class
@@ -31,6 +32,10 @@ class PMA_ExportLatex_Test extends PHPUnit_Framework_TestCase
      */
     function setup()
     {
+        if (!defined("PMA_DRIZZLE")) {
+            define("PMA_DRIZZLE", false);
+        }
+
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;
         $GLOBALS['output_charset_conversion'] = false;

--- a/test/classes/plugin/export/PMA_ExportOdt_test.php
+++ b/test/classes/plugin/export/PMA_ExportOdt_test.php
@@ -14,6 +14,7 @@ require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
 require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/relation.lib.php';
+require_once 'libraries/transformations.lib.php';
 require_once 'export.php';
 
 /**
@@ -32,6 +33,10 @@ class PMA_ExportOdt_Test extends PHPUnit_Framework_TestCase
      */
     function setup()
     {
+        if (!defined("PMA_DRIZZLE")) {
+            define("PMA_DRIZZLE", false);
+        }
+
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;
         $GLOBALS['output_charset_conversion'] = false;

--- a/test/classes/plugin/export/PMA_ExportSql_test.php
+++ b/test/classes/plugin/export/PMA_ExportSql_test.php
@@ -15,8 +15,10 @@ require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
 require_once 'libraries/mysql_charsets.lib.php';
 require_once 'libraries/relation.lib.php';
+require_once 'libraries/transformations.lib.php';
 require_once 'libraries/Table.class.php';
 require_once 'libraries/sqlparser.lib.php';
+require_once 'libraries/charset_conversion.lib.php';
 require_once 'export.php';
 /**
  * tests for ExportSql class
@@ -34,6 +36,10 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
      */
     function setup()
     {
+        if (!defined("PMA_DRIZZLE")) {
+            define("PMA_DRIZZLE", false);
+        }
+
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;
         $GLOBALS['buffer_needed'] = false;

--- a/test/classes/plugin/export/PMA_ExportTexytext_test.php
+++ b/test/classes/plugin/export/PMA_ExportTexytext_test.php
@@ -15,6 +15,7 @@ require_once 'libraries/config.default.php';
 require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/relation.lib.php';
 require_once 'libraries/sqlparser.lib.php';
+require_once 'libraries/transformations.lib.php';
 require_once 'export.php';
 /**
  * tests for ExportTexytext class
@@ -32,6 +33,10 @@ class PMA_ExportTexytext_Test extends PHPUnit_Framework_TestCase
      */
     function setup()
     {
+        if (!defined("PMA_DRIZZLE")) {
+            define("PMA_DRIZZLE", false);
+        }
+
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;
         $GLOBALS['buffer_needed'] = false;

--- a/test/classes/plugin/export/PMA_ExportXml_test.php
+++ b/test/classes/plugin/export/PMA_ExportXml_test.php
@@ -7,7 +7,9 @@
  */
 $GLOBALS['db'] = 'db';
 require_once 'libraries/plugins/export/ExportXml.class.php';
+require_once 'libraries/DatabaseInterface.class.php';
 require_once 'libraries/Util.class.php';
+require_once 'libraries/export.lib.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/Config.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
@@ -29,6 +31,10 @@ class PMA_ExportXml_Test extends PHPUnit_Framework_TestCase
      */
     function setup()
     {
+        if (!defined("PMA_DRIZZLE")) {
+            define("PMA_DRIZZLE", false);
+        }
+
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;
         $GLOBALS['buffer_needed'] = false;

--- a/test/classes/plugin/transformations/Image_JPEG_Inline_test.php
+++ b/test/classes/plugin/transformations/Image_JPEG_Inline_test.php
@@ -13,6 +13,8 @@
 require_once 'libraries/plugins/PluginManager.class.php';
 require_once 'libraries/plugins/transformations/Image_JPEG_Inline.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'libraries/Config.class.php';
+require_once 'libraries/config.default.php';
 
 /**
  * Tests for Image_JPEG_Inline class
@@ -35,6 +37,8 @@ class Image_JPEG_Inline_Test extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        $GLOBALS['PMA_Config'] = new PMA_Config();
+        $GLOBALS['PMA_Config']->enableBc();
         $this->object = new Image_JPEG_Inline(new PluginManager());
     }
 

--- a/test/classes/plugin/transformations/Image_PNG_Inline_test.php
+++ b/test/classes/plugin/transformations/Image_PNG_Inline_test.php
@@ -13,6 +13,8 @@
 require_once 'libraries/plugins/PluginManager.class.php';
 require_once 'libraries/plugins/transformations/Image_PNG_Inline.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'libraries/Config.class.php';
+require_once 'libraries/config.default.php';
 
 /**
  * Tests for Image_PNG_Inline class
@@ -35,6 +37,8 @@ class Image_PNG_Inline_Test extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        $GLOBALS['PMA_Config'] = new PMA_Config();
+        $GLOBALS['PMA_Config']->enableBc();
         $this->object = new Image_PNG_Inline(new PluginManager());
     }
 

--- a/test/classes/plugin/transformations/Text_Plain_Substring_test.php
+++ b/test/classes/plugin/transformations/Text_Plain_Substring_test.php
@@ -13,6 +13,7 @@
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/plugins/PluginManager.class.php';
 require_once 'libraries/plugins/transformations/Text_Plain_Substring.class.php';
+require_once 'libraries/string.inc.php';
 
 /**
  * Tests for Text_Plain_Substring class

--- a/test/libraries/PMA_ConfigGenerator_test.php
+++ b/test/libraries/PMA_ConfigGenerator_test.php
@@ -33,6 +33,8 @@ class PMA_ConfigGenerator_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['AvailableCharsets'] = array();
         unset($_SESSION['eol']);
 
+        $GLOBALS['PMA_Config'] = new PMA_Config();
+
         $GLOBALS['server'] = 0;
         $cf = new ConfigFile();
         $_SESSION['ConfigFile0'] = array('a', 'b', 'c');

--- a/test/libraries/PMA_display_change_password_test.php
+++ b/test/libraries/PMA_display_change_password_test.php
@@ -17,6 +17,8 @@ require_once 'libraries/Theme.class.php';
 require_once 'libraries/database_interface.inc.php';
 require_once 'libraries/sanitizing.lib.php';
 require_once 'libraries/js_escape.lib.php';
+require_once 'libraries/Config.class.php';
+require_once 'libraries/config.default.php';
 
 /**
  * class PMA_DisplayChangePassword_Test
@@ -35,6 +37,8 @@ class PMA_DisplayChangePassword_Test extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         //$GLOBALS
+        $GLOBALS['PMA_Config'] = new PMA_Config();
+        $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['cfg']['MaxRows'] = 10;
         $GLOBALS['cfg']['ServerDefault'] = "PMA_server";
         $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';

--- a/test/libraries/PMA_mysql_charsets_test.php
+++ b/test/libraries/PMA_mysql_charsets_test.php
@@ -9,7 +9,7 @@
 /*
  * Include to test.
  */
-require_once 'libraries/mysql_charsets.lib.php';
+require_once 'libraries/mysql_charsets.inc.php';
 require_once 'libraries/php-gettext/gettext.inc';
 
 /**

--- a/test/libraries/PMA_server_databases_test.php
+++ b/test/libraries/PMA_server_databases_test.php
@@ -21,6 +21,8 @@ require_once 'libraries/Message.class.php';
 require_once 'libraries/sanitizing.lib.php';
 require_once 'libraries/sqlparser.lib.php';
 require_once 'libraries/js_escape.lib.php';
+require_once 'libraries/Config.class.php';
+require_once 'libraries/config.default.php';
 
 /**
  * PMA_ServerDatabases_Test class
@@ -44,6 +46,8 @@ class PMA_ServerDatabases_Test extends PHPUnit_Framework_TestCase
         $_REQUEST['pos'] = 3;
 
         //$GLOBALS
+        $GLOBALS['PMA_Config'] = new PMA_Config();
+        $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['cfg']['MaxRows'] = 10;
         $GLOBALS['cfg']['MaxDbList'] = 100;
         $GLOBALS['cfg']['ServerDefault'] = "server";

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -39,6 +39,11 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        //Constants
+        if (!defined("PMA_USR_BROWSER_AGENT")) {
+            define("PMA_USR_BROWSER_AGENT", "other");
+        }
+
         //$_REQUEST
         $_REQUEST['log'] = "index1";
         $_REQUEST['pos'] = 3;

--- a/test/libraries/PMA_sql_query_form_test.php
+++ b/test/libraries/PMA_sql_query_form_test.php
@@ -24,7 +24,7 @@ require_once 'libraries/js_escape.lib.php';
 require_once 'libraries/database_interface.inc.php';
 require_once 'libraries/sql_query_form.lib.php';
 require_once 'libraries/kanji-encoding.lib.php';
-require_once 'libraries/mysql_charsets.lib.php';
+require_once 'libraries/mysql_charsets.inc.php';
 
 /**
  * class PMA_SqlQueryForm_Test

--- a/test/libraries/PMA_tbl_columns_definition_form_test.php
+++ b/test/libraries/PMA_tbl_columns_definition_form_test.php
@@ -17,7 +17,7 @@ require_once 'libraries/Types.class.php';
 require_once 'libraries/Theme.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/transformations.lib.php';
-require_once 'libraries/mysql_charsets.lib.php';
+require_once 'libraries/mysql_charsets.inc.php';
 require_once 'libraries/StorageEngine.class.php';
 
 /**


### PR DESCRIPTION
The HHVM test runner runs the unit tests in parallel. Currently some tests
fail because not all the dependencies are properly included.

This is similar to 607cb3b0b3b877456dd328594610202d1078bdc9

Signed-off-by: Jeff Chan jefftchan@gmail.com
