### PR TITLE
Fixed typo in variable name $curl_handle

### DIFF
--- a/libraries/error_report.lib.php
+++ b/libraries/error_report.lib.php
@@ -210,7 +210,7 @@ function PMA_sendErrorReport($report)
     }
 
     $curl_handle = curl_init(SUBMISSION_URL);
-    if ($curl_hadle === false) {
+    if ($curl_handle === false) {
         return null;
     }
     $curl_handle = PMA_Util::configureCurl($curl_handle);


### PR DESCRIPTION
With this small typo curl cannot be used for error reporting
Signed-Off-By: Tekin Birdüzen t.birduezen@web-coding.eu
