### PR TITLE
rfe#1603 select structure or data for each table when exporting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -69,6 +69,7 @@ phpMyAdmin - ChangeLog
 + rfe #1531 Cant use external config file
 + rfe #1552 CSV import: Allow "Columns escaped with" to be optional
 + rfe #1561 Being able to use multiple servers at the same time when using cookie auth
++ rfe #1603 select structure or data for each table when exporting
 
 4.4.11.0 (not yet released)
 - bug       Missing selected/entered values when editing active options in visual query builder

--- a/db_export.php
+++ b/db_export.php
@@ -37,21 +37,25 @@ if ($num_tables < 1) {
     exit;
 } // end if
 
-$multi_values  = '<div>';
-$multi_values .= '<a href="#"';
-$multi_values .= ' onclick="setSelectOptions(\'dump\', \'table_select[]\', true);'
-    . ' return false;">';
-$multi_values .= __('Select All');
-$multi_values .= '</a>';
-$multi_values .= ' / ';
-$multi_values .= '<a href="#"';
-$multi_values .= ' onclick="setSelectOptions(\'dump\', \'table_select[]\', false);'
-    . ' return false;">';
-$multi_values .= __('Unselect All');
-$multi_values .= '</a><br />';
-
-$multi_values .= '<select name="table_select[]" id="table_select" size="10"'
-    . ' multiple="multiple">';
+$multi_values  = '<div class="export_table_list_container">';
+if (isset($_GET['structure_or_data_forced'])) {
+    $force_val = htmlspecialchars($_GET['structure_or_data_forced']);
+} else {
+    $force_val = 0;
+}
+$multi_values .= '<input type="hidden" name="structure_or_data_forced" value="' . $force_val . '">';
+$multi_values .= '<table class="export_table_select">'
+    . '<thead><tr><th></th>'
+    . '<th>' . __('Tables') . '</th>'
+    . '<th class="export_structure">' . __('Structure') . '</th>'
+    . '<th class="export_data">' . __('Data') . '</th>'
+    . '</tr><tr>'
+    . '<td></td>'
+    . '<td class="export_table_name all">' . __('Select all') . '</td>'
+    . '<td class="export_structure all"><input type="checkbox" id="table_structure_all" /></td>'
+    . '<td class="export_data all"><input type="checkbox" id="table_data_all" /></td>'
+    . '</tr></thead>'
+    . '<tbody>';
 $multi_values .= "\n";
 
 // when called by libraries/mult_submits.inc.php
@@ -65,31 +69,63 @@ if (isset($_GET['table_select'])) {
     $_GET['table_select'] = urldecode($_GET['table_select']);
     $_GET['table_select'] = explode(",", $_GET['table_select']);
 }
