### PR TITLE
Changed the mysql reserved words conflicting column names in Designer settings

### DIFF
--- a/db_designer.php
+++ b/db_designer.php
@@ -97,7 +97,7 @@ if (isset($_REQUEST['operation'])) {
                 . '.' . PMA_Util::backquote($cfgDesigner['table'])
                 . ' VALUES("' . $cfgDesigner['user'] . '", "'
                 . $_REQUEST['index'] . '", "' . $_REQUEST['value'] . '") ON DUPLICATE KEY '
-                . 'UPDATE VALUE = "' . $_REQUEST['value'] . '";';
+                . 'UPDATE `stored_value` = "' . $_REQUEST['value'] . '";';
 
             $success = $GLOBALS['dbi']->query($query);
             $response->isSuccess($success);

--- a/libraries/db_designer.lib.php
+++ b/libraries/db_designer.lib.php
@@ -186,60 +186,60 @@ function PMA_getSideMenuParamsArray()
 
     if ($GLOBALS['cfgRelation']['designer_settingswork']) {
         // angular_direct
-        $query = 'SELECT `value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
+        $query = 'SELECT `stored_value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
             . PMA_Util::backquote($cfgRelation['designer_settings']) . ' WHERE ' . PMA_Util::backquote('username') . ' = "'
-            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('index') . ' = "angular_direct"';
+            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('setting') . ' = "angular_direct"';
 
         $result = $GLOBALS['dbi']->fetchSingleRow($query);
-        $params['angular_direct'] = $result['value'];
+        $params['angular_direct'] = $result['stored_value'];
 
         // snap_to_grid
-        $query = 'SELECT `value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
+        $query = 'SELECT `stored_value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
             . PMA_Util::backquote($cfgRelation['designer_settings']) . ' WHERE ' . PMA_Util::backquote('username') . ' = "'
-            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('index') . ' = "snap_to_grid"';
+            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('setting') . ' = "snap_to_grid"';
 
         $result = $GLOBALS['dbi']->fetchSingleRow($query);
-        $params['snap_to_grid'] = $result['value'];
+        $params['snap_to_grid'] = $result['stored_value'];
 
         // small_big_all
-        $query = 'SELECT `value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
+        $query = 'SELECT `stored_value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
             . PMA_Util::backquote($cfgRelation['designer_settings']) . ' WHERE ' . PMA_Util::backquote('username') . ' = "'
-            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('index') . ' = "small_big_all"';
+            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('setting') . ' = "small_big_all"';
 
         $result = $GLOBALS['dbi']->fetchSingleRow($query);
-        $params['small_big_all'] = $result['value'];
+        $params['small_big_all'] = $result['stored_value'];
 
         // relation_lines
-        $query = 'SELECT `value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
+        $query = 'SELECT `stored_value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
             . PMA_Util::backquote($cfgRelation['designer_settings']) . ' WHERE ' . PMA_Util::backquote('username') . ' = "'
-            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('index') . ' = "relation_lines"';
+            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('setting') . ' = "relation_lines"';
 
         $result = $GLOBALS['dbi']->fetchSingleRow($query);
-        $params['relation_lines'] = $result['value'];
+        $params['relation_lines'] = $result['stored_value'];
 
         // full_screen
-        $query = 'SELECT `value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
+        $query = 'SELECT `stored_value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
             . PMA_Util::backquote($cfgRelation['designer_settings']) . ' WHERE ' . PMA_Util::backquote('username') . ' = "'
-            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('index') . ' = "full_screen"';
+            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('setting') . ' = "full_screen"';
 
         $result = $GLOBALS['dbi']->fetchSingleRow($query);
-        $params['full_screen'] = $result['value'];
+        $params['full_screen'] = $result['stored_value'];
 
         // side_menu
-        $query = 'SELECT `value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
+        $query = 'SELECT `stored_value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
             . PMA_Util::backquote($cfgRelation['designer_settings']) . ' WHERE ' . PMA_Util::backquote('username') . ' = "'
-            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('index') . ' = "side_menu"';
+            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('setting') . ' = "side_menu"';
 
         $result = $GLOBALS['dbi']->fetchSingleRow($query);
-        $params['side_menu'] = $result['value'];
+        $params['side_menu'] = $result['stored_value'];
 
         // pin_text
-        $query = 'SELECT `value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
+        $query = 'SELECT `stored_value` FROM ' . PMA_Util::backquote($cfgRelation['db']) . '.'
             . PMA_Util::backquote($cfgRelation['designer_settings']) . ' WHERE ' . PMA_Util::backquote('username') . ' = "'
-            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('index') . ' = "pin_text"';
+            . $GLOBALS['cfg']['Server']['user'] . '" AND ' . PMA_Util::backquote('setting') . ' = "pin_text"';
 
         $result = $GLOBALS['dbi']->fetchSingleRow($query);
-        $params['pin_text'] = $result['value'];
+        $params['pin_text'] = $result['stored_value'];
     }
 
     return $params;

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -330,9 +330,9 @@ CREATE TABLE IF NOT EXISTS `pma__central_columns` (
 
 CREATE TABLE IF NOT EXISTS `pma__designer_settings` (
   `username` varchar(64) NOT NULL,
-  `index` varchar(64) NOT NULL,
-  `value` varchar(64) NOT NULL,
-  PRIMARY KEY (`username`,`index`)
+  `setting` varchar(64) NOT NULL,
+  `stored_value` varchar(64) NOT NULL,
+  PRIMARY KEY (`username`,`setting`)
 )
   COMMENT='Settings related to Designer'
   DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;

--- a/sql/create_tables_drizzle.sql
+++ b/sql/create_tables_drizzle.sql
@@ -282,9 +282,9 @@ CREATE TABLE IF NOT EXISTS `pma__savedsearches` (
 
 CREATE TABLE IF NOT EXISTS `pma__designer_settings` (
   `username` varchar(64) NOT NULL,
-  `index` varchar(64) NOT NULL,
-  `value` varchar(64) NOT NULL,
-  PRIMARY KEY (`username`,`index`)
+  `setting` varchar(64) NOT NULL,
+  `stored_value` varchar(64) NOT NULL,
+  PRIMARY KEY (`username`,`setting`)
 )
   COMMENT='Settings related to Designer'
   DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;


### PR DESCRIPTION
Changed the conflicting column names of `index` and `value` to `setting` and `stored_value`.

Any suggestions over these renaming are welcome.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
