### PR TITLE
Refactor - Move duplicate code to a parent class

### DIFF
--- a/libraries/schema/Dia_Relation_Schema.class.php
+++ b/libraries/schema/Dia_Relation_Schema.class.php
@@ -249,7 +249,7 @@ class Table_Stats_Dia extends TableStats
     }
 
     /**
-     * Diaplays an error on missing coordinates
+     * Displays an error on missing coordinates
      *
      * @return void
      */

--- a/libraries/schema/Dia_Relation_Schema.class.php
+++ b/libraries/schema/Dia_Relation_Schema.class.php
@@ -343,7 +343,7 @@ class Table_Stats_Dia extends TableStats
                 <dia:real val="0.10000000000000001"/>
             </dia:attribute>
             <dia:attribute name="name">
-                <dia:string>#' . $this->_tableName . '#</dia:string>
+                <dia:string>#' . $this->tableName . '#</dia:string>
             </dia:attribute>
             <dia:attribute name="comment">
                 <dia:string>##</dia:string>

--- a/libraries/schema/Dia_Relation_Schema.class.php
+++ b/libraries/schema/Dia_Relation_Schema.class.php
@@ -187,6 +187,8 @@ class PMA_DIA extends XMLWriter
     }
 }
 
+require_once './libraries/schema/TableStats.class.php';
+
 /**
  * Table preferences/statistics
  *
@@ -197,15 +199,11 @@ class PMA_DIA extends XMLWriter
  * @name    Table_Stats_Dia
  * @see     PMA_DIA
  */
-class Table_Stats_Dia
+class Table_Stats_Dia extends TableStats
 {
     /**
      * Defines properties
      */
-    public $tableName;
-    public $fields = array();
-    public $x, $y;
-    public $primary = array();
     public $tableId;
     public $tableColor;
 
@@ -226,80 +224,8 @@ class Table_Stats_Dia
     function __construct($tableName, $pageNumber, $showKeys = false)
     {
         global $dia, $cfgRelation, $db;
+        parent::__construct($dia, $db, $pageNumber, $tableName, $showKeys, false);
 
-        $this->tableName = $tableName;
-        $sql = 'DESCRIBE ' . PMA_Util::backquote($tableName);
-        $result = $GLOBALS['dbi']->tryQuery(
-            $sql, null, PMA_DatabaseInterface::QUERY_STORE
-        );
-        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
-            $dia->dieSchema(
-                $pageNumber, "DIA",
-                sprintf(__('The %s table doesn\'t exist!'), $tableName)
-            );
-        }
-        /*
-         * load fields
-         * check to see if it will load all fields or only the foreign keys
-         */
-        if ($showKeys) {
-            $indexes = PMA_Index::getFromTable($this->tableName, $db);
-            $all_columns = array();
-            foreach ($indexes as $index) {
-                $all_columns = array_merge(
-                    $all_columns,
-                    array_flip(array_keys($index->getColumns()))
-                );
-            }
-            $this->fields = array_keys($all_columns);
-        } else {
-            while ($row = $GLOBALS['dbi']->fetchRow($result)) {
-                $this->fields[] = $row[0];
-            }
-        }
-
-        $sql = 'SELECT x, y FROM '
-            . PMA_Util::backquote($GLOBALS['cfgRelation']['db']) . '.'
-            . PMA_Util::backquote($cfgRelation['table_coords'])
-            . ' WHERE db_name = \'' . PMA_Util::sqlAddSlashes($db) . '\''
-            . ' AND table_name = \''
-            . PMA_Util::sqlAddSlashes($tableName) . '\''
-            . ' AND pdf_page_number = ' . $pageNumber;
-        $result = PMA_queryAsControlUser(
-            $sql, false, PMA_DatabaseInterface::QUERY_STORE
-        );
-        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
-            $dia->dieSchema(
-                $pageNumber,
-                "DIA",
-                sprintf(
-                    __('Please configure the coordinates for table %s'),
-                    $tableName
-                )
-            );
-        }
-        list($this->x, $this->y) = $GLOBALS['dbi']->fetchRow($result);
-        $this->x = (double) $this->x;
-        $this->y = (double) $this->y;
-        /*
-         * displayfield
-         */
-        $this->displayfield = PMA_getDisplayField($db, $tableName);
-        /*
-         * index
-         */
-        $result = $GLOBALS['dbi']->query(
-            'SHOW INDEX FROM ' . PMA_Util::backquote($tableName) . ';',
-            null,
-            PMA_DatabaseInterface::QUERY_STORE
-        );
-        if ($GLOBALS['dbi']->numRows($result) > 0) {
-            while ($row = $GLOBALS['dbi']->fetchAssoc($result)) {
-                if ($row['Key_name'] == 'PRIMARY') {
-                    $this->primary[] = $row['Column_name'];
-                }
-            }
-        }
         /**
          * Every object in Dia document needs an ID to identify
          * so, we used a static variable to keep the things unique
@@ -307,6 +233,38 @@ class Table_Stats_Dia
         PMA_Dia_Relation_Schema::$objectId += 1;
         $this->tableId = PMA_Dia_Relation_Schema::$objectId;
     }
+
+    /**
+     * Displays an error when the table cannot be found.
+     *
+     * @return void
+     */
+    protected function showMissingTableError()
+    {
+        $this->diagram->dieSchema(
+            $this->pageNumber,
+            "DIA",
+            sprintf(__('The %s table doesn\'t exist!'), $this->tableName)
+        );
+    }
+
+    /**
+     * Diaplays an error on missing coordinates
+     *
+     * @return void
+     */
+    protected function showMissingCoordinatesError()
+    {
+        $this->diagram->dieSchema(
+            $this->pageNumber,
+            "DIA",
+            sprintf(
+                __('Please configure the coordinates for table %s'),
+                $this->tableName
+            )
+        );
+    }
+
 
     /**
      * Do draw the table
@@ -385,7 +343,7 @@ class Table_Stats_Dia
                 <dia:real val="0.10000000000000001"/>
             </dia:attribute>
             <dia:attribute name="name">
-                <dia:string>#' . $this->tableName . '#</dia:string>
+                <dia:string>#' . $this->_tableName . '#</dia:string>
             </dia:attribute>
             <dia:attribute name="comment">
                 <dia:string>##</dia:string>

--- a/libraries/schema/Eps_Relation_Schema.class.php
+++ b/libraries/schema/Eps_Relation_Schema.class.php
@@ -297,6 +297,8 @@ class PMA_EPS
     }
 }
 
+require_once './libraries/schema/TableStats.class.php';
+
 /**
  * Table preferences/statistics
  *
@@ -307,22 +309,15 @@ class PMA_EPS
  * @name    Table_Stats_Eps
  * @see     PMA_EPS
  */
