### PR TITLE
Fix links in home page.

### DIFF
--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -835,7 +835,7 @@ function PMA_isAllowedDomain($url)
         /* Include current domain */
         $_SERVER['SERVER_NAME'],
         /* phpMyAdmin domains */
-        'wiki.phpmyadmin.net', 'www.phpMyAdmin.net', 'phpmyadmin.net',
+        'wiki.phpmyadmin.net', 'www.phpmyadmin.net', 'phpmyadmin.net',
         'docs.phpmyadmin.net',
         /* mysql.com domains */
         'dev.mysql.com','bugs.mysql.com',
@@ -846,7 +846,7 @@ function PMA_isAllowedDomain($url)
         /* Following are doubtful ones. */
         'www.primebase.com','pbxt.blogspot.com'
     );
-    if (in_array($domain, $domainWhiteList)) {
+    if (in_array(strtolower($domain), $domainWhiteList)) {
         return true;
     }
 


### PR DESCRIPTION
Web site: url.php?url=http://www.phpMyAdmin.net/ => OK
Improve:  url.php?url=http://www.phpmyadmin.neti/home_page/improve.php => broken
Support:  url.php?url=http://www.phpmyadmin.net/home_page/support.php  => broken

As domain name are not case sensitive, this seems the simpler fix.
(other solution, fix index.php to use CamelCase names for all links)
