### PR TITLE
Disable foreign key checks in SQL query box

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1275,6 +1275,16 @@ Generic settings
     middle-clicking for pasting the clipboard contents in some Linux
     distributions (such as Ubuntu) is not supported by all browsers.
 
+.. config:option:: $cfg['DefaultForeignKeyChecks']
+
+    :type: string
+    :default: ``'default'``
+
+    Default values for checkbox for foreign key checks, to disable/enable
+    foreign key checks for certain queries. Value can be either of ``'default'``,
+    ``'enable'`` or ``'disable'``. If set to ``'default'``, the value of
+    MySQL variable ``FOREIGN_KEY_CHECKS`` is used.
+
 .. config:option:: $cfg['AllowUserDropDatabase']
 
     :type: boolean
@@ -2019,8 +2029,8 @@ Languages
     :default: ``'utf8_general_ci'``
 
     Defines the default connection collation to use, if not user-defined.
-    See the `MySQL documentation for charsets 
-    <http://dev.mysql.com/doc/mysql/en/charset-charsets.html>`_ 
+    See the `MySQL documentation for charsets
+    <http://dev.mysql.com/doc/mysql/en/charset-charsets.html>`_
     for list of possible values. This setting is
     ignored when connected to Drizzle server.
 
@@ -2817,4 +2827,3 @@ Developer
 
     Enable to let server present itself as demo server.
     This is used for <http://demo.phpmyadmin.net/>.
-

