### PR TITLE
Explicitly cast ArrayObject to array for reset()

### DIFF
--- a/libraries/List.class.php
+++ b/libraries/List.class.php
@@ -49,7 +49,8 @@ abstract class PMA_List extends ArrayObject
     public function getSingleItem()
     {
         if (count($this) === 1) {
-            return reset($this);
+            $array = (array) $this;
+            return reset($array);
         }
 
         return $this->getEmpty();


### PR DESCRIPTION
HHVM does not support objects in reset(). See:
https://github.com/facebook/hhvm/blob/master/hphp/doc/inconsistencies#L90

This change should not incur a performance penalty because this function
is not actually used anywhere currently besides in tests.

Signed-off-by: Jeff Chan jefftchan@gmail.com
