### PR TITLE
Few fixes related RFE#946 & RFE#657 - PR #1686 &  PR #1664

### DIFF
--- a/js/tbl_structure.js
+++ b/js/tbl_structure.js
@@ -108,33 +108,6 @@ AJAX.registerOnload('tbl_structure.js', function () {
         var $form = $(this);
         var field_cnt = $form.find('input[name=orig_num_fields]').val();
 
-        /*
-         * First validate the form; if there is a problem, avoid submitting it
-         *
-         * checkTableEditForm() needs a pure element and not a jQuery object,
-         * this is why we pass $form[0] as a parameter (the jQuery object
-         * is actually an array of DOM elements)
-         */
-        if (checkTableEditForm($form[0], field_cnt)) {
-            // OK, form passed validation step
-
-            PMA_prepareForAjaxRequest($form);
-            if (PMA_checkReservedWordColumns($form)) {
-                //User wants to submit the form
-
-                // If Collation is changed, Warn and Confirm
-                if (checkIfConfirmRequired($form, field_cnt)){
-                    var question = sprintf(
-                        PMA_messages.strChangeColumnCollation, 'http://wiki.phpmyadmin.net/pma/Garbled_data'
-                    );
-                    $form.PMA_confirm(question, $form.attr('action'), function (url) {
-                        submitForm();
-                    });
-                } else {
-                    submitForm();
-                }
-            }
-        }
 
         function submitForm(){
             $msg = PMA_ajaxShowMessage(PMA_messages.strProcessingRequest);
@@ -180,6 +153,34 @@ AJAX.registerOnload('tbl_structure.js', function () {
                 }
             }
             return checkRequired;
+        }
+
+        /*
+         * First validate the form; if there is a problem, avoid submitting it
+         *
+         * checkTableEditForm() needs a pure element and not a jQuery object,
+         * this is why we pass $form[0] as a parameter (the jQuery object
+         * is actually an array of DOM elements)
+         */
+        if (checkTableEditForm($form[0], field_cnt)) {
+            // OK, form passed validation step
+
+            PMA_prepareForAjaxRequest($form);
+            if (PMA_checkReservedWordColumns($form)) {
+                //User wants to submit the form
+
+                // If Collation is changed, Warn and Confirm
+                if (checkIfConfirmRequired($form, field_cnt)){
+                    var question = sprintf(
+                        PMA_messages.strChangeColumnCollation, 'http://wiki.phpmyadmin.net/pma/Garbled_data'
+                    );
+                    $form.PMA_confirm(question, $form.attr('action'), function (url) {
+                        submitForm();
+                    });
+                } else {
+                    submitForm();
+                }
+            }
         }
     }); // end change table button "do_save_data"
 

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -2596,6 +2596,7 @@ function PMA_updateColumns($db, $table)
 
             if (isset($_REQUEST['field_adjust_privileges'][$i])
                 && ! empty($_REQUEST['field_adjust_privileges'][$i])
+                && $_REQUEST['field_orig'][$i] != $_REQUEST['field_name'][$i]
             ) {
                     $adjust_privileges[$_REQUEST['field_orig'][$i]] = $_REQUEST['field_name'][$i];
             }
@@ -2799,9 +2800,11 @@ function PMA_adjustColumnPrivileges($db, $table, $adjust_privileges)
         $changed = true;
     }
 
-    // Finally FLUSH the new privileges
-    $flushPrivQuery = "FLUSH PRIVILEGES;";
-    $GLOBALS['dbi']->query($flushPrivQuery);
+    if ($changed) {
+        // Finally FLUSH the new privileges
+        $flushPrivQuery = "FLUSH PRIVILEGES;";
+        $GLOBALS['dbi']->query($flushPrivQuery);
+    }
 
     return $changed;
 }

--- a/libraries/structure.lib.php
+++ b/libraries/structure.lib.php
@@ -2645,8 +2645,8 @@ function PMA_updateColumns($db, $table)
                 && $_REQUEST['field_collation'][$i] !== $_REQUEST['field_collation_orig'][$i]
             ) {
                 $secondary_query = 'ALTER TABLE ' . PMA_Util::backquote($table)
-                    . ' CHANGE ' . PMA_Util::backquote($_REQUEST['field_name'][$i])
-                    . ' ' . PMA_Util::backquote($_REQUEST['field_name'][$i])
+                    . ' CHANGE ' . PMA_Util::backquote($_REQUEST['field_orig'][$i])
+                    . ' ' . PMA_Util::backquote($_REQUEST['field_orig'][$i])
                     . ' BLOB;';
                 $GLOBALS['dbi']->query($secondary_query);
                 $changedToBlob[$i] = true;


### PR DESCRIPTION
Fixes:
1. Move JS function definitions before usage to make Scrutinizer happy. (PR #1686)
2. Run "FLUSH PRIVILEGES" only when at least one of the column names have been changed (PR #1664 ).
3. Also, changing collation along with some other changes to the column definition (esp. to column name) was not working as expected, as it was using the new column name instead of the old one in an intermediate query. This commit should fix it. 

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
