### PR TITLE
Performance improvements related to IS

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -998,6 +998,16 @@ Server connection settings
 
     * ``xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xx[yyy-zzz]`` (partial :term:`IPv6` address range)
 
+.. config:option:: $cfg['Servers'][$i]['DisableIS']
+
+    :type: boolean
+    :default: false
+
+    Disable using ``INFORMATION_SCHEMA`` to retrieve information (use
+    ``SHOW`` commands instead), because of speed issues when many
+    databases are present. Currently used in some parts of the code, more
+    to come.
+
 .. config:option:: $cfg['Servers'][$i]['SignonScript']
 
     :type: string

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -718,6 +718,8 @@ class PMA_DatabaseInterface
                         && $each_tables[$table_name]['Engine'] == null
                     ) {
                         $each_tables[$table_name]['TABLE_TYPE'] = 'VIEW';
+                    } elseif ($each_database == 'information_schema') {
+                        $each_tables[$table_name]['TABLE_TYPE'] = 'SYSTEM VIEW';
                     } else {
                         /**
                          * @todo difference between 'TEMPORARY' and 'BASE TABLE'

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -2091,22 +2091,37 @@ class PMA_DatabaseInterface
         }
 
         $result = array();
-        // Note: in http://dev.mysql.com/doc/refman/5.0/en/faqs-triggers.html
-        // their example uses WHERE TRIGGER_SCHEMA='dbname' so let's use this
-        // instead of WHERE EVENT_OBJECT_SCHEMA='dbname'
-        $query = 'SELECT TRIGGER_SCHEMA, TRIGGER_NAME, EVENT_MANIPULATION'
-            . ', EVENT_OBJECT_TABLE, ACTION_TIMING, ACTION_STATEMENT'
-            . ', EVENT_OBJECT_SCHEMA, EVENT_OBJECT_TABLE, DEFINER'
-            . ' FROM information_schema.TRIGGERS'
-            . ' WHERE TRIGGER_SCHEMA= \'' . PMA_Util::sqlAddSlashes($db) . '\'';
+        if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+            // Note: in http://dev.mysql.com/doc/refman/5.0/en/faqs-triggers.html
+            // their example uses WHERE TRIGGER_SCHEMA='dbname' so let's use this
+            // instead of WHERE EVENT_OBJECT_SCHEMA='dbname'
+            $query = 'SELECT TRIGGER_SCHEMA, TRIGGER_NAME, EVENT_MANIPULATION'
+                . ', EVENT_OBJECT_TABLE, ACTION_TIMING, ACTION_STATEMENT'
+                . ', EVENT_OBJECT_SCHEMA, EVENT_OBJECT_TABLE, DEFINER'
+                . ' FROM information_schema.TRIGGERS'
+                . ' WHERE TRIGGER_SCHEMA= \'' . PMA_Util::sqlAddSlashes($db) . '\'';
 
-        if (! empty($table)) {
-            $query .= " AND EVENT_OBJECT_TABLE = '"
-                . PMA_Util::sqlAddSlashes($table) . "';";
+            if (! empty($table)) {
+                $query .= " AND EVENT_OBJECT_TABLE = '"
+                    . PMA_Util::sqlAddSlashes($table) . "';";
+            }
+        } else {
+            $query = "SHOW TRIGGERS FROM " . PMA_Util::backquote($db);
+            if (! empty($table)) {
+                $query .= " LIKE '" . PMA_Util::sqlAddSlashes($table, true) . "';";
+            }
         }
 
         if ($triggers = $this->fetchResult($query)) {
             foreach ($triggers as $trigger) {
+                if ($GLOBALS['cfg']['Server']['DisableIS']) {
+                    $trigger['TRIGGER_NAME'] = $trigger['Trigger'];
+                    $trigger['ACTION_TIMING'] = $trigger['Timing'];
+                    $trigger['EVENT_MANIPULATION'] = $trigger['Event'];
+                    $trigger['EVENT_OBJECT_TABLE'] = $trigger['Table'];
+                    $trigger['ACTION_STATEMENT'] = $trigger['Statement'];
+                    $trigger['DEFINER'] = $trigger['Definer'];
+                }
                 $one_result = array();
                 $one_result['name'] = $trigger['TRIGGER_NAME'];
                 $one_result['table'] = $trigger['EVENT_OBJECT_TABLE'];

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -552,7 +552,7 @@ class PMA_DatabaseInterface
         // this is why we fall back to SHOW TABLE STATUS even for MySQL >= 50002
         if (empty($tables) && !PMA_DRIZZLE) {
             foreach ($databases as $each_database) {
-                if ($table || (true === $tbl_is_group) || $tble_type) {
+                if ($table || (true === $tbl_is_group) || $table_type) {
                     $sql = 'SHOW TABLE STATUS FROM '
                         . PMA_Util::backquote($each_database)
                         .' WHERE';
@@ -565,13 +565,13 @@ class PMA_DatabaseInterface
                             . "%'";
                         $needAnd = true;
                     }
-                    if ($tble_type) {
+                    if ($table_type) {
                         if ($needAnd) {
                             $sql .= " AND";
                         }
-                        if ($tble_type == 'view') {
+                        if ($table_type == 'view') {
                             $sql .= " `Comment` = 'VIEW'";
-                        } else if ($tble_type == 'table') {
+                        } else if ($table_type == 'table') {
                             $sql .= " `Comment` != 'VIEW'";
                         }
                     }

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -2262,11 +2262,23 @@ class PMA_DatabaseInterface
         if ($type === 'super') {
             $query = 'SELECT 1 FROM mysql.user LIMIT 1';
         } elseif ($type === 'create') {
-            $query = 'SELECT 1 FROM INFORMATION_SCHEMA.USER_PRIVILEGES '
-                . 'WHERE PRIVILEGE_TYPE = \'CREATE USER\' LIMIT 1';
+            list($user, $host) = $this->_getCurrentUserAndHost();
+            $query = "SELECT 1 FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES` "
+                . "WHERE `PRIVILEGE_TYPE` = 'CREATE USER' "
+                . "AND '''" . $user . "''@''" . $host . "''' LIKE `GRANTEE` LIMIT 1";
         } elseif ($type === 'grant') {
-            $query = 'SELECT 1 FROM INFORMATION_SCHEMA.USER_PRIVILEGES '
-                . 'WHERE IS_GRANTABLE = \'YES\' LIMIT 1';
+            list($user, $host) = $this->_getCurrentUserAndHost();
+            $query = "SELECT 1 FROM ("
+                . "SELECT `GRANTEE`, `IS_GRANTABLE` FROM "
+                . "`INFORMATION_SCHEMA`.`COLUMN_PRIVILEGES` UNION "
+                . "SELECT `GRANTEE`, `IS_GRANTABLE` FROM "
+                . "`INFORMATION_SCHEMA`.`TABLE_PRIVILEGES` UNION "
+                . "SELECT `GRANTEE`, `IS_GRANTABLE` FROM "
+                . "`INFORMATION_SCHEMA`.`SCHEMA_PRIVILEGES` UNION "
+                . "SELECT `GRANTEE`, `IS_GRANTABLE` FROM "
+                . "`INFORMATION_SCHEMA`.`USER_PRIVILEGES`) t "
+                . "WHERE `IS_GRANTABLE` = 'YES' "
+                . "AND '''" . $user . "''@''" . $host . "''' LIKE `GRANTEE` LIMIT 1";
         }
 
         // when connection failed we don't have a $userlink
@@ -2298,6 +2310,17 @@ class PMA_DatabaseInterface
         }
 
         return PMA_Util::cacheGet('is_' . $type . 'user');
+    }
+
+    /**
+     * Get the current user and host
+     *
+     * @return array arrya of username and hostname
+     */
+    private function _getCurrentUserAndHost()
+    {
+        $user = $GLOBALS['dbi']->fetchValue("SELECT CURRENT_USER();");
+        return explode("@", $user);
     }
 
     /**

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -1222,6 +1222,7 @@ class PMA_DatabaseInterface
             }
             return $this->fetchResult($sql, $array_keys, null, $link);
         } else {
+            $columns = array();
             if (null === $database) {
                 foreach ($GLOBALS['pma']->databases as $database) {
                     $columns[$database] = $this->getColumnsFull(

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -2299,8 +2299,6 @@ class PMA_DatabaseInterface
             }
 
             $is = false;
-            // Check information_schema.user_privileges table
-            // for global create user rights
             $result = $GLOBALS['dbi']->tryQuery(
                 $query,
                 $GLOBALS['userlink'],

--- a/libraries/Table.class.php
+++ b/libraries/Table.class.php
@@ -192,6 +192,7 @@ class PMA_Table
 
         // use cached data or load information with SHOW command
         if (isset(PMA_Table::$cache[$db][$table])
+            || $GLOBALS['cfg']['Server']['DisableIS']
         ) {
             $type = PMA_Table::sGetStatusInfo($db, $table, 'TABLE_TYPE');
             return $type == 'VIEW';

--- a/libraries/Table.class.php
+++ b/libraries/Table.class.php
@@ -195,7 +195,12 @@ class PMA_Table
             || $GLOBALS['cfg']['Server']['DisableIS']
         ) {
             $type = PMA_Table::sGetStatusInfo($db, $table, 'TABLE_TYPE');
-            return $type == 'VIEW';
+            return $type == 'VIEW' || $type == 'SYSTEM VIEW';
+        }
+
+        // information_schema tables are 'SYSTEM VIEW's
+        if ($db == 'information_schema') {
+            return true;
         }
 
         // query information_schema

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -1015,6 +1015,9 @@ if (! defined('PMA_MINIMUM_COMMON')) {
         }
 
         if (PMA_DRIZZLE) {
+            // DisableIS must be set to false for Drizzle, it maps SHOW commands
+            // to INFORMATION_SCHEMA queries anyway so it's fast on large servers
+            $cfg['Server']['DisableIS'] = false;
             // SHOW OPEN TABLES is not supported by Drizzle
             $cfg['SkipLockedTables'] = false;
         }

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -521,6 +521,15 @@ $cfg['Servers'][$i]['AllowDeny']['order'] = '';
 $cfg['Servers'][$i]['AllowDeny']['rules'] = array();
 
 /**
+ * Disable use of INFORMATION_SCHEMA. Is always 'false' for Drizzle.
+ *
+ * @see https://sourceforge.net/p/phpmyadmin/bugs/2606/
+ * @see http://bugs.mysql.com/19588
+ * @global boolean $cfg['Servers'][$i]['DisableIS']
+ */
+$cfg['Servers'][$i]['DisableIS'] = false;
+
+/**
  * Whether the tracking mechanism creates
  * versions for tables and views automatically.
  *

--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -583,6 +583,8 @@ $strConfigServers_controlport_desc = __(
 $strConfigServers_controlport_name = __('Control port');
 $strConfigServers_hide_db_desc
     = __('Hide databases matching regular expression (PCRE).');
+$strConfigServers_DisableIS_desc = __('More information on [a@https://sourceforge.net/p/phpmyadmin/bugs/2606/]PMA bug tracker[/a] and [a@http://bugs.mysql.com/19588]MySQL Bugs[/a]');
+$strConfigServers_DisableIS_name = __('Disable use of INFORMATION_SCHEMA');
 $strConfigServers_hide_db_name = __('Hide databases');
 $strConfigServers_history_desc = __(
     'Leave blank for no SQL query history support, suggested: '

--- a/libraries/config/setup.forms.php
+++ b/libraries/config/setup.forms.php
@@ -56,6 +56,7 @@ $forms['Servers']['Server_config'] = array('Servers' => array(1 => array(
     'hide_db',
     'AllowRoot',
     'AllowNoPassword',
+    'DisableIS',
     'AllowDeny/order',
     'AllowDeny/rules')));
 $forms['Servers']['Server_pmadb'] = array('Servers' => array(1 => array(

--- a/libraries/dbi/DBIDummy.class.php
+++ b/libraries/dbi/DBIDummy.class.php
@@ -493,18 +493,18 @@ $GLOBALS['dummy_queries'] = array(
     ),
     array(
         'query' => "SELECT `SCHEMA_NAME` FROM `INFORMATION_SCHEMA`.`SCHEMATA`, "
-            . "(select DB_first_level from ( SELECT distinct "
+            . "(SELECT DB_first_level FROM ( SELECT DISTINCT "
             . "SUBSTRING_INDEX(SCHEMA_NAME, '_', 1) DB_first_level "
             . "FROM INFORMATION_SCHEMA.SCHEMATA WHERE TRUE ) t ORDER BY "
-            . "DB_first_level ASC LIMIT 0, 250) t2 where 1 = locate("
-            . "concat(DB_first_level, '_'), concat(SCHEMA_NAME, '_')) "
-            . "order by SCHEMA_NAME ASC",
+            . "DB_first_level ASC LIMIT 0, 250) t2 WHERE 1 = LOCATE("
+            . "CONCAT(DB_first_level, '_'), CONCAT(SCHEMA_NAME, '_')) "
+            . "ORDER BY SCHEMA_NAME ASC",
         'result' => array(
             "test",
         )
     ),
     array(
-        'query' => "select COUNT(*) from ( SELECT distinct SUBSTRING_INDEX("
+        'query' => "SELECT COUNT(*) FROM ( SELECT DISTINCT SUBSTRING_INDEX("
             . "SCHEMA_NAME, '_', 1) DB_first_level "
             . "FROM INFORMATION_SCHEMA.SCHEMATA WHERE TRUE ) t",
         'result' => array(

--- a/libraries/dbi/DBIDummy.class.php
+++ b/libraries/dbi/DBIDummy.class.php
@@ -30,13 +30,22 @@ $GLOBALS['dummy_queries'] = array(
         'result' => array(array('1')),
     ),
     array(
-        'query' => 'SELECT 1 FROM INFORMATION_SCHEMA.USER_PRIVILEGES '
-            . 'WHERE PRIVILEGE_TYPE = \'CREATE USER\' LIMIT 1',
+        'query' => "SELECT 1 FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES`"
+            . " WHERE `PRIVILEGE_TYPE` = 'CREATE USER'"
+            . " AND '''pma_test''@''localhost''' LIKE `GRANTEE` LIMIT 1",
         'result' => array(array('1')),
     ),
     array(
-        'query' => 'SELECT 1 FROM INFORMATION_SCHEMA.USER_PRIVILEGES '
-            . 'WHERE IS_GRANTABLE = \'YES\' LIMIT 1',
+        'query' => "SELECT 1 FROM (SELECT `GRANTEE`, `IS_GRANTABLE`"
+            . " FROM `INFORMATION_SCHEMA`.`COLUMN_PRIVILEGES`"
+            . " UNION SELECT `GRANTEE`, `IS_GRANTABLE`"
+            . " FROM `INFORMATION_SCHEMA`.`TABLE_PRIVILEGES`"
+            . " UNION SELECT `GRANTEE`, `IS_GRANTABLE`"
+            . " FROM `INFORMATION_SCHEMA`.`SCHEMA_PRIVILEGES`"
+            . " UNION SELECT `GRANTEE`, `IS_GRANTABLE`"
+            . " FROM `INFORMATION_SCHEMA`.`USER_PRIVILEGES`) t"
+            . " WHERE `IS_GRANTABLE` = 'YES'"
+            . " AND '''pma_test''@''localhost''' LIKE `GRANTEE` LIMIT 1",
         'result' => array(array('1')),
     ),
     array(

--- a/libraries/mysql_charsets.lib.php
+++ b/libraries/mysql_charsets.lib.php
@@ -114,14 +114,26 @@ function PMA_getDbCollation($db)
         return 'utf8_general_ci';
     }
 
-    $sql = PMA_DRIZZLE
-        ? 'SELECT DEFAULT_COLLATION_NAME FROM data_dictionary.SCHEMAS'
-        . ' WHERE SCHEMA_NAME = \'' . PMA_Util::sqlAddSlashes($db)
-        . '\' LIMIT 1'
-        : 'SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA'
-        . ' WHERE SCHEMA_NAME = \'' . PMA_Util::sqlAddSlashes($db)
-        . '\' LIMIT 1';
-    return $GLOBALS['dbi']->fetchValue($sql);
+    if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+        // this is slow with thousands of databases
+        $sql = PMA_DRIZZLE
+            ? 'SELECT DEFAULT_COLLATION_NAME FROM data_dictionary.SCHEMAS'
+            . ' WHERE SCHEMA_NAME = \'' . PMA_Util::sqlAddSlashes($db)
+            . '\' LIMIT 1'
+            : 'SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA'
+            . ' WHERE SCHEMA_NAME = \'' . PMA_Util::sqlAddSlashes($db)
+            . '\' LIMIT 1';
+        return $GLOBALS['dbi']->fetchValue($sql);
+    } else {
+        $GLOBALS['dbi']->selectDb($db);
+        $return = $GLOBALS['dbi']->fetchValue(
+            'SHOW VARIABLES LIKE \'collation_database\'', 0, 1
+        );
+        if ($db !== $GLOBALS['db']) {
+            $GLOBALS['dbi']->selectDb($GLOBALS['db']);
+        }
+        return $return;
+    }
 }
 
 /**

--- a/libraries/navigation/Nodes/Node.class.php
+++ b/libraries/navigation/Nodes/Node.class.php
@@ -395,7 +395,7 @@ class Node
      */
     public function getPresence($type = '', $searchClause = '')
     {
-        if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+        if (! $GLOBALS['cfg']['Server']['DisableIS']) {
             $query = "select COUNT(*) ";
             $query .= "from ( ";
             $query .= "SELECT distinct SUBSTRING_INDEX(SCHEMA_NAME, ";

--- a/libraries/navigation/Nodes/Node.class.php
+++ b/libraries/navigation/Nodes/Node.class.php
@@ -461,7 +461,7 @@ class Node
             if (! $GLOBALS['cfg']['Server']['DisableIS']) {
                 $query = "SELECT COUNT(*) ";
                 $query .= "FROM ( ";
-                $query .= "SELECT distinct SUBSTRING_INDEX(SCHEMA_NAME, ";
+                $query .= "SELECT DISTINCT SUBSTRING_INDEX(SCHEMA_NAME, ";
                 $query .= "'$dbSeperator', 1) ";
                 $query .= "DB_first_level ";
                 $query .= "FROM INFORMATION_SCHEMA.SCHEMATA ";

--- a/libraries/navigation/Nodes/Node.class.php
+++ b/libraries/navigation/Nodes/Node.class.php
@@ -360,27 +360,37 @@ class Node
     public function getData($type, $pos, $searchClause = '')
     {
         // @todo obey the DisableIS directive
-        $query  = "SELECT `SCHEMA_NAME` ";
-        $query .= "FROM `INFORMATION_SCHEMA`.`SCHEMATA`, ";
-        $query .= "(";
-        $query .= "SELECT DB_first_level ";
-        $query .= "FROM ( ";
-        $query .= "SELECT DISTINCT SUBSTRING_INDEX(SCHEMA_NAME, ";
-        $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}', 1) ";
-        $query .= "DB_first_level ";
-        $query .= "FROM INFORMATION_SCHEMA.SCHEMATA ";
-        $query .= $this->_getWhereClause('SCHEMA_NAME', $searchClause);
-        $query .= ") t ";
-        $query .= "ORDER BY DB_first_level ASC ";
-        $query .= "LIMIT $pos, {$GLOBALS['cfg']['FirstLevelNavigationItems']}";
-        $query .= ") t2 ";
-        $query .= "WHERE 1 = LOCATE(CONCAT(DB_first_level, ";
-        $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}'), ";
-        $query .= "CONCAT(SCHEMA_NAME, ";
-        $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}')) ";
-        $query .= "ORDER BY SCHEMA_NAME ASC";
+        if ($GLOBALS['cfg']['NavigationTreeEnableGrouping']) {
+            $query  = "SELECT `SCHEMA_NAME` ";
+            $query .= "FROM `INFORMATION_SCHEMA`.`SCHEMATA`, ";
+            $query .= "(";
+            $query .= "SELECT DB_first_level ";
+            $query .= "FROM ( ";
+            $query .= "SELECT DISTINCT SUBSTRING_INDEX(SCHEMA_NAME, ";
+            $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}', 1) ";
+            $query .= "DB_first_level ";
+            $query .= "FROM INFORMATION_SCHEMA.SCHEMATA ";
+            $query .= $this->_getWhereClause('SCHEMA_NAME', $searchClause);
+            $query .= ") t ";
+            $query .= "ORDER BY DB_first_level ASC ";
+            $query .= "LIMIT $pos, {$GLOBALS['cfg']['FirstLevelNavigationItems']}";
+            $query .= ") t2 ";
+            $query .= "WHERE 1 = LOCATE(CONCAT(DB_first_level, ";
+            $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}'), ";
+            $query .= "CONCAT(SCHEMA_NAME, ";
+            $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}')) ";
+            $query .= "ORDER BY SCHEMA_NAME ASC";
+            $retval = $GLOBALS['dbi']->fetchResult($query);
+        } else {
+            $query  = "SELECT `SCHEMA_NAME` ";
+            $query .= "FROM `INFORMATION_SCHEMA`.`SCHEMATA` ";
+            $query .= $this->_getWhereClause('SCHEMA_NAME', $searchClause);
+            $query .= "ORDER BY `SCHEMA_NAME` ";
+            $query .= "LIMIT $pos, {$GLOBALS['cfg']['FirstLevelNavigationItems']}";
+            $retval = $GLOBALS['dbi']->fetchResult($query);
+        }
 
