### PR TITLE
update bug fix #4487

### DIFF
--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1490,8 +1490,6 @@ class ExportSql extends ExportPlugin
                 $auto_increment,
                 $schema_create
             );
-        } else {
-            $schema_create .= ($compat != 'MSSQL') ? $auto_increment : '';
         }
 
         $GLOBALS['dbi']->freeResult($result);


### PR DESCRIPTION
I had this doubt why are we appending auto_increment=## even if SHOW CREATE result is not having AUTO_INCREMENT in it as SHOW CREATE always gives AUTO INCREMENT whenever needed that is whenever we have some value for it. ? I dont think it is needed to append every time. So I have removed it. let me know if it can be an issue in any case.

Signed-off-by: Smita Kumari kumarismita62@gmail.com
