### PR TITLE
Remove code coverage from scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,8 +5,6 @@ imports:
 filter:
     excluded_paths: [libraries/php-gettext/*, libraries/tcpdf/*, libraries/bfShapeFiles/*, PMAStandard/*, libraries/phpseclib/*, libraries/plugins/auth/recaptchalib.php, libraries/plugins/auth/swekey/swekey.php, libraries/sql-formatter/*, js/jquery/*, js/jqplot/*, js/openlayers/*, js/codemirror/*, js/canvg/*, js/tracekit/*, js/OpenStreetMap.js, js/sprintf.js, test/libraries/php-gettext/*, test/libraries/sql-formatter/*]
 tools:
-    external_code_coverage:
-        timeout: 3600 # Timeout in seconds.
     php_code_sniffer:
         config:
             standard: "PMAStandard"


### PR DESCRIPTION
- Let coveralls maintain code coverage, no need to have 2 code coverage tools.
