### PR TITLE
Fix: broken skip slave error functionality

### DIFF
--- a/libraries/replication_gui.lib.php
+++ b/libraries/replication_gui.lib.php
@@ -198,6 +198,7 @@ function PMA_getHtmlForSlaveConfiguration(
             . PMA_URL_getCommon($_url_params);
 
         $_url_params = $GLOBALS['url_params'];
+        $_url_params['sr_take_action'] = true;
         $_url_params['sr_slave_skip_error'] = true;
         $slave_skip_error_link = 'server_replication.php'
             . PMA_URL_getCommon($_url_params);


### PR DESCRIPTION
libraries/replication_gui.lib.php:908
function PMA_handleControlRequest()
checks for
if (isset($_REQUEST['sr_take_action']))
libraries/replication_gui.lib.php:202
but sr_take_action variable isn't included in $slave_skip_error_link generation

Signed-off-by: Igor Prokopenkov cmyk777@gmail.com
