### PR TITLE
fix bug #4540 #4541

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -2504,7 +2504,16 @@ AJAX.registerOnload('functions.js', function () {
                 .submit();
         }
     });
-
+    $("input[value=AUTO_INCREMENT]").change(function(){
+        if (this.checked) {
+            var col = /\d/.exec($(this).attr('name'));
+            col = col[0];
+            var index_val = $('select[name="field_key['+col+']"]').val();
+            if (index_val === 'none_'+col) {
+                $('select[name="field_key['+col+']"]').val('primary_'+col).change();
+            }
+        }
+    });
     $('body')
     .off('click', 'input.preview_sql')
     .on('click', 'input.preview_sql', function () {
@@ -2911,7 +2920,7 @@ function autoPopulate(input_id, offset)
     $('#'+input_id+'5').val(central_column_list[db+'_'+table][offset].col_collation);
     $('#'+input_id+'6').val(central_column_list[db+'_'+table][offset].col_extra);
     if(central_column_list[db+'_'+table][offset].col_extra.toUpperCase() === 'AUTO_INCREMENT') {
-        $('#'+input_id+'9').attr("checked","checked");
+        $('#'+input_id+'9').attr("checked","checked").change();
     } else {
         $('#'+input_id+'9').removeAttr("checked");
     }

--- a/js/indexes.js
+++ b/js/indexes.js
@@ -460,7 +460,7 @@ AJAX.registerTeardown('indexes.js', function () {
     $('a.drop_primary_key_index_anchor.ajax').die('click');
     $("#table_index tbody tr td.edit_index.ajax, #indexes .add_index.ajax").die('click');
     $('#index_frm input[type=submit]').die('click');
-    $('body').off('click', 'select[name*="field_key"]');
+    $('body').off('change', 'select[name*="field_key"]');
 });
 
 /**
@@ -590,7 +590,7 @@ AJAX.registerOnload('indexes.js', function () {
      * Ajax event handler for advanced index creation during table creation
      * and column addition.
      */
-    $('body').on('click', 'select[name*="field_key"]', function () {
+    $('body').on('change', 'select[name*="field_key"]', function () {
         // Index of column on Table edit and create page.
         var col_index = /\d/.exec($(this).attr('name'));
         col_index = col_index[0];

--- a/libraries/Table.class.php
+++ b/libraries/Table.class.php
@@ -515,35 +515,6 @@ class PMA_Table
 
         if (!empty($extra)) {
             $query .= ' ' . $extra;
-            // Force an auto_increment field to be part of the primary key
-            // even if user did not tick the PK box;
-            if ($extra == 'AUTO_INCREMENT') {
-                $primary_cnt = count($field_primary);
-                if (1 == $primary_cnt) {
-                    for ($j = 0; $j < $primary_cnt; $j++) {
-                        if ($field_primary[$j] == $index) {
-                            break;
-                        }
-                    }
-                    if (isset($field_primary[$j]) && $field_primary[$j] == $index) {
-                        $query .= ' PRIMARY KEY';
-                        unset($field_primary[$j]);
-                    }
-                } else {
-                    // but the PK could contain other columns so do not append
-                    // a PRIMARY KEY clause, just add a member to $field_primary
-                    $found_in_pk = false;
-                    for ($j = 0; $j < $primary_cnt; $j++) {
-                        if ($field_primary[$j] == $index) {
-                            $found_in_pk = true;
-                            break;
-                        }
-                    } // end for
-                    if (! $found_in_pk) {
-                        $field_primary[] = $index;
-                    }
-                }
-            } // end if (auto_increment)
         }
         if (!empty($comment)) {
             $query .= " COMMENT '" . PMA_Util::sqlAddSlashes($comment) . "'";


### PR DESCRIPTION
bug #4540: once selected a index type, user should be able change to another index type.
bug #4541: I have removed the backend code that was forcing the auto_increment column to be part of primary key and wasn't working anyway. Instead in frontend, if user checks the auto_increment box, add index index dialog will show up if none of the index is selected.
Signed-off-by: Smita Kumari kumarismita62@gmail.com
