### PR TITLE
Fix bug #4459

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ phpMyAdmin - ChangeLog
 - bug #4440 Javascript error when renaming table
 - bug #4483 'New window' link (selflink) disappears, causing Javascript error
 - bug #4489 Incorrect detection of privileges for routine creation
+- bug #4459 First database in navigation bar isn't clickable when expanded
 
 4.2.5.0 (2014-06-26)
 - bug #4467 shell_exec() has been disabled for security reasons

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,7 @@ phpMyAdmin - ChangeLog
 - bug #4440 Javascript error when renaming table
 - bug #4483 'New window' link (selflink) disappears, causing Javascript error
 - bug #4489 Incorrect detection of privileges for routine creation
-- bug #4459 First database in navigation bar isn't clickable when expanded
+- bug #4459 First few characters of database name aren't clickable when expanded
 
 4.2.5.0 (2014-06-26)
 - bug #4467 shell_exec() has been disabled for security reasons

--- a/themes/original/css/navigation.css.php
+++ b/themes/original/css/navigation.css.php
@@ -127,6 +127,10 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
     position: absolute;
     height: 100%;
 }
+#pma_navigation_tree_content a.hover_show_full {
+    position: relative;
+    z-index: 9999;
+}
 #pma_navigation_tree a {
     color: <?php echo $GLOBALS['cfg']['NaviColor']; ?>;
 }
@@ -199,6 +203,8 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
 #pma_navigation_tree div.block i {
     border-<?php echo $left; ?>: 1px solid #666;
     border-bottom: 1px solid #666;
+    position: relative;
+    z-index: 0;
 }
 #pma_navigation_tree div.block i.first { /* Removes top segment */
     border-<?php echo $left; ?>: 0;

--- a/themes/pmahomme/css/navigation.css.php
+++ b/themes/pmahomme/css/navigation.css.php
@@ -113,6 +113,10 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
     position: absolute;
     height: 100%;
 }
+#pma_navigation_tree_content a.hover_show_full {
+    position: relative;
+    z-index: 9999;
+}
 #pma_navigation_tree a {
     color: <?php echo $GLOBALS['cfg']['NaviColor']; ?>;
 }
@@ -189,6 +193,8 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
     display: block;
     border-<?php echo $left; ?>: 1px solid #666;
     border-bottom: 1px solid #666;
+    position: relative;
+    z-index: 0;
 }
 #pma_navigation_tree div.block i.first { /* Removes top segment */
     border-<?php echo $left; ?>: 0;


### PR DESCRIPTION
Since 4.X, there is a little bug when trying to click on a DB name expanded in the navigation tree.
To easily reproduce it, create a DB named "a". With the bug it's quite impossible to click on it when it's expanded. With the fix, it should be ok.
