### PR TITLE
handling failed ajax request

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -184,6 +184,9 @@ var PMA_console = {
                     PMA_console.ajaxCallback(data);
                 } catch (e) {
                     console.log("Invalid JSON!" + e.message);
+                    PMA_ajaxShowMessage(PMA_messages.strRequestFailed);
+                    AJAX.active = false;
+                    AJAX.xhr = null;
                 }
             });
 

--- a/js/messages.php
+++ b/js/messages.php
@@ -257,6 +257,7 @@ $js_messages['strCancel'] = __('Cancel');
 /* For Ajax Notifications */
 $js_messages['strLoading'] = __('Loading…');
 $js_messages['strAbortedRequest'] = __('Request Aborted!!');
+$js_messages['strRequestFailed'] = __('Request Failed!!');
 $js_messages['strProcessingRequest'] = __('Processing Request');
 $js_messages['strErrorProcessingRequest'] = __('Error in Processing Request');
 $js_messages['strErrorCode'] = __('Error code: %s');


### PR DESCRIPTION
Signed-off-by: Kushagra Pandey kushagra4296@gmail.com

Two things:
1. If an ajax request fails, the [Loading...] notification is replaced by [Request Failed] and is dismissed after default time (5000ms)
1. Figured out that there was a bug which prevented any AJAX request once any AJAX request has failed. So corrected that too by making AJAX.active = false; and AJAX.xhr = null;
