### PR TITLE
Remove unneeded closing tags

### DIFF
--- a/browse_foreigners.php
+++ b/browse_foreigners.php
@@ -58,4 +58,3 @@ $html = PMA_getHtmlForRelationalFieldSelection(
 );
 
 $response->addHtml($html);
-?>

--- a/chk_rel.php
+++ b/chk_rel.php
@@ -23,5 +23,3 @@ $response = PMA_Response::getInstance();
 $response->addHTML(
     PMA_getRelationsParamDiagnostic($cfgRelation)
 );
-
-?>

--- a/db_central_columns.php
+++ b/db_central_columns.php
@@ -142,4 +142,3 @@ $message = PMA_Message::success(
 if (isset($tmp_msg) && $tmp_msg !== true) {
     $message = $tmp_msg;
 }
-?>

--- a/db_create.php
+++ b/db_create.php
@@ -138,4 +138,3 @@ if (! $result) {
         include_once '' . $cfg['DefaultTabDatabase'];
     }
 }
-?>

--- a/db_datadict.php
+++ b/db_datadict.php
@@ -204,5 +204,3 @@ foreach ($tables as $table) {
  * Displays the footer
  */
 echo PMA_Util::getButton();
-
-?>

--- a/db_designer.php
+++ b/db_designer.php
@@ -170,4 +170,3 @@ if (isset($_REQUEST['query'])) {
 }
 
 $response->addHTML(PMA_getCacheImages());
-?>

--- a/db_events.php
+++ b/db_events.php
@@ -22,5 +22,3 @@ require_once 'libraries/rte/rte_events.lib.php';
  */
 $_PMA_RTE = 'EVN';
 require_once 'libraries/rte/rte_main.inc.php';
-
-?>

--- a/db_export.php
+++ b/db_export.php
@@ -90,5 +90,3 @@ $multi_values .= '</select></div>';
 
 $export_type = 'database';
 require_once 'libraries/display_export.inc.php';
-
-?>

--- a/db_import.php
+++ b/db_import.php
@@ -21,5 +21,3 @@ require 'libraries/db_info.inc.php';
 
 $import_type = 'database';
 require 'libraries/display_import.inc.php';
-
-?>

--- a/db_operations.php
+++ b/db_operations.php
@@ -287,5 +287,3 @@ if ($cfgRelation['pdfwork'] && $num_tables > 0) {
         PMA_DatabaseInterface::QUERY_STORE
     );
 } // end if
-
-?>

--- a/db_printview.php
+++ b/db_printview.php
@@ -172,4 +172,3 @@ if ($num_tables == 0) {
 echo PMA_Util::getButton();
 
 echo "<div id='PMA_disable_floating_menubar'></div>\n";
-?>

--- a/db_qbe.php
+++ b/db_qbe.php
@@ -130,4 +130,3 @@ if ($cfgRelation['pdfwork']) {
 }
 
 $response->addHTML($db_qbe->getSelectionForm());
-?>

--- a/db_routines.php
+++ b/db_routines.php
@@ -23,5 +23,3 @@ require_once 'libraries/rte/rte_routines.lib.php';
  */
 $_PMA_RTE = 'RTN';
 require_once 'libraries/rte/rte_main.inc.php';
-
-?>

--- a/db_search.php
+++ b/db_search.php
@@ -60,4 +60,3 @@ $response->addHTML(
 );
 $response->addHTML($db_search->getSelectionForm());
 $response->addHTML($db_search->getResultDivs());
-?>

--- a/db_sql.php
+++ b/db_sql.php
@@ -41,5 +41,3 @@ $response->addHTML(
         : ';'
     )
 );
-
-?>

--- a/db_structure.php
+++ b/db_structure.php
@@ -341,5 +341,3 @@ $response->addHTML(
 );
 
 PMA_possiblyShowCreateTableDialog($db, $db_is_system_schema, $response);
-
-?>

--- a/db_tracking.php
+++ b/db_tracking.php
@@ -346,5 +346,3 @@ if (count($data['ddlog']) > 0) {
     }
     echo PMA_Util::getMessage(__('Database Log'), $log);
 }
-
-?>

