### PR TITLE
Bug #4798 Missing column when exporting in sql 

### DIFF
--- a/libraries/plugins/export/ExportSql.class.php
+++ b/libraries/plugins/export/ExportSql.class.php
@@ -1435,9 +1435,10 @@ class ExportSql extends ExportPlugin
                 // lets find first line with constraints
                 $first_occur = -1;
                 for ($i = 0; $i < $sql_count; $i++) {
+					$sql_line = current(explode(' COMMENT ',$sql_lines[$i],2));
                     if (preg_match(
                         '@[\s]+(CONSTRAINT|KEY)@',
-                        $sql_lines[$i]
+                        $sql_line
                     ) && $first_occur == -1) {
                         $first_occur = $i;
                     }


### PR DESCRIPTION
Export failure when the comments contains reserved keyword (KEY, CONSTRAINT)
To resolve I removed the comment from the current line before checking.

Signed-off-by: Andrea Vallorani andrea.vallorani@gmail.com
