### PR TITLE
Fixing isset check in getHtmlForRowStatsTable()

### DIFF
--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -1864,7 +1864,7 @@ function getHtmlForRowStatsTable($showtable, $tbl_collation,
         $odd_row = !$odd_row;
     }
     if (!$is_innodb
-        && isset($showtable['Data_length'])
+        && isset($showtable['Rows'])
         && $showtable['Rows'] > 0
         && $mergetable == false
     ) {


### PR DESCRIPTION
There is a typo where isset is checking the wrong key.

The key `Data_length` should be `Rows`.

The following error is being displayed:

```
Notice in ./libraries/structure.lib.php#1868
 Undefined index: Rows

Backtrace

./libraries/structure.lib.php#2376: getHtmlForRowStatsTable(
array,
NULL,
boolean false,
boolean false,
string '',
string '',
)
./libraries/display_structure.inc.php#262: PMA_getHtmlForDisplayTableStats(
string '',
NULL,
NULL,
boolean false,
NULL,
string '?db=cabuds&amp;table=AccountTypes&amp;token=8b3f9dff29f03fcafcb05cc1c3ad89e5&amp;goto=tbl_structure.php&amp;back=tbl_structure.php',
NULL,
)
./tbl_structure.php#207: require_once(./libraries/display_structure.inc.php)
```
