### PR TITLE
RFE#657 Correction : Reselect Original DB after Renaming Table

### DIFF
--- a/tbl_operations.php
+++ b/tbl_operations.php
@@ -122,6 +122,10 @@ if (isset($_REQUEST['submitoptions'])) {
                 );
             }
 
+            // Reselect the original DB
+            $GLOBALS['db'] = $oldDb;
+            $GLOBALS['dbi']->selectDb($oldDb);
+
             $_message .= $pma_table->getLastMessage();
             $result = true;
             $GLOBALS['table'] = $pma_table->getName();


### PR DESCRIPTION
Re-select back the Original DB after Renaming Table.

While renaming, we have selected the 'mysql' db for adjusting the privileges.

Please comment if it still does not work appropriately.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
