### PR TITLE
Ignore ./vendor directory of composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ phpunit.xml
 /.pydevproject
 # Ant cache
 cache.properties
+# Composer
+/vendor/


### PR DESCRIPTION
The _./vendor_ directory of composer should be ignored by Git, the build script or CI script should install composer dependencies when needed.
