### PR TITLE
Feature Request: #1329 Can't rename column with foreign key constraint.

### DIFF
--- a/libraries/relation.lib.php
+++ b/libraries/relation.lib.php
@@ -1530,4 +1530,76 @@ function PMA_REL_createPage($newpage, $cfgRelation, $db)
         isset($GLOBALS['controllink']) ? $GLOBALS['controllink'] : ''
     );
 }
+
+/**
+ * Get child table references for a table column.
+ *
+ * @param string $db     name of master table db.
+ * @param string $table  name of master table.
+ * @param string $column name of master table column.
+ *
+ * @return array $child_references
+ */
+function PMA_getChildReferences($db, $table, $column)
+{
+    $child_references = array();
+    $i=0;
+    $rel_query = 'SELECT `column_name`,'
+                . ' `table_name`,'
+                . '`table_schema`'
+                . ' FROM `information_schema`.`key_column_usage`'
+                . ' WHERE `referenced_column_name` = \''
+                . PMA_Util::sqlAddSlashes($column) . '\''
+                . ' AND `referenced_table_name` = \''
+                . PMA_Util::sqlAddSlashes($table) . '\''
+                . ' AND `referenced_table_schema` = \''
+                . PMA_Util::sqlAddSlashes($db) . '\'';
+
+    $result = $GLOBALS['dbi']->tryQuery($rel_query, $GLOBALS['controllink']);
+    if ($result == true) {
+        while(($row = $GLOBALS['dbi']->fetchAssoc($result))) {
+            $child_references[$i++] = $row;
+        }
+    }
+    return $child_references;
+}
+
+/**
+ * Check child table references and foreign key for a table column.
+ *
+ * @param string $db     name of master table db.
+ * @param string $table  name of master table.
+ * @param string $column name of master table column.
+ *
+ * @return array $column_status telling about references if foreign key.
+ */
+function PMA_checkChildForeignReferences($db, $table, $column)
+{
+    $column_status = array();
+    $column_status['isEditable'] = false;
+    $column_status['isReferenced'] = false;
+    $column_status['isForeignKey'] = false;
+    $column_status['references'] = array();
+    $foreigners = PMA_getForeigners($db, $table, $column);
+    $child_references = PMA_getChildReferences($db, $table, $column);
+
+    if (sizeof($child_references, 0) > 0 || sizeof($foreigners[$column], 0) > 0) {
+        if (sizeof($child_references, 0) > 0) {
+            $column_status['isReferenced'] = true;
+            foreach ($child_references as $row => $columns) {
+                array_push($column_status['references'],
+                    PMA_Util::backquote($columns['table_schema'])
+                    . '.' . PMA_Util::backquote($columns['table_name']));
+            }
+        }
+
+        if (sizeof($foreigners[$column], 0) > 0) {
+            $column_status['isForeignKey'] = true;
+        }
+    } else {
+        $column_status['isEditable'] = true;
+    }
+
+    return $column_status;
+}
 ?>

--- a/libraries/tbl_columns_definition_form.inc.php
+++ b/libraries/tbl_columns_definition_form.inc.php
@@ -79,6 +79,7 @@ if (isset($_REQUEST['submit_num_fields'])) {
     //if adding new fields, set regenerate to keep the original values
     $regenerate = 1;
 }
