### PR TITLE
Set cursor at end in console while navigating with up/down key

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -582,6 +582,9 @@ var PMA_consoleInput = {
             if (queryString !== false) {
                 PMA_consoleInput._historyCount = nextCount;
                 PMA_consoleInput.setText(queryString, 'console');
+                if (PMA_consoleInput._codemirror) {
+                    editor.setCursor(editor.lineCount(), 0);
+                }
                 event.preventDefault();
             }
         }


### PR DESCRIPTION
When using CodeMirror in console, set cursor at end while navigating in history with up/down key.

If CodeMirror is not used, textarea automatically sets cursor at end.
