### PR TITLE
Validate $socket/$port construction (bug #4478)

### DIFF
--- a/libraries/config/Validator.class.php
+++ b/libraries/config/Validator.class.php
@@ -225,13 +225,15 @@ class PMA_Validator
         $error_key = 'Server'
     ) {
         //    static::testPHPErrorMsg();
-        $socket = empty($socket) || $connect_type == 'tcp' ? null : $socket;
-        $port = empty($port) || $connect_type == 'socket' ? null : ':' . $port;
         $error = null;
 
         if (PMA_DatabaseInterface::checkDbExtension('mysqli')) {
+            $socket = empty($socket) || $connect_type == 'tcp' ? null : $socket;
+            $port = empty($port) || $connect_type == 'socket' ? null : $port;
             $extension = 'mysqli';
         } else {
+            $socket = empty($socket) || $connect_type == 'tcp' ? null : ':' . ($socket[0] == '/' ? '' : '/') . $socket;
+            $port = empty($port) || $connect_type == 'socket' ? null : ':' . $port;
             $extension = 'mysql';
         }
 
@@ -266,7 +268,7 @@ class PMA_Validator
                 break;
             }
         } else if ($extension == 'mysql') {
-            $conn = @mysql_connect($host . $socket . $port, $user, $pass);
+            $conn = @mysql_connect($host . $port . $socket, $user, $pass);
             if (! $conn) {
                 $error = __('Could not connect to the database server!');
             } else {


### PR DESCRIPTION
Method: PMA_Validator::testDBConnection(). $port <=> $socket in mysql_connect() is for the sake of php_mysql.c's convention only.
Signed-off-by: Cezary H. Noweta chn@poczta.onet.pl