--- a/db_triggers.php
+++ b/db_triggers.php
@@ -21,5 +21,3 @@ require_once 'libraries/rte/rte_triggers.lib.php';
  */
 $_PMA_RTE = 'TRI';
 require_once 'libraries/rte/rte_main.inc.php';
-
-?>

--- a/error_report.php
+++ b/error_report.php
@@ -127,4 +127,3 @@ if (isset($_REQUEST['send_error_report'])
         $GLOBALS['error_handler']->savePreviousErrors();
     }
 }
-?>

--- a/export.php
+++ b/export.php
@@ -477,4 +477,3 @@ if (!defined('TESTSUITE')) {
         echo PMA_getHtmlForDisplayedExportFooter($back_button);
     } // end if
 }
-?>

--- a/file_echo.php
+++ b/file_echo.php
@@ -78,4 +78,3 @@ if (isset($_REQUEST['filename']) && isset($_REQUEST['image'])) {
     }
     echo file_get_contents($_FILES['file']['tmp_name']);
 }
-?>

--- a/gis_data_editor.php
+++ b/gis_data_editor.php
@@ -426,4 +426,3 @@ echo '</form>';
 
 PMA_Response::getInstance()->addJSON('gis_editor', ob_get_contents());
 ob_end_clean();
-?>

--- a/import.php
+++ b/import.php
@@ -759,4 +759,3 @@ if ($go_sql) {
 if (isset($_REQUEST['rollback_query'])) {
     $GLOBALS['dbi']->query('ROLLBACK');
 }
-?>

--- a/import_status.php
+++ b/import_status.php
@@ -100,4 +100,3 @@ if (isset($_GET["message"]) && $_GET["message"]) {
 } else {
     PMA_importAjaxStatus($_GET["id"]);
 }
-?>

--- a/index.php
+++ b/index.php
@@ -698,4 +698,3 @@ function PMA_printListItem($name, $listId = null, $url = null,
     }
     echo '</li>';
 }
-?>

--- a/license.php
+++ b/license.php
@@ -27,5 +27,3 @@ if (is_readable($filename)) {
 } else {
     printf(__('The %s file is not available on this system, please visit www.phpmyadmin.net for more information.'), $filename);
 }
-
-?>

--- a/navigation.php
+++ b/navigation.php
@@ -68,4 +68,3 @@ if (isset($cfgRelation['navwork']) && $cfgRelation['navwork']) {
 
 // Do the magic
 $response->addJSON('message', $navigation->getDisplay());
-?>

--- a/phpinfo.php
+++ b/phpinfo.php
@@ -18,4 +18,3 @@ PMA_Response::getInstance()->disable();
 if ($GLOBALS['cfg']['ShowPhpInfo']) {
     phpinfo();
 }
-?>

--- a/phpmyadmin.css.php
+++ b/phpmyadmin.css.php
@@ -29,4 +29,3 @@ header('Content-Type: text/css; charset=UTF-8');
 header('Expires: ' . gmdate('D, d M Y H:i:s', time() + 3600) . ' GMT');
 
 $_SESSION['PMA_Theme_Manager']->printCss();
-?>

--- a/prefs_forms.php
+++ b/prefs_forms.php
@@ -89,4 +89,3 @@ if ($form_display->hasErrors()) {
     <?php
 }
 $form_display->display(true, true);
-?>

--- a/schema_export.php
+++ b/schema_export.php
@@ -74,4 +74,3 @@ function PMA_processExportSchema($export_type)
     $GLOBALS['dbi']->selectDb($GLOBALS['db']);
     $export_plugin->exportSchema($GLOBALS['db']);
 }
-?>

--- a/server_binlog.php
+++ b/server_binlog.php
@@ -50,5 +50,3 @@ $response->addHTML(PMA_getLogSelector($binary_logs, $url_params));
 $response->addHTML(PMA_getLogInfo($url_params));
 
 exit;
-
-?>

--- a/server_collations.php
+++ b/server_collations.php
@@ -35,5 +35,3 @@ $response->addHTML(
         $mysql_collations_available
     )
 );
-
-?>

