### PR TITLE
fix bug #4720 (problem with missing php-mbstring warning)

### DIFF
--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -239,7 +239,13 @@ function PMA_fatalError(
         }
 
         // these variables are used in the included file libraries/error.inc.php
-        $error_header = __('Error');
+        //first check if php-mbstring is available
+        if (function_exists('mb_detect_encoding')) {
+            //If present use gettext
+            $error_header = __('Error');
+        } else {
+            $error_header = 'Error';
+        }
         $lang = $GLOBALS['available_languages'][$GLOBALS['lang']][1];
         $dir = $GLOBALS['text_dir'];
 


### PR DESCRIPTION
When php-mbstring extension is not available, phpMyAdmin exits without any error message.
As reported in the bug, this error is caused as PMA_warnMissingExtension() for fatal errors uses _encode function in gettext.inc which in turn uses mb_detect_encoding to detect the encoding of the text in error message.
Based on suggestions, PMA_fatalError function checks for mbsring before using gettext
refer to: https://github.com/phpmyadmin/phpmyadmin/pull/1465
https://sourceforge.net/p/phpmyadmin/bugs/4720/
Signed-off-by: Rohit Mulange rohit@rohit.codes
