### PR TITLE
Fix undefined max_input_vars.

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -4117,6 +4117,9 @@ function checkNumberOfFields() {
     if (typeof maxInputVars === 'undefined') {
         return false;
     }
+    if (false === maxInputVars) {
+        return false;
+    }
     $('form').each(function() {
         var nbInputs = $(this).find(':input').length;
         if (nbInputs > maxInputVars) {

--- a/js/messages.php
+++ b/js/messages.php
@@ -424,7 +424,9 @@ echo "var pmaversion = '" . PMA_VERSION . "';\n";
 echo "var mysql_doc_template = '" . PMA_Util::getMySQLDocuURL('%s') . "';\n";
 
 //Max input vars allowed by PHP.
-echo 'var maxInputVars = ' . ini_get('max_input_vars') . ';';
+$maxInputVars = ini_get('max_input_vars');
+echo 'var maxInputVars = ' . (false === $maxInputVars ? 'false' : $maxInputVars)
+    . ';';
 
 echo "if ($.datepicker) {\n";
 /* l10n: Display text for calendar close link */


### PR DESCRIPTION
max_input_vars was defined in PHP 5.3.9. So if the variable is not defined, the warning is not displayed.
