### PR TITLE
Feature Request:#1608 Allowing signed/unsigned attribute central column

### DIFF
--- a/db_central_columns.php
+++ b/db_central_columns.php
@@ -19,20 +19,24 @@ if (isset($_POST['edit_save']) || isset($_POST['add_new_column'])) {
         $orig_col_name = $_POST['orig_col_name'];
     }
     $col_default = $_POST['col_default'];
+    if ($col_default == 'NONE' && $_POST['col_default_sel'] != 'USER_DEFINED') {
+        $col_default = "";
+    }
     $col_extra = $_POST['col_extra'];
     $col_isNull = isset($_POST['col_isNull'])?1:0;
     $col_length = $_POST['col_length'];
+    $col_attribute = $_POST['col_attribute'];
     $col_type = $_POST['col_type'];
     $collation = $_POST['collation'];
     if (isset($orig_col_name) && $orig_col_name) {
         echo PMA_updateOneColumn(
-            $db, $orig_col_name, $col_name, $col_type,
+            $db, $orig_col_name, $col_name, $col_type,$col_attribute,
             $col_length, $col_isNull, $collation, $col_extra, $col_default
         );
         exit;
     } else {
         $tmp_msg = PMA_updateOneColumn(
-            $db, "", $col_name, $col_type,
+            $db, "", $col_name, $col_type,$col_attribute,
             $col_length, $col_isNull, $collation, $col_extra, $col_default
         );
     }
