### PR TITLE
fix bug #4487

### DIFF
--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1481,13 +1481,18 @@ class ExportSql extends ExportPlugin
         // that could be there starting with MySQL 5.0.24
         // in Drizzle it's useless as it contains the value given at table
         // creation time
-        $schema_create = preg_replace(
-            '/AUTO_INCREMENT\s*=\s*([0-9])+/',
-            '',
-            $schema_create
-        );
-
-        $schema_create .= ($compat != 'MSSQL') ? $auto_increment : '';
+        if (preg_match('/AUTO_INCREMENT\s*=\s*([0-9])+/', $schema_create)) {
+            if ($compat == 'MSSQL' || $auto_increment == '') {
+                $auto_increment = ' ';
+            }
+            $schema_create = preg_replace(
+                '/\sAUTO_INCREMENT\s*=\s*([0-9])+\s/',
+                $auto_increment,
+                $schema_create
+            );
+        } else {
+            $schema_create .= ($compat != 'MSSQL') ? $auto_increment : '';
+        }
 
         $GLOBALS['dbi']->freeResult($result);
         return $schema_create . ($add_semicolon ? ';' . $crlf : '');


### PR DESCRIPTION
Instead of always appending auto_increment in the end , if auto_increment was already there in result from SHOW CREATE then just replace the original auto_increment string in place from new one. In all other cases, append in the end if needed as it was happening before.
Signed-off-by: Smita Kumari kumarismita62@gmail.com
