### PR TITLE
Sanity Check for table name : Feature request #723

### DIFF
--- a/libraries/create_addfield.lib.php
+++ b/libraries/create_addfield.lib.php
@@ -261,7 +261,7 @@ function PMA_getTableCreationQuery($db, $table)
 
     // Builds the 'create table' statement
     $sql_query = 'CREATE TABLE ' . PMA_Util::backquote($db) . '.'
-        . PMA_Util::backquote($table) . ' (' . $sql_statement . ')';
+        . PMA_Util::backquote(trim($table)) . ' (' . $sql_statement . ')';
 
     // Adds table type, character set, comments and partition definition
     if (!empty($_REQUEST['tbl_storage_engine'])

--- a/tbl_structure.php
+++ b/tbl_structure.php
@@ -45,23 +45,32 @@ if (isset($_REQUEST['reserved_word_check'])) {
     $response = PMA_Response::getInstance();
     if ($GLOBALS['cfg']['ReservedWordDisableWarning'] === false) {
         $columns_names = $_REQUEST['field_name'];
-        $reserved_keywords_columns = array();
+        $reserved_keywords_names = array();
+        $reserved_keywords_fields = array();
         foreach ($columns_names as $column) {
-            if (PMA_SQP_isKeyWord($column)) {
-                $reserved_keywords_columns[] = $column;
+            if (PMA_SQP_isKeyWord(trim($column))) {
+                $reserved_keywords_names[] = trim($column);
             }
         }
-        if (count($reserved_keywords_columns) == 0) {
+        if (count($reserved_keywords_names) > 0) {
+            $reserved_keywords_fields[] = 'Column';
+        }
+        if (PMA_SQP_isKeyWord(trim($table))) {
+            $reserved_keywords_fields[] = 'Table';
+            $reserved_keywords_names[] = trim($table);
+        }
+        if (count($reserved_keywords_names) == 0) {
             $response->isSuccess(false);
         }
         $response->addJSON(
             'message', sprintf(
                 _ngettext(
-                    'The column name \'%s\' is a MySQL reserved keyword.',
-                    'The column names \'%s\' are MySQL reserved keywords.',
-                    count($reserved_keywords_columns)
+                    'The %s name \'%s\' is a MySQL reserved keyword.',
+                    'The %s names \'%s\' are MySQL reserved keywords.',
+                    count($reserved_keywords_names)
                 ),
-                implode(',', $reserved_keywords_columns)
+                implode(' and ', $reserved_keywords_fields),
+                implode(',', $reserved_keywords_names)
             )
         );
     } else {


### PR DESCRIPTION
A new variable '$reserved_keywords_fields' comprising of either column or table name is declared and a previous function which was used for checking column name for being a reserved word is used for the table name and accordingly warning message is shown.
Also table name is trimmed before creation.

Signed-off-by: RAKESH KUMAR rakeshkumar4294@gmail.com
