### PR TITLE
bug-4473: incorrect result count when having clause is used w/o group by

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ phpMyAdmin - ChangeLog
 - bug #4467 shell_exec() has been disabled for security reasons
 - bug #4470 Error while submitting empty query
 - bug #4463 Fatal error: Class 'PMA_DatabaseInterface' not found
+- bug #4473 incorrect result count when having clause is used
 
 4.2.4.0 (2014-06-20)
 - bug #4449 Mediawiki export does not produce table header row; also fix related PHP warnings

--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -897,6 +897,7 @@ function PMA_isJustBrowsing($analyzed_sql_results, $find_real_end)
         && empty($analyzed_sql_results['analyzed_sql'][0]['group_by_clause'])
         && ! isset($find_real_end)
         && !$analyzed_sql_results['is_subquery']
+        && empty($analyzed_sql_results['analyzed_sql'][0]['having_clause'])
     ) {
         return true;
     } else {


### PR DESCRIPTION
With reference to this stackoverflow post: http://stackoverflow.com/questions/24384953/phpmyadmin-incorrect-results-count

Signed-off-by: Chirayu Chiripal chirayu.chiripal@gmail.com