+if (isset($_GET['table_structure'])) {
+    $_GET['table_structure'] = urldecode($_GET['table_structure']);
+    $_GET['table_structure'] = explode(",", $_GET['table_structure']);
+}
+if (isset($_GET['table_data'])) {
+    $_GET['table_data'] = urldecode($_GET['table_data']);
+    $_GET['table_data'] = explode(",", $_GET['table_data']);
+}
 
 foreach ($tables as $each_table) {
     if (isset($_GET['table_select'])) {
         if (in_array($each_table['Name'], $_GET['table_select'])) {
-            $is_selected = ' selected="selected"';
+            $is_checked = ' checked="checked"';
         } else {
-            $is_selected = '';
+            $is_checked = '';
         }
     } elseif (isset($table_select)) {
         if (in_array($each_table['Name'], $table_select)) {
-            $is_selected = ' selected="selected"';
+            $is_checked = ' checked="checked"';
         } else {
-            $is_selected = '';
+            $is_checked = '';
         }
     } else {
-        $is_selected = ' selected="selected"';
+        $is_checked = ' checked="checked"';
+    }
+    if (isset($_GET['table_structure'])) {
+        if (in_array($each_table['Name'], $_GET['table_structure'])) {
+            $str_checked = ' checked="checked"';
+        } else {
+            $str_checked = '';
+        }
+    } else {
+        $str_checked = $is_checked;
+    }
+    if (isset($_GET['table_data'])) {
+        if (in_array($each_table['Name'], $_GET['table_data'])) {
+            $data_checked = ' checked="checked"';
+        } else {
+            $data_checked = '';
+        }
+    } else {
+        $data_checked = $is_checked;
     }
     $table_html   = htmlspecialchars($each_table['Name']);
-    $multi_values .= '                <option value="' . $table_html . '"'
-        . $is_selected . '>'
-        . str_replace(' ', '&nbsp;', $table_html) . '</option>' . "\n";
+    $multi_values .= '<tr>';
+    $multi_values .= '<td><input type="checkbox" name="table_select[]"'
+        . ' value="' . $table_html . '"' . $is_checked . ' /></td>';
+    $multi_values .= '<td class="export_table_name">' . str_replace(' ', '&nbsp;', $table_html) . '</td>';
+    $multi_values .= '<td class="export_structure"><input type="checkbox" name="table_structure[]"'
+        . ' value="' . $table_html . '"' . $str_checked . ' /></td>';
+    $multi_values .= '<td class="export_data"><input type="checkbox" name="table_data[]"'
+        . ' value="' . $table_html . '"' . $data_checked . ' /></td>';
+    $multi_values .= '</tr>';
 } // end for
 
 $multi_values .= "\n";
-$multi_values .= '</select></div>';
+$multi_values .= '</tbody></table></div>';
 
 $export_type = 'database';
 require_once 'libraries/display_export.inc.php';

