### PR TITLE
Fix for missing 'Trigger' menu for older MySQL versions

### DIFF
--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -3817,6 +3817,12 @@ class PMA_Util
      */
     public static function currentUserHasPrivilege($priv, $db = null, $tbl = null)
     {
+	// TRIGGER privilege was added in MySQL 5.1.6.
+	// Before MySQL 5.1.6, the SUPER privilege was required to create or drop triggers.
+	if ($priv == "TRIGGER" && PMA_MYSQL_INT_VERSION < 50160) {
+	    $priv = "SUPER";
+	}
+
         // Get the username for the current user in the format
         // required to use in the information schema database.
         $user = $GLOBALS['dbi']->fetchValue("SELECT CURRENT_USER();");


### PR DESCRIPTION
This fixes an issue when "Triggers" menu won't show up for MySQL versions older than 5.1.6.
Before MySQL 5.1.6, the SUPER privilege was required to create or drop triggers. 
Possible fix is to substitute TRIGGER privilege with SUPER privilege in currentUserHasPrivilege function for MySQL versions older than 5.1.6.
