### PR TITLE
phpmyadmin refuses to show tables with enums containing special data

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -54,6 +54,7 @@ phpMyAdmin - ChangeLog
 - bug #4375 Group two DB, one's name is the prefix of the other one
 - bug #4070 Confusing database/table grouping
 - bug #4366 Creating Index doesn't update index-list
+- bug #4080 phpmyadmin refuses to show tables with enums containing special data
 
 4.1.14.0 (2014-04-26)
 - bug #4365 Creating bookmark with multiple queries not working

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -3028,7 +3028,9 @@ class PMA_Util
         $displayed_type = htmlspecialchars($printtype);
         if (strlen($printtype) > $GLOBALS['cfg']['LimitChars']) {
             $displayed_type  = '<abbr title="' . $printtype . '">';
-            $displayed_type .= mb_substr($printtype, 0, $GLOBALS['cfg']['LimitChars']);
+            $displayed_type .= $GLOBALS['PMA_String']->substr(
+                $printtype, 0, $GLOBALS['cfg']['LimitChars']
+            );
             $displayed_type .= '</abbr>';
         }
 

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -3028,7 +3028,7 @@ class PMA_Util
         $displayed_type = htmlspecialchars($printtype);
         if (strlen($printtype) > $GLOBALS['cfg']['LimitChars']) {
             $displayed_type  = '<abbr title="' . $printtype . '">';
-            $displayed_type .= substr($printtype, 0, $GLOBALS['cfg']['LimitChars']);
+            $displayed_type .= mb_substr($printtype, 0, $GLOBALS['cfg']['LimitChars']);
             $displayed_type .= '</abbr>';
         }
 


### PR DESCRIPTION
Same PR than https://github.com/phpmyadmin/phpmyadmin/pull/1158 but from QA_4_2.
