### PR TITLE
Move slow test in HHVM to group medium

### DIFF
--- a/test/classes/PMA_Config_test.php
+++ b/test/classes/PMA_Config_test.php
@@ -75,6 +75,7 @@ class PMA_ConfigTest extends PHPUnit_Framework_TestCase
      * Test for CheckSystem
      *
      * @return void
+     * @group medium
      */
     public function testCheckSystem()
     {

--- a/test/classes/PMA_DisplayResults_test.php
+++ b/test/classes/PMA_DisplayResults_test.php
@@ -89,6 +89,7 @@ class PMA_DisplayResults_Test extends PHPUnit_Framework_TestCase
      * @return void
      *
      * @dataProvider providerForTestSetDisplayModeCase1
+     * @group medium
      */
     public function testSetDisplayModeCase1($the_disp_mode, $the_total, $output)
     {

--- a/test/classes/PMA_Header_test.php
+++ b/test/classes/PMA_Header_test.php
@@ -28,6 +28,7 @@ require_once 'libraries/js_escape.lib.php';
  * Test for PMA_Header class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_Header_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/PMA_Theme_test.php
+++ b/test/classes/PMA_Theme_test.php
@@ -57,6 +57,7 @@ class PMA_ThemeTest extends PHPUnit_Framework_TestCase
      * Test for PMA_Theme::loadInfo
      *
      * @return void
+     * @group medium
      */
     public function testCheckImgPathNotExisted()
     {

--- a/test/classes/plugin/export/PMA_ExportCodegen_test.php
+++ b/test/classes/plugin/export/PMA_ExportCodegen_test.php
@@ -18,6 +18,7 @@ require_once 'export.php';
  * tests for ExportCodegen class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportCodegen_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportCsv_test.php
+++ b/test/classes/plugin/export/PMA_ExportCsv_test.php
@@ -19,6 +19,7 @@ require_once 'export.php';
  * tests for ExportCsv class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportCsv_Test extends PHPUnit_Framework_TestCase
 {
@@ -474,7 +475,6 @@ class PMA_ExportCsv_Test extends PHPUnit_Framework_TestCase
      * Test for ExportCsv::exportData
      *
      * @return void
-     * @group medium
      */
     public function testExportData()
     {

--- a/test/classes/plugin/export/PMA_ExportExcel_test.php
+++ b/test/classes/plugin/export/PMA_ExportExcel_test.php
@@ -17,6 +17,7 @@ require_once 'export.php';
  * tests for ExportExcel class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportExcel_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportHtmlword_test.php
+++ b/test/classes/plugin/export/PMA_ExportHtmlword_test.php
@@ -20,6 +20,7 @@ require_once 'export.php';
  * tests for ExportHtmlword class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportHtmlword_Test extends PHPUnit_Framework_TestCase
 {
@@ -460,7 +461,6 @@ class PMA_ExportHtmlword_Test extends PHPUnit_Framework_TestCase
      * Test for ExportHtmlword::getTableDef
      *
      * @return void
-     * @group medium
      */
     public function testGetTableDef()
     {

--- a/test/classes/plugin/export/PMA_ExportJson_test.php
+++ b/test/classes/plugin/export/PMA_ExportJson_test.php
@@ -18,6 +18,7 @@ require_once 'export.php';
  * tests for ExportJson class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportJson_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportLatex_test.php
+++ b/test/classes/plugin/export/PMA_ExportLatex_test.php
@@ -20,6 +20,7 @@ require_once 'export.php';
  * tests for ExportLatex class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportLatex_Test extends PHPUnit_Framework_TestCase
 {
@@ -63,7 +64,6 @@ class PMA_ExportLatex_Test extends PHPUnit_Framework_TestCase
      * Test for ExportLatex::setProperties
      *
      * @return void
-     * @group medium
      */
     public function testSetProperties()
     {
@@ -552,7 +552,6 @@ class PMA_ExportLatex_Test extends PHPUnit_Framework_TestCase
      * Test for ExportLatex::exportData
      *
      * @return void
-     * @group medium
      */
     public function testExportData()
     {
@@ -668,7 +667,6 @@ class PMA_ExportLatex_Test extends PHPUnit_Framework_TestCase
      * Test for ExportLatex::exportStructure
      *
      * @return void
-     * @group medium
      */
     public function testExportStructure()
     {

--- a/test/classes/plugin/export/PMA_ExportMediawiki_test.php
+++ b/test/classes/plugin/export/PMA_ExportMediawiki_test.php
@@ -18,6 +18,7 @@ require_once 'export.php';
  * tests for ExportMediawiki class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportMediawiki_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportOds_test.php
+++ b/test/classes/plugin/export/PMA_ExportOds_test.php
@@ -18,6 +18,7 @@ require_once 'export.php';
  * tests for ExportOds class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportOds_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportOdt_test.php
+++ b/test/classes/plugin/export/PMA_ExportOdt_test.php
@@ -21,6 +21,7 @@ require_once 'export.php';
  * tests for ExportOdt class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportOdt_Test extends PHPUnit_Framework_TestCase
 {
@@ -64,7 +65,6 @@ class PMA_ExportOdt_Test extends PHPUnit_Framework_TestCase
      * Test for ExportOdt::setProperties
      *
      * @return void
-     * @group medium
      */
     public function testSetProperties()
     {
@@ -680,7 +680,6 @@ class PMA_ExportOdt_Test extends PHPUnit_Framework_TestCase
      * Test for ExportOdt::getTableDef
      *
      * @return void
-     * @group medium
      */
     public function testGetTableDef()
     {

--- a/test/classes/plugin/export/PMA_ExportPdf_test.php
+++ b/test/classes/plugin/export/PMA_ExportPdf_test.php
@@ -19,6 +19,7 @@ require_once 'export.php';
  * tests for ExportPdf class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportPdf_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportPhparray_test.php
+++ b/test/classes/plugin/export/PMA_ExportPhparray_test.php
@@ -18,6 +18,7 @@ require_once 'export.php';
  * tests for ExportPhparray class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportPhparray_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportSql_test.php
+++ b/test/classes/plugin/export/PMA_ExportSql_test.php
@@ -24,6 +24,7 @@ require_once 'export.php';
  * tests for ExportSql class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportTexytext_test.php
+++ b/test/classes/plugin/export/PMA_ExportTexytext_test.php
@@ -21,6 +21,7 @@ require_once 'export.php';
  * tests for ExportTexytext class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportTexytext_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportXml_test.php
+++ b/test/classes/plugin/export/PMA_ExportXml_test.php
@@ -19,6 +19,7 @@ require_once 'export.php';
  * tests for ExportXml class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportXml_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/classes/plugin/export/PMA_ExportYaml_test.php
+++ b/test/classes/plugin/export/PMA_ExportYaml_test.php
@@ -18,6 +18,7 @@ require_once 'export.php';
  * tests for ExportYaml class
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_ExportYaml_Test extends PHPUnit_Framework_TestCase
 {

--- a/test/libraries/PMA_ConfigFile_test.php
+++ b/test/libraries/PMA_ConfigFile_test.php
@@ -336,6 +336,7 @@ class PMA_ConfigFile_Test extends PHPUnit_Framework_TestCase
      *
      * @return void
      * @test
+     * @group medium
      */
     public function testGetFlatDefaultConfig()
     {

--- a/test/libraries/PMA_display_export_test.php
+++ b/test/libraries/PMA_display_export_test.php
@@ -32,6 +32,7 @@ require_once 'libraries/relation.lib.php';
  * this class is for testing display_export.lib.php functions
  *
  * @package PhpMyAdmin-test
+ * @group large
  */
 class PMA_DisplayExport_Test extends PHPUnit_Framework_TestCase
 {
@@ -125,7 +126,6 @@ class PMA_DisplayExport_Test extends PHPUnit_Framework_TestCase
      * Test for PMA_getHtmlForExportOptions
      *
      * @return vgetUserValue
-     * @group medium
      */
     public function testPMAGetHtmlForExportOptions()
     {

--- a/test/libraries/PMA_insert_edit_test.php
+++ b/test/libraries/PMA_insert_edit_test.php
@@ -29,6 +29,7 @@ require_once 'libraries/Table.class.php';
  * Tests for libraries/insert_edit.lib.php
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
 {

--- a/test/libraries/PMA_relation_test.php
+++ b/test/libraries/PMA_relation_test.php
@@ -20,6 +20,7 @@ require_once 'libraries/relation.lib.php';
  * Tests for libraries/relation.lib.php
  *
  * @package PhpMyAdmin-test
+ * @group medium
  */
 class PMA_Relation_Test extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
These tests were failing on HHVM because of the default 3 second timeout.
Yes, HHVM is supposed to be faster, but there's a "warmup" time for scripts
in JIT mode (which is on by default). I suspect that's why they're failing.

Signed-off-by: Jeff Chan jefftchan@gmail.com
