### PR TITLE
Add HHVM to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - "5.5"
   - "5.4"
   - "5.3"
+  - hhvm
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq ant
@@ -19,3 +20,7 @@ script:
   - if [[ $TRAVIS_PULL_REQUEST != "false" ]] ; then ./scripts/check-dco origin/$TRAVIS_BRANCH..FETCH_HEAD ; fi
 after_script:
   - php vendor/bin/coveralls -v
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,11 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq ant
 before_script:
-  - git clone git://github.com/zenovich/runkit.git && cd runkit && phpize && ./configure && make && make install && cd ..
-  - phpenv config-add test/travis.php.ini
-  - pear channel-discover pear.phpunit.de
-  - pear install phpunit/PHPUnit_Selenium
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev --no-interaction
+  - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]] ; then git clone git://github.com/zenovich/runkit.git && cd runkit && phpize && ./configure && make && make install && cd .. ; fi
+  - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]] ; then phpenv config-add test/travis.php.ini ; fi
+  - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]] ; then pear channel-discover pear.phpunit.de ; fi
+  - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]] ; then pear install phpunit/PHPUnit_Selenium ; fi
+  - composer install --dev --no-interaction
 script:
   - ./scripts/generate-mo --quiet
   - PHPUNIT_ARGS=--debug ant phpunit lint


### PR DESCRIPTION
This is a work in progress -- need to have this here to test Travis.

Until HHVM 2.5 is released and added to Travis, the builds will be failing because MySQLi hasn't been implemented yet. See http://www.hhvm.com/blog/3689/implementing-mysqli
I can confirm that all tests except 1 pass on HHVM nightly.

---

Tests skipped right now due to lack of HHVM support:
- runkit related tests
- gmp related tests
- selenium? (not sure -- need to see if Travis' HHVM works)
