### PR TITLE
Add option for exporting pretty-printed JSON

### DIFF
--- a/export.php
+++ b/export.php
@@ -86,6 +86,7 @@ if (!defined('TESTSUITE')) {
             'ods_structure_or_data',
             'ods_columns',
             'json_structure_or_data',
+            'json_pretty_print',
             'xml_structure_or_data',
             'xml_export_events',
             'xml_export_functions',

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -1802,6 +1802,13 @@ $cfg['Export']['phparray_structure_or_data'] = 'data';
 $cfg['Export']['json_structure_or_data'] = 'data';
 
 /**
+ * Export functions
+ *
+ * @global string $cfg['Export']['json_pretty_print']
+ */
+$cfg['Export']['json_pretty_print'] = false;
+
+/**
  *
  *
  * @global string $cfg['Export']['sql_structure_or_data']

--- a/libraries/plugins/export/ExportJson.class.php
+++ b/libraries/plugins/export/ExportJson.class.php
@@ -41,6 +41,7 @@ class ExportJson extends ExportPlugin
         include_once "$props/options/groups/OptionsPropertyRootGroup.class.php";
         include_once "$props/options/groups/OptionsPropertyMainGroup.class.php";
         include_once "$props/options/items/HiddenPropertyItem.class.php";
+        include_once "$props/options/items/BoolPropertyItem.class.php";
 
         $exportPluginProperties = new ExportPluginProperties();
         $exportPluginProperties->setText('JSON');
@@ -61,6 +62,15 @@ class ExportJson extends ExportPlugin
         $leaf = new HiddenPropertyItem();
         $leaf->setName("structure_or_data");
         $generalOptions->addProperty($leaf);
+        
+        // JSON_PRETTY_PRINT is available since 5.4.0
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            $leaf = new BoolPropertyItem();
+            $leaf->setName('pretty_print');
+            $leaf->setText(__('Output pretty-printed JSON (Use human-readable formatting)'));
+            $generalOptions->addProperty($leaf);
+        }
+        
         // add the main group to the root group
         $exportSpecificOptions->addProperty($generalOptions);
 
@@ -196,8 +206,14 @@ class ExportJson extends ExportPlugin
             for ($i = 0; $i < $columns_cnt; $i++) {
                 $data[$columns[$i]] = $record[$i];
             }
+            
+            if (isset($GLOBALS['json_pretty_print']) && $GLOBALS['json_pretty_print']) {
+                $encoded = json_encode($data, JSON_PRETTY_PRINT);
+            } else {
+                $encoded = json_encode($data);
+            }
 
-            if (! PMA_exportOutputHandler(json_encode($data))) {
+            if (! PMA_exportOutputHandler($encoded)) {
                 return false;
             }
         }

--- a/libraries/plugins/export/ExportJson.class.php
+++ b/libraries/plugins/export/ExportJson.class.php
@@ -62,7 +62,7 @@ class ExportJson extends ExportPlugin
         $leaf = new HiddenPropertyItem();
         $leaf->setName("structure_or_data");
         $generalOptions->addProperty($leaf);
-        
+
         // JSON_PRETTY_PRINT is available since 5.4.0
         if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
             $leaf = new BoolPropertyItem();
@@ -70,7 +70,7 @@ class ExportJson extends ExportPlugin
             $leaf->setText(__('Output pretty-printed JSON (Use human-readable formatting)'));
             $generalOptions->addProperty($leaf);
         }
-        
+
         // add the main group to the root group
         $exportSpecificOptions->addProperty($generalOptions);
 
@@ -206,7 +206,7 @@ class ExportJson extends ExportPlugin
             for ($i = 0; $i < $columns_cnt; $i++) {
                 $data[$columns[$i]] = $record[$i];
             }
-            
+
             if (isset($GLOBALS['json_pretty_print']) && $GLOBALS['json_pretty_print']) {
                 $encoded = json_encode($data, JSON_PRETTY_PRINT);
             } else {


### PR DESCRIPTION
This adds a single option to the JSON export plugin,
which, if available (PHP >= 5.4.0) corresponds to passing
`JSON_PRETTY_PRINT` to `json_encode`.
