### PR TITLE
Fix #4648 Missing borders

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ phpMyAdmin - ChangeLog
 4.3.3.0 (not yet released)
 - bug       The "Recently used tables" setting should be with Nav panel
 - bug #4647 Can't disable Favorites
+- bug #4648 Missing borders
 
 4.3.2.0 (2014-12-12)
 - bug #4628 PHP error while exporting schema as PDF

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -401,8 +401,11 @@ table {
     border-collapse: collapse;
 }
 
-th {
+thead th {
     border-right: 1px solid #fff;
+}
+
+th {
     text-align: left;
 }
 


### PR DESCRIPTION
Remove borders on &lt;th&gt; out of &lt;thead&gt;.
Warning: these borders were visible in many tables, so they all disappear. 
