### PR TITLE
BUG #4839. Wrong documentation link.

### DIFF
--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -249,7 +249,7 @@ $strConfigForm_Other_core_settings_desc
 $strConfigForm_Page_titles = __('Page titles');
 $strConfigForm_Page_titles_desc = __(
     'Specify browser\'s title bar text. Refer to '
-    . '[doc@cfg_TitleTable]documentation[/doc] for magic strings that can be used '
+    . '[doc@faq6-27]documentation[/doc] for magic strings that can be used '
     . 'to get special values.'
 );
 $strConfigForm_Query_window = __('Query window');


### PR DESCRIPTION
BUG [#4839](https://sourceforge.net/p/phpmyadmin/bugs/4839/). Wrong documentation link.

Signed-off-by: Dan Ungureanu udan1107@gmail.com
