### PR TITLE
enum editor and pick from central column dialogues were going out of screen

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -3080,6 +3080,7 @@ AJAX.registerOnload('functions.js', function () {
         }
         $enum_editor_dialog = $(dialog).dialog({
             minWidth: width,
+            maxHeight: 450,
             modal: true,
             title: PMA_messages.enum_editor,
             buttons: buttonOptions,
@@ -3186,6 +3187,7 @@ AJAX.registerOnload('functions.js', function () {
         var buttonOptions = {};
         var $central_columns_dialog = $(central_columns_dialog).dialog({
             minWidth: width,
+            maxHeight: 450,
             modal: true,
             title: PMA_messages.pickColumnTitle,
             buttons: buttonOptions,


### PR DESCRIPTION
If there are lots of columns in central list, the "pick from central column" dialogue on table creation page going out of screen. Same for enum editor. 
Its working fine on QA_4_3. Git bisect on master says "Update jquery-ui to version 1.11.2" is first bad commit. 
I have set the maxHeight attribute for both the dialogues. Please let me know if there is a better way to fix this issue.
Signed-off-by: Smita Kumari kumarismita62@gmail.com
