### PR TITLE
Drag n drop import - feature request 1522

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -482,12 +482,14 @@ PMA_DROP_IMPORT = {
                    .html('<span>Failed</a>');
                    icon = 'icon ic_s_error';
             }
-            $('.pma_sql_import_status div li[data-hash="' +hash
-                +'"] span.filesize span.pma_drop_file_status')
-                .attr('task', 'info');
         } else {
             icon = 'icon ic_s_notice';
         }
+
+        // Prevents multiple abort, adds placeholder to view status
+        $('.pma_sql_import_status div li[data-hash="' +hash
+            +'"] span.filesize span.pma_drop_file_status')
+            .attr('task', 'info');
 
         // Set icon
         $('.pma_sql_import_status div li[data-hash="' +hash +'"]')

--- a/js/common.js
+++ b/js/common.js
@@ -454,6 +454,7 @@ PMA_DROP_IMPORT = {
     _dragleave: function (event) {
         event.stopPropagation();
         event.preventDefault();
+        $(".pma_drop_handler").clearQueue().stop();
         $(".pma_drop_handler").fadeOut();
         $(".pma_drop_handler").html("Drop Files Here");
     },
@@ -575,7 +576,8 @@ PMA_DROP_IMPORT = {
  */
 $(document).live('dragenter', PMA_DROP_IMPORT._dragenter);
 $(document).live('dragover', PMA_DROP_IMPORT._dragover);
-$(".pma_drop_handler").live('dragleave', PMA_DROP_IMPORT._dragleave);
+$(".pma_drop_handler,"
+    +".pma_navigation_resizer").live('dragleave', PMA_DROP_IMPORT._dragleave);
 
 //when file is dropped to PMA UI
 $('body').live('drop', PMA_DROP_IMPORT._drop);

--- a/js/common.js
+++ b/js/common.js
@@ -300,3 +300,245 @@ var PMA_querywindow = (function ($, window) {
         }
     };
 })(jQuery, window);
