### PR TITLE
Bug #4754 pMA DB not detected properly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ phpMyAdmin - ChangeLog
 - bug       Missing sort icons in monitor
 - bug #4805 Inline edit broken when using functions in query
 - bug #4821 Timed-out import fails to restart when file represented
+- bug #4754 pMA DB not detected properly
 
 4.4.0.0 (not yet released)
 + rfe #1553 InnoDB presently supports one FULLTEXT index creation at a time

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -1184,5 +1184,13 @@ if (! defined('PMA_MINIMUM_COMMON')
             PMA_fixPMATables($GLOBALS['db'], false);
         }
     }
+    $cfgRelation = PMA_getRelationsParam();
+    if (empty($cfgRelation['db'])) {
+        foreach ($GLOBALS['pma']->databases as $database) {
+            if ($database == 'phpmyadmin') {
+                PMA_fixPMATables($database, false);
+            }
+        }
+    }
 }
 ?>


### PR DESCRIPTION
As per the discussion on February team meeting it was decided to check for PMA tables inside phpmyadmin database if such exists under ZeroConf functionality [1]. This is implemented here.

However, It was decide to look inside the current db prior to checking the phpmyadmin database. But the problem with this is that the user needs to go into some database to trigger this detection. So here, when the user is at the server level tables are looked  for in the phpmyadmin database.

[1] https://wiki.phpmyadmin.net/pma/2015-02_Meeting#Bug_discussion:_Zero_Conf
