### PR TITLE
fix bug #4772 and other similar issues

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -2932,14 +2932,14 @@ function autoPopulate(input_id, offset)
     $('#'+input_id+'5').val(central_column_list[db+'_'+table][offset].col_collation);
     $('#'+input_id+'6').val(central_column_list[db+'_'+table][offset].col_extra);
     if(central_column_list[db+'_'+table][offset].col_extra.toUpperCase() === 'AUTO_INCREMENT') {
-        $('#'+input_id+'9').attr("checked","checked").change();
+        $('#'+input_id+'9').prop("checked",true).change();
     } else {
-        $('#'+input_id+'9').removeAttr("checked");
+        $('#'+input_id+'9').prop("checked",false);
     }
     if(central_column_list[db+'_'+table][offset].col_isNull !== '0') {
-        $('#'+input_id+'7').attr("checked","checked");
+        $('#'+input_id+'7').prop("checked",true);
     } else {
-        $('#'+input_id+'7').removeAttr("checked");
+        $('#'+input_id+'7').prop("checked",false);
     }
 }
 

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -2120,8 +2120,8 @@ function PMA_getHtmlForActionsInTableStructure($type, $tbl_storage_engine,
         $html_output .= '<li class="browse nowrap">';
         if ($isInCentralColumns) {
             $html_output .=
-                '<a href="#" onclick=$("input:checkbox").removeAttr("checked");'
-                . '$("#checkbox_row_' . $rownum . '").attr("checked","checked");'
+                '<a href="#" onclick=$("input:checkbox").prop("checked",false);'
+                . '$("#checkbox_row_' . $rownum . '").prop("checked",true);'
                 . '$("button[value=remove_from_central_columns]").click();>'
             . PMA_Util::getIcon(
                 'centralColumns_delete.png',
@@ -2130,8 +2130,8 @@ function PMA_getHtmlForActionsInTableStructure($type, $tbl_storage_engine,
             . '</a>';
         } else {
             $html_output .=
-                '<a href="#" onclick=$("input:checkbox").removeAttr("checked");'
-                . '$("#checkbox_row_' . $rownum . '").attr("checked","checked");'
+                '<a href="#" onclick=$("input:checkbox").prop("checked",false);'
+                . '$("#checkbox_row_' . $rownum . '").prop("checked",true);'
                 . '$("button[value=add_to_central_columns]").click();>'
             . PMA_Util::getIcon(
                 'centralColumns_add.png',


### PR DESCRIPTION
Git bisect tells the problem started from the commit where we updated jquery to version 1.11.1. 
And it seems in jQuery v 1.11.1 have some issues with checkboxes when used with ".attr". see the link , https://github.com/travist/jquery.treeselect.js/issues/9. 
So when we use ".prop" in place of ".attr", it works. I have replced all such ".attr" which i could find.

Signed-off-by: Smita Kumari kumarismita62@gmail.com
