### PR TITLE
RFE#1594 : More plain english config words

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1598,16 +1598,16 @@ Navigation panel setup
 .. config:option:: $cfg['NavigationTreeDefaultTabTable']
 
     :type: string
-    :default: ``'tbl_structure.php'``
+    :default: ``'structure'``
 
     Defines the tab displayed by default when clicking the small icon next
     to each table name in the navigation panel. Possible values:
 
-    * ``tbl_structure.php``
-    * ``tbl_sql.php``
-    * ``tbl_select.php``
-    * ``tbl_change.php``
-    * ``sql.php``
+    * ``structure``
+    * ``sql``
+    * ``search``
+    * ``insert``
+    * ``browse``
 
 .. config:option:: $cfg['NavigationTreeDefaultTabTable2']
 
@@ -1618,11 +1618,11 @@ Navigation panel setup
     to each table name in the navigation panel. Possible values:
 
     * ``(empty)``
-    * ``tbl_structure.php``
-    * ``tbl_sql.php``
-    * ``tbl_select.php``
-    * ``tbl_change.php``
-    * ``sql.php``
+    * ``structure``
+    * ``sql``
+    * ``search``
+    * ``insert``
+    * ``browse``
 
 .. config:option:: $cfg['NavigationTreeEnableExpansion']
 
@@ -1957,40 +1957,41 @@ Tabs display settings
 .. config:option:: $cfg['DefaultTabServer']
 
     :type: string
-    :default: ``'index.php'``
+    :default: ``'welcome'``
 
     Defines the tab displayed by default on server view. Possible values:
 
-    * ``main.php`` (recommended for multi-user setups)
-    * ``server_databases.php``,
-    * ``server_status.php``
-    * ``server_variables.php``
-    * ``server_privileges.php``
+    * ``welcome`` (recommended for multi-user setups)
+    * ``databases``,
+    * ``status``
+    * ``variables``
+    * ``privileges``
 
 .. config:option:: $cfg['DefaultTabDatabase']
 
     :type: string
-    :default: ``'db_structure.php'``
+    :default: ``'structure'``
 
     Defines the tab displayed by default on database view. Possible
     values:
 
-    * ``db_structure.php``
-    * ``db_sql.php``
-    * ``db_search.php``.
+    * ``structure``
+    * ``sql``
+    * ``search``
+    * ``operations``
 
 .. config:option:: $cfg['DefaultTabTable']
 
     :type: string
-    :default: ``'sql.php'``
+    :default: ``'browse'``
 
     Defines the tab displayed by default on table view. Possible values:
 
-    * ``tbl_structure.php``
-    * ``tbl_sql.php``
-    * ``tbl_select.php``
-    * ``tbl_change.php``
-    * ``sql.php``
+    * ``structure``
+    * ``sql``
+    * ``search``
+    * ``insert``
+    * ``browse``
 
 PDF Options
 -----------

--- a/index.php
+++ b/index.php
@@ -61,9 +61,13 @@ if (isset($_REQUEST['ajax_request']) && ! empty($_REQUEST['access_time'])) {
 if (! empty($_REQUEST['db'])) {
     $page = null;
     if (! empty($_REQUEST['table'])) {
-        $page = $GLOBALS['cfg']['DefaultTabTable'];
+        $page = PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabTable'], 'table'
+        );
     } else {
-        $page = $GLOBALS['cfg']['DefaultTabDatabase'];
+        $page = PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+        );
     }
     include $page;
     exit;

--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -230,7 +230,9 @@ class PMA_Header
 
         $params = array(
             'common_query' => PMA_URL_getCommon(array(), 'text'),
-            'opendb_url' => $GLOBALS['cfg']['DefaultTabDatabase'],
+            'opendb_url' => PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+            ),
             'safari_browser' => PMA_USR_BROWSER_AGENT == 'SAFARI' ? 1 : 0,
             'collation_connection' => $GLOBALS['collation_connection'],
             'lang' => $GLOBALS['lang'],

--- a/libraries/Menu.class.php
+++ b/libraries/Menu.class.php
@@ -191,7 +191,9 @@ class PMA_Menu
         }
         $retval .= sprintf(
             $item,
-            $GLOBALS['cfg']['DefaultTabServer'],
+            PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabServer'], 'server'
+            ),
             PMA_URL_getCommon(),
             htmlspecialchars($server_info),
             __('Server')
@@ -208,7 +210,9 @@ class PMA_Menu
             }
             $retval .= sprintf(
                 $item,
-                $GLOBALS['cfg']['DefaultTabDatabase'],
+                PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+                ),
                 PMA_URL_getCommon(array('db' => $this->_db)),
                 htmlspecialchars($this->_db),
                 __('Database')
