### PR TITLE
Handling failed AJAX requests

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -184,6 +184,11 @@ var PMA_console = {
                     PMA_console.ajaxCallback(data);
                 } catch (e) {
                     console.log("Invalid JSON!" + e.message);
+                    if(AJAX.xhr.status === 0 && AJAX.xhr.statusText !== 'abort') {
+                        PMA_ajaxShowMessage($('<div />',{class:'error',html:PMA_messages.strRequestFailed+' ( '+AJAX.xhr.statusText+' )'}));
+                        AJAX.active = false;
+                        AJAX.xhr = null;
+                    }
                 }
             });
 

--- a/js/messages.php
+++ b/js/messages.php
@@ -258,6 +258,7 @@ $js_messages['strCancel'] = __('Cancel');
 $js_messages['strLoading'] = __('Loading…');
 $js_messages['strAbortedRequest'] = __('Request Aborted!!');
 $js_messages['strProcessingRequest'] = __('Processing Request');
+$js_messages['strRequestFailed'] = __('Request Failed!!');
 $js_messages['strErrorProcessingRequest'] = __('Error in Processing Request');
 $js_messages['strErrorCode'] = __('Error code: %s');
 $js_messages['strErrorText'] = __('Error text: %s');


### PR DESCRIPTION
Signed-off-by: Kushagra Pandey kushagra4296@gmail.com
- If an ajax request fails, the [Loading...] notification is replaced by [Request Failed (statusText)] and is dismissed after default time (5000ms)
- Figured out that there was a bug which prevented any AJAX request once any AJAX request has failed. So corrected that too by making AJAX.active = false; and AJAX.xhr = null;
- Also handles the cases when the returned data is not JSON, which is a fail for the client. Shows [Request Failed (statusText)] for this too.

Update from previous pull request: No more blocking the mechanism of aborting a new call.
