### PR TITLE
Workaround for token mismatch error on server session timeout for config and http authentication types

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -443,7 +443,9 @@ var AJAX = {
             AJAX.xhr = null;
             if (parseInt(data.redirect_flag) == 1) {
                 // add one more GET param to display session expiry msg
-                window.location.href += '&session_expired=1';
+                var url = window.location.href;
+                var tokenlessUrl = url.replace(/&?token=[^&#]*/g, "");
+                window.location.href = tokenlessUrl + '&session_expired=1';
                 window.location.reload();
             }
             if (data.fieldWithError) {

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -443,9 +443,11 @@ var AJAX = {
             AJAX.xhr = null;
             if (parseInt(data.redirect_flag) == 1) {
                 // add one more GET param to display session expiry msg
-                var url = window.location.href;
-                var tokenlessUrl = url.replace(/&?token=[^&#]*/g, "");
-                window.location.href = tokenlessUrl + '&session_expired=1';
+                window.location.href += '&session_expired=1';
+                window.location.reload();
+            } else if (parseInt(data.reload_flag) == 1) {
+                // remove the token param and reload
+                window.location.href = window.location.href.replace(/&?token=[^&#]*/g, "");
                 window.location.reload();
             }
             if (data.fieldWithError) {

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -470,7 +470,9 @@ if (PMA_checkPageValidity($_REQUEST['back'], $goto_whitelist)) {
  * f.e. lang, server, collation_connection in PMA_Config
  */
 $token_mismatch = true;
+$token_provided = false;
 if (PMA_isValid($_REQUEST['token'])) {
+    $token_provided = true;
     $token_mismatch = ($_SESSION[' PMA_token '] != $_REQUEST['token']);
 }
 

--- a/libraries/plugins/auth/AuthenticationConfig.class.php
+++ b/libraries/plugins/auth/AuthenticationConfig.class.php
@@ -30,7 +30,7 @@ class AuthenticationConfig extends AuthenticationPlugin
         $response = PMA_Response::getInstance();
         if ($response->isAjax()) {
             $response->isSuccess(false);
-            $response->addJSON('redirect_flag', '1');
+            $response->addJSON('reload_flag', '1');
             if (defined('TESTSUITE')) {
                 return true;
             } else {

--- a/libraries/plugins/auth/AuthenticationConfig.class.php
+++ b/libraries/plugins/auth/AuthenticationConfig.class.php
@@ -30,6 +30,7 @@ class AuthenticationConfig extends AuthenticationPlugin
         $response = PMA_Response::getInstance();
         if ($response->isAjax()) {
             $response->isSuccess(false);
+            // reload_flag removes the token parameter from the URL and reload
             $response->addJSON('reload_flag', '1');
             if (defined('TESTSUITE')) {
                 return true;

--- a/libraries/plugins/auth/AuthenticationConfig.class.php
+++ b/libraries/plugins/auth/AuthenticationConfig.class.php
@@ -27,6 +27,16 @@ class AuthenticationConfig extends AuthenticationPlugin
      */
     public function auth()
     {
+        $response = PMA_Response::getInstance();
+        if ($response->isAjax()) {
+            $response->isSuccess(false);
+            $response->addJSON('redirect_flag', '1');
+            if (defined('TESTSUITE')) {
+                return true;
+            } else {
+                exit;
+            }
+        }
         return true;
     }
 
@@ -37,6 +47,9 @@ class AuthenticationConfig extends AuthenticationPlugin
      */
     public function authCheck()
     {
+        if ($GLOBALS['token_provided'] && $GLOBALS['token_mismatch']) {
+            return false;
+        }
         return true;
     }
 

--- a/libraries/plugins/auth/AuthenticationCookie.class.php
+++ b/libraries/plugins/auth/AuthenticationCookie.class.php
@@ -62,6 +62,7 @@ class AuthenticationCookie extends AuthenticationPlugin
         $response = PMA_Response::getInstance();
         if ($response->isAjax()) {
             $response->isSuccess(false);
+            // redirect_flag redirects to the loging page
             $response->addJSON('redirect_flag', '1');
             if (defined('TESTSUITE')) {
                 return true;

--- a/libraries/plugins/auth/AuthenticationCookie.class.php
+++ b/libraries/plugins/auth/AuthenticationCookie.class.php
@@ -62,11 +62,7 @@ class AuthenticationCookie extends AuthenticationPlugin
         $response = PMA_Response::getInstance();
         if ($response->isAjax()) {
             $response->isSuccess(false);
-
-            $response->addJSON(
-                'redirect_flag',
-                '1'
-            );
+            $response->addJSON('redirect_flag', '1');
             if (defined('TESTSUITE')) {
                 return true;
             } else {

--- a/libraries/plugins/auth/AuthenticationHttp.class.php
+++ b/libraries/plugins/auth/AuthenticationHttp.class.php
@@ -35,7 +35,7 @@ class AuthenticationHttp extends AuthenticationPlugin
         $response = PMA_Response::getInstance();
         if ($response->isAjax()) {
             $response->isSuccess(false);
-            $response->addJSON('redirect_flag', '1');
+            $response->addJSON('reload_flag', '1');
             if (defined('TESTSUITE')) {
                 return true;
             } else {

--- a/libraries/plugins/auth/AuthenticationHttp.class.php
+++ b/libraries/plugins/auth/AuthenticationHttp.class.php
@@ -35,6 +35,7 @@ class AuthenticationHttp extends AuthenticationPlugin
         $response = PMA_Response::getInstance();
         if ($response->isAjax()) {
             $response->isSuccess(false);
+            // reload_flag removes the token parameter from the URL and reload
             $response->addJSON('reload_flag', '1');
             if (defined('TESTSUITE')) {
                 return true;

--- a/libraries/plugins/auth/AuthenticationHttp.class.php
+++ b/libraries/plugins/auth/AuthenticationHttp.class.php
@@ -32,6 +32,17 @@ class AuthenticationHttp extends AuthenticationPlugin
      */
     public function auth()
     {
+        $response = PMA_Response::getInstance();
+        if ($response->isAjax()) {
+            $response->isSuccess(false);
+            $response->addJSON('redirect_flag', '1');
+            if (defined('TESTSUITE')) {
+                return true;
+            } else {
+                exit;
+            }
+        }
+
         /* Perform logout to custom URL */
         if (! empty($_REQUEST['old_usr'])
             && ! empty($GLOBALS['cfg']['Server']['LogoutURL'])
@@ -114,6 +125,10 @@ class AuthenticationHttp extends AuthenticationPlugin
     public function authCheck()
     {
         global $PHP_AUTH_USER, $PHP_AUTH_PW;
+
+        if ($GLOBALS['token_provided'] && $GLOBALS['token_mismatch']) {
+            return false;
+        }
 
         // Grabs the $PHP_AUTH_USER variable whatever are the values of the
         // 'register_globals' and the 'variables_order' directives

--- a/test/classes/plugin/auth/PMA_AuthenticationConfig_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationConfig_test.php
@@ -35,6 +35,8 @@ class PMA_AuthenticationConfig_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['PMA_Config'] = new PMA_Config();
         $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['server'] = 0;
+        $GLOBALS['token_provided'] = true;
+        $GLOBALS['token_mismatch'] = false;
         $this->object = new AuthenticationConfig();
     }
 

--- a/test/classes/plugin/auth/PMA_AuthenticationHttp_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationHttp_test.php
@@ -44,6 +44,8 @@ class PMA_AuthenticationHttp_Test extends PHPUnit_Framework_TestCase
             "en" => array("English", "US-ENGLISH"),
             "ch" => array("Chinese", "TW-Chinese")
         );
+        $GLOBALS['token_provided'] = true;
+        $GLOBALS['token_mismatch'] = false;
         $this->object = new AuthenticationHttp();
     }
 


### PR DESCRIPTION
I'm trying to use a mechanism similar to the one used by cookie authentication as a workaround to the token mismatch problem. Please see whether there are any security implications.
