### PR TITLE
phpmyadmin refuses to show tables with enums containing special data

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,6 +51,7 @@ phpMyAdmin - ChangeLog
 - bug #4337 "More" in Actions area doesn't collapse to fit available space
 - bug #4375 Group two DB, one's name is the prefix of the other one
 - bug #4070 Confusing database/table grouping
+- bug #4080 phpmyadmin refuses to show tables with enums containing special data
 
 4.1.14.0 (2014-04-26)
 - bug #4365 Creating bookmark with multiple queries not working

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -3028,7 +3028,9 @@ class PMA_Util
         $displayed_type = htmlspecialchars($printtype);
         if (strlen($printtype) > $GLOBALS['cfg']['LimitChars']) {
             $displayed_type  = '<abbr title="' . $printtype . '">';
-            $displayed_type .= mb_substr($printtype, 0, $GLOBALS['cfg']['LimitChars']);
+            $displayed_type .= $GLOBALS['PMA_String']->substr(
+                $printtype, 0, $GLOBALS['cfg']['LimitChars']
+            );
             $displayed_type .= '</abbr>';
         }
 

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -3028,7 +3028,7 @@ class PMA_Util
         $displayed_type = htmlspecialchars($printtype);
         if (strlen($printtype) > $GLOBALS['cfg']['LimitChars']) {
             $displayed_type  = '<abbr title="' . $printtype . '">';
-            $displayed_type .= substr($printtype, 0, $GLOBALS['cfg']['LimitChars']);
+            $displayed_type .= mb_substr($printtype, 0, $GLOBALS['cfg']['LimitChars']);
             $displayed_type .= '</abbr>';
         }
 


### PR DESCRIPTION
Fix bug #4380 (See: https://sourceforge.net/p/phpmyadmin/bugs/4380/)

I used the multi-bytes substr function instead of standard substr function.
As 4.2 is near to be released, this fix is from master. If the same is needed for 4.1, please, tell me.
