### PR TITLE
Fix #4523: tbl_change.js: insert as new row submit type on multiple selected records does not set all AUTO_INCREMENTs to 0 value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ phpMyAdmin - ChangeLog
 4.2.8.1 (not yet released)
 - bug #4530 [security] DOM based XSS that results to a CSRF that creates a
             ROOT account in certain conditions
+- bug #4523 tbl_change.js: insert as new row submit type on multiple selected records does not set all AUTO_INCREMENTs to 0 value
 
 4.2.8.0 (2014-08-31)
 - bug #4516 Odd export behavior

--- a/js/tbl_change.js
+++ b/js/tbl_change.js
@@ -311,20 +311,28 @@ AJAX.registerOnload('tbl_change.js', function () {
      * available).
      */
     $('select[name="submit_type"]').bind('change', function (e) {
+        var $thisElemSubmitTypeField = $(this);
         var $table = $('table.insertRowTable');
-        var auto_increment_column = $table.find('input[name^="auto_increment"]').attr('name');
-        if (auto_increment_column) {
-            var prev_value_field = $table.find('input[name="' + auto_increment_column.replace('auto_increment', 'fields_prev') + '"]');
-            var value_field = $table.find('input[name="' + auto_increment_column.replace('auto_increment', 'fields') + '"]');
+        var auto_increment_column = $table.find('input[name^="auto_increment"]');
+        auto_increment_column.each(function () {
+            var $thisElemAIField = $(this);
+            var thisElemName = $thisElemAIField.attr('name');
+
+            var prev_value_field = $table.find('input[name="' + thisElemName.replace('auto_increment', 'fields_prev') + '"]');
+            var value_field = $table.find('input[name="' + thisElemName.replace('auto_increment', 'fields') + '"]');
             var previous_value = $(prev_value_field).val();
             if (previous_value !== undefined) {
-                if ($(this).val() == 'insert' || $(this).val() == 'insertignore' || $(this).val() == 'showinsert') {
+                if ($thisElemSubmitTypeField.val() == 'insert'
+                    || $thisElemSubmitTypeField.val() == 'insertignore'
+                    || $thisElemSubmitTypeField.val() == 'showinsert'
+                ) {
                     $(value_field).val(0);
                 } else {
                     $(value_field).val(previous_value);
                 }
             }
-        }
+        });
+
     });
 
     /**

--- a/js/tbl_change.js
+++ b/js/tbl_change.js
@@ -311,7 +311,7 @@ AJAX.registerOnload('tbl_change.js', function () {
      * available).
      */
     $('select[name="submit_type"]').bind('change', function (e) {
-        var $thisElemSubmitTypeField = $(this);
+        var thisElemSubmitTypeVal = $(this).val();
         var $table = $('table.insertRowTable');
         var auto_increment_column = $table.find('input[name^="auto_increment"]');
         auto_increment_column.each(function () {
@@ -322,9 +322,9 @@ AJAX.registerOnload('tbl_change.js', function () {
             var value_field = $table.find('input[name="' + thisElemName.replace('auto_increment', 'fields') + '"]');
             var previous_value = $(prev_value_field).val();
             if (previous_value !== undefined) {
-                if ($thisElemSubmitTypeField.val() == 'insert'
-                    || $thisElemSubmitTypeField.val() == 'insertignore'
-                    || $thisElemSubmitTypeField.val() == 'showinsert'
+                if (thisElemSubmitTypeVal == 'insert'
+                    || thisElemSubmitTypeVal == 'insertignore'
+                    || thisElemSubmitTypeVal == 'showinsert'
                 ) {
                     $(value_field).val(0);
                 } else {


### PR DESCRIPTION
In previous version, the script managed only first auto_increment field.
I improved it to manage all the auto_increment fields.
