### PR TITLE
Fix token error on Status menu items

### DIFF
--- a/libraries/ServerStatusData.class.php
+++ b/libraries/ServerStatusData.class.php
@@ -399,7 +399,7 @@ class PMA_ServerStatusData
             }
             $retval .= '<li>';
             $retval .= '<a' . $class;
-            $retval .= ' href="' . $item['url'] . '?' . $url_params . '">';
+            $retval .= ' href="' . $item['url'] . $url_params . '">';
             $retval .= $item['name'];
             $retval .= '</a>';
             $retval .= '</li>';


### PR DESCRIPTION
Remove a '?' missed from a540e6ba878bae1fc352fadb8aad278a69f17365

Signed-off-by: Daniel Rix drainx1@live.com
