### PR TITLE
Bug fix #4411 : Fixed ProtectBinary behaviour on insert operation

### DIFF
--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -1099,9 +1099,9 @@ function PMA_getBinaryAndBlobColumn(
     $vkey, $is_upload
 ) {
     $html_output = '';
-    if (($GLOBALS['cfg']['ProtectBinary'] && $column['is_blob'])
-        || ($GLOBALS['cfg']['ProtectBinary'] == 'all' && $column['is_binary'])
-        || ($GLOBALS['cfg']['ProtectBinary'] == 'noblob' && !$column['is_blob'])
+    if (($GLOBALS['cfg']['ProtectBinary'] === 'blob' && $column['is_blob'])
+        || ($GLOBALS['cfg']['ProtectBinary'] === 'all')
+        || ($GLOBALS['cfg']['ProtectBinary'] === 'noblob' && !$column['is_blob'])
     ) {
         $html_output .= __('Binary - do not edit');
         if (isset($data)) {

--- a/test/libraries/PMA_insert_edit_test.php
+++ b/test/libraries/PMA_insert_edit_test.php
@@ -1127,7 +1127,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
      */
     public function testGetBinaryAndBlobColumn()
     {
-        $GLOBALS['cfg']['ProtectBinary'] = true;
+        $GLOBALS['cfg']['ProtectBinary'] = 'blob';
         $column['is_blob'] = true;
         $column['Field_md5'] = '123';
         $column['pma_type'] = 'blob';


### PR DESCRIPTION
Bug Fix #4411: Protect Binary when set to no in settings still does not allow insert binary data

Signed-off-by: Chirayu Chiripal chirayu.chiripal@gmail.com

test case fix

Signed-off-by: Chirayu Chiripal chirayu.chiripal@gmail.com
