### PR TITLE
The fixes for failures caused by strtoupper & strtolower on systems using Turkish locale.

### DIFF
--- a/PMAStandard/Sniffs/Commenting/ClassCommentSniff.php
+++ b/PMAStandard/Sniffs/Commenting/ClassCommentSniff.php
@@ -79,7 +79,7 @@ class PMAStandard_Sniffs_Commenting_ClassCommentSniff extends PMAStandard_Sniffs
         $this->currentFile = $phpcsFile;
 
         $tokens    = $phpcsFile->getTokens();
-        $type      = strtolower($tokens[$stackPtr]['content']);
+        $type      = mb_strtolower($tokens[$stackPtr]['content']);
         $errorData = array($type);
         $find      = array(
                       T_ABSTRACT,

--- a/PMAStandard/Sniffs/Commenting/FileCommentSniff.php
+++ b/PMAStandard/Sniffs/Commenting/FileCommentSniff.php
@@ -568,9 +568,9 @@ class PMAStandard_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_
                     $newContent = str_replace(' ', '_', $content);
                     $nameBits   = explode('_', $newContent);
                     $firstBit   = array_shift($nameBits);
-                    $newName    = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
+                    $newName    = mb_strtoupper($firstBit{0}).substr($firstBit, 1).'_';
                     foreach ($nameBits as $bit) {
-                        $newName .= strtoupper($bit{0}).substr($bit, 1).'_';
+                        $newName .= mb_strtoupper($bit{0}).substr($bit, 1).'_';
                     }
 
                     $error     = 'Package name "%s" is not valid; consider "%s" instead';
@@ -607,9 +607,9 @@ class PMAStandard_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_
                     $newContent = str_replace(' ', '_', $content);
                     $nameBits   = explode('_', $newContent);
                     $firstBit   = array_shift($nameBits);
-                    $newName    = strtoupper($firstBit{0}).substr($firstBit, 1).'_';
+                    $newName    = mb_strtoupper($firstBit{0}).substr($firstBit, 1).'_';
                     foreach ($nameBits as $bit) {
-                        $newName .= strtoupper($bit{0}).substr($bit, 1).'_';
+                        $newName .= mb_strtoupper($bit{0}).substr($bit, 1).'_';
                     }
 
                     $error     = 'Subpackage name "%s" is not valid; consider "%s" instead';

--- a/PMAStandard/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/PMAStandard/Sniffs/Commenting/FunctionCommentSniff.php
@@ -278,10 +278,10 @@ class PMAStandard_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSnif
         $className = '';
         if ($this->_classToken !== null) {
             $className = $this->currentFile->getDeclarationName($this->_classToken);
-            $className = strtolower(ltrim($className, '_'));
+            $className = mb_strtolower(ltrim($className, '_'));
         }
 
-        $methodName      = strtolower(ltrim($this->_methodName, '_'));
+        $methodName      = mb_strtolower(ltrim($this->_methodName, '_'));
         $isSpecialMethod = ($this->_methodName === '__construct' || $this->_methodName === '__destruct');
 
         if ($isSpecialMethod === false && $methodName !== $className) {
@@ -413,7 +413,7 @@ class PMAStandard_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSnif
                                 );
 
                         $error  = 'Doc comment for var %s does not match ';
-                        if (strtolower($paramName) === strtolower($realName)) {
+                        if (mb_strtolower($paramName) === mb_strtolower($realName)) {
                             $error .= 'case of ';
                             $code   = 'ParamNameNoCaseMatch';
                         }

--- a/db_printview.php
+++ b/db_printview.php
@@ -58,7 +58,7 @@ if ($num_tables == 0) {
     $odd_row = true;
     foreach ($tables as $sts_data) {
         if (PMA_Table::isMerge($db, $sts_data['TABLE_NAME'])
-            || strtoupper($sts_data['ENGINE']) == 'FEDERATED'
+            || mb_strtoupper($sts_data['ENGINE']) == 'FEDERATED'
         ) {
             $merged_size = true;
         } else {

--- a/gis_data_editor.php
+++ b/gis_data_editor.php
@@ -44,7 +44,7 @@ $gis_types = array(
 // Extract from field's values if availbale, if not use the column type passed.
 if (! isset($gis_data['gis_type'])) {
     if (isset($_REQUEST['type']) && $_REQUEST['type'] != '') {
-        $gis_data['gis_type'] = strtoupper($_REQUEST['type']);
+        $gis_data['gis_type'] = mb_strtoupper($_REQUEST['type']);
     }
     if (isset($_REQUEST['value']) && trim($_REQUEST['value']) != '') {
         $start = (substr($_REQUEST['value'], 0, 1) == "'") ? 1 : 0;

--- a/import.php
+++ b/import.php
@@ -390,11 +390,11 @@ if ($memory_limit == -1) {
 }
 
 // Calculate value of the limit
-if (strtolower(substr($memory_limit, -1)) == 'm') {
+if (mb_strtolower(substr($memory_limit, -1)) == 'm') {
     $memory_limit = (int)substr($memory_limit, 0, -1) * 1024 * 1024;
-} elseif (strtolower(substr($memory_limit, -1)) == 'k') {
+} elseif (mb_strtolower(substr($memory_limit, -1)) == 'k') {
     $memory_limit = (int)substr($memory_limit, 0, -1) * 1024;
-} elseif (strtolower(substr($memory_limit, -1)) == 'g') {
+} elseif (mb_strtolower(substr($memory_limit, -1)) == 'g') {
     $memory_limit = (int)substr($memory_limit, 0, -1) * 1024 * 1024 * 1024;
 } else {
     $memory_limit = (int)$memory_limit;

--- a/libraries/Config.class.php
+++ b/libraries/Config.class.php
@@ -148,7 +148,7 @@ class PMA_Config
         }
 
         // disable output-buffering (if set to 'auto') for IE6, else enable it.
-        if (strtolower($this->get('OBGzip')) == 'auto') {
+        if (mb_strtolower($this->get('OBGzip')) == 'auto') {
             if ($this->get('PMA_USR_BROWSER_AGENT') == 'IE'
                 && $this->get('PMA_USR_BROWSER_VER') >= 6
                 && $this->get('PMA_USR_BROWSER_VER') < 7
@@ -528,7 +528,7 @@ class PMA_Config
                         }
                     }
                 }
-                $hash = strtolower($hash);
+                $hash = mb_strtolower($hash);
                 foreach ($pack_names as $pack_name) {
                     $index_name = str_replace('.pack', '.idx', $pack_name);
 
@@ -566,7 +566,7 @@ class PMA_Config
                     $found = false;
                     $offset = 8 + (256 * 4);
                     for ($position = $start; $position < $end; $position++) {
-                        $sha = strtolower(
+                        $sha = mb_strtolower(
                             bin2hex(
                                 substr(
                                     $index_data, $offset + ($position * 20), 20
@@ -1478,7 +1478,7 @@ class PMA_Config
             $this->set('enable_upload', true);
             // if set "php_admin_value file_uploads Off" in httpd.conf
             // ini_get() also returns the string "Off" in this case:
-            if ('off' == strtolower(ini_get('file_uploads'))) {
+            if ('off' == mb_strtolower(ini_get('file_uploads'))) {
                 $this->set('enable_upload', false);
             }
         } else {
@@ -1565,18 +1565,18 @@ class PMA_Config
             if (PMA_getenv('HTTP_SCHEME')) {
                 $url['scheme'] = PMA_getenv('HTTP_SCHEME');
             } elseif (PMA_getenv('HTTPS')
-                && strtolower(PMA_getenv('HTTPS')) == 'on'
+                && mb_strtolower(PMA_getenv('HTTPS')) == 'on'
             ) {
                 $url['scheme'] = 'https';
                 // A10 Networks load balancer:
             } elseif (PMA_getenv('HTTP_HTTPS_FROM_LB')
-                && strtolower(PMA_getenv('HTTP_HTTPS_FROM_LB')) == 'on'
+                && mb_strtolower(PMA_getenv('HTTP_HTTPS_FROM_LB')) == 'on'
             ) {
                 $url['scheme'] = 'https';
             } elseif (PMA_getenv('HTTP_X_FORWARDED_PROTO')) {
-                $url['scheme'] = strtolower(PMA_getenv('HTTP_X_FORWARDED_PROTO'));
+                $url['scheme'] = mb_strtolower(PMA_getenv('HTTP_X_FORWARDED_PROTO'));
             } elseif (PMA_getenv('HTTP_FRONT_END_HTTPS')
-                && strtolower(PMA_getenv('HTTP_FRONT_END_HTTPS')) == 'on'
+                && mb_strtolower(PMA_getenv('HTTP_FRONT_END_HTTPS')) == 'on'
             ) {
                 $url['scheme'] = 'https';
             } else {

--- a/libraries/DBQbe.class.php
+++ b/libraries/DBQbe.class.php
@@ -1009,7 +1009,7 @@ class PMA_DbQbe
                 && isset($this->_curAndOrCol)
             ) {
                 $where_clause .= ' '
-                    . strtoupper($this->_curAndOrCol[$last_where]) . ' ';
+                    . mb_strtoupper($this->_curAndOrCol[$last_where]) . ' ';
             }
             if (! empty($this->_curField[$column_index])
                 && ! empty($this->_curCriteria[$column_index])
@@ -1045,7 +1045,7 @@ class PMA_DbQbe
                     && $column_index
                 ) {
                     $qry_orwhere .= ' '
-                        . strtoupper($this->_curAndOrCol[$last_orwhere]) . ' ';
+                        . mb_strtoupper($this->_curAndOrCol[$last_orwhere]) . ' ';
                 }
                 if (! empty($this->_curField[$column_index])
                     && ! empty($_REQUEST['Or' . $row_index][$column_index])
@@ -1063,7 +1063,7 @@ class PMA_DbQbe
             }
             if (! empty($qry_orwhere)) {
                 $where_clause .= "\n"
-                    .  strtoupper(
+                    .  mb_strtoupper(
                         isset($this->_curAndOrRow[$row_index])
                         ? $this->_curAndOrRow[$row_index] . ' '
                         : ''

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -502,7 +502,7 @@ class PMA_DatabaseInterface
             // Drizzle generally uses lower case for them,
             // but TABLES returns uppercase
             foreach ((array)$database as $db) {
-                $db_upper = strtoupper($db);
+                $db_upper = mb_strtoupper($db);
                 if (!isset($tables[$db]) && isset($tables[$db_upper])) {
                     $tables[$db] = $tables[$db_upper];
                     unset($tables[$db_upper]);
@@ -546,14 +546,14 @@ class PMA_DatabaseInterface
         if (! is_array($database)) {
             if (isset($tables[$database])) {
                 return $tables[$database];
-            } elseif (isset($tables[strtolower($database)])) {
+            } elseif (isset($tables[mb_strtolower($database)])) {
                 // on windows with lower_case_table_names = 1
                 // MySQL returns
                 // with SHOW DATABASES or information_schema.SCHEMATA: `Test`
                 // but information_schema.TABLES gives `test`
                 // bug #2036
                 // https://sourceforge.net/p/phpmyadmin/bugs/2036/
-                return $tables[strtolower($database)];
+                return $tables[mb_strtolower($database)];
             } else {
                 // one database but inexact letter case match
                 // as Drizzle is always case insensitive,
@@ -640,7 +640,7 @@ class PMA_DatabaseInterface
             $tables[$table_name]['TABLE_COMMENT']
                 =& $tables[$table_name]['Comment'];
 
-            if (strtoupper($tables[$table_name]['Comment']) === 'VIEW'
+            if (mb_strtoupper($tables[$table_name]['Comment']) === 'VIEW'
                 && $tables[$table_name]['Engine'] == null
             ) {
                 $tables[$table_name]['TABLE_TYPE'] = 'VIEW';
@@ -701,7 +701,7 @@ class PMA_DatabaseInterface
         $link = null, $sort_by = 'SCHEMA_NAME', $sort_order = 'ASC',
         $limit_offset = 0, $limit_count = false
     ) {
-        $sort_order = strtoupper($sort_order);
+        $sort_order = mb_strtoupper($sort_order);
 
         if (true === $limit_count) {
             $limit_count = $GLOBALS['cfg']['MaxDbList'];
@@ -1951,9 +1951,9 @@ class PMA_DatabaseInterface
      */
     public function isSystemSchema($schema_name, $testForMysqlSchema = false)
     {
-        return strtolower($schema_name) == 'information_schema'
-            || (!PMA_DRIZZLE && strtolower($schema_name) == 'performance_schema')
-            || (PMA_DRIZZLE && strtolower($schema_name) == 'data_dictionary')
+        return mb_strtolower($schema_name) == 'information_schema'
+            || (!PMA_DRIZZLE && mb_strtolower($schema_name) == 'performance_schema')
+            || (PMA_DRIZZLE && mb_strtolower($schema_name) == 'data_dictionary')
             || ($testForMysqlSchema && !PMA_DRIZZLE && $schema_name == 'mysql');
     }
 

--- a/libraries/DisplayResults.class.php
+++ b/libraries/DisplayResults.class.php
@@ -433,7 +433,7 @@ class PMA_DisplayResults
                     $this->__get('sql_query'), $which
                 );
                 if (isset($which[1])
-                    && (strpos(' ' . strtoupper($which[1]), 'PROCESSLIST') > 0)
+                    && (strpos(' ' . mb_strtoupper($which[1]), 'PROCESSLIST') > 0)
                 ) {
                     // no edit link
                     $do_display['edit_lnk'] = self::NO_EDIT_OR_DELETE;
@@ -1999,7 +1999,7 @@ class PMA_DisplayResults
                         $sort_direction, $single_sort_order, $column_index, $index
                     );
                 } else {
-                    $single_sort_order .= strtoupper($sort_direction[$index]);
+                    $single_sort_order .= mb_strtoupper($sort_direction[$index]);
                 }
             }
             if ($current_name == $name_to_use_in_sort && $is_in_sort) {
@@ -2009,7 +2009,7 @@ class PMA_DisplayResults
                 );
                 $order_img .= " <small>" . ($index + 1) . "</small>";
             } else {
-                $sort_order .= strtoupper($sort_direction[$index]);
+                $sort_order .= mb_strtoupper($sort_direction[$index]);
             }
             // Separate columns by a comma
             $sort_order .= ", ";
@@ -2117,7 +2117,7 @@ class PMA_DisplayResults
     private function _getSortingUrlParams(
         $sort_direction, $sort_order, $column_index, $index
     ) {
-        if (strtoupper(trim($sort_direction[$index])) ==  self::DESCENDING_SORT_DIR) {
+        if (mb_strtoupper(trim($sort_direction[$index])) ==  self::DESCENDING_SORT_DIR) {
             $sort_order .= ' ASC';
             $order_img   = ' ' . PMA_Util::getImage(
                 's_desc.png', __('Descending'),
@@ -2912,18 +2912,18 @@ class PMA_DisplayResults
 
             // Check whether the field needs to display with syntax highlighting
 
-            if (! empty($this->transformation_info[strtolower($this->__get('db'))][strtolower($this->__get('table'))][strtolower($meta->name)])
+            if (! empty($this->transformation_info[mb_strtolower($this->__get('db'))][mb_strtolower($this->__get('table'))][mb_strtolower($meta->name)])
                 && (trim($row[$i]) != '')
             ) {
                 $row[$i] = PMA_Util::formatSql($row[$i]);
                 include_once $this->transformation_info
-                    [strtolower($this->__get('db'))]
-                    [strtolower($this->__get('table'))]
-                    [strtolower($meta->name)][0];
+                    [mb_strtolower($this->__get('db'))]
+                    [mb_strtolower($this->__get('table'))]
+                    [mb_strtolower($meta->name)][0];
                 $transformation_plugin = new $this->transformation_info
-                    [strtolower($this->__get('db'))]
-                    [strtolower($this->__get('table'))]
-                    [strtolower($meta->name)][1](null);
+                    [mb_strtolower($this->__get('db'))]
+                    [mb_strtolower($this->__get('table'))]
+                    [mb_strtolower($meta->name)][1](null);
 
                 $transform_options  = PMA_Transformation_getOptions(
                     isset($mime_map[$meta->name]['transformation_options'])
@@ -2933,9 +2933,9 @@ class PMA_DisplayResults
 
                 $meta->mimetype = str_replace(
                     '_', '/',
-                    $this->transformation_info[strtolower($this->__get('db'))]
-                    [strtolower($this->__get('table'))]
-                    [strtolower($meta->name)][2]
+                    $this->transformation_info[mb_strtolower($this->__get('db'))]
+                    [mb_strtolower($this->__get('table'))]
+                    [mb_strtolower($meta->name)][2]
                 );
 
             }
@@ -2944,11 +2944,11 @@ class PMA_DisplayResults
             include_once 'libraries/special_schema_links.lib.php';
 
             if (isset($GLOBALS['special_schema_links'])
-                && (! empty($GLOBALS['special_schema_links'][strtolower($this->__get('db'))][strtolower($this->__get('table'))][strtolower($meta->name)]))
+                && (! empty($GLOBALS['special_schema_links'][mb_strtolower($this->__get('db'))][mb_strtolower($this->__get('table'))][mb_strtolower($meta->name)]))
             ) {
 
                 $linking_url = $this->_getSpecialLinkUrl(
-                    $row[$i], $row_info, strtolower($meta->name)
+                    $row[$i], $row_info, mb_strtolower($meta->name)
                 );
                 include_once
                     "libraries/plugins/transformations/Text_Plain_Link.class.php";
@@ -3153,8 +3153,8 @@ class PMA_DisplayResults
 
         $linking_url_params = array();
         $link_relations = $GLOBALS['special_schema_links']
-            [strtolower($this->__get('db'))]
-            [strtolower($this->__get('table'))]
+            [mb_strtolower($this->__get('db'))]
+            [mb_strtolower($this->__get('table'))]
             [$field_name];
 
         if (! is_array($link_relations['link_param'])) {
@@ -3180,12 +3180,12 @@ class PMA_DisplayResults
                 } else {
 
                     $linking_url_params[$new_param['param_info']]
-                        = $row_info[strtolower($new_param['column_name'])];
+                        = $row_info[mb_strtolower($new_param['column_name'])];
 
                     // Special case 1 - when executing routines, according
                     // to the type of the routine, url param changes
                     if (!empty($row_info['routine_type'])) {
-                        $lowerRoutineType = strtolower($row_info['routine_type']);
+                        $lowerRoutineType = mb_strtolower($row_info['routine_type']);
                         if ($lowerRoutineType == self::ROUTINE_PROCEDURE
                             || $lowerRoutineType == self::ROUTINE_FUNCTION
                         ) {
@@ -3220,7 +3220,7 @@ class PMA_DisplayResults
 
         for ($n = 0; $n < $this->__get('fields_cnt'); ++$n) {
             $m = $col_order ? $col_order[$n] : $n;
-            $row_info[strtolower($fields_meta[$m]->name)] = $row[$m];
+            $row_info[mb_strtolower($fields_meta[$m]->name)] = $row[$m];
         }
 
         return $row_info;
@@ -3761,7 +3761,7 @@ class PMA_DisplayResults
             if ($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_GEOM) {
 
                 $geometry_text = $this->_handleNonPrintableContents(
-                    strtoupper(self::GEOMETRY_FIELD),
+                    mb_strtoupper(self::GEOMETRY_FIELD),
                     (isset($column) ? $column : ''), $transformation_plugin,
                     $transform_options, $default_function, $meta
                 );
@@ -4781,7 +4781,7 @@ class PMA_DisplayResults
                     $column_for_first_row = $row[$sorted_column_index];
                 }
 
-                $column_for_first_row = strtoupper(
+                $column_for_first_row = mb_strtoupper(
                     substr($column_for_first_row, 0, $GLOBALS['cfg']['LimitChars'])
                 );
 
@@ -4805,7 +4805,7 @@ class PMA_DisplayResults
                     $column_for_last_row = $row[$sorted_column_index];
                 }
 
-                $column_for_last_row = strtoupper(
+                $column_for_last_row = mb_strtoupper(
                     substr($column_for_last_row, 0, $GLOBALS['cfg']['LimitChars'])
                 );
 

--- a/libraries/Font.class.php
+++ b/libraries/Font.class.php
@@ -115,7 +115,7 @@ class PMA_Font
         $count = $count + (strlen(preg_replace("/[a-z0-9]/i", "", $text)) * 0.3);
 
         $modifier = 1;
-        $font = strtolower($font);
+        $font = mb_strtolower($font);
         switch ($font) {
         /*
          * no modifier for arial and sans-serif

--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -559,8 +559,8 @@ class PMA_Header
 
         $retval  = "<!DOCTYPE HTML>";
         $retval .= "<html lang='$lang' dir='$dir' class='";
-        $retval .= strtolower(PMA_USR_BROWSER_AGENT) . " ";
-        $retval .= strtolower(PMA_USR_BROWSER_AGENT)
+        $retval .= mb_strtolower(PMA_USR_BROWSER_AGENT) . " ";
+        $retval .= mb_strtolower(PMA_USR_BROWSER_AGENT)
             . intval(PMA_USR_BROWSER_VER) . "'>";
 
         return $retval;

--- a/libraries/ServerStatusData.class.php
+++ b/libraries/ServerStatusData.class.php
@@ -315,7 +315,7 @@ class PMA_ServerStatusData
 
         // Set all class properties
         $this->db_isLocal = false;
-        if (strtolower($GLOBALS['cfg']['Server']['host']) === 'localhost'
+        if (mb_strtolower($GLOBALS['cfg']['Server']['host']) === 'localhost'
             || $GLOBALS['cfg']['Server']['host'] === '127.0.0.1'
             || $GLOBALS['cfg']['Server']['host'] === '::1'
         ) {

--- a/libraries/StorageEngine.class.php
+++ b/libraries/StorageEngine.class.php
@@ -132,7 +132,7 @@ class PMA_StorageEngine
         $name = 'engine', $id = null,
         $selected = null, $offerUnavailableEngines = false
     ) {
-        $selected   = strtolower($selected);
+        $selected   = mb_strtolower($selected);
         $output     = '<select name="' . $name . '"'
             . (empty($id) ? '' : ' id="' . $id . '"') . '>' . "\n";
 
@@ -151,7 +151,7 @@ class PMA_StorageEngine
             $output .= '    <option value="' . htmlspecialchars($key) . '"'
                 . (empty($details['Comment'])
                     ? '' : ' title="' . htmlspecialchars($details['Comment']) . '"')
-                . (strtolower($key) == $selected
+                . (mb_strtolower($key) == $selected
                     || (empty($selected) && $details['Support'] == 'DEFAULT')
                     ? ' selected="selected"' : '')
                 . '>' . "\n"
@@ -173,9 +173,9 @@ class PMA_StorageEngine
     static public function getEngine($engine)
     {
         $engine = str_replace('/', '', str_replace('.', '', $engine));
-        $filename = './libraries/engines/' . strtolower($engine) . '.lib.php';
+        $filename = './libraries/engines/' . mb_strtolower($engine) . '.lib.php';
         if (file_exists($filename) && include_once $filename) {
-            switch(strtolower($engine)) {
+            switch(mb_strtolower($engine)) {
             case 'bdb':
                 return new PMA_StorageEngine_Bdb($engine);
             case 'berkeleydb':
@@ -318,7 +318,7 @@ class PMA_StorageEngine
                 $mysql_vars[$row['Variable_name']]
                     = $variables[$row['Variable_name']];
             } elseif (! $like
-                && strpos(strtolower($row['Variable_name']), strtolower($this->engine)) !== 0
+                && strpos(mb_strtolower($row['Variable_name']), mb_strtolower($this->engine)) !== 0
             ) {
                 continue;
             }

--- a/libraries/Table.class.php
+++ b/libraries/Table.class.php
@@ -262,7 +262,7 @@ class PMA_Table
             );
             foreach ($results as $result) {
                 $analyzed_sql[0]['create_table_fields'][$result['COLUMN_NAME']]
-                    = array('type' => strtoupper($result['DATA_TYPE']));
+                    = array('type' => mb_strtoupper($result['DATA_TYPE']));
             }
         } else {
             $show_create_table = $GLOBALS['dbi']->fetchValue(
@@ -333,7 +333,7 @@ class PMA_Table
         }
 
         // any of known merge engines?
-        return in_array(strtoupper($engine), array('MERGE', 'MRG_MYISAM'));
+        return in_array(mb_strtoupper($engine), array('MERGE', 'MRG_MYISAM'));
     }
 
     /**
@@ -422,7 +422,7 @@ class PMA_Table
         $default_type = 'USER_DEFINED', $default_value = '',  $extra = '',
         $comment = '', &$field_primary = null, $move_to = ''
     ) {
-        $is_timestamp = strpos(strtoupper($type), 'TIMESTAMP') !== false;
+        $is_timestamp = strpos(mb_strtoupper($type), 'TIMESTAMP') !== false;
 
         $query = PMA_Util::backquote($name) . ' ' . $type;
 
@@ -965,7 +965,7 @@ class PMA_Table
 
                 for ($j = $i; $j < $cnt; $j++) {
                     if ($parsed_sql[$j]['type'] == 'alpha_reservedWord'
-                        && strtoupper($parsed_sql[$j]['data']) == 'CONSTRAINT'
+                        && mb_strtoupper($parsed_sql[$j]['data']) == 'CONSTRAINT'
                     ) {
                         if ($parsed_sql[$j+1]['type'] == $table_delimiter) {
                             $parsed_sql[$j+1]['data'] = '';
@@ -1001,7 +1001,7 @@ class PMA_Table
 
                 for ($j = $i; $j < $cnt; $j++) {
                     if ($parsed_sql[$j]['type'] == 'alpha_reservedWord'
-                        && strtoupper($parsed_sql[$j]['data']) == 'CONSTRAINT'
+                        && mb_strtoupper($parsed_sql[$j]['data']) == 'CONSTRAINT'
                     ) {
                         if ($parsed_sql[$j+1]['type'] == $table_delimiter) {
                             $parsed_sql[$j+1]['data'] = '';

--- a/libraries/TableSearch.class.php
+++ b/libraries/TableSearch.class.php
@@ -151,7 +151,7 @@ class PMA_TableSearch
                 }
                 $type = preg_replace('@ZEROFILL@i', '', $type);
                 $type = preg_replace('@UNSIGNED@i', '', $type);
-                $type = strtolower($type);
+                $type = mb_strtolower($type);
             }
             if (empty($type)) {
                 $type = '&nbsp;';

--- a/libraries/Tracker.class.php
+++ b/libraries/Tracker.class.php
@@ -709,7 +709,7 @@ class PMA_Tracker
 
         $tokens = explode(" ", $query);
         foreach ($tokens as $key => $value) {
-            $tokens[$key] = strtoupper($value);
+            $tokens[$key] = mb_strtoupper($value);
         }
 
         // Parse USE statement, need it for SQL dump imports
@@ -734,7 +734,7 @@ class PMA_Tracker
 
             $index = array_search('VIEW', $tokens);
 
-            $result['tablename'] = strtolower(
+            $result['tablename'] = mb_strtolower(
                 self::getTableName($tokens[$index + 1])
             );
         }
@@ -749,7 +749,7 @@ class PMA_Tracker
 
             $index = array_search('VIEW', $tokens);
 
-            $result['tablename'] = strtolower(
+            $result['tablename'] = mb_strtolower(
                 self::getTableName($tokens[$index + 1])
             );
         }

--- a/libraries/Types.class.php
+++ b/libraries/Types.class.php
@@ -314,7 +314,7 @@ class PMA_Types_MySQL extends PMA_Types
      */
     public function getTypeDescription($type)
     {
-        $type = strtoupper($type);
+        $type = mb_strtoupper($type);
         switch ($type) {
         case 'TINYINT':
             return __('A 1-byte integer, signed range is -128 to 127, unsigned range is 0 to 255');
@@ -409,7 +409,7 @@ class PMA_Types_MySQL extends PMA_Types
      */
     public function getTypeClass($type)
     {
-        $type = strtoupper($type);
+        $type = mb_strtoupper($type);
         switch ($type) {
         case 'TINYINT':
         case 'SMALLINT':
@@ -769,7 +769,7 @@ class PMA_Types_Drizzle extends PMA_Types
      */
     public function getTypeDescription($type)
     {
-        $type = strtoupper($type);
+        $type = mb_strtoupper($type);
         switch ($type) {
         case 'INTEGER':
             return __('A 4-byte integer, range is -2,147,483,648 to 2,147,483,647');
@@ -818,7 +818,7 @@ class PMA_Types_Drizzle extends PMA_Types
      */
     public function getTypeClass($type)
     {
-        $type = strtoupper($type);
+        $type = mb_strtoupper($type);
         switch ($type) {
         case 'INTEGER':
         case 'BIGINT':

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -442,7 +442,7 @@ class PMA_Util
     public static function getMySQLDocuURL($link, $anchor = '')
     {
         // Fixup for newly used names:
-        $link = str_replace('_', '-', strtolower($link));
+        $link = str_replace('_', '-', mb_strtolower($link));
 
         if (empty($link)) {
             $link = 'index';
@@ -637,7 +637,7 @@ class PMA_Util
             // ---
             // modified to show the help on sql errors
             $error_msg .= '<p><strong>' . __('SQL query:') . '</strong>' . "\n";
-            if (strstr(strtolower($formatted_sql), 'select')) {
+            if (strstr(mb_strtolower($formatted_sql), 'select')) {
                 // please show me help to the error on select
                 $error_msg .= self::showMySQLDocu('SELECT');
             }
@@ -889,7 +889,7 @@ class PMA_Util
 
         if (! $do_it) {
             global $PMA_SQPdata_forbidden_word;
-            if (! in_array(strtoupper($a_name), $PMA_SQPdata_forbidden_word)) {
+            if (! in_array(mb_strtoupper($a_name), $PMA_SQPdata_forbidden_word)) {
                 return $a_name;
             }
         }
@@ -935,7 +935,7 @@ class PMA_Util
 
         if (! $do_it) {
             global $PMA_SQPdata_forbidden_word;
-            if (! in_array(strtoupper($a_name), $PMA_SQPdata_forbidden_word)) {
+            if (! in_array(mb_strtoupper($a_name), $PMA_SQPdata_forbidden_word)) {
                 return $a_name;
             }
         }
@@ -2935,12 +2935,12 @@ class PMA_Util
                 )
             );
             // convert to lowercase just to be sure
-            $type = strtolower(chop(substr($columnspec, 0, $first_bracket_pos)));
+            $type = mb_strtolower(chop(substr($columnspec, 0, $first_bracket_pos)));
         } else {
             // Split trailing attributes such as unsigned,
             // binary, zerofill and get data type name
             $type_parts = explode(' ', $columnspec);
-            $type = strtolower($type_parts[0]);
+            $type = mb_strtolower($type_parts[0]);
             $spec_in_brackets = '';
         }
 
@@ -2956,7 +2956,7 @@ class PMA_Util
             $enum_set_values = array();
 
             /* Create printable type name */
-            $printtype = strtolower($columnspec);
+            $printtype = mb_strtolower($columnspec);
 
             // Strip the "BINARY" attribute, except if we find "BINARY(" because
             // this would be a BINARY or VARBINARY column type;
@@ -3035,7 +3035,7 @@ class PMA_Util
      */
     public static function isForeignKeySupported($engine)
     {
-        $engine = strtoupper($engine);
+        $engine = mb_strtoupper($engine);
         if (($engine == 'INNODB') || ($engine == 'PBXT')) {
             return true;
         } elseif ($engine == 'NDBCLUSTER' || $engine == 'NDB') {
@@ -3482,7 +3482,7 @@ class PMA_Util
         );
         if ($upper_case) {
             for ($i = 0, $nb = count($gis_data_types); $i < $nb; $i++) {
-                $gis_data_types[$i] = strtoupper($gis_data_types[$i]);
+                $gis_data_types[$i] = mb_strtoupper($gis_data_types[$i]);
             }
         }
         return $gis_data_types;
@@ -3539,7 +3539,7 @@ class PMA_Util
         $funcs['IsEmpty']      = array('params' => 1, 'type' => 'int');
         $funcs['IsSimple']     = array('params' => 1, 'type' => 'int');
 
-        $geom_type = trim(strtolower($geom_type));
+        $geom_type = trim(mb_strtolower($geom_type));
         if ($display && $geom_type != 'geometry' && $geom_type != 'multipoint') {
             $funcs[] = array('display' => '--------');
         }
@@ -4012,19 +4012,19 @@ class PMA_Util
         if (isset($table['Create_time']) && !empty($table['Create_time'])) {
             $tooltip_aliasname[$table['Name']] .= ', ' . __('Creation')
                 . ': '
-                . PMA_Util::localisedDate(strtotime($table['Create_time']));
+                . PMA_Util::localisedDate(mb_strtotime($table['Create_time']));
         }
 
         if (! empty($table['Update_time'])) {
             $tooltip_aliasname[$table['Name']] .= ', ' . __('Last update')
                 . ': '
-                . PMA_Util::localisedDate(strtotime($table['Update_time']));
+                . PMA_Util::localisedDate(mb_strtotime($table['Update_time']));
         }
 
         if (! empty($table['Check_time'])) {
             $tooltip_aliasname[$table['Name']] .= ', ' . __('Last check')
                 . ': '
-                . PMA_Util::localisedDate(strtotime($table['Check_time']));
+                . PMA_Util::localisedDate(mb_strtotime($table['Check_time']));
         }
     }
 

--- a/libraries/bfShapeFiles/ShapeFile.lib.php
+++ b/libraries/bfShapeFiles/ShapeFile.lib.php
@@ -155,7 +155,7 @@
     function getIndexFromDBFData($field, $value) {
       $result = -1;
       for ($i = 0; $i < (count($this->records) - 1); $i++) {
-        if (isset($this->records[$i]->DBFData[$field]) && (strtoupper($this->records[$i]->DBFData[$field]) == strtoupper($value))) {
+        if (isset($this->records[$i]->DBFData[$field]) && (mb_strtoupper($this->records[$i]->DBFData[$field]) == mb_strtoupper($value))) {
           $result = $i;
         }
       }

--- a/libraries/central_columns.lib.php
+++ b/libraries/central_columns.lib.php
@@ -776,7 +776,7 @@ function PMA_getHTMLforCentralColumnsTableRow($row, $odd_row, $row_num, $db)
         '<td name = "col_type" class="nowrap"><span>'
         . htmlspecialchars($row['col_type']) . '</span>'
         . PMA_getHtmlForColumnType(
-            $row_num, 1, 0, strtoupper($row['col_type']), array()
+            $row_num, 1, 0, mb_strtoupper($row['col_type']), array()
         )
         . '</td>';
     $tableHtml .=
@@ -826,7 +826,7 @@ function PMA_getHTMLforCentralColumnsTableRow($row, $odd_row, $row_num, $db)
         ? htmlspecialchars($row['col_default']) : 'None')
         . '</span>'
         . PMA_getHtmlForColumnDefault(
-            $row_num, 5, 0, strtoupper($row['col_type']), '', $meta
+            $row_num, 5, 0, mb_strtoupper($row['col_type']), '', $meta
         )
         . '</td>';
     $tableHtml .= '</tr>';

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -753,8 +753,8 @@ if (! defined('PMA_MINIMUM_COMMON')) {
         foreach ($cfg['Servers'] as $i => $server) {
             if ($server['host'] == $_REQUEST['server']
                 || $server['verbose'] == $_REQUEST['server']
-                || $PMA_String->strtolower($server['verbose']) == $PMA_String->strtolower($_REQUEST['server'])
-                || md5($PMA_String->strtolower($server['verbose'])) == $PMA_String->strtolower($_REQUEST['server'])
+                || $PMA_String->mb_strtolower($server['verbose']) == $PMA_String->mb_strtolower($_REQUEST['server'])
+                || md5($PMA_String->mb_strtolower($server['verbose'])) == $PMA_String->mb_strtolower($_REQUEST['server'])
             ) {
                 $_REQUEST['server'] = $i;
                 break;
@@ -843,7 +843,7 @@ if (! defined('PMA_MINIMUM_COMMON')) {
         // and run authentication
 
         // to allow HTTP or http
-        $cfg['Server']['auth_type'] = strtolower($cfg['Server']['auth_type']);
+        $cfg['Server']['auth_type'] = mb_strtolower($cfg['Server']['auth_type']);
 
         /**
          * the required auth type plugin
@@ -933,7 +933,7 @@ if (! defined('PMA_MINIMUM_COMMON')) {
         }
 
         // if using TCP socket is not needed
-        if (strtolower($cfg['Server']['connect_type']) == 'tcp') {
+        if (mb_strtolower($cfg['Server']['connect_type']) == 'tcp') {
             $cfg['Server']['socket'] = '';
         }
 

--- a/libraries/config/FormDisplay.tpl.php
+++ b/libraries/config/FormDisplay.tpl.php
@@ -254,7 +254,7 @@ function PMA_displayInput($path, $name, $type, $value, $description = '',
         foreach ($opts['values'] as $opt_value_key => $opt_value) {
             // set names for boolean values
             if (is_bool($opt_value)) {
-                $opt_value = strtolower($opt_value ? __('Yes') : __('No'));
+                $opt_value = mb_strtolower($opt_value ? __('Yes') : __('No'));
             }
             // escape if necessary
             if ($escape) {

--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -108,7 +108,7 @@ function PMA_isValid(&$var, $type = 'length', $compare = null)
     }
 
     // allow some aliaes of var types
-    $type = strtolower($type);
+    $type = mb_strtolower($type);
     switch ($type) {
     case 'identic' :
         $type = 'identical';
@@ -363,7 +363,7 @@ function PMA_getRealSize($size = 0)
 
     foreach ($scan as $unit => $factor) {
         if (strlen($size) > strlen($unit)
-            && strtolower(substr($size, strlen($size) - strlen($unit))) == $unit
+            && mb_strtolower(substr($size, strlen($size) - strlen($unit))) == $unit
         ) {
             return substr($size, 0, strlen($size) - strlen($unit)) * $factor;
         }
@@ -846,7 +846,7 @@ function PMA_isAllowedDomain($url)
         /* Following are doubtful ones. */
         'www.primebase.com','pbxt.blogspot.com'
     );
-    if (in_array(strtolower($domain), $domainWhiteList)) {
+    if (in_array(mb_strtolower($domain), $domainWhiteList)) {
         return true;
     }
 

--- a/libraries/export.lib.php
+++ b/libraries/export.lib.php
@@ -203,11 +203,11 @@ function PMA_getMemoryLimitForExport()
     // 2 MB as default
     if (empty($memory_limit) || '-1' == $memory_limit) {
         $memory_limit = 2 * 1024 * 1024;
-    } elseif (strtolower(substr($memory_limit, -1)) == 'm') {
+    } elseif (mb_strtolower(substr($memory_limit, -1)) == 'm') {
         $memory_limit = $memory_limit_num * 1024 * 1024;
-    } elseif (strtolower(substr($memory_limit, -1)) == 'k') {
+    } elseif (mb_strtolower(substr($memory_limit, -1)) == 'k') {
         $memory_limit = $memory_limit_num * 1024;
-    } elseif (strtolower(substr($memory_limit, -1)) == 'g') {
+    } elseif (mb_strtolower(substr($memory_limit, -1)) == 'g') {
         $memory_limit = $memory_limit_num * 1024 * 1024 * 1024;
     } else {
         $memory_limit = (int)$memory_limit;
@@ -278,7 +278,7 @@ function PMA_getExportFilenameAndMimetype(
     ) - 1;
     $user_extension = substr($filename, $extension_start_pos, strlen($filename));
     $required_extension = "." . $export_plugin->getProperties()->getExtension();
-    if (strtolower($user_extension) != $required_extension) {
+    if (mb_strtolower($user_extension) != $required_extension) {
         $filename  .= $required_extension;
     }
     $mime_type  = $export_plugin->getProperties()->getMimeType();

--- a/libraries/gis/GIS_Factory.class.php
+++ b/libraries/gis/GIS_Factory.class.php
@@ -32,12 +32,12 @@ class PMA_GIS_Factory
     {
         include_once './libraries/gis/GIS_Geometry.class.php';
 
-        $file = './libraries/gis/GIS_' . ucfirst(strtolower($type)) . '.class.php';
+        $file = './libraries/gis/GIS_' . ucfirst(mb_strtolower($type)) . '.class.php';
         if (! file_exists($file)) {
             return false;
         }
         if (include_once $file) {
-            switch(strtoupper($type)) {
+            switch(mb_strtoupper($type)) {
             case 'MULTIPOLYGON' :
                 return PMA_GIS_Multipolygon::singleton();
             case 'POLYGON' :

--- a/libraries/gis/GIS_Visualization.class.php
+++ b/libraries/gis/GIS_Visualization.class.php
@@ -133,7 +133,7 @@ class PMA_GIS_Visualization
             $file_name, $extension_start_pos, strlen($file_name)
         );
         $required_extension = "." . $ext;
-        if (strtolower($user_extension) != $required_extension) {
+        if (mb_strtolower($user_extension) != $required_extension) {
             $file_name  .= $required_extension;
         }
         return $file_name;

--- a/libraries/iconv_wrapper.lib.php
+++ b/libraries/iconv_wrapper.lib.php
@@ -76,7 +76,7 @@ function PMA_convertAIXMapCharsets($in_charset, $out_charset)
     global $gnu_iconv_to_aix_iconv_codepage_map;
 
     // Check for transliteration argument at the end of output character set name
-    $translit_search = strpos(strtolower($out_charset), '//translit');
+    $translit_search = strpos(mb_strtolower($out_charset), '//translit');
     $using_translit = (!($translit_search === false));
 
     // Extract "plain" output character set name
@@ -87,21 +87,21 @@ function PMA_convertAIXMapCharsets($in_charset, $out_charset)
 
     // Transform name of input character set (if found)
     $in_charset_exisits = array_key_exists(
-        strtolower($in_charset),
+        mb_strtolower($in_charset),
         $gnu_iconv_to_aix_iconv_codepage_map
     );
     if ($in_charset_exisits) {
-        $in_charset = $gnu_iconv_to_aix_iconv_codepage_map[strtolower($in_charset)];
+        $in_charset = $gnu_iconv_to_aix_iconv_codepage_map[mb_strtolower($in_charset)];
     }
 
     // Transform name of "plain" output character set (if found)
     $out_charset_plain_exists = array_key_exists(
-        strtolower($out_charset_plain),
+        mb_strtolower($out_charset_plain),
         $gnu_iconv_to_aix_iconv_codepage_map
     );
     if ($out_charset_plain_exists) {
         $out_charset_plain = $gnu_iconv_to_aix_iconv_codepage_map[
-            strtolower($out_charset_plain)];
+            mb_strtolower($out_charset_plain)];
     }
 
     // Add transliteration argument again (exactly as specified by user) if used

--- a/libraries/import.lib.php
+++ b/libraries/import.lib.php
@@ -488,7 +488,7 @@ function PMA_getColumnNumberFromName($name)
         return 0;
     }
 
-    $name = strtoupper($name);
+    $name = mb_strtoupper($name);
     $num_chars = strlen($name);
     $column_number = 0;
     for ($i = 0; $i < $num_chars; ++$i) {

--- a/libraries/ip_allow_deny.lib.php
+++ b/libraries/ip_allow_deny.lib.php
@@ -179,8 +179,8 @@ function PMA_ipv6MaskTest($test_range, $ip_to_test)
     $result = true;
 
     // convert to lowercase for easier comparison
-    $test_range = strtolower($test_range);
-    $ip_to_test = strtolower($ip_to_test);
+    $test_range = mb_strtolower($test_range);
+    $ip_to_test = mb_strtolower($ip_to_test);
 
     $is_cidr = strpos($test_range, '/') > -1;
     $is_range = strpos($test_range, '[') > -1;

--- a/libraries/navigation/NavigationHeader.class.php
+++ b/libraries/navigation/NavigationHeader.class.php
@@ -104,7 +104,7 @@ class PMA_NavigationHeader
                 case 'main':
                     // do not add our parameters for an external link
                     if (substr(
-                        strtolower($GLOBALS['cfg']['NavigationLogoLink']), 0, 4
+                        mb_strtolower($GLOBALS['cfg']['NavigationLogoLink']), 0, 4
                     ) !== '://') {
                         $retval .= '?' . $GLOBALS['url_query'] . '"';
                     } else {

--- a/libraries/normalization.lib.php
+++ b/libraries/normalization.lib.php
@@ -42,7 +42,7 @@ function PMA_getHtmlForColumnsList(
             $extracted_columnspec = PMA_Util::extractColumnSpec($def['Type']);
             $type = $extracted_columnspec['type'];
         }
-        if (empty($columnTypeList) || in_array(strtoupper($type), $columnTypeList)) {
+        if (empty($columnTypeList) || in_array(mb_strtoupper($type), $columnTypeList)) {
             if ($listType == 'checkbox') {
                 $selectColHtml .= '<input type="checkbox" value="'
                     . htmlspecialchars($column) . '"/>'

--- a/libraries/operations.lib.php
+++ b/libraries/operations.lib.php
@@ -313,7 +313,7 @@ function PMA_getSqlQueryAndCreateDbBeforeCopy()
             'SHOW VARIABLES LIKE "lower_case_table_names"', 0, 1
         );
         if ($lowerCaseTableNames === '1') {
-            $_REQUEST['newname'] = $GLOBALS['PMA_String']->strtolower(
+            $_REQUEST['newname'] = $GLOBALS['PMA_String']->mb_strtolower(
                 $_REQUEST['newname']
             );
         }
@@ -875,7 +875,7 @@ function PMA_getTableOptionFieldset($comment, $tbl_collation,
     // (if the table was compressed, it can be seen on the Structure page)
 
     if (isset($possible_row_formats[$tbl_storage_engine])) {
-        $current_row_format = strtoupper($GLOBALS['showtable']['Row_format']);
+        $current_row_format = mb_strtoupper($GLOBALS['showtable']['Row_format']);
         $html_output .= '<tr><td>'
             . '<label for="new_row_format">ROW_FORMAT</label></td>'
             . '<td>';
@@ -1448,7 +1448,7 @@ function PMA_getTableAltersArray($is_myisam_or_aria, $is_isam, $pack_keys,
             . PMA_Util::sqlAddSlashes($_REQUEST['comment']) . '\'';
     }
     if (! empty($newTblStorageEngine)
-        && strtolower($newTblStorageEngine) !== strtolower($GLOBALS['tbl_storage_engine'])
+        && mb_strtolower($newTblStorageEngine) !== mb_strtolower($GLOBALS['tbl_storage_engine'])
     ) {
         $table_alters[] = 'ENGINE = ' . $newTblStorageEngine;
     }
@@ -1509,7 +1509,7 @@ function PMA_getTableAltersArray($is_myisam_or_aria, $is_isam, $pack_keys,
     if (($is_myisam_or_aria || $is_innodb || $is_pbxt)
         &&  ! empty($_REQUEST['new_row_format'])
         && (!strlen($row_format)
-        || strtolower($_REQUEST['new_row_format']) !== strtolower($row_format))
+        || mb_strtolower($_REQUEST['new_row_format']) !== mb_strtolower($row_format))
     ) {
         $table_alters[] = 'ROW_FORMAT = '
             . PMA_Util::sqlAddSlashes($_REQUEST['new_row_format']);
@@ -1528,7 +1528,7 @@ function PMA_getTableAltersArray($is_myisam_or_aria, $is_isam, $pack_keys,
  */
 function PMA_setGlobalVariablesForEngine($tbl_storage_engine)
 {
-    $upperTblStorEngine = strtoupper($tbl_storage_engine);
+    $upperTblStorEngine = mb_strtoupper($tbl_storage_engine);
 
     //Options that apply to MYISAM usually apply to ARIA
     $is_myisam_or_aria = ($upperTblStorEngine == 'MYISAM'

--- a/libraries/phpseclib/Crypt/Random.php
+++ b/libraries/phpseclib/Crypt/Random.php
@@ -49,7 +49,7 @@ if (!function_exists('crypt_random_string')) {
      *
      * @access private
      */
-    define('CRYPT_RANDOM_IS_WINDOWS', strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
+    define('CRYPT_RANDOM_IS_WINDOWS', mb_strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
 
     /**
      * Generate a random string.

--- a/libraries/plugin_interface.lib.php
+++ b/libraries/plugin_interface.lib.php
@@ -24,10 +24,10 @@ function PMA_getPlugin(
     $plugin_param = false
 ) {
     $GLOBALS['plugin_param'] = $plugin_param;
-    $class_name = strtoupper($plugin_type[0])
-        . strtolower(substr($plugin_type, 1))
-        . strtoupper($plugin_format[0])
-        . strtolower(substr($plugin_format, 1));
+    $class_name = mb_strtoupper($plugin_type[0])
+        . mb_strtolower(substr($plugin_type, 1))
+        . mb_strtoupper($plugin_format[0])
+        . mb_strtolower(substr($plugin_format, 1));
     $file = $class_name . ".class.php";
     if (is_file($plugins_dir . $file)) {
         include_once $plugins_dir . $file;
@@ -191,7 +191,7 @@ function PMA_pluginGetChoice($section, $name, &$list, $cfgname = null)
     $ret = '<select id="plugins" name="' . $name . '">';
     $default = PMA_pluginGetDefault($section, $cfgname);
     foreach ($list as $plugin) {
-        $plugin_name = strtolower(substr(get_class($plugin), strlen($section)));
+        $plugin_name = mb_strtolower(substr(get_class($plugin), strlen($section)));
         $ret .= '<option';
          // If the form is being repopulated using $_GET data, that is priority
         if (isset($_GET[$name])
@@ -215,7 +215,7 @@ function PMA_pluginGetChoice($section, $name, &$list, $cfgname = null)
 
     // Whether each plugin has to be saved as a file
     foreach ($list as $plugin) {
-        $plugin_name = strtolower(substr(get_class($plugin), strlen($section)));
+        $plugin_name = mb_strtolower(substr(get_class($plugin), strlen($section)));
         $ret .= '<input type="hidden" id="force_file_' . $plugin_name
             . '" value="';
         $properties = $plugin->getProperties();
@@ -484,7 +484,7 @@ function PMA_pluginGetOptions($section, &$list)
             $options = $properties->getOptions();
         }
 
-        $plugin_name = strtolower(substr(get_class($plugin), strlen($section)));
+        $plugin_name = mb_strtolower(substr(get_class($plugin), strlen($section)));
         $ret .= '<div id="' . $plugin_name
             . '_options" class="format_specific_options">';
         $ret .= '<h3>' . PMA_getString($text) . '</h3>';

--- a/libraries/plugins/auth/swekey/swekey.php
+++ b/libraries/plugins/auth/swekey/swekey.php
@@ -429,7 +429,7 @@ function Swekey_GetFastRndToken()
 {
     $res = Swekey_GetFastHalfRndToken();
     if (strlen($res) == 64) {
-        return substr($res, 0, 32).strtoupper(md5("Musbe Authentication Key" . mt_rand() . date(DATE_ATOM)));
+        return substr($res, 0, 32).mb_strtoupper(md5("Musbe Authentication Key" . mt_rand() . date(DATE_ATOM)));
     }
     return "";
 }

--- a/libraries/plugins/export/ExportCsv.class.php
+++ b/libraries/plugins/export/ExportCsv.class.php
@@ -131,7 +131,7 @@ class ExportCsv extends ExportPlugin
                 $GLOBALS['csv_columns'] = 'yes';
             }
         } else {
-            if (empty($csv_terminated) || strtolower($csv_terminated) == 'auto') {
+            if (empty($csv_terminated) || mb_strtolower($csv_terminated) == 'auto') {
                 $csv_terminated = $GLOBALS['crlf'];
             } else {
                 $csv_terminated = str_replace('\\r', "\015", $csv_terminated);

--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -2401,9 +2401,9 @@ class ExportSql extends ExportPlugin
             $d_unq = PMA_Util::unQuote($data);
             $d_unq_next = PMA_Util::unQuote($data_next);
             $d_unq_prev = PMA_Util::unQuote($data_prev);
-            $d_upper = strtoupper($d_unq);
-            $d_upper_next = strtoupper($d_unq_next);
-            $d_upper_prev = strtoupper($d_unq_prev);
+            $d_upper = mb_strtoupper($d_unq);
+            $d_upper_next = mb_strtoupper($d_unq_next);
+            $d_upper_prev = mb_strtoupper($d_unq_prev);
             $pos = $tokens[$i]['pos'] + $offset;
             if ($type === 'alpha_reservedWord') {
                 if ($query_type === ''

--- a/libraries/plugins/import/ImportSql.class.php
+++ b/libraries/plugins/import/ImportSql.class.php
@@ -354,7 +354,7 @@ class ImportSql extends ImportPlugin
                 // Change delimiter, if redefined, and skip it
                 // (don't send to server!)
                 if (($i + $length_of_delimiter_keyword < $len)
-                    && strtoupper(
+                    && mb_strtoupper(
                         substr($buffer, $i, $length_of_delimiter_keyword)
                     ) == $delimiter_keyword
                 ) {

--- a/libraries/plugins/transformations/abstract/DateFormatTransformationsPlugin.class.php
+++ b/libraries/plugins/transformations/abstract/DateFormatTransformationsPlugin.class.php
@@ -61,7 +61,7 @@ abstract class DateFormatTransformationsPlugin extends TransformationsPlugin
         if (empty($options[2])) {
             $options[2] = 'local';
         } else {
-            $options[2] = strtolower($options[2]);
+            $options[2] = mb_strtolower($options[2]);
         }
 
         if (empty($options[1])) {

--- a/libraries/pmd_common.php
+++ b/libraries/pmd_common.php
@@ -55,7 +55,7 @@ function PMA_getTablesInfo()
             $one_table['TABLE_NAME'], ENT_QUOTES
         );
 
-        $GLOBALS['PMD']['TABLE_TYPE'][$i] = strtoupper($one_table['ENGINE']);
+        $GLOBALS['PMD']['TABLE_TYPE'][$i] = mb_strtoupper($one_table['ENGINE']);
 
         $DF = PMA_getDisplayField($GLOBALS['db'], $one_table['TABLE_NAME']);
         if ($DF != '') {
@@ -470,9 +470,9 @@ function PMA_saveDisplayField($db, $table, $field)
 function PMA_addNewRelation($db, $T1, $F1, $T2, $F2, $on_delete, $on_update)
 {
     $tables = $GLOBALS['dbi']->getTablesFull($db, $T1);
-    $type_T1 = strtoupper($tables[$T1]['ENGINE']);
+    $type_T1 = mb_strtoupper($tables[$T1]['ENGINE']);
     $tables = $GLOBALS['dbi']->getTablesFull($db, $T2);
-    $type_T2 = strtoupper($tables[$T2]['ENGINE']);
+    $type_T2 = mb_strtoupper($tables[$T2]['ENGINE']);
 
     // native foreign key
     if (PMA_Util::isForeignKeySupported($type_T1)
@@ -580,9 +580,9 @@ function PMA_removeRelation($T1, $F1, $T2, $F2)
     list($DB2, $T2) = explode(".", $T2);
 
     $tables = $GLOBALS['dbi']->getTablesFull($DB1, $T1);
-    $type_T1 = strtoupper($tables[$T1]['ENGINE']);
+    $type_T1 = mb_strtoupper($tables[$T1]['ENGINE']);
     $tables = $GLOBALS['dbi']->getTablesFull($DB2, $T2);
-    $type_T2 = strtoupper($tables[$T2]['ENGINE']);
+    $type_T2 = mb_strtoupper($tables[$T2]['ENGINE']);
 
     $try_to_delete_internal_relation = false;
 

--- a/libraries/relation.lib.php
+++ b/libraries/relation.lib.php
@@ -680,8 +680,8 @@ function PMA_getForeigners($db, $table, $column = '', $source = 'both')
     /**
      * Emulating relations for some information_schema and data_dictionary tables
      */
-    $isInformationSchema = strtolower($db) == 'information_schema';
-    $is_data_dictionary = PMA_DRIZZLE && strtolower($db) == 'data_dictionary';
+    $isInformationSchema = mb_strtolower($db) == 'information_schema';
+    $is_data_dictionary = PMA_DRIZZLE && mb_strtolower($db) == 'data_dictionary';
     if (($isInformationSchema || $is_data_dictionary)
         && ($source == 'internal' || $source == 'both')
     ) {

--- a/libraries/replication.inc.php
+++ b/libraries/replication.inc.php
@@ -191,8 +191,8 @@ function PMA_extractDbOrTable($string, $what = 'db')
  */
 function PMA_Replication_Slave_control($action, $control = null, $link = null)
 {
-    $action = strtoupper($action);
-    $control = strtoupper($control);
+    $action = mb_strtoupper($action);
+    $control = mb_strtoupper($control);
 
     if ($action != "START" && $action != "STOP") {
         return -1;

--- a/libraries/replication_gui.lib.php
+++ b/libraries/replication_gui.lib.php
@@ -704,7 +704,7 @@ function PMA_getHtmlForReplicationMasterAddSlaveuser()
 
     // when we start editing a user, $GLOBALS['pred_hostname'] is not defined
     if (! isset($GLOBALS['pred_hostname']) && isset($_REQUEST['hostname'])) {
-        switch (strtolower($_REQUEST['hostname'])) {
+        switch (mb_strtolower($_REQUEST['hostname'])) {
         case 'localhost':
         case '127.0.0.1':
             $GLOBALS['pred_hostname'] = 'localhost';

--- a/libraries/rte/rte_events.lib.php
+++ b/libraries/rte/rte_events.lib.php
@@ -199,7 +199,7 @@ function PMA_EVN_handleEditor()
                 $event   = $GLOBALS['dbi']->fetchSingleRow($query);
                 $response->addJSON(
                     'name',
-                    htmlspecialchars(strtoupper($_REQUEST['item_name']))
+                    htmlspecialchars(mb_strtoupper($_REQUEST['item_name']))
                 );
                 $response->addJSON('new_row', PMA_EVN_getRowForList($event));
                 $response->addJSON('insert', ! empty($event));
@@ -414,7 +414,7 @@ function PMA_EVN_getEditorForm($mode, $operation, $item)
     }
     // Create the output
     $retval  = "";
-    $retval .= "<!-- START " . strtoupper($mode) . " EVENT FORM -->\n\n";
+    $retval .= "<!-- START " . mb_strtoupper($mode) . " EVENT FORM -->\n\n";
     $retval .= "<form class='rte_form' action='db_events.php' method='post'>\n";
     $retval .= "<input name='{$mode}_item' type='hidden' value='1' />\n";
     $retval .= $original_data;
@@ -549,7 +549,7 @@ function PMA_EVN_getEditorForm($mode, $operation, $item)
         $retval .= "</fieldset>\n";
     }
     $retval .= "</form>\n\n";
-    $retval .= "<!-- END " . strtoupper($mode) . " EVENT FORM -->\n\n";
+    $retval .= "<!-- END " . mb_strtoupper($mode) . " EVENT FORM -->\n\n";
 
     return $retval;
 } // end PMA_EVN_getEditorForm()

--- a/libraries/rte/rte_footer.lib.php
+++ b/libraries/rte/rte_footer.lib.php
@@ -22,14 +22,14 @@ function PMA_RTE_getFooterLinks($docu, $priv, $name)
 {
     global $db, $url_query, $ajax_class;
 
-    $icon = 'b_' . strtolower($name) . '_add.png';
+    $icon = 'b_' . mb_strtolower($name) . '_add.png';
     $retval  = "";
     $retval .= "<!-- ADD " . $name . " FORM START -->\n";
     $retval .= "<fieldset class='left'>\n";
     $retval .= "<legend>" . _pgettext('Create new procedure', 'New') . "</legend>\n";
     $retval .= "        <div class='wrap'>\n";
     $retval .= "            <a {$ajax_class['add']} ";
-    $retval .= "href='db_" . strtolower($name) . "s.php";
+    $retval .= "href='db_" . mb_strtolower($name) . "s.php";
     $retval .= "?$url_query&amp;add_item=1' onclick='$.datepicker.initialized = false;'>";
     $retval .= PMA_Util::getIcon($icon);
     $retval .= PMA_RTE_getWord('add') . "</a>\n";
@@ -80,7 +80,7 @@ function PMA_EVN_getFooterLinks()
         0,
         1
     );
-    $es_state = strtolower($es_state);
+    $es_state = mb_strtolower($es_state);
     $options = array(
                     0 => array(
                         'label' => __('OFF'),

--- a/libraries/rte/rte_routines.lib.php
+++ b/libraries/rte/rte_routines.lib.php
@@ -104,8 +104,8 @@ function PMA_RTN_parseOneParameter($value)
                     4 => '');
     $parsed_param = PMA_SQP_parse($value);
     $pos = 0;
-    if (in_array(strtoupper($parsed_param[$pos]['data']), $param_directions)) {
-        $retval[0] = strtoupper($parsed_param[0]['data']);
+    if (in_array(mb_strtoupper($parsed_param[$pos]['data']), $param_directions)) {
+        $retval[0] = mb_strtoupper($parsed_param[0]['data']);
         $pos++;
     }
     if ($parsed_param[$pos]['type'] == 'alpha_identifier'
@@ -123,7 +123,7 @@ function PMA_RTN_parseOneParameter($value)
         if (($parsed_param[$i]['type'] == 'alpha_columnType'
             || $parsed_param[$i]['type'] == 'alpha_functionName') && $depth == 0
         ) {
-            $retval[2] = strtoupper($parsed_param[$i]['data']);
+            $retval[2] = mb_strtoupper($parsed_param[$i]['data']);
         } else if ($parsed_param[$i]['type'] == 'punct_bracket_open_round'
             && $depth == 0
         ) {
@@ -135,17 +135,17 @@ function PMA_RTN_parseOneParameter($value)
         } else if ($depth == 1) {
             $param_length .= $parsed_param[$i]['data'];
         } else if ($parsed_param[$i]['type'] == 'alpha_reservedWord'
-            && strtoupper($parsed_param[$i]['data']) == 'CHARSET' && $depth == 0
+            && mb_strtoupper($parsed_param[$i]['data']) == 'CHARSET' && $depth == 0
         ) {
             if ($parsed_param[$i+1]['type'] == 'alpha_charset'
                 || $parsed_param[$i+1]['type'] == 'alpha_identifier'
             ) {
-                $param_opts[] = strtolower($parsed_param[$i+1]['data']);
+                $param_opts[] = mb_strtolower($parsed_param[$i+1]['data']);
             }
         } else if ($parsed_param[$i]['type'] == 'alpha_columnAttrib'
             && $depth == 0
         ) {
-            $param_opts[] = strtoupper($parsed_param[$i]['data']);
+            $param_opts[] = mb_strtoupper($parsed_param[$i]['data']);
         }
     }
     $retval[3] = $param_length;
@@ -402,7 +402,7 @@ function PMA_RTN_handleEditor()
                     . " WHERE $where;"
                 );
                 $response->addJSON(
-                    'name', htmlspecialchars(strtoupper($_REQUEST['item_name']))
+                    'name', htmlspecialchars(mb_strtoupper($_REQUEST['item_name']))
                 );
                 $response->addJSON('new_row', PMA_RTN_getRowForList($routine));
                 $response->addJSON('insert', ! empty($routine));
@@ -581,7 +581,7 @@ function PMA_RTN_getDataFromRequest()
 
     $retval['item_isdeterministic'] = '';
     if (isset($_REQUEST['item_isdeterministic'])
-        && strtolower($_REQUEST['item_isdeterministic']) == 'on'
+        && mb_strtolower($_REQUEST['item_isdeterministic']) == 'on'
     ) {
         $retval['item_isdeterministic'] = " checked='checked'";
     }
@@ -680,7 +680,7 @@ function PMA_RTN_getDataFromName($name, $type, $all = true)
             $fetching = false;
             for ($i=0; $i<$parsed_query['len']; $i++) {
                 if ($parsed_query[$i]['type'] == 'alpha_reservedWord'
-                    && strtoupper($parsed_query[$i]['data']) == 'RETURNS'
+                    && mb_strtoupper($parsed_query[$i]['data']) == 'RETURNS'
                 ) {
                     $fetching = true;
                 } else if ($fetching == true
@@ -692,7 +692,7 @@ function PMA_RTN_getDataFromName($name, $type, $all = true)
                     // characters. We can safely assume that the return
                     // datatype is either ENUM or SET, so we only look
                     // for CHARSET.
-                    $word = strtoupper($parsed_query[$i]['data']);
+                    $word = mb_strtoupper($parsed_query[$i]['data']);
                     if ($word == 'CHARSET'
                         && ($parsed_query[$i+1]['type'] == 'alpha_charset'
                         || $parsed_query[$i+1]['type'] == 'alpha_identifier')
@@ -937,7 +937,7 @@ function PMA_RTN_getEditorForm($mode, $operation, $routine)
 
     // Create the output
     $retval  = "";
-    $retval .= "<!-- START " . strtoupper($mode) . " ROUTINE FORM -->\n\n";
+    $retval .= "<!-- START " . mb_strtoupper($mode) . " ROUTINE FORM -->\n\n";
     $retval .= "<form class='rte_form' action='db_routines.php' method='post'>\n";
     $retval .= "<input name='{$mode}_item' type='hidden' value='1' />\n";
     $retval .= $original_routine;
@@ -1096,7 +1096,7 @@ function PMA_RTN_getEditorForm($mode, $operation, $routine)
         $retval .= "</fieldset>";
     }
     $retval .= "</form>";
-    $retval .= "<!-- END " . strtoupper($mode) . " ROUTINE FORM -->";
+    $retval .= "<!-- END " . mb_strtoupper($mode) . " ROUTINE FORM -->";
 
     return $retval;
 } // end PMA_RTN_getEditorForm()
@@ -1201,13 +1201,13 @@ function PMA_RTN_getQueryFromRequest()
                 if (! empty($_REQUEST['item_param_opts_text'][$i])) {
                     if ($PMA_Types->getTypeClass($item_param_type[$i]) == 'CHAR') {
                         $params .= ' CHARSET '
-                            . strtolower($_REQUEST['item_param_opts_text'][$i]);
+                            . mb_strtolower($_REQUEST['item_param_opts_text'][$i]);
                     }
                 }
                 if (! empty($_REQUEST['item_param_opts_num'][$i])) {
                     if ($PMA_Types->getTypeClass($item_param_type[$i]) == 'NUMBER') {
                         $params .= ' '
-                            . strtoupper($_REQUEST['item_param_opts_num'][$i]);
+                            . mb_strtoupper($_REQUEST['item_param_opts_num'][$i]);
                     }
                 }
                 if ($i != (count($item_param_name) - 1)) {
@@ -1261,12 +1261,12 @@ function PMA_RTN_getQueryFromRequest()
         if (! empty($_REQUEST['item_returnopts_text'])) {
             if ($PMA_Types->getTypeClass($item_returntype) == 'CHAR') {
                 $query .= ' CHARSET '
-                    . strtolower($_REQUEST['item_returnopts_text']);
+                    . mb_strtolower($_REQUEST['item_returnopts_text']);
             }
         }
         if (! empty($_REQUEST['item_returnopts_num'])) {
             if ($PMA_Types->getTypeClass($item_returntype) == 'NUMBER') {
-                $query .= ' ' . strtoupper($_REQUEST['item_returnopts_num']);
+                $query .= ' ' . mb_strtoupper($_REQUEST['item_returnopts_num']);
             }
         }
         $query .= ' ';
@@ -1624,13 +1624,13 @@ function PMA_RTN_getExecuteForm($routine)
             if (stristr($routine['item_param_type'][$i], 'enum')
                 || stristr($routine['item_param_type'][$i], 'set')
                 || in_array(
-                    strtolower($routine['item_param_type'][$i]), $no_support_types
+                    mb_strtolower($routine['item_param_type'][$i]), $no_support_types
                 )
             ) {
                 $retval .= "--\n";
             } else {
                 $field = array(
-                    'True_Type'       => strtolower($routine['item_param_type'][$i]),
+                    'True_Type'       => mb_strtolower($routine['item_param_type'][$i]),
                     'Type'            => '',
                     'Key'             => '',
                     'Field'           => '',
@@ -1676,7 +1676,7 @@ function PMA_RTN_getExecuteForm($routine)
                 }
             }
         } else if (in_array(
-            strtolower($routine['item_param_type'][$i]), $no_support_types
+            mb_strtolower($routine['item_param_type'][$i]), $no_support_types
         )) {
             $retval .= "\n";
         } else {

--- a/libraries/rte/rte_triggers.lib.php
+++ b/libraries/rte/rte_triggers.lib.php
@@ -178,7 +178,7 @@ function PMA_TRI_handleEditor()
                     $response->addJSON(
                         'name',
                         htmlspecialchars(
-                            strtoupper($_REQUEST['item_name'])
+                            mb_strtoupper($_REQUEST['item_name'])
                         )
                     );
                 }
@@ -344,7 +344,7 @@ function PMA_TRI_getEditorForm($mode, $item)
 
     // Create the output
     $retval  = "";
-    $retval .= "<!-- START " . strtoupper($mode) . " TRIGGER FORM -->\n\n";
+    $retval .= "<!-- START " . mb_strtoupper($mode) . " TRIGGER FORM -->\n\n";
     $retval .= "<form class='rte_form' action='db_triggers.php' method='post'>\n";
     $retval .= "<input name='{$mode}_item' type='hidden' value='1' />\n";
     $retval .= $original_data;
@@ -427,7 +427,7 @@ function PMA_TRI_getEditorForm($mode, $item)
         $retval .= "</fieldset>\n";
     }
     $retval .= "</form>\n\n";
-    $retval .= "<!-- END " . strtoupper($mode) . " TRIGGER FORM -->\n\n";
+    $retval .= "<!-- END " . mb_strtoupper($mode) . " TRIGGER FORM -->\n\n";
 
     return $retval;
 } // end PMA_TRI_getEditorForm()

--- a/libraries/server_databases.lib.php
+++ b/libraries/server_databases.lib.php
@@ -439,7 +439,7 @@ function PMA_getListForSortDatabase()
     }
 
     if (isset($_REQUEST['sort_order'])
-        && strtolower($_REQUEST['sort_order']) == 'desc'
+        && mb_strtolower($_REQUEST['sort_order']) == 'desc'
     ) {
         $sort_order = 'desc';
     } else {

--- a/libraries/server_plugins.lib.php
+++ b/libraries/server_plugins.lib.php
@@ -50,7 +50,7 @@ function PMA_getPluginTab($plugins)
     $html .= '<div id="sectionlinks">';
 
     foreach ($plugins as $plugin_type => $plugin_list) {
-        $key = 'plugins-' . preg_replace('/[^a-z]/', '', strtolower($plugin_type));
+        $key = 'plugins-' . preg_replace('/[^a-z]/', '', mb_strtolower($plugin_type));
         $html .= '<a href="#' . $key . '">'
             . htmlspecialchars($plugin_type) . '</a>' . "\n";
     }
@@ -59,7 +59,7 @@ function PMA_getPluginTab($plugins)
     $html .= '<br />';
 
     foreach ($plugins as $plugin_type => $plugin_list) {
-        $key = 'plugins-' . preg_replace('/[^a-z]/', '', strtolower($plugin_type));
+        $key = 'plugins-' . preg_replace('/[^a-z]/', '', mb_strtolower($plugin_type));
         sort($plugin_list);
 
         $html .= '<table class="data_full_width" id="' . $key . '">';

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -82,7 +82,7 @@ function PMA_rangeOfUsers($initial = '')
         $ret = " WHERE `User` LIKE '"
             . PMA_Util::sqlAddSlashes($initial, true) . "%'"
             . " OR `User` LIKE '"
-            . PMA_Util::sqlAddSlashes(strtolower($initial), true) . "%'";
+            . PMA_Util::sqlAddSlashes(mb_strtolower($initial), true) . "%'";
     } else {
         $ret = '';
     }
@@ -967,7 +967,7 @@ function PMA_getHtmlForNotAttachedPrivilegesToTableSpecificColumn($row)
                 ]
             )
             . '">'
-            . strtoupper(
+            . mb_strtoupper(
                 substr($current_grant, 0, strlen($current_grant) - 5)
             )
             . '</dfn></code></label>' . "\n"
@@ -1384,7 +1384,7 @@ function PMA_getHtmlForLoginInformationFields($mode = 'new')
 
     // when we start editing a user, $GLOBALS['pred_hostname'] is not defined
     if (! isset($GLOBALS['pred_hostname']) && isset($GLOBALS['hostname'])) {
-        switch (strtolower($GLOBALS['hostname'])) {
+        switch (mb_strtolower($GLOBALS['hostname'])) {
         case 'localhost':
         case '127.0.0.1':
             $GLOBALS['pred_hostname'] = 'localhost';
@@ -2415,7 +2415,7 @@ function PMA_getExtraDataForAjaxBehavior(
          * Generate the string for this alphabet's initial, to update the user
          * pagination
          */
-        $new_user_initial = strtoupper(substr($username, 0, 1));
+        $new_user_initial = mb_strtoupper(substr($username, 0, 1));
         $newUserInitialString = '<a href="server_privileges.php'
             . PMA_URL_getCommon(array('initial' => $new_user_initial)) . '">'
             . $new_user_initial . '</a>';

--- a/libraries/server_status_monitor.lib.php
+++ b/libraries/server_status_monitor.lib.php
@@ -577,7 +577,7 @@ function PMA_getJsonForLogDataTypeSlow($start, $end)
     $return = array('rows' => array(), 'sum' => array());
 
     while ($row = $GLOBALS['dbi']->fetchAssoc($result)) {
-        $type = strtolower(
+        $type = mb_strtolower(
             substr($row['sql_text'], 0, strpos($row['sql_text'], ' '))
         );
 
@@ -649,7 +649,7 @@ function PMA_getJsonForLogDataTypeGeneral($start, $end)
 
     while ($row = $GLOBALS['dbi']->fetchAssoc($result)) {
         preg_match('/^(\w+)\s/', $row['argument'], $match);
-        $type = strtolower($match[1]);
+        $type = mb_strtolower($match[1]);
 
         if (! isset($return['sum'][$type])) {
             $return['sum'][$type] = 0;

--- a/libraries/server_status_processes.lib.php
+++ b/libraries/server_status_processes.lib.php
@@ -237,7 +237,7 @@ function PMA_getHtmlForServerProcessItem($process, $odd_row, $show_full_sql)
     // to display column values
     if (! empty($_REQUEST['order_by_field']) && ! empty($_REQUEST['sort_order']) ) {
         foreach (array_keys($process) as $key) {
-            $new_key = ucfirst(strtolower($key));
+            $new_key = ucfirst(mb_strtolower($key));
             if ($new_key !== $key) {
                 $process[$new_key] = $process[$key];
                 unset($process[$key]);

--- a/libraries/server_variables.lib.php
+++ b/libraries/server_variables.lib.php
@@ -78,7 +78,7 @@ function PMA_getAjaxReturnForSetVal($variable_doc_links)
         );
         $value = floatval($matches[1]) * PMA_Util::pow(
             1024,
-            $exp[strtolower($matches[3])]
+            $exp[mb_strtolower($matches[3])]
         );
     } else {
         $value = PMA_Util::sqlAddSlashes($value);

--- a/libraries/sqlparser.lib.php
+++ b/libraries/sqlparser.lib.php
@@ -771,7 +771,7 @@ function PMA_SQP_parse($sql)
         $d_prev           = '';
         $d_bef_prev       = '';
         $d_cur            = '';
-        $d_next_upper     = $t_next == 'alpha' ? strtoupper($d_next) : $d_next;
+        $d_next_upper     = $t_next == 'alpha' ? mb_strtoupper($d_next) : $d_next;
         $d_prev_upper     = '';
         $d_bef_prev_upper = '';
         $d_cur_upper      = '';
@@ -790,7 +790,7 @@ function PMA_SQP_parse($sql)
         if (($i + 1) < $arraysize) {
             $t_next = $sql_array[$i + 1]['type'];
             $d_next = $sql_array[$i + 1]['data'];
-            $d_next_upper = $t_next == 'alpha' ? strtoupper($d_next) : $d_next;
+            $d_next_upper = $t_next == 'alpha' ? mb_strtoupper($d_next) : $d_next;
         } else {
             $t_next       = '';
             $d_next       = '';
@@ -1239,7 +1239,7 @@ function PMA_SQP_analyze($arr)
         }
         // ==============================================================
         if ($arr[$i]['type'] == 'alpha_functionName') {
-            $upper_data = strtoupper($arr[$i]['data']);
+            $upper_data = mb_strtoupper($arr[$i]['data']);
             if ($upper_data =='EXTRACT') {
                 $in_extract = true;
                 $number_of_brackets_in_extract = 0;
@@ -1254,7 +1254,7 @@ function PMA_SQP_analyze($arr)
         if ($arr[$i]['type'] == 'alpha_reservedWord') {
             // We don't know what type of query yet, so run this
             if ($subresult['querytype'] == '') {
-                $subresult['querytype'] = strtoupper($arr[$i]['data']);
+                $subresult['querytype'] = mb_strtoupper($arr[$i]['data']);
             } // end if (querytype was empty)
 
             // Check if we support this type of query
@@ -1265,7 +1265,7 @@ function PMA_SQP_analyze($arr)
             } // end if (query not supported)
 
             // upper once
-            $upper_data = strtoupper($arr[$i]['data']);
+            $upper_data = mb_strtoupper($arr[$i]['data']);
             /**
              * @todo reset for each query?
              */
@@ -1671,7 +1671,7 @@ function PMA_SQP_analyze($arr)
         }
 
         if ($arr[$i]['type'] == 'alpha_reservedWord') {
-            $upper_data = strtoupper($arr[$i]['data']);
+            $upper_data = mb_strtoupper($arr[$i]['data']);
 
             if ($upper_data == 'SELECT' && $number_of_brackets > 0) {
                 $in_subquery = true;
@@ -1744,7 +1744,7 @@ function PMA_SQP_analyze($arr)
                     && $subresult['queryflags']['select_from'] == 1
                     && ($i + 1) < $size
                     && $arr[$i + 1]['type'] == 'alpha_reservedWord'
-                    && strtoupper($arr[$i + 1]['data']) == 'ANALYSE'
+                    && mb_strtoupper($arr[$i + 1]['data']) == 'ANALYSE'
                 ) {
                     $subresult['queryflags']['is_analyse'] = 1;
                 }
@@ -1756,7 +1756,7 @@ function PMA_SQP_analyze($arr)
                 && $subresult['queryflags']['select_from'] == 1
                 && ($i + 1) < $size
                 && $arr[$i + 1]['type'] == 'alpha_reservedWord'
-                && strtoupper($arr[$i + 1]['data']) == 'OUTFILE'
+                && mb_strtoupper($arr[$i + 1]['data']) == 'OUTFILE'
             ) {
                 $subresult['queryflags']['is_export'] = 1;
             }
@@ -1773,7 +1773,7 @@ function PMA_SQP_analyze($arr)
                     && !isset($subresult['queryflags']['is_group'])
                     && ($i + 1) < $size
                     && $arr[$i + 1]['type'] == 'alpha_functionName'
-                    && strtoupper($arr[$i + 1]['data']) == 'COUNT'
+                    && mb_strtoupper($arr[$i + 1]['data']) == 'COUNT'
                 ) {
                     $subresult['queryflags']['is_count'] = 1;
                 }
@@ -1830,10 +1830,10 @@ function PMA_SQP_analyze($arr)
                     && $subresult['queryflags']['select_from'] == 1
                     && ($i + 1) < $size
                     && $arr[$i + 1]['type'] == 'alpha_reservedWord'
-                    && in_array(strtoupper($arr[$i + 1]['data']), $arrayKeyWords)
+                    && in_array(mb_strtoupper($arr[$i + 1]['data']), $arrayKeyWords)
                     && ($i + 2) < $size
                     && $arr[$i + 2]['type'] == 'alpha_reservedWord'
-                    && strtoupper($arr[$i + 2]['data']) == 'DISTINCT'
+                    && mb_strtoupper($arr[$i + 2]['data']) == 'DISTINCT'
                 ) {
                     $subresult['queryflags']['is_group'] = 1;
                 }
@@ -1913,7 +1913,7 @@ function PMA_SQP_analyze($arr)
         $sep = ' ';
         if ($arr[$i]['type'] == 'alpha_functionName') {
             $sep='';
-            $upper_data = strtoupper($arr[$i]['data']);
+            $upper_data = mb_strtoupper($arr[$i]['data']);
             if ($upper_data =='GROUP_CONCAT') {
                 $in_group_concat = true;
                 $number_of_brackets_in_group_concat = 0;
@@ -1950,10 +1950,10 @@ function PMA_SQP_analyze($arr)
 
         // for the presence of INSERT|LOAD DATA
         if ($arr[$i]['type'] == 'alpha_identifier'
-            && strtoupper($arr[$i]['data']) == 'DATA'
+            && mb_strtoupper($arr[$i]['data']) == 'DATA'
             && ($i - 1) >= 0
             && $arr[$i - 1]['type'] == 'alpha_reservedWord'
-            && in_array(strtoupper($arr[$i - 1]['data']), array("INSERT", "LOAD"))
+            && in_array(mb_strtoupper($arr[$i - 1]['data']), array("INSERT", "LOAD"))
         ) {
             $subresult['queryflags']['is_insert'] = 1;
             $subresult['queryflags']['is_affected'] = 1;
@@ -1961,7 +1961,7 @@ function PMA_SQP_analyze($arr)
 
         // for the presence of SUM|AVG|STD|STDDEV|MIN|MAX|BIT_OR|BIT_AND
         if ($arr[$i]['type'] == 'alpha_functionName'
-            && in_array(strtoupper($arr[$i]['data']), $arrayFunctions)
+            && in_array(mb_strtoupper($arr[$i]['data']), $arrayFunctions)
             && isset($subresult['queryflags']['select_from'])
             && $subresult['queryflags']['select_from'] == 1
             && !isset($subresult['queryflags']['is_group'])
@@ -2064,7 +2064,7 @@ function PMA_SQP_analyze($arr)
 
     for ($i = 0; $i < $size; $i++) {
         if ($arr[$i]['type'] == 'alpha_reservedWord') {
-            $upper_data = strtoupper($arr[$i]['data']);
+            $upper_data = mb_strtoupper($arr[$i]['data']);
 
             if ($upper_data == 'NOT' && $in_timestamp_options) {
                 if (! isset($create_table_fields)) {
@@ -2127,7 +2127,7 @@ function PMA_SQP_analyze($arr)
                 if (isset($arr[$i+1])
                     && $arr[$i+1]['type'] == 'alpha_reservedWord'
                 ) {
-                    $second_upper_data = strtoupper($arr[$i+1]['data']);
+                    $second_upper_data = mb_strtoupper($arr[$i+1]['data']);
                     if ($second_upper_data == 'DELETE') {
                         $clause = 'on_delete';
                     }
@@ -2141,9 +2141,9 @@ function PMA_SQP_analyze($arr)
                     if (isset($clause)
                         && ($arr[$i+2]['type'] == 'alpha_reservedWord'
                         || ($arr[$i+2]['type'] == 'alpha_identifier'
-                        && strtoupper($arr[$i+2]['data'])=='NO'))
+                        && mb_strtoupper($arr[$i+2]['data'])=='NO'))
                     ) {
-                        $third_upper_data = strtoupper($arr[$i+2]['data']);
+                        $third_upper_data = mb_strtoupper($arr[$i+2]['data']);
                         if ($third_upper_data == 'CASCADE'
                             || $third_upper_data == 'RESTRICT'
                         ) {
@@ -2153,7 +2153,7 @@ function PMA_SQP_analyze($arr)
                         ) {
                             if ($arr[$i+3]['type'] == 'alpha_reservedWord') {
                                 $value = $third_upper_data . '_'
-                                    . strtoupper($arr[$i+3]['data']);
+                                    . mb_strtoupper($arr[$i+3]['data']);
                             }
                         } elseif ($third_upper_data == 'CURRENT_TIMESTAMP') {
                             if ($clause == 'on_update'
@@ -2197,7 +2197,7 @@ function PMA_SQP_analyze($arr)
         }
 
         if (($arr[$i]['type'] == 'alpha_columnAttrib')) {
-            $upper_data = strtoupper($arr[$i]['data']);
+            $upper_data = mb_strtoupper($arr[$i]['data']);
             if ($seen_create_table && $in_create_table_fields) {
                 if ($upper_data == 'DEFAULT') {
                     $seen_default = true;
@@ -2213,7 +2213,7 @@ function PMA_SQP_analyze($arr)
         if (($arr[$i]['type'] == 'alpha_columnType')
             || ($arr[$i]['type'] == 'alpha_functionName' && $seen_create_table)
         ) {
-            $upper_data = strtoupper($arr[$i]['data']);
+            $upper_data = mb_strtoupper($arr[$i]['data']);
             if ($seen_create_table && $in_create_table_fields
                 && isset($current_identifier)
             ) {
@@ -2464,10 +2464,10 @@ function PMA_SQP_format(
             $bracketlevel++;
             $infunction = false;
             $keyword_brackets_2before = isset(
-                $keywords_with_brackets_2before[strtoupper($arr[$i - 2]['data'])]
+                $keywords_with_brackets_2before[mb_strtoupper($arr[$i - 2]['data'])]
             );
             $keyword_brackets_1before = isset(
-                $keywords_with_brackets_1before[strtoupper($arr[$i - 1]['data'])]
+                $keywords_with_brackets_1before[mb_strtoupper($arr[$i - 1]['data'])]
             );
             // Make sure this array is sorted!
             if (($typearr[1] == 'alpha_functionName')
@@ -2599,7 +2599,7 @@ function PMA_SQP_format(
             // select * from mysql.user where binary user="root"
             // binary is marked as alpha_columnAttrib
             // but should be marked as a reserved word
-            if (strtoupper($arr[$i]['data']) == 'BINARY'
+            if (mb_strtoupper($arr[$i]['data']) == 'BINARY'
                 && $typearr[3] == 'alpha_identifier'
             ) {
                 $after     .= ' ';
@@ -2615,7 +2615,7 @@ function PMA_SQP_format(
             // as an identifier name)
 
             if ($mode != 'query_only') {
-                $arr[$i]['data'] = strtoupper($arr[$i]['data']);
+                $arr[$i]['data'] = mb_strtoupper($arr[$i]['data']);
             }
 
             list($before, $in_priv_list) = PMA_SQP_format_getBeforeAndInPrivList(
@@ -2731,7 +2731,7 @@ function PMA_SQP_format_getBeforeAndInPrivList(
 ) {
     if (!((($typearr[1] != 'alpha_reservedWord')
         || (($typearr[1] == 'alpha_reservedWord')
-        && isset($keywords_no_newline[strtoupper($arr[$index - 1]['data'])])))
+        && isset($keywords_no_newline[mb_strtoupper($arr[$index - 1]['data'])])))
         && ($typearr[1] != 'punct_level_plus')
         && (!isset($keywords_no_newline[$arr[$index]['data']])))
     ) {
@@ -2893,7 +2893,7 @@ function PMA_SQP_formatNone($arr)
 function PMA_SQP_isKeyWord($column)
 {
     global $PMA_SQPdata_forbidden_word;
-    return in_array(strtoupper($column), $PMA_SQPdata_forbidden_word);
+    return in_array(mb_strtoupper($column), $PMA_SQPdata_forbidden_word);
 }
 
 /**

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -1353,7 +1353,7 @@ function PMA_getHtmlTableStructureRow($row, $rownum,
     }
     $html_output .= '</td>';
 
-    $html_output .= '<td class="nowrap">' . strtoupper($row['Extra']) . '</td>';
+    $html_output .= '<td class="nowrap">' . mb_strtoupper($row['Extra']) . '</td>';
 
     $html_output .= PMA_getHtmlForDropColumn(
         $tbl_is_view, $db_is_system_schema,
@@ -2633,7 +2633,7 @@ function PMA_moveColumns($db, $table)
         $changes[] = 'CHANGE ' . PMA_Table::generateAlter(
             $column,
             $column,
-            strtoupper($extracted_columnspec['type']),
+            mb_strtoupper($extracted_columnspec['type']),
             $extracted_columnspec['spec_in_brackets'],
             $extracted_columnspec['attribute'],
             isset($data['Collation']) ? $data['Collation'] : '',

--- a/libraries/tbl_columns_definition_form.inc.php
+++ b/libraries/tbl_columns_definition_form.inc.php
@@ -154,7 +154,7 @@ for ($columnNumber = 0; $columnNumber < $num_fields; $columnNumber++) {
 
     $content_cells[$columnNumber] = PMA_getHtmlForColumnAttributes(
         $columnNumber, isset($columnMeta) ? $columnMeta : array(),
-        strtoupper($type), $length_values_input_size, $length,
+        mb_strtoupper($type), $length_values_input_size, $length,
         isset($default_current_timestamp) ? $default_current_timestamp : null,
         isset($extracted_columnspec) ? $extracted_columnspec : null,
         isset($submit_attribute) ? $submit_attribute : null,

--- a/libraries/tbl_columns_definition_form.lib.php
+++ b/libraries/tbl_columns_definition_form.lib.php
@@ -868,7 +868,7 @@ function PMA_getHtmlForColumnAutoIncrement($columnNumber, $ci, $ci_offset,
     $html = '<input name="field_extra[' . $columnNumber . ']"'
         . ' id="field_' . $columnNumber . '_' . ($ci - $ci_offset) . '"';
     if (isset($columnMeta['Extra'])
-        && strtolower($columnMeta['Extra']) == 'auto_increment'
+        && mb_strtolower($columnMeta['Extra']) == 'auto_increment'
     ) {
         $html .= ' checked="checked"';
     }
@@ -928,13 +928,13 @@ function PMA_getHtmlForColumnIndexes($columnNumber, $ci, $ci_offset, $columnMeta
 
 function PMA_getHtmlForIndexTypeOption($columnNumber, $columnMeta, $type, $key)
 {
-    $html = '<option value="' . strtolower($type) . '_' . $columnNumber
+    $html = '<option value="' . mb_strtolower($type) . '_' . $columnNumber
         . '" title="'
         . __($type) . '"';
     if (isset($columnMeta['Key']) && $columnMeta['Key'] == $key) {
         $html .= ' selected="selected"';
     }
-    $html .= '>' . strtoupper($type) . '</option>';
+    $html .= '>' . mb_strtoupper($type) . '</option>';
 
     return $html;
 }
@@ -1042,7 +1042,7 @@ function PMA_getHtmlForColumnAttribute($columnNumber, $ci, $ci_offset,
     for ($j = 0; $j < $cnt_attribute_types; $j++) {
         $html
             .= '                <option value="' . $attribute_types[$j] . '"';
-        if (strtoupper($attribute) == strtoupper($attribute_types[$j])) {
+        if (mb_strtoupper($attribute) == mb_strtoupper($attribute_types[$j])) {
             $html .= ' selected="selected"';
         }
         $html .= '>' . $attribute_types[$j] . '</option>';
@@ -1373,12 +1373,12 @@ function PMA_getFormParamsForOldColumn(
     if (isset($columnMeta['Type'])) {
         // keep in uppercase because the new type will be in uppercase
         $form_params['field_type_orig[' . $columnNumber . ']']
-            = strtoupper($type);
+            = mb_strtoupper($type);
         if (isset($columnMeta['column_status'])
             && !$columnMeta['column_status']['isEditable']
         ) {
             $form_params['field_type[' . $columnNumber . ']']
-                = strtoupper($type);
+                = mb_strtoupper($type);
         }
     } else {
         $form_params['field_type_orig[' . $columnNumber . ']'] = '';

--- a/libraries/tbl_info.inc.php
+++ b/libraries/tbl_info.inc.php
@@ -61,7 +61,7 @@ if ($showtable) {
     } else {
         $tbl_is_view     = false;
         $tbl_storage_engine = isset($showtable['Engine'])
-            ? strtoupper($showtable['Engine'])
+            ? mb_strtoupper($showtable['Engine'])
             : '';
         $show_comment = '';
         if (isset($showtable['Comment'])) {

--- a/libraries/tbl_relation.lib.php
+++ b/libraries/tbl_relation.lib.php
@@ -567,7 +567,7 @@ function PMA_getHtmlForForeignKeyRow($one_key, $odd_row, $columns, $i,
                     'Engine'
                 );
                 if (isset($engine)
-                    && strtoupper($engine) == $tbl_storage_engine
+                    && mb_strtoupper($engine) == $tbl_storage_engine
                 ) {
                     $tables[] = $row[0];
                 }
@@ -580,7 +580,7 @@ function PMA_getHtmlForForeignKeyRow($one_key, $odd_row, $columns, $i,
             );
             while ($row = $GLOBALS['dbi']->fetchRow($tables_rs)) {
                 if (isset($row[1])
-                    && strtoupper($row[1]) == $tbl_storage_engine
+                    && mb_strtoupper($row[1]) == $tbl_storage_engine
                 ) {
                     $tables[] = $row[0];
                 }
@@ -736,7 +736,7 @@ function PMA_sendHtmlForTableDropdownList()
 
     $foreign = isset($_REQUEST['foreign']) && $_REQUEST['foreign'] === 'true';
     if ($foreign) {
-        $tbl_storage_engine = strtoupper(
+        $tbl_storage_engine = mb_strtoupper(
             PMA_Table::sGetStatusInfo(
                 $_REQUEST['db'],
                 $_REQUEST['table'],
@@ -759,7 +759,7 @@ function PMA_sendHtmlForTableDropdownList()
 
         while ($row = $GLOBALS['dbi']->fetchArray($tables_rs)) {
             if (isset($row['Engine'])
-                && strtoupper($row['Engine']) == $tbl_storage_engine
+                && mb_strtoupper($row['Engine']) == $tbl_storage_engine
             ) {
                 $tables[] = htmlspecialchars($row['Name']);
             }
@@ -774,7 +774,7 @@ function PMA_sendHtmlForTableDropdownList()
         );
         while ($row = $GLOBALS['dbi']->fetchArray($tables_rs)) {
             if ($foreign && PMA_DRIZZLE) {
-                $engine = strtoupper(
+                $engine = mb_strtoupper(
                     PMA_Table::sGetStatusInfo(
                         $_REQUEST['foreignDb'],
                         $row[0],

--- a/libraries/tcpdf/include/tcpdf_colors.php
+++ b/libraries/tcpdf/include/tcpdf_colors.php
@@ -251,7 +251,7 @@ class TCPDF_COLORS {
 			return $spotc[$name];
 		}
 		$color = preg_replace('/[\s]*/', '', $name); // remove extra spaces
-		$color = strtolower($color);
+		$color = mb_strtolower($color);
 		if (isset(self::$spotcolor[$color])) {
 			if (!isset($spotc[$name])) {
 				$i = (1 + count($spotc));
@@ -272,7 +272,7 @@ class TCPDF_COLORS {
 	 */
 	public static function convertHTMLColorToDec($hcolor, &$spotc, $defcol=array('R'=>128,'G'=>128,'B'=>128)) {
 		$color = preg_replace('/[\s]*/', '', $hcolor); // remove extra spaces
-		$color = strtolower($color);
+		$color = mb_strtolower($color);
 		// check for javascript color array syntax
 		if (strpos($color, '[') !== false) {
 			if (preg_match('/[\[][\"\'](t|g|rgb|cmyk)[\"\'][\,]?([0-9\.]*)[\,]?([0-9\.]*)[\,]?([0-9\.]*)[\,]?([0-9\.]*)[\]]/', $color, $m) > 0) {

--- a/libraries/tcpdf/include/tcpdf_fonts.php
+++ b/libraries/tcpdf/include/tcpdf_fonts.php
@@ -81,7 +81,7 @@ class TCPDF_FONTS {
 		if (!isset($font_path_parts['filename'])) {
 			$font_path_parts['filename'] = substr($font_path_parts['basename'], 0, -(strlen($font_path_parts['extension']) + 1));
 		}
-		$font_name = strtolower($font_path_parts['filename']);
+		$font_name = mb_strtolower($font_path_parts['filename']);
 		$font_name = preg_replace('/[^a-z0-9_]/', '', $font_name);
 		$search  = array('bold', 'oblique', 'italic', 'regular');
 		$replace = array('b', 'i', 'i', '');

--- a/libraries/tcpdf/include/tcpdf_images.php
+++ b/libraries/tcpdf/include/tcpdf_images.php
@@ -73,13 +73,13 @@ class TCPDF_IMAGES {
 		if (isset($iminfo['mime']) AND !empty($iminfo['mime'])) {
 			$mime = explode('/', $iminfo['mime']);
 			if ((count($mime) > 1) AND ($mime[0] == 'image') AND (!empty($mime[1]))) {
-				$type = strtolower(trim($mime[1]));
+				$type = mb_strtolower(trim($mime[1]));
 			}
 		}
 		if (empty($type)) {
 			$fileinfo = pathinfo($imgfile);
 			if (isset($fileinfo['extension']) AND (!TCPDF_STATIC::empty_string($fileinfo['extension']))) {
-				$type = strtolower(trim($fileinfo['extension']));
+				$type = mb_strtolower(trim($fileinfo['extension']));
 			}
 		}
 		if ($type == 'jpg') {

--- a/libraries/tcpdf/include/tcpdf_static.php
+++ b/libraries/tcpdf/include/tcpdf_static.php
@@ -477,7 +477,7 @@ class TCPDF_STATIC {
 	 */
 	public static function getPageSizeFromFormat($format) {
 		// Paper cordinates are calculated in this way: (inches * 72) where (1 inch = 25.4 mm)
-		switch (strtoupper($format)) {
+		switch (mb_strtoupper($format)) {
 			// ISO 216 A Series + 2 SIS 014711 extensions
 			case 'A0' : {$pf = array( 2383.937, 3370.394); break;}
 			case 'A1' : {$pf = array( 1683.780, 2383.937); break;}
@@ -1348,7 +1348,7 @@ class TCPDF_STATIC {
 	 */
 	public static function getRandomSeed($seed='') {
 		$seed .= microtime();
-		if (function_exists('openssl_random_pseudo_bytes') AND (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN')) {
+		if (function_exists('openssl_random_pseudo_bytes') AND (mb_strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN')) {
 			// this is not used on windows systems because it is very slow for a know bug
 			$seed .= openssl_random_pseudo_bytes(512);
 		} else {
@@ -2109,7 +2109,7 @@ class TCPDF_STATIC {
 		$css = str_replace('/*]]>*/', '', $css);
 		preg_match('/<style>(.*)<\/style>/ims', $css, $matches);
 		if (isset($matches[1])) {
-			$css = strtolower($matches[1]);
+			$css = mb_strtolower($matches[1]);
 		} else {
 			$css = '';
 		}
@@ -2145,11 +2145,11 @@ class TCPDF_STATIC {
 		$tag = $dom[$key]['value'];
 		$class = array();
 		if (isset($dom[$key]['attribute']['class']) AND !empty($dom[$key]['attribute']['class'])) {
-			$class = explode(' ', strtolower($dom[$key]['attribute']['class']));
+			$class = explode(' ', mb_strtolower($dom[$key]['attribute']['class']));
 		}
 		$id = '';
 		if (isset($dom[$key]['attribute']['id']) AND !empty($dom[$key]['attribute']['id'])) {
-			$id = strtolower($dom[$key]['attribute']['id']);
+			$id = mb_strtolower($dom[$key]['attribute']['id']);
 		}
 		$selector = preg_replace('/([\>\+\~\s]{1})([\.]{1})([^\>\+\~\s]*)/si', '\\1*.\\3', $selector);
 		$matches = array();
@@ -2158,11 +2158,11 @@ class TCPDF_STATIC {
 			$operator = $parentop[0];
 			$offset = $parentop[1];
 			$lasttag = array_pop($matches[2]);
-			$lasttag = strtolower(trim($lasttag[0]));
+			$lasttag = mb_strtolower(trim($lasttag[0]));
 			if (($lasttag == '*') OR ($lasttag == $tag)) {
 				// the last element on selector is our tag or 'any tag'
 				$attrib = array_pop($matches[3]);
-				$attrib = strtolower(trim($attrib[0]));
+				$attrib = mb_strtolower(trim($attrib[0]));
 				if (!empty($attrib)) {
 					// check if matches class, id, attribute, pseudo-class or pseudo-element
 					switch ($attrib[0]) {
@@ -2181,7 +2181,7 @@ class TCPDF_STATIC {
 						case '[': { // attribute
 							$attrmatch = array();
 							if (preg_match('/\[([a-zA-Z0-9]*)[\s]*([\~\^\$\*\|\=]*)[\s]*["]?([^"\]]*)["]?\]/i', $attrib, $attrmatch) > 0) {
-								$att = strtolower($attrmatch[1]);
+								$att = mb_strtolower($attrmatch[1]);
 								$val = $attrmatch[3];
 								if (isset($dom[$key]['attribute'][$att])) {
 									switch ($attrmatch[2]) {

--- a/libraries/tcpdf/tcpdf_autoconfig.php
+++ b/libraries/tcpdf/tcpdf_autoconfig.php
@@ -79,7 +79,7 @@ if (!defined('K_PATH_FONTS')) {
 if (!defined('K_PATH_URL')) {
 	$k_path_url = K_PATH_MAIN; // default value for console mode
 	if (isset($_SERVER['HTTP_HOST']) AND (!empty($_SERVER['HTTP_HOST']))) {
-		if(isset($_SERVER['HTTPS']) AND (!empty($_SERVER['HTTPS'])) AND (strtolower($_SERVER['HTTPS']) != 'off')) {
+		if(isset($_SERVER['HTTPS']) AND (!empty($_SERVER['HTTPS'])) AND (mb_strtolower($_SERVER['HTTPS']) != 'off')) {
 			$k_path_url = 'https://';
 		} else {
 			$k_path_url = 'http://';

--- a/libraries/transformations.lib.php
+++ b/libraries/transformations.lib.php
@@ -291,8 +291,8 @@ function PMA_setMIME($db, $table, $key, $mimetype, $transformation,
     }
 
     // lowercase mimetype & transformation
-    $mimetype = strtolower($mimetype);
-    $transformation = strtolower($transformation);
+    $mimetype = mb_strtolower($mimetype);
+    $transformation = mb_strtolower($transformation);
 
     $test_qry = '
          SELECT `mimetype`,

--- a/tbl_operations.php
+++ b/tbl_operations.php
@@ -108,7 +108,7 @@ if (isset($_REQUEST['submitoptions'])) {
     }
 
     if (! empty($_REQUEST['new_tbl_storage_engine'])
-        && strtolower($_REQUEST['new_tbl_storage_engine']) !== strtolower($tbl_storage_engine)
+        && mb_strtolower($_REQUEST['new_tbl_storage_engine']) !== mb_strtolower($tbl_storage_engine)
     ) {
         $new_tbl_storage_engine = $_REQUEST['new_tbl_storage_engine'];
         // reset the globals for the new engine

--- a/test/libraries/PMA_central_columns_test.php
+++ b/test/libraries/PMA_central_columns_test.php
@@ -369,7 +369,7 @@ class PMA_Central_Columns_Test extends PHPUnit_Framework_TestCase
         );
         $this->assertContains(
             PMA_getHtmlForColumnDefault(
-                1, 5, 0, strtoupper($row['col_type']), '',
+                1, 5, 0, mb_strtoupper($row['col_type']), '',
                 array('DefaultType'=>'NONE')
             ),
             $result
@@ -380,7 +380,7 @@ class PMA_Central_Columns_Test extends PHPUnit_Framework_TestCase
         );
         $this->assertContains(
             PMA_getHtmlForColumnDefault(
-                1, 5, 0, strtoupper($row['col_type']), '',
+                1, 5, 0, mb_strtoupper($row['col_type']), '',
                 array('DefaultType'=>'USER_DEFINED', 'DefaultValue'=>100)
             ),
             $result_1
@@ -391,7 +391,7 @@ class PMA_Central_Columns_Test extends PHPUnit_Framework_TestCase
         );
         $this->assertContains(
             PMA_getHtmlForColumnDefault(
-                1, 5, 0, strtoupper($row['col_type']), '',
+                1, 5, 0, mb_strtoupper($row['col_type']), '',
                 array('DefaultType'=>'CURRENT_TIMESTAMP')
             ),
             $result_2

--- a/test/selenium/PmaSeleniumTableInsertTest.php
+++ b/test/selenium/PmaSeleniumTableInsertTest.php
@@ -58,7 +58,7 @@ class PMA_SeleniumTableInsertTest extends PMA_SeleniumBase
      */
     public function testAddData()
     {
-        if (strtolower($this->getBrowser()) == 'safari') {
+        if (mb_strtolower($this->getBrowser()) == 'safari') {
             /* TODO: this should be fixed, but the cause is unclear to me */
             $this->markTestIncomplete('Fails with Safari');
         }

--- a/test/selenium/PmaSeleniumXssTest.php
+++ b/test/selenium/PmaSeleniumXssTest.php
@@ -27,7 +27,7 @@ class PMA_SeleniumXSSTest extends PMA_SeleniumBase
      */
     public function testQueryTabWithNullValue()
     {
-        if (strtolower($this->getBrowser()) == 'safari') {
+        if (mb_strtolower($this->getBrowser()) == 'safari') {
             $this->markTestSkipped('Alerts not supported on Safari browser.');
         }
         $this->login();

--- a/test/selenium/TestBase.php
+++ b/test/selenium/TestBase.php
@@ -461,7 +461,7 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
          * Not supported in Safari Webdriver, see
          * http://code.google.com/p/selenium/issues/detail?id=4136
          */
-        if (strtolower($this->getBrowser()) == 'safari') {
+        if (mb_strtolower($this->getBrowser()) == 'safari') {
             $this->markTestSkipped('Can not send keys to Safari browser.');
         }
         parent::keys($text);
@@ -481,7 +481,7 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
          * Not supported in Safari Webdriver, see
          * http://code.google.com/p/selenium/issues/detail?id=4136
          */
-        if (strtolower($this->getBrowser()) == 'safari') {
+        if (mb_strtolower($this->getBrowser()) == 'safari') {
             $this->markTestSkipped('MoveTo not supported on Safari browser.');
         }
         parent::moveto($element);
@@ -499,7 +499,7 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
          * Not supported in Safari Webdriver, see
          * http://code.google.com/p/selenium/issues/detail?id=4136
          */
-        if (strtolower($this->getBrowser()) == 'safari') {
+        if (mb_strtolower($this->getBrowser()) == 'safari') {
             $this->markTestSkipped('Alerts not supported on Safari browser.');
         }
         return parent::alertText();
@@ -518,7 +518,7 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
          * Firefox needs some escaping of a text, see
          * http://code.google.com/p/selenium/issues/detail?id=1723
          */
-        if (strtolower($this->getBrowser()) == 'firefox') {
+        if (mb_strtolower($this->getBrowser()) == 'firefox') {
             $text = str_replace(
                 "(",
                 PHPUnit_Extensions_Selenium2TestCase_Keys::SHIFT


### PR DESCRIPTION
strtoupper & strtolower functions in (as explained here ) PHP are locale aware and refuse to convert the chars that is not alphabetic to its language. Thus on the systems that use locale "tr_TR.UTF-8" strtoupper & strtolower fails because of Turkish 'I'. Since the lowercase of 'I' is 'ı' (w/o dot) and uppercase of 'i' is 'İ', case conversion functions of PHP thinks they are not alphabetic and refuse to convert 'I' to 'i' or 'i' to 'I'. So I changed the relevant lines of code with mbstring ones. mb_ ones successfully make the conversions.

I reported a feature request to PHP team but they are not willing to fix it and it has been there since 2002.
https://bugs.php.net/bug.php?id=67815 (My feature request)
https://bugs.php.net/bug.php?id=18556 (Similar bug reports that goes nowhere)
https://bugs.php.net/bug.php?id=35050

Signed-off-by: Ongun Kanat ongun.kanat@gmail.com
