### PR TITLE
Allow processes to be killed on Amazon RDS

### DIFF
--- a/config.sample.inc.php
+++ b/config.sample.inc.php
@@ -33,9 +33,6 @@ $cfg['Servers'][$i]['connect_type'] = 'tcp';
 $cfg['Servers'][$i]['compress'] = false;
 $cfg['Servers'][$i]['AllowNoPassword'] = false;
 
-/* Servers running on Amazon RDS don't act 100% like regular mysql servers */
-// $cfg['Servers'][$i]['amazon_rds'] = true;
-
 /*
  * phpMyAdmin configuration storage settings.
  */

--- a/config.sample.inc.php
+++ b/config.sample.inc.php
@@ -33,6 +33,9 @@ $cfg['Servers'][$i]['connect_type'] = 'tcp';
 $cfg['Servers'][$i]['compress'] = false;
 $cfg['Servers'][$i]['AllowNoPassword'] = false;
 
+/* Servers running on Amazon RDS don't act 100% like regular mysql servers */
+// $cfg['Servers'][$i]['amazon_rds'] = true;
+
 /*
  * phpMyAdmin configuration storage settings.
  */

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -298,15 +298,6 @@ Server connection settings
     Whether to use a compressed protocol for the MySQL server connection
     or not (experimental).
 
-.. config:option:: $cfg['Servers'][$i]['amazon_rds']
-
-    :type: boolean
-    :default: false
-
-    Whether this server is running on Amazon's RDS hosting service or not.
-    Some functionality is restricted or handled differently, setting this
-    option to true will allow phpMyAdmin to function correctly.
-
 .. _controlhost:
 .. config:option:: $cfg['Servers'][$i]['controlhost']
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -298,6 +298,15 @@ Server connection settings
     Whether to use a compressed protocol for the MySQL server connection
     or not (experimental).
 
+.. config:option:: $cfg['Servers'][$i]['amazon_rds']
+
+    :type: boolean
+    :default: false
+
+    Whether this server is running on Amazon's RDS hosting service or not.
+    Some functionality is restricted or handled differently, setting this
+    option to true will allow phpMyAdmin to function correctly.
+
 .. _controlhost:
 .. config:option:: $cfg['Servers'][$i]['controlhost']
 
@@ -2782,4 +2791,3 @@ Developer
 
     Whether to display icons or text or both icons and text in table row action
     segment. Value can be either of ``'icons'``, ``'text'`` or ``'both'``.
-

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -2485,5 +2485,27 @@ class PMA_DatabaseInterface
             return false;
         }
     }
+
+    /**
+     * Checks if this database server is running on Amazon RDS.
+     *
+     * @return boolean
+     */
+    public function isAmazonRds()
+    {
+
+        if (PMA_Util::cacheExists('is_amazon_rds')) {
+            return PMA_Util::cacheGet('is_amazon_rds');
+        }
+
+        $sql = 'SELECT @@basedir';
+        $result = $this->fetchResult($sql);
+        $rds = ($result[0] == '/rdsdbbin/mysql/');
+
+        PMA_Util::cacheSet('is_amazon_rds', $rds);
+
+        return $rds;
+    }
+
 }
 ?>

--- a/libraries/DisplayResults.class.php
+++ b/libraries/DisplayResults.class.php
@@ -3457,7 +3457,7 @@ class PMA_DisplayResults
                     $_url_params, 'text'
                 );
 
-            if ($cfg['Server']['amazon_rds']) {
+            if($GLOBALS['dbi']->isAmazonRds()) {
                 $kill = 'CALL mysql.rds_kill(' . $row[0] . ');';
             } else {
                 $kill = 'KILL ' . $row[0] . ';';

--- a/libraries/DisplayResults.class.php
+++ b/libraries/DisplayResults.class.php
@@ -3457,15 +3457,21 @@ class PMA_DisplayResults
                     $_url_params, 'text'
                 );
 
+            if ($cfg['Server']['amazon_rds']) {
+                $kill = 'CALL mysql.rds_kill(' . $row[0] . ');';
+            } else {
+                $kill = 'KILL ' . $row[0] . ';';
+            }
+
             $_url_params = array(
                     'db'        => 'mysql',
-                    'sql_query' => 'KILL ' . $row[0],
+                    'sql_query' => $kill,
                     'goto'      => $lnk_goto,
                 );
 
             $del_url  = 'sql.php' . PMA_URL_getCommon($_url_params);
-            $del_query = 'KILL ' . $row[0];
-            $js_conf  = 'KILL ' . $row[0];
+            $del_query = $kill;
+            $js_conf  = $kill;
             $del_str = PMA_Util::getIcon(
                 'b_drop.png', __('Kill')
             );

--- a/server_status.php
+++ b/server_status.php
@@ -28,7 +28,12 @@ $ServerStatusData = new PMA_ServerStatusData();
  * Kills a selected process
  */
 if (! empty($_REQUEST['kill'])) {
-    if ($GLOBALS['dbi']->tryQuery('KILL ' . $_REQUEST['kill'] . ';')) {
+    if ($cfg['Server']['amazon_rds']) {
+        $query = 'CALL mysql.rds_kill(' . $_REQUEST['kill'] . ');';
+    } else {
+        $query = 'KILL ' . $_REQUEST['kill'] . ';';
+    }
+    if ($GLOBALS['dbi']->tryQuery($query)) {
         $message = PMA_Message::success(__('Thread %s was successfully killed.'));
     } else {
         $message = PMA_Message::error(

--- a/server_status.php
+++ b/server_status.php
@@ -28,7 +28,7 @@ $ServerStatusData = new PMA_ServerStatusData();
  * Kills a selected process
  */
 if (! empty($_REQUEST['kill'])) {
-    if ($cfg['Server']['amazon_rds']) {
+    if ($GLOBALS['dbi']->isAmazonRds()) {
         $query = 'CALL mysql.rds_kill(' . $_REQUEST['kill'] . ');';
     } else {
         $query = 'KILL ' . $_REQUEST['kill'] . ';';


### PR DESCRIPTION
The 'KILL' syntax isn't available but a procedure to do the same thing is
http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MySQL.CommonDBATasks.html

Signed-off-by: Craig Duncan git@duncanc.co.uk