--- a/export.php
+++ b/export.php
@@ -49,6 +49,8 @@ if (!defined('TESTSUITE')) {
             'quick_or_custom',
             'db_select',
             'table_select',
+            'table_structure',
+            'table_data',
             'limit_to',
             'limit_from',
             'allrows',
@@ -432,13 +434,23 @@ if (!defined('TESTSUITE')) {
                 $aliases, $separate_files
             );
         } elseif ($export_type == 'database') {
+            if (!isset($table_structure) || !is_array($table_structure)) {
+                $table_structure = array();
+            }
+            if (!isset($table_data) || !is_array($table_data)) {
+                $table_data = array();
+            }
+            if (!empty($_REQUEST['structure_or_data_forced'])) {
+                $table_structure = $tables;
+                $table_data = $tables;
+            }
             if (isset($lock_tables)) {
                 PMA_lockTables($db, $tables, "READ");
                 try {
                     PMA_exportDatabase(
-                        $db, $tables, $whatStrucOrData, $export_plugin, $crlf,
-                        $err_url, $export_type, $do_relation, $do_comments,
-                        $do_mime, $do_dates, $aliases, $separate_files
+                        $db, $tables, $whatStrucOrData, $table_structure, $table_data,
+                        $export_plugin, $crlf, $err_url, $export_type, $do_relation,
+                        $do_comments, $do_mime, $do_dates, $aliases, $separate_files
                     );
                     PMA_unlockTables();
                 } catch (Exception $e) { // TODO use finally when PHP version is 5.5
@@ -447,9 +459,9 @@ if (!defined('TESTSUITE')) {
                 }
             } else {
                 PMA_exportDatabase(
-                    $db, $tables, $whatStrucOrData, $export_plugin, $crlf, $err_url,
-                    $export_type, $do_relation, $do_comments, $do_mime, $do_dates,
-                    $aliases, $separate_files
+                    $db, $tables, $whatStrucOrData, $table_structure, $table_data,
+                    $export_plugin, $crlf, $err_url, $export_type, $do_relation,
+                    $do_comments, $do_mime, $do_dates, $aliases, $separate_files
                 );
             }
         } else {

--- a/js/functions.js
+++ b/js/functions.js
@@ -1744,7 +1744,6 @@ AJAX.registerTeardown('functions.js', function () {
         $(document).off('blur', '#sqlquery');
     }
     $(document).off('change', '#parameterized');
-    $("#export_type").unbind('change');
     $('#sqlquery').unbind('keydown');
     $('#sql_query_edit').unbind('keydown');
 

--- a/libraries/display_export.lib.php
+++ b/libraries/display_export.lib.php
@@ -260,7 +260,23 @@ function PMA_getHtmlForExportOptionsSelection($export_type, $multi_values)
 }
 
 /**
- * Prints Html For Export Options Format
+ * Prints Html For Export Options Format dropdown
+ *
+ * @param ExportPlugin[] $export_list Export List
+ *
+ * @return string
+ */
+function PMA_getHtmlForExportOptionsFormatDropdown($export_list)
+{
+    $html  = '<div class="exportoptions" id="format">';
+    $html .= '<h3>' . __('Format:') . '</h3>';
+    $html .= PMA_pluginGetChoice('Export', 'what', $export_list, 'format');
+    $html .= '</div>';
+    return $html;
+}
+
+/**
+ * Prints Html For Export Options Format-specific options
  *
  * @param ExportPlugin[] $export_list Export List
  *
@@ -268,12 +284,7 @@ function PMA_getHtmlForExportOptionsSelection($export_type, $multi_values)
  */
 function PMA_getHtmlForExportOptionsFormat($export_list)
 {
-    $html  = '<div class="exportoptions" id="format">';
-    $html .= '<h3>' . __('Format:') . '</h3>';
-    $html .= PMA_pluginGetChoice('Export', 'what', $export_list, 'format');
-    $html .= '</div>';
-
-    $html .= '<div class="exportoptions" id="format_specific_opts">';
+    $html = '<div class="exportoptions" id="format_specific_opts">';
     $html .= '<h3>' . __('Format-specific options:') . '</h3>';
     $html .= '<p class="no_js_msg" id="scroll_to_options_msg">';
     $html .= __(
@@ -760,6 +771,7 @@ function PMA_getHtmlForExportOptions(
     global $cfg;
     $html  = PMA_getHtmlForExportOptionHeader($export_type, $db, $table);
     $html .= PMA_getHtmlForExportOptionsMethod();
+    $html .= PMA_getHtmlForExportOptionsFormatDropdown($export_list);
     $html .= PMA_getHtmlForExportOptionsSelection($export_type, $multi_values);
 
     $tableLength = /*overload*/mb_strlen($table);

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -1508,6 +1508,30 @@ select.invalid_value,
   * Export and Import styles
   */
 
+.export_table_list_container {
+    display: inline-block;
+    max-height: 20em;
+    overflow-y: scroll;
+}
+
+.export_table_select th {
+    text-align: center;
+    vertical-align: middle;
+}
+
+.export_table_select .all {
+    font-weight: bold;
+    border-bottom: 1px solid black;
+}
+
+.export_structure, .export_data {
+    text-align: center;
+}
+
+.export_table_name {
+    vertical-align: middle;
+}
+
 .exportoptions h3, .importoptions h3 {
     border-bottom: 1px #999999 solid;
     font-size: 110%;

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -1994,6 +1994,30 @@ select.invalid_value,
   * Export and Import styles
   */
 
+.export_table_list_container {
+    display: inline-block;
+    max-height: 20em;
+    overflow-y: scroll;
+}
+
+.export_table_select th {
+    text-align: center;
+    vertical-align: middle;
+}
+
+.export_table_select .all {
+    font-weight: bold;
+    border-bottom: 1px solid black;
+}
+
+.export_structure, .export_data {
+    text-align: center;
+}
+
+.export_table_name {
+    vertical-align: middle;
+}
+
 .exportoptions h3,
 .importoptions h3 {
     border-bottom: 1px #999 solid;


### PR DESCRIPTION
Finally, I had to keep the the current options, too. As they also control whether to export database structure and all. So, now the current radio buttons enables or disables data/structure selectors for tables. Also, if there is no choice available by plugin, both the checkboxes(data,structures) are disabled.

I was stuck with this for a really long time, so the chances of errors in slightly high.
