### PR TITLE
fix bug #4867

### DIFF
--- a/js/tbl_structure.js
+++ b/js/tbl_structure.js
@@ -190,6 +190,8 @@ AJAX.registerOnload('tbl_structure.js', function () {
                     }
                     $after_field_item.remove();
                     $curr_row.hide("medium").remove();
+                    //by default select the last option to add new column (in case last column is dropped)
+                    $("select[name=after_field] option:last").attr("selected","selected");
                     //refresh table stats
                     if (data.tableStat) {
                         $('#tablestatistics').html(data.tableStat);


### PR DESCRIPTION
If last column (selected value) is dropped, "add column" select dropdown was selecting by default to first value "at begining of table". So to fix this, when column is being dropped, I have selected the last value.
