### PR TITLE
'As Separate files' export works with ZIP compression only

### DIFF
--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -1403,7 +1403,7 @@ $cfg['Export']['compression'] = 'none';
 $cfg['Export']['lock_tables'] = false;
 
 /**
- * Whether to export databases/tablse as seperate files
+ * Whether to export databases/tables as separate files
  *
  * @global boolean $cfg['Export']['as_separate_files']
  */

--- a/libraries/display_export.lib.php
+++ b/libraries/display_export.lib.php
@@ -586,6 +586,13 @@ function PMA_getHtmlForExportOptionsOutputCompression()
         $selected_compression = "none";
     }
 
+    // Since separate files export works with ZIP only
+    if (isset($cfg['Export']['as_separate_files'])
+        && $cfg['Export']['as_separate_files']
+    ) {
+        $selected_compression = "zip";
+    }
+
     $html = "";
     // zip and gzip encode features
     $is_zip  = ($cfg['ZipDump']  && @function_exists('gzcompress'));


### PR DESCRIPTION
When exporting 'as_separate_files', compression method should be fixed as 'zip', as it currently supports only ZIP compression.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
