### PR TITLE
Bug fix for Server-Process refresh rate

### DIFF
--- a/js/server_status_processes.js
+++ b/js/server_status_processes.js
@@ -152,6 +152,7 @@ AJAX.registerOnload('server_status_processes.js', function() {
     // Bind event handler for change in refresh rate
     $('#id_refreshRate').on('change', function(event) {
         processList.refreshInterval = $(this).val();
+        processList.refresh();
     });
     // Bind event handler for table header links
     $('#tableprocesslist').on('click', 'thead a', function() {


### PR DESCRIPTION
Server Status refresh not behaving as expected.

To reproduce the bug follow these steps:
1. Go to Server->Status->Processes
2. Start the auto refresh feature
3. Set the refresh rate to 20 min
4. Change the refresh rate to 2 sec

We expect the refresh to happen after 2 sec of change in refresh rate but it wait for a refresh to happen in 20 min and only then it refreshes for every 2 sec.
