### PR TITLE
Browser local storage support for Favorite tables feature.

### DIFF
--- a/db_structure.php
+++ b/db_structure.php
@@ -18,11 +18,38 @@ require_once 'libraries/structure.lib.php';
 
 // Add/Remove favorite tables using Ajax request.
 if ($GLOBALS['is_ajax_request'] && ! empty($_REQUEST['favorite_table'])) {
+    $fav_instance = PMA_RecentFavoriteTable::getInstance('favorite');
+    $favorite_tables = json_decode($_REQUEST['favorite_tables'], true);
+    // Required to keep each user's preferences seperate.
+    $user = sha1($GLOBALS['cfg']['Server']['user']);
+    // Request for Synchronization of favorite tables.
+    if (isset($_REQUEST['sync_favorite_tables'])) {
+        if (empty($fav_instance->tables)
+            && isset($favorite_tables[$user])) {
+            foreach ($favorite_tables[$user] as $key => $value) {
+                $fav_instance->add($value['db'], $value['table']);
+            }
+        }
+        $favorite_tables[$user] = $fav_instance->tables;
+
+        $ajax_response = PMA_Response::getInstance();
+        $ajax_response->addJSON(
+            'favorite_tables',
+            json_encode($favorite_tables)
+        );
+        $ajax_response->addJSON(
+            'options',
+            $fav_instance->getHtmlSelectOption()
+        );
+        $server_id = $GLOBALS['server'];
+        // Set flag when localStorage and pmadb(if present) are in sync.
+        $_SESSION['tmpval']['favorites_synced'][$server_id] = true;
+        exit;
+    }
     global $db;
     $changes = true;
     $msg = '';
     $titles = PMA_Util::buildActionTitles();
-    $fav_instance = PMA_RecentFavoriteTable::getInstance('favorite');
     $favorite_table = $_REQUEST['favorite_table'];
     $already_favorite = PMA_checkFavoriteTable($db, $favorite_table);
 
@@ -48,6 +75,7 @@ if ($GLOBALS['is_ajax_request'] && ! empty($_REQUEST['favorite_table'])) {
 
     }
 
+    $favorite_tables[$user] = $fav_instance->tables;
     $ajax_response = PMA_Response::getInstance();
     $ajax_response->addJSON(
         'changes',
@@ -55,8 +83,16 @@ if ($GLOBALS['is_ajax_request'] && ! empty($_REQUEST['favorite_table'])) {
     );
     if ($changes) {
         $ajax_response->addJSON(
+            'user',
+            $user
+        );
+        $ajax_response->addJSON(
+            'favorite_tables',
+            json_encode($favorite_tables)
+        );
+        $ajax_response->addJSON(
             'options',
-            PMA_RecentFavoriteTable::getInstance('favorite')->getHtmlSelectOption()
+            $fav_instance->getHtmlSelectOption()
         );
         $ajax_response->addJSON(
             'anchor',

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -1929,8 +1929,13 @@ Favorite Tables feature is very much similar to Recent Tables feature.
 It allows you to add a shortcut for the frequently used tables of any
 database in the navigation panel . You can easily navigate to any table
 in the list by simply choosing it from the list. These tables are stored
-temporarily in your session if you have not configured your
-`phpMyAdmin Configuration Storage`. Otherwise these entries are permanent.
+in your browser's local storage if you have not configured your
+`phpMyAdmin Configuration Storage`. Otherwise these entries are stored in
+`phpMyAdmin Configuration Storage`.
+
+IMPORTANT: In absence of `phpMyAdmin Configuration Storage`, your Favorite
+tables may be different in different browsers based on your different
+selections in them.
 
 To add a table to Favorite list simply click on the `Gray` star in front
 of a table name in the list of tables of a Database and wait until it

--- a/index.php
+++ b/index.php
@@ -117,6 +117,8 @@ if ($server > 0) {
 }
 
 echo '<div id="maincontainer">' . "\n";
+// Anchor for favorite tables synchronization.
+echo PMA_RecentFavoriteTable::getInstance('favorite')->_getHtmlSyncFavoriteTables();
 echo '<div id="main_pane_left">';
 if ($server > 0 || count($cfg['Servers']) > 1
 ) {

--- a/js/db_structure.js
+++ b/js/db_structure.js
@@ -401,26 +401,34 @@ AJAX.registerOnload('db_structure.js', function () {
     $(".favorite_table_anchor").live("click", function (event) {
         event.preventDefault();
         var anchor_id = $(this).attr("id");
-        $.get(
-            $(this).attr('href'),
-            function (data) {
-                if (data.success === true) {
-                    if (data.changes) {
-                        $('#favoriteTable').html(data.options);
-                        $('#' + anchor_id).parent().html(data.anchor);
-                        PMA_tooltip(
-                            $('#' + anchor_id),
-                            'a',
-                            $('#' + anchor_id).attr("title")
-                        );
-                    } else {
-                        PMA_ajaxShowMessage(data.message);
+        $.ajax({
+            url: $(this).attr('href'),
+            cache: false,
+            type: 'POST',
+            data: {
+                favorite_tables: (window.localStorage['favorite_tables']
+                    !== undefined)
+                    ? window.localStorage['favorite_tables']
+                    : ''
+            },
+            success: function (data) {
+                if (data.changes) {
+                    $('#favoriteTable').html(data.options);
+                    $('#' + anchor_id).parent().html(data.anchor);
+                    PMA_tooltip(
+                        $('#' + anchor_id),
+                        'a',
+                        $('#' + anchor_id).attr("title")
+                    );
+                    // Update localStorage.
+                    if (window.localStorage !== undefined) {
+                        window.localStorage['favorite_tables']
+                            = data.favorite_tables;
                     }
                 } else {
                     PMA_ajaxShowMessage(data.message);
                 }
             }
-        );
+        });
     });
-
 }); // end $()

--- a/js/functions.js
+++ b/js/functions.js
@@ -3256,6 +3256,7 @@ AJAX.registerTeardown('functions.js', function () {
     $('#pageselector').die('change');
     $('a.formLinkSubmit').die('click');
     $('#update_recent_tables').unbind('ready');
+    $('#sync_favorite_tables').unbind('ready');
 });
 /**
  * Vertical pointer
@@ -3360,6 +3361,28 @@ AJAX.registerOnload('functions.js', function () {
         );
     }
 
+    // Sync favorite tables from localStorage to pmadb.
+    if ($('#sync_favorite_tables').length) {
+        $.ajax({
+            url: $('#sync_favorite_tables').attr("href"),
+            cache: false,
+            type: 'POST',
+            data: {
+                favorite_tables: (window.localStorage['favorite_tables']
+                    !== undefined)
+                    ? window.localStorage['favorite_tables']
+                    : ''
+            },
+            success: function (data) {
+                // Update localStorage.
+                if (window.localStorage !== undefined) {
+                    window.localStorage['favorite_tables']
+                        = data.favorite_tables;
+                }
+                $('#favoriteTable').html(data.options);
+            }
+        });
+    }
 }); // end of $()
 
 

--- a/libraries/RecentFavoriteTable.class.php
+++ b/libraries/RecentFavoriteTable.class.php
@@ -283,5 +283,27 @@ class PMA_RecentFavoriteTable
         }
         return true;
     }
+
+    /**
+     * Generate Html for sync Favorite tables anchor. (from localStorage to pmadb)
+     *
+     * @return string
+     */
+    public function _getHtmlSyncFavoriteTables()
+    {
+        $retval = '';
+        $server_id = $GLOBALS['server'];
+        // Not to show this once list is synchronized.
+        $is_synced = isset($_SESSION['tmpval']['favorites_synced'][$server_id]) ?
+            true : false;
+        if (!$is_synced) {
+            $params  = array('ajax_request' => true, 'favorite_table' => true,
+                'sync_favorite_tables' => true);
+            $url     = 'db_structure.php' . PMA_URL_getCommon($params);
+            $retval  = '<a class="hide" id="sync_favorite_tables"';
+            $retval .= ' href="' . $url . '"></a>';
+        }
+        return $retval;
+    }
 }
 ?>


### PR DESCRIPTION
After this commit:
- If "pmadb" is available, then browser's localStorage will be updated with "Favorite tables" from pmadb or if pmadb is empty, then it will be updated with localStorage's entries.
- If "pmadb" is not available, then "Favorite tables" will be loaded from localStorage and new tables will be added to localStorage only.

Signed-off-by: Ashutosh Dhundhara ashutoshdhundhara@yahoo.com
