### PR TITLE
Fix 'token mismatch' due to missing server parameter for some AJAX reqs

### DIFF
--- a/js/error_report.js
+++ b/js/error_report.js
@@ -21,6 +21,7 @@ var ErrorReport = {
         ErrorReport._last_exception = exception;
         $.get("error_report.php", {
             ajax_request: true,
+            server: PMA_commonParams.get('server'),
             token: PMA_commonParams.get('token'),
             get_settings: true
         }, function (data) {

--- a/js/server_privileges.js
+++ b/js/server_privileges.js
@@ -193,6 +193,7 @@ AJAX.registerOnload('server_privileges.js', function () {
             var params = {
                 'ajax_request' : true,
                 'token' : PMA_commonParams.get('token'),
+                'server' : PMA_commonParams.get('server'),
                 'validate_username' : true,
                 'username' : username
             };


### PR DESCRIPTION
- server_privileges user duplicate request
- js error_reporting
- cf. https://sourceforge.net/p/phpmyadmin/bugs/3893

Signed-off-by: Christian Simon simon@swine.de