@@ -231,7 +235,9 @@ class PMA_Menu
                 }
                 $retval .= sprintf(
                     $item,
-                    $GLOBALS['cfg']['DefaultTabTable'],
+                    PMA_Util::getScriptNameForOption(
+                        $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                    ),
                     PMA_URL_getCommon(
                         array(
                             'db' => $this->_db, 'table' => $this->_table

--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -2657,7 +2657,10 @@ class PMA_Util
             $database = self::unescapeMysqlWildcards($database);
         }
 
-        return '<a href="' . $GLOBALS['cfg']['DefaultTabDatabase']
+        return '<a href="'
+            . PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+            )
             . PMA_URL_getCommon(array('db' => $database)) . '" title="'
             . htmlspecialchars(
                 sprintf(
@@ -3333,18 +3336,26 @@ class PMA_Util
      *                       $cfg['NavigationTreeDefaultTabTable2'],
      *                       $cfg['DefaultTabTable'] or $cfg['DefaultTabDatabase']
      *
-     * @return array
+     * @return string Title for the $cfg value
      */
     public static function getTitleForTarget($target)
     {
         $mapping = array(
+            'structure' =>  __('Structure'),
+            'sql' => __('SQL'),
+            'search' =>__('Search'),
+            'insert' =>__('Insert'),
+            'browse' => __('Browse'),
+            'operations' => __('Operations'),
+
+            // For backward compatiblity
+
             // Values for $cfg['DefaultTabTable']
             'tbl_structure.php' =>  __('Structure'),
             'tbl_sql.php' => __('SQL'),
             'tbl_select.php' =>__('Search'),
             'tbl_change.php' =>__('Insert'),
             'sql.php' => __('Browse'),
-
             // Values for $cfg['DefaultTabDatabase']
             'db_structure.php' => __('Structure'),
             'db_sql.php' => __('SQL'),
@@ -3352,6 +3363,91 @@ class PMA_Util
             'db_operations.php' => __('Operations'),
         );
         return isset($mapping[$target]) ? $mapping[$target] : false;
+    }
+
+    /**
+     * Get the script name corresponding to a plain English config word
+     * in order to append in links on navigation and main panel
+     *
+     * @param string $target   a valid value for $cfg['NavigationTreeDefaultTabTable'],
+     *                         $cfg['NavigationTreeDefaultTabTable2'],
+     *                         $cfg['DefaultTabTable'], $cfg['DefaultTabDatabase'] or
+     *                         $cfg['DefaultTabServer']
+     * @param string $location one out of 'server', 'table', 'database'
+     *
+     * @return string script name corresponding to the config word
+     */
+    public static function getScriptNameForOption($target, $location)
+    {
+        $retval = '';
+
+        if ($location == 'server') {
+            // Values for $cfg['DefaultTabServer']
+            switch ($target) {
+            case 'welcome':
+                $retval = 'index.php';
+                break;
+            case 'databases':
+                $retval = 'server_databases.php';
+                break;
+            case 'status':
+                $retval = 'server_status.php';
+                break;
+            case 'variables':
+                $retval = 'server_variables.php';
+                break;
+            case 'privileges':
+                $retval = 'server_privileges.php';
+                break;
+            default:
+                $retval = $target;
+            }
+        } elseif ($location == 'database') {
+            // Values for $cfg['DefaultTabDatabase']
+            switch ($target) {
+            case 'structure':
+                $retval = 'db_structure.php';
+                break;
+            case 'sql':
+                $retval = 'db_sql.php';
+                break;
+            case 'search':
+                $retval = 'db_search.php';
+                break;
+            case 'operations':
+                $retval = 'db_operations.php';
+                break;
+            default:
+                $retval = $target;
+            }
+        } elseif ($location == 'table') {
+            // Values for $cfg['DefaultTabTable'],
+            // $cfg['NavigationTreeDefaultTabTable'] and
+            // $cfg['NavigationTreeDefaultTabTable2']
+            switch ($target) {
+            case 'structure':
+                $retval = 'tbl_structure.php';
+                break;
+            case 'sql':
+                $retval = 'tbl_sql.php';
+                break;
+            case 'search':
+                $retval = 'tbl_select.php';
+                break;
+            case 'insert':
+                $retval = 'tbl_change.php';
+                break;
+            case 'browse':
+                $retval = 'sql.php';
+                break;
+            default:
+                $retval = $target;
+            }
+        } else {
+            $retval = $target;
+        }
+
+        return $retval;
     }
 
     /**

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -958,25 +958,25 @@ $cfg['NavigationTreeDisplayDbFilterMinimum'] = 30;
  * target of the navigation panel quick access icon
  *
  * Possible values:
- * 'tbl_structure.php' = fields list
- * 'tbl_sql.php' = SQL form
- * 'tbl_select.php' = search page
- * 'tbl_change.php' = insert row page
- * 'sql.php' = browse page
+ * 'structure.php' = fields list
+ * 'sql' = SQL form
+ * 'search' = search page
+ * 'insert' = insert row page
+ * 'browse' = browse page
  *
  * @global string $cfg['NavigationTreeDefaultTabTable']
  */
-$cfg['NavigationTreeDefaultTabTable'] = 'tbl_structure.php';
+$cfg['NavigationTreeDefaultTabTable'] = 'structure';
 
 /**
  * target of the navigation panel quick second access icon
  *
  * Possible values:
- * 'tbl_structure.php' = fields list
- * 'tbl_sql.php' = SQL form
- * 'tbl_select.php' = search page
- * 'tbl_change.php' = insert row page
- * 'sql.php' = browse page
+ * 'structure' = fields list
+ * 'sql' = SQL form
+ * 'search' = search page
+ * 'insert' = insert row page
+ * 'browse' = browse page
  * '' = no link
  *
  * @global string $cfg['NavigationTreeDefaultTabTable2']
@@ -1285,39 +1285,39 @@ $cfg['PropertiesNumColumns'] = 1;
 
 /**
  * Possible values:
- * 'index.php' = the welcome page
+ * 'welcome' = the welcome page
  * (recommended for multiuser setups)
- * 'server_databases.php' = list of databases
- * 'server_status.php' = runtime information
- * 'server_variables.php' = MySQL server variables
- * 'server_privileges.php' = user management
+ * 'databases' = list of databases
+ * 'status' = runtime information
+ * 'variables' = MySQL server variables
+ * 'privileges' = user management
  *
  * @global string $cfg['DefaultTabServer']
  */
-$cfg['DefaultTabServer'] = 'index.php';
+$cfg['DefaultTabServer'] = 'welcome';
 
 /**
  * Possible values:
- * 'db_structure.php' = tables list
- * 'db_sql.php' = SQL form
- * 'db_search.php' = search query
- * 'db_operations.php' = operations on database
+ * 'structure' = tables list
+ * 'sql' = SQL form
+ * 'search' = search query
+ * 'operations' = operations on database
  *
  * @global string $cfg['DefaultTabDatabase']
  */
-$cfg['DefaultTabDatabase'] = 'db_structure.php';
+$cfg['DefaultTabDatabase'] = 'structure';
 
 /**
  * Possible values:
- * 'tbl_structure.php' = fields list
- * 'tbl_sql.php' = SQL form
- * 'tbl_select.php' = search page
- * 'tbl_change.php' = insert row page
- * 'sql.php' = browse page
+ * 'structure' = fields list
+ * 'sql' = SQL form
+ * 'search' = search page
+ * 'insert' = insert row page
+ * 'browse' = browse page
  *
  * @global string $cfg['DefaultTabTable']
  */
-$cfg['DefaultTabTable'] = 'sql.php';
+$cfg['DefaultTabTable'] = 'browse';
 
 /**
  * Whether to display image or text or both image and text in table row

--- a/libraries/config.values.php
+++ b/libraries/config.values.php
@@ -36,19 +36,19 @@ $cfg_db['OBGzip'] = array('auto', true, false);
 $cfg_db['MemoryLimit'] = 'short_string';
 $cfg_db['NavigationLogoLinkWindow'] = array('main', 'new');
 $cfg_db['NavigationTreeDefaultTabTable'] = array(
-    'tbl_structure.php', // fields list
-    'tbl_sql.php',       // SQL form
-    'tbl_select.php',    // search page
-    'tbl_change.php',    // insert row page
-    'sql.php'            // browse page
+    'structure' => __('Structure'), // fields list
+    'sql' => __('SQL'),             // SQL form
+    'search' => __('Search'),       // search page
+    'insert' => __('Insert'),       // insert row page
+    'browse' => __('Browse')        // browse page
 );
 $cfg_db['NavigationTreeDefaultTabTable2'] = array(
     '', //don't display
-    'tbl_structure.php', // fields list
-    'tbl_sql.php',       // SQL form
-    'tbl_select.php',    // search page
-    'tbl_change.php',    // insert row page
-    'sql.php'            // browse page
+    'structure' => __('Structure'), // fields list
+    'sql' => __('SQL'),             // SQL form
+    'search' => __('Search'),       // search page
+    'insert' => __('Insert'),       // insert row page
+    'browse' => __('Browse')        // browse page
 );
 $cfg_db['NavigationTreeDbSeparator'] = 'short_string';
 $cfg_db['NavigationTreeTableSeparator'] = 'short_string';
@@ -99,24 +99,24 @@ $cfg_db['RelationalDisplay'] = array(
     'D' => __('display column')
 );
 $cfg_db['DefaultTabServer'] = array(
-    'index.php',               // the welcome page (recommended for multiuser setups)
-    'server_databases.php',    // list of databases
-    'server_status.php',       // runtime information
-    'server_variables.php',    // MySQL server variables
-    'server_privileges.php'    // user management
+    'welcome' => __('Welcome'),        // the welcome page (recommended for multiuser setups)
+    'databases' => __('Databases'),    // list of databases
+    'status' => __('Status'),          // runtime information
+    'variables' => __('Variables'),    // MySQL server variables
+    'privileges' => __('Privileges')   // user management
 );
 $cfg_db['DefaultTabDatabase'] = array(
-    'db_structure.php',   // tables list
-    'db_sql.php',         // SQL form
-    'db_search.php',      // search query
-    'db_operations.php'   // operations on database
+    'structure' => __('Structure'),   // tables list
+    'sql' => __('SQL'),               // SQL form
+    'search' => __('Search'),         // search query
+    'operations' => __('Operations')  // operations on database
 );
 $cfg_db['DefaultTabTable'] = array(
-    'tbl_structure.php', // fields list
-    'tbl_sql.php',       // SQL form
-    'tbl_select.php',    // search page
-    'tbl_change.php',    // insert row page
-    'sql.php'            // browse page
+    'structure' => __('Structure'),  // fields list
+    'sql' => __('SQL'),              // SQL form
+    'search' => __('Search'),        // search page
+    'insert' => __('Insert'),        // insert row page
+    'browse' => __('Browse')         // browse page
 );
 $cfg_db['InitialSlidersState'] = array(
     'open'     => __('Open'),

--- a/libraries/db_common.inc.php
+++ b/libraries/db_common.inc.php
@@ -27,7 +27,10 @@ if ($db_is_system_schema) {
  * Defines the urls to return to in case of error in a sql statement
  */
 $err_url_0 = 'index.php' . PMA_URL_getCommon();
-$err_url   = $cfg['DefaultTabDatabase']
+
+$err_url = PMA_Util::getScriptNameForOption(
+    $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+)
     . PMA_URL_getCommon(array('db' => $db));
 
 /** @var PMA_String $pmaString */

--- a/libraries/navigation/Nodes/Node_Database.class.php
+++ b/libraries/navigation/Nodes/Node_Database.class.php
@@ -40,8 +40,12 @@ class Node_Database extends Node
             's_db.png',
             __('Database operations')
         );
+
+        $script_name = PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+        );
         $this->links = array(
-            'text' => $GLOBALS['cfg']['DefaultTabDatabase']
+            'text' => $script_name
                     . '?server=' . $GLOBALS['server']
                     . '&amp;db=%1$s&amp;token=' . $_SESSION[' PMA_token '],
             'icon' => 'db_operations.php?server=' . $GLOBALS['server']

--- a/libraries/navigation/Nodes/Node_Table.class.php
+++ b/libraries/navigation/Nodes/Node_Table.class.php
@@ -32,36 +32,39 @@ class Node_Table extends Node_DatabaseChild
     {
         parent::__construct($name, $type, $is_group);
         $this->icon = array();
-        $this->_addIcon($GLOBALS['cfg']['NavigationTreeDefaultTabTable']);
-        $this->_addIcon($GLOBALS['cfg']['NavigationTreeDefaultTabTable2']);
-        switch($GLOBALS['cfg']['DefaultTabTable']) {
-        case 'tbl_structure.php':
-            $this->title = __('Structure');
-            break;
-        case 'tbl_select.php':
-            $this->title = __('Search');
-            break;
-        case 'tbl_change.php':
-            $this->title = __('Insert');
-            break;
-        case 'tbl_sql.php':
-            $this->title = __('SQL');
-            break;
-        case 'sql.php':
-            $this->title = __('Browse');
-            break;
-        }
+        $this->_addIcon(
+            PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['NavigationTreeDefaultTabTable'], 'table'
+            )
+        );
+        $this->_addIcon(
+            PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['NavigationTreeDefaultTabTable2'], 'table'
+            )
+        );
+        $title = PMA_Util::getTitleForTarget(
+            $GLOBALS['cfg']['DefaultTabTable']
+        );
+        $this->title = $title;
+
+        $script_name = PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabTable'], 'table'
+        );
         $this->links = array(
-            'text' => $GLOBALS['cfg']['DefaultTabTable']
+            'text' => $script_name
                     . '?server=' . $GLOBALS['server']
                     . '&amp;db=%2$s&amp;table=%1$s'
                     . '&amp;pos=0&amp;token=' . $_SESSION[' PMA_token '],
             'icon' => array(
-                $GLOBALS['cfg']['NavigationTreeDefaultTabTable']
+                PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['NavigationTreeDefaultTabTable'], 'table'
+                )
                 . '?server=' . $GLOBALS['server']
                 . '&amp;db=%2$s&amp;table=%1$s&amp;token='
                 . $_SESSION[' PMA_token '],
-                $GLOBALS['cfg']['NavigationTreeDefaultTabTable2']
+                PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['NavigationTreeDefaultTabTable2'], 'table'
+                )
                 . '?server=' . $GLOBALS['server']
                 . '&amp;db=%2$s&amp;table=%1$s&amp;token='
                 . $_SESSION[' PMA_token ']

