### PR TITLE
Allow TCPDF to be removed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ phpMyAdmin - ChangeLog
 4.1.12.0 (not yet released)
 - bug #4334 Add event : datepicker won't open
 - bug #4338 Fix missing value error while executing SQL query
+- TCPDF library is now optional dependency
 
 4.1.11.0 (2014-03-23)
 - bug #4335 reCaptcha problem (4.1.10 regression) 

--- a/libraries/plugins/export/ExportPdf.class.php
+++ b/libraries/plugins/export/ExportPdf.class.php
@@ -10,6 +10,14 @@ if (! defined('PHPMYADMIN')) {
     exit;
 }
 
+/**
+ * Skip the plugin if TCPDF is not available.
+ */
+if (! file_exists(TCPDF_INC)) {
+    $GLOBALS['skip_import'] = true;
+    return;
+}
+
 /* Get the export interface */
 require_once 'libraries/plugins/ExportPlugin.class.php';
 /* Get the PMA_ExportPdf class */

--- a/libraries/schema/Pdf_Relation_Schema.class.php
+++ b/libraries/schema/Pdf_Relation_Schema.class.php
@@ -10,6 +10,14 @@ if (! defined('PHPMYADMIN')) {
 }
 
 /**
+ * Skip the plugin if TCPDF is not available.
+ */
+if (! file_exists(TCPDF_INC)) {
+    $GLOBALS['skip_import'] = true;
+    return;
+}
+
+/**
  * block attempts to directly run this script
  */
 if (getcwd() == dirname(__FILE__)) {

--- a/libraries/schema/User_Schema.class.php
+++ b/libraries/schema/User_Schema.class.php
@@ -419,12 +419,19 @@ class PMA_User_Schema
             $htmlString .= PMA_Util::getImage('b_views.png');
         }
 
+        /*
+         * TODO: This list should be generated dynamically based on list of
+         * available plugins.
+         */
         $htmlString .= __('Display relational schema')
             . ':'
             . '</legend>'
-            . '<select name="export_type" id="export_type">'
-            . '<option value="pdf" selected="selected">PDF</option>'
-            . '<option value="svg">SVG</option>'
+            . '<select name="export_type" id="export_type">';
+        if (file_exists(TCPDF_INC)) {
+            $htmlString .= '<option value="pdf" selected="selected">PDF</option>';
+        }
+        $htmlString .=
+            '<option value="svg">SVG</option>'
             . '<option value="dia">DIA</option>'
             . '<option value="eps">EPS</option>'
             . '</select>'

--- a/libraries/schema/User_Schema.class.php
+++ b/libraries/schema/User_Schema.class.php
@@ -663,7 +663,15 @@ class PMA_User_Schema
                 __('File doesn\'t exist')
             );
         }
+        $GLOBALS['skip_import'] = false;
         include $filename;
+        if ( $GLOBALS['skip_import']) {
+            PMA_Export_Relation_Schema::dieSchema(
+                $_POST['chpage'],
+                $export_type,
+                __('Plugin is disabled')
+            );
+        }
         $class_name = 'PMA_' . $path . '_Relation_Schema';
         $obj_schema = new $class_name();
         $obj_schema->showOutput();


### PR DESCRIPTION
We currently require TCPDF to be present, but in most cases this is
feature which users do not need and thus can reduce size of installed
phpMyAdmin.

Also this is helpful for Linux distributions as they can provide soft
dependency on tcpdf package.

Signed-off-by: Michal Čihař michal@cihar.com
