### PR TITLE
BUG #4784. Incomplete bookmarks from the SQL tab.

### DIFF
--- a/import.php
+++ b/import.php
@@ -756,7 +756,7 @@ if ($go_sql) {
         $cfgBookmark = PMA_Bookmark_getParams();
         PMA_storeTheQueryAsBookmark(
             $db, $cfgBookmark['user'],
-            $import_text, $_POST['bkm_label'],
+            $_REQUEST['sql_query'], $_POST['bkm_label'],
             isset($_POST['bkm_replace']) ? $_POST['bkm_replace'] : null
         );
     }


### PR DESCRIPTION
BUG [#4784](https://sourceforge.net/p/phpmyadmin/bugs/4784/). Incomplete bookmarks from the SQL tab.
https://sourceforge.net/p/phpmyadmin/bugs/4784/

Signed-off-by: Dan Ungureanu udan1107@gmail.com

Only last ~200 bytes of a query were bookmarked from the SQL tab. This happened because `$import_text` is modified by the call of `PMA_importGetNextChunk(200)` inside `$import_plugin->doImport($sql_data)`.
