### PR TITLE
Fix bug on result info display

### DIFF
--- a/libraries/DisplayResults.class.php
+++ b/libraries/DisplayResults.class.php
@@ -5256,7 +5256,7 @@ class PMA_DisplayResults
 
         // in PHP < 5.5, empty() only checks variables
         $tmpdb = $this->__get('db');
-        if (! empty($tmpdb) && ! empty($meta->orgtable)) {
+        if ((count($url_params) > 0) && (! empty($tmpdb) && ! empty($meta->orgtable))) {
             $result = '<a href="tbl_get_field.php'
                 . PMA_URL_getCommon($url_params)
                 . '" class="disableAjax">'


### PR DESCRIPTION
Reference image from : http://puu.sh/hIn2q/237524ef12.png for a text BLOB field.

Bisect determined 34c2837894d712ae0148be6aad385d3b3f77995a to be the cause.

Signed-off-by: Daniel Rix Drainx1@live.com
