### PR TITLE
Fix default port to null for hhvm

### DIFF
--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -2300,7 +2300,7 @@ class PMA_DatabaseInterface
      *
      * @param array|null $server host/port/socket/persistent
      *
-     * @return false|integer
+     * @return null|integer
      */
     public function getServerPort($server = null)
     {
@@ -2309,7 +2309,7 @@ class PMA_DatabaseInterface
         }
 
         if (empty($server['port'])) {
-            return false;
+            return null;
         } else {
             return intval($server['port']);
         }

--- a/libraries/dbi/DBIMysql.class.php
+++ b/libraries/dbi/DBIMysql.class.php
@@ -99,7 +99,7 @@ class PMA_DBI_Mysql implements PMA_DBI_Extension
         $server_port = $GLOBALS['dbi']->getServerPort($server);
         $server_socket = $GLOBALS['dbi']->getServerSocket($server);
 
-        if ($server_port === false) {
+        if ($server_port === null) {
             $server_port = '';
         } else {
             $server_port = ':' . $server_port;


### PR DESCRIPTION
HHVM doesn't allow false to be passed as port to mysqli_real_connect.
It only allows a nullable integer until ZendParamMode is finished.

See facebook/hhvm#1817

Signed-off-by: Tim Siebels tim_siebels_aurich@yahoo.de
