### PR TITLE
Fix #4416: new lines are removed when editing

### DIFF
--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -640,6 +640,10 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                             ? data.truncatableFieldValue
                             : $this_field.data('value');
 
+                        //Add <br> before carriage return.
+                        new_html = escapeHtml(new_html);
+                        new_html = new_html.replace('\n', '<br>\n');
+
                         //remove decimal places if column type not supported
                         if (($this_field.attr('data-decimals') === 0) && ( $this_field.attr('data-type').indexOf('time') != -1)) {
                             new_html = new_html.substring(0, new_html.indexOf('.'));
@@ -657,7 +661,7 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                         if ($this_field.hasClass('hex') && $this_field.find('a').length) {
                             selector = 'a';
                         }
-                        $this_field.find(selector).text(new_html);
+                        $this_field.find(selector).html(new_html);
                     }
                     if ($this_field.is('.bit')) {
                         $this_field.find('span').text($this_field.data('value'));

--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -573,6 +573,13 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
             {
                 if (!g.isCellEditActive) {
                     var $cell = $(cell);
+
+                    if ($cell.is('.text')) {
+                        g.cEdit = g.cEditTextarea;
+                    } else {
+                        g.cEdit = g.cEditStd;
+                    }
+
                     // remove all edit area and hide it
                     $(g.cEdit).find('.edit_area').empty().hide();
                     // reposition the cEdit element
@@ -808,7 +815,7 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                 }
 
                 //reset the position of the edit_area div after closing datetime picker
-                $('.edit_area').css({'top' :'0','position':''});
+                $(g.cEdit).find('.edit_area').css({'top' :'0','position':''});
 
                 if ($td.is('.relation')) {
                     //handle relations
@@ -1012,10 +1019,10 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                     $('.cEdit').append(datepicker_div);
 
                     var edit_area_top = $('#ui-datepicker-div').height()+32;
-                    $('.edit_area').css({'top' : edit_area_top+'px', 'position': 'absolute'});
+                    $(g.cEdit).find('.edit_area').css({'top' : edit_area_top+'px', 'position': 'absolute'});
 
                     if(is_null){
-                        $('.edit_area').hide();
+                        $(g.cEdit).find('.edit_area').hide();
                     }
 
                     // cancel any click on the datepicker element
@@ -1653,12 +1660,19 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
             }
 
             // create cell edit wrapper element
-            g.cEdit = document.createElement('div');
+            g.cEditStd = document.createElement('div');
+            g.cEdit = g.cEditStd;
+            g.cEditTextarea = document.createElement('div');
+
+            // adjust g.cEditStd
+            g.cEditStd.className = 'cEdit';
+            $(g.cEditStd).html('<input class="edit_box" rows="1" ></input><div class="edit_area" />');
+            $(g.cEditStd).hide();
 
             // adjust g.cEdit
-            g.cEdit.className = 'cEdit';
-            $(g.cEdit).html('<input class="edit_box" rows="1" ></input><div class="edit_area" />');
-            $(g.cEdit).hide();
+            g.cEditTextarea.className = 'cEdit';
+            $(g.cEditTextarea).html('<textarea class="edit_box" rows="1" ></textarea><div class="edit_area" />');
+            $(g.cEditTextarea).hide();
 
             // assign cell editing hint
             g.cellEditHint = PMA_messages.strCellEditHint;
@@ -1724,17 +1738,33 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                     }
                 });
 
-            $(g.cEdit).find('.edit_box').focus(function (e) {
+            $(g.cEditStd).find('.edit_box').focus(function (e) {
                 g.showEditArea();
             });
-            $(g.cEdit).find('.edit_box, select').live('keydown', function (e) {
+            $(g.cEditStd).find('.edit_box, select').live('keydown', function (e) {
                 if (e.which == 13) {
                     // post on pressing "Enter"
                     e.preventDefault();
                     g.saveOrPostEditedCell();
                 }
             });
-            $(g.cEdit).keydown(function (e) {
+            $(g.cEditStd).keydown(function (e) {
+                if (!g.isEditCellTextEditable) {
+                    // prevent text editing
+                    e.preventDefault();
+                }
+            });
+            $(g.cEditTextarea).find('.edit_box').focus(function (e) {
+                g.showEditArea();
+            });
+            $(g.cEditTextarea).find('.edit_box, select').live('keydown', function (e) {
+                if (e.which == 13) {
+                    // post on pressing "Enter"
+                    e.preventDefault();
+                    g.saveOrPostEditedCell();
+                }
+            });
+            $(g.cEditTextarea).keydown(function (e) {
                 if (!g.isEditCellTextEditable) {
                     // prevent text editing
                     e.preventDefault();
@@ -1766,7 +1796,8 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
             });
 
             // attach to global div
-            $(g.gDiv).append(g.cEdit);
+            $(g.gDiv).append(g.cEditStd);
+            $(g.gDiv).append(g.cEditTextarea);
 
             // add hint for grid editing feature when hovering "Edit" link in each table row
             if (PMA_messages.strGridEditFeatureHint !== undefined) {

--- a/libraries/DisplayResults.class.php
+++ b/libraries/DisplayResults.class.php
@@ -3637,6 +3637,8 @@ class PMA_DisplayResults
             $field_type_class = 'datefield';
         } elseif ($type == self::TIME_FIELD) {
             $field_type_class = 'timefield';
+        } elseif ($type == self::STRING_FIELD) {
+            $field_type_class = 'text';
         } else {
             $field_type_class = '';
         }

--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -901,7 +901,7 @@ function PMA_mimeDefaultFunction($buffer)
         ' &nbsp;&nbsp;&nbsp;',
         str_replace('  ', ' &nbsp;', $buffer)
     );
-    $buffer = preg_replace("@((\015\012)|(\015)|(\012))@", '<br />', $buffer);
+    $buffer = preg_replace("@((\015\012)|(\015)|(\012))@", '<br />' . "\n", $buffer);
 
     return $buffer;
 }

--- a/test/classes/PMA_DisplayResults_test.php
+++ b/test/classes/PMA_DisplayResults_test.php
@@ -567,7 +567,7 @@ class PMA_DisplayResults_Test extends PHPUnit_Framework_TestCase
     public function testGetClassForDateTimeRelatedFieldsCase3()
     {
         $this->assertEquals(
-            '',
+            'text',
             $this->_callPrivateFunction(
                 '_getClassForDateTimeRelatedFields',
                 array(PMA_DisplayResults::STRING_FIELD)


### PR DESCRIPTION
Bacause an input text is used to edit all data, the new lines in text are lost.
So I added a textarea to edit text fields.

Even if the ticket is defined as a bug, I think this is almost an evolution, so I do it on master.
I can try to do it on QA_4_2 if you really think this is a bug to fix…
