### PR TITLE
Fix #4593 Manual SELECT doesn't change active table

### DIFF
--- a/import.php
+++ b/import.php
@@ -695,19 +695,24 @@ if (isset($my_die)) {
 }
 
 if ($go_sql) {
+
     // parse sql query
     include_once 'libraries/parse_analyze.inc.php';
 
-    if (isset($ajax_reload) && $ajax_reload['reload'] === true) {
-        $response = PMA_Response::getInstance();
-        $response->addJSON('ajax_reload', $ajax_reload);
-    }
     PMA_executeQueryAndSendQueryResponse(
         $analyzed_sql_results, false, $db, $table, null, $import_text, null,
         $analyzed_sql_results['is_affected'], null,
         null, null, $sql_data, $goto, $pmaThemeImage, null, null, null, $sql_query,
         null, null
     );
+
+    if (!isset($ajax_reload)) {
+        $ajax_reload = array();
+    }
+    $ajax_reload['table_name'] = $table;
+
+    $response = PMA_Response::getInstance();
+    $response->addJSON('ajax_reload', $ajax_reload);
 } else if ($result) {
     // Save a Bookmark with more than one queries (if Bookmark label given).
     if (! empty($_POST['bkm_label']) && ! empty($import_text)) {

--- a/js/sql.js
+++ b/js/sql.js
@@ -335,6 +335,13 @@ AJAX.registerOnload('sql.js', function () {
                 }
                 PMA_highlightSQL($('#result_query'));
 
+                if (data._menu) {
+                    AJAX.cache.menus.replace(data._menu);
+                    AJAX.cache.menus.add(data._menuHash, data._menu);
+                } else if (data._menuHash) {
+                    AJAX.cache.menus.replace(AJAX.cache.menus.get(data._menuHash));
+                }
+
                 if (typeof data.ajax_reload != 'undefined') {
                     if (data.ajax_reload.reload) {
                         if (data.ajax_reload.table_name) {

--- a/js/sql.js
+++ b/js/sql.js
@@ -342,6 +342,10 @@ AJAX.registerOnload('sql.js', function () {
                     AJAX.cache.menus.replace(AJAX.cache.menus.get(data._menuHash));
                 }
 
+                if (data._params) {
+                    PMA_commonParams.setAll(data._params);
+                }
+
                 if (typeof data.ajax_reload != 'undefined') {
                     if (data.ajax_reload.reload) {
                         if (data.ajax_reload.table_name) {

--- a/libraries/Menu.class.php
+++ b/libraries/Menu.class.php
@@ -608,6 +608,19 @@ class PMA_Menu
         }
         return $tabs;
     }
+
+    /**
+     * Set current table
+     *
+     * @param string $table Current table
+     *
+     * @return $this
+     */
+    public function setTable($table)
+    {
+        $this->_table = $table;
+        return $this;
+    }
 }
 
 ?>

--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -1518,6 +1518,9 @@ function PMA_countQueryResults(
 function PMA_executeTheQuery($analyzed_sql_results, $full_sql_query, $is_gotofile,
     $db, $table, $find_real_end, $sql_query_for_bookmark, $extra_data
 ) {
+    $response = PMA_Response::getInstance();
+    $response->getHeader()->getMenu()->setTable($table);
+
     // Only if we ask to see the php code
     if (isset($GLOBALS['show_as_php'])) {
         $result = null;

--- a/test/classes/PMA_Menu_test.php
+++ b/test/classes/PMA_Menu_test.php
@@ -124,10 +124,10 @@ class PMA_Menu_Test extends PHPUnit_Framework_TestCase
      */
     function testSetTable()
     {
-        $menu = new PMA_Menu('pma_testServer', 'pma_test', 'table1');
-        $menu->setTable('pma_tbl');
+        $menu = new PMA_Menu('server', 'pma_test', '');
+        $menu->setTable('table1');
         $this->assertContains(
-            'pma_tbl',
+            'table1',
             $menu->getDisplay()
         );
     }

--- a/test/classes/PMA_Menu_test.php
+++ b/test/classes/PMA_Menu_test.php
@@ -115,4 +115,20 @@ class PMA_Menu_Test extends PHPUnit_Framework_TestCase
         );
         $menu->display();
     }
+
+
+    /**
+     * Table menu setTable test
+     *
+     * @return void
+     */
+    function testSetTable()
+    {
+        $menu = new PMA_Menu('pma_testServer', 'pma_testDb', 'pma_testTable');
+        $menu->setTable('pma_testOtherTable');
+        $this->assertContains(
+            'pma_testOtherTable',
+            $menu->getDisplay()
+        );
+    }
 }

--- a/test/classes/PMA_Menu_test.php
+++ b/test/classes/PMA_Menu_test.php
@@ -124,10 +124,10 @@ class PMA_Menu_Test extends PHPUnit_Framework_TestCase
      */
     function testSetTable()
     {
-        $menu = new PMA_Menu('pma_testServer', 'pma_testDb', 'pma_testTable');
-        $menu->setTable('pma_testOtherTable');
+        $menu = new PMA_Menu('pma_testServer', 'pma_test', 'table1');
+        $menu->setTable('table2');
         $this->assertContains(
-            'pma_testOtherTable',
+            'table2',
             $menu->getDisplay()
         );
     }

--- a/test/classes/PMA_Menu_test.php
+++ b/test/classes/PMA_Menu_test.php
@@ -125,9 +125,9 @@ class PMA_Menu_Test extends PHPUnit_Framework_TestCase
     function testSetTable()
     {
         $menu = new PMA_Menu('pma_testServer', 'pma_test', 'table1');
-        $menu->setTable('table2');
+        $menu->setTable('pma_tbl');
         $this->assertContains(
-            'table2',
+            'pma_tbl',
             $menu->getDisplay()
         );
     }


### PR DESCRIPTION
This should fix both issues reported in ticket:
- update breadcrumb while editing inline a query
- update breadcrumb and navigation tree while editing a query in SQL tab

Does anyone experence a JS error while editing inline a query? I get a new one since my last add, but I don't understand why…

Thanks.
