### PR TITLE
Dark theme for console & Minor bug fixes in designer

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -110,6 +110,10 @@ var PMA_console = {
                 if(ConsoleEnterExecutes === true) {
                     $('#pma_console_options input[name=enter_executes]').prop('checked', true);
                 }
+                if(tempConfig.darkTheme === true) {
+                    $('#pma_console_options input[name=dark_theme]').prop('checked', true);
+                    $('#pma_console>.content').addClass('console_dark_theme');
+                }
             } else {
                 $('#pma_console_options input[name=current_query]').prop('checked', true);
             }
@@ -168,6 +172,7 @@ var PMA_console = {
                 $('#pma_console_options input[name=start_history]').prop('checked', false);
                 $('#pma_console_options input[name=current_query]').prop('checked', true);
                 $('#pma_console_options input[name=enter_executes]').prop('checked', false);
+                $('#pma_console_options input[name=dark_theme]').prop('checked', false);
                 PMA_console.updateConfig();
             });
 
@@ -395,9 +400,16 @@ var PMA_console = {
             alwaysExpand: $('#pma_console_options input[name=always_expand]').prop('checked'),
             startHistory: $('#pma_console_options input[name=start_history]').prop('checked'),
             currentQuery: $('#pma_console_options input[name=current_query]').prop('checked'),
-            enterExecutes: $('#pma_console_options input[name=enter_executes]').prop('checked')
+            enterExecutes: $('#pma_console_options input[name=enter_executes]').prop('checked'),
+            darkTheme: $('#pma_console_options input[name=dark_theme]').prop('checked')
         };
         $.cookie('pma_console_config', JSON.stringify(PMA_console.config));
+        /*Setting the dark theme of the console*/
+        if(PMA_console.config.darkTheme) {
+            $('#pma_console>.content').addClass('console_dark_theme');
+        } else {
+            $('#pma_console>.content').removeClass('console_dark_theme');
+        }
     },
     isSelect: function (queryString) {
         var reg_exp = /^SELECT\s+/i;

--- a/libraries/Console.class.php
+++ b/libraries/Console.class.php
@@ -316,6 +316,8 @@ class PMA_Console
                     .  '<label><input type="checkbox" name="enter_executes">'
                     .  __('Execute queries on Enter and insert new line with Shift + Enter. '
                     .     'To make this permanent, view settings.') . '</label><br>'
+                    .  '<label><input type="checkbox" name="dark_theme">'
+                    .  __('Switch to dark theme') . '</label><br>'
                     .  '</div>';
             $output .= '</div>'; // Options card
 

--- a/libraries/db_designer.lib.php
+++ b/libraries/db_designer.lib.php
@@ -286,18 +286,18 @@ function PMA_getDesignerPageMenu($visualBuilder, $selected_page)
 
         $html .= '<a href="#" id="savePos" ';
         $html .= 'class="M_butt" target="_self">';
-        $html .= '<img class="' . $iconClass . '" title="' . __('Save position') . '" alt="" ';
+        $html .= '<img class="' . $iconClass . '" title="' . __('Save page') . '" alt="" ';
         $html .= 'src="' . $_SESSION['PMA_Theme']->getImgPath('pmd/save.png')
             . '" />';
-        $html .= '<span class="' . $textClass . '">' . __('Save position') . '</span>';
+        $html .= '<span class="' . $textClass . '">' . __('Save page') . '</span>';
         $html .= '</a>';
 
         $html .= '<a href="#" id="SaveAs" ';
         $html .= 'class="M_butt ajax" target="_self">';
-        $html .= '<img class="' . $iconClass . '" title="' . __('Save positions as') . '" alt="" ';
+        $html .= '<img class="' . $iconClass . '" title="' . __('Save page as') . '" alt="" ';
         $html .= 'src="' . $_SESSION['PMA_Theme']->getImgPath('pmd/save_as.png')
             . '" />';
-        $html .= '<span class="' . $textClass . '">' . __('Save positions as') . '</span>';
+        $html .= '<span class="' . $textClass . '">' . __('Save page as') . '</span>';
         $html .= '</a>';
 
         $html .= '<a href="#" id="delPages" ';

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -3074,6 +3074,26 @@ table.show_create td {
     background: #fff;
     padding-top: .4em;
 }
+#pma_console .content.console_dark_theme {
+    background: #000;
+    color: #fff;
+}
+#pma_console .content.console_dark_theme .CodeMirror-wrap {
+    background: #000;
+    color: #fff;
+}
+#pma_console .content.console_dark_theme .action_content {
+    color: #000;
+}
+#pma_console .content.console_dark_theme .message {
+    border-color: #373B41;
+}
+#pma_console .content.console_dark_theme .CodeMirror-cursor {
+    border-color: #fff;
+}
+#pma_console .content.console_dark_theme .cm-keyword {
+    color: #de935f;
+}
 #pma_console .message,
 #pma_console .query_input {
     position: relative;

--- a/themes/pmahomme/css/pmd.css.php
+++ b/themes/pmahomme/css/pmd.css.php
@@ -351,7 +351,7 @@ a.M_butt:hover {
 }
 
 #layer_menu {
-    z-index: 100;
+    z-index: 98;
     position: relative;
     float: right;
     background-color: #EAEEF0;
@@ -387,6 +387,10 @@ a.M_butt:hover {
 
 #layer_menu_sizer {
     background-image: url(<?php echo $resizeImg; ?>);
+    cursor: ne-resize;
+}
+
+.left #layer_menu_sizer {
     cursor: nw-resize;
 }
 


### PR DESCRIPTION
Generally people like to have their terminal dark. So, to give a more terminal kind of look, added an option of switching to dark theme for the console. This is a minor UI improvement. Some more improvements are needed for console. I am currently working on some of them.

And also minor bugs in designer are fixed:
- Tables List having z-index of 100 which is greater than floating menu bar(99), So, I changed it to 98
- When Tables List is in right side cursor to resize is showing NW instead of NE. Fixed it too
- Supporting http://sourceforge.net/p/phpmyadmin/bugs/4792/ his statement, changed the menu Item to Save Page instead of Save Position.

Feedback appreciated!

Signed-Off-By Harish Kandala kandalaharish95@gmail.com
