### PR TITLE
fix for broken test suite

### DIFF
--- a/test/classes/plugin/PMA_PluginManager_test.php
+++ b/test/classes/plugin/PMA_PluginManager_test.php
@@ -91,7 +91,6 @@ class PMA_PluginManager_Test extends PHPUnit_Framework_TestCase
         $observer = new PMA_TestObserver();
 
         $mock = $this->getMockBuilder('SplObjectStorage')
-            ->disableOriginalConstructor()
             ->setMethods(array('attach'))
             ->getMock();
 
@@ -115,7 +114,6 @@ class PMA_PluginManager_Test extends PHPUnit_Framework_TestCase
         $observer = new PMA_TestObserver();
 
         $mock = $this->getMockBuilder('SplObjectStorage')
-            ->disableOriginalConstructor()
             ->setMethods(array('detach'))
             ->getMock();
 


### PR DESCRIPTION
This might probably fix the test suite for now.
- no need to disable contructor of SplObjectStorage

Signed-off-by: Chirayu Chiripal chirayu.chiripal@gmail.com
