### PR TITLE
Fix #4495 Comment lines in multiquery

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -54,6 +54,7 @@ phpMyAdmin - ChangeLog
 + rfe #1547 Wrap No Tables Found message with message box
 - bug #4559 Logging in causes 100% CPU usage
 - bug #4564 Designer: spaces in table name with edit table link generates bad links
+- bug #4495 Comment lines in multiquery
 
 4.2.12.0 (not yet released)
 - bug #4574 Blank/white page when JavaScript disabled

--- a/libraries/plugins/import/ImportSql.class.php
+++ b/libraries/plugins/import/ImportSql.class.php
@@ -296,6 +296,11 @@ class ImportSql extends ImportPlugin
                     //throw new Exception('Unknown case.');
                     break;
                 }
+
+                if (0 === $this->_firstSearchChar) {
+                    $this->_queryBeginPosition = $this->_delimiterPosition;
+                }
+
                 continue;
             }
 

--- a/libraries/tracking.lib.php
+++ b/libraries/tracking.lib.php
@@ -698,7 +698,7 @@ function PMA_getHtmlForOneStatement($entry, $filter_users,
  * @param array  $url_params         url parameters
  * @param string $drop_image_or_text drop image or text
  *
- * @return array 
+ * @return array
  */
 function PMA_getHtmlForDataDefinitionStatements($data, $filter_users,
     $filter_ts_from, $filter_ts_to, $url_params, $drop_image_or_text


### PR DESCRIPTION
This fix is for master (4.3). It can't be applied on 4.2.
