### PR TITLE
Fix issue with dropdown in Settings > Navi panel > Tables

### DIFF
--- a/libraries/config.values.php
+++ b/libraries/config.values.php
@@ -43,7 +43,7 @@ $cfg_db['NavigationTreeDefaultTabTable'] = array(
     'browse' => __('Browse')        // browse page
 );
 $cfg_db['NavigationTreeDefaultTabTable2'] = array(
-    '', //don't display
+    '' => '', //don't display
     'structure' => __('Structure'), // fields list
     'sql' => __('SQL'),             // SQL form
     'search' => __('Search'),       // search page


### PR DESCRIPTION
dropdown for NavigationTreeDefaultTabTable2 was not behaving properly

Signed-off-by: Nisarg Jhaveri nisargjhaveri@gmail.com
