### PR TITLE
Dark Theme for Console

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -110,6 +110,10 @@ var PMA_console = {
                 if(ConsoleEnterExecutes === true) {
                     $('#pma_console_options input[name=enter_executes]').prop('checked', true);
                 }
+                if(tempConfig.darkTheme === true) {
+                    $('#pma_console_options input[name=dark_theme]').prop('checked', true);
+                    $('#pma_console>.content').addClass('console_dark_theme');
+                }
             } else {
                 $('#pma_console_options input[name=current_query]').prop('checked', true);
             }
@@ -171,6 +175,7 @@ var PMA_console = {
                 $('#pma_console_options input[name=start_history]').prop('checked', false);
                 $('#pma_console_options input[name=current_query]').prop('checked', true);
                 $('#pma_console_options input[name=enter_executes]').prop('checked', false);
+                $('#pma_console_options input[name=dark_theme]').prop('checked', false);
                 PMA_console.updateConfig();
             });
 
@@ -398,9 +403,16 @@ var PMA_console = {
             alwaysExpand: $('#pma_console_options input[name=always_expand]').prop('checked'),
             startHistory: $('#pma_console_options input[name=start_history]').prop('checked'),
             currentQuery: $('#pma_console_options input[name=current_query]').prop('checked'),
-            enterExecutes: $('#pma_console_options input[name=enter_executes]').prop('checked')
+            enterExecutes: $('#pma_console_options input[name=enter_executes]').prop('checked'),
+            darkTheme: $('#pma_console_options input[name=dark_theme]').prop('checked')
         };
         $.cookie('pma_console_config', JSON.stringify(PMA_console.config));
+        /*Setting the dark theme of the console*/
+        if(PMA_console.config.darkTheme) {
+            $('#pma_console>.content').addClass('console_dark_theme');
+        } else {
+            $('#pma_console>.content').removeClass('console_dark_theme');
+        }
     },
     isSelect: function (queryString) {
         var reg_exp = /^SELECT\s+/i;

--- a/libraries/Console.class.php
+++ b/libraries/Console.class.php
@@ -316,6 +316,8 @@ class PMA_Console
                     .  '<label><input type="checkbox" name="enter_executes">'
                     .  __('Execute queries on Enter and insert new line with Shift + Enter. '
                     .     'To make this permanent, view settings.') . '</label><br>'
+                    .  '<label><input type="checkbox" name="dark_theme">'
+                    .  __('Switch to dark theme') . '</label><br>'
                     .  '</div>';
             $output .= '</div>'; // Options card
 

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -2756,6 +2756,26 @@ table.show_create td {
     background: #fff;
     padding-top: .4em;
 }
+#pma_console .content.console_dark_theme {
+    background: #000;
+    color: #fff;
+}
+#pma_console .content.console_dark_theme .CodeMirror-wrap {
+    background: #000;
+    color: #fff;
+}
+#pma_console .content.console_dark_theme .action_content {
+    color: #000;
+}
+#pma_console .content.console_dark_theme .message {
+    border-color: #373B41;
+}
+#pma_console .content.console_dark_theme .CodeMirror-cursor {
+    border-color: #fff;
+}
+#pma_console .content.console_dark_theme .cm-keyword {
+    color: #de935f;
+}
 #pma_console .message,
 #pma_console .query_input {
     position: relative;

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -3075,6 +3075,26 @@ table.show_create td {
     background: #fff;
     padding-top: .4em;
 }
+#pma_console .content.console_dark_theme {
+    background: #000;
+    color: #fff;
+}
+#pma_console .content.console_dark_theme .CodeMirror-wrap {
+    background: #000;
+    color: #fff;
+}
+#pma_console .content.console_dark_theme .action_content {
+    color: #000;
+}
+#pma_console .content.console_dark_theme .message {
+    border-color: #373B41;
+}
+#pma_console .content.console_dark_theme .CodeMirror-cursor {
+    border-color: #fff;
+}
+#pma_console .content.console_dark_theme .cm-keyword {
+    color: #de935f;
+}
 #pma_console .message,
 #pma_console .query_input {
     position: relative;


### PR DESCRIPTION
Resubmitting #1573 as different pull requests

Generally people like to have their terminal dark. So, to give a more terminal kind of look, added an option of switching to dark theme for the console. This is a minor UI improvement. Some more improvements are needed for console. I am currently working on some of them.

Signed-off-by: harish095 kandalaharish95@gmail.com
