### PR TITLE
Fix bug #4518

### DIFF
--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1363,10 +1363,11 @@ class ExportSql extends ExportPlugin
                             " AUTO_INCREMENT", "", $sql_lines[$k]
                         );
                     }
-                    if ($update_indexes_increments && preg_match(
-                        '@[\s]+(AUTO_INCREMENT=)@',
-                        $sql_lines[$k]
-                    )) {
+                    if (isset($GLOBALS['sql_auto_increment'])
+                        && $update_indexes_increments && preg_match(
+                            '@[\s]+(AUTO_INCREMENT=)@',
+                            $sql_lines[$k]
+                        )) {
                         //adds auto increment value
                         $increment_value = substr(
                             $sql_lines[$k],


### PR DESCRIPTION
While appending the "AUTO_INCREMENT="  in alter table query, added an additional check for if checkbox named "sql_auto_increment" has been chacked or unchecked.
Signed-off-by: Smita Kumari kumarismita62@gmail.com
