### PR TITLE
Feature Request: #1329 Can't rename column with foreign key constraint.

### DIFF
--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -1312,7 +1312,7 @@ function PMA_getHtmlForLoginInformationFields($mode = 'new')
         . ((! isset($GLOBALS['pred_username'])
                 || $GLOBALS['pred_username'] == 'userdefined'
             )
-            ? 'required'
+            ? 'required="required"'
             : '') . ' />' . "\n";
 
     $html_output .= '<div id="user_exists_warning"'
@@ -1437,7 +1437,7 @@ function PMA_getHtmlForLoginInformationFields($mode = 'new')
         . ((isset($GLOBALS['pred_hostname'])
                 && $GLOBALS['pred_hostname'] == 'userdefined'
             )
-            ? 'required'
+            ? 'required="required"'
             : '')
         . ' />' . "\n"
         . PMA_Util::showHint(
@@ -1484,7 +1484,7 @@ function PMA_getHtmlForLoginInformationFields($mode = 'new')
         . '<input type="password" id="text_pma_pw" name="pma_pw" '
         . 'title="' . __('Password') . '" '
         . 'onchange="pred_password.value = \'userdefined\'; this.required = true; pma_pw2.required = true;" '
-        . (isset($GLOBALS['username']) ? '' : 'required')
+        . (isset($GLOBALS['username']) ? '' : 'required="required"')
         . '/>' . "\n"
         . '</div>' . "\n";
 
@@ -1497,7 +1497,7 @@ function PMA_getHtmlForLoginInformationFields($mode = 'new')
         . '<input type="password" name="pma_pw2" id="text_pma_pw2" '
         . 'title="' . __('Re-type') . '" '
         . 'onchange="pred_password.value = \'userdefined\'; this.required = true; pma_pw.required = true;" '
-        . (isset($GLOBALS['username']) ? '' : 'required')
+        . (isset($GLOBALS['username']) ? '' : 'required="required"')
         . '/>' . "\n"
         . '</div>' . "\n"
        // Generate password added here via jQuery

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -2232,7 +2232,7 @@ function PMA_getHtmlForDisplayTableStats($showtable, $table_info_num_rows,
         (isset ($avg_size) ? $avg_size : ''),
         (isset ($avg_unit) ? $avg_unit : '')
     );
-    
+
     $html_output .= '</fieldset>'
         . '</div>';
 

--- a/libraries/tbl_columns_definition_form.inc.php
+++ b/libraries/tbl_columns_definition_form.inc.php
@@ -79,6 +79,7 @@ if (isset($_REQUEST['submit_num_fields'])) {
     //if adding new fields, set regenerate to keep the original values
     $regenerate = 1;
 }
+
 for ($columnNumber = 0; $columnNumber < $num_fields; $columnNumber++) {
     if (! empty($regenerate)) {
         list($columnMeta, $submit_length, $submit_attribute,
@@ -133,6 +134,10 @@ for ($columnNumber = 0; $columnNumber < $num_fields; $columnNumber++) {
             $columnMeta, $length, $_form_params, $columnNumber
         );
     }
+    // Variable tell if current column is bound in a foreign key constraint or not.
+    $columnMeta['column_status'] = PMA_checkChildForeignReferences($_form_params['db'],
+        $_form_params['table'],
+        isset($columnMeta) ? $columnMeta['Field'] : null);
 
     $content_cells[$columnNumber] = PMA_getHtmlForColumnAttributes(
         $columnNumber, isset($columnMeta) ? $columnMeta : null, strtoupper($type),
@@ -148,7 +153,6 @@ for ($columnNumber = 0; $columnNumber < $num_fields; $columnNumber++) {
         $mime_map
     );
 } // end for
-
 $html = PMA_getHtmlForTableCreateOrAddField(
     $action, $_form_params, $content_cells, $header_cells
 );

--- a/libraries/tbl_columns_definition_form.lib.php
+++ b/libraries/tbl_columns_definition_form.lib.php
@@ -562,9 +562,16 @@ function PMA_getColumnMetaForDefault($columnMeta, $isDefault)
  */
 function PMA_getHtmlForColumnName($columnNumber, $ci, $ci_offset, $columnMeta)
 {
-    $html = '<input id="field_' . $columnNumber . '_' . ($ci - $ci_offset)
+    $title = '';
+    $title .= (isset($columnMeta['column_status']) && $columnMeta['column_status']['isReferenced']) ? __('Referenced by ')
+        . implode(",", $columnMeta['column_status']['references']) . "." : '';
+    $title .= (!empty($title) && isset($columnMeta['column_status']) && $columnMeta['column_status']['isForeignKey']) ? "\n" : '';
+    $title .= (isset($columnMeta['column_status']) && $columnMeta['column_status']['isForeignKey']) ? __('Is a Foreign Key.') : '';
+    $title .= (empty($title)) ? __('Column') : '';
+    $html = '<input' . (isset($columnMeta['column_status']) && !$columnMeta['column_status']['isEditable']?' disabled="disabled" ':' ')
+        . 'id="field_' . $columnNumber . '_' . ($ci - $ci_offset)
         . '"' . ' type="text" name="field_name[' . $columnNumber . ']"'
-        . ' maxlength="64" class="textfield" title="' . __('Column') . '"'
+        . ' maxlength="64" class="textfield" title="' . $title . '"'
         . ' size="10"'
         . ' value="'
         . (isset($columnMeta['Field'])
@@ -584,10 +591,10 @@ function PMA_getHtmlForColumnName($columnNumber, $ci, $ci_offset, $columnMeta)
  *
  * @return string
  */
-function PMA_getHtmlForColumnType($columnNumber, $ci, $ci_offset, $type_upper)
+function PMA_getHtmlForColumnType($columnNumber, $ci, $ci_offset, $type_upper, $columnMeta)
 {
     $select_id = 'field_' . $columnNumber . '_' . ($ci - $ci_offset);
-    $html = '<select class="column_type" name="field_type[' .
+    $html = '<select' . (isset($columnMeta['column_status']) && !$columnMeta['column_status']['isEditable']?' disabled="disabled" ':' ') . 'class="column_type" name="field_type[' .
         $columnNumber . ']"' . ' id="' . $select_id . '">';
     $html .= PMA_Util::getSupportedDatatypes(true, $type_upper);
     $html .= '    </select>';
@@ -1155,7 +1162,7 @@ function PMA_getHtmlForColumnAttributes($columnNumber, $columnMeta, $type_upper,
 
     // column type
     $content_cell[$ci] = PMA_getHtmlForColumnType(
-        $columnNumber, $ci, $ci_offset, $type_upper
+        $columnNumber, $ci, $ci_offset, $type_upper, isset($columnMeta) ? $columnMeta : null
     );
     $ci++;
 

--- a/test/libraries/PMA_tbl_columns_definition_form_test.php
+++ b/test/libraries/PMA_tbl_columns_definition_form_test.php
@@ -608,7 +608,7 @@ class PMA_TblColumnsDefinitionFormTest extends PHPUnit_Framework_TestCase
     public function testGetHtmlForColumnName()
     {
         $result = PMA_getHtmlForColumnName(
-            2, 4, 4, array('Field' => "fieldname")
+            2, 4, 4, array('Field' => "fieldname", 'column_status' => array('isReferenced' => false, 'isForeignKey' => false))
         );
 
         $this->assertTag(
@@ -630,7 +630,7 @@ class PMA_TblColumnsDefinitionFormTest extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['PMA_Types'] = new PMA_Types;
         $result = PMA_getHtmlForColumnType(
-            1, 4, 3, false
+            1, 4, 3, false, array('column_status' => array('isReferenced' => false, 'isForeignKey' => false))
         );
 
         $this->assertTag(


### PR DESCRIPTION
Feature Request: #1329 Can't rename column with foreign key constraint.
https://sourceforge.net/p/phpmyadmin/feature-requests/1329/

1) When a column is referenced by other:
![referenced](https://f.cloud.github.com/assets/6863616/2492929/8353a6b4-b268-11e3-9338-e9d2b97889b4.png)

2) When a column is a foreign key:
![foreign_key](https://f.cloud.github.com/assets/6863616/2492930/97a7d770-b268-11e3-993b-7de027a47d92.png)

3) When its both:
![both](https://f.cloud.github.com/assets/6863616/2492931/a533361e-b268-11e3-98bd-61264cab0c49.png)

Signed-off-by: Ashutosh Dhundhara ashutoshdhundhara@yahoo.com