--- a/libraries/plugins/auth/AuthenticationConfig.class.php
+++ b/libraries/plugins/auth/AuthenticationConfig.class.php
@@ -159,7 +159,9 @@ class AuthenticationConfig extends AuthenticationPlugin
         <tr>
             <td>' . "\n";
         echo '<a href="'
-            . $GLOBALS['cfg']['DefaultTabServer']
+            . PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabServer'], 'server'
+            )
             . PMA_URL_getCommon(array()) . '" class="button disableAjax">'
             . __('Retry to connect')
             . '</a>' . "\n";

--- a/libraries/select_server.lib.php
+++ b/libraries/select_server.lib.php
@@ -31,7 +31,10 @@ function PMA_selectServer($not_only_options, $omit_fieldset)
 
     if ($not_only_options) {
         $retval .= '<form method="post" action="'
-            . $GLOBALS['cfg']['DefaultTabServer'] . '" class="disableAjax">';
+            . PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabServer'], 'server'
+            )
+            . '" class="disableAjax">';
         $retval .= PMA_getHiddenFields(array('token' => $_SESSION[' PMA_token ']));
 
         if (! $omit_fieldset) {
@@ -84,7 +87,9 @@ function PMA_selectServer($not_only_options, $omit_fieldset)
             } else {
 
                 $retval .= '<a class="disableAjax item" href="'
-                    . $GLOBALS['cfg']['DefaultTabServer']
+                    . PMA_Util::getScriptNameForOption(
+                        $GLOBALS['cfg']['DefaultTabServer'], 'server'
+                    )
                     . PMA_URL_getCommon(array('server' => $key))
                     . '" >' . htmlspecialchars($label) . '</a>';
             }

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -2060,7 +2060,9 @@ function PMA_getHtmlForSpecificDbPrivileges($db)
             . '    '
             . sprintf(
                 __('Users having access to "%s"'),
-                '<a href="' . $GLOBALS['cfg']['DefaultTabDatabase']
+                '<a href="' . PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+                )
                 . PMA_URL_getCommon(array('db' => $db)) . '">'
                 .  htmlspecialchars($db)
                 . '</a>'