@@ -113,6 +117,17 @@ $result = PMA_getColumnsList($db, $pos, $max_rows);
 $odd_row = false;
 $row_num=0;
 foreach ($result as $row) {
+    if (is_object(json_decode($row['col_extra']))) {
+        //Decode the json data of col_extra to col_extra and col_attribute
+        $row['col_extra'] = json_decode($row['col_extra'], true);
+    } else {
+        //it is not json string [FOR the case to handle previous inserted value]
+        //like extra column having only increment value,then to deal with it
+        $row['col_extra'] = array(
+            "col_extra" => $row['col_extra'],
+            "col_attribute" => ""
+        );
+    }
     $tableHtmlRow = PMA_getHTMLforCentralColumnsTableRow(
         $row, $odd_row, $row_num, $db
     );

--- a/js/db_central_columns.js
+++ b/js/db_central_columns.js
@@ -54,7 +54,7 @@ AJAX.registerOnload('db_central_columns.js', function () {
         });
     window.scrollTo(0, 0);
     $(document).on("keyup", ".filter_rows", function () {
-        var cols = ["Name", "Type", "Length/Values", "Collation", "Null", "Extra", "Default"];
+        var cols = ["Name", "Type", "Attribute","Length/Values", "Collation", "Null", "Extra", "Default"];
         $.uiTableFilter($("#table_columns"), $(this).val(), cols, null, "td span");
     });
     $('.edit').click(function() {
@@ -64,6 +64,8 @@ AJAX.registerOnload('db_central_columns.js', function () {
         $('#f_' + rownum + ' td span').hide();
         $('#f_' + rownum + ' input, #f_' + rownum + ' select, #f_' + rownum + ' .open_enum_editor').show();
         var extra_val = $('#f_' + rownum + ' td[name=col_extra] span').html();
+        var attribute_val = $('#f_' + rownum + ' td[name=col_attribute] span').html();
+        $('#f_' + rownum + ' select[name=field_attribute\\['+ rownum +'\\] ] option[value="' + attribute_val + '"]').attr("selected","selected");
         $('#f_' + rownum + ' select[name=col_extra] option[value="' + extra_val + '"]').attr("selected","selected");
         if($('#f_' + rownum + ' .default_type').val() === 'USER_DEFINED') {
             $('#f_' + rownum + ' .default_type').siblings('.default_value').show();
@@ -128,6 +130,7 @@ AJAX.registerOnload('db_central_columns.js', function () {
                     $('#f_' + rownum + ' td[name=col_type] span').text($('#f_' + rownum + ' select[name=col_type]').val()).html();
                     $('#f_' + rownum + ' td[name=col_length] span').text($('#f_' + rownum + ' input[name=col_length]').val()).html();
                     $('#f_' + rownum + ' td[name=collation] span').text($('#f_' + rownum + ' select[name=collation]').val()).html();
+                    $('#f_' + rownum + ' td[name=col_attribute] span').text($('#f_' + rownum + ' select[name=col_attribute]').val()).html();
                     $('#f_' + rownum + ' td[name=col_isNull] span').text($('#f_' + rownum + ' input[name=col_isNull]').val()).html();
                     $('#f_' + rownum + ' td[name=col_extra] span').text($('#f_' + rownum + ' select[name=col_extra]').val()).html();
                     $('#f_' + rownum + ' td[name=col_default] span').text($('#f_' + rownum + ' :input[name=col_default]').val()).html();

--- a/js/functions.js
+++ b/js/functions.js
@@ -2934,8 +2934,11 @@ function autoPopulate(input_id, offset)
         $('#'+input_id+'4').next().next().hide();
     }
     $('#'+input_id+'5').val(central_column_list[db+'_'+table][offset].col_collation);
-    $('#'+input_id+'6').val(central_column_list[db+'_'+table][offset].col_extra);
-    if(central_column_list[db+'_'+table][offset].col_extra.toUpperCase() === 'AUTO_INCREMENT') {
+    $('#'+input_id+'6').val(central_column_list[db+'_'+table][offset].extra.col_attribute);
+    if(central_column_list[db+'_'+table][offset].extra.col_extra === 'on update CURRENT_TIMESTAMP') {
+        $('#'+input_id+'6').val(central_column_list[db+'_'+table][offset].extra.col_extra);
+    }
+    if(central_column_list[db+'_'+table][offset].extra.col_extra.toUpperCase() === 'AUTO_INCREMENT') {
         $('#'+input_id+'9').prop("checked",true).change();
     } else {
         $('#'+input_id+'9').prop("checked",false);
@@ -3148,13 +3151,26 @@ AJAX.registerOnload('functions.js', function () {
         var list_size = central_column_list[db + '_' + table].length;
         var min = (list_size <= maxRows) ? list_size : maxRows;
         for (i = 0; i < min; i++) {
+            try {
+                central_column_list[db + '_' + table][i].extra = $.parseJSON(central_column_list[db + '_' + table][i].col_extra);
+            } catch (error) {
+                //it is not json encoded so make it [FOR the case to handle previous inserted values]
+                //like extra column having only increment value,then to deal with it
+                central_column_list[db + '_' + table][i].col_extra = '{"col_extra":"'+central_column_list[db + '_' + table][i].col_extra+'","col_attribute":""}';
+                central_column_list[db + '_' + table][i].extra = $.parseJSON(central_column_list[db + '_' + table][i].col_extra);
+            }
+
             fields += '<tr><td><div><span style="font-size:14px; font-weight:bold">' +
                 escapeHtml(central_column_list[db + '_' + table][i].col_name) +
                 '</span><br><span style="color:gray">' + central_column_list[db + '_' + table][i].col_type;
+
+            if (central_column_list[db + '_' + table][i].extra.col_attribute !== '') {
+                fields += '(' + escapeHtml(central_column_list[db + '_' + table][i].extra.col_attribute) + ') ';
+            }
             if (central_column_list[db + '_' + table][i].col_length !== '') {
                 fields += '(' + escapeHtml(central_column_list[db + '_' + table][i].col_length) +') ';
             }
-            fields += escapeHtml(central_column_list[db + '_' + table][i].col_extra) + '</span>' +
+            fields += escapeHtml(central_column_list[db + '_' + table][i].extra.col_extra) + '</span>' +
                 '</div></td>';
             if (pick) {
                 fields += '<td><input class="pick" style="width:100%" type="submit" value="' +
@@ -3206,14 +3222,25 @@ AJAX.registerOnload('functions.js', function () {
                     fields = '';
                     min = (list_size <= maxRows + result_pointer) ? list_size : maxRows + result_pointer;
                     for (i = result_pointer; i < min; i++) {
+                        try {
+                            central_column_list[db + '_' + table][i].extra = $.parseJSON(central_column_list[db + '_' + table][i].col_extra);
+                        } catch (error) {
+                            central_column_list[db + '_' + table][i].col_extra = '{"col_extra":"'+central_column_list[db + '_' + table][i].col_extra+'","col_attribute":""}';
+                            central_column_list[db + '_' + table][i].extra = $.parseJSON(central_column_list[db + '_' + table][i].col_extra);
+                        }
+
                         fields += '<tr><td><div><span style="font-size:14px; font-weight:bold">' +
                             central_column_list[db + '_' + table][i].col_name +
                             '</span><br><span style="color:gray">' +
                             central_column_list[db + '_' + table][i].col_type;
+
+                        if (central_column_list[db + '_' + table][i].extra.col_attribute !== '') {
+                            fields += '(' + central_column_list[db + '_' + table][i].extra.col_attribute + ') ';
+                        }
                         if (central_column_list[db + '_' + table][i].col_length !== '') {
                             fields += '(' + central_column_list[db + '_' + table][i].col_length + ') ';
                         }
-                        fields += central_column_list[db + '_' + table][i].col_extra + '</span>' +
+                        fields += central_column_list[db + '_' + table][i].extra.col_extra + '</span>' +
                             '</div></td>';
                         if (pick) {
                             fields += '<td><input class="pick" style="width:100%" type="submit" value="' +

--- a/test/libraries/PMA_central_columns_test.php
+++ b/test/libraries/PMA_central_columns_test.php
@@ -271,12 +271,12 @@ class PMA_Central_Columns_Test extends PHPUnit_Framework_TestCase
     {
         $this->assertTrue(
             PMA_updateOneColumn(
-                "phpmyadmin", "", "", "", "", "", "", "", ""
+                "phpmyadmin", "", "", "", "","", "", "", "", ""
             )
         );
         $this->assertTrue(
             PMA_updateOneColumn(
-                "phpmyadmin", "col1", "", "", "", "", "", "", ""
+                "phpmyadmin", "col1", "", "", "","", "", "", "", ""
             )
         );
     }
@@ -352,7 +352,7 @@ class PMA_Central_Columns_Test extends PHPUnit_Framework_TestCase
             'col_length'=>12,
             'col_collation'=>'utf8_general_ci',
             'col_isNull'=>1,
-            'col_extra'=>''
+            'col_extra'=>array('col_extra'=>'','col_attribute'=>'')
         );
         $result = PMA_getHTMLforCentralColumnsTableRow($row, false, 1, 'phpmyadmin');
         $this->assertTag(
@@ -371,7 +371,7 @@ class PMA_Central_Columns_Test extends PHPUnit_Framework_TestCase
         );
         $this->assertContains(
             PMA_getHtmlForColumnDefault(
-                1, 5, 0, /*overload*/mb_strtoupper($row['col_type']), '',
+                1, 6, 0, /*overload*/mb_strtoupper($row['col_type']), '',
                 array('DefaultType'=>'NONE')
             ),
             $result
@@ -382,7 +382,7 @@ class PMA_Central_Columns_Test extends PHPUnit_Framework_TestCase
         );
         $this->assertContains(
             PMA_getHtmlForColumnDefault(
-                1, 5, 0, /*overload*/mb_strtoupper($row['col_type']), '',
+                1, 6, 0, /*overload*/mb_strtoupper($row['col_type']), '',
                 array('DefaultType'=>'USER_DEFINED', 'DefaultValue'=>100)
             ),
             $result_1
@@ -393,7 +393,7 @@ class PMA_Central_Columns_Test extends PHPUnit_Framework_TestCase
         );
         $this->assertContains(
             PMA_getHtmlForColumnDefault(
-                1, 5, 0, /*overload*/mb_strtoupper($row['col_type']), '',
+                1, 6, 0, /*overload*/mb_strtoupper($row['col_type']), '',
                 array('DefaultType'=>'CURRENT_TIMESTAMP')
             ),
             $result_2


### PR DESCRIPTION
The 'attribute' and 'extra' is stored in col_extra column in json_encoded form.During fetching of columns if col_extra is a json string then it is decoded and resulting array is stored in same variable as col_extra and col_attribute.Similarly it is done in javascript.
But If col_extra is not a json string (to make compatible with old column values) then simply col_attribute is assigned null string and remaining are done in similar way.
Signed-off-by: Rakesh Kumar rakeshkumar4294@gmail.com
