### PR TITLE
RFE #1570, part 2 (2). Added the possibility of permanently using Enter instead of Ctrl+Enter in console.

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -144,6 +144,17 @@ Basic settings
     set, and the :config:option:`$cfg['UserprefsDisallow']` directive should
     contain ``'SendErrorReports'`` in one of its array values.
 
+.. config:option:: $cfg['ConsoleEnterExecutes']
+
+    :type: boolean
+    :default: false
+
+    Setting this to ``true`` allows the user to execute queries by pressing Enter
+    instead of Ctrl+Enter. A new line can be inserted by pressing Shift + Enter.
+
+    The behaviour of the console can be temporary changed using console's
+    settings interface.
+
 .. config:option:: $cfg['AllowThirdPartyFraming']
 
     :type: boolean

--- a/js/console.js
+++ b/js/console.js
@@ -107,7 +107,7 @@ var PMA_console = {
                 if(tempConfig.currentQuery === true) {
                     $('#pma_console_options input[name=current_query]').prop('checked', true);
                 }
-                if(tempConfig.enterExecutes === true) {
+                if(ConsoleEnterExecutes === true) {
                     $('#pma_console_options input[name=enter_executes]').prop('checked', true);
                 }
             } else {

--- a/libraries/Console.class.php
+++ b/libraries/Console.class.php
@@ -314,7 +314,8 @@ class PMA_Console
                     .  '<label><input type="checkbox" name="current_query">'
                     .  __('Show current browsing query') . '</label><br>'
                     .  '<label><input type="checkbox" name="enter_executes">'
-                    .  __('Execute queries on ENTER and insert new line with SHIFT + ENTER.') . '</label><br>'
+                    .  __('Execute queries on Enter and insert new line with Shift + Enter. '
+                    .     'To make this permanent, view settings.') . '</label><br>'
                     .  '</div>';
             $output .= '</div>'; // Options card
 

--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -397,6 +397,8 @@ class PMA_Header
                     $this->_scripts->addFile('codemirror/addon/hint/show-hint.js');
                     $this->_scripts->addFile('codemirror/addon/hint/sql-hint.js');
                 }
+                $this->_scripts->addCode('ConsoleEnterExecutes='
+                    . ($GLOBALS['cfg']['ConsoleEnterExecutes'] ? 'true' : 'false'));
                 if ($this->_userprefsOfferImport) {
                     $this->_scripts->addFile('config.js');
                 }

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -2959,6 +2959,13 @@ $cfg['DisableMultiTableMaintenance'] = false;
 $cfg['SendErrorReports'] = 'ask';
 
 /**
+ * Whether Enter or Ctrl+Enter executes queries in the console.
+ *
+ * @global boolean $cfg['ConsoleEnterExecutes']
+ */
+$cfg['ConsoleEnterExecutes'] = false;
+
+/**
  * Zero Configuration mode.
  *
  * @global boolean $cfg['ZeroConf']

--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -807,6 +807,10 @@ $strConfigCaptchaLoginPrivateKey_name = __('Private key for reCaptcha');
 
 $strConfigSendErrorReports_desc = __('Choose the default action when sending error reports.');
 $strConfigSendErrorReports_name = __('Send error reports');
+
+$strConfigConsoleEnterExecutes_desc = __('Queries are executed by pressing Enter (instead of Ctrl+Enter). New lines will be inserted with Shift+Enter');
+$strConfigConsoleEnterExecutes_name = __('Enter executes queries in console');
+
 $strConfigZeroConf_desc = __(
     'Enable Zero Configuration mode which lets you setup phpMyAdmin '
     . 'configuration storage tables automatically.'

--- a/libraries/config/user_preferences.forms.php
+++ b/libraries/config/user_preferences.forms.php
@@ -34,7 +34,8 @@ $forms['Features']['General'] = array(
     'MaxTableList',
     'NumFavoriteTables',
     'ShowHint',
-    'SendErrorReports'
+    'SendErrorReports',
+    'ConsoleEnterExecutes'
 );
 $forms['Features']['Text_fields'] = array(
     'CharEditing',


### PR DESCRIPTION
RFE [#1570](https://sourceforge.net/p/phpmyadmin/feature-requests/1570/), part 2 (2). Added the possibility of permanently using Enter instead of Ctrl+Enter in console.
https://sourceforge.net/p/phpmyadmin/feature-requests/1570/

Signed-off-by: Dan Ungureanu udan1107@gmail.com
