### PR TITLE
Fixed bug #4421. 

### DIFF
--- a/js/messages.php
+++ b/js/messages.php
@@ -431,8 +431,8 @@ echo "var mysql_doc_template = '" . PMA_Util::getMySQLDocuURL('%s') . "';\n";
 
 //Max input vars allowed by PHP.
 $maxInputVars = ini_get('max_input_vars');
-echo 'var maxInputVars = ' . (false === $maxInputVars ? 'false' : $maxInputVars)
-    . ';';
+  echo 'var maxInputVars = ' . ($maxInputVars === false || $maxInputVars == '' ? 'false' : $maxInputVars)
+  . ';';
 
 echo "if ($.datepicker) {\n";
 /* l10n: Display text for calendar close link */


### PR DESCRIPTION
Fixed js/messages.php to allow an empty string to be returned from ini_get()
Signed-off-by: Todd Crane todd.crane@n5tech.com
