### PR TITLE
Update transformations.lib.php

### DIFF
--- a/libraries/transformations.lib.php
+++ b/libraries/transformations.lib.php
@@ -107,6 +107,8 @@ function PMA_getAvailableMIMEtypes()
     sort($filestack);
 
     foreach ($filestack as $file) {
+        if(!preg_match('|._*|', $file)){
+            // File is a OSX-generated ._ file, ignore it.
         if (preg_match('|^.*_.*_.*\.class\.php$|', $file)) {
             // File contains transformation functions.
             $parts = explode('_', str_replace('.class.php', '', $file));
@@ -124,6 +126,7 @@ function PMA_getAvailableMIMEtypes()
                 $stack['mimetype'][$mimetype] = $mimetype;
                 $stack['empty_mimetype'][$mimetype] = $mimetype;
             }
+        }
         }
     }
 


### PR DESCRIPTION
Updated PMA_getAvailableMIMEtypes to ignore OSX-generated ._ files.  Issue documented at: http://stackoverflow.com/questions/22699057/phpmyadmin-configuration-storage-error/22716021.

Signed-off-by: Eric Johnson eric.johnson.x@gmail.com
