### PR TITLE
Possible fix for bug 4805. 

### DIFF
--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -2147,7 +2147,7 @@ function PMA_sendQueryResponseForResultsReturned($result,
 
     $just_one_table = PMA_resultSetHasJustOneTable($fields_meta);
 
-    $editable = ($has_unique || $updatableView) && $just_one_table;
+    $editable = ($has_unique || $updatableView) && $just_one_table && !strpos($sele_exp_cls, '(');
 
     // Displays the results in a table
     if (empty($disp_mode)) {


### PR DESCRIPTION
Disables inline editing those result tables that were generated by queries containing functions.

Signed-off-by: Aditya Sastry ganeshaditya1@gmail.com