@@ -2124,7 +2126,9 @@ function PMA_getHtmlForSpecificTablePrivileges($db, $table)
             . PMA_Util::getIcon('b_usrcheck.png')
             . sprintf(
                 __('Users having access to "%s"'),
-                '<a href="' . $GLOBALS['cfg']['DefaultTabTable']
+                '<a href="' . PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
                 . PMA_URL_getCommon(
                     array(
                         'db' => $db,
@@ -2757,7 +2761,9 @@ function PMA_getChangeLoginInformationHtmlForm($username, $hostname)
 function PMA_getLinkToDbAndTable($url_dbname, $dbname, $tablename)
 {
     $html_output = '[ ' . __('Database')
-        . ' <a href="' . $GLOBALS['cfg']['DefaultTabDatabase']
+        . ' <a href="' . PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+        )
         . PMA_URL_getCommon(
             array(
                 'db' => $url_dbname,
@@ -2773,7 +2779,9 @@ function PMA_getLinkToDbAndTable($url_dbname, $dbname, $tablename)
 
     if (/*overload*/mb_strlen($tablename)) {
         $html_output .= ' [ ' . __('Table') . ' <a href="'
-            . $GLOBALS['cfg']['DefaultTabTable']
+            . PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabTable'], 'table'
+            )
             . PMA_URL_getCommon(
                 array(
                     'db' => $url_dbname,

--- a/libraries/special_schema_links.lib.php
+++ b/libraries/special_schema_links.lib.php
@@ -65,7 +65,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'Db'
                     ),
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
             'column_name' => array(
                 'link_param' => 'field',
@@ -116,7 +118,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'database_name'
                     ),
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
             'index_name' => array(
                 'link_param' => 'index',
@@ -142,7 +146,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'database_name'
                     ),
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
         ),
         'proc' => array(
@@ -232,7 +238,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'Db'
                     ),
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
         ),
         'user' => array(
@@ -258,7 +266,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'table_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
             'column_name' => array(
                 'link_param' => 'field',
@@ -284,7 +294,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'constraint_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
             'column_name' => array(
                 'link_param' => 'field',
@@ -308,7 +320,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'referenced_table_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
             'referenced_column_name' => array(
                 'link_param' => 'field',
@@ -334,7 +348,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'table_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             )
         ),
         'processlist' => array(
@@ -358,7 +374,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'constraint_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
             'referenced_table_name' => array(
                 'link_param' => 'table',
@@ -368,7 +386,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'constraint_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             )
         ),
         'routines' => array(
@@ -390,7 +410,9 @@ $GLOBALS['special_schema_links'] = array(
         'schemata' => array(
             'schema_name' => array(
                 'link_param' => 'db',
-                'default_page' => $GLOBALS['cfg']['DefaultTabDatabase']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             )
         ),
         'statistics' => array(
@@ -402,7 +424,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'table_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
             'column_name' => array(
                 'link_param' => 'field',
@@ -428,7 +452,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'table_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
         ),
         'table_constraints' => array(
@@ -440,7 +466,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'table_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
         ),
         'views' => array(
@@ -452,7 +480,9 @@ $GLOBALS['special_schema_links'] = array(
                         'column_name' => 'table_schema'
                     )
                 ),
-                'default_page' => $GLOBALS['cfg']['DefaultTabTable']
+                'default_page' => PMA_Util::getScriptNameForOption(
+                    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+                )
             ),
         ),
     )

--- a/libraries/sql_query_form.lib.php
+++ b/libraries/sql_query_form.lib.php
@@ -161,7 +161,9 @@ function PMA_getHtmlForSqlQueryFormInsert(
         // prepare for db related
         $db     = $GLOBALS['db'];
         // if you want navigation:
-        $tmp_db_link = '<a href="' . $GLOBALS['cfg']['DefaultTabDatabase']
+        $tmp_db_link = '<a href="' . PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+        )
             . PMA_URL_getCommon(array('db' => $db)) . '"';
         $tmp_db_link .= '>'
             . htmlspecialchars($db) . '</a>';
@@ -182,7 +184,9 @@ function PMA_getHtmlForSqlQueryFormInsert(
             $db, $GLOBALS['table'], null, true
         );
 
-        $tmp_db_link = '<a href="' . $GLOBALS['cfg']['DefaultTabDatabase']
+        $tmp_db_link = '<a href="' . PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+        )
             . PMA_URL_getCommon(array('db' => $db)) . '"';
         $tmp_db_link .= '>'
             . htmlspecialchars($db) . '</a>';

--- a/libraries/tbl_common.inc.php
+++ b/libraries/tbl_common.inc.php
@@ -35,9 +35,15 @@ $url_params['table'] = $table;
 /**
  * Defines the urls to return to in case of error in a sql statement
  */
-$err_url_0 = $cfg['DefaultTabDatabase']
+$err_url_0 = PMA_Util::getScriptNameForOption(
+    $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+)
     . PMA_URL_getCommon(array('db' => $db));
-$err_url   = $cfg['DefaultTabTable'] . PMA_URL_getCommon($url_params);
+
+$err_url = PMA_Util::getScriptNameForOption(
+    $GLOBALS['cfg']['DefaultTabTable'], 'table'
+)
+    . PMA_URL_getCommon($url_params);
 
 
 /**

--- a/sql.php
+++ b/sql.php
@@ -54,9 +54,13 @@ if (! empty($goto)) {
     }
 } else {
     if (empty($table)) {
-        $goto = $cfg['DefaultTabDatabase'];
+        $goto = PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+        );
     } else {
-        $goto = $cfg['DefaultTabTable'];
+        $goto = PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabTable'], 'table'
+        );
     }
     $is_gotofile  = true;
 } // end if

--- a/tbl_chart.php
+++ b/tbl_chart.php
@@ -80,17 +80,23 @@ $scripts->addFile('jqplot/plugins/jqplot.highlighter.js');
  * Runs common work
  */
 if (/*overload*/mb_strlen($GLOBALS['table'])) {
-    $url_params['goto'] = $cfg['DefaultTabTable'];
+    $url_params['goto'] = PMA_Util::getScriptNameForOption(
+        $GLOBALS['cfg']['DefaultTabTable'], 'table'
+    );
     $url_params['back'] = 'tbl_sql.php';
     include 'libraries/tbl_common.inc.php';
     include 'libraries/tbl_info.inc.php';
 } elseif (/*overload*/mb_strlen($GLOBALS['db'])) {
-    $url_params['goto'] = $cfg['DefaultTabDatabase'];
+    $url_params['goto'] = PMA_Util::getScriptNameForOption(
+        $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+    );
     $url_params['back'] = 'sql.php';
     include 'libraries/db_common.inc.php';
     include 'libraries/db_info.inc.php';
 } else {
-    $url_params['goto'] = $cfg['DefaultTabServer'];
+    $url_params['goto'] = PMA_Util::getScriptNameForOption(
+        $GLOBALS['cfg']['DefaultTabServer'], 'server'
+    );
     $url_params['back'] = 'sql.php';
     include 'libraries/server_common.inc.php';
 }

--- a/tbl_find_replace.php
+++ b/tbl_find_replace.php
@@ -54,7 +54,9 @@ if (isset($_POST['replace'])) {
 }
 
 if (! isset($goto)) {
-    $goto = $GLOBALS['cfg']['DefaultTabTable'];
+    $goto = PMA_Util::getScriptNameForOption(
+        $GLOBALS['cfg']['DefaultTabTable'], 'table'
+    );
 }
 // Defines the url to return to in case of error in the next sql statement
 $params = array('db' => $db, 'table' => $table);

--- a/tbl_gis_visualization.php
+++ b/tbl_gis_visualization.php
@@ -10,7 +10,9 @@ require_once 'libraries/common.inc.php';
 
 // Runs common work
 require_once 'libraries/db_common.inc.php';
-$url_params['goto'] = $cfg['DefaultTabDatabase'];
+$url_params['goto'] = PMA_Util::getScriptNameForOption(
+    $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+);
 $url_params['back'] = 'sql.php';
 
 // Import visualization functions

--- a/tbl_select.php
+++ b/tbl_select.php
@@ -53,7 +53,9 @@ if (! isset($_POST['columnsToDisplay']) && ! isset($_POST['displayAllColumns']))
     include_once 'libraries/tbl_info.inc.php';
 
     if (! isset($goto)) {
-        $goto = $GLOBALS['cfg']['DefaultTabTable'];
+        $goto = PMA_Util::getScriptNameForOption(
+            $GLOBALS['cfg']['DefaultTabTable'], 'table'
+        );
     }
     // Defines the url to return to in case of error in the next sql statement
     $err_url   = $goto . PMA_URL_getCommon(array('db' => $db, 'table' => $table));

--- a/tbl_zoom_select.php
+++ b/tbl_zoom_select.php
@@ -97,7 +97,9 @@ $url_query .= '&amp;goto=tbl_select.php&amp;back=tbl_select.php';
 require_once './libraries/tbl_info.inc.php';
 
 if (! isset($goto)) {
-    $goto = $GLOBALS['cfg']['DefaultTabTable'];
+    $goto = PMA_Util::getScriptNameForOption(
+        $GLOBALS['cfg']['DefaultTabTable'], 'table'
+    );
 }
 // Defines the url to return to in case of error in the next sql statement
 $err_url   = $goto . PMA_URL_getCommon(array('db' => $db, 'table' => $table));

--- a/test/classes/PMA_Footer_test.php
+++ b/test/classes/PMA_Footer_test.php
@@ -60,7 +60,7 @@ class PMA_Footer_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['collation_connection'] = 'utf8_general_ci';
         $GLOBALS['cfg']['Server']['verbose'] = 'verbose host';
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
+        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
         $GLOBALS['server'] = '1';
         $_GET['reload_left_frame'] = '1';
         $GLOBALS['focus_querywindow'] = 'main_pane_left';

--- a/test/classes/PMA_Menu_test.php
+++ b/test/classes/PMA_Menu_test.php
@@ -47,9 +47,9 @@ class PMA_Menu_Test extends PHPUnit_Framework_TestCase
         $_SESSION['PMA_Theme'] = new PMA_Theme();
         $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
         $GLOBALS['pmaThemeImage'] = 'theme/';
-        $GLOBALS['cfg']['DefaultTabServer'] = 'main.php';
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
-        $GLOBALS['cfg']['DefaultTabTable'] = 'sql.php';
+        $GLOBALS['cfg']['DefaultTabServer'] = 'welcome';
+        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
+        $GLOBALS['cfg']['DefaultTabTable'] = 'browse';
         $GLOBALS['cfg']['OBGzip'] = false;
         $GLOBALS['cfg']['NaturalOrder'] = true;
         $GLOBALS['cfg']['TabsMode'] = 'both';

--- a/test/classes/dbi/DBIDrizzle_test.php
+++ b/test/classes/dbi/DBIDrizzle_test.php
@@ -69,7 +69,7 @@ class PMA_DBI_Drizzle_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['Server']['ssl'] = false;
         $GLOBALS['cfg']['MaxCharactersInDisplayedSQL'] = 1000;
         $GLOBALS['cfg']['ActionLinksMode'] = "both";
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
+        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
         $GLOBALS['pmaThemeImage'] = 'image';
 
         //$_SESSION

--- a/test/classes/navigation/PMA_Node_DatabaseChild_test.php
+++ b/test/classes/navigation/PMA_Node_DatabaseChild_test.php
@@ -38,7 +38,7 @@ class Node_DatabaseChildTest extends PHPUnit_Framework_TestCase
         $_SESSION['PMA_Theme'] = new PMA_Theme();
         $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
         $GLOBALS['pmaThemeImage'] = 'theme/';
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
+        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
         $GLOBALS['server'] = 1;
         $GLOBALS['cfg']['ServerDefault'] = 1;
         $_SESSION['relation'][1]['navwork'] = true;

--- a/test/classes/navigation/PMA_Node_Database_test.php
+++ b/test/classes/navigation/PMA_Node_Database_test.php
@@ -26,7 +26,7 @@ class Node_Database_Test extends PHPUnit_Framework_TestCase
     public function setup()
     {
         $GLOBALS['server'] = 0;
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
+        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
         $GLOBALS['cfg']['MaxNavigationItems'] = 250;
         $_SESSION['PMA_Theme'] = PMA_Theme::load('./themes/pmahomme');
     }

--- a/test/classes/navigation/PMA_Node_Table_test.php
+++ b/test/classes/navigation/PMA_Node_Table_test.php
@@ -27,7 +27,8 @@ class Node_Table_Test extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['NavigationTreeDefaultTabTable'] = 'b_browse';
-        $GLOBALS['cfg']['DefaultTabTable'] = 'sql.php';
+        $GLOBALS['cfg']['NavigationTreeDefaultTabTable2'] = '';
+        $GLOBALS['cfg']['DefaultTabTable'] = 'browse';
         $GLOBALS['cfg']['MaxNavigationItems'] = 250;
         $GLOBALS['cfg']['NavigationTreeEnableGrouping'] = true;
         $GLOBALS['cfg']['NavigationTreeDbSeparator'] = '_';
@@ -80,11 +81,11 @@ class Node_Table_Test extends PHPUnit_Framework_TestCase
     public function providerForTestIcon()
     {
         return array(
-            array('tbl_structure.php', 'b_props'),
-            array('tbl_select.php', 'b_search'),
-            array('tbl_change.php', 'b_insrow'),
-            array('tbl_sql.php', 'b_sql'),
-            array('sql.php', 'b_browse'),
+            array('structure', 'b_props'),
+            array('search', 'b_search'),
+            array('insert', 'b_insrow'),
+            array('sql', 'b_sql'),
+            array('browse', 'b_browse'),
         );
     }
 }

--- a/test/classes/plugin/auth/PMA_AuthenticationConfig_test.php
+++ b/test/classes/plugin/auth/PMA_AuthenticationConfig_test.php
@@ -35,6 +35,7 @@ class PMA_AuthenticationConfig_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['PMA_Config'] = new PMA_Config();
         $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['server'] = 0;
+        $GLOBALS['cfg']['DefaultTabServer'] = 'welcome';
         $GLOBALS['token_provided'] = true;
         $GLOBALS['token_mismatch'] = false;
         $this->object = new AuthenticationConfig();

--- a/test/libraries/PMA_build_html_for_db_test.php
+++ b/test/libraries/PMA_build_html_for_db_test.php
@@ -48,7 +48,7 @@ class PMA_BuildHtmlForDb_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
         $GLOBALS['pmaThemeImage'] = 'theme/';
 
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
+        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
     }
 
     /**

--- a/test/libraries/PMA_select_server_test.php
+++ b/test/libraries/PMA_select_server_test.php
@@ -69,7 +69,7 @@ class PMA_SelectServer_Test extends PHPUnit_Framework_TestCase
         $not_only_options = false;
         $omit_fieldset = false;
 
-        $GLOBALS['cfg']['DefaultTabServer'] = "DefaultTabServer";
+        $GLOBALS['cfg']['DefaultTabServer'] = "welcome";
 
         $GLOBALS['cfg']['Servers'] = array(
             '0' => array(
@@ -119,7 +119,9 @@ class PMA_SelectServer_Test extends PHPUnit_Framework_TestCase
 
         //$GLOBALS['cfg']['DefaultTabServer']
         $this->assertContains(
-            $GLOBALS['cfg']['DefaultTabServer'],
+            PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabServer'], 'server'
+            ),
             $html
         );
 

--- a/test/libraries/PMA_server_databases_test.php
+++ b/test/libraries/PMA_server_databases_test.php
@@ -59,7 +59,7 @@ class PMA_ServerDatabases_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['LimitChars'] = 100;
         $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['cfg']['ActionLinksMode'] = "both";
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
+        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
 
         $GLOBALS['table'] = "table";
         $GLOBALS['replication_info']['master']['status'] = false;

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -64,10 +64,10 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['LimitChars'] = 100;
         $GLOBALS['cfg']['AllowThirdPartyFraming'] = false;
         $GLOBALS['cfg']['ActionLinksMode'] = "both";
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'db_structure.php';
+        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
         $GLOBALS['cfg']['PmaAbsoluteUri'] = "PmaAbsoluteUri";
-        $GLOBALS['cfg']['DefaultTabTable'] = "db_structure.php";
-        $GLOBALS['cfg']['NavigationTreeDefaultTabTable'] = "db_structure.php";
+        $GLOBALS['cfg']['DefaultTabTable'] = "structure";
+        $GLOBALS['cfg']['NavigationTreeDefaultTabTable'] = "structure";
         $GLOBALS['cfg']['Confirm'] = "Confirm";
         $GLOBALS['cfg']['ShowHint'] = true;
 
@@ -1672,7 +1672,9 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
             $html
         );
         $this->assertContains(
-            $GLOBALS['cfg']['DefaultTabDatabase'],
+            PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+            ),
             $html
         );
         $item = PMA_URL_getCommon(
@@ -1696,7 +1698,9 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
             $html
         );
         $this->assertContains(
-            $GLOBALS['cfg']['DefaultTabTable'],
+            PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabTable'], 'table'
+            ),
             $html
         );
         $item = PMA_URL_getCommon(

--- a/test/libraries/PMA_sql_query_form_test.php
+++ b/test/libraries/PMA_sql_query_form_test.php
@@ -57,7 +57,7 @@ class PMA_SqlQueryForm_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['TextareaAutoSelect'] = true;
         $GLOBALS['cfg']['TextareaRows'] = 100;
         $GLOBALS['cfg']['TextareaCols'] = 11;
-        $GLOBALS['cfg']['DefaultTabDatabase'] = "default_database";
+        $GLOBALS['cfg']['DefaultTabDatabase'] = "structure";
         $GLOBALS['cfg']['RetainQueryBox'] = true;
         $GLOBALS['cfg']['ActionLinksMode'] = 'both';
 

--- a/test/libraries/common/PMA_getDbLink_test.php
+++ b/test/libraries/common/PMA_getDbLink_test.php
@@ -62,7 +62,11 @@ class PMA_GetDbLink_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['db'] = 'test_db';
         $database = $GLOBALS['db'];
         $this->assertEquals(
-            '<a href="' . $cfg['DefaultTabDatabase'] . '?db=' . $database
+            '<a href="'
+            . PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+            )
+            . '?db=' . $database
             . '&amp;server=99&amp;lang=en&amp;token=token" '
             . 'title="Jump to database &quot;'
             . htmlspecialchars($database) . '&quot;.">'
@@ -81,7 +85,10 @@ class PMA_GetDbLink_Test extends PHPUnit_Framework_TestCase
         global $cfg;
         $database = 'test_database';
         $this->assertEquals(
-            '<a href="' . $cfg['DefaultTabDatabase'] . '?db=' . $database
+            '<a href="' . PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+            )
+            . '?db=' . $database
             . '&amp;server=99&amp;lang=en&amp;token=token" title="Jump to database &quot;'
             . htmlspecialchars($database) . '&quot;.">'
             . htmlspecialchars($database) . '</a>',
@@ -99,7 +106,11 @@ class PMA_GetDbLink_Test extends PHPUnit_Framework_TestCase
         global $cfg;
         $database = 'test&data\'base';
         $this->assertEquals(
-            '<a href="' . $cfg['DefaultTabDatabase'] . '?db='
+            '<a href="'
+            . PMA_Util::getScriptNameForOption(
+                $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+            )
+            . '?db='
             . htmlspecialchars(urlencode($database))
             . '&amp;server=99&amp;lang=en&amp;token=token" title="Jump to database &quot;'
             . htmlspecialchars($database) . '&quot;.">'

--- a/test/theme.php
+++ b/test/theme.php
@@ -52,7 +52,9 @@ $item = '<a href="%1$s?%2$s" class="item">'
 echo '<div id="serverinfo">' . "\n";
 printf(
     $item,
-    $GLOBALS['cfg']['DefaultTabServer'],
+    PMA_Util::getScriptNameForOption(
+        $GLOBALS['cfg']['DefaultTabserver'], 'server'
+    ),
     PMA_URL_getCommon(),
     'Server',
     __('Server'),
@@ -62,7 +64,9 @@ printf(
 echo $separator;
 printf(
     $item,
-    $GLOBALS['cfg']['DefaultTabDatabase'],
+    PMA_Util::getScriptNameForOption(
+        $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
+    ),
     '',
     'Database',
     __('Database'),
@@ -72,7 +76,9 @@ printf(
 echo $separator;
 printf(
     $item,
-    $GLOBALS['cfg']['DefaultTabTable'],
+    PMA_Util::getScriptNameForOption(
+        $GLOBALS['cfg']['DefaultTabTable'], 'table'
+    ),
     '',
     'Table',
     (isset($GLOBALS['tbl_is_view']) && $GLOBALS['tbl_is_view']


### PR DESCRIPTION
Replaces the existing use of 'script_names' like 'db_structure.php', 'sql.php' etc. as config options with more simple english words like 'structure', 'browse' etc.

Feedback welcome. Please suggest changes. 

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
