### PR TITLE
Fix for bug #4547

### DIFF
--- a/js/server_privileges.js
+++ b/js/server_privileges.js
@@ -414,6 +414,9 @@ AJAX.registerOnload('server_privileges.js', function () {
 
         // hide all sections but the first
         $("#edit_user_dialog .submenu-item").hide().eq(0).show();
+
+        // scroll to the top
+        $('html, body').animate({scrollTop: 0}, 'fast');
     };
 
     $("input.autofocus").focus();

--- a/libraries/display_change_password.lib.php
+++ b/libraries/display_change_password.lib.php
@@ -34,9 +34,7 @@ function PMA_getHtmlForChangePassword($username, $hostname)
     $html = '<form method="post" id="change_password_form" '
         . 'action="' . basename($GLOBALS['PMA_PHP_SELF']) . '" '
         . 'name="chgPassword" '
-        . 'class="ajax'
-        . ($is_privileges ? ' submenu-item' : '')
-        . '">';
+        . 'class="' . ($is_privileges ? 'submenu-item' : '') . '">';
 
     $html .= PMA_URL_getHiddenInputs();
 
@@ -109,7 +107,8 @@ function PMA_getHtmlForChangePassword($username, $hostname)
     $html .=  '</table>'
         . '</fieldset>'
         . '<fieldset id="fieldset_change_password_footer" class="tblFooters">'
-        . '<input type="submit" name="change_pw" value="' . __('Go') . '" />'
+        . '<input type="hidden" name="change_pw" value="1" />'
+        . '<input type="submit" value="' . __('Go') . '" />'
         . '</fieldset>'
         . '</form>';
     return $html;

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -699,9 +699,9 @@ function PMA_getHtmlToDisplayPrivilegesTable($db = '*',
     if ($submit) {
         $html_output .= '<fieldset id="fieldset_user_privtable_footer" '
             . 'class="tblFooters">' . "\n"
-           . '<input type="submit" name="update_privs" '
-            . 'value="' . __('Go') . '" />' . "\n"
-           . '</fieldset>' . "\n";
+            . '<input type="hidden" name="update_privs" value="1" />' . "\n"
+            . '<input type="submit" value="' . __('Go') . '" />' . "\n"
+            . '</fieldset>' . "\n";
     }
     return $html_output;
 } // end of the 'PMA_displayPrivTable()' function
@@ -2239,7 +2239,7 @@ function PMA_getHtmlListOfPrivs(
  */
 function PMA_getUserEditLink($username, $hostname, $dbname = '', $tablename = '')
 {
-    return '<a class="edit_user_anchor ajax"'
+    return '<a class="edit_user_anchor"'
         . ' href="server_privileges.php'
         . PMA_URL_getCommon(
             array(
@@ -2511,7 +2511,8 @@ function PMA_getChangeLoginInformationHtmlForm($username, $hostname)
     );
 
     $html_output = '<form action="server_privileges.php" '
-        . 'method="post" class="copyUserForm ajax submenu-item">' . "\n"
+        . 'onsubmit="return checkAddUser(this);" '
+        . 'method="post" class="copyUserForm submenu-item">' . "\n"
         . PMA_URL_getHiddenInputs('', '')
         . '<input type="hidden" name="old_username" '
         . 'value="' . htmlspecialchars($username) . '" />' . "\n"
@@ -2535,8 +2536,8 @@ function PMA_getChangeLoginInformationHtmlForm($username, $hostname)
 
     $html_output .= '<fieldset id="fieldset_change_copy_user_footer" '
         . 'class="tblFooters">' . "\n"
-        . '<input type="submit" name="change_copy" '
-        . 'value="' . __('Go') . '" />' . "\n"
+        . '<input type="hidden" name="change_copy" value="1" />' . "\n"
+        . '<input type="submit" value="' . __('Go') . '" />' . "\n"
         . '</fieldset>' . "\n"
         . '</form>' . "\n";
 
@@ -3849,7 +3850,7 @@ function PMA_getAddUserHtmlFieldset($db = '', $table = '')
         . (!empty($rel_params)
             ? ('rel="' . PMA_URL_getCommon($rel_params) . '" ')
             : '')
-        . 'class="ajax">' . "\n"
+        . '">' . "\n"
         . PMA_Util::getIcon('b_usradd.png')
         . '            ' . __('Add user') . '</a>' . "\n"
         . '</fieldset>' . "\n";
@@ -3876,7 +3877,7 @@ function PMA_getHtmlHeaderForUserProperties(
        . __('User');
 
     if (! empty($dbname)) {
-        $html_output .= ' <i><a class="edit_user_anchor ajax"'
+        $html_output .= ' <i><a class="edit_user_anchor"'
             . ' href="server_privileges.php'
             . PMA_URL_getCommon(
                 array(
@@ -4109,7 +4110,7 @@ function PMA_getHtmlForUserProperties($dbname_is_wildcard,$url_dbname,
         $_params['dbname'] = $dbname;
     }
 
-    $html_output .= '<form class="ajax submenu-item" name="usersForm" '
+    $html_output .= '<form class="submenu-item" name="usersForm" '
         . 'id="addUsersForm" action="server_privileges.php" method="post">' . "\n";
     $html_output .= PMA_URL_getHiddenInputs($_params);
     $html_output .= PMA_getHtmlToDisplayPrivilegesTable(

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -1754,7 +1754,8 @@ function PMA_getHtmlForAddUser($dbname)
     $html_output = '<h2>' . "\n"
        . PMA_Util::getIcon('b_usradd.png') . __('Add user') . "\n"
        . '</h2>' . "\n"
-       . '<form name="usersForm" class="ajax" id="addUsersForm"'
+       . '<form name="usersForm" id="addUsersForm"'
+       . ' onsubmit="return checkAddUser(this);"'
        . ' action="server_privileges.php" method="post" autocomplete="off" >' . "\n"
        . PMA_URL_getHiddenInputs('', '')
        . PMA_getHtmlForLoginInformationFields('new');
@@ -1796,8 +1797,8 @@ function PMA_getHtmlForAddUser($dbname)
     }
     $html_output .= '<fieldset id="fieldset_add_user_footer" class="tblFooters">'
         . "\n"
-        . '<input type="submit" name="adduser_submit" '
-        . 'value="' . __('Go') . '" />' . "\n"
+        . '<input type="hidden" name="adduser_submit" value="1" />' . "\n"
+        . '<input type="submit" id="adduser_submit" value="' . __('Go') . '" />' . "\n"
         . '</fieldset>' . "\n"
         . '</form>' . "\n";
 
@@ -2375,7 +2376,7 @@ function PMA_getExtraDataForAjaxBehavior(
         $extra_data['sql_query'] = PMA_Util::getMessage(null, $sql_query);
     }
 
-    if (isset($_REQUEST['adduser_submit']) || isset($_REQUEST['change_copy'])) {
+    if (isset($_REQUEST['change_copy'])) {
         /**
          * generate html on the fly for the new user that was just created.
          */
@@ -4074,7 +4075,8 @@ function PMA_getHtmlForUserOverview($pmaThemeImage, $text_dir)
 function PMA_getHtmlForUserProperties($dbname_is_wildcard,$url_dbname,
     $username, $hostname, $dbname, $tablename
 ) {
-    $html_output = PMA_getHtmlHeaderForUserProperties(
+    $html_output  = '<div id="edit_user_dialog">';
+    $html_output .= PMA_getHtmlHeaderForUserProperties(
         $dbname_is_wildcard, $url_dbname, $dbname, $username, $hostname, $tablename
     );
 
@@ -4166,6 +4168,7 @@ function PMA_getHtmlForUserProperties($dbname_is_wildcard,$url_dbname,
         $html_output .= PMA_getHtmlForChangePassword($username, $hostname);
         $html_output .= PMA_getChangeLoginInformationHtmlForm($username, $hostname);
     }
+    $html_output .= '</div>';
 
     return $html_output;
 }

--- a/libraries/server_user_groups.lib.php
+++ b/libraries/server_user_groups.lib.php
@@ -283,7 +283,7 @@ function PMA_getHtmlToEditUserGroup($userGroup = null)
 
     $html_output .= '<fieldset id="fieldset_user_group_rights_footer"'
         . ' class="tblFooters">';
-    $html_output .= '<input type="submit" name="update_privs" value="Go">';
+    $html_output .= '<input type="submit" value="' . __('Go') . '">';
     $html_output .= '</fieldset>';
 
     return $html_output;

--- a/server_privileges.php
+++ b/server_privileges.php
@@ -277,12 +277,10 @@ if ($GLOBALS['is_ajax_request']
     && empty($_REQUEST['ajax_page_request'])
     && ! isset($_REQUEST['export'])
     && (! isset($_REQUEST['submit_mult']) || $_REQUEST['submit_mult'] != 'export')
-    && (! isset($_REQUEST['adduser']) || $_add_user_error)
     && ((! isset($_REQUEST['initial']) || $_REQUEST['initial'] === null
     || $_REQUEST['initial'] === '')
     || (isset($_REQUEST['delete']) && $_REQUEST['delete'] === 'Go'))
     && ! isset($_REQUEST['showall'])
-    && ! isset($_REQUEST['edit_user_dialog'])
     && ! isset($_REQUEST['edit_user_group_dialog'])
     && ! isset($_REQUEST['db_specific'])
 ) {

--- a/server_privileges.php
+++ b/server_privileges.php
@@ -386,20 +386,19 @@ if (isset($_REQUEST['adduser'])) {
         if ($GLOBALS['is_ajax_request'] == true) {
             header('Cache-Control: no-cache');
         }
-        if (! is_array($dbname)) {
+        if (isset($dbname) && ! is_array($dbname)) {
             $url_dbname = urlencode(
                 str_replace(
                     array('\_', '\%'),
                     array('_', '%'), $_REQUEST['dbname']
                 )
             );
-        } else {
-            $url_dbname = '';
         }
         $response->addHTML(
             PMA_getHtmlForUserProperties(
-                ((isset ($dbname_is_wildcard)) ? $dbname_is_wildcard : ''),
-                $url_dbname, $username, $hostname,
+                (isset($dbname_is_wildcard) ? $dbname_is_wildcard : ''),
+                (isset($url_dbname) ? $url_dbname : ''),
+                $username, $hostname,
                 (isset($dbname) ? $dbname : ''),
                 (isset($tablename) ? $tablename : '')
             )


### PR DESCRIPTION
Sometime back 'Add user' and 'Edit privileges' functionalities were Ajaxified and they used a jQuery dialog to display the relevant forms. However, due to the lack of space in jQuery dialogs, those functonalities needed to be reverted. This was temporarily done by directing the content which earlier went into the jQuery dialogs to a div above #page_content div. This wasn't the cleanest approach and it also broke the micro history. In this PR I am proposing to fix this and revert the ajaxification altogether, hence big deletions in js/server_privileges.js
