### PR TITLE
Fix bug #4753 | Added a 6px margin to Textarea fields

### DIFF
--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -324,10 +324,12 @@ input.button:disabled {
 
 textarea {
     overflow: visible;
+    margin: 6px;
     height: <?php echo ceil($GLOBALS['cfg']['TextareaRows'] * 1.2); ?>em;
 }
 
 textarea.char {
+    margin: 6px;
     height: <?php echo ceil($GLOBALS['cfg']['CharTextareaRows'] * 1.2); ?>em;
 }
 


### PR DESCRIPTION
Added a 6px margin to Textarea fields to bring them inline with other input elements in insert row form.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