-        return $GLOBALS['dbi']->fetchResult($query);
+        return $retval;
     }
 
     /**
@@ -395,20 +405,42 @@ class Node
      */
     public function getPresence($type = '', $searchClause = '')
     {
-        if (! $GLOBALS['cfg']['Server']['DisableIS']) {
-            $query = "SELECT COUNT(*) ";
-            $query .= "FROM ( ";
-            $query .= "SELECT distinct SUBSTRING_INDEX(SCHEMA_NAME, ";
-            $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}', 1) ";
-            $query .= "DB_first_level ";
-            $query .= "FROM INFORMATION_SCHEMA.SCHEMATA ";
-            $query .= $this->_getWhereClause('SCHEMA_NAME', $searchClause);
-            $query .= ") t ";
-            $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+        if ($GLOBALS['cfg']['NavigationTreeEnableGrouping']) {
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+                $query = "SELECT COUNT(*) ";
+                $query .= "FROM ( ";
+                $query .= "SELECT distinct SUBSTRING_INDEX(SCHEMA_NAME, ";
+                $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}', 1) ";
+                $query .= "DB_first_level ";
+                $query .= "FROM INFORMATION_SCHEMA.SCHEMATA ";
+                $query .= $this->_getWhereClause('SCHEMA_NAME', $searchClause);
+                $query .= ") t ";
+                $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            } else {
+                // TODO This does not return the correct count since grouping is not
+                // taken into considetarion. While this can be corrected by fetching
+                // all the databse names and process in PHP, not sure whether this is
+                // acceptable in cases where there are thousands of databases
+                // (especially since DisableIS is true)
+                $query = "SHOW DATABASES ";
+                $query .= $this->_getWhereClause('Database', $searchClause);
+                $retval = $GLOBALS['dbi']->numRows(
+                    $GLOBALS['dbi']->tryQuery($query)
+                );
+            }
         } else {
-            $query = "SHOW DATABASES ";
-            $query .= $this->_getWhereClause('Database', $searchClause);
-            $retval = $GLOBALS['dbi']->numRows($GLOBALS['dbi']->tryQuery($query));
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+                $query = "SELECT COUNT(*) ";
+                $query .= "FROM INFORMATION_SCHEMA.SCHEMATA ";
+                $query .= $this->_getWhereClause('SCHEMA_NAME', $searchClause);
+                $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            } else {
+                $query = "SHOW DATABASES ";
+                $query .= $this->_getWhereClause('Database', $searchClause);
+                $retval = $GLOBALS['dbi']->numRows(
+                    $GLOBALS['dbi']->tryQuery($query)
+                );
+            }
         }
         return $retval;
     }

