### PR TITLE
Allow to user set option "Columns escaped with" to blank.

### DIFF
--- a/libraries/plugins/import/ImportCsv.class.php
+++ b/libraries/plugins/import/ImportCsv.class.php
@@ -150,7 +150,7 @@ class ImportCsv extends AbstractImportCsv
             $message->addParam(__('Columns enclosed with'), false);
             $error = true;
             $param_error = true;
-        } elseif (strlen($csv_escaped) != 1) {
+        } elseif (!empty($csv_escaped) && strlen($csv_escaped) != 1) {
             $message = PMA_Message::error(
                 __('Invalid parameter for CSV import: %s')
             );


### PR DESCRIPTION
I was need to remove requirement for this option, and than i've found issue: #1552 CSV Export: Allow "Columns escaped with" to be optional.
