### PR TITLE
Moved "Favorite tables" from session to browser-based localStorage.

### DIFF
--- a/index.php
+++ b/index.php
@@ -117,6 +117,8 @@ if ($server > 0) {
 }
 
 echo '<div id="maincontainer">' . "\n";
+// Anchor for favorite tables synchronization.
+echo PMA_RecentFavoriteTable::getInstance('favorite')->_getHtmlSyncFavoriteTables();
 echo '<div id="main_pane_left">';
 if ($server > 0 || count($cfg['Servers']) > 1
 ) {

--- a/js/db_structure.js
+++ b/js/db_structure.js
@@ -413,6 +413,8 @@ AJAX.registerOnload('db_structure.js', function () {
                             'a',
                             $('#' + anchor_id).attr("title")
                         );
+                        // Update localStorage.
+                        window.localStorage['favorite_tables'] = data.favorite_tables;
                     } else {
                         PMA_ajaxShowMessage(data.message);
                     }
@@ -422,5 +424,4 @@ AJAX.registerOnload('db_structure.js', function () {
             }
         );
     });
-
 }); // end $()

--- a/js/functions.js
+++ b/js/functions.js
@@ -3256,6 +3256,7 @@ AJAX.registerTeardown('functions.js', function () {
     $('#pageselector').die('change');
     $('a.formLinkSubmit').die('click');
     $('#update_recent_tables').unbind('ready');
+    $('#sync_favorite_tables').unbind('ready');
 });
 /**
  * Vertical pointer
@@ -3360,6 +3361,23 @@ AJAX.registerOnload('functions.js', function () {
         );
     }
 
+    // Sync favorite tables from localStorage to pmadb.
+    if ($('#sync_favorite_tables').length) {
+        $.ajax({
+            url: $('#sync_favorite_tables').attr("href"),
+            cache: false,
+            type: 'POST',
+            data: {
+                favorite_tables: (window.localStorage['favorite_tables'] !== '')
+                    ? window.localStorage['favorite_tables']
+                    : ''
+            },
+            success: function (data) {
+                window.localStorage['favorite_tables'] = data.favorite_tables;
+                $('#favoriteTable').html(data.options);
+            }
+        });
+    }
 }); // end of $()
 
 

--- a/libraries/RecentFavoriteTable.class.php
+++ b/libraries/RecentFavoriteTable.class.php
@@ -283,5 +283,27 @@ class PMA_RecentFavoriteTable
         }
         return true;
     }
+
+    /**
+     * Generate Html for sync Favorite tables anchor. (from localStorage to pmadb)
+     *
+     * @return string
+     */
+    public function _getHtmlSyncFavoriteTables()
+    {
+        $retval = '';
+        $server_id = $GLOBALS['server'];
+        // Not to show this once list is synchronized.
+        $is_synced = isset($_SESSION['tmpval']['favorites_synced'][$server_id]) ?
+            true : false;
+        if (!$is_synced) {
+            $params  = array('ajax_request' => true, 'favorite_table' => true,
+                'sync_favorite_tables' => true);
+            $url     = 'db_structure.php' . PMA_URL_getCommon($params);
+            $retval  = '<a class="hide" id="sync_favorite_tables"';
+            $retval .= ' href="' . $url . '"></a>';
+        }
+        return $retval;
+    }
 }
 ?>


### PR DESCRIPTION
After this commit:
- "Favorite tables" are no longer stored in session but in browser-based localStorage.
- If "pmadb" is available, then browser's localStorage will be updated with "Favorite tables" from pmadb or if pmadb is empty, then it will be updated with localStorage's entries.
- If "pmadb" is not available, then "Favorite tables" will be loaded from localStorage and new tables will be added to localStorage only.

Signed-off-by: Ashutosh Dhundhara ashutoshdhundhara@yahoo.com
