### PR TITLE
jquery-ui css should have low priority over phpmyadmin.css.php

### DIFF
--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -589,11 +589,11 @@ class PMA_Header
                 . $basedir . 'print.css" />';
         } else {
             $retval .= '<link rel="stylesheet" type="text/css" href="'
+                . $theme_path . '/jquery/jquery-ui-1.9.2.custom.css" />';
+            $retval .= '<link rel="stylesheet" type="text/css" href="'
                 . $basedir . 'phpmyadmin.css.php'
                 . $common_url . '&amp;nocache='
                 . $theme_id . $GLOBALS['text_dir'] . '" />';
-            $retval .= '<link rel="stylesheet" type="text/css" href="'
-                . $theme_path . '/jquery/jquery-ui-1.9.2.custom.css" />';
         }
 
         return $retval;


### PR DESCRIPTION
phpmyadmin.css.php should be after jquery-ui-1.9.2.custom.css so that we can override properties of jquery-ui-1.9.2.custom.css in phpmyadmin.css.php as per our theme.

Signed-off-by: Chirayu Chiripal chirayu.chiripal@gmail.com