+
 for ($columnNumber = 0; $columnNumber < $num_fields; $columnNumber++) {
     if (! empty($regenerate)) {
         list($columnMeta, $submit_length, $submit_attribute,
@@ -133,6 +134,10 @@ for ($columnNumber = 0; $columnNumber < $num_fields; $columnNumber++) {
             $columnMeta, $length, $_form_params, $columnNumber
         );
     }
+    // Variable tell if current column is bound in a foreign key constraint or not.
+    $columnMeta['column_status'] = PMA_checkChildForeignReferences($_form_params['db'],
+        $_form_params['table'],
+        isset($columnMeta) ? $columnMeta['Field'] : null);
 
     $content_cells[$columnNumber] = PMA_getHtmlForColumnAttributes(
         $columnNumber, isset($columnMeta) ? $columnMeta : null, strtoupper($type),
@@ -148,7 +153,6 @@ for ($columnNumber = 0; $columnNumber < $num_fields; $columnNumber++) {
         $mime_map
     );
 } // end for
-
 $html = PMA_getHtmlForTableCreateOrAddField(
     $action, $_form_params, $content_cells, $header_cells
 );

--- a/libraries/tbl_columns_definition_form.lib.php
+++ b/libraries/tbl_columns_definition_form.lib.php
@@ -562,9 +562,20 @@ function PMA_getColumnMetaForDefault($columnMeta, $isDefault)
  */
 function PMA_getHtmlForColumnName($columnNumber, $ci, $ci_offset, $columnMeta)
 {
-    $html = '<input id="field_' . $columnNumber . '_' . ($ci - $ci_offset)
+    $title = '';
+    $title .= (isset($columnMeta['column_status'])
+        && $columnMeta['column_status']['isReferenced']) ? __('Referenced by ')
+        . implode(",", $columnMeta['column_status']['references']) . "." : '';
+    $title .= (!empty($title) && isset($columnMeta['column_status'])
+        && $columnMeta['column_status']['isForeignKey']) ? "\n" : '';
+    $title .= (isset($columnMeta['column_status'])
+        && $columnMeta['column_status']['isForeignKey']) ? __('Is a Foreign Key.') : '';
+    $title .= (empty($title)) ? __('Column') : '';
+    $html = '<input' . (isset($columnMeta['column_status'])
+        && !$columnMeta['column_status']['isEditable']?' disabled="disabled" ':' ')
+        . 'id="field_' . $columnNumber . '_' . ($ci - $ci_offset)
         . '"' . ' type="text" name="field_name[' . $columnNumber . ']"'
-        . ' maxlength="64" class="textfield" title="' . __('Column') . '"'
+        . ' maxlength="64" class="textfield" title="' . $title . '"'
         . ' size="10"'
         . ' value="'
         . (isset($columnMeta['Field'])
@@ -584,11 +595,14 @@ function PMA_getHtmlForColumnName($columnNumber, $ci, $ci_offset, $columnMeta)
  *
  * @return string
  */
-function PMA_getHtmlForColumnType($columnNumber, $ci, $ci_offset, $type_upper)
+function PMA_getHtmlForColumnType($columnNumber, $ci, $ci_offset,
+    $type_upper, $columnMeta)
 {
     $select_id = 'field_' . $columnNumber . '_' . ($ci - $ci_offset);
-    $html = '<select class="column_type" name="field_type[' .
-        $columnNumber . ']"' . ' id="' . $select_id . '">';
+    $html = '<select' . (isset($columnMeta['column_status'])
+        && !$columnMeta['column_status']['isEditable']?' disabled="disabled" ':' ')
+        . 'class="column_type" name="field_type['
+        . $columnNumber . ']"' . ' id="' . $select_id . '">';
     $html .= PMA_Util::getSupportedDatatypes(true, $type_upper);
     $html .= '    </select>';
 
@@ -1155,7 +1169,7 @@ function PMA_getHtmlForColumnAttributes($columnNumber, $columnMeta, $type_upper,
 
     // column type
     $content_cell[$ci] = PMA_getHtmlForColumnType(
-        $columnNumber, $ci, $ci_offset, $type_upper
+        $columnNumber, $ci, $ci_offset, $type_upper, isset($columnMeta) ? $columnMeta : null
     );
     $ci++;
 

--- a/test/libraries/PMA_tbl_columns_definition_form_test.php
+++ b/test/libraries/PMA_tbl_columns_definition_form_test.php
@@ -608,7 +608,9 @@ class PMA_TblColumnsDefinitionFormTest extends PHPUnit_Framework_TestCase
     public function testGetHtmlForColumnName()
     {
         $result = PMA_getHtmlForColumnName(
-            2, 4, 4, array('Field' => "fieldname")
+            2, 4, 4, array('Field' => "fieldname",
+            'column_status' => array('isReferenced' => false,
+            'isForeignKey' => false, 'isEditable' => true))
         );
 
         $this->assertTag(
@@ -630,7 +632,8 @@ class PMA_TblColumnsDefinitionFormTest extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['PMA_Types'] = new PMA_Types;
         $result = PMA_getHtmlForColumnType(
-            1, 4, 3, false
+            1, 4, 3, false, array('column_status' => array('isReferenced' => false,
+            'isForeignKey' => false, 'isEditable' => true))
         );
 
         $this->assertTag(


### PR DESCRIPTION
Feature Request: #1329 Can't rename column with foreign key constraint.
https://sourceforge.net/p/phpmyadmin/feature-requests/1329/

1) When a column is referenced by other:
![referenced](https://f.cloud.github.com/assets/6863616/2492929/8353a6b4-b268-11e3-9338-e9d2b97889b4.png)

2) When a column is a foreign key:
![foreign_key](https://f.cloud.github.com/assets/6863616/2492930/97a7d770-b268-11e3-993b-7de027a47d92.png)

3) When its both:
![both](https://f.cloud.github.com/assets/6863616/2492931/a533361e-b268-11e3-98bd-61264cab0c49.png)

Signed-off-by: Ashutosh Dhundhara ashutoshdhundhara@yahoo.com
