### PR TITLE
Added configuration directive to define logo filename within the theme

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1529,6 +1529,14 @@ Navigation panel setup
     Defines whether or not to display the phpMyAdmin logo at the top of
     the navigation panel.
 
+.. config:option:: $cfg['NavigationLogo']
+
+    :type: string
+    :default: ``'logo_left.png'``
+
+    Defines the filename of the logo displayed at the top of the
+    navigation panel.
+
 .. config:option:: $cfg['NavigationLogoLink']
 
     :type: string
@@ -2020,8 +2028,8 @@ Languages
     :default: ``'utf8_general_ci'``
 
     Defines the default connection collation to use, if not user-defined.
-    See the `MySQL documentation for charsets 
-    <http://dev.mysql.com/doc/mysql/en/charset-charsets.html>`_ 
+    See the `MySQL documentation for charsets
+    <http://dev.mysql.com/doc/mysql/en/charset-charsets.html>`_
     for list of possible values. This setting is
     ignored when connected to Drizzle server.
 

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -896,6 +896,13 @@ $cfg['NavigationLinkWithMainPanel'] = true;
 $cfg['NavigationDisplayLogo'] = true;
 
 /**
+ * logo displayed in the navigation panel
+ *
+ * @global string $cfg['NavigationLogo']
+ */
+$cfg['NavigationLogo'] = 'logo_left.png';
+
+/**
  * where should logo link point to (can also contain an external URL)
  *
  * @global string $cfg['NavigationLogoLink']

--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -439,6 +439,8 @@ $strConfigNavigationLinkWithMainPanel_desc = __('Link with main panel by highlig
 $strConfigNavigationLinkWithMainPanel_name = __('Link with main panel');
 $strConfigNavigationDisplayLogo_desc = __('Show logo in navigation panel.');
 $strConfigNavigationDisplayLogo_name = __('Display logo');
+$strConfigNavigationLogo_desc = __('Filename of the logo displayed in the navigation panel.');
+$strConfigNavigationLogo_name = __('Logo filename');
 $strConfigNavigationLogoLink_desc
     = __('URL where logo in the navigation panel will point to.');
 $strConfigNavigationLogoLink_name = __('Logo link URL');

--- a/libraries/navigation/NavigationHeader.class.php
+++ b/libraries/navigation/NavigationHeader.class.php
@@ -81,7 +81,10 @@ class PMA_NavigationHeader
         }
 
         $logo = 'phpMyAdmin';
-        if (@file_exists($GLOBALS['pmaThemeImage'] . 'logo_left.png')) {
+        if (@file_exists($GLOBALS['pmaThemeImage'] . $GLOBALS['cfg']['NavigationLogo'])) {
+            $logo = '<img src="' . $GLOBALS['pmaThemeImage'] . $GLOBALS['cfg']['NavigationLogo'] . '" '
+                . 'alt="' . $logo . '" id="imgpmalogo" />';
+        } elseif ($GLOBALS['cfg']['NavigationLogo'] != 'logo_left.png' && @file_exists($GLOBALS['pmaThemeImage'] . 'logo_left.png')) {
             $logo = '<img src="' . $GLOBALS['pmaThemeImage'] . 'logo_left.png" '
                 . 'alt="' . $logo . '" id="imgpmalogo" />';
         } elseif (@file_exists($GLOBALS['pmaThemeImage'] . 'pma_logo2.png')) {

--- a/libraries/navigation/NavigationHeader.class.php
+++ b/libraries/navigation/NavigationHeader.class.php
@@ -81,14 +81,9 @@ class PMA_NavigationHeader
         }
 
         $logo = 'phpMyAdmin';
-        if (@file_exists($GLOBALS['pmaThemeImage'] . $GLOBALS['cfg']['NavigationLogo'])) {
-            $logo = '<img src="' . $GLOBALS['pmaThemeImage'] . $GLOBALS['cfg']['NavigationLogo'] . '" '
-                . 'alt="' . $logo . '" id="imgpmalogo" />';
-        } elseif ($GLOBALS['cfg']['NavigationLogo'] != 'logo_left.png' && @file_exists($GLOBALS['pmaThemeImage'] . 'logo_left.png')) {
-            $logo = '<img src="' . $GLOBALS['pmaThemeImage'] . 'logo_left.png" '
-                . 'alt="' . $logo . '" id="imgpmalogo" />';
-        } elseif (@file_exists($GLOBALS['pmaThemeImage'] . 'pma_logo2.png')) {
-            $logo = '<img src="' . $GLOBALS['pmaThemeImage'] . 'pma_logo2.png" '
+        $logo_path = $GLOBALS['pmaThemeImage'] . $GLOBALS['cfg']['NavigationLogo'];
+        if (@file_exists($logo_path)) {
+            $logo = '<img src="' . $logo_path . '" '
                 . 'alt="' . $logo . '" id="imgpmalogo" />';
         }
         $retval .= '<div id="pmalogo">';


### PR DESCRIPTION
$cfg['NavigationLogo'] can be set to define a custom filename for the logo displayed at top of navigation panel.

Signed-Off-By: Geoffray Warnants gwarnants+github@gmail.com
