### PR TITLE
Fix error when clicking 'Go' and having an empty textarea in SQL tab.

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -422,9 +422,8 @@ function checkSqlQuery(theForm)
     isEmpty = 1;
 
     if (isEmpty) {
-        sqlQuery.select();
         alert(PMA_messages.strFormEmpty);
-        sqlQuery.focus();
+        codemirror_editor.focus();
         return false;
     }
 


### PR DESCRIPTION
Connect and don't select any DB:
- Go into SQL tab
- Leave SQL textarea blank
- Click on "Go"
  A JS error appears.

This PR should fix this.

Previously, a "select()" was done, but I don't know why. I just kept the "focus()".
Hope this is ok.
