### PR TITLE
Import dependencies to make unit tests friendlier to running independently

### DIFF
--- a/test/libraries/PMA_Tracker_test.php
+++ b/test/libraries/PMA_Tracker_test.php
@@ -11,6 +11,7 @@
  */
 require_once 'libraries/Tracker.class.php';
 require_once 'libraries/DatabaseInterface.class.php';
+require_once 'libraries/database_interface.inc.php';
 require_once 'libraries/Util.class.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/relation.lib.php';


### PR DESCRIPTION
The HHVM test runner runs the unit tests in parallel. Currently some tests
fail because not all the dependencies are properly included.

Signed-off-by: Jeff Chan jefftchan@gmail.com
