### PR TITLE
Bug #4718 simulate query fails

### DIFF
--- a/libraries/import.lib.php
+++ b/libraries/import.lib.php
@@ -1527,11 +1527,11 @@ function PMA_getSimulatedUpdateQuery($analyzed_sql_results)
             else if($term['type'] == 'punct_bracket_close_round'){
                 $in_function--;
             }
-			
+
             if($term['type'] == 'alpha_functionName'){
                 $in_function++;
             }
-			
+
             // Get columns in SET expression.
             if ($prev_term != 'punct') {
                 if ($term['type'] != 'punct_listsep'

--- a/libraries/import.lib.php
+++ b/libraries/import.lib.php
@@ -1517,18 +1517,18 @@ function PMA_getSimulatedUpdateQuery($analyzed_sql_results)
                     $extra_where_clause .= ' OR ';
                 } else if ($term['type'] == 'punct') {
                     $extra_where_clause .= ' <> ';
-                } else if($term['type'] == 'alpha_functionName'){
+                } else if($term['type'] == 'alpha_functionName') {
                     array_pop($extra_where_clause);
                     array_pop($extra_where_clause);
                 } else {
                     $extra_where_clause .= $term['data'];
                 }
             }
-            else if($term['type'] == 'punct_bracket_close_round'){
+            else if($term['type'] == 'punct_bracket_close_round') {
                 $in_function--;
             }
 
-            if($term['type'] == 'alpha_functionName'){
+            if($term['type'] == 'alpha_functionName') {
                 $in_function++;
             }
 
@@ -1563,7 +1563,7 @@ function PMA_getSimulatedUpdateQuery($analyzed_sql_results)
     // Get WHERE clause.
     $where_clause .= $analyzed_sql_results['analyzed_sql'][0]['where_clause'];
     if (empty($where_clause)) {
-        $where_clause = (!empty($extra_where_clause) && $extra_where_clause[0]) ? implode(' ',$extra_where_clause) : 1;
+        $where_clause = (!empty($extra_where_clause) && $extra_where_clause[0]) ? implode(' ',$extra_where_clause) : '1';
     }
 
     $matched_row_query = 'SELECT '

--- a/libraries/import.lib.php
+++ b/libraries/import.lib.php
@@ -1487,11 +1487,12 @@ function PMA_getMatchedRows($analyzed_sql_results = array())
 function PMA_getSimulatedUpdateQuery($analyzed_sql_results)
 {
     $where_clause = '';
-    $extra_where_clause = '';
+    $extra_where_clause = array();
     $target_cols = array();
 
     $prev_term = '';
     $i = 0;
+    $in_function = 0;
     foreach ($analyzed_sql_results['parsed_sql'] as $key => $term) {
         if (! isset($get_set_expr)
             && preg_match(
@@ -1511,19 +1512,33 @@ function PMA_getSimulatedUpdateQuery($analyzed_sql_results)
             ) {
                 break;
             }
-
-            if ($term['type'] == 'punct_listsep') {
-                $extra_where_clause .= ' OR ';
-            } else if ($term['type'] == 'punct') {
-                $extra_where_clause .= ' <> ';
-            } else {
-                $extra_where_clause .= $term['data'];
+            if(!$in_function){
+                if ($term['type'] == 'punct_listsep') {
+                    $extra_where_clause .= ' OR ';
+                } else if ($term['type'] == 'punct') {
+                    $extra_where_clause .= ' <> ';
+                } else if($term['type'] == 'alpha_functionName'){
+                    array_pop($extra_where_clause);
+                    array_pop($extra_where_clause);
+                } else {
+                    $extra_where_clause .= $term['data'];
+                }
             }
-
+            else if($term['type'] == 'punct_bracket_close_round'){
+                $in_function--;
+            }
+			
+            if($term['type'] == 'alpha_functionName'){
+                $in_function++;
+            }
+			
             // Get columns in SET expression.
             if ($prev_term != 'punct') {
                 if ($term['type'] != 'punct_listsep'
                     && $term['type'] != 'punct'
+                    && $term['type'] != 'punct_bracket_open_round'
+                    && $term['type'] != 'punct_bracket_close_round'
+                    && !$in_function
                     && isset($term['data'])
                 ) {
                     if (isset($target_cols[$i])) {
@@ -1547,8 +1562,8 @@ function PMA_getSimulatedUpdateQuery($analyzed_sql_results)
 
     // Get WHERE clause.
     $where_clause .= $analyzed_sql_results['analyzed_sql'][0]['where_clause'];
-    if (empty($where_clause) && empty($extra_where_clause)) {
-        $where_clause = '1';
+    if (empty($where_clause)) {
+        $where_clause = (!empty($extra_where_clause) && $extra_where_clause[0]) ? implode(' ',$extra_where_clause) : 1;
     }
 
     $matched_row_query = 'SELECT '


### PR DESCRIPTION
It is not an elegant solution, but it seems functional.
It avoids all the errors caused by the presence of functions in the query.
The $extra_where_clause variable was valorized but never appended to the WHERE clause. (I think that was a mistake)

Signed-off-by: Andrea Vallorani andrea.vallorani@gmail.com
