### PR TITLE
Adds the maximum table size to export option (Feature request 1515)

### DIFF
--- a/export.php
+++ b/export.php
@@ -54,6 +54,7 @@ if (!defined('TESTSUITE')) {
             'allrows',
             'output_format',
             'filename_template',
+            'maxsize',
             'remember_template',
             'charset_of_file',
             'compression',

--- a/libraries/display_export.lib.php
+++ b/libraries/display_export.lib.php
@@ -654,6 +654,11 @@ function PMA_getHtmlForExportOptionsOutput($export_type)
     $html .= PMA_getHtmlForExportOptionsOutputRadio();
 
     $html .= '</ul>';
+
+    $html .= '<label for="maxsize">'
+        . __('Skip tables larger than') . '</label>';
+    $html .= '<input type = "text" name = "maxsize">MB</pre>';
+
     $html .= '</div>';
 
     return $html;

--- a/libraries/export.lib.php
+++ b/libraries/export.lib.php
@@ -545,9 +545,27 @@ function PMA_exportDatabase(
                         break 1;
                     }
                 }
-                
+
             } else if (isset($GLOBALS['sql_create_table'])) {
-                
+
+                $table_size = $GLOBALS['maxsize'];
+                // Checking if the maximum table size constrain has been set
+                // And if that constrain is a valid number or not
+                if ($table_size !== '' && is_numeric($table_size)) {
+                    // This obtains the current table's size
+                    $query = 'SELECT data_length + index_length
+                          from information_schema.TABLES
+                          WHERE table_schema = "'.$db.'"
+                          AND table_name = "'.$table.'"';
+
+                    $size = $GLOBALS['dbi']->fetchValue($query);
+                    //Converting the size to MB
+                    $size = ($size / 1024) / 1024;
+                    if ($size > $table_size) {
+                        continue;
+                    }
+                }
+
                 if (! $export_plugin->exportStructure(
                     $db, $table, $crlf, $err_url,
                     'create_table', $export_type,


### PR DESCRIPTION
Added a textbox to the custom export options, in the loop where the
Exporting is done, I added a query which checks the current table's size.
If this size is greater than the limit specified we don't export the current
table.

Signed-off-by: Aditya Sastry ganeshaditya1@gmail.com
