### PR TITLE
Bug: None of the live charts shown on "Status -> Monitor" page in Google Chrome on Ubuntu.

### DIFF
--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -1025,6 +1025,8 @@ div#chartVariableSettings {
 
 table#chartGrid div.monitorChart {
     background: #EBEBEB;
+    width: 400px;
+    height: 300px;
 }
 
 div#serverstatus div.tabLinks {

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -1329,6 +1329,8 @@ div#chartVariableSettings {
 
 table#chartGrid div.monitorChart {
     background: #EBEBEB;
+    width: 400px;
+    height: 300px;
 }
 
 div#serverstatus div.tabLinks {


### PR DESCRIPTION
Hello Marc,
As I told you in one my mails that I was getting a bug that none of the Live Charts on "Status -> Monitor" page were shown in Google Chrome (even in latest version) in Ubuntu.

Line #1173 of  "js/server_status_monitor.js"  :
chartObj.chart = $.jqplot('gridchart' + runtime.chartAI, series, settings);
throws an exception "Canvas dimension not set".
Please have a look on this.

Signed-off-by: Ashutosh Dhundhara ashutoshdhundhara@yahoo.com