-class Table_Stats_Eps
+class Table_Stats_Eps extends TableStats
 {
     /**
      * Defines properties
      */
-
-    private $_tableName;
-    private $_showInfo = false;
-
     public $width = 0;
     public $height;
-    public $fields = array();
     public $heightCell = 0;
     public $currentCell = 0;
-    public $x, $y;
-    public $primary = array();
 
     /**
      * The "Table_Stats_Eps" constructor
@@ -350,88 +345,49 @@ class Table_Stats_Eps
         $showKeys = false, $showInfo = false
     ) {
         global $eps, $cfgRelation, $db;
-
-        $this->_tableName = $tableName;
-        $sql = 'DESCRIBE ' . PMA_Util::backquote($tableName);
-        $result = $GLOBALS['dbi']->tryQuery(
-            $sql, null, PMA_DatabaseInterface::QUERY_STORE
+        parent::__construct(
+            $esp, $db, $pageNumber, $tableName, $showKeys, $showInfo
         );
-        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
-            $eps->dieSchema(
-                $pageNumber, "EPS",
-                sprintf(__('The %s table doesn\'t exist!'), $tableName)
-            );
-        }
-
-        /*
-        * load fields
-        * check to see if it will load all fields or only the foreign keys
-        */
-        if ($showKeys) {
-            $indexes = PMA_Index::getFromTable($this->_tableName, $db);
-            $all_columns = array();
-            foreach ($indexes as $index) {
-                $all_columns = array_merge(
-                    $all_columns,
-                    array_flip(array_keys($index->getColumns()))
-                );
-            }
-            $this->fields = array_keys($all_columns);
-        } else {
-            while ($row = $GLOBALS['dbi']->fetchRow($result)) {
-                $this->fields[] = $row[0];
-            }
-        }
-
-        $this->_showInfo = $showInfo;
 
         // height and width
         $this->_setHeightTable($fontSize);
-
         // setWidth must me after setHeight, because title
         // can include table height which changes table width
         $this->_setWidthTable($font, $fontSize);
         if ($same_wide_width < $this->width) {
             $same_wide_width = $this->width;
         }
+    }
 
