### PR TITLE
avoid session timeout when user is active FR#1529

### DIFF
--- a/index.php
+++ b/index.php
@@ -53,6 +53,9 @@ if (! empty($_REQUEST['target'])
     exit;
 }
 
+if (isset($_REQUEST['ajax_request']) && ! empty($_REQUEST['access_time'])) {
+    exit;
+}
 /**
  * Check if it is an ajax request to reload the recent tables list.
  */

--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -237,7 +237,9 @@ class PMA_Header
             ),
             'LimitChars' => $GLOBALS['cfg']['LimitChars'],
             'pftext' => $pftext,
-            'confirm' => $GLOBALS['cfg']['Confirm']
+            'confirm' => $GLOBALS['cfg']['Confirm'],
+            'LoginCookieValidity' => $GLOBALS['cfg']['LoginCookieValidity'],
+            'logged_in' => isset($GLOBALS['userlink']) ? true : false
         );
     }
 

--- a/libraries/plugins/auth/AuthenticationConfig.class.php
+++ b/libraries/plugins/auth/AuthenticationConfig.class.php
@@ -49,7 +49,11 @@ class AuthenticationConfig extends AuthenticationPlugin
     {
         // try to workaround PHP 5 session garbage collection which
         // looks at the session file's last modified time
-        $_SESSION['last_access_time'] = time();
+        if (isset($_REQUEST['access_time'])) {
+            $_SESSION['last_access_time'] = time()- $_REQUEST['access_time'];
+        } else {
+            $_SESSION['last_access_time'] = time();
+        }
 
         return true;
     }

--- a/libraries/plugins/auth/AuthenticationCookie.class.php
+++ b/libraries/plugins/auth/AuthenticationCookie.class.php
@@ -554,8 +554,11 @@ class AuthenticationCookie extends AuthenticationPlugin
         // Avoid showing the password in phpinfo()'s output
         unset($GLOBALS['PHP_AUTH_PW']);
         unset($_SERVER['PHP_AUTH_PW']);
-
-        $_SESSION['last_access_time'] = time();
+        if (isset($_REQUEST['access_time'])) {
+            $_SESSION['last_access_time'] = time() - $_REQUEST['access_time'];
+        } else {
+            $_SESSION['last_access_time'] = time();
+        }
 
         $this->createIV();
 


### PR DESCRIPTION
For review.
Please have a look if this workaround will work to avoid the session timeout. I have a timer on the frontend and that reset when any browser activity occur. Five seconds ahead of when a time out is supposed to occur, the script update the backed with the last time when user was active on the browser.
Suggest if I can do any modifications to make it better.
Signed-off-by: Smita Kumari kumarismita62@gmail.com
