### PR TITLE
Update functions.js

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -3789,7 +3789,7 @@ AJAX.registerOnload('functions.js', function () {
             cache: false,
             type: 'POST',
             data: {
-                favorite_tables: (isStorageSupported('localStorage'))
+                favorite_tables: (isStorageSupported('localStorage') && typeof window.localStorage['favorite_tables'] != 'undefined')
                     ? window.localStorage['favorite_tables']
                     : ''
             },

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -487,7 +487,7 @@ $(function () {
             cache: false,
             type: 'POST',
             data: {
-                favorite_tables: (isStorageSupported('localStorage'))
+                favorite_tables: (isStorageSupported('localStorage') && typeof window.localStorage.favorite_tables != 'undefined')
                     ? window.localStorage.favorite_tables
                     : ''
             },


### PR DESCRIPTION
favorite tables localStorage sync: avoid sending undefined objects or empty strings via ajax

we had problems with a php 5.6.6 CGI/FastCGI suphp setup (internal server errors because of those ajax posts. I have not been able to verify why those errors occured, but a simple jquery ajax call like

$.ajax({cache: false, type: 'POST', data: { '': undefined }})

triggered them and the favorites sync is doing exactly the same when the localStorate is supported but empty

Signed-off-by: Martin Herndl martin.herndl@gmail.com
