### PR TITLE
Send server id to import.php in SQL console

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -206,6 +206,7 @@ var PMA_console = {
             return;
         }
         PMA_console.$requestForm.children('textarea').val(queryString);
+        PMA_console.$requestForm.children('[name=server]').attr('value', PMA_commonParams.get('server'));
         if(options && options.db) {
             PMA_console.$requestForm.children('[name=db]').val(options.db);
             if(options.table) {


### PR DESCRIPTION
Include server id in ajax post request, when sending the SQL from the ajax
request from SQL console.

We run phpMyAdmin with multiple database hosts and the Console runs into to following error:

 PHP Fatal error:  Call to a member function getTables() on a non-object in [...]/phpMyAdmin-4.3.8-all-languages/libraries/relation.lib.php on line 1890

This patch solves our problem
