### PR TITLE
Bug#4511: QBE fails to generate LEFT join for InnoDB foreign keys in absence of configuration storage.

### DIFF
--- a/libraries/DBQbe.class.php
+++ b/libraries/DBQbe.class.php
@@ -1366,7 +1366,7 @@ class PMA_DbQbe
             } // end while
 
             // Create LEFT JOINS out of Relations
-            if ($cfgRelation['relwork'] && count($all_tables) > 0) {
+            if (count($all_tables) > 0) {
                 // Get tables and columns with valid where clauses
                 $valid_where_clauses = $this->_getWhereClauseTablesAndColumns();
                 $where_clause_tables = $valid_where_clauses['where_clause_tables'];

--- a/libraries/relation.lib.php
+++ b/libraries/relation.lib.php
@@ -1334,7 +1334,7 @@ function PMA_getRelatives($all_tables, $master)
     $known_tables = array();
     $known_tables[$master] = $master;
     $run = 0;
-    while (count($remaining_tables) > 0) {
+    while ($GLOBALS['cfgRelation']['relwork'] && count($remaining_tables) > 0) {
         // Whether to go from master to foreign or vice versa
         if ($run % 2 == 0) {
             $from = 'master';

--- a/tbl_relation.php
+++ b/tbl_relation.php
@@ -152,7 +152,8 @@ $columns = $GLOBALS['dbi']->getColumns($db, $table);
 
 // common form
 $html_output .= PMA_getHtmlForCommonForm(
-    $db, $table, $columns, $cfgRelation, $tbl_storage_engine, $existrel,
+    $db, $table, $columns, $cfgRelation, $tbl_storage_engine,
+    isset($existrel) ? $existrel : null,
     isset($existrel_foreign) ? $existrel_foreign['foreign_keys_data'] : null,
     $options_array
 );


### PR DESCRIPTION
Bug#4511: QBE fails to generate LEFT join for InnoDB foreign keys in absence of configuration storage.

Signed-off-by: Ashutosh Dhundhara ashutoshdhundhara@yahoo.com
