### PR TITLE
Smaller number field

### DIFF
--- a/libraries/display_create_table.lib.php
+++ b/libraries/display_create_table.lib.php
@@ -63,7 +63,7 @@ function PMA_getHtmlForCreateTable($db)
     $html .= ' </div>';
     $html .= '  <div class="formelement">';
     $html .= __('Number of columns') . ":";
-    $html .= '  <input type="number" min="1" name="num_fields" size="2" value="4" required="required" />';
+    $html .= '  <input type="number" min="1" name="num_fields" value="4" required="required" />';
     $html .= ' </div>';
     $html .= '  <div class="clearfloat"></div>';
     $html .= '</fieldset>';

--- a/libraries/index.lib.php
+++ b/libraries/index.lib.php
@@ -32,7 +32,7 @@ function PMA_getHtmlForDisplayIndexes()
     );
     $html_output .= sprintf(
         __('Create an index on &nbsp;%s&nbsp;columns'),
-        '<input type="number" size="2" name="added_fields" value="1" '
+        '<input type="number" name="added_fields" value="1" '
         . 'min="1" required />'
     );
     $html_output .= '<input type="hidden" name="create_index" value="1" />'

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -716,8 +716,7 @@ function PMA_getHtmlForResourceLimits($row)
         . 'MAX QUERIES PER HOUR'
         . '</dfn></code></label>' . "\n"
         . '<input type="number" name="max_questions" id="text_max_questions" '
-        . 'value="' . $row['max_questions'] . '" '
-        . 'size="6" maxlength="11" min="0" '
+        . 'value="' . $row['max_questions'] . '" min="0" '
         . 'title="'
         . __(
             'Limits the number of queries the user may send to the server per hour.'

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -1587,7 +1587,7 @@ function PMA_getHtmlForAddColumn($columns_list)
             __('Add column')
         );
     }
-    $num_fields = '<input type="number" name="num_fields" size="2" '
+    $num_fields = '<input type="number" name="num_fields" '
         . 'maxlength="2" value="1" onfocus="this.select()" '
         . 'min="1" required />';
     $html_output .= sprintf(__('Add %s column(s)'), $num_fields);

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2438,6 +2438,10 @@ fieldset .disabled-field td {
     background: #F7FBFF;
 }
 
+input[type="number"] {
+	width: 50px;
+}
+
 .config-form .field-comment-mark {
     font-family: serif;
     color: #007;

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2439,7 +2439,7 @@ fieldset .disabled-field td {
 }
 
 input[type="number"] {
-	width: 50px;
+    width: 50px;
 }
 
 .config-form .field-comment-mark {


### PR DESCRIPTION
Since Firefox 29 the number field is implemented and activated. Now the number field is very large. Now I have set the witdh to 50px. It looks better. you can see the large field if you select a database with Firefox 29 and create a new table at the bottom of the overview.
It is an option for you?
I think the large field is not very nice :)

And I have deleted the "size" attribute. That's not allowed in number fields.

Thank you!

Signed-off-by: Marvin Wegener mw197@web.de
