### PR TITLE
Fix #4445 Fatal error on SQL Export of join query

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ phpMyAdmin - ChangeLog
 ======================
 
 4.2.4.0 (not yet released)
+- #4445 Fatal error on SQL Export of join query
 
 4.2.3.0 (2014-06-08)
 - bug #4423 Moving fields not working

--- a/libraries/plugin_interface.lib.php
+++ b/libraries/plugin_interface.lib.php
@@ -75,7 +75,10 @@ function PMA_getPlugins($plugin_type, $plugins_dir, $plugin_param)
             include_once $plugins_dir . $file;
             if (! $GLOBALS['skip_import']) {
                 $class_name = $class_type . $matches[1];
-                $plugin_list [] = new $class_name;
+                $plugin = new $class_name;
+                if (null !== $plugin->getProperties()) {
+                    $plugin_list[] = $plugin;
+                }
             }
         }
     }


### PR DESCRIPTION
SQL export for multi-table queries don't seem relevant. So SQL is removed from export format.
