### PR TITLE
BUG #4791. Zoom search: JavaScript error

### DIFF
--- a/js/tbl_zoom_plot_jqplot.js
+++ b/js/tbl_zoom_plot_jqplot.js
@@ -142,7 +142,12 @@ AJAX.registerOnload('tbl_zoom_plot_jqplot.js', function () {
 
 
     // Get query result
-    var searchedData = jQuery.parseJSON($('#querydata').html());
+    var searchedData;
+    try {
+        searchedData = jQuery.parseJSON($('#querydata').html());
+    } catch (err) {
+        searchedData = null;
+    }
 
     /**
      ** Input form submit on field change

--- a/tbl_zoom_select.php
+++ b/tbl_zoom_select.php
@@ -30,6 +30,7 @@ $scripts->addFile('jqplot/plugins/jqplot.cursor.js');
 $scripts->addFile('canvg/canvg.js');
 $scripts->addFile('jquery/jquery-ui-timepicker-addon.js');
 $scripts->addFile('tbl_zoom_plot_jqplot.js');
+$scripts->addFile('tbl_change.js');
 
 $table_search = new PMA_TableSearch($db, $table, "zoom");
 


### PR DESCRIPTION
BUG [#4791](https://sourceforge.net/p/phpmyadmin/bugs/4791/). Zoom search: JavaScript error
https://sourceforge.net/p/phpmyadmin/bugs/4791/

Signed-off-by: Dan Ungureanu udan1107@gmail.com

In commit 80f4bb9, the jQuery version was updated from version 1.8.3 to 1.11.1 which introduced the issue. 

> Prior to jQuery 1.9, `$.parseJSON` returned `null` instead of throwing an error if it was passed an empty string, `null`, or `undefined`, even though those are not valid JSON.

Also, a script was not included (`tbl_change.js`) which was required (there was a ReferenceError because of missing `changeValueFieldType`).
