### PR TITLE
Old MySQL extension is not available in newer PHP versions.

### DIFF
--- a/libraries/dbi/DBIMysql.class.php
+++ b/libraries/dbi/DBIMysql.class.php
@@ -10,6 +10,13 @@ if (! defined('PHPMYADMIN')) {
     exit;
 }
 
+if (! extension_loaded('mysql')) {
+    // The old MySQL extension is deprecated as of PHP 5.5.0, and will be
+    // removed in the future. Instead, the `MySQLi` or `PDO_MySQL` extension
+    // should be used.
+    return;
+}
+
 require_once './libraries/dbi/DBIExtension.int.php';
 
 /**

--- a/test/classes/dbi/DBIMysql_test.php
+++ b/test/classes/dbi/DBIMysql_test.php
@@ -38,6 +38,9 @@ class PMA_DBI_Mysql_Test extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        if (! extension_loaded('mysql')) {
+            $this->markTestSkipped('The MySQL extension is not available.');
+        }
         $GLOBALS['cfg']['Server']['ssl'] = true;
         $GLOBALS['cfg']['PersistentConnections'] = false;
         $GLOBALS['cfg']['Server']['compress'] = true;


### PR DESCRIPTION
Fixes the failing test. This comes as an addition to commit f9873b553a9b8b406087fb2d490411d5d662c860.

Signed-off-by: Dan Ungureanu udan1107@gmail.com