-        // x and y
-        $sql = 'SELECT x, y FROM '
-            . PMA_Util::backquote($GLOBALS['cfgRelation']['db']) . '.'
-            . PMA_Util::backquote($cfgRelation['table_coords'])
-            . ' WHERE db_name = \'' . PMA_Util::sqlAddSlashes($db) . '\''
-            . ' AND   table_name = \'' . PMA_Util::sqlAddSlashes($tableName) . '\''
-            . ' AND   pdf_page_number = ' . $pageNumber;
-        $result = PMA_queryAsControlUser(
-            $sql, false, PMA_DatabaseInterface::QUERY_STORE
+    /**
+     * Displays an error when the table cannot be found.
+     *
+     * @return void
+     */
+    protected function showMissingTableError()
+    {
+        $this->diagram->dieSchema(
+            $this->pageNumber,
+            "EPS",
+            sprintf(__('The %s table doesn\'t exist!'), $this->tableName)
         );
+    }
 
-        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
-            $eps->dieSchema(
-                $pageNumber, "EPS",
-                sprintf(
-                    __('Please configure the coordinates for table %s'),
-                    $tableName
-                )
-            );
-        }
-        list($this->x, $this->y) = $GLOBALS['dbi']->fetchRow($result);
-        $this->x = (double) $this->x;
-        $this->y = (double) $this->y;
-        // displayfield
-        $this->displayfield = PMA_getDisplayField($db, $tableName);
-        // index
-        $result = $GLOBALS['dbi']->query(
-            'SHOW INDEX FROM ' . PMA_Util::backquote($tableName) . ';',
-            null, PMA_DatabaseInterface::QUERY_STORE
+    /**
+     * Diaplays an error on missing coordinates
+     *
+     * @return void
+     */
+    protected function showMissingCoordinatesError()
+    {
+        $this->diagram->dieSchema(
+            $this->pageNumber,
+            "EPS",
+            sprintf(
+                __('Please configure the coordinates for table %s'),
+                $this->tableName
+            )
         );
-        if ($GLOBALS['dbi']->numRows($result) > 0) {
-            while ($row = $GLOBALS['dbi']->fetchAssoc($result)) {
-                if ($row['Key_name'] == 'PRIMARY') {
-                    $this->primary[] = $row['Column_name'];
-                }
-            }
-        }
     }
 
     /**
@@ -443,7 +399,7 @@ class Table_Stats_Eps
      */
     private function _getTitle()
     {
-        return ($this->_showInfo
+        return ($this->showInfo
             ? sprintf('%.0f', $this->width) . 'x'
                 . sprintf('%.0f', $this->heightCell)
             : '') . ' ' . $this->_tableName;

--- a/libraries/schema/Eps_Relation_Schema.class.php
+++ b/libraries/schema/Eps_Relation_Schema.class.php
@@ -346,7 +346,7 @@ class Table_Stats_Eps extends TableStats
     ) {
         global $eps, $cfgRelation, $db;
         parent::__construct(
-            $esp, $db, $pageNumber, $tableName, $showKeys, $showInfo
+            $eps, $db, $pageNumber, $tableName, $showKeys, $showInfo
         );
 
         // height and width
@@ -402,7 +402,7 @@ class Table_Stats_Eps extends TableStats
         return ($this->showInfo
             ? sprintf('%.0f', $this->width) . 'x'
                 . sprintf('%.0f', $this->heightCell)
-            : '') . ' ' . $this->_tableName;
+            : '') . ' ' . $this->tableName;
     }
 
     /**
@@ -466,7 +466,7 @@ class Table_Stats_Eps extends TableStats
     public function tableDraw($showColor)
     {
         global $eps;
-        //echo $this->_tableName.'<br />';
+        //echo $this->tableName.'<br />';
         $eps->rect($this->x, $this->y + 12, $this->width, $this->heightCell, 1);
         $eps->showXY($this->_getTitle(), $this->x + 5, $this->y + 14);
         foreach ($this->fields as $field) {

--- a/libraries/schema/Eps_Relation_Schema.class.php
+++ b/libraries/schema/Eps_Relation_Schema.class.php
@@ -372,7 +372,7 @@ class Table_Stats_Eps extends TableStats
     }
 
     /**
-     * Diaplays an error on missing coordinates
+     * Displays an error on missing coordinates
      *
      * @return void
      */

--- a/libraries/schema/Eps_Relation_Schema.class.php
+++ b/libraries/schema/Eps_Relation_Schema.class.php
@@ -314,9 +314,7 @@ class Table_Stats_Eps extends TableStats
     /**
      * Defines properties
      */
-    public $width = 0;
     public $height;
-    public $heightCell = 0;
     public $currentCell = 0;
 
     /**
@@ -391,21 +389,6 @@ class Table_Stats_Eps extends TableStats
     }
 
     /**
-     * Returns title of the current table,
-     * title can have the dimensions/co-ordinates of the table
-     *
-     * @return string The relation/table name
-     * @access private
-     */
-    private function _getTitle()
-    {
-        return ($this->showInfo
-            ? sprintf('%.0f', $this->width) . 'x'
-                . sprintf('%.0f', $this->heightCell)
-            : '') . ' ' . $this->tableName;
-    }
-
-    /**
      * Sets the width of the table
      *
      * @param string  $font     The font name
@@ -432,7 +415,7 @@ class Table_Stats_Eps extends TableStats
          * table title is affected by the tabe width value
          */
         while ($this->width
-            < PMA_Font::getStringWidth($this->_getTitle(), $font, $fontSize)) {
+            < PMA_Font::getStringWidth($this->getTitle(), $font, $fontSize)) {
             $this->width += 7;
         }
     }
@@ -468,7 +451,7 @@ class Table_Stats_Eps extends TableStats
         global $eps;
         //echo $this->tableName.'<br />';
         $eps->rect($this->x, $this->y + 12, $this->width, $this->heightCell, 1);
