### PR TITLE
Prevents console window from moving out of the screen height

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -456,6 +456,9 @@ var PMA_consoleResizer = {
      * @return void
      */
     _mousemove: function(event) {
+        if (event.pageY < 35) {
+            event.pageY = 35
+        }
         PMA_consoleResizer._resultHeight = PMA_consoleResizer._height + (PMA_consoleResizer._posY -event.pageY);
         // Content min-height is 32, if adjusting height small than it we'll move it out of the page
         if(PMA_consoleResizer._resultHeight <= 32) {


### PR DESCRIPTION
Signed-off-by: sukhtaaj sukhtaaj@gmail.com

Console window moves out of the screen when expanded upwards and there is no way to bring it back. Which leaves the user puzzled for how to get back the normal view. And remains the same even after logging in again.

Merging this pull request will prevent the console window from going above the serverinfo bar. ( HTML div with id = "serverinfo" )

![console_window_bug](https://cloud.githubusercontent.com/assets/4622682/6993876/923a4af6-db21-11e4-9ae1-bdd8f498cc11.png)

![solved_console_window_bug](https://cloud.githubusercontent.com/assets/4622682/6993877/94eb138e-db21-11e4-88c6-3191abfe76ca.png)
