### PR TITLE
Multi-file export with ZIP

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -86,6 +86,19 @@ AJAX.registerOnload('export.js', function () {
             $("#checkbox_sql_auto_increment").removeProp('disabled').parent().fadeTo('fast', 1);
         }
     });
+
+    // For separate-file exports only ZIP compression is allowed
+    $('input[type="checkbox"][name="as_separate_files"]').change(function(){
+        if (! $(this).attr('checked')) {
+            $('#compression').val('zip');
+        }
+    });
+
+    $('#compression').change(function(){
+        if ($('option:selected').val() !== 'zip') {
+            $('input[type="checkbox"][name="as_separate_files"]').attr('checked', false);
+        }
+    });
 });
 
 

--- a/libraries/display_export.lib.php
+++ b/libraries/display_export.lib.php
@@ -629,6 +629,34 @@ function PMA_getHtmlForExportOptionsOutputRadio()
 }
 
 /**
+ * Prints Html For Export Options Checkbox - Separate files
+ *
+ * @param String $export_type Selected Export Type
+ *
+ * @return string
+ */
+function PMA_getHtmlForExportOptionsOutputSeparateFiles($export_type)
+{
+    $html  = '<li>';
+    $html .= '<input type="checkbox" id="checkbox_separate_files" '
+        . ' name="as_separate_files" value="'
+        . $export_type
+        . '" ';
+    $html .= '/>';
+    $html .= '<label for="checkbox_separate_files">';
+
+    if ($export_type == 'server') {
+        $html .= __('Export databases as separate files');
+    } elseif ($export_type == 'database') {
+        $html .= __('Export tables as separate files');
+    }
+
+    $html .= '</label></li>';
+
+    return $html;
+}
+
+/**
  * Prints Html For Export Options
  *
  * @param String $export_type Selected Export Type
@@ -685,6 +713,12 @@ function PMA_getHtmlForExportOptionsOutput($export_type)
     } // end if
 
     $html .= PMA_getHtmlForExportOptionsOutputCompression();
+
+    if ($export_type == 'server'
+        || $export_type == 'database'
+    ) {
+        $html .= PMA_getHtmlForExportOptionsOutputSeparateFiles($export_type);
+    }
 
     $html .= '</ul>';
     $html .= '</li>';


### PR DESCRIPTION
Provide an option to :
1. Export (selected) tables in a database as separate files.
2. Export (databases) in a server as separate files.

All formats should work (ex. SQL, CSV, JSON etc.).
Please comment if you find an error related to any specific format.

Currently, only zip is the supported compression.

Thanks @udan11 for a great head start in : [`8054b83`](https://github.com/udan11/phpmyadmin/commit/8054b83b1c1edf33a76aff95e56d298878deaa9f)

Testing with various cases still required.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
