### PR TITLE
Move slow tests in HHVM to group medium

### DIFF
--- a/test/classes/PMA_Footer_test.php
+++ b/test/classes/PMA_Footer_test.php
@@ -238,6 +238,7 @@ class PMA_Footer_Test extends PHPUnit_Framework_TestCase
      * Test for displaying footer
      *
      * @return void
+     * @group medium
      */
     public function testDisplay()
     {

--- a/test/classes/PMA_TableReplaceSearch_test.php
+++ b/test/classes/PMA_TableReplaceSearch_test.php
@@ -63,6 +63,7 @@ class PMA_TableReplaceSearchTest extends PHPUnit_Framework_TestCase
      * Tests getReplacePreview() method
      *
      * @return void
+     * @group medium
      */
     public function testGetReplacePreview()
     {

--- a/test/classes/PMA_TableSearch_test.php
+++ b/test/classes/PMA_TableSearch_test.php
@@ -114,6 +114,7 @@ class PMA_TableSearch_Test extends PHPUnit_Framework_TestCase
      * Test for __construct
      *
      * @return void
+     * @group medium
      */
     public function testConstruct()
     {
@@ -133,6 +134,7 @@ class PMA_TableSearch_Test extends PHPUnit_Framework_TestCase
      * Test for getSelectionForm
      *
      * @return void
+     * @group medium
      */
     public function testGetSelectionForm()
     {

--- a/test/classes/config/PMA_FormDisplay_test.php
+++ b/test/classes/config/PMA_FormDisplay_test.php
@@ -59,6 +59,7 @@ class PMA_FormDisplay_Test extends PHPUnit_Framework_TestCase
      * Test for FormDisplay::__constructor
      *
      * @return void
+     * @group medium
      */
     public function testFormDisplayContructor()
     {
@@ -72,6 +73,7 @@ class PMA_FormDisplay_Test extends PHPUnit_Framework_TestCase
      * Test for FormDisplay::registerForm
      *
      * @return void
+     * @group medium
      */
     public function testRegisterForm()
     {
@@ -117,6 +119,7 @@ class PMA_FormDisplay_Test extends PHPUnit_Framework_TestCase
      * Test for FormDisplay::process
      *
      * @return void
+     * @group medium
      */
     public function testProcess()
     {

--- a/test/classes/plugin/auth/PMA_AuthenticationCookie_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationCookie_test.php
@@ -58,6 +58,7 @@ class PMA_AuthenticationCookie_Test extends PHPUnit_Framework_TestCase
      * Test for AuthenticationConfig::auth
      *
      * @return void
+     * @group medium
      */
     public function testAuth()
     {

--- a/test/classes/plugin/export/PMA_ExportCsv_test.php
+++ b/test/classes/plugin/export/PMA_ExportCsv_test.php
@@ -474,6 +474,7 @@ class PMA_ExportCsv_Test extends PHPUnit_Framework_TestCase
      * Test for ExportCsv::exportData
      *
      * @return void
+     * @group medium
      */
     public function testExportData()
     {

--- a/test/classes/plugin/export/PMA_ExportHtmlword_test.php
+++ b/test/classes/plugin/export/PMA_ExportHtmlword_test.php
@@ -460,6 +460,7 @@ class PMA_ExportHtmlword_Test extends PHPUnit_Framework_TestCase
      * Test for ExportHtmlword::getTableDef
      *
      * @return void
+     * @group medium
      */
     public function testGetTableDef()
     {

--- a/test/classes/plugin/export/PMA_ExportLatex_test.php
+++ b/test/classes/plugin/export/PMA_ExportLatex_test.php
@@ -63,6 +63,7 @@ class PMA_ExportLatex_Test extends PHPUnit_Framework_TestCase
      * Test for ExportLatex::setProperties
      *
      * @return void
+     * @group medium
      */
     public function testSetProperties()
     {
@@ -551,6 +552,7 @@ class PMA_ExportLatex_Test extends PHPUnit_Framework_TestCase
      * Test for ExportLatex::exportData
      *
      * @return void
+     * @group medium
      */
     public function testExportData()
     {
@@ -666,6 +668,7 @@ class PMA_ExportLatex_Test extends PHPUnit_Framework_TestCase
      * Test for ExportLatex::exportStructure
      *
      * @return void
+     * @group medium
      */
     public function testExportStructure()
     {

--- a/test/classes/plugin/export/PMA_ExportOdt_test.php
+++ b/test/classes/plugin/export/PMA_ExportOdt_test.php
@@ -64,6 +64,7 @@ class PMA_ExportOdt_Test extends PHPUnit_Framework_TestCase
      * Test for ExportOdt::setProperties
      *
      * @return void
+     * @group medium
      */
     public function testSetProperties()
     {
@@ -679,6 +680,7 @@ class PMA_ExportOdt_Test extends PHPUnit_Framework_TestCase
      * Test for ExportOdt::getTableDef
      *
      * @return void
+     * @group medium
      */
     public function testGetTableDef()
     {

--- a/test/classes/plugin/export/PMA_ExportSql_test.php
+++ b/test/classes/plugin/export/PMA_ExportSql_test.php
@@ -66,6 +66,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
      * Test for ExportSql::setProperties
      *
      * @return void
+     * @group medium
      */
     public function testSetProperties()
     {
@@ -1133,6 +1134,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
      * Test for ExportSql::getTableDef
      *
      * @return void
+     * @group medium
      */
     public function testGetTableDefWithoutDrizzle()
     {
@@ -1610,6 +1612,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
      * Test for ExportSql::exportStructure
      *
      * @return void
+     * @group medium
      */
     public function testExportStructure()
     {
@@ -1778,6 +1781,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
      * Test for ExportSql::exportData
      *
      * @return void
+     * @group medium
      */
     public function testExportData()
     {
@@ -1909,6 +1913,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
      * Test for ExportSql::exportData
      *
      * @return void
+     * @group medium
      */
     public function testExportDataWithUpdate()
     {

--- a/test/classes/plugin/export/PMA_ExportXml_test.php
+++ b/test/classes/plugin/export/PMA_ExportXml_test.php
@@ -61,6 +61,7 @@ class PMA_ExportXml_Test extends PHPUnit_Framework_TestCase
      * Test for ExportXml::setProperties
      *
      * @return void
+     * @group medium
      */
     public function testSetProperties()
     {
@@ -219,6 +220,7 @@ class PMA_ExportXml_Test extends PHPUnit_Framework_TestCase
      * Test for ExportXml::exportHeader
      *
      * @return void
+     * @group medium
      */
     public function testExportHeaderWithoutDrizzle()
     {

--- a/test/classes/schema/Pdf_Relation_Schema_test.php
+++ b/test/classes/schema/Pdf_Relation_Schema_test.php
@@ -198,7 +198,7 @@ class PMA_Pdf_Relation_Schema_Test extends PHPUnit_Framework_TestCase
      *
      * @return void
      *
-     * @group medium
+     * @group large
      */
     public function testConstructor()
     {

--- a/test/libraries/PMA_SetupIndex_test.php
+++ b/test/libraries/PMA_SetupIndex_test.php
@@ -399,6 +399,7 @@ class PMA_SetupIndex_Test extends PHPUnit_Framework_TestCase
      * Test for ServerConfigChecks::performConfigChecks
      *
      * @return void
+     * @group medium
      */
     public function testServerConfigChecksPerformConfigChecks()
     {

--- a/test/libraries/PMA_display_export_test.php
+++ b/test/libraries/PMA_display_export_test.php
@@ -125,6 +125,7 @@ class PMA_DisplayExport_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getHtmlForExportOptions
      *
      * @return vgetUserValue
+     * @group medium
      */
     public function testPMAGetHtmlForExportOptions()
     {

--- a/test/libraries/PMA_relation_cleanup_test.php
+++ b/test/libraries/PMA_relation_cleanup_test.php
@@ -73,6 +73,7 @@ class PMA_Relation_Cleanup_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_relationsCleanupColumn
      *
      * @return void
+     * @group medium
      */
     public function testPMARelationsCleanupColumn()
     {

--- a/test/libraries/PMA_server_binlog_test.php
+++ b/test/libraries/PMA_server_binlog_test.php
@@ -94,6 +94,7 @@ class PMA_ServerBinlog_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getLogInfo
      *
      * @return void
+     * @group medium
      */
     public function testPMAGetLogInfo()
     {

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -798,6 +798,7 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getHtmlToDisplayPrivilegesTable
      *
      * @return void
+     * @group medium
      */
     public function testPMAGetHtmlToDisplayPrivilegesTable()
     {
@@ -1177,6 +1178,7 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getHtmlForAddUser
      *
      * @return void
+     * @group medium
      */
     public function testPMAGetHtmlForAddUser()
     {

--- a/test/libraries/PMA_server_replication_test.php
+++ b/test/libraries/PMA_server_replication_test.php
@@ -105,6 +105,7 @@ class PMA_ServerReplication_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getHtmlForMasterReplication
      *
      * @return void
+     * @group medium
      */
     public function testPMAGetHtmlForMasterReplication()
     {

--- a/test/libraries/PMA_server_status_advisor_test.php
+++ b/test/libraries/PMA_server_status_advisor_test.php
@@ -135,6 +135,7 @@ class PMA_ServerStatusAdvisor_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getHTMLForAdvisor
      *
      * @return void
+     * @group medium
      */
     public function testPMAGetHTMLForAdvisor()
     {

--- a/test/libraries/PMA_server_status_monitor_test.php
+++ b/test/libraries/PMA_server_status_monitor_test.php
@@ -130,6 +130,7 @@ class PMA_ServerStatusMonitor_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getHtmlForMonitor
      *
      * @return void
+     * @group medium
      */
     public function testPMAGetHtmlForMonitor()
     {

--- a/test/libraries/PMA_server_status_test.php
+++ b/test/libraries/PMA_server_status_test.php
@@ -136,6 +136,7 @@ class PMA_ServerStatus_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getHtmlForServerStatus
      *
      * @return void
+     * @group medium
      */
     public function testPMAGetHtmlForServerStatus()
     {

--- a/test/libraries/PMA_server_status_variables_test.php
+++ b/test/libraries/PMA_server_status_variables_test.php
@@ -200,6 +200,7 @@ class PMA_ServerStatusVariables_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getHtmlForVariablesList
      *
      * @return void
+     * @group medium
      */
     public function testPMAGetHtmlForVariablesList()
     {

--- a/test/libraries/common/PMA_getDbLink_test.php
+++ b/test/libraries/common/PMA_getDbLink_test.php
@@ -25,12 +25,18 @@ class PMA_GetDbLink_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['server'] = 99;
     }
 
+    /**
+     * @group medium
+     */
     function testGetDbLinkEmpty()
     {
         $GLOBALS['db'] = null;
         $this->assertEmpty(PMA_Util::getDbLink());
     }
 
+    /**
+     * @group medium
+     */
     function testGetDbLinkNull()
     {
         global $cfg;


### PR DESCRIPTION
These tests were failing on HHVM because of the default 3 second timeout.
Yes, HHVM is supposed to be faster, but there's a "warmup" time for scripts
in JIT mode (which is on by default). I suspect that's why they're failing.

Signed-off-by: Jeff Chan jefftchan@gmail.com

---

With this PR, all tests except 1 pass. See https://github.com/phpmyadmin/phpmyadmin/pull/1056