+
+/**
+ * Class to handle PMA Drag and Drop Import
+ *      feature
+ */
+PMA_DROP_IMPORT = {
+    /**
+     * @var int, count of total uploads in this view
+     */
+    uploadCount: 0,
+    /**
+     * @var int, count of live uploads
+     */
+    liveUploadCount: 0,
+    /**
+     * @var  string array, allowed extensions
+     */
+    allowedExtensions: ['sql', 'xml', 'ldi', 'mediawiki', 'shp'],
+    /**
+     * @var  string array, allowed extensions for compressed files
+     */
+    allowedCompressedExtensions: ['gzip', 'bzip2', 'zip'],
+    /**
+     * Checks if database is selected
+     *
+     * @param void
+     *
+     * @return string, name of db if any selected, '' otherwise
+     */
+    _getDbName: function() {
+        var dbname = '';
+        var selflink = $("#selflink a").attr("href");
+        if ((dbname = /db=(.*)&table/.exec(selflink)[1]) != "")
+            return dbname;
+        return '';
+    },
+    /**
+     * Checks if any dropped file has valid extension or not
+     *
+     * @param string, filename
+     *
+     * @return string, extension for valid extension, '' otherwise
+     */
+    _getExtension: function(file) {
+        var arr = file.split('.');
+        ext = arr[arr.length - 1];
+
+        //check if compressed
+        if (jQuery.inArray(ext.toLowerCase(), 
+            PMA_DROP_IMPORT.allowedCompressedExtensions) !== -1)
+                ext = arr[arr.length - 2];
+
+        //Now check for extension
+        if (jQuery.inArray(ext.toLowerCase(), 
+            PMA_DROP_IMPORT.allowedExtensions) !== -1)
+                return ext;
+            return '';
+    },
+    _setProgress: function(hash, percent) {
+        $('.pma_sql_import_status div li[data-hash="' +hash +'"]')
+            .children('progress').val(percent);
+    },
+    /**
+     * Function to upload the file asyncronously
+     *
+     * @param formData, FormData object for a specific file
+     * @param hash, hash of the current file upload
+     *
+     * @return void
+     */
+    _sendFileToServer: function(formData, hash) {
+        var uploadURL ="./import.php"; //Upload URL
+        var extraData ={}; //Extra Data.
+        console.log(formData);
+        //return;
+        var jqXHR=$.ajax({
+            xhr: function() {
+            var xhrobj = $.ajaxSettings.xhr();
+            if (xhrobj.upload) {
+                    xhrobj.upload.addEventListener('progress', function(event) {
+                        var percent = 0;
+                        var position = event.loaded || event.position;
+                        var total = event.total;
+                        if (event.lengthComputable) {
+                            percent = Math.ceil(position / total * 100);
+                        }
+                        //Set progress
+                        PMA_DROP_IMPORT._setProgress(hash, percent);
+                    }, false);
+                }
+                return xhrobj;
+            },
+            url: uploadURL,
+            type: "POST",
+            contentType:false,
+            processData: false,
+            cache: false,
+            data: formData,
+            success: function(data){
+                PMA_DROP_IMPORT._importFinished(hash);
+            }
+        });
+    },
+    /**
+     * Triggered when an object is dragged into the PMA UI
+     *
+     * @param event obj
+     *
+     * @return void
+     */
+    _dragenter : function (event) {
+        if (PMA_DROP_IMPORT._getDbName() !== '') {
+            $(".pma_drop_handler").html("Select Database First");
+        }
+        $(".pma_drop_handler").fadeIn();
+        event.stopPropagation();
+        event.preventDefault();
+    },
+    /**
+     * Triggered when dragged file is being dragged over PMA UI
+     *
+     * @param event obj
+     *
+     * @return void
+     */
+    _dragover: function (event) {
+        $(".pma_drop_handler").fadeIn();
+        event.stopPropagation();
+        event.preventDefault();
+    },
+    /**
+     * Triggered when dragged objects are left
+     *
+     * @param event obj
+     *
+     * @return void
+     */
+    _dragleave: function (event) {
+        event.stopPropagation();
+        event.preventDefault();
+        $(".pma_drop_handler").fadeOut();
+        $(".pma_drop_handler").html("Drop Files Here");
+    },
+    /**
+     *
+     *
+     * @param string, uniques hash for a certain upload
+     *
+     * @return void
+     */
+    _importFinished: function(hash) {
+        $('.pma_sql_import_status div li[data-hash="' +hash +'"]')
+            .prepend('<img src="./themes/dot.gif" title="finished" class="icon ic_s_success"> ')
+            .children("progress").hide();
+        //#todo: these two can be merged together
+
+        // Decrease liveUploadCount by one
+        $('.pma_import_count').html(--PMA_DROP_IMPORT.liveUploadCount);
+    },
+    /**
+     * Triggered when dragged objects are dropped to UI
+     * From this function, the AJAX Upload operation is initated
+     *
+     * @param event object
+     *
+     * @return void
+     */
+    _drop: function (event) {
+        var dbname = PMA_DROP_IMPORT._getDbName();
+        //if no database is selected -- no
+        if (dbname !== '') {
+            $(".pma_sql_import_status").slideDown();
+            var files = event.originalEvent.dataTransfer.files;
+            for (var i = 0; i < files.length; i++) {
+                var ext  = (PMA_DROP_IMPORT._getExtension(files[i].name));
+                var hash = AJAX.hash(++PMA_DROP_IMPORT.uploadCount);
+
+                $(".pma_sql_import_status div").append('<li data-hash="' +hash +'">'
+                    +((ext !== '') ? '' : '<img src="./themes/dot.gif" title="invalid format" class="icon ic_s_notice"> ')
+                    +files[i].name + '<span class="filesize">' 
+                    +(files[i].size/1024).toFixed(2) +' kb</span></li>');
+
+                //scroll the UI to bottom
+                $(".pma_sql_import_status div").scrollTop(
+                    $(".pma_sql_import_status div").scrollTop() + 50);  //50 hardcoded for now
+
+                if (ext !== '') {
+                    // Increment liveUploadCount by one
+                    $('.pma_import_count').html(++PMA_DROP_IMPORT.liveUploadCount);
+                    $('.pma_sql_import_status div li[data-hash="' +hash +'"]')
+                        .append('<br><progress max="100" value="2"></progress>');
+
+                    //uploading
+                    var fd = new FormData();
+                    fd.append('import_file', files[i]);
+                    fd.append('noplugin', '539de66e760ee');
+                    fd.append('db', dbname);
+                    fd.append('token', 'f14184fd61baa4a132bb9a9682ae65f9');
+                    fd.append('import_type', 'database');
+                    fd.append('MAX_FILE_SIZE', '4194304');
+                    fd.append('charset_of_file','utf-8');
+                    fd.append('allow_interrupt', 'yes');
+                    fd.append('skip_queries', '0');
+                    fd.append('format',ext);
+                    fd.append('sql_compatibility','NONE');
+                    fd.append('sql_no_auto_value_on_zero','something');
+                    fd.append('isAjax','true');
+
+                    // init uploading
+                    PMA_DROP_IMPORT._sendFileToServer(fd, hash);
+                }
+            }
+        }
+        $(".pma_drop_handler").fadeOut();
+        event.stopPropagation();
+        event.preventDefault();
+    }
+};
+
+/**
+ * Called when some user drags, dragover, leave
+ *       a file to the PMA UI
+ * @param object Event data
+ * @return void
+ */
+$(document).live('dragenter', PMA_DROP_IMPORT._dragenter);
+$(document).live('dragover', PMA_DROP_IMPORT._dragover);
+$(".pma_drop_handler").live('dragleave', PMA_DROP_IMPORT._dragleave);
+
+//when file is dropped to PMA UI
+$('body').live('drop', PMA_DROP_IMPORT._drop);
+
+// minimizing-maximising the sql ajax upload status 
+$('.pma_sql_import_status h2 .minimize').live('click', function() {
+    if ($(this).attr('toggle') === 'off') {
+        $('.pma_sql_import_status div').css('height','270px');
+        $(this).attr('toggle','on');
+    } else {
+        $('.pma_sql_import_status div').css("height","0px");
+        $(this).attr('toggle','off');
+    }
+});