--- a/js/functions.js
+++ b/js/functions.js
@@ -1718,8 +1718,15 @@ AJAX.registerOnload('functions.js', function () {
         var sql_query  = $form.find("input[name='sql_query']").val().trim();
         var $inner_sql = $(this).parent().prev().find('code.sql');
         var old_text   = $inner_sql.html();
+        var default_fk_check_value = $form.find("input[name='default_fk_check_value']").val() == 'true';
 
         var new_content = "<textarea name=\"sql_query_edit\" id=\"sql_query_edit\">" + sql_query + "</textarea>\n";
+        new_content    += "<div>";
+        new_content    += "<input type=\"hidden\" name=\"fk_checks\" value=\"0\" />";
+        new_content    += "<input type=\"checkbox\" name=\"fk_checks\""
+            + " id=\"fk_checks\"" + (default_fk_check_value ? " checked=\"checked\"" : "") + " />";
+        new_content    += "<label for=\"fk_checks\">" + PMA_messages.strForeignKeyCheck + "</label>";
+        new_content    += "</div>";
         new_content    += "<input type=\"submit\" id=\"sql_query_edit_save\" class=\"button btnSave\" value=\"" + PMA_messages.strGo + "\"/>\n";
         new_content    += "<input type=\"button\" id=\"sql_query_edit_discard\" class=\"button btnDiscard\" value=\"" + PMA_messages.strCancel + "\"/>\n";
         var $editor_area = $('div#inline_editor');
@@ -1742,15 +1749,17 @@ AJAX.registerOnload('functions.js', function () {
             codemirror_inline_editor.save();
             sql_query = codemirror_inline_editor.getValue();
         } else {
-            sql_query = $(this).prev().val();
+            sql_query = $(this).parent().find('#sql_query_edit').val();
         }
+        var fk_check = $(this).parent().find('#fk_checks').is(':checked');
 
         var $form = $("a.inline_edit_sql").prev('form');
         var $fake_form = $('<form>', {action: 'import.php', method: 'post'})
                 .append($form.find("input[name=server], input[name=db], input[name=table], input[name=token]").clone())
                 .append($('<input/>', {type: 'hidden', name: 'show_query', value: 1}))
                 .append($('<input/>', {type: 'hidden', name: 'is_js_confirmed', value: 0}))
-                .append($('<input/>', {type: 'hidden', name: 'sql_query', value: sql_query}));
+                .append($('<input/>', {type: 'hidden', name: 'sql_query', value: sql_query}))
+                .append($('<input/>', {type: 'hidden', name: 'fk_checks', value: fk_check ? 1 : 0}));
         if (! checkSqlQuery($fake_form[0])) {
             return false;
         }
@@ -4290,13 +4299,6 @@ AJAX.registerOnload('functions.js', function () {
 
     syntaxHighlighter = PMA_getSQLEditor($('textarea[name="view[as]"]'));
 
-    $(document).on('change', '#fkc_checkbox', function () {
-        if ($(this).prop("checked")) {
-            $("#fkc_status").html(PMA_messages.strForeignKeyCheckEnabled);
-        } else {
-            $("#fkc_status").html(PMA_messages.strForeignKeyCheckDisabled);
-        }
-    }); // End of event handler for 'Foreign Key Check'
 });
 
 function PMA_createViewDialog($this)

--- a/js/messages.php
+++ b/js/messages.php
@@ -300,10 +300,10 @@ $js_messages['strCopyingDatabase'] = __('Copying Database');
 $js_messages['strChangingCharset'] = __('Changing Charset');
 $js_messages['strNo'] = __('No');
 
+/* For Foreign key checks */
+$js_messages['strForeignKeyCheck'] = __('Enable foreign key checks');
+
 /* For db_stucture.js */
-$js_messages['strForeignKeyCheck'] = __('Foreign key check:');
-$js_messages['strForeignKeyCheckEnabled'] = __('(Enabled)');
-$js_messages['strForeignKeyCheckDisabled'] = __('(Disabled)');
 $js_messages['strErrorRealRowCount'] = __('Failed to get real row count.');
 
 /* For db_search.js */

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -1651,6 +1651,20 @@ class PMA_DatabaseInterface
     }
 
     /**
+     * Set foreign key check variable in session
+     *
+     * @param bool $value Turn it on or off
+     *
+     * @return void
+     */
+    public function setForeignKeyCheck($value) {
+        $current_fk_check_value = $GLOBALS['dbi']->getVariable('FOREIGN_KEY_CHECKS') == 'ON';
+        if ($current_fk_check_value == $value) return;
+
+        $this->query('SET FOREIGN_KEY_CHECKS = ' . ($value ? 1 : 0) . ';');
+    }
+
+    /**
      * Function called just after a connection to the MySQL database server has
      * been established. It sets the connection collation, and determines the
      * version of MySQL which is running.

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -1275,6 +1275,11 @@ class PMA_Util
                     'profiling', __('Profiling'), isset($_SESSION['profiling']), true
                 );
             }
+
+            // Pass default foreign_key_checks
+            $default_fk_check_value = $GLOBALS['dbi']->getVariable('FOREIGN_KEY_CHECKS') == 'ON';
+            $retval .= '<input type="hidden" disabled name="default_fk_check_value"'
+                . 'value="' . ($default_fk_check_value ? 'true' : 'false') . '"/>';
             $retval .= '</form>';
 
             /**
@@ -3183,6 +3188,60 @@ class PMA_Util
         } else {
             return false;
         }
+    }
+
+    /**
+    * Get HTML for Foreign key check checkbox
+    *
+    * @return string HTML for checkbox
+    */
+    public static function getFKCheckbox()
+    {
+        if ($GLOBALS['cfg']['DefaultForeignKeyChecks'] === 'enable') {
+            $checked = true;
+        } else if ($GLOBALS['cfg']['DefaultForeignKeyChecks'] === 'disable') {
+            $checked = false;
+        } else {
+            $checked = $GLOBALS['dbi']->getVariable('FOREIGN_KEY_CHECKS') == 'ON';
+        }
+        $html = '<input type="hidden" name="fk_checks" value="0" />';
+        $html .= '<input type="checkbox" name="fk_checks"'
+            . ' id="fk_checks" value="1"'
+            . ($checked ? ' checked="checked"' : '') . '/>';
+        $html .= '<label for="fk_checks">' . __('Enable foreign key checks') . '</label>';
+        return $html;
+    }
+
+    /**
+     * Handle foreign key check request
+     *
+     * @return bool Default foreign key checks value
+     */
+    public static function handleDisableFKCheckInit()
+    {
+        $default_fk_check_value = $GLOBALS['dbi']->getVariable('FOREIGN_KEY_CHECKS') == 'ON';
+        if (isset($_REQUEST['fk_checks'])) {
+            if (empty($_REQUEST['fk_checks'])) {
+                // Disable foreign key checks
+                $GLOBALS['dbi']->setForeignKeyCheck(false);
+            } else {
+                // Enable foreign key checks
+                $GLOBALS['dbi']->setForeignKeyCheck(true);
+            }
+        } // else do nothing, go with default
+        return $default_fk_check_value;
+    }
+
+    /**
+     * Cleanup changes done for foreign key check
+     *
+     * @param bool $default_fk_check_value
+     *
+     * @return void
+     */
+    public static function handleDisableFKCheckCleanup($default_fk_check_value)
+    {
+        $GLOBALS['dbi']->setForeignKeyCheck($default_fk_check_value);
     }
 
     /**

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -1216,6 +1216,12 @@ $cfg['ForeignKeyDropdownOrder'] = array('content-id', 'id-content');
  */
 $cfg['ForeignKeyMaxLimit'] = 100;
 
+/**
+ * Whether to disable foreign key checks while importing
+ *
+ * @global boolean $cfg['DefaultForeignKeyChecks']
+ */
+$cfg['DefaultForeignKeyChecks'] = 'default';
 
 /*******************************************************************************
  * For the export features...
@@ -2136,13 +2142,6 @@ $cfg['Import']['allow_interrupt'] = true;
  * @global integer $cfg['Import']['skip_queries']
  */
 $cfg['Import']['skip_queries'] = 0;
-
-/**
- * Whether to disable foreign key checks while importing
- *
- * @global boolean $cfg['Import']['disable_foreign_keys']
- */
-$cfg['Import']['disable_foreign_keys'] = false;
 
 /**
  *

--- a/libraries/config.values.php
+++ b/libraries/config.values.php
@@ -128,6 +128,11 @@ $cfg_db['SendErrorReports'] = array(
     'always'   => __('Always send error reports'),
     'never' => __('Never send error reports')
 );
+$cfg_db['DefaultForeignKeyChecks'] = array(
+    'default'   => __('Server default'),
+    'enable'    => __('Enable'),
+    'disable'   => __('Disable')
+);
 $cfg_db['Import']['format'] = array(
     'csv',    // CSV
     'docsql', // DocSQL

--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -212,6 +212,10 @@ $strConfigForeignKeyDropdownOrder_name = __('Foreign key dropdown order');
 $strConfigForeignKeyMaxLimit_desc
     = __('A dropdown will be used if fewer items are present.');
 $strConfigForeignKeyMaxLimit_name = __('Foreign key limit');
+$strConfigDefaultForeignKeyChecks_desc = __(
+    'Default value for foreign key checks checkbox for some queries.'
+);
+$strConfigDefaultForeignKeyChecks_name = __('Foreign key checks');
 $strConfigForm_Browse = __('Browse mode');
 $strConfigForm_Browse_desc = __('Customize browse mode.');
 $strConfigForm_CodeGen = 'CodeGen';
@@ -334,10 +338,6 @@ $strConfigImport_allow_interrupt_desc = __(
     . 'transactions.'
 );
 $strConfigImport_allow_interrupt_name = __('Partial import: allow interrupt');
-$strConfigImport_disable_foreign_keys_desc = __(
-    'Temporarily disable foreign key checks while importing'
-);
-$strConfigImport_disable_foreign_keys_name = __('Disable foreign key checks');
 $strConfigImport_charset_name = __('Character set of the file');
 $strConfigImport_csv_col_names_name = __('Lines terminated with');
 $strConfigImport_csv_enclosed_name = __('Columns enclosed with');

--- a/libraries/config/setup.forms.php
+++ b/libraries/config/setup.forms.php
@@ -160,7 +160,8 @@ $forms['Sql_queries']['Sql_queries'] = array(
     'MaxCharactersInDisplayedSQL',
     'RetainQueryBox',
     'CodemirrorEnable',
-    'EnableAutocompleteForTablesAndColumns');
+    'EnableAutocompleteForTablesAndColumns',
+    'DefaultForeignKeyChecks');
 $forms['Sql_queries']['Sql_box'] = array('SQLQuery' => array(
     'Edit',
     'Explain',
@@ -246,8 +247,7 @@ $forms['Import']['Import_defaults'] = array('Import' => array(
     'format',
     'charset',
     'allow_interrupt',
-    'skip_queries',
-    'disable_foreign_keys'));
+    'skip_queries'));
 $forms['Import']['Sql'] = array('Import' => array(
     'sql_compatibility',
     'sql_no_auto_value_on_zero'));

--- a/libraries/config/user_preferences.forms.php
+++ b/libraries/config/user_preferences.forms.php
@@ -70,7 +70,8 @@ $forms['Sql_queries']['Sql_queries'] = array(
     'MaxCharactersInDisplayedSQL',
     'RetainQueryBox',
     'CodemirrorEnable',
-    'EnableAutocompleteForTablesAndColumns');
+    'EnableAutocompleteForTablesAndColumns',
+    'DefaultForeignKeyChecks');
 $forms['Sql_queries']['Sql_box'] = array(
     'SQLQuery/Edit',
     'SQLQuery/Explain',
@@ -146,8 +147,7 @@ $forms['Import']['Import_defaults'] = array(
     'Import/format',
     'Import/charset',
     'Import/allow_interrupt',
-    'Import/skip_queries',
-    'Import/disable_foreign_keys'
+    'Import/skip_queries'
 );
 $forms['Import']['Sql'] = array(
     'Import/sql_compatibility',

--- a/libraries/display_import.lib.php
+++ b/libraries/display_import.lib.php
@@ -337,12 +337,7 @@ function PMA_getHtmlForImportOptionsOther()
     $html  = '   <div class="importoptions">';
     $html .= '       <h3>' . __('Other Options:') . '</h3>';
     $html .= '       <div class="formelementrow">';
-    $html .= '           <input type="checkbox" name="disable_foreign_keys"';
-    $html .= '               value="yes" id="checkbox_disable_foreign_keys" ';
-    $html .= PMA_pluginCheckboxCheck('Import', 'disable_foreign_keys') . '/>';
-    $html .= '           <label for="checkbox_disable_foreign_keys">';
-    $html .= __('Disable foreign key check');
-    $html .= '           </label>';
+    $html .= PMA_Util::getFKCheckbox();
     $html .= '       </div>';
     $html .= '   </div>';
 

--- a/libraries/import.lib.php
+++ b/libraries/import.lib.php
@@ -136,7 +136,7 @@ function PMA_importRunQuery($sql = '', $full = '', $controluser = false,
                 && ((! empty($import_run_buffer['sql'])
                 && preg_match($pattern, $import_run_buffer['sql']))
                 || ($executed_queries == 1
-                && ! isset($_REQUEST['disable_foreign_keys'])))
+                && ! isset($_REQUEST['fk_checks'])))
             ) {
                 $go_sql = true;
                 if (! $sql_query_disabled) {

--- a/libraries/mult_submits.inc.php
+++ b/libraries/mult_submits.inc.php
@@ -217,17 +217,11 @@ if (!empty($submit_mult) && !empty($what)) {
         $GLOBALS['dbi']->freeResult($result);
     }
 
-    if (! isset($_REQUEST['fk_check'])
-        && ($query_type == 'drop_tbl'
+    if ($query_type == 'drop_tbl'
         || $query_type == 'empty_tbl'
-        || $query_type == 'row_delete')
+        || $query_type == 'row_delete'
     ) {
-        $default_fk_check_value = $GLOBALS['dbi']->fetchValue(
-            'SHOW VARIABLES LIKE \'foreign_key_checks\';', 0, 1
-        ) == 'ON';
-
-        // for disabling foreign key checks while dropping tables
-        $GLOBALS['dbi']->query('SET FOREIGN_KEY_CHECKS = 0;');
+        $default_fk_check_value = PMA_Util::handleDisableFKCheckInit();
     }
 
     list(
@@ -277,13 +271,11 @@ if (!empty($submit_mult) && !empty($what)) {
             $message = PMA_Message::error($GLOBALS['dbi']->getError());
         }
     }
-    if (! isset($_REQUEST['fk_check'])
-        && ($query_type == 'drop_tbl'
+    if ($query_type == 'drop_tbl'
         || $query_type == 'empty_tbl'
-        || $query_type == 'row_delete')
-        && $default_fk_check_value
+        || $query_type == 'row_delete'
     ) {
-        $GLOBALS['dbi']->query('SET FOREIGN_KEY_CHECKS = 1;');
+        PMA_Util::handleDisableFKCheckCleanup($default_fk_check_value);
     }
     if ($rebuild_database_list) {
         // avoid a problem with the database list navigator

--- a/libraries/mult_submits.lib.php
+++ b/libraries/mult_submits.lib.php
@@ -434,22 +434,7 @@ function PMA_getHtmlForOtherActions($what, $action, $_url_params, $full_query)
     // Display option to disable foreign key checks while dropping tables
     if ($what === 'drop_tbl' || $what === 'empty_tbl' || $what === 'row_delete') {
         $html .= '<div id="foreignkeychk">';
-        $html .= '<label for="fkc_checkbox">';
-        $html .= __('Foreign key check:');
-        $html .= '</label>';
-        $html .= '<span class="checkbox">';
-        $html .= '<input type="checkbox" name="fk_check" value="1" '
-            . 'id="fkc_checkbox"';
-        $default_fk_check_value = $GLOBALS['dbi']->fetchValue(
-            'SHOW VARIABLES LIKE \'foreign_key_checks\';', 0, 1
-        ) == 'ON';
-        if ($default_fk_check_value) {
-            $html .= ' checked="checked"';
-        }
-        $html .= '/></span>';
-        $html .= '<label id="fkc_status" for="fkc_checkbox">';
-        $html .= ($default_fk_check_value) ? __('(Enabled)') : __('(Disabled)');
-        $html .= '</label>';
+        $html .= PMA_Util::getFKCheckbox();
         $html .= '</div>';
     }
     $html .= '<input id="buttonYes" type="submit" name="mult_btn" value="'

--- a/libraries/sql_query_form.lib.php
+++ b/libraries/sql_query_form.lib.php
@@ -240,6 +240,11 @@ function PMA_getHtmlForSqlQueryFormInsert(
     $html .= '<input type="button" value="' . __('Get auto-saved query') . '" id="saved"'
         . ' class="button sqlbutton" />';
 
+    // Disable/Enable foreign key checks
+    $html .= '<div>';
+    $html .= PMA_Util::getFKCheckbox();
+    $html .= '</div>';
+
     // parameter binding
     $html .= '<div>';
     $html .= '<input type="checkbox" name="parameterized" id="parameterized" />';


### PR DESCRIPTION
The problem with this is, you cannot enable foreign key checks if global `foreign_key_checks` is `OFF`. Which is also the current behavior of "Disable foreign key checks" in import. 

I think, even when global `foreign_key_checks` is `OFF`, one should be able to turn it on by unchecking the checkbox. If it looks good, I'll implement that. Another option is to completely hide these checkbox when global is disabled.
