### PR TITLE
fix bug #4720 (problem with missing php-mbstring warning)

### DIFF
--- a/libraries/php-gettext/gettext.inc
+++ b/libraries/php-gettext/gettext.inc
@@ -174,10 +174,15 @@ function _get_codeset($domain=null) {
  * Convert the given string to the encoding set by bind_textdomain_codeset.
  */
 function _encode($text) {
-    $source_encoding = mb_detect_encoding($text);
-    $target_encoding = _get_codeset();
-    if ($source_encoding != $target_encoding) {
-        return mb_convert_encoding($text, $target_encoding, $source_encoding);
+    if (function_exists('mb_detect_encoding')) {
+        $source_encoding = mb_detect_encoding($text);
+        $target_encoding = _get_codeset();
+        if ($source_encoding != $target_encoding) {
+            return mb_convert_encoding($text, $target_encoding, $source_encoding);
+        }
+        else {
+            return $text;
+        }
     }
     else {
         return $text;


### PR DESCRIPTION
When php-mbstring extension is not available, phpMyAdmin exits without any error message.
As reported in the bug, this error is caused as PMA_warnMissingExtension() for fatal errors uses _encode function in gettext.inc which in turn uses mb_detect_encoding to detect the encoding of the text in error message.

So basically, error reporting machanism uses mbstring functions, hence system stops aburptly without any message to user, when error is about mbstring itself being not installed.

A quick fix for the above problem where we check if mbstring exists when calling mb_sdetect_encoding in gettext.inc _encode() function.

This meakes sure that user atleast sees some message. Tested on PHP 5.6
https://sourceforge.net/p/phpmyadmin/bugs/4720/

Signed-off-by: Rohit Mulange rohit@rohit.codes
