### PR TITLE
Add option to show/hide git revision on main panel

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1675,6 +1675,14 @@ Main panel
     in the configuration file, end users can't be allowed to change their
     passwords.
 
+.. config:option:: $cfg['ShowGitRevision']
+
+    :type: boolean
+    :default: true
+
+    Defines whether to display informations about the current Git revision (if
+    applicable) on the main panel.
+
 Database structure
 ------------------
 

--- a/libraries/Config.class.php
+++ b/libraries/Config.class.php
@@ -396,6 +396,10 @@ class PMA_Config
      */
     function isGitRevision()
     {
+        if (!$this->get('ShowGitRevision')) {
+            return false;
+        }
+
         // caching
         if (isset($_SESSION['is_git_revision'])) {
             if ($_SESSION['is_git_revision']) {

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -3047,4 +3047,11 @@ $cfg['DefaultFunctions'] = array(
  */
 $cfg['maxRowPlotLimit'] = 500;
 
+/**
+ * Show Git revision if applicable
+ *
+ * @global boolean $cfg['ShowGitRevision']
+ */
+$cfg['ShowGitRevision'] = true;
+
 ?>


### PR DESCRIPTION
By default phpMyAdmin shows current Git revision if it finds a .git folder. It can be annoying when PMA is maintained in a private Git repository and we don't want to show this kind of data on the main panel.

This option lets the administrator hide the Git revision even if .git folder exists.
