### PR TITLE
BUG #4725. Added integrity check for navigation tree.

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -474,7 +474,8 @@ $(function () {
         ) {
             navTreeStateUpdate();
         } else if (PMA_commonParams.get('server') === storage.server &&
-            PMA_commonParams.get('token') === storage.token
+            PMA_commonParams.get('token') === storage.token &&
+            $('#pma_navigation_tree_hash').html() === storage.navHash
         ) {
             // Restore the tree from storage
             $('#pma_navigation_tree_content').html(storage.navTree);
@@ -504,6 +505,7 @@ function navTreeStateUpdate() {
         // content to be stored exceeds storage capacity
         try {
             storage.setItem('navTree', $('#pma_navigation_tree_content').html());
+            storage.setItem('navHash', $('#pma_navigation_tree_hash').html());
             storage.setItem('navSelect', $('#pma_navigation_db_select').html());
             storage.setItem('server', PMA_commonParams.get('server'));
             storage.setItem('token', PMA_commonParams.get('token'));
@@ -512,6 +514,7 @@ function navTreeStateUpdate() {
             // storage capacity exceeded & old navigation tree
             // state is no more valid, so remove it
             storage.removeItem('navTree');
+            storage.removeItem('navHash');
             storage.removeItem('server');
             storage.removeItem('navSelect');
             storage.removeItem('token');

--- a/libraries/navigation/NavigationTree.class.php
+++ b/libraries/navigation/NavigationTree.class.php
@@ -781,20 +781,25 @@ class PMA_NavigationTree
         $retval .= '</ul>';
         $retval .= $this->_getPageSelector($this->_tree);
         $this->groupTree();
-        $retval .= "<div id='pma_navigation_tree_content'><ul>";
+        $retval .= "<div id='pma_navigation_tree_content'>";
+        $treeContent = "<ul>";
         $children = $this->_tree->children;
         usort($children, array('PMA_NavigationTree', 'sortNode'));
         $this->_setVisibility();
         for ($i=0, $nbChildren = count($children); $i < $nbChildren; $i++) {
             if ($i == 0) {
-                $retval .= $this->_renderNode($children[0], true, 'first');
+                $treeContent .= $this->_renderNode($children[0], true, 'first');
             } else if ($i + 1 != $nbChildren) {
-                $retval .= $this->_renderNode($children[$i], true);
+                $treeContent .= $this->_renderNode($children[$i], true);
             } else {
-                $retval .= $this->_renderNode($children[$i], true, 'last');
+                $treeContent .= $this->_renderNode($children[$i], true, 'last');
             }
         }
-        $retval .= "</ul></div>";
+        $treeContent .= "</ul>";
+        $retval .= $treeContent;
+        $retval .= "</div>";
+        $retval .= "<div class='hide' id='pma_navigation_tree_hash'>"
+            . md5($treeContent) . "</div>";
         return $retval;
     }
 


### PR DESCRIPTION
BUG [#4725](https://sourceforge.net/p/phpmyadmin/bugs/4725/). Added integrity check for navigation tree.
https://sourceforge.net/p/phpmyadmin/bugs/4725/

Signed-off-by: Dan Ungureanu udan1107@gmail.com

Performs an integrity check on the navigation tree. The hash is computed server side and send along with the navigation tree. When the navigation tree is stored, so is the hash. For each page reload, the two hashes (the one sent by the server and the one stored) are compared and if they don't match, the new tree, sent by the server, is used, else the old tree, from the previous page.

This actually fixes another bug which caused the navigation tree not to update. It can be easily reproduced by following these steps: log in phpMyAdmin; log in another database managing software; create a new database in that other software and reload the phpMyAdmin page; the new database will not show unless you log out and log in again or if you press the little reload icon above the navigation tree.

This patch adds integrity check only for databases.