--- a/js/common.js
+++ b/js/common.js
@@ -334,12 +334,12 @@ PMA_DROP_IMPORT = {
         ext = arr[arr.length - 1];
 
         //check if compressed
-        if (jQuery.inArray(ext.toLowerCase(), 
+        if (jQuery.inArray(ext.toLowerCase(),
             PMA_DROP_IMPORT.allowedCompressedExtensions) !== -1)
                 ext = arr[arr.length - 2];
 
         //Now check for extension
-        if (jQuery.inArray(ext.toLowerCase(), 
+        if (jQuery.inArray(ext.toLowerCase(),
             PMA_DROP_IMPORT.allowedExtensions) !== -1)
                 return ext;
             return '';
@@ -396,12 +396,12 @@ PMA_DROP_IMPORT = {
         });
 
         // -- provide link to cancel the upload
-        $('.pma_sql_import_status div li[data-hash="' +hash 
+        $('.pma_sql_import_status div li[data-hash="' +hash
             +'"] span.filesize').html('<span hash="'
             +hash +'" class="pma_drop_file_status" task="cancel">cancel</span>');
 
         // -- add event listener to this link to abort upload operation
-        $('.pma_sql_import_status div li[data-hash="' +hash 
+        $('.pma_sql_import_status div li[data-hash="' +hash
             +'"] span.filesize span.pma_drop_file_status')
             .live('click', function() {
                 if ($(this).attr('task') === 'cancel') {
@@ -409,8 +409,8 @@ PMA_DROP_IMPORT = {
                     $(this).html('<span>Aborted</span>');
                     PMA_DROP_IMPORT._importFinished(hash, true, false);
                 }
-                /** 
-                 * #todo: add a view to check import result, in a lightbox 
+                /**
+                 * #todo: add a view to check import result, in a lightbox
                  *          in case task == info
                 */
             });
@@ -485,8 +485,6 @@ PMA_DROP_IMPORT = {
         } else {
             icon = 'icon ic_s_notice';
         }
-
-        // Prevents multiple abort, adds placeholder to view status
         $('.pma_sql_import_status div li[data-hash="' +hash
             +'"] span.filesize span.pma_drop_file_status')
             .attr('task', 'info');
@@ -522,7 +520,7 @@ PMA_DROP_IMPORT = {
 
                 $(".pma_sql_import_status div").append('<li data-hash="' +hash +'">'
                     +((ext !== '') ? '' : '<img src="./themes/dot.gif" title="invalid format" class="icon ic_s_notice"> ')
-                    +files[i].name + '<span class="filesize">' 
+                    +files[i].name + '<span class="filesize">'
                     +(files[i].size/1024).toFixed(2) +' kb</span></li>');
 
                 //scroll the UI to bottom
@@ -582,7 +580,7 @@ $(".pma_drop_handler").live('dragleave', PMA_DROP_IMPORT._dragleave);
 //when file is dropped to PMA UI
 $('body').live('drop', PMA_DROP_IMPORT._drop);
 
-// minimizing-maximising the sql ajax upload status 
+// minimizing-maximising the sql ajax upload status
 $('.pma_sql_import_status h2 .minimize').live('click', function() {
     if ($(this).attr('toggle') === 'off') {
         $('.pma_sql_import_status div').css('height','270px');
@@ -593,7 +591,7 @@ $('.pma_sql_import_status h2 .minimize').live('click', function() {
     }
 });
 
-// closing sql ajax upload status 
+// closing sql ajax upload status
 $('.pma_sql_import_status h2 .close').live('click', function() {
     $('.pma_sql_import_status').fadeOut(function() {
         $('.pma_sql_import_status div').html('');

--- a/js/common.js
+++ b/js/common.js
@@ -468,24 +468,31 @@ PMA_DROP_IMPORT = {
      */
     _importFinished: function(hash, aborted, status) {
         $('.pma_sql_import_status div li[data-hash="' +hash +'"]')
-            .prepend('<img src="./themes/dot.gif" title="finished" class="icon ic_s_success"> ')
             .children("progress").hide();
-
+        var icon = 'icon ic_s_success';
         // -- provide link to view upload status
         if (!aborted) {
             if (status) {
-                $('.pma_sql_import_status div li[data-hash="' +hash 
+                $('.pma_sql_import_status div li[data-hash="' +hash
                     +'"] span.filesize span.pma_drop_file_status')
                    .html('<span>Success</a>');
             } else {
-                $('.pma_sql_import_status div li[data-hash="' +hash 
+                $('.pma_sql_import_status div li[data-hash="' +hash
                     +'"] span.filesize span.pma_drop_file_status')
                    .html('<span>Failed</a>');
+                   icon = 'icon ic_s_error';
             }
-            $('.pma_sql_import_status div li[data-hash="' +hash 
+            $('.pma_sql_import_status div li[data-hash="' +hash
                 +'"] span.filesize span.pma_drop_file_status')
                 .attr('task', 'info');
+        } else {
+            icon = 'icon ic_s_notice';
         }
+
+        // Set icon
+        $('.pma_sql_import_status div li[data-hash="' +hash +'"]')
+            .prepend('<img src="./themes/dot.gif" title="finished" class="'
+            +icon +'"> ');
 
         // Decrease liveUploadCount by one
         $('.pma_import_count').html(--PMA_DROP_IMPORT.liveUploadCount);

--- a/js/common.js
+++ b/js/common.js
@@ -576,8 +576,7 @@ PMA_DROP_IMPORT = {
  */
 $(document).live('dragenter', PMA_DROP_IMPORT._dragenter);
 $(document).live('dragover', PMA_DROP_IMPORT._dragover);
-$(".pma_drop_handler,"
-    +".pma_navigation_resizer").live('dragleave', PMA_DROP_IMPORT._dragleave);
+$(".pma_drop_handler").live('dragleave', PMA_DROP_IMPORT._dragleave);
 
 //when file is dropped to PMA UI
 $('body').live('drop', PMA_DROP_IMPORT._drop);

--- a/js/common.js
+++ b/js/common.js
@@ -300,3 +300,301 @@ var PMA_querywindow = (function ($, window) {
         }
     };
 })(jQuery, window);
+
+/**
+ * Class to handle PMA Drag and Drop Import
+ *      feature
+ */
+PMA_DROP_IMPORT = {
+    /**
+     * @var int, count of total uploads in this view
+     */
+    uploadCount: 0,
+    /**
+     * @var int, count of live uploads
+     */
+    liveUploadCount: 0,
+    /**
+     * @var  string array, allowed extensions
+     */
+    allowedExtensions: ['sql', 'xml', 'ldi', 'mediawiki', 'shp'],
+    /**
+     * @var  string array, allowed extensions for compressed files
+     */
+    allowedCompressedExtensions: ['gzip', 'bzip2', 'zip'],
+    /**
+     * Checks if any dropped file has valid extension or not
+     *
+     * @param string, filename
+     *
+     * @return string, extension for valid extension, '' otherwise
+     */
+    _getExtension: function(file) {
+        var arr = file.split('.');
+        ext = arr[arr.length - 1];
+
+        //check if compressed
+        if (jQuery.inArray(ext.toLowerCase(),
+            PMA_DROP_IMPORT.allowedCompressedExtensions) !== -1)
+                ext = arr[arr.length - 2];
+
+        //Now check for extension
+        if (jQuery.inArray(ext.toLowerCase(),
+            PMA_DROP_IMPORT.allowedExtensions) !== -1)
+                return ext;
+            return '';
+    },
+    /**
+     * Shows upload progress for different sql uploads
+     *
+     * @param: hash (string), hash for specific file upload
+     * @param: percent (float), file upload percentage
+     *
+     * @return void
+     */
+    _setProgress: function(hash, percent) {
+        $('.pma_sql_import_status div li[data-hash="' +hash +'"]')
+            .children('progress').val(percent);
+    },
+    /**
+     * Function to upload the file asyncronously
+     *
+     * @param formData, FormData object for a specific file
+     * @param hash, hash of the current file upload
+     *
+     * @return void
+     */
+    _sendFileToServer: function(formData, hash) {
+        var uploadURL ="./import.php"; //Upload URL
+        var extraData ={};
+        var jqXHR = $.ajax({
+            xhr: function() {
+            var xhrobj = $.ajaxSettings.xhr();
+            if (xhrobj.upload) {
+                    xhrobj.upload.addEventListener('progress', function(event) {
+                        var percent = 0;
+                        var position = event.loaded || event.position;
+                        var total = event.total;
+                        if (event.lengthComputable) {
+                            percent = Math.ceil(position / total * 100);
+                        }
+                        //Set progress
+                        PMA_DROP_IMPORT._setProgress(hash, percent);
+                    }, false);
+                }
+                return xhrobj;
+            },
+            url: uploadURL,
+            type: "POST",
+            contentType:false,
+            processData: false,
+            cache: false,
+            data: formData,
+            success: function(data){
+                PMA_DROP_IMPORT._importFinished(hash, false, data.success);
+            }
+        });
+
+        // -- provide link to cancel the upload
+        $('.pma_sql_import_status div li[data-hash="' +hash
+            +'"] span.filesize').html('<span hash="'
+            +hash +'" class="pma_drop_file_status" task="cancel">cancel</span>');
+
+        // -- add event listener to this link to abort upload operation
+        $('.pma_sql_import_status div li[data-hash="' +hash
+            +'"] span.filesize span.pma_drop_file_status')
+            .live('click', function() {
+                if ($(this).attr('task') === 'cancel') {
+                    jqXHR.abort();
+                    $(this).html('<span>Aborted</span>');
+                    PMA_DROP_IMPORT._importFinished(hash, true, false);
+                }
+                /**
+                 * #todo: add a view to check import result, in a lightbox
+                 *          in case task == info
+                */
+            });
+    },
+    /**
+     * Triggered when an object is dragged into the PMA UI
+     *
+     * @param event obj
+     *
+     * @return void
+     */
+    _dragenter : function (event) {
+        if (PMA_commonParams.get('db') === '') {
+            $(".pma_drop_handler").html("Select Database First");
+        } else {
+            $(".pma_drop_handler").html("Drop Files Here");
+        }
+        $(".pma_drop_handler").fadeIn();
+        event.stopPropagation();
+        event.preventDefault();
+    },
+    /**
+     * Triggered when dragged file is being dragged over PMA UI
+     *
+     * @param event obj
+     *
+     * @return void
+     */
+    _dragover: function (event) {
+        $(".pma_drop_handler").fadeIn();
+        event.stopPropagation();
+        event.preventDefault();
+    },
+    /**
+     * Triggered when dragged objects are left
+     *
+     * @param event obj
+     *
+     * @return void
+     */
+    _dragleave: function (event) {
+        event.stopPropagation();
+        event.preventDefault();
+        $(".pma_drop_handler").clearQueue().stop();
+        $(".pma_drop_handler").fadeOut();
+        $(".pma_drop_handler").html("Drop Files Here");
+    },
+    /**
+     * Called when upload has finished
+     *
+     * @param string, uniques hash for a certain upload
+     * @param bool, true if upload was aborted
+     * @param bool, status of sql upload, as sent by server
+     *
+     * @return void
+     */
+    _importFinished: function(hash, aborted, status) {
+        $('.pma_sql_import_status div li[data-hash="' +hash +'"]')
+            .children("progress").hide();
+        var icon = 'icon ic_s_success';
+        // -- provide link to view upload status
+        if (!aborted) {
+            if (status) {
+                $('.pma_sql_import_status div li[data-hash="' +hash
+                    +'"] span.filesize span.pma_drop_file_status')
+                   .html('<span>Success</a>');
+            } else {
+                $('.pma_sql_import_status div li[data-hash="' +hash
+                    +'"] span.filesize span.pma_drop_file_status')
+                   .html('<span>Failed</a>');
+                   icon = 'icon ic_s_error';
+            }
+        } else {
+            icon = 'icon ic_s_notice';
+        }
+        $('.pma_sql_import_status div li[data-hash="' +hash
+            +'"] span.filesize span.pma_drop_file_status')
+            .attr('task', 'info');
+
+        // Set icon
+        $('.pma_sql_import_status div li[data-hash="' +hash +'"]')
+            .prepend('<img src="./themes/dot.gif" title="finished" class="'
+            +icon +'"> ');
+
+        // Decrease liveUploadCount by one
+        $('.pma_import_count').html(--PMA_DROP_IMPORT.liveUploadCount);
+        if (!PMA_DROP_IMPORT.liveUploadCount) {
+            $('.pma_sql_import_status h2 .close').fadeIn();
+        }
+    },
+    /**
+     * Triggered when dragged objects are dropped to UI
+     * From this function, the AJAX Upload operation is initated
+     *
+     * @param event object
+     *
+     * @return void
+     */
+    _drop: function (event) {
+        var dbname = PMA_commonParams.get('db');
+        //if no database is selected -- no
+        if (dbname !== '') {
+            $(".pma_sql_import_status").slideDown();
+            var files = event.originalEvent.dataTransfer.files;
+            for (var i = 0; i < files.length; i++) {
+                var ext  = (PMA_DROP_IMPORT._getExtension(files[i].name));
+                var hash = AJAX.hash(++PMA_DROP_IMPORT.uploadCount);
+
+                $(".pma_sql_import_status div").append('<li data-hash="' +hash +'">'
+                    +((ext !== '') ? '' : '<img src="./themes/dot.gif" title="invalid format" class="icon ic_s_notice"> ')
+                    +files[i].name + '<span class="filesize">'
+                    +(files[i].size/1024).toFixed(2) +' kb</span></li>');
+
+                //scroll the UI to bottom
+                $(".pma_sql_import_status div").scrollTop(
+                    $(".pma_sql_import_status div").scrollTop() + 50);  //50 hardcoded for now
+
+                if (ext !== '') {
+                    // Increment liveUploadCount by one
+                    $('.pma_import_count').html(++PMA_DROP_IMPORT.liveUploadCount);
+                    $('.pma_sql_import_status h2 .close').fadeOut();
+
+                    $('.pma_sql_import_status div li[data-hash="' +hash +'"]')
+                        .append('<br><progress max="100" value="2"></progress>');
+
+                    //uploading
+                    var fd = new FormData();
+                    fd.append('import_file', files[i]);
+                    // todo: method to find the value below
+                    fd.append('noplugin', '539de66e760ee');
+                    fd.append('db', dbname);
+                    fd.append('token', PMA_commonParams.get('token'));
+                    fd.append('import_type', 'database');
+                    // todo: method to find the value below
+                    fd.append('MAX_FILE_SIZE', '4194304');
+                    // todo: method to find the value below
+                    fd.append('charset_of_file','utf-8');
+                    // todo: method to find the value below
+                    fd.append('allow_interrupt', 'yes');
+                    fd.append('skip_queries', '0');
+                    fd.append('format',ext);
+                    fd.append('sql_compatibility','NONE');
+                    fd.append('sql_no_auto_value_on_zero','something');
+                    fd.append('ajax_request','true');
+                    fd.append('hash', hash);
+
+                    // init uploading
+                    PMA_DROP_IMPORT._sendFileToServer(fd, hash);
+                }
+            }
+        }
+        $(".pma_drop_handler").fadeOut();
+        event.stopPropagation();
+        event.preventDefault();
+    }
+};
+
+/**
+ * Called when some user drags, dragover, leave
+ *       a file to the PMA UI
+ * @param object Event data
+ * @return void
+ */
+$(document).live('dragenter', PMA_DROP_IMPORT._dragenter);
+$(document).live('dragover', PMA_DROP_IMPORT._dragover);
+$(".pma_drop_handler").live('dragleave', PMA_DROP_IMPORT._dragleave);
+
+//when file is dropped to PMA UI
+$('body').live('drop', PMA_DROP_IMPORT._drop);
+
+// minimizing-maximising the sql ajax upload status
+$('.pma_sql_import_status h2 .minimize').live('click', function() {
+    if ($(this).attr('toggle') === 'off') {
+        $('.pma_sql_import_status div').css('height','270px');
+        $(this).attr('toggle','on');
+    } else {
+        $('.pma_sql_import_status div').css("height","0px");
+        $(this).attr('toggle','off');
+    }
+});
+
+// closing sql ajax upload status
+$('.pma_sql_import_status h2 .close').live('click', function() {
+    $('.pma_sql_import_status').fadeOut(function() {
+        $('.pma_sql_import_status div').html('');
+    });
+});

--- a/libraries/navigation/Navigation.class.php
+++ b/libraries/navigation/Navigation.class.php
@@ -63,6 +63,26 @@ class PMA_Navigation
     }
 
     /**
+     * Inserts Drag and Drop Import handler
+     *
+     * @param: void
+     * @return: html code for drop handler
+     */
+    private function _getDropHandler()
+    {
+        $retval = '';
+        $retval .= '<div class="pma_drop_handler">Drop Files Here</div>';
+        $retval .= '<div class="pma_sql_import_status">';
+        $retval .= '<h2>SQL upload ( ';
+        $retval .= '<span class="pma_import_count">0</span> ';
+        $retval .= ') <span class="close">x</span>';
+        $retval .= '<span class="minimize">-</span></h2>';
+        $retval .= '<div></div>';
+        $retval .= '</div>';
+        return $retval;
+    }
+
+    /**
      * Add an item of navigation tree to the hidden items list in PMA database.
      *
      * @param string $itemName  name of the navigation tree item

--- a/libraries/navigation/NavigationHeader.class.php
+++ b/libraries/navigation/NavigationHeader.class.php
@@ -59,8 +59,6 @@ class PMA_NavigationHeader
         );
         $buffer .= '</div>'; // pma_navigation_header
 
-        // Add Drop Handler
-        $buffer .= $this->_getDropHandler();
         $buffer .= '<div id="pma_navigation_tree"' . $class . '>';
         return $buffer;
     }
@@ -172,26 +170,6 @@ class PMA_NavigationHeader
         if ($showText) {
             $retval .= '<br />';
         }
-        return $retval;
-    }
-
-     /**
-     * Inserts Drag and Drop Import handler
-     *
-     * @param: void
-     * @return: html code for drop handler
-     */
-    private function _getDropHandler()
-    {
-        $retval = '';
-        $retval .= '<div class="pma_drop_handler">Drop Files Here</div>';
-        $retval .= '<div class="pma_sql_import_status">';
-        $retval .= '<h2>SQL upload ( ';
-        $retval .= '<span class="pma_import_count">0</span> ';
-        $retval .= ') <span class="close">x</span>';
-        $retval .= '<span class="minimize">-</span></h2>';
-        $retval .= '<div></div>';
-        $retval .= '</div>';
         return $retval;
     }
 

--- a/libraries/navigation/NavigationHeader.class.php
+++ b/libraries/navigation/NavigationHeader.class.php
@@ -58,6 +58,7 @@ class PMA_NavigationHeader
             )
         );
         $buffer .= '</div>'; // pma_navigation_header
+
         $buffer .= '<div id="pma_navigation_tree"' . $class . '>';
         return $buffer;
     }

--- a/libraries/navigation/NavigationHeader.class.php
+++ b/libraries/navigation/NavigationHeader.class.php
@@ -188,7 +188,8 @@ class PMA_NavigationHeader
         $retval .= '<div class="pma_sql_import_status">';
         $retval .= '<h2>SQL upload ( ';
         $retval .= '<span class="pma_import_count">0</span> ';
-        $retval .= ') <span class="minimize">-</span></h2>';
+        $retval .= ') <span class="close">x</span>';
+        $retval .= '<span class="minimize">-</span></h2>';
         $retval .= '<div></div>';
         $retval .= '</div>';
         return $retval;

--- a/libraries/navigation/NavigationHeader.class.php
+++ b/libraries/navigation/NavigationHeader.class.php
@@ -58,6 +58,9 @@ class PMA_NavigationHeader
             )
         );
         $buffer .= '</div>'; // pma_navigation_header
+
+        // Add Drop Handler
+        $buffer .= $this->_getDropHandler();
         $buffer .= '<div id="pma_navigation_tree"' . $class . '>';
         return $buffer;
     }
@@ -169,6 +172,25 @@ class PMA_NavigationHeader
         if ($showText) {
             $retval .= '<br />';
         }
+        return $retval;
+    }
+
+     /**
+     * Inserts Drag and Drop Import handler
+     *
+     * @param: void
+     * @return: html code for drop handler
+     */
+    private function _getDropHandler()
+    {
+        $retval = '';
+        $retval .= '<div class="pma_drop_handler">Drop Files Here</div>';
+        $retval .= '<div class="pma_sql_import_status">';
+        $retval .= '<h2>SQL upload ( ';
+        $retval .= '<span class="pma_import_count">0</span> ';
+        $retval .= ') <span class="minimize">-</span></h2>';
+        $retval .= '<div></div>';
+        $retval .= '</div>';
         return $retval;
     }
 

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -2663,3 +2663,83 @@ table.show_create {
 table.show_create td {
     border-right: 1px solid #bbb;
 }
+.pma_drop_handler {
+    display: none;
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    height: 100%;
+    z-index: 999;
+    color: white;
+    font-size: 100pt;
+    text-align: center;
+    padding-top: 20%;
+}
+.pma_sql_import_status {
+    display: none;
+    position: fixed;
+    bottom: 0px;
+    right: 25px;
+    width: 400px;
+    border: 1px solid #999;
+    background: #f3f3f3;
+    -moz-border-radius: 4px;
+    -webkit-border-radius: 4px;
+    border-radius: 4px;
+    -moz-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>2px 2px 5px #ccc;
+    -webkit-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>2px 2px 5px #ccc;
+    box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>2px 2px 5px #ccc;
+}
+.pma_sql_import_status h2 {
+    background-color: #bbb;
+    padding: .1em .3em;
+    margin-top: 0;
+    margin-bottom: 0;
+    color: #fff;
+    font-size: 1.6em;
+    font-weight: normal;
+    text-shadow: 0 1px 0 #777;
+    -moz-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>1px 1px 15px #999 inset;
+    -webkit-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>1px 1px 15px #999 inset;
+    box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>1px 1px 15px #999 inset;
+}
+.pma_sql_import_status div {
+    height: 270px;
+    overflow-y:auto;
+    overflow-x:hidden;
+    list-style-type: none;
+}
+.pma_sql_import_status div li {
+    padding: 8px 10px;
+    border-bottom: 1px solid #bbb;
+    color: rgb(148, 14, 14);
+    background: white;
+}
+.pma_sql_import_status div li .filesize {
+    float: right;
+}
+.pma_sql_import_status h2 .minimize {
+    float: right;
+    margin-right: 5px;
+    padding: 0px 10px;
+}
+.pma_sql_import_status h2 .close {
+    float: right;
+    margin-right: 5px;
+    padding: 0px 10px;
+    display: none;
+}
+.pma_sql_import_status h2 .minimize:hover,
+.pma_sql_import_status h2 .close:hover {
+    background: rgba(155, 149, 149, 0.78);
+    cursor: pointer;
+}
+.pma_drop_file_status {
+    color: #235a81;
+}
+.pma_drop_file_status:hover {
+    cursor: pointer;
+    text-decoration: underline;
+}

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2955,3 +2955,69 @@ table.show_create {
 table.show_create td {
     border-right: 1px solid #bbb;
 }
+.pma_drop_handler {
+    display: none;
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    height: 100%;
+    z-index: 999;
+    color: white;
+    font-size: 100pt;
+    text-align: center;
+    padding-top: 20%;
+}
+.pma_sql_import_status {
+    display: none;
+    position: fixed;
+    bottom: 0px;
+    right: 25px;
+    width: 250px;
+    border: 1px solid #999;
+    background: #f3f3f3;
+    -moz-border-radius: 4px;
+    -webkit-border-radius: 4px;
+    border-radius: 4px;
+    -moz-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>2px 2px 5px #ccc;
+    -webkit-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>2px 2px 5px #ccc;
+    box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>2px 2px 5px #ccc;
+}
+.pma_sql_import_status h2 {
+    background-color: #bbb;
+    padding: .1em .3em;
+    margin-top: 0;
+    margin-bottom: 0;
+    color: #fff;
+    font-size: 1.6em;
+    font-weight: normal;
+    text-shadow: 0 1px 0 #777;
+    -moz-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>1px 1px 15px #999 inset;
+    -webkit-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>1px 1px 15px #999 inset;
+    box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>1px 1px 15px #999 inset;
+}
+.pma_sql_import_status div {
+    height: 270px;
+    overflow-y:auto;
+    overflow-x:hidden;
+    list-style-type: none;
+}
+.pma_sql_import_status div li {
+    padding: 8px 10px;
+    border-bottom: 1px solid #bbb;
+    color: rgb(148, 14, 14);
+    background: white;
+}
+.pma_sql_import_status div li .filesize {
+    float: right;
+}
+.minimize {
+    float: right;
+    margin-right: 5px;
+    padding: 0px 10px;
+}
+.minimize:hover {
+    background: rgba(155, 149, 149, 0.78);
+    cursor: pointer;
+}

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2974,7 +2974,7 @@ table.show_create td {
     position: fixed;
     bottom: 0px;
     right: 25px;
-    width: 250px;
+    width: 400px;
     border: 1px solid #999;
     background: #f3f3f3;
     -moz-border-radius: 4px;
@@ -3012,12 +3012,26 @@ table.show_create td {
 .pma_sql_import_status div li .filesize {
     float: right;
 }
-.minimize {
+.pma_sql_import_status h2 .minimize {
     float: right;
     margin-right: 5px;
     padding: 0px 10px;
 }
-.minimize:hover {
+.pma_sql_import_status h2 .close {
+    float: right;
+    margin-right: 5px;
+    padding: 0px 10px;
+    display: none;
+}
+.pma_sql_import_status h2 .minimize:hover,
+.pma_sql_import_status h2 .close:hover {
     background: rgba(155, 149, 149, 0.78);
     cursor: pointer;
+}
+.pma_drop_file_status {
+    color: #235a81;
+}
+.pma_drop_file_status:hover {
+    cursor: pointer;
+    text-decoration: underline;
 }

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2955,3 +2955,83 @@ table.show_create {
 table.show_create td {
     border-right: 1px solid #bbb;
 }
+.pma_drop_handler {
+    display: none;
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    height: 100%;
+    z-index: 999;
+    color: white;
+    font-size: 100pt;
+    text-align: center;
+    padding-top: 20%;
+}
+.pma_sql_import_status {
+    display: none;
+    position: fixed;
+    bottom: 0px;
+    right: 25px;
+    width: 400px;
+    border: 1px solid #999;
+    background: #f3f3f3;
+    -moz-border-radius: 4px;
+    -webkit-border-radius: 4px;
+    border-radius: 4px;
+    -moz-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>2px 2px 5px #ccc;
+    -webkit-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>2px 2px 5px #ccc;
+    box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>2px 2px 5px #ccc;
+}
+.pma_sql_import_status h2 {
+    background-color: #bbb;
+    padding: .1em .3em;
+    margin-top: 0;
+    margin-bottom: 0;
+    color: #fff;
+    font-size: 1.6em;
+    font-weight: normal;
+    text-shadow: 0 1px 0 #777;
+    -moz-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>1px 1px 15px #999 inset;
+    -webkit-box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>1px 1px 15px #999 inset;
+    box-shadow: <?php echo $GLOBALS['text_dir'] === 'rtl' ? '-' : ''; ?>1px 1px 15px #999 inset;
+}
+.pma_sql_import_status div {
+    height: 270px;
+    overflow-y:auto;
+    overflow-x:hidden;
+    list-style-type: none;
+}
+.pma_sql_import_status div li {
+    padding: 8px 10px;
+    border-bottom: 1px solid #bbb;
+    color: rgb(148, 14, 14);
+    background: white;
+}
+.pma_sql_import_status div li .filesize {
+    float: right;
+}
+.pma_sql_import_status h2 .minimize {
+    float: right;
+    margin-right: 5px;
+    padding: 0px 10px;
+}
+.pma_sql_import_status h2 .close {
+    float: right;
+    margin-right: 5px;
+    padding: 0px 10px;
+    display: none;
+}
+.pma_sql_import_status h2 .minimize:hover,
+.pma_sql_import_status h2 .close:hover {
+    background: rgba(155, 149, 149, 0.78);
+    cursor: pointer;
+}
+.pma_drop_file_status {
+    color: #235a81;
+}
+.pma_drop_file_status:hover {
+    cursor: pointer;
+    text-decoration: underline;
+}


### PR DESCRIPTION
<h4>Drag and drop file upload</h4>

Video Preview of working code: https://www.youtube.com/watch?v=Hsi46nKsbNI&feature=youtu.be

**Features**
- [x] Drag and Drop sql (or other supported extensions) to PMA interface to initiate FILE uploads. (Allowed files will be uploaded)
- [x] View status of file-upload on bottom right corner of the screen (includes progress percentage)
- [x] Option to abort upload while uploading
- [x] Once upload has finished, show status as success (file was uploaded, and import process was successful), failed (file was uploaded, but import failed) & Aborted (file was not uploaded but aborted)
- [x] Different icons for different status (success, failed and aborted)

**todo later**
- Way to advertise this feature, like a message in import page or some tour guide
- Once import is finished (success/failed) or aborted. Clicking on these status should open a light box, showing result of import as shown in case of original import page.  
