### PR TITLE
Allow import SQL without delimiter till EOF.

### DIFF
--- a/libraries/plugins/import/ImportSql.class.php
+++ b/libraries/plugins/import/ImportSql.class.php
@@ -465,7 +465,15 @@ class ImportSql extends ImportPlugin
         }
 
         //Commit any possible data in buffers
-        PMA_importRunQuery('', $this->_data, false, $sql_data);
+        PMA_importRunQuery(
+            $this->_stringFctToUse['substr'](
+                $this->_data,
+                $this->_queryBeginPosition
+            ), //Query to execute
+            $this->_data,
+            false,
+            $sql_data
+        );
         PMA_importRunQuery('', '', false, $sql_data);
     }
 


### PR DESCRIPTION
For example, allow one line SQL without ; at end.

This again allows execution of SQL queries from query builder and auto-generated queries from query_result box without appending ;(semi-colon)

Partially fixes bug 4581.
