### PR TITLE
Fixed some issues in Pull#1662 commit for RFE#1485

### DIFF
--- a/libraries/operations.lib.php
+++ b/libraries/operations.lib.php
@@ -1284,10 +1284,10 @@ function PMA_getHtmlForPartitionMaintenance($partition_names, $url_params)
         $GLOBALS['db'], $GLOBALS['table']
     );
     // add COALESCE or DROP option to choices array depeding on Partition method
-    if ($partition_method == 'KEY' || $partition_method == 'HASH') {
-        $choices['COALESCE'] = __('Coalesce');
-    } else {
+    if ($partition_method == 'RANGE' || $partition_method == 'LIST') {
         $choices['DROP'] = __('Drop');
+    } else {
+        $choices['COALESCE'] = __('Coalesce');
     }
 
     $html_output = '<div class="operations_half_width">'


### PR DESCRIPTION
Checks for LINEAR HASH and LINEAR KEY partition types were missing.
These can not be DROPped, should be COALESCEd instead.

Now checking for RANGE and LIST specifically, all others can be only COALESCEd and not DROPped.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
