### PR TITLE
Fix #4427: action icons not in horizontal order

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ phpMyAdmin - ChangeLog
 4.2.7.0 (not yet released)
 - bug       Broken links on home page
 - bug #4494 Overlap in navigation panel
+- bug #4427 Action icons not in horizontal order
 
 4.2.6.0 (2014-07-17)
 - bug #4471 Undefined index warning with referenced column.

--- a/libraries/display_structure.inc.php
+++ b/libraries/display_structure.inc.php
@@ -21,9 +21,7 @@ if (! defined('PHPMYADMIN')) {
 
 
 $HideStructureActions = '';
-if (PMA_Util::showText('ActionLinksMode')
-    && $GLOBALS['cfg']['HideStructureActions'] === true
-) {
+if ($GLOBALS['cfg']['HideStructureActions'] === true) {
     $HideStructureActions .= ' HideStructureActions';
 }
 


### PR DESCRIPTION
Remove the condition not to use the compressed menu only when text is displayed.
