### PR TITLE
Add a tool tip explaining the Lock symbol | Feat Req 1607

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -165,7 +165,7 @@ var AJAX = {
         // Show lock icon if locked targets is not empty.
         // otherwise remove lock icon
         if (!jQuery.isEmptyObject(AJAX.lockedTargets)) {
-            $('#lock_page_icon').html(PMA_getImage('s_lock.png').toString());
+            $('#lock_page_icon').html(PMA_getImage('s_lock.png',PMA_messages.strLockToolTip).toString());
         } else {
             $('#lock_page_icon').html('');
         }

--- a/js/messages.php
+++ b/js/messages.php
@@ -398,6 +398,12 @@ $js_messages['strYes'] = __('Yes');
 $js_messages['strCopyEncryptionKey'] = __('Do you want to copy encryption key?');
 $js_messages['strEncryptionKey'] = __('Encryption key');
 
+/* For Lock symbol Tooltip */
+$js_messages['strLockToolTip'] = __(
+    'Indicates that you have made changes to this page;'
+    . ' you will be prompted for confirmation before abandoning changes'
+);
+
 /* Designer (js/pmd/move.js) */
 $js_messages['strSelectReferencedKey'] = __('Select referenced key');
 $js_messages['strSelectForeignKey'] = __('Select Foreign Key');


### PR DESCRIPTION
Add a tool tip to explain the lock symbol appearing in the top right corner while you have made some un-saved changes to a page like inserting data or sql query.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