--- a/server_databases.php
+++ b/server_databases.php
@@ -114,5 +114,3 @@ if ($databases_count > 0) {
 unset($databases_count);
 
 $response->addHTML($html);
-
-?>

--- a/server_engines.php
+++ b/server_engines.php
@@ -30,5 +30,3 @@ $response->addHTML(PMA_getHtmlForSubPageHeader('engines'));
 $response->addHTML(PMA_getHtmlForServerEngines());
 
 exit;
-
-?>

--- a/server_export.php
+++ b/server_export.php
@@ -25,5 +25,3 @@ $multi_values  = PMA_getHtmlForExportSelectOptions($select_item);
 
 $export_type = 'server';
 require_once 'libraries/display_export.inc.php';
-
-?>

--- a/server_import.php
+++ b/server_import.php
@@ -23,5 +23,3 @@ require 'libraries/server_common.inc.php';
 
 $import_type = 'server';
 require 'libraries/display_import.inc.php';
-
-?>

--- a/server_plugins.php
+++ b/server_plugins.php
@@ -55,5 +55,3 @@ $response->addHTML(PMA_getHtmlForSubPageHeader('plugins'));
 $response->addHTML(PMA_getPluginAndModuleInfo($plugins, $modules));
 
 exit;
-
-?>

--- a/server_privileges.php
+++ b/server_privileges.php
@@ -406,5 +406,3 @@ if ((isset($_REQUEST['viewing_mode']) && $_REQUEST['viewing_mode'] == 'server')
 ) {
     $response->addHTML('</div>');
 }
-
-?>

--- a/server_replication.php
+++ b/server_replication.php
@@ -80,4 +80,3 @@ if (! isset($_REQUEST['repl_clear_scr'])) {
 if (isset($_REQUEST['sl_configure'])) {
     $response->addHTML(PMA_getHtmlForReplicationChangeMaster("slave_changemaster"));
 }
-?>

--- a/server_sql.php
+++ b/server_sql.php
@@ -28,5 +28,3 @@ require_once 'libraries/sql_query_form.lib.php';
  * Query box, bookmark, insert data from textfile
  */
 $response->addHTML(PMA_getHtmlForSqlQueryForm());
-
-?>

--- a/server_status.php
+++ b/server_status.php
@@ -35,4 +35,3 @@ $response->addHTML(PMA_getHtmlForServerStatus($ServerStatusData));
 $response->addHTML('</div>');
 
 exit;
-?>

--- a/server_status_advisor.php
+++ b/server_status_advisor.php
@@ -35,5 +35,3 @@ $response->addHTML(PMA_getHtmlForAdvisor());
 $response->addHTML('</div>');
 
 exit;
-
-?>

--- a/server_status_monitor.php
+++ b/server_status_monitor.php
@@ -109,5 +109,3 @@ $response->addHTML(PMA_getHtmlForMonitor($ServerStatusData));
 $response->addHTML(PMA_getHtmlForClientSideDataAndLinks($ServerStatusData));
 $response->addHTML('</div>');
 exit;
-
-?>

--- a/server_status_processes.php
+++ b/server_status_processes.php
@@ -61,4 +61,3 @@ if ($response->isAjax() && !empty($_REQUEST['kill'])) {
     $response->addHTML('</div>');
 }
 exit;
-?>

--- a/server_status_queries.php
+++ b/server_status_queries.php
@@ -50,5 +50,3 @@ $response->addHTML($ServerStatusData->getMenuHtml());
 $response->addHTML(PMA_getHtmlForQueryStatistics($ServerStatusData));
 $response->addHTML('</div>');
 exit;
-
-?>

--- a/server_status_variables.php
+++ b/server_status_variables.php
@@ -53,5 +53,3 @@ $response->addHTML(PMA_getHtmlForVariablesList($ServerStatusData));
 $response->addHTML('</div>');
 
 exit;
-
-?>

--- a/server_user_groups.php
+++ b/server_user_groups.php
@@ -69,4 +69,3 @@ if (isset($_REQUEST['addUserGroup'])) {
 }
 
 $response->addHTML('</div>');
-?>

--- a/server_variables.php
+++ b/server_variables.php
@@ -56,5 +56,3 @@ $response->addHtml(PMA_getHtmlForLinkTemplates());
 $response->addHtml(PMA_getHtmlForServerVariables($variable_doc_links));
 
 exit;
-
-?>

--- a/show_config_errors.php
+++ b/show_config_errors.php
@@ -37,4 +37,3 @@ error_reporting(E_ALL);
 if (is_readable(CONFIG_FILE)) {
     include CONFIG_FILE;
 }
-?>

--- a/sql.php
+++ b/sql.php
@@ -199,5 +199,3 @@ PMA_executeQueryAndSendQueryResponse(
     isset($selected) ? $selected : null,
     isset($complete_query) ? $complete_query : null
 );
-
-?>

--- a/tbl_addfield.php
+++ b/tbl_addfield.php
@@ -121,4 +121,3 @@ if ($abort == false) {
     $action = 'tbl_addfield.php';
     include_once 'libraries/tbl_columns_definition_form.inc.php';
 }
-?>

--- a/tbl_change.php
+++ b/tbl_change.php
@@ -229,4 +229,3 @@ if ($insert_mode) {
 }
 
 $response->addHTML($html_output);
-?>

--- a/tbl_chart.php
+++ b/tbl_chart.php
@@ -139,4 +139,3 @@ $htmlString = PMA_getHtmlForTableChartDisplay(
 );
 
 $response->addHTML($htmlString);
-?>

--- a/tbl_create.php
+++ b/tbl_create.php
@@ -104,5 +104,3 @@ $GLOBAL['table'] = '';
  * Displays the form used to define the structure of the table
  */
 require 'libraries/tbl_columns_definition_form.inc.php';
-
-?>

--- a/tbl_export.php
+++ b/tbl_export.php
@@ -104,4 +104,3 @@ if (! empty($sql_query)) {
 
 $export_type = 'table';
 require_once 'libraries/display_export.inc.php';
-?>

--- a/tbl_find_replace.php
+++ b/tbl_find_replace.php
@@ -62,5 +62,3 @@ $err_url = $goto . '?' . PMA_URL_getCommon($params);
 // Displays the find and replace form
 $htmlOutput .= $table_search->getSelectionForm($goto);
 $response->addHTML($htmlOutput);
-
-?>

--- a/tbl_get_field.php
+++ b/tbl_get_field.php
@@ -52,4 +52,3 @@ PMA_downloadHeader(
     /*overload*/mb_strlen($result)
 );
 echo $result;
-?>

--- a/tbl_gis_visualization.php
+++ b/tbl_gis_visualization.php
@@ -111,5 +111,3 @@ $html = PMA_getHtmlForGisVisualization(
 );
 
 $response->addHTML($html);
-
-?>

--- a/tbl_import.php
+++ b/tbl_import.php
@@ -26,5 +26,3 @@ require_once 'libraries/tbl_info.inc.php';
 
 $import_type = 'table';
 require_once 'libraries/display_import.inc.php';
-
-?>

--- a/tbl_indexes.php
+++ b/tbl_indexes.php
@@ -57,4 +57,3 @@ $response->addHTML($html);
 $header   = $response->getHeader();
 $scripts  = $header->getScripts();
 $scripts->addFile('indexes.js');
-?>

--- a/tbl_operations.php
+++ b/tbl_operations.php
@@ -419,5 +419,3 @@ if ($cfgRelation['relwork'] && ! $is_innodb) {
 } // end  if (!empty($cfg['Server']['relation']))
 
 $response->addHTML('</div>');
-
-?>

--- a/tbl_printview.php
+++ b/tbl_printview.php
@@ -71,4 +71,3 @@ $response->addHTML(
 $response->addHTML(PMA_getHtmlForPrintViewFooter());
 
 exit;
-?>

--- a/tbl_recent_favorite.php
+++ b/tbl_recent_favorite.php
@@ -16,4 +16,3 @@ PMA_RecentFavoriteTable::getInstance('favorite')
     ->removeIfInvalid($_REQUEST['db'], $_REQUEST['table']);
 
 require 'sql.php';
-?>

--- a/tbl_relation.php
+++ b/tbl_relation.php
@@ -153,4 +153,3 @@ if (PMA_Util::isForeignKeySupported($tbl_storage_engine)) {
 $response->addHTML($html_output);
 
 $response->addHTML('</div>');
-?>

--- a/tbl_replace.php
+++ b/tbl_replace.php
@@ -464,5 +464,3 @@ if (isset($_REQUEST['after_insert']) && 'new_insert' == $_REQUEST['after_insert'
  */
 require '' . PMA_securePath($goto_include);
 exit;
-
-?>

--- a/tbl_row_action.php
+++ b/tbl_row_action.php
@@ -143,4 +143,3 @@ if (!empty($submit_mult)) {
         );
     }
 }
-?>

--- a/tbl_select.php
+++ b/tbl_select.php
@@ -78,4 +78,3 @@ if (! isset($_POST['columnsToDisplay']) && ! isset($_POST['displayAllColumns']))
         null, null, $sql_query, null, null
     );
 }
-?>

--- a/tbl_sql.php
+++ b/tbl_sql.php
@@ -48,5 +48,3 @@ $response->addHTML(
         : ';'
     )
 );
-
-?>

--- a/tbl_structure.php
+++ b/tbl_structure.php
@@ -207,4 +207,3 @@ $hidden_titles = PMA_getHiddenTitlesArray();
 require_once 'libraries/display_structure.inc.php';
 
 $response->addHTML('</div>');
-?>

--- a/tbl_tracking.php
+++ b/tbl_tracking.php
@@ -205,5 +205,3 @@ $html .= '<br class="clearfloat"/>';
 
 $response = PMA_Response::getInstance();
 $response->addHTML($html);
-
-?>

--- a/tbl_triggers.php
+++ b/tbl_triggers.php
@@ -7,4 +7,3 @@
  */
 
 require_once './db_triggers.php';
-?>

--- a/tbl_zoom_select.php
+++ b/tbl_zoom_select.php
@@ -161,4 +161,3 @@ if (isset($_POST['zoom_submit'])
     //Displays form for point data and scatter plot
     $response->addHTML($table_search->getZoomResultsForm($goto, $data));
 }
-?>

--- a/themes.php
+++ b/themes.php
@@ -28,5 +28,3 @@ $output .= '</p>';
 $output .= $_SESSION['PMA_Theme_Manager']->getPrintPreviews();
 
 $response->addHTML($output);
-
-?>

--- a/transformation_wrapper.php
+++ b/transformation_wrapper.php
@@ -145,4 +145,3 @@ if (! isset($_REQUEST['resize'])) {
     ImageDestroy($srcImage);
     ImageDestroy($destImage);
 }
-?>

--- a/url.php
+++ b/url.php
@@ -35,4 +35,3 @@ if (! PMA_isValid($_GET['url'])
     printf(__('Taking you to %s.'), htmlspecialchars($_GET['url']));
 }
 die();
-?>

--- a/user_password.php
+++ b/user_password.php
@@ -197,4 +197,3 @@ function PMA_changePassDisplayPage($message, $sql_query)
         . '<strong>' . __('Back') . '</strong></a>';
     exit;
 }
-?>

--- a/version_check.php
+++ b/version_check.php
@@ -26,5 +26,3 @@ if (empty($version)) {
         )
     );
 }
-
-?>

--- a/view_create.php
+++ b/view_create.php
@@ -288,4 +288,3 @@ $htmlString .= '</form>'
     . '</div>';
 
 echo $htmlString;
-?>

--- a/webapp.php
+++ b/webapp.php
@@ -52,4 +52,3 @@ $zip->setDoWrite();
 $zip->addFile($ini_file, 'webapp.ini');
 $zip->addFile(file_get_contents($icon), 'phpMyAdmin.ico');
 $zip->file();
-?>


### PR DESCRIPTION
Closing tags at the end of file are not mandatory. It is often suggested to omit to closing tags at the end of file to prevent unwanted effects as PHP will start output buffering if there is any character after closing tag.

Also all the changed files are pure PHP.

Reference: http://php.net/manual/en/language.basic-syntax.phptags.php
