### PR TITLE
Bug: Datepicker icon not showing on "Add Event" dialog.

### DIFF
--- a/js/rte.js
+++ b/js/rte.js
@@ -304,13 +304,19 @@ RTE.COMMON = {
                     buttons: that.buttonOptions,
                     title: data.title,
                     modal: true,
+                    open: function () {
+                        $(this).find('input[name=item_name]').focus();
+                        $(this).find('input.datefield').each(function () {
+                            PMA_addDatepicker($(this).css('width', '95%'), 'date');
+                        });
+                        $(this).find('input.datetimefield').each(function () {
+                            PMA_addDatepicker($(this).css('width', '95%'), 'datetime');
+                        });
+                        $.datepicker.initialized = false;
+                    },
                     close: function () {
                         $(this).remove();
                     }
-                });
-                that.$ajaxDialog.find('input[name=item_name]').focus();
-                that.$ajaxDialog.find('input.datefield, input.datetimefield').each(function () {
-                    PMA_addDatepicker($(this).css('width', '95%'));
                 });
                 /**
                  * @var mode Used to remeber whether the editor is in


### PR DESCRIPTION
Bug: Datepicker icon not showing on "Add Event" dialog.

This time it works. Shows datepicker icon as well as no more bug #4334.

Signed-off-by: Ashutosh Dhundhara ashutoshdhundhara@yahoo.com
