### PR TITLE
Add bug tracker link.

### DIFF
--- a/error_report.php
+++ b/error_report.php
@@ -48,8 +48,9 @@ if (isset($_REQUEST['send_error_report'])
                     . ' '
                     . __(
                         'If you experience any '
-                        . 'problems please submit a bug report manually.'
+                        . 'problems please submit a bug report manually on '
                     )
+                    . '<a href="https://sourceforge.net/p/phpmyadmin/bugs/new/" target="_blank">sourceforge</a>'
                     . '<br />'
                     . __('You may want to refresh the page.')
                 )
@@ -75,8 +76,9 @@ if (isset($_REQUEST['send_error_report'])
                     . ' '
                     . __(
                         'If you experience any '
-                        . 'problems please submit a bug report manually.'
+                        . 'problems please submit a bug report manually on'
                     )
+                    . '<a href="https://sourceforge.net/p/phpmyadmin/bugs/new/" target="_blank">sourceforge</a>'
                     . '<br />'
                     . __('You may want to refresh the page.')
                 )


### PR DESCRIPTION
Signed-off-by: Dhananjay Nakrani dhananjaynakrani@gmail.com

Providing a link to bug tracker in automatic report submission failure msg.
<i>My apologies for making an incorrect pull (#1053).</i>

I noticed that in `/po/` directory there are several `.po` files which contain the affected msg string. As far as I understand these files are for language localization. If someone changes the msg string, should all those files be changed too, or is it taken care by some automatic tool?