--- a/libraries/navigation/Nodes/Node.class.php
+++ b/libraries/navigation/Nodes/Node.class.php
@@ -394,15 +394,27 @@ class Node
      */
     public function getPresence($type = '', $searchClause = '')
     {
-        $query = "select COUNT(*) ";
-        $query .= "from ( ";
-        $query .= "SELECT distinct SUBSTRING_INDEX(SCHEMA_NAME, ";
-        $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}', 1) ";
-        $query .= "DB_first_level ";
-        $query .= "FROM INFORMATION_SCHEMA.SCHEMATA ";
-        $query .= $this->_getWhereClause($searchClause);
-        $query .= ") t ";
-        $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+        if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+            $query = "select COUNT(*) ";
+            $query .= "from ( ";
+            $query .= "SELECT distinct SUBSTRING_INDEX(SCHEMA_NAME, ";
+            $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}', 1) ";
+            $query .= "DB_first_level ";
+            $query .= "FROM INFORMATION_SCHEMA.SCHEMATA ";
+            $query .= $this->_getWhereClause($searchClause);
+            $query .= ") t ";
+            $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+        } else {
+            $query = "SHOW DATABASES ";
+            if (! empty($searchClause)) {
+                $query .= "LIKE '%";
+                $query .= PMA_Util::sqlAddSlashes(
+                    $searchClause, true
+                );
+                $query .= "%' ";
+            }
+            $retval = $GLOBALS['dbi']->numRows($GLOBALS['dbi']->tryQuery($query));
+        }
         return $retval;
     }
 

--- a/libraries/navigation/Nodes/Node.class.php
+++ b/libraries/navigation/Nodes/Node.class.php
@@ -363,9 +363,9 @@ class Node
         $query  = "SELECT `SCHEMA_NAME` ";
         $query .= "FROM `INFORMATION_SCHEMA`.`SCHEMATA`, ";
         $query .= "(";
-        $query .= "select DB_first_level ";
-        $query .= "from ( ";
-        $query .= "SELECT distinct SUBSTRING_INDEX(SCHEMA_NAME, ";
+        $query .= "SELECT DB_first_level ";
+        $query .= "FROM ( ";
+        $query .= "SELECT DISTINCT SUBSTRING_INDEX(SCHEMA_NAME, ";
         $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}', 1) ";
         $query .= "DB_first_level ";
         $query .= "FROM INFORMATION_SCHEMA.SCHEMATA ";
@@ -374,11 +374,11 @@ class Node
         $query .= "ORDER BY DB_first_level ASC ";
         $query .= "LIMIT $pos, {$GLOBALS['cfg']['FirstLevelNavigationItems']}";
         $query .= ") t2 ";
-        $query .= "where 1 = locate(concat(DB_first_level, ";
+        $query .= "WHERE 1 = LOCATE(CONCAT(DB_first_level, ";
         $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}'), ";
-        $query .= "concat(SCHEMA_NAME, ";
+        $query .= "CONCAT(SCHEMA_NAME, ";
         $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}')) ";
-        $query .= "order by SCHEMA_NAME ASC";
+        $query .= "ORDER BY SCHEMA_NAME ASC";
 
         return $GLOBALS['dbi']->fetchResult($query);
     }
