### PR TITLE
Use $replication_info everywhere, instead of $server_* variables.

### DIFF
--- a/db_create.php
+++ b/db_create.php
@@ -114,7 +114,7 @@ if (! $result) {
 
         list($column_order, $generated_html) = PMA_buildHtmlForDb(
             $current, $is_superuser, $url_query,
-            $column_order, $replication_types, $replication_info
+            $column_order, $replication_types, $GLOBALS['replication_info']
         );
         $new_db_string .= $generated_html;
 

--- a/db_structure.php
+++ b/db_structure.php
@@ -67,7 +67,7 @@ if ($GLOBALS['is_ajax_request']
 if (!PMA_DRIZZLE) {
     include_once 'libraries/replication.inc.php';
 } else {
-    $server_slave_status = false;
+    $replication_info['slave']['status'] = false;
 }
 
 require_once 'libraries/bookmark.lib.php';
@@ -123,7 +123,7 @@ $response->addHTML(
 $response->addHTML(PMA_URL_getHiddenInputs($db));
 
 $response->addHTML(
-    PMA_tableHeader($db_is_system_schema, $server_slave_status)
+    PMA_tableHeader($db_is_system_schema, $replication_info['slave']['status'])
 );
 
 $i = $sum_entries = 0;
@@ -255,11 +255,13 @@ foreach ($tables as $keyname => $current_table) {
             '</tr></tbody></table>'
         );
 
-        $response->addHTML(PMA_tableHeader(false, $server_slave_status));
+        $response->addHTML(
+            PMA_tableHeader(false, $replication_info['slave']['status'])
+        );
     }
 
     list($do, $ignored) = PMA_getServerSlaveStatus(
-        $server_slave_status, $truename
+        $replication_info['slave']['status'], $truename
     );
     // Handle favorite table list. ----START----
     $already_favorite = PMA_checkFavoriteTable($db, $current_table['TABLE_NAME']);
@@ -282,7 +284,7 @@ foreach ($tables as $keyname => $current_table) {
 
     list($html_output, $odd_row, $approx_rows) = PMA_getHtmlForStructureTableRow(
         $i, $odd_row, $table_is_view, $current_table,
-        $browse_table_label, $tracking_icon, $server_slave_status,
+        $browse_table_label, $tracking_icon, $replication_info['slave']['status'],
         $browse_table, $tbl_url_query, $search_table, $db_is_system_schema,
         $titles, $empty_table, $drop_query, $drop_message, $collation,
         $formatted_size, $unit, $overhead,
@@ -299,9 +301,10 @@ foreach ($tables as $keyname => $current_table) {
 $response->addHTML('</tbody>');
 $response->addHTML(
     PMA_getHtmlBodyForTableSummary(
-        $num_tables, $server_slave_status, $db_is_system_schema, $sum_entries,
-        $db_collation, $is_show_stats, $sum_size, $overhead_size, $create_time_all,
-        $update_time_all, $check_time_all, isset($approx_rows) ? $approx_rows : false
+        $num_tables, $replication_info['slave']['status'], $db_is_system_schema,
+        $sum_entries, $db_collation, $is_show_stats, $sum_size, $overhead_size,
+        $create_time_all, $update_time_all, $check_time_all,
+        isset($approx_rows) ? $approx_rows : false
     )
 );
 $response->addHTML('</table>');

--- a/db_structure.php
+++ b/db_structure.php
@@ -67,7 +67,7 @@ if ($GLOBALS['is_ajax_request']
 if (!PMA_DRIZZLE) {
     include_once 'libraries/replication.inc.php';
 } else {
-    $replication_info['slave']['status'] = false;
+    $GLOBALS['replication_info']['slave']['status'] = false;
 }
 
 require_once 'libraries/bookmark.lib.php';
@@ -123,7 +123,9 @@ $response->addHTML(
 $response->addHTML(PMA_URL_getHiddenInputs($db));
 
 $response->addHTML(
-    PMA_tableHeader($db_is_system_schema, $replication_info['slave']['status'])
+    PMA_tableHeader(
+        $db_is_system_schema, $GLOBALS['replication_info']['slave']['status']
+    )
 );
 
 $i = $sum_entries = 0;
@@ -256,12 +258,12 @@ foreach ($tables as $keyname => $current_table) {
         );
 
         $response->addHTML(
-            PMA_tableHeader(false, $replication_info['slave']['status'])
+            PMA_tableHeader(false, $GLOBALS['replication_info']['slave']['status'])
         );
     }
 
     list($do, $ignored) = PMA_getServerSlaveStatus(
-        $replication_info['slave']['status'], $truename
+        $GLOBALS['replication_info']['slave']['status'], $truename
     );
     // Handle favorite table list. ----START----
     $already_favorite = PMA_checkFavoriteTable($db, $current_table['TABLE_NAME']);
@@ -284,7 +286,7 @@ foreach ($tables as $keyname => $current_table) {
 
     list($html_output, $odd_row, $approx_rows) = PMA_getHtmlForStructureTableRow(
         $i, $odd_row, $table_is_view, $current_table,
-        $browse_table_label, $tracking_icon, $replication_info['slave']['status'],
+        $browse_table_label, $tracking_icon, $GLOBALS['replication_info']['slave']['status'],
         $browse_table, $tbl_url_query, $search_table, $db_is_system_schema,
         $titles, $empty_table, $drop_query, $drop_message, $collation,
         $formatted_size, $unit, $overhead,
@@ -301,7 +303,7 @@ foreach ($tables as $keyname => $current_table) {
 $response->addHTML('</tbody>');
 $response->addHTML(
     PMA_getHtmlBodyForTableSummary(
-        $num_tables, $replication_info['slave']['status'], $db_is_system_schema,
+        $num_tables, $GLOBALS['replication_info']['slave']['status'], $db_is_system_schema,
         $sum_entries, $db_collation, $is_show_stats, $sum_size, $overhead_size,
         $create_time_all, $update_time_all, $check_time_all,
         isset($approx_rows) ? $approx_rows : false

--- a/libraries/ServerStatusData.class.php
+++ b/libraries/ServerStatusData.class.php
@@ -225,7 +225,7 @@ class PMA_ServerStatusData
                 )
             );
 
-        if ($GLOBALS['server_master_status']) {
+        if ($GLOBALS['replication_info']['master']['status']) {
             $links['repl'][__('Show slave hosts')]
                 = 'sql.php' . PMA_URL_getCommon(
                     array(
@@ -235,7 +235,7 @@ class PMA_ServerStatusData
                 );
             $links['repl'][__('Show master status')] = '#replication_master';
         }
-        if ($GLOBALS['server_slave_status']) {
+        if ($GLOBALS['replication_info']['slave']['status']) {
             $links['repl'][__('Show slave status')] = '#replication_slave';
         }
 

--- a/libraries/replication.inc.php
+++ b/libraries/replication.inc.php
@@ -115,21 +115,21 @@ $slave_variables_oks = array(
 // set $server_{master/slave}_status and assign values
 
 // replication info is more easily passed to functions
-$replication_info = array();
+$GLOBALS['replication_info'] = array();
 
 foreach ($replication_types as $type) {
     if (count(${"server_{$type}_replication"}) > 0) {
-        $replication_info[$type]['status'] = true;
+        $GLOBALS['replication_info'][$type]['status'] = true;
     } else {
-        $replication_info[$type]['status'] = false;
+        $GLOBALS['replication_info'][$type]['status'] = false;
     }
-    if ($replication_info[$type]['status']) {
+    if ($GLOBALS['replication_info'][$type]['status']) {
         if ($type == "master") {
-            $replication_info[$type]['Do_DB'] = explode(
+            $GLOBALS['replication_info'][$type]['Do_DB'] = explode(
                 ",", $server_master_replication[0]["Binlog_Do_DB"]
             );
 
-            $replication_info[$type]['Ignore_DB'] = explode(
+            $GLOBALS['replication_info'][$type]['Ignore_DB'] = explode(
                 ",", $server_master_replication[0]["Binlog_Ignore_DB"]
             );
         } elseif ($type == "slave") {
@@ -137,27 +137,27 @@ foreach ($replication_types as $type) {
                 ",", $server_slave_replication[0]["Replicate_Do_DB"]
             );
             if (!empty($doDB)) {
-                $replication_info[$type]['Do_DB'] = $doDB;
+                $GLOBALS['replication_info'][$type]['Do_DB'] = $doDB;
             }
             unset($doDB);
 
-            $replication_info[$type]['Ignore_DB'] = explode(
+            $GLOBALS['replication_info'][$type]['Ignore_DB'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Ignore_DB"]
             );
 
-            $replication_info[$type]['Do_Table'] = explode(
+            $GLOBALS['replication_info'][$type]['Do_Table'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Do_Table"]
             );
 
-            $replication_info[$type]['Ignore_Table'] = explode(
+            $GLOBALS['replication_info'][$type]['Ignore_Table'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Ignore_Table"]
             );
 
-            $replication_info[$type]['Wild_Do_Table'] = explode(
+            $GLOBALS['replication_info'][$type]['Wild_Do_Table'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Wild_Do_Table"]
             );
 
-            $replication_info[$type]['Wild_Ignore_Table'] = explode(
+            $GLOBALS['replication_info'][$type]['Wild_Ignore_Table'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Wild_Ignore_Table"]
             );
         }

--- a/libraries/replication.inc.php
+++ b/libraries/replication.inc.php
@@ -115,65 +115,51 @@ $slave_variables_oks = array(
 // set $server_{master/slave}_status and assign values
 
 // replication info is more easily passed to functions
-/*
- * @todo use $replication_info everywhere instead of the generated variable names
- */
 $replication_info = array();
 
 foreach ($replication_types as $type) {
     if (count(${"server_{$type}_replication"}) > 0) {
-        ${"server_{$type}_status"} = true;
         $replication_info[$type]['status'] = true;
     } else {
-        ${"server_{$type}_status"} = false;
         $replication_info[$type]['status'] = false;
     }
-    if (${"server_{$type}_status"}) {
+    if ($replication_info[$type]['status']) {
         if ($type == "master") {
-            ${"server_{$type}_Do_DB"} = explode(
+            $replication_info[$type]['Do_DB'] = explode(
                 ",", $server_master_replication[0]["Binlog_Do_DB"]
             );
-            $replication_info[$type]['Do_DB'] = ${"server_{$type}_Do_DB"};
 
-            ${"server_{$type}_Ignore_DB"} = explode(
+            $replication_info[$type]['Ignore_DB'] = explode(
                 ",", $server_master_replication[0]["Binlog_Ignore_DB"]
             );
-            $replication_info[$type]['Ignore_DB'] = ${"server_{$type}_Ignore_DB"};
         } elseif ($type == "slave") {
-            ${"server_{$type}_Do_DB"} = explode(
+            $doDB = explode(
                 ",", $server_slave_replication[0]["Replicate_Do_DB"]
             );
-            if (! empty(${"server_{$type}_Do_DB"})) {
-                $replication_info[$type]['Do_DB'] = ${"server_{$type}_Do_DB"};
+            if (!empty($doDB)) {
+                $replication_info[$type]['Do_DB'] = $doDB;
             }
+            unset($doDB);
 
-            ${"server_{$type}_Ignore_DB"} = explode(
+            $replication_info[$type]['Ignore_DB'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Ignore_DB"]
             );
-            $replication_info[$type]['Ignore_DB'] = ${"server_{$type}_Ignore_DB"};
 
-            ${"server_{$type}_Do_Table"} = explode(
+            $replication_info[$type]['Do_Table'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Do_Table"]
             );
-            $replication_info[$type]['Do_Table'] = ${"server_{$type}_Do_Table"};
 
-            ${"server_{$type}_Ignore_Table"} = explode(
+            $replication_info[$type]['Ignore_Table'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Ignore_Table"]
             );
-            $replication_info[$type]['Ignore_Table']
-                = ${"server_{$type}_Ignore_Table"};
 
-            ${"server_{$type}_Wild_Do_Table"} = explode(
+            $replication_info[$type]['Wild_Do_Table'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Wild_Do_Table"]
             );
-            $replication_info[$type]['Wild_Do_Table']
-                = ${"server_{$type}_Wild_Do_Table"};
 
-            ${"server_{$type}_Wild_Ignore_Table"} = explode(
+            $replication_info[$type]['Wild_Ignore_Table'] = explode(
                 ",", $server_slave_replication[0]["Replicate_Wild_Ignore_Table"]
             );
-            $replication_info[$type]['Wild_Ignore_Table']
-                = ${"server_{$type}_Wild_Ignore_Table"};
         }
     }
 }

--- a/libraries/server_databases.lib.php
+++ b/libraries/server_databases.lib.php
@@ -180,7 +180,7 @@ function PMA_getHtmlForTableFooter(
     $html .= PMA_getHtmlForColumnOrder($column_order, $first_database);
 
     foreach ($replication_types as $type) {
-        if ($GLOBALS["server_" . $type . "_status"]) {
+        if ($GLOBALS['replication_info'][$type]['status']) {
             $html .= '    <th></th>' . "\n";
         }
     }
@@ -394,7 +394,7 @@ function PMA_getHtmlForReplicationType(
             $name = __('Slave replication');
         }
 
-        if ($GLOBALS["server_{$type}_status"]) {
+        if ($GLOBALS['replication_info'][$type]['status']) {
             $html .= '    <th>' . $name . '</th>' . "\n";
         }
     }

--- a/libraries/server_status.lib.php
+++ b/libraries/server_status.lib.php
@@ -69,19 +69,23 @@ function PMA_getHtmlForServerStateGeneralInfo($ServerStatusData)
     ) . "\n";
     $retval .= '</p>';
 
-    if ($GLOBALS['server_master_status'] || $GLOBALS['server_slave_status']) {
+    if ($GLOBALS['replication_info']['master']['status']
+        || $GLOBALS['replication_info']['slave']['status']
+    ) {
         $retval .= '<p class="notice">';
-        if ($GLOBALS['server_master_status'] && $GLOBALS['server_slave_status']) {
+        if ($GLOBALS['replication_info']['master']['status']
+            && $GLOBALS['replication_info']['slave']['status']
+        ) {
             $retval .= __(
                 'This MySQL server works as <b>master</b> and '
                 . '<b>slave</b> in <b>replication</b> process.'
             );
-        } elseif ($GLOBALS['server_master_status']) {
+        } elseif ($GLOBALS['replication_info']['master']['status']) {
             $retval .= __(
                 'This MySQL server works as <b>master</b> '
                 . 'in <b>replication</b> process.'
             );
-        } elseif ($GLOBALS['server_slave_status']) {
+        } elseif ($GLOBALS['replication_info']['slave']['status']) {
             $retval .= __(
                 'This MySQL server works as <b>slave</b> '
                 . 'in <b>replication</b> process.'
@@ -94,13 +98,17 @@ function PMA_getHtmlForServerStateGeneralInfo($ServerStatusData)
      * if the server works as master or slave in replication process,
      * display useful information
      */
-    if ($GLOBALS['server_master_status'] || $GLOBALS['server_slave_status']) {
+    if ($GLOBALS['replication_info']['master']['status']
+        || $GLOBALS['replication_info']['slave']['status']
+    ) {
         $retval .= '<hr class="clearfloat" />';
         $retval .= '<h3><a name="replication">';
         $retval .= __('Replication status');
         $retval .= '</a></h3>';
         foreach ($GLOBALS['replication_types'] as $type) {
-            if (isset(${"server_{$type}_status"}) && ${"server_{$type}_status"}) {
+            if (isset($GLOBALS['replication_info'][$type]['status'])
+                && $GLOBALS['replication_info'][$type]['status']
+            ) {
                 $retval .= PMA_getHtmlForReplicationStatusTable($type);
             }
         }

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -1024,12 +1024,18 @@ function PMA_getServerSlaveStatus($server_slave_status, $truename)
         return array($do, $ignored);
     }
 
-    $nbServerSlaveDoDb = count($GLOBALS['replication_info']['slave']['Do_DB']);
-    $nbServerSlaveIgnoreDb
+    $nbServSlaveDoDb = count($GLOBALS['replication_info']['slave']['Do_DB']);
+    $nbServSlaveIgnoreDb
         = count($GLOBALS['replication_info']['slave']['Ignore_DB']);
-    if ((strlen(array_search($truename, $GLOBALS['replication_info']['slave']['Do_DB'])) > 0)
-        || strlen(array_search($GLOBALS['db'], $GLOBALS['replication_info']['slave']['Do_DB'])) > 0
-        || ($nbServerSlaveDoDb == 1 && $nbServerSlaveIgnoreDb == 1)
+    $searchDoDBInTruename = array_search(
+        $truename, $GLOBALS['replication_info']['slave']['Do_DB']
+    );
+    $searchDoDBInDB = array_search(
+        $GLOBALS['db'], $GLOBALS['replication_info']['slave']['Do_DB']
+    );
+    if (strlen($searchDoDBInTruename) > 0
+        || strlen($searchDoDBInDB) > 0
+        || ($nbServSlaveDoDb == 1 && $nbServSlaveIgnoreDb == 1)
     ) {
         $do = true;
     }

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -1024,15 +1024,16 @@ function PMA_getServerSlaveStatus($server_slave_status, $truename)
         return array($do, $ignored);
     }
 
-    $nbServerSlaveDoDb = count($server_slave_Do_DB);
-    $nbServerSlaveIgnoreDb = count($server_slave_Ignore_DB);
-    if ((strlen(array_search($truename, $server_slave_Do_Table)) > 0)
-        || strlen(array_search($GLOBALS['db'], $server_slave_Do_DB)) > 0
+    $nbServerSlaveDoDb = count($GLOBALS['replication_info']['slave']['Do_DB']);
+    $nbServerSlaveIgnoreDb
+        = count($GLOBALS['replication_info']['slave']['Ignore_DB']);
+    if ((strlen(array_search($truename, $GLOBALS['replication_info']['slave']['Do_DB'])) > 0)
+        || strlen(array_search($GLOBALS['db'], $GLOBALS['replication_info']['slave']['Do_DB'])) > 0
         || ($nbServerSlaveDoDb == 1 && $nbServerSlaveIgnoreDb == 1)
     ) {
         $do = true;
     }
-    foreach ($server_slave_Wild_Do_Table as $db_table) {
+    foreach ($GLOBALS['replication_info']['slave']['Wild_Do_Table'] as $db_table) {
         $table_part = PMA_extractDbOrTable($db_table, 'table');
         $pattern = "@^"
             . /*overload*/mb_substr($table_part, 0, -1)
@@ -1044,13 +1045,18 @@ function PMA_getServerSlaveStatus($server_slave_status, $truename)
         }
     }
 
-    $search = array_search($GLOBALS['db'], $server_slave_Ignore_DB);
-    if ((strlen(array_search($truename, $server_slave_Ignore_Table)) > 0)
-        || strlen($search) > 0
-    ) {
+    $searchDb = array_search(
+        $GLOBALS['db'],
+        $GLOBALS['replication_info']['slave']['Ignore_DB']
+    );
+    $searchTable = array_search(
+        $truename,
+        $GLOBALS['replication_info']['slave']['Ignore_Table']
+    );
+    if ((strlen($searchTable) > 0) || strlen($searchDb) > 0) {
         $ignored = true;
     }
-    foreach ($server_slave_Wild_Ignore_Table as $db_table) {
+    foreach ($GLOBALS['replication_info']['slave']['Wild_Ignore_Table'] as $db_table) {
         $table_part = PMA_extractDbOrTable($db_table, 'table');
         $pattern = "@^"
             . /*overload*/mb_substr($table_part, 0, -1)

--- a/server_databases.php
+++ b/server_databases.php
@@ -22,7 +22,7 @@ if (! PMA_DRIZZLE) {
     include_once 'libraries/replication.inc.php';
 } else {
     $replication_types = array();
-    $replication_info = null;
+    $GLOBALS['replication_info'] = null;
 }
 require 'libraries/build_html_for_db.lib.php';
 
@@ -105,7 +105,7 @@ if ($databases_count > 0) {
         $is_superuser,
         $cfg,
         $replication_types,
-        $replication_info,
+        $GLOBALS['replication_info'],
         $url_query
     );
 } else {

--- a/server_replication.php
+++ b/server_replication.php
@@ -52,7 +52,7 @@ $response->addHTML(PMA_getHtmlForSubPageHeader('replication'));
 // Display error messages
 $response->addHTML(PMA_getHtmlForErrorMessage());
 
-if ($server_master_status) {
+if ($replication_info['master']['status']) {
     $response->addHTML(PMA_getHtmlForMasterReplication());
 } elseif (! isset($_REQUEST['mr_configure'])
     && ! isset($_REQUEST['repl_clear_scr'])
@@ -72,7 +72,7 @@ if (! isset($_REQUEST['repl_clear_scr'])) {
     // Render the 'Slave configuration' section
     $response->addHTML(
         PMA_getHtmlForSlaveConfiguration(
-            $server_slave_status,
+            $replication_info['slave']['status'],
             $server_slave_replication
         )
     );

--- a/server_replication.php
+++ b/server_replication.php
@@ -52,7 +52,7 @@ $response->addHTML(PMA_getHtmlForSubPageHeader('replication'));
 // Display error messages
 $response->addHTML(PMA_getHtmlForErrorMessage());
 
-if ($replication_info['master']['status']) {
+if ($GLOBALS['replication_info']['master']['status']) {
     $response->addHTML(PMA_getHtmlForMasterReplication());
 } elseif (! isset($_REQUEST['mr_configure'])
     && ! isset($_REQUEST['repl_clear_scr'])
@@ -72,7 +72,7 @@ if (! isset($_REQUEST['repl_clear_scr'])) {
     // Render the 'Slave configuration' section
     $response->addHTML(
         PMA_getHtmlForSlaveConfiguration(
-            $replication_info['slave']['status'],
+            $GLOBALS['replication_info']['slave']['status'],
             $server_slave_replication
         )
     );

--- a/server_status.php
+++ b/server_status.php
@@ -15,9 +15,9 @@ require_once 'libraries/server_status.lib.php';
  * Replication library
  */
 if (PMA_DRIZZLE) {
-    $replication_info = array();
-    $replication_info['master']['status'] = false;
-    $replication_info['slave']['status'] = false;
+    $GLOBALS['replication_info'] = array();
+    $GLOBALS['replication_info']['master']['status'] = false;
+    $GLOBALS['replication_info']['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status.php
+++ b/server_status.php
@@ -15,8 +15,9 @@ require_once 'libraries/server_status.lib.php';
  * Replication library
  */
 if (PMA_DRIZZLE) {
-    $server_master_status = false;
-    $server_slave_status = false;
+    $replication_info = array();
+    $replication_info['master']['status'] = false;
+    $replication_info['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_advisor.php
+++ b/server_status_advisor.php
@@ -12,8 +12,9 @@ require_once 'libraries/ServerStatusData.class.php';
 require_once 'libraries/server_status_advisor.lib.php';
 
 if (PMA_DRIZZLE) {
-    $server_master_status = false;
-    $server_slave_status = false;
+    $replication_info = array();
+    $replication_info['master']['status'] = false;
+    $replication_info['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_advisor.php
+++ b/server_status_advisor.php
@@ -12,9 +12,9 @@ require_once 'libraries/ServerStatusData.class.php';
 require_once 'libraries/server_status_advisor.lib.php';
 
 if (PMA_DRIZZLE) {
-    $replication_info = array();
-    $replication_info['master']['status'] = false;
-    $replication_info['slave']['status'] = false;
+    $GLOBALS['replication_info'] = array();
+    $GLOBALS['replication_info']['master']['status'] = false;
+    $GLOBALS['replication_info']['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_monitor.php
+++ b/server_status_monitor.php
@@ -10,9 +10,11 @@ require_once 'libraries/common.inc.php';
 require_once 'libraries/server_common.inc.php';
 require_once 'libraries/ServerStatusData.class.php';
 require_once 'libraries/server_status_monitor.lib.php';
+
 if (PMA_DRIZZLE) {
-    $server_master_status = false;
-    $server_slave_status = false;
+    $replication_info = array();
+    $replication_info['master']['status'] = false;
+    $replication_info['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_monitor.php
+++ b/server_status_monitor.php
@@ -12,9 +12,9 @@ require_once 'libraries/ServerStatusData.class.php';
 require_once 'libraries/server_status_monitor.lib.php';
 
 if (PMA_DRIZZLE) {
-    $replication_info = array();
-    $replication_info['master']['status'] = false;
-    $replication_info['slave']['status'] = false;
+    $GLOBALS['replication_info'] = array();
+    $GLOBALS['replication_info']['master']['status'] = false;
+    $GLOBALS['replication_info']['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_processes.php
+++ b/server_status_processes.php
@@ -15,8 +15,9 @@ require_once 'libraries/server_status_processes.lib.php';
  * Replication library
  */
 if (PMA_DRIZZLE) {
-    $server_master_status = false;
-    $server_slave_status = false;
+    $replication_info = array();
+    $replication_info['master']['status'] = false;
+    $replication_info['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_processes.php
+++ b/server_status_processes.php
@@ -15,9 +15,9 @@ require_once 'libraries/server_status_processes.lib.php';
  * Replication library
  */
 if (PMA_DRIZZLE) {
-    $replication_info = array();
-    $replication_info['master']['status'] = false;
-    $replication_info['slave']['status'] = false;
+    $GLOBALS['replication_info'] = array();
+    $GLOBALS['replication_info']['master']['status'] = false;
+    $GLOBALS['replication_info']['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_queries.php
+++ b/server_status_queries.php
@@ -13,8 +13,9 @@ require_once 'libraries/ServerStatusData.class.php';
 require_once 'libraries/server_status_queries.lib.php';
 
 if (PMA_DRIZZLE) {
-    $server_master_status = false;
-    $server_slave_status = false;
+    $replication_info = array();
+    $replication_info['master']['status'] = false;
+    $replication_info['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_queries.php
+++ b/server_status_queries.php
@@ -13,9 +13,9 @@ require_once 'libraries/ServerStatusData.class.php';
 require_once 'libraries/server_status_queries.lib.php';
 
 if (PMA_DRIZZLE) {
-    $replication_info = array();
-    $replication_info['master']['status'] = false;
-    $replication_info['slave']['status'] = false;
+    $GLOBALS['replication_info'] = array();
+    $GLOBALS['replication_info']['master']['status'] = false;
+    $GLOBALS['replication_info']['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_variables.php
+++ b/server_status_variables.php
@@ -12,8 +12,9 @@ require_once 'libraries/ServerStatusData.class.php';
 require_once 'libraries/server_status_variables.lib.php';
 
 if (PMA_DRIZZLE) {
-    $server_master_status = false;
-    $server_slave_status = false;
+    $replication_info = array();
+    $replication_info['master']['status'] = false;
+    $replication_info['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/server_status_variables.php
+++ b/server_status_variables.php
@@ -12,9 +12,9 @@ require_once 'libraries/ServerStatusData.class.php';
 require_once 'libraries/server_status_variables.lib.php';
 
 if (PMA_DRIZZLE) {
-    $replication_info = array();
-    $replication_info['master']['status'] = false;
-    $replication_info['slave']['status'] = false;
+    $GLOBALS['replication_info'] = array();
+    $GLOBALS['replication_info']['master']['status'] = false;
+    $GLOBALS['replication_info']['slave']['status'] = false;
 } else {
     include_once 'libraries/replication.inc.php';
     include_once 'libraries/replication_gui.lib.php';

--- a/test/classes/PMA_ServerStatusData_test.php
+++ b/test/classes/PMA_ServerStatusData_test.php
@@ -36,8 +36,8 @@ class PMA_ServerStatusData_Test extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['PMA_PHP_SELF'] = PMA_getenv('PHP_SELF');
         $GLOBALS['cfg']['Server']['host'] = "::1";
-        $GLOBALS['server_master_status'] = true;
-        $GLOBALS['server_slave_status'] = true;
+        $GLOBALS['replication_info']['master']['status'] = true;
+        $GLOBALS['replication_info']['slave']['status'] = true;
         $GLOBALS['replication_types'] = array();
 
         //Mock DBI

--- a/test/libraries/PMA_server_databases_test.php
+++ b/test/libraries/PMA_server_databases_test.php
@@ -62,8 +62,8 @@ class PMA_ServerDatabases_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
 
         $GLOBALS['table'] = "table";
-        $GLOBALS['server_master_status'] = false;
-        $GLOBALS['server_slave_status'] = false;
+        $GLOBALS['replication_info']['master']['status'] = false;
+        $GLOBALS['replication_info']['slave']['status'] = false;
         $GLOBALS['pmaThemeImage'] = 'image';
         $GLOBALS['text_dir'] = "text_dir";
 

--- a/test/libraries/PMA_server_status_advisor_test.php
+++ b/test/libraries/PMA_server_status_advisor_test.php
@@ -63,8 +63,8 @@ class PMA_ServerStatusAdvisor_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['ShowHint'] = true;
         $GLOBALS['cfg']['ActionLinksMode'] = 'icons';
         $GLOBALS['PMA_PHP_SELF'] = PMA_getenv('PHP_SELF');
-        $GLOBALS['server_master_status'] = false;
-        $GLOBALS['server_slave_status'] = false;
+        $GLOBALS['replication_info']['master']['status'] = false;
+        $GLOBALS['replication_info']['slave']['status'] = false;
 
         $GLOBALS['table'] = "table";
         $GLOBALS['pmaThemeImage'] = 'image';

--- a/test/libraries/PMA_server_status_monitor_test.php
+++ b/test/libraries/PMA_server_status_monitor_test.php
@@ -58,8 +58,8 @@ class PMA_ServerStatusMonitor_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['Server']['host'] = "localhost";
         $GLOBALS['cfg']['ShowHint'] = true;
         $GLOBALS['PMA_PHP_SELF'] = PMA_getenv('PHP_SELF');
-        $GLOBALS['server_master_status'] = false;
-        $GLOBALS['server_slave_status'] = false;
+        $GLOBALS['replication_info']['master']['status'] = false;
+        $GLOBALS['replication_info']['slave']['status'] = false;
 
         $GLOBALS['table'] = "table";
         $GLOBALS['pmaThemeImage'] = 'image';

--- a/test/libraries/PMA_server_status_processes_test.php
+++ b/test/libraries/PMA_server_status_processes_test.php
@@ -37,8 +37,8 @@ class PMA_ServerStatusProcesses_Test extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['cfg']['Server']['host'] = "localhost";
         $GLOBALS['PMA_PHP_SELF'] = PMA_getenv('PHP_SELF');
-        $GLOBALS['server_master_status'] = true;
-        $GLOBALS['server_slave_status'] = false;
+        $GLOBALS['replication_info']['master']['status'] = true;
+        $GLOBALS['replication_info']['slave']['status'] = false;
         $GLOBALS['replication_types'] = array();
 
         $GLOBALS['pmaThemeImage'] = 'image';

--- a/test/libraries/PMA_server_status_queries_test.php
+++ b/test/libraries/PMA_server_status_queries_test.php
@@ -57,8 +57,8 @@ class PMA_ServerStatusQueries_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['cfg']['Server']['host'] = "localhost";
         $GLOBALS['PMA_PHP_SELF'] = PMA_getenv('PHP_SELF');
-        $GLOBALS['server_master_status'] = false;
-        $GLOBALS['server_slave_status'] = false;
+        $GLOBALS['replication_info']['master']['status'] = false;
+        $GLOBALS['replication_info']['slave']['status'] = false;
 
         $GLOBALS['table'] = "table";
         $GLOBALS['pmaThemeImage'] = 'image';

--- a/test/libraries/PMA_server_status_test.php
+++ b/test/libraries/PMA_server_status_test.php
@@ -44,8 +44,8 @@ class PMA_ServerStatus_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['ShowHint'] = true;
         $GLOBALS['cfg']['ActionLinksMode'] = 'icons';
         $GLOBALS['PMA_PHP_SELF'] = PMA_getenv('PHP_SELF');
-        $GLOBALS['server_master_status'] = true;
-        $GLOBALS['server_slave_status'] = false;
+        $GLOBALS['replication_info']['master']['status'] = true;
+        $GLOBALS['replication_info']['slave']['status'] = false;
         $GLOBALS['replication_types'] = array();
 
         $GLOBALS['table'] = "table";
@@ -221,8 +221,8 @@ class PMA_ServerStatus_Test extends PHPUnit_Framework_TestCase
             $html
         );
 
-        $GLOBALS['server_master_status'] = true;
-        $GLOBALS['server_slave_status'] = true;
+        $GLOBALS['replication_info']['master']['status'] = true;
+        $GLOBALS['replication_info']['slave']['status'] = true;
         $this->ServerStatusData->status['Connections'] = 0;
         $html = PMA_getHtmlForServerStatus($this->ServerStatusData);
 
@@ -231,8 +231,8 @@ class PMA_ServerStatus_Test extends PHPUnit_Framework_TestCase
             $html
         );
 
-        $GLOBALS['server_master_status'] = false;
-        $GLOBALS['server_slave_status'] = true;
+        $GLOBALS['replication_info']['master']['status'] = false;
+        $GLOBALS['replication_info']['slave']['status'] = true;
         $html = PMA_getHtmlForServerStatus($this->ServerStatusData);
 
         $this->assertContains(

--- a/test/libraries/PMA_server_status_variables_test.php
+++ b/test/libraries/PMA_server_status_variables_test.php
@@ -60,8 +60,8 @@ class PMA_ServerStatusVariables_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['cfg']['Server']['host'] = "localhost";
         $GLOBALS['PMA_PHP_SELF'] = PMA_getenv('PHP_SELF');
-        $GLOBALS['server_master_status'] = false;
-        $GLOBALS['server_slave_status'] = false;
+        $GLOBALS['replication_info']['master']['status'] = false;
+        $GLOBALS['replication_info']['slave']['status'] = false;
 
         $GLOBALS['table'] = "table";
         $GLOBALS['pmaThemeImage'] = 'image';


### PR DESCRIPTION
As suggested in todo [1], $replication_info has been used everywhere, instead of $server_master/slave variables.
Does someone with replication can test it please?

[1] libraries/replication.inc.php:119