-        $eps->showXY($this->_getTitle(), $this->x + 5, $this->y + 14);
+        $eps->showXY($this->getTitle(), $this->x + 5, $this->y + 14);
         foreach ($this->fields as $field) {
             $this->currentCell += $this->heightCell;
             $showColor    = 'none';

--- a/libraries/schema/Pdf_Relation_Schema.class.php
+++ b/libraries/schema/Pdf_Relation_Schema.class.php
@@ -358,6 +358,8 @@ class PMA_Schema_PDF extends PMA_PDF
     }
 }
 
+require_once './libraries/schema/TableStats.class.php';
+
 /**
  * Table preferences/statistics
  *
@@ -368,21 +370,15 @@ class PMA_Schema_PDF extends PMA_PDF
  * @package PhpMyAdmin
  * @see     PMA_Schema_PDF
  */
-class Table_Stats_Pdf
+class Table_Stats_Pdf extends TableStats
 {
     /**
      * Defines properties
      */
-    private $_tableName;
-    private $_showInfo = false;
-
     public $nb_fiels;
     public $width = 0;
     public $height;
-    public $fields = array();
     public $heightCell = 6;
-    public $x, $y;
-    public $primary = array();
     private $_ff = PMA_PDF_FONT;
 
     /**
@@ -407,34 +403,10 @@ class Table_Stats_Pdf
         $showKeys = false, $showInfo = false
     ) {
         global $pdf, $cfgRelation, $db;
-
-        $this->_tableName = $tableName;
-        $sql = 'DESCRIBE ' . PMA_Util::backquote($tableName);
-        $result = $GLOBALS['dbi']->tryQuery(
-            $sql, null, PMA_DatabaseInterface::QUERY_STORE
+        parent::__construct(
+            $pdf, $db, $pageNumber, $tableName, $showKeys, $showInfo
         );
-        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
-            $pdf->Error(sprintf(__('The %s table doesn\'t exist!'), $tableName));
-        }
-        // load fields
-        //check to see if it will load all fields or only the foreign keys
-        if ($showKeys) {
-            $indexes = PMA_Index::getFromTable($this->_tableName, $db);
-            $all_columns = array();
-            foreach ($indexes as $index) {
-                $all_columns = array_merge(
-                    $all_columns,
-                    array_flip(array_keys($index->getColumns()))
-                );
-            }
-            $this->fields = array_keys($all_columns);
-        } else {
-            while ($row = $GLOBALS['dbi']->fetchRow($result)) {
-                $this->fields[] = $row[0];
-            }
-        }
 
-        $this->_showInfo = $showInfo;
         $this->_setHeight();
         /*
          * setWidth must me after setHeight, because title
@@ -444,44 +416,37 @@ class Table_Stats_Pdf
         if ($sameWideWidth < $this->width) {
             $sameWideWidth = $this->width;
         }
-        $sql = 'SELECT x, y FROM '
-             . PMA_Util::backquote($GLOBALS['cfgRelation']['db']) . '.'
-             . PMA_Util::backquote($cfgRelation['table_coords'])
-             . ' WHERE db_name = \'' . PMA_Util::sqlAddSlashes($db) . '\''
-             . ' AND   table_name = \'' . PMA_Util::sqlAddSlashes($tableName) . '\''
-             . ' AND   pdf_page_number = ' . $pageNumber;
-        $result = PMA_queryAsControlUser(
-            $sql, false, PMA_DatabaseInterface::QUERY_STORE
+    }
+
+    /**
+     * Displays an error when the table cannot be found.
+     *
+     * @return void
+     */
+    protected function showMissingTableError()
+    {
+        $this->diagram->dieSchema(
+            $this->pageNumber,
+            "PDF",
+            sprintf(__('The %s table doesn\'t exist!'), $this->tableName)
         );
-        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
-            $pdf->Error(
-                sprintf(
-                    __('Please configure the coordinates for table %s'),
-                    $tableName
-                )
-            );
-        }
-        list($this->x, $this->y) = $GLOBALS['dbi']->fetchRow($result);
-        $this->x = (double) $this->x;
-        $this->y = (double) $this->y;
-        /*
-         * displayfield
-         */
-        $this->displayfield = PMA_getDisplayField($db, $tableName);
-        /*
-         * index
-         */
-        $result = $GLOBALS['dbi']->query(
-            'SHOW INDEX FROM ' . PMA_Util::backquote($tableName) . ';',
-            null, PMA_DatabaseInterface::QUERY_STORE
+    }
+
+    /**
+     * Diaplays an error on missing coordinates
+     *
+     * @return void
+     */
+    protected function showMissingCoordinatesError()
+    {
+        $this->diagram->dieSchema(
+            $this->pageNumber,
+            "PDF",
+            sprintf(
+                __('Please configure the coordinates for table %s'),
+                $this->tableName
+            )
         );
-        if ($GLOBALS['dbi']->numRows($result) > 0) {
-            while ($row = $GLOBALS['dbi']->fetchAssoc($result)) {
-                if ($row['Key_name'] == 'PRIMARY') {
-                    $this->primary[] = $row['Column_name'];
-                }
-            }
-        }
     }
 
     /**
@@ -493,7 +458,7 @@ class Table_Stats_Pdf
     private function _getTitle()
     {
         $ret = '';
-        if ($this->_showInfo) {
+        if ($this->showInfo) {
             $ret = sprintf('%.0fx%0.f', $this->width, $this->height);
         }
         return $ret . ' ' . $this->_tableName;

--- a/libraries/schema/Pdf_Relation_Schema.class.php
+++ b/libraries/schema/Pdf_Relation_Schema.class.php
@@ -461,7 +461,7 @@ class Table_Stats_Pdf extends TableStats
         if ($this->showInfo) {
             $ret = sprintf('%.0fx%0.f', $this->width, $this->height);
         }
-        return $ret . ' ' . $this->_tableName;
+        return $ret . ' ' . $this->tableName;
     }
 
     /**
@@ -534,9 +534,9 @@ class Table_Stats_Pdf extends TableStats
             $pdf->SetFillColor(0, 0, 128);
         }
         if ($withDoc) {
-            $pdf->SetLink($pdf->PMA_links['RT'][$this->_tableName]['-'], -1);
+            $pdf->SetLink($pdf->PMA_links['RT'][$this->tableName]['-'], -1);
         } else {
-            $pdf->PMA_links['doc'][$this->_tableName]['-'] = '';
+            $pdf->PMA_links['doc'][$this->tableName]['-'] = '';
         }
 
         $pdf->cellScale(
@@ -547,7 +547,7 @@ class Table_Stats_Pdf extends TableStats
             1,
             'C',
             $setColor,
-            $pdf->PMA_links['doc'][$this->_tableName]['-']
+            $pdf->PMA_links['doc'][$this->tableName]['-']
         );
         $pdf->setXScale($this->x);
         $pdf->SetFont($this->_ff, '', $fontSize);
@@ -564,9 +564,9 @@ class Table_Stats_Pdf extends TableStats
                 }
             }
             if ($withDoc) {
-                $pdf->SetLink($pdf->PMA_links['RT'][$this->_tableName][$field], -1);
+                $pdf->SetLink($pdf->PMA_links['RT'][$this->tableName][$field], -1);
             } else {
-                $pdf->PMA_links['doc'][$this->_tableName][$field] = '';
+                $pdf->PMA_links['doc'][$this->tableName][$field] = '';
             }
 
             $pdf->cellScale(
@@ -577,7 +577,7 @@ class Table_Stats_Pdf extends TableStats
                 1,
                 'L',
                 $setColor,
-                $pdf->PMA_links['doc'][$this->_tableName][$field]
+                $pdf->PMA_links['doc'][$this->tableName][$field]
             );
             $pdf->setXScale($this->x);
             $pdf->SetFillColor(255);

--- a/libraries/schema/Pdf_Relation_Schema.class.php
+++ b/libraries/schema/Pdf_Relation_Schema.class.php
@@ -376,9 +376,7 @@ class Table_Stats_Pdf extends TableStats
      * Defines properties
      */
     public $nb_fiels;
-    public $width = 0;
     public $height;
-    public $heightCell = 6;
     private $_ff = PMA_PDF_FONT;
 
     /**
@@ -407,6 +405,7 @@ class Table_Stats_Pdf extends TableStats
             $pdf, $db, $pageNumber, $tableName, $showKeys, $showInfo
         );
 
+        $this->heightCell = 6;
         $this->_setHeight();
         /*
          * setWidth must me after setHeight, because title
@@ -455,7 +454,7 @@ class Table_Stats_Pdf extends TableStats
      *
      * @return string
      */
-    private function _getTitle()
+    protected function getTitle()
     {
         $ret = '';
         if ($this->showInfo) {
@@ -490,7 +489,7 @@ class Table_Stats_Pdf extends TableStats
          * it is unknown what value must be added, because
          * table title is affected by the tabe width value
          */
-        while ($this->width < $pdf->GetStringWidth($this->_getTitle())) {
+        while ($this->width < $pdf->GetStringWidth($this->getTitle())) {
             $this->width += 5;
         }
         $pdf->SetFont($this->_ff, '', $fontSize);
@@ -542,7 +541,7 @@ class Table_Stats_Pdf extends TableStats
         $pdf->cellScale(
             $this->width,
             $this->heightCell,
-            $this->_getTitle(),
+            $this->getTitle(),
             1,
             1,
             'C',

--- a/libraries/schema/Pdf_Relation_Schema.class.php
+++ b/libraries/schema/Pdf_Relation_Schema.class.php
@@ -432,7 +432,7 @@ class Table_Stats_Pdf extends TableStats
     }
 
     /**
-     * Diaplays an error on missing coordinates
+     * Displays an error on missing coordinates
      *
      * @return void
      */

--- a/libraries/schema/Svg_Relation_Schema.class.php
+++ b/libraries/schema/Svg_Relation_Schema.class.php
@@ -263,6 +263,8 @@ class PMA_SVG extends XMLWriter
     }
 }
 
+require_once './libraries/schema/TableStats.class.php';
+
 /**
  * Table preferences/statistics
  *
@@ -273,22 +275,15 @@ class PMA_SVG extends XMLWriter
  * @name    Table_Stats_Svg
  * @see     PMA_SVG
  */
-class Table_Stats_Svg
+class Table_Stats_Svg extends TableStats
 {
     /**
      * Defines properties
      */
-
-    private $_tableName;
-    private $_showInfo = false;
-
     public $width = 0;
     public $height;
-    public $fields = array();
     public $heightCell = 0;
     public $currentCell = 0;
-    public $x, $y;
-    public $primary = array();
 
     /**
      * The "Table_Stats_Svg" constructor
@@ -317,92 +312,49 @@ class Table_Stats_Svg
         &$same_wide_width, $showKeys = false, $showInfo = false
     ) {
         global $svg, $cfgRelation, $db;
-
-        $this->_tableName = $tableName;
-        $sql = 'DESCRIBE ' . PMA_Util::backquote($tableName);
-        $result = $GLOBALS['dbi']->tryQuery(
-            $sql, null, PMA_DatabaseInterface::QUERY_STORE
+        parent::__construct(
+            $svg, $db, $pageNumber, $tableName, $showKeys, $showInfo
         );
-        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
-            $svg->dieSchema(
-                $pageNumber,
-                "SVG",
-                sprintf(__('The %s table doesn\'t exist!'), $tableName)
-            );
-        }
-
-        /*
-        * load fields
-        * check to see if it will load all fields or only the foreign keys
-        */
-
-        if ($showKeys) {
-            $indexes = PMA_Index::getFromTable($this->_tableName, $db);
-            $all_columns = array();
-            foreach ($indexes as $index) {
-                $all_columns = array_merge(
-                    $all_columns,
-                    array_flip(array_keys($index->getColumns()))
-                );
-            }
-            $this->fields = array_keys($all_columns);
-        } else {
-            while ($row = $GLOBALS['dbi']->fetchRow($result)) {
-                $this->fields[] = $row[0];
-            }
-        }
-
-        $this->_showInfo = $showInfo;
 
         // height and width
         $this->_setHeightTable($fontSize);
-
         // setWidth must me after setHeight, because title
         // can include table height which changes table width
         $this->_setWidthTable($font, $fontSize);
         if ($same_wide_width < $this->width) {
             $same_wide_width = $this->width;
         }
+    }
 
-        // x and y
-        $sql = 'SELECT x, y FROM '
-         . PMA_Util::backquote($GLOBALS['cfgRelation']['db']) . '.'
-         . PMA_Util::backquote($cfgRelation['table_coords'])
-         . ' WHERE db_name = \'' . PMA_Util::sqlAddSlashes($db) . '\''
-         . ' AND   table_name = \'' . PMA_Util::sqlAddSlashes($tableName) . '\''
-         . ' AND   pdf_page_number = ' . $pageNumber;
-        $result = PMA_queryAsControlUser(
-            $sql, false, PMA_DatabaseInterface::QUERY_STORE
+    /**
+     * Displays an error when the table cannot be found.
+     *
+     * @return void
+     */
+    protected function showMissingTableError()
+    {
+        $this->diagram->dieSchema(
+            $this->pageNumber,
+            "SVG",
+            sprintf(__('The %s table doesn\'t exist!'), $this->tableName)
         );
+    }
 
-        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
-            $svg->dieSchema(
-                $pageNumber,
-                "SVG",
-                sprintf(
-                    __('Please configure the coordinates for table %s'),
-                    $tableName
-                )
-            );
-        }
-        list($this->x, $this->y) = $GLOBALS['dbi']->fetchRow($result);
-        $this->x = (double) $this->x;
-        $this->y = (double) $this->y;
-        // displayfield
-        $this->displayfield = PMA_getDisplayField($db, $tableName);
-        // index
-        $result = $GLOBALS['dbi']->query(
-            'SHOW INDEX FROM ' . PMA_Util::backquote($tableName) . ';',
-            null,
-            PMA_DatabaseInterface::QUERY_STORE
+    /**
+     * Diaplays an error on missing coordinates
+     *
+     * @return void
+     */
+    protected function showMissingCoordinatesError()
+    {
+        $this->diagram->dieSchema(
+            $this->pageNumber,
+            "SVG",
+            sprintf(
+                __('Please configure the coordinates for table %s'),
+                $this->tableName
+            )
         );
-        if ($GLOBALS['dbi']->numRows($result) > 0) {
-            while ($row = $GLOBALS['dbi']->fetchAssoc($result)) {
-                if ($row['Key_name'] == 'PRIMARY') {
-                    $this->primary[] = $row['Column_name'];
-                }
-            }
-        }
     }
 
     /**
@@ -414,7 +366,7 @@ class Table_Stats_Svg
      */
     private function _getTitle()
     {
-        return ($this->_showInfo
+        return ($this->showInfo
             ? sprintf('%.0f', $this->width) . 'x'
             . sprintf('%.0f', $this->heightCell)
             : ''

--- a/libraries/schema/Svg_Relation_Schema.class.php
+++ b/libraries/schema/Svg_Relation_Schema.class.php
@@ -370,7 +370,7 @@ class Table_Stats_Svg extends TableStats
             ? sprintf('%.0f', $this->width) . 'x'
             . sprintf('%.0f', $this->heightCell)
             : ''
-        ) . ' ' . $this->_tableName;
+        ) . ' ' . $this->tableName;
     }
 
     /**
@@ -436,7 +436,7 @@ class Table_Stats_Svg extends TableStats
     public function tableDraw($showColor)
     {
         global $svg;
-        //echo $this->_tableName.'<br />';
+        //echo $this->tableName.'<br />';
         $svg->printElement(
             'rect', $this->x, $this->y, $this->width,
             $this->heightCell, null, 'fill:red;stroke:black;'

--- a/libraries/schema/Svg_Relation_Schema.class.php
+++ b/libraries/schema/Svg_Relation_Schema.class.php
@@ -339,7 +339,7 @@ class Table_Stats_Svg extends TableStats
     }
 
     /**
-     * Diaplays an error on missing coordinates
+     * Displays an error on missing coordinates
      *
      * @return void
      */

--- a/libraries/schema/Svg_Relation_Schema.class.php
+++ b/libraries/schema/Svg_Relation_Schema.class.php
@@ -280,9 +280,7 @@ class Table_Stats_Svg extends TableStats
     /**
      * Defines properties
      */
-    public $width = 0;
     public $height;
-    public $heightCell = 0;
     public $currentCell = 0;
 
     /**
@@ -358,22 +356,6 @@ class Table_Stats_Svg extends TableStats
     }
 
     /**
-     * Returns title of the current table,
-     * title can have the dimensions/co-ordinates of the table
-     *
-     * @return string title of the current table
-     * @access private
-     */
-    private function _getTitle()
-    {
-        return ($this->showInfo
-            ? sprintf('%.0f', $this->width) . 'x'
-            . sprintf('%.0f', $this->heightCell)
-            : ''
-        ) . ' ' . $this->tableName;
-    }
-
-    /**
      * Sets the width of the table
      *
      * @param string  $font     The font size
@@ -401,7 +383,7 @@ class Table_Stats_Svg extends TableStats
          * table title is affected by the tabe width value
          */
         while ($this->width
-            < PMA_Font::getStringWidth($this->_getTitle(), $font, $fontSize)
+            < PMA_Font::getStringWidth($this->getTitle(), $font, $fontSize)
         ) {
             $this->width += 7;
         }
@@ -443,7 +425,7 @@ class Table_Stats_Svg extends TableStats
         );
         $svg->printElement(
             'text', $this->x + 5, $this->y+ 14, $this->width, $this->heightCell,
-            $this->_getTitle(), 'fill:none;stroke:black;'
+            $this->getTitle(), 'fill:none;stroke:black;'
         );
         foreach ($this->fields as $field) {
             $this->currentCell += $this->heightCell;

--- a/libraries/schema/TableStats.class.php
+++ b/libraries/schema/TableStats.class.php
@@ -136,7 +136,7 @@ abstract class TableStats
     }
 
     /**
-     * Diaplays an error on missing coordinates
+     * Displays an error on missing coordinates
      *
      * @return void
      * @abstract

--- a/libraries/schema/TableStats.class.php
+++ b/libraries/schema/TableStats.class.php
@@ -1,0 +1,174 @@
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * Contains abstract class to hold table preferences/statistics
+ *
+ * @package PhpMyAdmin
+ */
+if (! defined('PHPMYADMIN')) {
+    exit;
+}
+
+/**
+ * Table preferences/statistics
+ *
+ * This class preserves the table co-ordinates,fields
+ * and helps in drawing/generating the tables.
+ *
+ * @package PhpMyAdmin
+ * @abstract
+ */
+abstract class TableStats
+{
+    protected $diagram;
+    protected $db;
+    protected $pageNumber;
+    protected $tableName;
+
+    protected $showKeys;
+    protected $showInfo;
+
+    public $displayField;
+    public $fields = array();
+    public $primary = array();
+    public $x, $y;
+
+
+    /**
+     * Constructor
+     *
+     * @param object  $diagram    schema diagram
+     * @param string  $db         current db name
+     * @param integer $pageNumber current page number (from the
+     *                            $cfg['Servers'][$i]['table_coords'] table)
+     * @param string  $tableName  table name
+     * @param boolean $showKeys   whether to display keys or not
+     * @param boolean $showInfo   whether to display table position or not
+     */
+    public function __construct(
+        $diagram, $db, $pageNumber, $tableName, $showKeys, $showInfo
+    ) {
+        $this->diagram    = $diagram;
+        $this->db         = $db;
+        $this->pageNumber = $pageNumber;
+        $this->tableName  = $tableName;
+
+        $this->showKeys   = $showKeys;
+        $this->showInfo   = $showInfo;
+
+        // checks whether the table exists
+        // and loads fields
+        $this->validateTableAndLoadFields();
+        // load table coordinates
+        $this->loadCoordinates();
+        // loads display field
+        $this->loadDisplayField();
+        // loads primary keys
+        $this->loadPrimaryKey();
+    }
+
+    /**
+     * Validate whether the table exists.
+     *
+     * @return void
+     */
+    protected function validateTableAndLoadFields()
+    {
+        $sql = 'DESCRIBE ' . PMA_Util::backquote($this->tableName);
+        $result = $GLOBALS['dbi']->tryQuery(
+            $sql, null, PMA_DatabaseInterface::QUERY_STORE
+        );
+        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
+            $this->showMissingTableError();
+        }
+
+        if ($this->showKeys) {
+            $indexes = PMA_Index::getFromTable($this->tableName, $this->db);
+            $all_columns = array();
+            foreach ($indexes as $index) {
+                $all_columns = array_merge(
+                    $all_columns,
+                    array_flip(array_keys($index->getColumns()))
+                );
+            }
+            $this->fields = array_keys($all_columns);
+        } else {
+            while ($row = $GLOBALS['dbi']->fetchRow($result)) {
+                $this->fields[] = $row[0];
+            }
+        }
+    }
+
+    /**
+     * Displays an error when the table cannot be found.
+     *
+     * @return void
+     * @abstract
+     */
+    protected abstract function showMissingTableError();
+
+    /**
+     * Loads coordinates of a table
+     *
+     * @return void
+     */
+    protected function loadCoordinates()
+    {
+        global $cfgRelation;
+
+        $sql = "SELECT x, y FROM "
+            . PMA_Util::backquote($GLOBALS['cfgRelation']['db']) . "."
+                . PMA_Util::backquote($cfgRelation['table_coords'])
+                . " WHERE db_name = '" . PMA_Util::sqlAddSlashes($this->db) . "'"
+                . " AND   table_name = '" . PMA_Util::sqlAddSlashes($this->tableName) . "'"
+                . " AND   pdf_page_number = " . $this->pageNumber;
+        $result = PMA_queryAsControlUser(
+            $sql, false, PMA_DatabaseInterface::QUERY_STORE
+        );
+        if (! $result || ! $GLOBALS['dbi']->numRows($result)) {
+            $this->showMissingCoordinatesError();
+        }
+        list($this->x, $this->y) = $GLOBALS['dbi']->fetchRow($result);
+        $this->x = (double) $this->x;
+        $this->y = (double) $this->y;
+    }
+
+    /**
+     * Diaplays an error on missing coordinates
+     *
+     * @return void
+     * @abstract
+     */
+    protected abstract function showMissingCoordinatesError();
+
+    /**
+     * Loads the table's display field
+     *
+     * @return void
+     */
+    protected function loadDisplayField()
+    {
+        $this->displayField = PMA_getDisplayField($this->db, $this->tableName);
+    }
+
+    /**
+     * Loads the PRIMARY key.
+     *
+     * @return void
+     */
+    protected function loadPrimaryKey()
+    {
+        $result = $GLOBALS['dbi']->query(
+            'SHOW INDEX FROM ' . PMA_Util::backquote($this->tableName) . ';',
+            null, PMA_DatabaseInterface::QUERY_STORE
+        );
+        if ($GLOBALS['dbi']->numRows($result) > 0) {
+            while ($row = $GLOBALS['dbi']->fetchAssoc($result)) {
+                if ($row['Key_name'] == 'PRIMARY') {
+                    $this->primary[] = $row['Column_name'];
+                }
+            }
+        }
+    }
+}
+?>

--- a/libraries/schema/TableStats.class.php
+++ b/libraries/schema/TableStats.class.php
@@ -33,6 +33,8 @@ abstract class TableStats
     public $primary = array();
     public $x, $y;
 
+    public $width = 0;
+    public $heightCell = 0;
 
     /**
      * Constructor
@@ -169,6 +171,21 @@ abstract class TableStats
                 }
             }
         }
+    }
+
+    /**
+     * Returns title of the current table,
+     * title can have the dimensions/co-ordinates of the table
+     *
+     * @return string title of the current table
+     */
+    protected function getTitle()
+    {
+        return ($this->showInfo
+            ? sprintf('%.0fx%0.f', $this->width, $this->heightCell)
+            : ''
+        )
+        . ' ' . $this->tableName;
     }
 }
 ?>

--- a/libraries/schema/TableStats.class.php
+++ b/libraries/schema/TableStats.class.php
@@ -28,7 +28,7 @@ abstract class TableStats
     protected $showKeys;
     protected $showInfo;
 
-    public $displayField;
+    public $displayfield;
     public $fields = array();
     public $primary = array();
     public $x, $y;
@@ -148,7 +148,7 @@ abstract class TableStats
      */
     protected function loadDisplayField()
     {
-        $this->displayField = PMA_getDisplayField($this->db, $this->tableName);
+        $this->displayfield = PMA_getDisplayField($this->db, $this->tableName);
     }
 
     /**


### PR DESCRIPTION
All the Table_Stats_\* classes had lots of code duplications and I re-factored this code duplication by adding a common parent class and moving the common code there.
