### PR TITLE
bug #4642 phpmyadmin often fails to load due to specific load order

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ phpMyAdmin - ChangeLog
 - bug #3794 failure to handle repeating empty columns when importing ODS
 - bug #4638 Default Export Method setting broken
 - bug #4639 Export SQL missing indentation first field
+- bug #4642 phpmyadmin often fails to load due to specific load order
 
 4.3.1.0 (2014-12-08)
 - bug #4609 'Show all' checkbox label is not clickable

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -359,7 +359,7 @@ var AJAX = {
                     $('#selflink > a').attr('href', data._selflink);
                 }
                 if (data._scripts) {
-                    AJAX.scriptHandler.load(data._scripts, data._params.token);
+                    AJAX.scriptHandler.load(data._scripts);
                 }
                 if (data._selflink && data._scripts && data._menuHash && data._params) {
                     AJAX.cache.add(
@@ -501,7 +501,7 @@ var AJAX = {
          *
          * @return void
          */
-        load: function (files, token) {
+        load: function (files) {
             var self = this;
             self._scriptsToBeLoaded = [];
             self._scriptsToBeFired = [];
@@ -523,7 +523,6 @@ var AJAX = {
                     request.push("scripts[]=" + script);
                 }
             }
-            request.push("token=" + token);
             request.push("call_done=1");
             // Download the composite js file, if necessary
             if (needRequest) {
@@ -734,7 +733,7 @@ AJAX.cache = {
                 $('#selflink').html(record.selflink);
                 AJAX.cache.menus.replace(AJAX.cache.menus.get(record.menu));
                 PMA_commonParams.setAll(record.params);
-                AJAX.scriptHandler.load(record.scripts, record.params ? record.params.token : PMA_commonParams.get('token'));
+                AJAX.scriptHandler.load(record.scripts);
                 AJAX.cache.current = ++index;
             });
         }

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -556,6 +556,7 @@ var AJAX = {
             var script = document.createElement('script');
             script.type = 'text/javascript';
             script.src = url;
+            script.async = false;
             head.appendChild(script);
         },
         /**

--- a/libraries/Scripts.class.php
+++ b/libraries/Scripts.class.php
@@ -82,9 +82,7 @@ class PMA_Scripts
             }
         }
         $separator = PMA_URL_getArgSeparator();
-        $url = 'js/get_scripts.js.php'
-            . PMA_URL_getCommon(array(), 'none')
-            . $separator . implode($separator, $scripts);
+        $url = 'js/get_scripts.js.php?' . implode($separator, $scripts);
 
         $static_scripts = sprintf(
             '<script type="text/javascript" src="%s"></script>',

--- a/test/classes/PMA_Scripts_test.php
+++ b/test/classes/PMA_Scripts_test.php
@@ -78,8 +78,8 @@ class PMA_Scripts_Test extends PHPUnit_Framework_TestCase
     public function testIncludeFile()
     {
         $this->assertEquals(
-            '<script type="text/javascript" src="js/get_scripts.js.php?lang=en'
-            . '&amp;token=token&amp;scripts[]=common.js"></script>',
+            '<script type="text/javascript" src="js/get_scripts.js.php?'
+            . 'scripts[]=common.js"></script>',
             $this->_callPrivateFunction(
                 '_includeFiles',
                 array(
@@ -107,8 +107,8 @@ class PMA_Scripts_Test extends PHPUnit_Framework_TestCase
         $this->object->addEvent('onClick', 'doSomething');
 
         $this->assertRegExp(
-            '@<script type="text/javascript" src="js/get_scripts.js.php\\?lang=en'
-            . '&amp;token=token&amp;scripts\\[\\]=common.js"></script><script type="text/'
+            '@<script type="text/javascript" src="js/get_scripts.js.php\\?'
+            . 'scripts\\[\\]=common.js"></script><script type="text/'
             . 'javascript">// <!\\[CDATA\\[' . "\n"
             . 'AJAX.scriptHandler.add\\("common.js",1\\);' . "\n"
             . '\\$\\(function\\(\\) \\{AJAX.fireOnload\\("common.js"\\);\\}\\);'


### PR DESCRIPTION
From what I read, modern browsers consider dynamically added script tags as 'async', which probably causes the issue described in the bug report. 
I'd like have someone else look at this before merging, since I am not very familiar with script loading.
