### PR TITLE
Fix #4471: Undefined index warning with referenced column.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ phpMyAdmin - ChangeLog
 ======================
 
 4.2.6.0 (not yet released)
+- bug #4471 Undefined index warning with referenced column.
 
 4.2.5.0 (2014-06-26)
 - bug #4467 shell_exec() has been disabled for security reasons

--- a/libraries/relation.lib.php
+++ b/libraries/relation.lib.php
@@ -1600,7 +1600,7 @@ function PMA_checkChildForeignReferences($db, $table, $column)
             }
         }
 
-        if (sizeof($foreigners[$column], 0) > 0) {
+        if (!empty($foreigners[$column]) && sizeof($foreigners[$column], 0) > 0) {
             $column_status['isForeignKey'] = true;
         }
     } else {


### PR DESCRIPTION
Hi,
I did this PR for https://sourceforge.net/p/phpmyadmin/bugs/4471/ .
The problem is that I can't reproduce it on 4.2, only on master… It works on master. But I would appreciate if someone can confirm this is ok on 4.2 please.
(If possible, I would like to try to merge it in 4.2 and master.)
Thanks.
