### PR TITLE
Handling failed AJAX requests

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -20,6 +20,11 @@ var AJAX = {
      * @var object lockedTargets, list of locked targets
      */
     lockedTargets: {},
+	/**
+	 * @var integer cancellingRequest to know if a request is being nullified
+	 *				Used for handling failed requests
+	 */
+	cancellingRequest: 0,
     /**
      * @var function Callback to execute after a successful request
      *               Used by PMA_commonFunctions from common.js
@@ -231,7 +236,7 @@ var AJAX = {
         }
         AJAX.resetLock();
 
-        if (AJAX.active === true) {
+        if (AJAX.cancellingRequest++ == 0 && AJAX.active === true) {
             // Cancel the old request if abortable, when the user requests
             // something else. Otherwise silently bail out, as there is already
             // a request well in progress.
@@ -251,6 +256,7 @@ var AJAX = {
                 //In case submitting a form, don't attempt aborting
                 return false;
             }
+			AJAX.cancellingRequest = 0;
         }
 
         AJAX.source = $(this);

--- a/js/console.js
+++ b/js/console.js
@@ -184,6 +184,12 @@ var PMA_console = {
                     PMA_console.ajaxCallback(data);
                 } catch (e) {
                     console.log("Invalid JSON!" + e.message);
+                    if(AJAX.cancellingRequest++ > 0) {
+                        PMA_ajaxShowMessage($('<div />',{class:'error',html:PMA_messages.strRequestFailed}));
+                        AJAX.active = false;
+                        AJAX.xhr = null;
+                        AJAX.cancellingRequest = 0;
+                    }
                 }
             });
 

--- a/js/messages.php
+++ b/js/messages.php
@@ -258,6 +258,7 @@ $js_messages['strCancel'] = __('Cancel');
 $js_messages['strLoading'] = __('Loading…');
 $js_messages['strAbortedRequest'] = __('Request Aborted!!');
 $js_messages['strProcessingRequest'] = __('Processing Request');
+$js_messages['strRequestFailed'] = __('Request Failed!!');
 $js_messages['strErrorProcessingRequest'] = __('Error in Processing Request');
 $js_messages['strErrorCode'] = __('Error code: %s');
 $js_messages['strErrorText'] = __('Error text: %s');


### PR DESCRIPTION
Signed-off-by: Kushagra Pandey kushagra4296@gmail.com
- If an ajax request fails, the [Loading...] notification is replaced by [Request Failed] and is dismissed after default time (5000ms)
- Figured out that there was a bug which prevented any AJAX request once any AJAX request has failed. So corrected that too by making AJAX.active = false; and AJAX.xhr = null;
- Also handles the cases when the returned data is not JSON, which is a fail for the client. Shows [Request Failed] for this too.

Update from previous pull request: No more blocking the mechanism of aborting a new call. 
