### PR TITLE
Tries to fix bug#4837

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -276,7 +276,8 @@ function PMA_current_version(data)
                 /* Security update */
                 htmlClass = 'error';
             }
-            $('#maincontainer').after('<div class="' + htmlClass + '">' + message + '</div>');
+            $('#newer_version_notice').remove();
+            $('#maincontainer').after('<div id="newer_version_notice" class="' + htmlClass + '">' + message + '</div>');
         }
         if (latest === current) {
             version_information_message = ' (' + PMA_messages.strUpToDate + ')';


### PR DESCRIPTION
Added an ID to the notice div.
While printing a new div, it will always removes the old div (if it exists) and then adds it. Thus prevents multiple notices.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
