### PR TITLE
Set $username_length & $hostname_length (server_privileges.lib.php) to higher values

### DIFF
--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -1514,8 +1514,8 @@ function PMA_getHtmlForLoginInformationFields($mode = 'new')
 function PMA_getUsernameAndHostnameLength()
 {
     $fields_info = $GLOBALS['dbi']->getColumns('mysql', 'user', null, true);
-    $username_length = 16;
-    $hostname_length = 41;
+    $username_length = 80;
+    $hostname_length = 60;
     foreach ($fields_info as $val) {
         if ($val['Field'] == 'User') {
             strtok($val['Type'], '()');


### PR DESCRIPTION
The hard-coded $username_length and $hostname_lenght variables aren't set high enough, resulting in duplicate/flawed entries in 'mysql.user' and 'mysql.db' when creating users and table permissions where the name is right at the currently allowed limit.

I don't know if the max. values are set in stone or if it differs from release to release or if it also depends on the fork (MySQL, Percona, MariaDB...).

An alternative way to solve it would be to query:
SELECT COLUMN_NAME, CHARACTER_MAXIMUM_LENGTH 
FROM information_schema.columns
WHERE table_schema = 'mysql' AND table_name = 'user' AND COLUMN_NAME = 'Host' OR table_schema = 'mysql' AND table_name = 'user' AND COLUMN_NAME = 'User'

Signed-off-by: Jacob T. L. tbk@jjtc.dk
