### PR TITLE
added group medium to test

### DIFF
--- a/test/libraries/config/PMA_messages_inc_test.php
+++ b/test/libraries/config/PMA_messages_inc_test.php
@@ -31,6 +31,7 @@ class PMA_MessagesIncTest extends PHPUnit_Framework_TestCase
      * Tests messages variables
      *
      * @return void
+     * @group medium
      */
     function testMessages()
     {


### PR DESCRIPTION
I recently noticed that many builds are failing on `HHVM` with this test failing with following error `PHP_Invoker_TimeoutException: Execution aborted after 10 seconds`. Lets increase the execution time limit for this test by adding `@group medium`.

Signed-off-by: Chirayu Chiripal chirayu.chiripal@gmail.com
