### PR TITLE
Multicolumn sorting feature request(1507)

### DIFF
--- a/js/columndelete.js
+++ b/js/columndelete.js
@@ -1,0 +1,68 @@
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * @fileoverview    Implements the shiftkey + click remove column 
+ *                  from order by clause funcationality
+ * @name            columndelete
+ *
+ * @requires    jQuery
+ */
+ 
+function captureURL(url)
+{
+    var URL = {};
+    url = '' + url;
+    // Exclude the url part till HTTP
+    url = url.substr(url.search("sql.php"), url.length);
+    // The url part between ORDER BY and &session_max_rows needs to be replaced.
+    URL['head'] = url.substr(0, url.indexOf('ORDER+BY') + 9);
+    URL['tail'] = url.substr(url.indexOf("&session_max_rows"), url.length); 
+    return URL;       
+} 
+
+/**
+ * This function is for navigating to the generated URL
+ *
+ * @param object   target HTMLAnchor element 
+ * @param object   parent HTMLDom Object
+ */
+
+function redirect(target, parent)
+{     
+    var URL = captureURL(target);
+    var begin = target.indexOf('ORDER+BY') + 8;
+    var end = target.indexOf('&session_max_rows');
+    // get the names of the columns involved
+    var between_part = target.substr(begin, end-begin);
+    var columns = between_part.split('%2C+'); 
+    // If the given column is not part of the order clause exit from this function
+    var index = parent.find('small').length ? parent.find('small').text() : ''; 
+    if (index == ''){
+        return;
+    }
+    // Remove the current clicked column
+    columns.splice(index-1, 1); 
+    // If all the columns have been removed dont submit a query with nothing
+    // After order by clause.
+    if (columns.length == 0){ 
+        var head = URL['head'];
+        head = head.slice(0,head.indexOf('ORDER+BY')); 
+        URL['head'] = head;
+    }
+    var middle_part = columns.join('%2C+');  
+    url = URL['head'] + middle_part + URL['tail'];  
+    window.location.replace(url);
+}
+
+
+AJAX.registerOnload('keyhandler.js', function () { 
+    $("th.draggable.column_heading.pointer.marker  a").live('click', function (event) { 
+        if (event.shiftKey) {
+            event.preventDefault();
+            redirect($(this).attr("href"), $(this).parent()); 
+        }
+    });  
+});
+
+AJAX.registerTeardown('keyhandler.js', function () {
+    $("th.draggable.column_heading.pointer.marker a").die('click');
+});

--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -438,6 +438,10 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                     text += text.length > 0 ? '<br />' : '';
                     text += g.sortHint;
                 }
+                 if (g.showRemColHint && g.strRemColHint) {
+                    text += text.length > 0 ? '<br />' : '';
+                    text += g.strRemColHint;
+                }
                 if (g.showMarkHint && g.markHint &&
                     !g.showSortHint      // we do not show mark hint, when sort hint is shown
                 ) {
@@ -1784,6 +1788,7 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
 
     // assign the hints
     g.sortHint = PMA_messages.strSortHint;
+    g.strRemColHint = PMA_messages.strRemColHint;
     g.markHint = PMA_messages.strColMarkHint;
     g.copyHint = PMA_messages.strColNameCopyHint;
 
@@ -1837,12 +1842,14 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
     $(t).find('th.draggable a')
         .mouseenter(function (e) {
             g.showSortHint = true;
+            g.showRemColHint = true;
             $(t).find("th.draggable").tooltip("option", {
                 content: g.updateHint()
             });
         })
         .mouseleave(function (e) {
-            g.showSortHint = false;
+            g.showSortHint = false;            
+            g.showRemColHint = false;
             $(t).find("th.draggable").tooltip("option", {
                 content: g.updateHint()
             });

--- a/js/messages.php
+++ b/js/messages.php
@@ -335,6 +335,7 @@ $js_messages['strCellEditHint'] = __('Press escape to cancel editing.');
 $js_messages['strSaveCellWarning'] = __('You have edited some data and they have not been saved. Are you sure you want to leave this page before saving the data?');
 $js_messages['strColOrderHint'] = __('Drag to reorder.');
 $js_messages['strSortHint'] = __('Click to sort.');
+$js_messages['strRemColHint'] = __('Hold shift and click to remove column from order by clause.');
 $js_messages['strColMarkHint'] = __('Click to mark/unmark.');
 $js_messages['strColNameCopyHint'] = __('Double-click to copy column name.');
 $js_messages['strColVisibHint'] = __(

--- a/sql.php
+++ b/sql.php
@@ -26,6 +26,7 @@ $scripts->addFile('jquery/jquery-ui-timepicker-addon.js');
 $scripts->addFile('tbl_change.js');
 $scripts->addFile('indexes.js');
 $scripts->addFile('gis_data_editor.js');
+$scripts->addFile('columndelete.js');
 
 /**
  * Set ajax_reload in the response if it was already set

--- a/test/classes/PMA_DisplayResults_test.php
+++ b/test/classes/PMA_DisplayResults_test.php
@@ -723,13 +723,21 @@ class PMA_DisplayResults_Test extends PHPUnit_Framework_TestCase
     public function dataProviderForGetSortParams()
     {
         return array(
-            array('', array('', '', '')),
+            array('', array(array(''), array(''), array(''))),
             array(
                 '`a_sales`.`customer_id` ASC',
                 array(
-                    '`a_sales`.`customer_id` ASC',
-                    '`a_sales`.`customer_id`',
-                    'ASC'
+                    array('`a_sales`.`customer_id` ASC'),
+                    array('`a_sales`.`customer_id`'),
+                    array('ASC')
+                )
+            ),
+            array(
+                '`a_sales`.`customer_id` ASC, `b_sales`.`customer_id` DESC',
+                array(
+                    array('`a_sales`.`customer_id` ASC', '`b_sales`.`customer_id` DESC'),
+                    array('`a_sales`.`customer_id`', '`b_sales`.`customer_id`'),
+                    array('ASC', 'DESC')
                 )
             ),
         );


### PR DESCRIPTION
This patch completely implements the feature requested, this is void of any
tests though. This patch modified 4 existing files and adds one extra
Javascript file. The existing system for one column sorting has been
refactored to be used for multicolumn sort.

Files messages.php and makegrid.js where modified to add the tool tip.

File sql.php was modified to add the import statement for the newly added JS
file.

The newly added columndelete.js is responsible for shift deleting the columns.
It gets the url of the link that was shift clicked and removes the name of the
column which we want to remove from the order by clause.

Finally, most of the crux of this feature request is implemented through
changes to the DisplayResult.class.php. 4 methods of this class have been
refactored to accomodate the required change. getsortparams() which process
the order by clause text remains the same, just the output parameters have
been turned into a array for each order by clause column. isInSort() has been
modified to check multiple order by clauses. The smart ordering feature in
getSortingUrlParams has been taken out and some functionality of getorderlinkandsortedhtml
to form a new function makeURL, which makes the url for multiple sorted table's
header's button's targets.

Signed-off-by: Aditya Sastry ganeshaditya1@gmail.com
