### PR TITLE
Bug #4786 SELECT width on relations page

### DIFF
--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -539,7 +539,7 @@ fieldset .formelement {
         width: 25%;
     }
     #foreign_keys.relationalTable td:first-child + td select {
-        width: 32%;
+        width: auto;
         margin-right: 1%;
     }
     #foreign_keys.relationalTable {


### PR DESCRIPTION
When the page width is greater than 1600px, the width of the SELECT tag  is incorrect
