### PR TITLE
Templating getStartAndNumberOfRowsPanel function, recursivity and failures

### DIFF
--- a/libraries/Util.class.php
+++ b/libraries/Util.class.php
@@ -9,6 +9,9 @@ if (! defined('PHPMYADMIN')) {
     exit;
 }
 
+require_once 'libraries/Template.class.php';
+use PMA\Template;
+
 /**
  * Misc functions used all over the scripts.
  *
@@ -4856,16 +4859,9 @@ class PMA_Util
      */
     public static function getStartAndNumberOfRowsPanel($sql_query)
     {
-        $html = '<fieldset><div>';
-
-        $pos = isset($_REQUEST['pos']) ? $_REQUEST['pos'] : $_SESSION['tmpval']['pos'];
-        $html .= '<label for="pos">' . __('Start row:') . '</label>'
-            . '<input type="number" name="pos" min="0" required="required"';
-        if ($_REQUEST['unlim_num_rows'] > 0) {
-            $html .= ' max="' . ($_REQUEST['unlim_num_rows'] - 1) . '"';
-        }
-        $html .= ' value="' . htmlspecialchars($pos) . '" />';
-
+        $pos = isset($_REQUEST['pos'])
+            ? $_REQUEST['pos']
+            : $_SESSION['tmpval']['pos'];
         if (isset($_REQUEST['session_max_rows'])) {
             $rows = $_REQUEST['session_max_rows'];
         } else {
@@ -4875,22 +4871,16 @@ class PMA_Util
                 $rows = $GLOBALS['cfg']['MaxRows'];
             }
         }
-        $html .= '<label for="session_max_rows">'
-            . __('Number of rows:')
-            . '</label>'
-            . '<input type="number" name="session_max_rows" min="1"'
-            . ' value="' . htmlspecialchars($rows) . '" required="required" />';
 
-        $html .= '<input type="submit" name="submit" class="Go"'
-            . ' value="' . __('Go') . '" />'
-            . '<input type="hidden" name="sql_query"'
-            . ' value="' . htmlspecialchars($sql_query) . '" />'
-            . '<input type="hidden" name="unlim_num_rows"'
-            . ' value="' . htmlspecialchars($_REQUEST['unlim_num_rows']) . '" />';
-
-        $html .= '</div></fieldset>';
-
-        return $html;
+        return Template::get('startAndNumberOfRowsPanel')
+            ->render(
+                array(
+                    'pos' => $pos,
+                    'unlim_num_rows' => $_REQUEST['unlim_num_rows'],
+                    'rows' => $rows,
+                    'sql_query' => $sql_query,
+                )
+            );
     }
 }
 

--- a/templates/startAndNumberOfRowsPanel.phtml
+++ b/templates/startAndNumberOfRowsPanel.phtml
@@ -1,0 +1,20 @@
+<fieldset>
+    <div>
+        <label for="pos"><?php echo__('Start row:'); ?></label>
+        <input type="number" name="pos" min="0" required="required"
+            <?php if ($unlim_num_rows > 0) : ?>
+                max="<?php echo ($unlim_num_rows - 1); ?>"
+            <?php endif; ?>
+            value="<?php echo htmlspecialchars($pos); ?>" />
+
+        <label for="session_max_rows"><?php echo __('Number of rows:'); ?></label>
+        <input type="number" name="session_max_rows" min="1"
+               value="<?php echo htmlspecialchars($rows); ?>" required="required" />
+        <input type="submit" name="submit" class="Go"
+               value="<?php echo __('Go'); ?>" />
+        <input type="hidden" name="sql_query"
+               value="<?php echo htmlspecialchars($sql_query); ?>" />
+        <input type="hidden" name="unlim_num_rows"
+               value="<?php echo htmlspecialchars($unlim_num_rows); ?>" />
+    </div>
+</fieldset>

--- a/templates/startAndNumberOfRowsPanel.phtml
+++ b/templates/startAndNumberOfRowsPanel.phtml
@@ -1,6 +1,6 @@
 <fieldset>
     <div>
-        <label for="pos"><?php echo__('Start row:'); ?></label>
+        <label for="pos"><?php echo __('Start row:'); ?></label>
         <input type="number" name="pos" min="0" required="required"
             <?php if ($unlim_num_rows > 0) : ?>
                 max="<?php echo ($unlim_num_rows - 1); ?>"


### PR DESCRIPTION
Please, do not merge this PR!

I wanted to do some templating on \PMA_Util::getStartAndNumberOfRowsPanel. But after doing the template, sending the right parameters and loading the page to check the result… I saw that it didn't work…
I think that this is because of use of ob_\* functions in \PMA\Template::render.

To understand, you need to know that:
- tbl_chart.php use tbl_chart.phtml
- tbl_chart.phtml use \PMA_Util::getStartAndNumberOfRowsPanel
- \PMA_Util::getStartAndNumberOfRowsPanel use startAndNumberOfRowsPanel.phtml (in this PR only)

As you can see, 2 phtml are used. So the code is going twice into \PMA\Template::render. So ob_start() is run twice (it seems that's not a big deal) and mostly, ob_get_clean() is run twice… And after the first one, the include is printing the data.

I see 2 ways to fix this:
- Create an "ob" object that manage the fact that ob_start / ob_get_clean is run many times (and so won't run it if already called)
- Return a value into phtml (see http://us2.php.net/manual/en/function.include.php); but I don't think this is a good thing, because that means that phtml are written in full PHP

Do you have any comment or idea to fix this issue?
