### PR TITLE
Make text and password fields in config forms smaller

### DIFF
--- a/libraries/config/FormDisplay.tpl.php
+++ b/libraries/config/FormDisplay.tpl.php
@@ -230,11 +230,11 @@ function PMA_displayInput($path, $name, $type, $value, $description = '',
 
     switch ($type) {
     case 'text':
-        $htmlOutput .= '<input type="text" size="60" ' . $name_id . $field_class
+        $htmlOutput .= '<input type="text" size="40" ' . $name_id . $field_class
             . ' value="' . htmlspecialchars($value) . '" />';
         break;
     case 'password':
-        $htmlOutput .= '<input type="password" size="60" ' . $name_id . $field_class
+        $htmlOutput .= '<input type="password" size="40" ' . $name_id . $field_class
             . ' value="' . htmlspecialchars($value) . '" />';
         break;
     case 'short_text':

--- a/test/libraries/PMA_FormDisplay_tpl_test.php
+++ b/test/libraries/PMA_FormDisplay_tpl_test.php
@@ -200,7 +200,7 @@ class PMA_FormDisplay_Tpl_Test extends PHPUnit_Framework_TestCase
         );
 
         $this->assertContains(
-            '<input type="text" size="60" name="test/path" id="test/path" ' .
+            '<input type="text" size="40" name="test/path" id="test/path" ' .
             'class="custom field-error" value="val" />',
             $result
         );


### PR DESCRIPTION
The size of these field in config forms was a little too big and was causing some problems with navigation panel settings dialig box
