### PR TITLE
Typo in comment and clarification of function PMA_configErrorMessage()

### DIFF
--- a/libraries/central_columns.lib.php
+++ b/libraries/central_columns.lib.php
@@ -130,7 +130,7 @@ function PMA_findExistingColNames($db, $cols, $allFields=false)
 
 /**
  * return error message to be displayed if central columns
- * configurartion storage is not completely configured
+ * configuration storage is not completely configured
  *
  * @return PMA_Message
  */


### PR DESCRIPTION
Fixed typo (configurartion -> configuration).

I'm doing the Danish translation, and the string "Central list of columns configuration Storage is not completely configured!" is difficult to understand - and I suggest rewriting it or providing a comment to translators if possible.

/**
- return error message to be displayed if central columns
- configurartion storage is not completely configured
  *
- @return PMA_Message
  */
  function PMA_configErrorMessage()
  {
  return PMA_Message::error(
      __(
          'Central list of columns configuration Storage '
          . 'is not completely configured!'
      )
  );
  }
