### PR TITLE
Add HHVM-specific phpunit configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_script:
   - composer install --dev --no-interaction
 script:
   - ./scripts/generate-mo --quiet
-  - PHPUNIT_ARGS=--debug ant phpunit lint
+  - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]] ; then PHPUNIT_ARGS=--debug ant phpunit lint ; fi
+  - if [[ $TRAVIS_PHP_VERSION == "hhvm" ]] ; then PHPUNIT_ARGS=--debug ant phpunit-hhvm lint ; fi
 after_script:
   - php vendor/bin/coveralls -v
 matrix:

--- a/build.xml
+++ b/build.xml
@@ -5,6 +5,8 @@
  <property name="source_comma_sep" value="."/>
  <property environment="env"/>
  <property name="env.PHPUNIT_XML" value="phpunit.xml.dist"/>
+ <property name="env.PHPUNIT_XML_NOCOVERAGE" value="phpunit.xml.nocoverage"/>
+ <property name="env.PHPUNIT_XML_HHVM" value="phpunit.xml.hhvm"/>
  <property name="env.PHPUNIT_ARGS" value=""/>
 
  <target name="clean" description="Clean up and create artifact directories">
@@ -29,7 +31,13 @@
 
  <target name="phpunit-nocoverage" description="Run unit tests using PHPUnit and generates junit.xml">
   <exec executable="phpunit" failonerror="true">
-      <arg line="--configuration phpunit.xml.nocoverage ${env.PHPUNIT_ARGS}"/>
+      <arg line="--configuration ${env.PHPUNIT_XML_NOCOVERAGE} ${env.PHPUNIT_ARGS}"/>
+  </exec>
+ </target>
+
+ <target name="phpunit-hhvm" description="Run unit tests using PHPUnit with HHVM specific config">
+  <exec executable="phpunit" failonerror="true">
+      <arg line="--configuration ${env.PHPUNIT_XML_HHVM} ${env.PHPUNIT_ARGS}"/>
   </exec>
  </target>
 

--- a/phpunit.xml.hhvm
+++ b/phpunit.xml.hhvm
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="test/bootstrap-dist.php"
+         backupGlobals="true"
+         backupStaticAttributes="false"
+         strict="true"
+         timeoutForSmallTests="10"
+         timeoutForMediumTests="30"
+         colors="true"
+         verbose="true">
+
+    <testsuites>
+        <testsuite name="Classes">
+            <directory suffix="_test.php">test/classes</directory>
+        </testsuite>
+        <testsuite name="Engines">
+            <directory suffix="_test.php">test/engines</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <file>test/Environment_test.php</file>
+            <directory suffix="_test.php">test/libraries/core</directory>
+            <directory suffix="_test.php">test/libraries/common</directory>
+            <directory suffix="_test.php">test/libraries/rte</directory>
+            <directory suffix="_test.php">test/libraries</directory>
+        </testsuite>
+    </testsuites>
+
+    <logging>
+        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+    </logging>
+</phpunit>


### PR DESCRIPTION
- Up the timeout
- No selenium testing
- No coverage

Also update Travis and build.xml to support it

Signed-off-by: Jeff Chan jefftchan@gmail.com

---

Note: Adding this because HHVM in JIT mode has extra penalty _initially_ (~50% slow down) -- it's not reasonable to change the timeouts for all individual tests when they're not failing on normal Zend PHP. **_The alternative is to just change increase the timeouts in `phpunit.xml`, rather than creating another config file (this PR).**_ I'm open to opinions.
