### PR TITLE
Close session for executing user SQL queries

### DIFF
--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -1106,6 +1106,9 @@ function PMA_storeTheQueryAsBookmark($db, $bkm_user, $sql_query_for_bookmark,
  */
 function PMA_executeQueryAndStoreResults($full_sql_query)
 {
+    // close session in case the query takes too long
+    session_write_close();
+
     // Measure query time.
     $querytime_before = array_sum(explode(' ', microtime()));
 
@@ -1113,6 +1116,9 @@ function PMA_executeQueryAndStoreResults($full_sql_query)
         $full_sql_query, null, PMA_DatabaseInterface::QUERY_STORE
     );
     $querytime_after = array_sum(explode(' ', microtime()));
+
+    // reopen session
+    session_start();
 
     $GLOBALS['querytime'] = $querytime_after - $querytime_before;
 


### PR DESCRIPTION
This allows other requests to be performed while executing long SQL
query.

https://sourceforge.net/p/phpmyadmin/feature-requests/1001/

I haven't seen any negative impact on performance, however the session_write close migth take some time in case there is big data in the session.

Also see PR #1544 
