### PR TITLE
Added basename() in  libraries/display_change_password.lib.php

### DIFF
--- a/libraries/display_change_password.lib.php
+++ b/libraries/display_change_password.lib.php
@@ -32,7 +32,7 @@ function PMA_getHtmlForChangePassword($username, $hostname)
     $is_privileges = basename($_SERVER['SCRIPT_NAME']) === 'server_privileges.php';
 
     $html = '<form method="post" id="change_password_form" '
-        . 'action="' . $GLOBALS['PMA_PHP_SELF'] . '" '
+        . 'action="' . basename($GLOBALS['PMA_PHP_SELF']) . '" '
         . 'name="chgPassword" '
         . 'class="ajax'
         . ($is_privileges ? ' submenu-item' : '')


### PR DESCRIPTION
Added basename() to fix path errors in the change_password_form when using a reverse proxy or non-root directory installation. Originally the form action url was "/server_privileges.php", with the fix it will be "server_privileges.php". 