@@ -396,8 +396,8 @@ class Node
     public function getPresence($type = '', $searchClause = '')
     {
         if (! $GLOBALS['cfg']['Server']['DisableIS']) {
-            $query = "select COUNT(*) ";
-            $query .= "from ( ";
+            $query = "SELECT COUNT(*) ";
+            $query .= "FROM ( ";
             $query .= "SELECT distinct SUBSTRING_INDEX(SCHEMA_NAME, ";
             $query .= "'{$GLOBALS['cfg']['NavigationTreeDbSeparator']}', 1) ";
             $query .= "DB_first_level ";

--- a/libraries/navigation/Nodes/Node.class.php
+++ b/libraries/navigation/Nodes/Node.class.php
@@ -359,6 +359,7 @@ class Node
      */
     public function getData($type, $pos, $searchClause = '')
     {
+        // @todo obey the DisableIS directive
         $query  = "SELECT `SCHEMA_NAME` ";
         $query .= "FROM `INFORMATION_SCHEMA`.`SCHEMATA`, ";
         $query .= "(";

--- a/libraries/navigation/Nodes/Node_Database.class.php
+++ b/libraries/navigation/Nodes/Node_Database.class.php
@@ -71,19 +71,9 @@ class Node_Database extends Node
                     $query .= "AND `TABLE_TYPE`='BASE TABLE' ";
                 }
                 if (! empty($searchClause)) {
-                    if ($singleItem) {
-                        $query .= "AND `TABLE_NAME` = '";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= "AND `TABLE_NAME` LIKE '%";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
+                    $query .= "AND " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'TABLE_NAME'
+                    );
                 }
                 $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             } else {
@@ -91,20 +81,9 @@ class Node_Database extends Node
                 $query .= PMA_Util::backquote($db);
                 $query .= " WHERE `Table_type`='BASE TABLE' ";
                 if (! empty($searchClause)) {
-                    $query .= "AND " . PMA_Util::backquote(
-                        "Tables_in_" . $db
+                    $query .= "AND " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'Tables_in_' . $db
                     );
-                    if ($singleItem) {
-                        $query .= " = '" . PMA_Util::sqlAddSlashes(
-                            $searchClause
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)
@@ -123,19 +102,9 @@ class Node_Database extends Node
                     $query .= "AND `TABLE_TYPE`!='BASE TABLE' ";
                 }
                 if (! empty($searchClause)) {
-                    if ($singleItem) {
-                        $query .= "AND `TABLE_NAME` = '";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= "AND `TABLE_NAME` LIKE '%";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
+                    $query .= "AND " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'TABLE_NAME'
+                    );
                 }
                 $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             } else {
@@ -143,20 +112,9 @@ class Node_Database extends Node
                 $query .= PMA_Util::backquote($db);
                 $query .= " WHERE `Table_type`!='BASE TABLE' ";
                 if (! empty($searchClause)) {
-                    $query .= "AND " . PMA_Util::backquote(
-                        "Tables_in_" . $db
+                    $query .= "AND " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'Tables_in_' . $db
                     );
-                    if ($singleItem) {
-                        $query .= " = '" . PMA_Util::sqlAddSlashes(
-                            $searchClause
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)
@@ -171,38 +129,18 @@ class Node_Database extends Node
                 $query .= "WHERE `ROUTINE_SCHEMA`='$db'";
                 $query .= "AND `ROUTINE_TYPE`='PROCEDURE' ";
                 if (! empty($searchClause)) {
-                    if ($singleItem) {
-                        $query .= "AND `ROUTINE_NAME` = '";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= "AND `ROUTINE_NAME` LIKE '%";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
+                    $query .= "AND " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'ROUTINE_NAME'
+                    );
                 }
                 $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             } else {
                 $db    = PMA_Util::sqlAddSlashes($db);
                 $query = "SHOW PROCEDURE STATUS WHERE `Db`='$db' ";
                 if (! empty($searchClause)) {
-                    if ($singleItem) {
-                        $query .= "AND `Name` = '";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= "AND `Name` LIKE '%";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
+                    $query .= "AND " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'Name'
+                    );
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)
@@ -217,38 +155,18 @@ class Node_Database extends Node
                 $query .= "WHERE `ROUTINE_SCHEMA`='$db' ";
                 $query .= "AND `ROUTINE_TYPE`='FUNCTION' ";
                 if (! empty($searchClause)) {
-                    if ($singleItem) {
-                        $query .= "AND `ROUTINE_NAME` = '";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= "AND `ROUTINE_NAME` LIKE '%";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
+                    $query .= "AND " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'ROUTINE_NAME'
+                    );
                 }
                 $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             } else {
                 $db    = PMA_Util::sqlAddSlashes($db);
                 $query = "SHOW FUNCTION STATUS WHERE `Db`='$db' ";
                 if (! empty($searchClause)) {
-                    if ($singleItem) {
-                        $query .= "AND `Name` = '";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= "AND `Name` LIKE '%";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
+                    $query .= "AND " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'Name'
+                    );
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)
@@ -262,38 +180,18 @@ class Node_Database extends Node
                 $query .= "FROM `INFORMATION_SCHEMA`.`EVENTS` ";
                 $query .= "WHERE `EVENT_SCHEMA`='$db' ";
                 if (! empty($searchClause)) {
-                    if ($singleItem) {
-                        $query .= "AND `EVENT_NAME` = '";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= "AND `EVENT_NAME` LIKE '%";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
+                    $query .= "AND " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'EVENT_NAME'
+                    );
                 }
                 $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             } else {
                 $db    = PMA_Util::backquote($db);
                 $query = "SHOW EVENTS FROM $db ";
                 if (! empty($searchClause)) {
-                    if ($singleItem) {
-                        $query .= "WHERE `Name` = '";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause
-                        );
-                        $query .= "'";
-                    } else {
-                        $query .= "WHERE `Name` LIKE '%";
-                        $query .= PMA_Util::sqlAddSlashes(
-                            $searchClause, true
-                        );
-                        $query .= "%'";
-                    }
+                    $query .= "WHERE " . $this->_getWhereClauseForSearch(
+                        $searchClause, $singleItem, 'Name'
+                    );
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)
@@ -304,6 +202,29 @@ class Node_Database extends Node
             break;
         }
         return $retval;
+    }
+
+    /**
+     * Returns the WHERE clause for searching inside a database
+     *
+     * @param string $searchClause A string used to filter the results of the query
+     * @param string $singleItem   Whether to get presence of a single known item
+     * @param string $columnName   Name of the column in the result set to match
+     *
+     * @return string WHERE clause for searching
+     */
+    private function _getWhereClauseForSearch(
+        $searchClause, $singleItem, $columnName
+    ) {
+        $query = '';
+        if ($singleItem) {
+            $query .= PMA_Util::backquote($columnName) . " = ";
+            $query .= "'" . PMA_Util::sqlAddSlashes($searchClause) . "'";
+        } else {
+            $query .= PMA_Util::backquote($columnName) . " LIKE ";
+            $query .= "'%" . PMA_Util::sqlAddSlashes($searchClause, true) . "%'";
+        }
+        return $query;
     }
 
     /**

--- a/libraries/navigation/Nodes/Node_Database.class.php
+++ b/libraries/navigation/Nodes/Node_Database.class.php
@@ -60,126 +60,207 @@ class Node_Database extends Node
         $db     = $this->real_name;
         switch ($type) {
         case 'tables':
-            $db     = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT COUNT(*) ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`TABLES` ";
-            $query .= "WHERE `TABLE_SCHEMA`='$db' ";
-            if (PMA_DRIZZLE) {
-                $query .= "AND `TABLE_TYPE`='BASE' ";
-            } else {
-                $query .= "AND `TABLE_TYPE`='BASE TABLE' ";
-            }
-            if (! empty($searchClause)) {
-                if ($singleItem) {
-                    $query .= "AND `TABLE_NAME` = '";
-                    $query .= PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "'";
+            if (! $GLOBALS['cfg']['Server']['DisableIS'] || PMA_DRIZZLE) {
+                $db     = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT COUNT(*) ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`TABLES` ";
+                $query .= "WHERE `TABLE_SCHEMA`='$db' ";
+                if (PMA_DRIZZLE) {
+                    $query .= "AND `TABLE_TYPE`='BASE' ";
                 } else {
-                    $query .= "AND `TABLE_NAME` LIKE '%";
-                    $query .= PMA_Util::sqlAddSlashes(
+                    $query .= "AND `TABLE_TYPE`='BASE TABLE' ";
+                }
+                if (! empty($searchClause)) {
+                    if ($singleItem) {
+                        $query .= "AND `TABLE_NAME` = '";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= "AND `TABLE_NAME` LIKE '%";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
+                }
+                $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            } else {
+                $query  = "SHOW FULL TABLES FROM ";
+                $query .= PMA_Util::backquote($db);
+                $query .= " WHERE `Table_type`='BASE TABLE' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND " . PMA_Util::backquote(
+                        "Tables_in_" . $db
+                    );
+                    $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
                         $searchClause, true
                     );
                     $query .= "%'";
                 }
+                $retval = $GLOBALS['dbi']->numRows(
+                    $GLOBALS['dbi']->tryQuery($query)
+                );
             }
-            $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             break;
         case 'views':
-            $db     = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT COUNT(*) ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`TABLES` ";
-            $query .= "WHERE `TABLE_SCHEMA`='$db' ";
-            if (PMA_DRIZZLE) {
-                $query .= "AND `TABLE_TYPE`!='BASE' ";
-            } else {
-                $query .= "AND `TABLE_TYPE`!='BASE TABLE' ";
-            }
-            if (! empty($searchClause)) {
-                if ($singleItem) {
-                    $query .= "AND `TABLE_NAME` = '";
-                    $query .= PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "'";
+            if (! $GLOBALS['cfg']['Server']['DisableIS'] || PMA_DRIZZLE) {
+                $db     = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT COUNT(*) ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`TABLES` ";
+                $query .= "WHERE `TABLE_SCHEMA`='$db' ";
+                if (PMA_DRIZZLE) {
+                    $query .= "AND `TABLE_TYPE`!='BASE' ";
                 } else {
-                    $query .= "AND `TABLE_NAME` LIKE '%";
-                    $query .= PMA_Util::sqlAddSlashes(
+                    $query .= "AND `TABLE_TYPE`!='BASE TABLE' ";
+                }
+                if (! empty($searchClause)) {
+                    if ($singleItem) {
+                        $query .= "AND `TABLE_NAME` = '";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= "AND `TABLE_NAME` LIKE '%";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
+                }
+                $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            } else {
+                $query  = "SHOW FULL TABLES FROM ";
+                $query .= PMA_Util::backquote($db);
+                $query .= " WHERE `Table_type`!='BASE TABLE' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND " . PMA_Util::backquote(
+                        "Tables_in_" . $db
+                    );
+                    $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
                         $searchClause, true
                     );
                     $query .= "%'";
                 }
+                $retval = $GLOBALS['dbi']->numRows(
+                    $GLOBALS['dbi']->tryQuery($query)
+                );
             }
-            $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             break;
         case 'procedures':
-            $db     = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT COUNT(*) ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`ROUTINES` ";
-            $query .= "WHERE `ROUTINE_SCHEMA`='$db'";
-            $query .= "AND `ROUTINE_TYPE`='PROCEDURE' ";
-            if (! empty($searchClause)) {
-                if ($singleItem) {
-                    $query .= "AND `ROUTINE_NAME` = '";
-                    $query .= PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "'";
-                } else {
-                    $query .= "AND `ROUTINE_NAME` LIKE '%";
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+                $db     = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT COUNT(*) ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`ROUTINES` ";
+                $query .= "WHERE `ROUTINE_SCHEMA`='$db'";
+                $query .= "AND `ROUTINE_TYPE`='PROCEDURE' ";
+                if (! empty($searchClause)) {
+                    if ($singleItem) {
+                        $query .= "AND `ROUTINE_NAME` = '";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= "AND `ROUTINE_NAME` LIKE '%";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
+                }
+                $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            } else {
+                $db    = PMA_Util::sqlAddSlashes($db);
+                $query = "SHOW PROCEDURE STATUS WHERE `Db`='$db' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND `Name` LIKE '%";
                     $query .= PMA_Util::sqlAddSlashes(
                         $searchClause, true
                     );
                     $query .= "%'";
                 }
+                $retval = $GLOBALS['dbi']->numRows(
+                    $GLOBALS['dbi']->tryQuery($query)
+                );
             }
-            $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             break;
         case 'functions':
-            $db     = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT COUNT(*) ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`ROUTINES` ";
-            $query .= "WHERE `ROUTINE_SCHEMA`='$db' ";
-            $query .= "AND `ROUTINE_TYPE`='FUNCTION' ";
-            if (! empty($searchClause)) {
-                if ($singleItem) {
-                    $query .= "AND `ROUTINE_NAME` = '";
-                    $query .= PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "'";
-                } else {
-                    $query .= "AND `ROUTINE_NAME` LIKE '%";
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+                $db     = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT COUNT(*) ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`ROUTINES` ";
+                $query .= "WHERE `ROUTINE_SCHEMA`='$db' ";
+                $query .= "AND `ROUTINE_TYPE`='FUNCTION' ";
+                if (! empty($searchClause)) {
+                    if ($singleItem) {
+                        $query .= "AND `ROUTINE_NAME` = '";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= "AND `ROUTINE_NAME` LIKE '%";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
+                }
+                $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            } else {
+                $db    = PMA_Util::sqlAddSlashes($db);
+                $query = "SHOW FUNCTION STATUS WHERE `Db`='$db' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND `Name` LIKE '%";
                     $query .= PMA_Util::sqlAddSlashes(
                         $searchClause, true
                     );
                     $query .= "%'";
                 }
+                $retval = $GLOBALS['dbi']->numRows(
+                    $GLOBALS['dbi']->tryQuery($query)
+                );
             }
-            $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             break;
         case 'events':
-            $db     = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT COUNT(*) ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`EVENTS` ";
-            $query .= "WHERE `EVENT_SCHEMA`='$db' ";
-            if (! empty($searchClause)) {
-                if ($singleItem) {
-                    $query .= "AND `EVENT_NAME` = '";
-                    $query .= PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "'";
-                } else {
-                    $query .= "AND `EVENT_NAME` LIKE '%";
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+                $db     = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT COUNT(*) ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`EVENTS` ";
+                $query .= "WHERE `EVENT_SCHEMA`='$db' ";
+                if (! empty($searchClause)) {
+                    if ($singleItem) {
+                        $query .= "AND `EVENT_NAME` = '";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= "AND `EVENT_NAME` LIKE '%";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
+                }
+                $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            } else {
+                $db    = PMA_Util::backquote($db);
+                $query = "SHOW EVENTS FROM $db ";
+                if (! empty($searchClause)) {
+                    $query .= "WHERE `Name` LIKE '%";
                     $query .= PMA_Util::sqlAddSlashes(
                         $searchClause, true
                     );
                     $query .= "%'";
                 }
+                $retval = $GLOBALS['dbi']->numRows(
+                    $GLOBALS['dbi']->tryQuery($query)
+                );
             }
-            $retval = (int)$GLOBALS['dbi']->fetchValue($query);
             break;
         default:
             break;
@@ -205,96 +286,217 @@ class Node_Database extends Node
         $db       = $this->real_name;
         switch ($type) {
         case 'tables':
-            $escdDb = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT `TABLE_NAME` AS `name` ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`TABLES` ";
-            $query .= "WHERE `TABLE_SCHEMA`='$escdDb' ";
-            if (PMA_DRIZZLE) {
-                $query .= "AND `TABLE_TYPE`='BASE' ";
+            if (! $GLOBALS['cfg']['Server']['DisableIS'] || PMA_DRIZZLE) {
+                $escdDb = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT `TABLE_NAME` AS `name` ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`TABLES` ";
+                $query .= "WHERE `TABLE_SCHEMA`='$escdDb' ";
+                if (PMA_DRIZZLE) {
+                    $query .= "AND `TABLE_TYPE`='BASE' ";
+                } else {
+                    $query .= "AND `TABLE_TYPE`='BASE TABLE' ";
+                }
+                if (! empty($searchClause)) {
+                    $query .= "AND `TABLE_NAME` LIKE '%";
+                    $query .= PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $query .= "ORDER BY `TABLE_NAME` ASC ";
+                $query .= "LIMIT " . intval($pos) . ", $maxItems";
+                $retval = $GLOBALS['dbi']->fetchResult($query);
             } else {
-                $query .= "AND `TABLE_TYPE`='BASE TABLE' ";
+                $query  = " SHOW FULL TABLES FROM ";
+                $query .= PMA_Util::backquote($db);
+                $query .= " WHERE `Table_type`='BASE TABLE' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND " . PMA_Util::backquote(
+                        "Tables_in_" . $db
+                    );
+                    $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $handle = $GLOBALS['dbi']->tryQuery($query);
+                if ($handle !== false) {
+                    $count = 0;
+                    while ($arr = $GLOBALS['dbi']->fetchArray($handle)) {
+                        if ($pos <= 0 && $count < $maxItems) {
+                            $retval[] = $arr[0];
+                            $count++;
+                        }
+                        $pos--;
+                    }
+                }
             }
-            if (! empty($searchClause)) {
-                $query .= "AND `TABLE_NAME` LIKE '%";
-                $query .= PMA_Util::sqlAddSlashes(
-                    $searchClause, true
-                );
-                $query .= "%'";
-            }
-            $query .= "ORDER BY `TABLE_NAME` ASC ";
-            $query .= "LIMIT " . intval($pos) . ", $maxItems";
-            $retval = $GLOBALS['dbi']->fetchResult($query);
             break;
         case 'views':
-            $escdDb = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT `TABLE_NAME` AS `name` ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`TABLES` ";
-            $query .= "WHERE `TABLE_SCHEMA`='$escdDb' ";
-            if (PMA_DRIZZLE) {
-                $query .= "AND `TABLE_TYPE`!='BASE' ";
+            if (! $GLOBALS['cfg']['Server']['DisableIS'] || PMA_DRIZZLE) {
+                $escdDb = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT `TABLE_NAME` AS `name` ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`TABLES` ";
+                $query .= "WHERE `TABLE_SCHEMA`='$escdDb' ";
+                if (PMA_DRIZZLE) {
+                    $query .= "AND `TABLE_TYPE`!='BASE' ";
+                } else {
+                    $query .= "AND `TABLE_TYPE`!='BASE TABLE' ";
+                }
+                if (! empty($searchClause)) {
+                    $query .= "AND `TABLE_NAME` LIKE '%";
+                    $query .= PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $query .= "ORDER BY `TABLE_NAME` ASC ";
+                $query .= "LIMIT " . intval($pos) . ", $maxItems";
+                $retval = $GLOBALS['dbi']->fetchResult($query);
             } else {
-                $query .= "AND `TABLE_TYPE`!='BASE TABLE' ";
+                $query  = "SHOW FULL TABLES FROM ";
+                $query .= PMA_Util::backquote($db);
+                $query .= " WHERE `Table_type`!='BASE TABLE' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND " . PMA_Util::backquote(
+                        "Tables_in_" . $db
+                    );
+                    $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $handle = $GLOBALS['dbi']->tryQuery($query);
+                if ($handle !== false) {
+                    $count = 0;
+                    while ($arr = $GLOBALS['dbi']->fetchArray($handle)) {
+                        if ($pos <= 0 && $count < $maxItems) {
+                            $retval[] = $arr[0];
+                            $count++;
+                        }
+                        $pos--;
+                    }
+                }
             }
-            if (! empty($searchClause)) {
-                $query .= "AND `TABLE_NAME` LIKE '%";
-                $query .= PMA_Util::sqlAddSlashes(
-                    $searchClause, true
-                );
-                $query .= "%'";
-            }
-            $query .= "ORDER BY `TABLE_NAME` ASC ";
-            $query .= "LIMIT " . intval($pos) . ", $maxItems";
-            $retval = $GLOBALS['dbi']->fetchResult($query);
             break;
         case 'procedures':
-            $escdDb = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT `ROUTINE_NAME` AS `name` ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`ROUTINES` ";
-            $query .= "WHERE `ROUTINE_SCHEMA`='$escdDb'";
-            $query .= "AND `ROUTINE_TYPE`='PROCEDURE' ";
-            if (! empty($searchClause)) {
-                $query .= "AND `ROUTINE_NAME` LIKE '%";
-                $query .= PMA_Util::sqlAddSlashes(
-                    $searchClause, true
-                );
-                $query .= "%'";
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+                $escdDb = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT `ROUTINE_NAME` AS `name` ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`ROUTINES` ";
+                $query .= "WHERE `ROUTINE_SCHEMA`='$escdDb'";
+                $query .= "AND `ROUTINE_TYPE`='PROCEDURE' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND `ROUTINE_NAME` LIKE '%";
+                    $query .= PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $query .= "ORDER BY `ROUTINE_NAME` ASC ";
+                $query .= "LIMIT " . intval($pos) . ", $maxItems";
+                $retval = $GLOBALS['dbi']->fetchResult($query);
+            } else {
+                $escdDb = PMA_Util::sqlAddSlashes($db);
+                $query  = "SHOW PROCEDURE STATUS WHERE `Db`='$escdDb' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND `Name` LIKE '%";
+                    $query .= PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $handle = $GLOBALS['dbi']->tryQuery($query);
+                if ($handle !== false) {
+                    $count = 0;
+                    while ($arr = $GLOBALS['dbi']->fetchArray($handle)) {
+                        if ($pos <= 0 && $count < $maxItems) {
+                            $retval[] = $arr['Name'];
+                            $count++;
+                        }
+                        $pos--;
+                    }
+                }
             }
-            $query .= "ORDER BY `ROUTINE_NAME` ASC ";
-            $query .= "LIMIT " . intval($pos) . ", $maxItems";
-            $retval = $GLOBALS['dbi']->fetchResult($query);
             break;
         case 'functions':
-            $escdDb = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT `ROUTINE_NAME` AS `name` ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`ROUTINES` ";
-            $query .= "WHERE `ROUTINE_SCHEMA`='$escdDb' ";
-            $query .= "AND `ROUTINE_TYPE`='FUNCTION' ";
-            if (! empty($searchClause)) {
-                $query .= "AND `ROUTINE_NAME` LIKE '%";
-                $query .= PMA_Util::sqlAddSlashes(
-                    $searchClause, true
-                );
-                $query .= "%'";
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+                $escdDb = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT `ROUTINE_NAME` AS `name` ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`ROUTINES` ";
+                $query .= "WHERE `ROUTINE_SCHEMA`='$escdDb' ";
+                $query .= "AND `ROUTINE_TYPE`='FUNCTION' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND `ROUTINE_NAME` LIKE '%";
+                    $query .= PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $query .= "ORDER BY `ROUTINE_NAME` ASC ";
+                $query .= "LIMIT " . intval($pos) . ", $maxItems";
+                $retval = $GLOBALS['dbi']->fetchResult($query);
+            } else {
+                $escdDb = PMA_Util::sqlAddSlashes($db);
+                $query  = "SHOW FUNCTION STATUS WHERE `Db`='$escdDb' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND `Name` LIKE '%";
+                    $query .= PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $handle = $GLOBALS['dbi']->tryQuery($query);
+                if ($handle !== false) {
+                    $count = 0;
+                    while ($arr = $GLOBALS['dbi']->fetchArray($handle)) {
+                        if ($pos <= 0 && $count < $maxItems) {
+                            $retval[] = $arr['Name'];
+                            $count++;
+                        }
+                        $pos--;
+                    }
+                }
             }
-            $query .= "ORDER BY `ROUTINE_NAME` ASC ";
-            $query .= "LIMIT " . intval($pos) . ", $maxItems";
-            $retval = $GLOBALS['dbi']->fetchResult($query);
             break;
         case 'events':
-            $escdDb = PMA_Util::sqlAddSlashes($db);
-            $query  = "SELECT `EVENT_NAME` AS `name` ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`EVENTS` ";
-            $query .= "WHERE `EVENT_SCHEMA`='$escdDb' ";
-            if (! empty($searchClause)) {
-                $query .= "AND `EVENT_NAME` LIKE '%";
-                $query .= PMA_Util::sqlAddSlashes(
-                    $searchClause, true
-                );
-                $query .= "%'";
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
+                $escdDb = PMA_Util::sqlAddSlashes($db);
+                $query  = "SELECT `EVENT_NAME` AS `name` ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`EVENTS` ";
+                $query .= "WHERE `EVENT_SCHEMA`='$escdDb' ";
+                if (! empty($searchClause)) {
+                    $query .= "AND `EVENT_NAME` LIKE '%";
+                    $query .= PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $query .= "ORDER BY `EVENT_NAME` ASC ";
+                $query .= "LIMIT " . intval($pos) . ", $maxItems";
+                $retval = $GLOBALS['dbi']->fetchResult($query);
+            } else {
+                $escdDb = PMA_Util::backquote($db);
+                $query  = "SHOW EVENTS FROM $escdDb ";
+                if (! empty($searchClause)) {
+                    $query .= "WHERE `Name` LIKE '%";
+                    $query .= PMA_Util::sqlAddSlashes(
+                        $searchClause, true
+                    );
+                    $query .= "%'";
+                }
+                $handle = $GLOBALS['dbi']->tryQuery($query);
+                if ($handle !== false) {
+                    $count = 0;
+                    while ($arr = $GLOBALS['dbi']->fetchArray($handle)) {
+                        if ($pos <= 0 && $count < $maxItems) {
+                            $retval[] = $arr['Name'];
+                            $count++;
+                        }
+                        $pos--;
+                    }
+                }
             }
-            $query .= "ORDER BY `EVENT_NAME` ASC ";
-            $query .= "LIMIT " . intval($pos) . ", $maxItems";
-            $retval = $GLOBALS['dbi']->fetchResult($query);
             break;
         default:
             break;

--- a/libraries/navigation/Nodes/Node_Database.class.php
+++ b/libraries/navigation/Nodes/Node_Database.class.php
@@ -94,10 +94,17 @@ class Node_Database extends Node
                     $query .= "AND " . PMA_Util::backquote(
                         "Tables_in_" . $db
                     );
-                    $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "%'";
+                    if ($singleItem) {
+                        $query .= " = '" . PMA_Util::sqlAddSlashes(
+                            $searchClause
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)
@@ -139,10 +146,17 @@ class Node_Database extends Node
                     $query .= "AND " . PMA_Util::backquote(
                         "Tables_in_" . $db
                     );
-                    $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "%'";
+                    if ($singleItem) {
+                        $query .= " = '" . PMA_Util::sqlAddSlashes(
+                            $searchClause
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= " LIKE '%" . PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)
@@ -176,11 +190,19 @@ class Node_Database extends Node
                 $db    = PMA_Util::sqlAddSlashes($db);
                 $query = "SHOW PROCEDURE STATUS WHERE `Db`='$db' ";
                 if (! empty($searchClause)) {
-                    $query .= "AND `Name` LIKE '%";
-                    $query .= PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "%'";
+                    if ($singleItem) {
+                        $query .= "AND `Name` = '";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= "AND `Name` LIKE '%";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)
@@ -214,11 +236,19 @@ class Node_Database extends Node
                 $db    = PMA_Util::sqlAddSlashes($db);
                 $query = "SHOW FUNCTION STATUS WHERE `Db`='$db' ";
                 if (! empty($searchClause)) {
-                    $query .= "AND `Name` LIKE '%";
-                    $query .= PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "%'";
+                    if ($singleItem) {
+                        $query .= "AND `Name` = '";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= "AND `Name` LIKE '%";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)
@@ -251,11 +281,19 @@ class Node_Database extends Node
                 $db    = PMA_Util::backquote($db);
                 $query = "SHOW EVENTS FROM $db ";
                 if (! empty($searchClause)) {
-                    $query .= "WHERE `Name` LIKE '%";
-                    $query .= PMA_Util::sqlAddSlashes(
-                        $searchClause, true
-                    );
-                    $query .= "%'";
+                    if ($singleItem) {
+                        $query .= "WHERE `Name` = '";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause
+                        );
+                        $query .= "'";
+                    } else {
+                        $query .= "WHERE `Name` LIKE '%";
+                        $query .= PMA_Util::sqlAddSlashes(
+                            $searchClause, true
+                        );
+                        $query .= "%'";
+                    }
                 }
                 $retval = $GLOBALS['dbi']->numRows(
                     $GLOBALS['dbi']->tryQuery($query)

--- a/libraries/navigation/Nodes/Node_Table.class.php
+++ b/libraries/navigation/Nodes/Node_Table.class.php
@@ -77,7 +77,7 @@ class Node_Table extends Node_DatabaseChild
         $table  = $this->real_name;
         switch ($type) {
         case 'columns':
-            if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
                 $db     = PMA_Util::sqlAddSlashes($db);
                 $table  = PMA_Util::sqlAddSlashes($table);
                 $query  = "SELECT COUNT(*) ";
@@ -103,7 +103,7 @@ class Node_Table extends Node_DatabaseChild
             );
             break;
         case 'triggers':
-            if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
                 $db     = PMA_Util::sqlAddSlashes($db);
                 $table  = PMA_Util::sqlAddSlashes($table);
                 $query  = "SELECT COUNT(*) ";
@@ -145,7 +145,7 @@ class Node_Table extends Node_DatabaseChild
         $table    = $this->real_name;
         switch ($type) {
         case 'columns':
-            if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
                 $db     = PMA_Util::sqlAddSlashes($db);
                 $table  = PMA_Util::sqlAddSlashes($table);
                 $query  = "SELECT `COLUMN_NAME` AS `name` ";
@@ -192,7 +192,7 @@ class Node_Table extends Node_DatabaseChild
             }
             break;
         case 'triggers':
-            if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+            if (! $GLOBALS['cfg']['Server']['DisableIS']) {
                 $db     = PMA_Util::sqlAddSlashes($db);
                 $table  = PMA_Util::sqlAddSlashes($table);
                 $query  = "SELECT `TRIGGER_NAME` AS `name` ";

--- a/libraries/navigation/Nodes/Node_Table.class.php
+++ b/libraries/navigation/Nodes/Node_Table.class.php
@@ -77,13 +77,22 @@ class Node_Table extends Node_DatabaseChild
         $table  = $this->real_name;
         switch ($type) {
         case 'columns':
-            $db     = PMA_Util::sqlAddSlashes($db);
-            $table  = PMA_Util::sqlAddSlashes($table);
-            $query  = "SELECT COUNT(*) ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`COLUMNS` ";
-            $query .= "WHERE `TABLE_NAME`='$table' ";
-            $query .= "AND `TABLE_SCHEMA`='$db'";
-            $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+                $db     = PMA_Util::sqlAddSlashes($db);
+                $table  = PMA_Util::sqlAddSlashes($table);
+                $query  = "SELECT COUNT(*) ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`COLUMNS` ";
+                $query .= "WHERE `TABLE_NAME`='$table' ";
+                $query .= "AND `TABLE_SCHEMA`='$db'";
+                $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            } else {
+                $db     = PMA_Util::backquote($db);
+                $table  = PMA_Util::backquote($table);
+                $query  = "SHOW COLUMNS FROM $table FROM $db";
+                $retval = (int)$GLOBALS['dbi']->numRows(
+                    $GLOBALS['dbi']->tryQuery($query)
+                );
+            }
             break;
         case 'indexes':
             $db     = PMA_Util::backquote($db);
@@ -94,13 +103,22 @@ class Node_Table extends Node_DatabaseChild
             );
             break;
         case 'triggers':
-            $db     = PMA_Util::sqlAddSlashes($db);
-            $table  = PMA_Util::sqlAddSlashes($table);
-            $query  = "SELECT COUNT(*) ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`TRIGGERS` ";
-            $query .= "WHERE `EVENT_OBJECT_SCHEMA`='$db' ";
-            $query .= "AND `EVENT_OBJECT_TABLE`='$table'";
-            $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+                $db     = PMA_Util::sqlAddSlashes($db);
+                $table  = PMA_Util::sqlAddSlashes($table);
+                $query  = "SELECT COUNT(*) ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`TRIGGERS` ";
+                $query .= "WHERE `EVENT_OBJECT_SCHEMA`='$db' ";
+                $query .= "AND `EVENT_OBJECT_TABLE`='$table'";
+                $retval = (int)$GLOBALS['dbi']->fetchValue($query);
+            } else {
+                $db     = PMA_Util::backquote($db);
+                $table  = PMA_Util::sqlAddSlashes($table);
+                $query  = "SHOW TRIGGERS FROM $db WHERE `Table` = '$table'";
+                $retval = (int)$GLOBALS['dbi']->numRows(
+                    $GLOBALS['dbi']->tryQuery($query)
+                );
+            }
             break;
         default:
             break;
@@ -127,15 +145,32 @@ class Node_Table extends Node_DatabaseChild
         $table    = $this->real_name;
         switch ($type) {
         case 'columns':
-            $db     = PMA_Util::sqlAddSlashes($db);
-            $table  = PMA_Util::sqlAddSlashes($table);
-            $query  = "SELECT `COLUMN_NAME` AS `name` ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`COLUMNS` ";
-            $query .= "WHERE `TABLE_NAME`='$table' ";
-            $query .= "AND `TABLE_SCHEMA`='$db' ";
-            $query .= "ORDER BY `COLUMN_NAME` ASC ";
-            $query .= "LIMIT " . intval($pos) . ", $maxItems";
-            $retval = $GLOBALS['dbi']->fetchResult($query);
+            if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+                $db     = PMA_Util::sqlAddSlashes($db);
+                $table  = PMA_Util::sqlAddSlashes($table);
+                $query  = "SELECT `COLUMN_NAME` AS `name` ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`COLUMNS` ";
+                $query .= "WHERE `TABLE_NAME`='$table' ";
+                $query .= "AND `TABLE_SCHEMA`='$db' ";
+                $query .= "ORDER BY `COLUMN_NAME` ASC ";
+                $query .= "LIMIT " . intval($pos) . ", $maxItems";
+                $retval = $GLOBALS['dbi']->fetchResult($query);
+            } else {
+                $db     = PMA_Util::backquote($db);
+                $table  = PMA_Util::backquote($table);
+                $query  = "SHOW COLUMNS FROM $table FROM $db";
+                $handle = $GLOBALS['dbi']->tryQuery($query);
+                if ($handle !== false) {
+                    $count = 0;
+                    while ($arr = $GLOBALS['dbi']->fetchArray($handle)) {
+                        if ($pos <= 0 && $count < $maxItems) {
+                            $retval[] = $arr['Field'];
+                            $count++;
+                        }
+                        $pos--;
+                    }
+                }
+            }
             break;
         case 'indexes':
             $db     = PMA_Util::backquote($db);
@@ -157,15 +192,32 @@ class Node_Table extends Node_DatabaseChild
             }
             break;
         case 'triggers':
-            $db     = PMA_Util::sqlAddSlashes($db);
-            $table  = PMA_Util::sqlAddSlashes($table);
-            $query  = "SELECT `TRIGGER_NAME` AS `name` ";
-            $query .= "FROM `INFORMATION_SCHEMA`.`TRIGGERS` ";
-            $query .= "WHERE `EVENT_OBJECT_SCHEMA`='$db' ";
-            $query .= "AND `EVENT_OBJECT_TABLE`='$table' ";
-            $query .= "ORDER BY `TRIGGER_NAME` ASC ";
-            $query .= "LIMIT " . intval($pos) . ", $maxItems";
-            $retval = $GLOBALS['dbi']->fetchResult($query);
+            if (! $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['DisableIS']) {
+                $db     = PMA_Util::sqlAddSlashes($db);
+                $table  = PMA_Util::sqlAddSlashes($table);
+                $query  = "SELECT `TRIGGER_NAME` AS `name` ";
+                $query .= "FROM `INFORMATION_SCHEMA`.`TRIGGERS` ";
+                $query .= "WHERE `EVENT_OBJECT_SCHEMA`='$db' ";
+                $query .= "AND `EVENT_OBJECT_TABLE`='$table' ";
+                $query .= "ORDER BY `TRIGGER_NAME` ASC ";
+                $query .= "LIMIT " . intval($pos) . ", $maxItems";
+                $retval = $GLOBALS['dbi']->fetchResult($query);
+            } else {
+                $db     = PMA_Util::backquote($db);
+                $table  = PMA_Util::sqlAddSlashes($table);
+                $query  = "SHOW TRIGGERS FROM $db WHERE `Table` = '$table'";
+                $handle = $GLOBALS['dbi']->tryQuery($query);
+                if ($handle !== false) {
+                    $count = 0;
+                    while ($arr = $GLOBALS['dbi']->fetchArray($handle)) {
+                        if ($pos <= 0 && $count < $maxItems) {
+                            $retval[] = $arr['Trigger'];
+                            $count++;
+                        }
+                        $pos--;
+                    }
+                }
+            }
             break;
         default:
             break;

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -728,7 +728,10 @@ function PMA_getHtmlForNotNullEngineViewTable($table_is_view, $current_table,
 
     if (!($GLOBALS['cfg']['PropertiesNumColumns'] > 1)) {
         $html_output .= '<td class="nowrap">'
-            . ($table_is_view ? __('View') : $current_table['ENGINE'])
+            . ( ! empty($current_table['ENGINE'])
+                ? $current_table['ENGINE']
+                : ($table_is_view ? __('View') : '')
+            )
             . '</td>';
         if ($GLOBALS['PMA_String']->strlen($collation)) {
             $html_output .= '<td class="nowrap">' . $collation . '</td>';
@@ -1131,15 +1134,7 @@ function PMA_getStuffForEngineTypeTable($current_table, $db_is_system_schema,
     case null :
     case 'SYSTEM VIEW' :
     case 'FunctionEngine' :
-        // if table is broken, Engine is reported as null, so one more test
-        if ($current_table['TABLE_TYPE'] == 'VIEW') {
-            // countRecords() takes care of $cfg['MaxExactCountViews']
-            $current_table['TABLE_ROWS'] = PMA_Table::countRecords(
-                $GLOBALS['db'], $current_table['TABLE_NAME'],
-                true, true
-            );
-            $table_is_view = true;
-        }
+        // possibly a view, do nothing
         break;
     default :
         // Unknown table type.
@@ -1148,6 +1143,17 @@ function PMA_getStuffForEngineTypeTable($current_table, $db_is_system_schema,
             $unit          =  '';
         }
     } // end switch
+
+    if ($current_table['TABLE_TYPE'] == 'VIEW'
+        || $current_table['TABLE_TYPE'] == 'SYSTEM VIEW'
+    ) {
+        // countRecords() takes care of $cfg['MaxExactCountViews']
+        $current_table['TABLE_ROWS'] = PMA_Table::countRecords(
+            $GLOBALS['db'], $current_table['TABLE_NAME'],
+            true, true
+        );
+        $table_is_view = true;
+    }
 
     return array($current_table, $formatted_size, $unit, $formatted_overhead,
         $overhead_unit, $overhead_size, $table_is_view, $sum_size
@@ -3196,13 +3202,13 @@ function PMA_handleRealRowCountRequest()
 }
 
 /**
- * Possibly show the table creation dialog 
+ * Possibly show the table creation dialog
  *
  * @param string       $db                  Current database name
  * @param bool         $db_is_system_schema Whether this db is a system schema
  * @param PMA_Response $response            PMA_Response instance
  *
- * @return void 
+ * @return void
  */
 function PMA_possiblyShowCreateTableDialog($db, $db_is_system_schema, $response)
 {

--- a/test/classes/PMA_Header_test.php
+++ b/test/classes/PMA_Header_test.php
@@ -54,6 +54,7 @@ class PMA_Header_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['table'] = 'table1';
         $GLOBALS['PMA_Config'] = new PMA_Config();
         $GLOBALS['PMA_Config']->enableBc();
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['Server']['verbose'] = 'verbose host';
         $GLOBALS['cfg']['Server']['pmadb'] = '';
         $GLOBALS['cfg']['Server']['user'] = '';

--- a/test/classes/PMA_Menu_test.php
+++ b/test/classes/PMA_Menu_test.php
@@ -39,6 +39,7 @@ class PMA_Menu_Test extends PHPUnit_Framework_TestCase
         if (!defined('PMA_IS_WINDOWS')) {
             define('PMA_IS_WINDOWS', false);
         }
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['ServerDefault'] = 1;
         $GLOBALS['cfg']['Server']['verbose'] = 'verbose host';

--- a/test/classes/PMA_TableSearch_test.php
+++ b/test/classes/PMA_TableSearch_test.php
@@ -54,6 +54,7 @@ class PMA_TableSearch_Test extends PHPUnit_Framework_TestCase
 
         $GLOBALS['cfg']['ServerDefault'] = 1;
         $GLOBALS['cfg']['maxRowPlotLimit'] = 500;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['ServerDefault'] = 1;
         $GLOBALS['cfg']['ActionLinksMode'] = 'both';
         $GLOBALS['cfg']['ForeignKeyMaxLimit'] = 100;

--- a/test/classes/PMA_Table_test.php
+++ b/test/classes/PMA_Table_test.php
@@ -38,6 +38,7 @@ class PMA_Table_Test extends PHPUnit_Framework_TestCase
          * SET these to avoid undefined index error
          */
         $GLOBALS['server'] = 0;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['ServerDefault'] = 1;
         $GLOBALS['cfg']['ActionLinksMode'] = 'both';
         $GLOBALS['cfg']['MaxExactCount'] = 100;

--- a/test/classes/navigation/PMA_NavigationTree_test.php
+++ b/test/classes/navigation/PMA_NavigationTree_test.php
@@ -51,6 +51,7 @@ class PMA_NavigationTreeTest extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['Server']['host'] = 'localhost';
         $GLOBALS['cfg']['Server']['user'] = 'root';
         $GLOBALS['cfg']['Server']['pmadb'] = '';
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $GLOBALS['pmaThemeImage'] = 'image';
         $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');

--- a/test/classes/navigation/PMA_NavigationTree_test.php
+++ b/test/classes/navigation/PMA_NavigationTree_test.php
@@ -11,6 +11,7 @@
  * since 'check_user_privileges.lib.php' will use it globally
  */
 $GLOBALS['server'] = 0;
+$GLOBALS['cfg']['Server']['DisableIS'] = false;
 
 require_once 'libraries/Util.class.php';
 require_once 'libraries/Theme.class.php';

--- a/test/classes/navigation/PMA_Node_test.php
+++ b/test/classes/navigation/PMA_Node_test.php
@@ -385,16 +385,7 @@ class Node_Test extends PHPUnit_Framework_TestCase
      */
     public function testGetPresenceWithEnabledIS()
     {
-        if (! isset($GLOBALS['cfg'])) {
-            $GLOBALS['cfg'] = array();
-        }
-        if (! isset($GLOBALS['cfg']['Servers'])) {
-            $GLOBALS['cfg']['Servers'] = array();
-        }
-        if (! isset($GLOBALS['cfg']['Servers'][0])) {
-            $GLOBALS['cfg']['Servers'][0] = array();
-        }
-        $GLOBALS['cfg']['Servers'][0]['DisableIS'] = false;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['NavigationTreeDbSeparator'] = '_';
 
         $query = "select COUNT(*) ";
@@ -427,16 +418,7 @@ class Node_Test extends PHPUnit_Framework_TestCase
      */
     public function testGetPresenceWithDisabledIS()
     {
-        if (! isset($GLOBALS['cfg'])) {
-            $GLOBALS['cfg'] = array();
-        }
-        if (! isset($GLOBALS['cfg']['Servers'])) {
-            $GLOBALS['cfg']['Servers'] = array();
-        }
-        if (! isset($GLOBALS['cfg']['Servers'][0])) {
-            $GLOBALS['cfg']['Servers'][0] = array();
-        }
-        $GLOBALS['cfg']['Servers'][0]['DisableIS'] = true;
+        $GLOBALS['cfg']['Server']['DisableIS'] = true;
 
         $node = PMA_NodeFactory::getInstance();
 

--- a/test/classes/navigation/PMA_Node_test.php
+++ b/test/classes/navigation/PMA_Node_test.php
@@ -26,6 +26,7 @@ class Node_Test extends PHPUnit_Framework_TestCase
     public function setup()
     {
         $GLOBALS['server'] = 0;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
     }
 

--- a/test/classes/navigation/PMA_Node_test.php
+++ b/test/classes/navigation/PMA_Node_test.php
@@ -377,12 +377,12 @@ class Node_Test extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests the getPresence method
+     * Tests the getPresence method when DisableIS is false
      *
      * @return void
      * @test
      */
-    public function testGetPresence()
+    public function testGetPresenceWithEnabledIS()
     {
         if (! isset($GLOBALS['cfg'])) {
             $GLOBALS['cfg'] = array();
@@ -393,6 +393,7 @@ class Node_Test extends PHPUnit_Framework_TestCase
         if (! isset($GLOBALS['cfg']['Servers'][0])) {
             $GLOBALS['cfg']['Servers'][0] = array();
         }
+        $GLOBALS['cfg']['Servers'][0]['DisableIS'] = false;
         $GLOBALS['cfg']['NavigationTreeDbSeparator'] = '_';
 
         $query = "select COUNT(*) ";
@@ -415,6 +416,48 @@ class Node_Test extends PHPUnit_Framework_TestCase
             ->with($query);
         $GLOBALS['dbi'] = $dbi;
         $node->getPresence();
+    }
+
+    /**
+     * Tests the getPresence method when DisableIS is true
+     *
+     * @return void
+     * @test
+     */
+    public function testGetPresenceWithDisabledIS()
+    {
+        if (! isset($GLOBALS['cfg'])) {
+            $GLOBALS['cfg'] = array();
+        }
+        if (! isset($GLOBALS['cfg']['Servers'])) {
+            $GLOBALS['cfg']['Servers'] = array();
+        }
+        if (! isset($GLOBALS['cfg']['Servers'][0])) {
+            $GLOBALS['cfg']['Servers'][0] = array();
+        }
+        $GLOBALS['cfg']['Servers'][0]['DisableIS'] = true;
+
+        $node = PMA_NodeFactory::getInstance();
+
+        // test with no search clause
+        $dbi = $this->getMockBuilder('PMA_DatabaseInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dbi->expects($this->once())
+            ->method('tryQuery')
+            ->with("SHOW DATABASES ");
+        $GLOBALS['dbi'] = $dbi;
+        $node->getPresence();
+
+        // test with a search clause
+        $dbi = $this->getMockBuilder('PMA_DatabaseInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dbi->expects($this->once())
+            ->method('tryQuery')
+            ->with("SHOW DATABASES LIKE '%dbname%' ");
+        $GLOBALS['dbi'] = $dbi;
+        $node->getPresence('', 'dbname');
     }
 }
 ?>

--- a/test/classes/plugin/export/PMA_ExportSql_test.php
+++ b/test/classes/plugin/export/PMA_ExportSql_test.php
@@ -817,11 +817,17 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
 
         // case2: no backquotes
         unset($GLOBALS['sql_compatibility']);
+        $GLOBALS['cfg']['Server']['DisableIS'] = true;
         unset($GLOBALS['sql_backquotes']);
 
         $dbi = $this->getMockBuilder('PMA_DatabaseInterface')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $dbi->expects($this->once())
+            ->method('fetchValue')
+            ->with('SHOW VARIABLES LIKE \'collation_database\'', 0, 1)
+            ->will($this->returnValue('testcollation'));
 
         $GLOBALS['dbi'] = $dbi;
 
@@ -837,7 +843,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
         );
 
         $this->assertContains(
-            'CREATE DATABASE IF NOT EXISTS db',
+            'CREATE DATABASE IF NOT EXISTS db DEFAULT CHARACTER SET testcollation;',
             $result
         );
 
@@ -1230,6 +1236,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
             ->will($this->returnValue($row));
 
         $GLOBALS['dbi'] = $dbi;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $result = $this->object->getTableDef(
             'db', 'table', "\n", "example.com/err", true, true, true
@@ -1406,6 +1413,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
             ->will($this->returnValue($row));
 
         $GLOBALS['dbi'] = $dbi;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $result = $this->object->getTableDef(
             'db', 'table', "\n", "example.com/err", true, true, true
@@ -1523,6 +1531,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
             ->will($this->returnValue('error occurred'));
 
         $GLOBALS['dbi'] = $dbi;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $result = $this->object->getTableDef(
             'db', 'table', "\n", "example.com/err", true, true, true
@@ -1873,6 +1882,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['sql_truncate'] = true;
         $GLOBALS['sql_insert_syntax'] = 'both';
         $GLOBALS['sql_hex_for_binary'] = true;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         ob_start();
         $this->object->exportData(
@@ -1988,6 +1998,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['sql_truncate'] = true;
         $GLOBALS['sql_insert_syntax'] = 'both';
         $GLOBALS['sql_hex_for_binary'] = true;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         ob_start();
         $this->object->exportData(
@@ -2020,6 +2031,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $GLOBALS['dbi'] = $dbi;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['sql_views_as_tables'] = false;
         $GLOBALS['sql_include_comments'] = true;
         $GLOBALS['crlf'] = "\n";
@@ -2057,6 +2069,7 @@ class PMA_ExportSql_Test extends PHPUnit_Framework_TestCase
             ->will($this->returnValue('err'));
 
         $GLOBALS['dbi'] = $dbi;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['sql_views_as_tables'] = true;
         $GLOBALS['sql_include_comments'] = true;
         $GLOBALS['crlf'] = "\n";

--- a/test/classes/plugin/export/PMA_ExportXml_test.php
+++ b/test/classes/plugin/export/PMA_ExportXml_test.php
@@ -249,6 +249,7 @@ class PMA_ExportXml_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['charset_of_file'] = 'iso-8859-1';
         $GLOBALS['cfg']['Server']['port'] = 80;
         $GLOBALS['cfg']['Server']['host'] = 'localhost';
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['xml_export_tables'] = 1;
         $GLOBALS['xml_export_triggers'] = 1;
         $GLOBALS['xml_export_procedures'] = 1;
@@ -494,6 +495,7 @@ class PMA_ExportXml_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['xml_export_triggers'] = true;
         $GLOBALS['cfg']['Server']['port'] = 80;
         $GLOBALS['cfg']['Server']['host'] = 'localhost';
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['crlf'] = "\n";
         $GLOBALS['db'] = 'd<b';
 

--- a/test/classes/plugin/import/ImportCsv_test.php
+++ b/test/classes/plugin/import/ImportCsv_test.php
@@ -54,6 +54,7 @@ class ImportCsv_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['finished'] = false;
         $GLOBALS['read_limit'] = 100000000;
         $GLOBALS['offset'] = 0;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['ServerDefault'] = 0;
         $GLOBALS['cfg']['AllowUserDropDatabase'] = false;
         $GLOBALS['cfg']['ShowHint'] = true;

--- a/test/classes/plugin/import/ImportLdi_test.php
+++ b/test/classes/plugin/import/ImportLdi_test.php
@@ -52,6 +52,7 @@ class ImportLdi_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['finished'] = false;
         $GLOBALS['read_limit'] = 100000000;
         $GLOBALS['offset'] = 0;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['ServerDefault'] = 0;
         $GLOBALS['cfg']['AllowUserDropDatabase'] = false;
 

--- a/test/classes/plugin/import/ImportMediawiki_test.php
+++ b/test/classes/plugin/import/ImportMediawiki_test.php
@@ -53,6 +53,7 @@ class ImportMediawiki_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['finished'] = false;
         $GLOBALS['read_limit'] = 100000000;
         $GLOBALS['offset'] = 0;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['ServerDefault'] = 0;
         $GLOBALS['cfg']['AllowUserDropDatabase'] = false;
 

--- a/test/classes/plugin/import/ImportOds_test.php
+++ b/test/classes/plugin/import/ImportOds_test.php
@@ -53,6 +53,7 @@ class ImportOds_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['finished'] = false;
         $GLOBALS['read_limit'] = 100000000;
         $GLOBALS['offset'] = 0;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['ServerDefault'] = 0;
         $GLOBALS['cfg']['AllowUserDropDatabase'] = false;
 

--- a/test/classes/plugin/import/ImportShp_test.php
+++ b/test/classes/plugin/import/ImportShp_test.php
@@ -60,6 +60,7 @@ class ImportShp_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['finished'] = false;
         $GLOBALS['read_limit'] = 100000000;
         $GLOBALS['offset'] = 0;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['ServerDefault'] = 0;
         $GLOBALS['cfg']['AllowUserDropDatabase'] = false;
         $GLOBALS['import_file'] = 'test/test_data/timezone.shp.zip';

--- a/test/classes/plugin/import/ImportSql_test.php
+++ b/test/classes/plugin/import/ImportSql_test.php
@@ -50,6 +50,7 @@ class ImportSql_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['finished'] = false;
         $GLOBALS['read_limit'] = 100000000;
         $GLOBALS['offset'] = 0;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['ServerDefault'] = 0;
         $GLOBALS['cfg']['AllowUserDropDatabase'] = false;
 

--- a/test/classes/plugin/import/ImportXml_test.php
+++ b/test/classes/plugin/import/ImportXml_test.php
@@ -50,6 +50,7 @@ class ImportXml_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['finished'] = false;
         $GLOBALS['read_limit'] = 100000000;
         $GLOBALS['offset'] = 0;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['ServerDefault'] = 0;
         $GLOBALS['cfg']['AllowUserDropDatabase'] = false;
 

--- a/test/libraries/PMA_Tracker_test.php
+++ b/test/libraries/PMA_Tracker_test.php
@@ -43,6 +43,7 @@ class PMA_Tracker_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['Server']['tracking_add_drop_database'] = '';
         $GLOBALS['cfg']['Server']['tracking_default_statements'] = '';
         $GLOBALS['cfg']['Server']['tracking_version_auto_create'] = '';
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['DBG']['sql'] = false;
 
         if (!defined("PMA_DRIZZLE")) {

--- a/test/libraries/PMA_mult_submits_test.php
+++ b/test/libraries/PMA_mult_submits_test.php
@@ -50,6 +50,7 @@ class PMA_MultSubmits_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['ShowSQL'] = true;
         $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
         $GLOBALS['cfg']['LimitChars'] = 100;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['ActionLinksMode'] = "both";
         $GLOBALS['pmaThemeImage'] = 'image';

--- a/test/libraries/PMA_mysql_charsets_test.php
+++ b/test/libraries/PMA_mysql_charsets_test.php
@@ -108,6 +108,7 @@ class PMA_MySQL_Charsets_Test extends PHPUnit_Framework_TestCase
                 define('PMA_DRIZZLE', false);
             }
 
+            $GLOBALS['cfg']['Server']['DisableIS'] = false;
             $GLOBALS['cfg']['DBG']['sql'] = false;
 
             $this->assertEquals(
@@ -122,6 +123,12 @@ class PMA_MySQL_Charsets_Test extends PHPUnit_Framework_TestCase
                 PMA_getDbCollation('pma_test')
             );
 
+            $GLOBALS['cfg']['Server']['DisableIS'] = true;
+            $GLOBALS['db'] = 'pma_test2';
+            $this->assertEquals(
+                'bar',
+                PMA_getDbCollation('pma_test')
+            );
             $this->assertNotEquals(
                 'pma_test',
                 $GLOBALS['dummy_db']

--- a/test/libraries/PMA_server_collations_test.php
+++ b/test/libraries/PMA_server_collations_test.php
@@ -22,6 +22,9 @@ $GLOBALS['available_languages']= array(
 );
 $GLOBALS['text_dir'] = "text_dir";
 $GLOBALS['cfg']['DBG']['sql'] = false;
+$GLOBALS['cfg']['Server'] = array(
+    'DisableIS' => false
+);
 //$_SESSION
 require_once 'libraries/Theme.class.php';
 $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');

--- a/test/libraries/PMA_structure_test.php
+++ b/test/libraries/PMA_structure_test.php
@@ -52,6 +52,7 @@ class PMA_Structure_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['ShowSQL'] = true;
         $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
         $GLOBALS['cfg']['LimitChars'] = 100;
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $GLOBALS['table'] = "table";
         $GLOBALS['pmaThemeImage'] = 'image';

--- a/test/libraries/common/PMA_showMessage_test_disabled.php
+++ b/test/libraries/common/PMA_showMessage_test_disabled.php
@@ -49,6 +49,7 @@ class PMA_ShowMessage_Test extends PHPUnit_Framework_TestCase
         global $cfg;
 
         $GLOBALS['is_ajax_request'] = true;
+        $cfg['Server']['DisableIS'] = false;
         $GLOBALS['table'] = 'tbl';
         $GLOBALS['db'] = 'db';
 


### PR DESCRIPTION
This PR is not for immediate merge. As you can see there are unit test failures. If you like the concept I will work on fixing them.

 Here is what I have done.
- Added back the `DisableIS` directive. This time its default value is set to false.
- Earlier, Node::getData() method (which is responsible of getting the list of databases to show in navigation) was not adhering to `DisableIS` directive. I have update the method to do so.
- Earlier, Node::getData() method did not adhere to `NavigationTreeEnableGrouping` directive, which is fixed now.
- Earlier, `SHOW TABLES` queries did not adhere to `hide_db` and `show_db` directive. Now they adhere to both of them.

There is still a case where navigation would still take long a long time to load. If the current navigation page has a database group(s) which contain(s) a very large number of databases, it would still cause slowness. However, this can be avoided by disabling groping in navigation (by setting `NavigationTreeEnableGrouping` to false). If grouping is required we can use `hide_db` and `only_db` directives to improve performance.
