### PR TITLE
Bug fix: Incorrect messages displayed in "Export settings" section.

### DIFF
--- a/prefs_manage.php
+++ b/prefs_manage.php
@@ -313,14 +313,14 @@ echo '</div>'
     . '<div id="opts_export_local_storage" class="prefsmanage_opts disabled">'
     . '<span class="localStorage-supported">'
     . __('Settings will be saved in your browser\'s local storage.')
-    . '<span class="localStorage-exists">'
-    . '<br /><b>' . __('Existing settings will be overwritten!') . '</b>'
+    . '<div class="localStorage-exists">'
+    . '<b>' . __('Existing settings will be overwritten!') . '</b>'
+    . '</div>'
     . '</span>'
-    . '</span>'
-    . '<div class="localStorage-unsupported">'
-    . PMA_Message::notice(
-        __('This feature is not supported by your web browser')
-    )->display();
+    . '<div class="localStorage-unsupported">';
+PMA_Message::notice(
+    __('This feature is not supported by your web browser')
+)->display();
 ?>
                     </div>
                 </div>


### PR DESCRIPTION
Incorrect messages are shown in "Export settings" section:
- "Existing settings will be overwritten" displayed even if the browser's localStorage doesn't contains any previously saved settings.
  ![existing_settings](https://cloud.githubusercontent.com/assets/6863616/2615233/bfd01270-bbf6-11e3-815f-b43580906d59.png)
- "This feature is not supported by your web browser" is displayed even if browser supports localStorage.
  ![not_supported](https://cloud.githubusercontent.com/assets/6863616/2615240/e93cbf46-bbf6-11e3-8664-fe1c229b3710.png)

Signed-Off-By: Ashutosh Dhundhara ashutoshdhundhara@yahoo.com
