### PR TITLE
Mark all option for sub categories while changing privileges

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -4301,6 +4301,35 @@ $(document).on("change", "input.checkall_box", function () {
 });
 
 /**
+ * Watches checkboxes in a sub form to set the sub checkall box accordingly
+ */
+var sub_checkboxes_changed = function () {
+    var $form = $(this).parent().parent();
+    // total number of checkboxes in current sub form
+    var total_boxes = $form.find(checkboxes_sel).length;
+    // number of checkboxes checked in current sub form
+    var checked_boxes = $form.find(checkboxes_sel + ":checked").length;
+    var $checkall = $form.find("input.sub_checkall_box");
+    if (total_boxes == checked_boxes) {
+        $checkall.prop({checked: true, indeterminate: false});
+    }
+    else if (checked_boxes > 0) {
+        $checkall.prop({checked: true, indeterminate: true});
+    }
+    else {
+        $checkall.prop({checked: false, indeterminate: false});
+    }
+};
+$(document).on("change", checkboxes_sel + ", input.checkall_box:checkbox:enabled", sub_checkboxes_changed);
+
+$(document).on("change", "input.sub_checkall_box", function () {
+    var is_checked = $(this).is(":checked");
+    var $form = $(this).parent().parent();
+    $form.find(checkboxes_sel).prop("checked", is_checked)
+    .parents("tr").toggleClass("marked", is_checked);
+});
+
+/**
  * Toggles row colors of a set of 'tr' elements starting from a given element
  *
  * @param $start Starting element

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -1403,7 +1403,13 @@ function PMA_getHtmlForGlobalPrivTableWithCheckboxes(
     $html_output = '';
     foreach ($privTable as $i => $table) {
         $html_output .= '<fieldset>' . "\n"
-            . '<legend>' . $privTable_names[$i] . '</legend>' . "\n";
+            . '<legend>' . "\n"
+            . '<input type="checkbox" class="sub_checkall_box"'
+            . ' id="checkall_' . $privTable_names[$i] . '_priv"'
+            . ' title="' . __('Check All') . '"/>'
+            . '<label for="checkall_' . $privTable_names[$i] . '_priv">'
+            . $privTable_names[$i] . '</label>' . "\n"
+            . '</legend>' . "\n";
         foreach ($table as $priv) {
             $html_output .= '<div class="item">' . "\n"
                 . '<input type="checkbox" class="checkall"'


### PR DESCRIPTION
While setting priviliges there is a check all option but it would be better if there is a check all option for sub categories too. Screenshot below will explain it clearly. Feedback appreciated.

![screenshot 42](https://cloud.githubusercontent.com/assets/9005092/6743410/8338a35e-cebf-11e4-9d04-743da2594f34.png)

Signed-off-by: Harish Kandala kandalaharish95@gmail.com
