### PR TITLE
Adding ToukDB to the list of supported engiens for db stats

### DIFF
--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -1095,6 +1095,7 @@ function PMA_getStuffForEngineTypeTable($current_table, $db_is_system_schema,
     case 'HEAP' :
     case 'MEMORY' :
     case 'ARCHIVE' :
+    case 'TokuDB' :
     case 'Aria' :
     case 'Maria' :
         list($current_table, $formatted_size, $unit, $formatted_overhead,
@@ -1105,7 +1106,6 @@ function PMA_getStuffForEngineTypeTable($current_table, $db_is_system_schema,
         );
         break;
     case 'InnoDB' :
-    case 'TokuDB' :
     case 'PBMS' :
         // InnoDB table: Row count is not accurate but data and index sizes are.
         // PBMS table in Drizzle: TABLE_ROWS is taken from table cache,

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -1105,6 +1105,7 @@ function PMA_getStuffForEngineTypeTable($current_table, $db_is_system_schema,
         );
         break;
     case 'InnoDB' :
+    case 'TokuDB' :
     case 'PBMS' :
         // InnoDB table: Row count is not accurate but data and index sizes are.
         // PBMS table in Drizzle: TABLE_ROWS is taken from table cache,


### PR DESCRIPTION
There was no info about db size for TokuDB databases

![mysql snrs pl 2014-9-22 11 45 29](https://cloud.githubusercontent.com/assets/8859134/4354364/31025e0e-423d-11e4-9ad8-ad6fed62c963.png)
