### PR TITLE
New patch for feature request 1518

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -17,6 +17,10 @@ var AJAX = {
      */
     xhr: null,
     /**
+     * @var bool, tells if user input was altered before this event was called
+     */
+    isInputAltered: false,
+    /**
      * @var function Callback to execute after a successful request
      *               Used by PMA_commonFunctions from common.js
      */
@@ -129,6 +133,19 @@ var AJAX = {
         }
     },
     /**
+     * Registers a keyup function when changes are made in input field
+     * @param event for the trigged function
+     * 
+     * @return void
+     */
+    inputAltered: function(event) {
+        if(event.target.value.length !== 0) {
+            AJAX.isInputAltered = true;
+        } else {
+            AJAX.isInputAltered = false;
+        }
+    },
+    /**
      * Event handler for clicks on links and form submissions
      *
      * @param object e Event data
@@ -160,6 +177,16 @@ var AJAX = {
             event.preventDefault();
             event.stopImmediatePropagation();
         }
+        
+        //sometime we accidently click on a url,refresh button or back button
+        //operation to confirm if user want to leave page in such cases
+        //trigger confirm dialog
+        if (event.type === 'click' && AJAX.isInputAltered && confirm(PMA_messages['strConfirmNavigation']) === false) {
+            return false;
+        }
+        //reset the flag for confirm navigation
+        AJAX.isInputAltered = false;
+        
         if (AJAX.active === true) {
             // Cancel the old request if abortable, when the user requests
             // something else. Otherwise silently bail out, as there is already
@@ -855,6 +882,12 @@ $(function () {
  */
 $('a').live('click', AJAX.requestHandler);
 $('form').live('submit', AJAX.requestHandler);
+
+/**
+ * Attach event listener to events when user modify visible
+ * Input fields to make changes in forms
+ */
+$('#page_content').live("keyup", "input[type='text']:visible", AJAX.inputAltered);
 
 /**
  * Gracefully handle fatal server errors

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -135,7 +135,7 @@ var AJAX = {
     /**
      * Registers a keyup function when changes are made in input field
      * @param event for the trigged function
-     * 
+     *
      * @return void
      */
     inputAltered: function(event) {

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -17,9 +17,9 @@ var AJAX = {
      */
     xhr: null,
     /**
-     * @var bool, tells if user input was altered before this event was called
+     * @var object array, list of altered targets
      */
-    isInputAltered: false,
+    alteredTargets: [],
     /**
      * @var function Callback to execute after a successful request
      *               Used by PMA_commonFunctions from common.js
@@ -139,10 +139,14 @@ var AJAX = {
      * @return void
      */
     inputAltered: function(event) {
-        if(event.target.value.length !== 0) {
-            AJAX.isInputAltered = true;
-        } else {
-            AJAX.isInputAltered = false;
+        var i;
+        for(i=0; i < AJAX.alteredTargets.length; i++) {
+            if(AJAX.alteredTargets[i] == event.target)
+                break;
+        }
+
+        if(i == AJAX.alteredTargets.length) {
+           AJAX.alteredTargets[i] = event.target; 
         }
     },
     /**
@@ -181,11 +185,18 @@ var AJAX = {
         //sometime we accidently click on a url,refresh button or back button
         //operation to confirm if user want to leave page in such cases
         //trigger confirm dialog
-        if (event.type === 'click' && AJAX.isInputAltered && confirm(PMA_messages['strConfirmNavigation']) === false) {
+        var isInputAltered = false;
+        for (var i = 0; i < AJAX.alteredTargets.length; i++) {
+            if(AJAX.alteredTargets[i].value.length != 0) {
+                isInputAltered = true;
+                break;
+            }
+        };
+        if (event.type === 'click' && isInputAltered && confirm(PMA_messages['strConfirmNavigation']) === false) {
             return false;
         }
-        //reset the flag for confirm navigation
-        AJAX.isInputAltered = false;
+        //reset
+        AJAX.alteredTargets.length = 0;
         
         if (AJAX.active === true) {
             // Cancel the old request if abortable, when the user requests
@@ -326,8 +337,8 @@ var AJAX = {
                     var source = data._selflink.split('?')[0];
                     //Check for faulty links
                     if (source == "import.php") {
-                    	var replacement = "tbl_sql.php";
-                    	data._selflink = data._selflink.replace(source,replacement);
+                        var replacement = "tbl_sql.php";
+                        data._selflink = data._selflink.replace(source,replacement);
                     }
                     $('#selflink > a').attr('href', data._selflink);
                 }

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -146,7 +146,7 @@ var AJAX = {
         }
 
         if(i == AJAX.alteredTargets.length) {
-           AJAX.alteredTargets[i] = event.target; 
+           AJAX.alteredTargets[i] = event.target;
         }
     },
     /**


### PR DESCRIPTION
There were certain problems with previous patch I sent for this request. It was working against expected behaviors in certain operations:
with this new patch: every reported issues have been fixed, **it works well with** `import/export`, `operations section`, `create table`, I have changed the algo, **confirm navigation dialog is now triggered if user has made changes to input values, not if those input values just have some content**

**it takes care if upon user action, input value is ` `i.e`empty`, no dialog is triggered**

Signed-off-by: A V Minhaz minhazav@gmail.com
