### PR TITLE
Actually display sent traffic per hour

### DIFF
--- a/libraries/server_status.lib.php
+++ b/libraries/server_status.lib.php
@@ -167,7 +167,7 @@ function PMA_getHtmlForServerStateTraffic($ServerStatusData)
         )
     );
     $retval .= '</td>';
-    $retval .= '<td class="value"><?php echo';
+    $retval .= '<td class="value">';
     $retval .= implode(
         ' ',
         PMA_Util::formatByteDown(


### PR DESCRIPTION
Bytes sent was commented out when viewing the element. This should remove the cause of said commenting.

Signed-off-by: Daniel Rix drainx1@live.com
