### PR TITLE
Bug#4975-Some Tbl/Db operations don't work on Drizzle

### DIFF
--- a/libraries/Table.class.php
+++ b/libraries/Table.class.php
@@ -1065,9 +1065,11 @@ class PMA_Table
         if (($what == 'data' || $what == 'dataonly')
             && ! PMA_Table::isView($target_db, $target_table)
         ) {
-            $sql_set_mode = "SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO'";
-            $GLOBALS['dbi']->query($sql_set_mode);
-            $GLOBALS['sql_query'] .= "\n\n" . $sql_set_mode . ';';
+            if (! PMA_DRIZZLE) {
+                $sql_set_mode = "SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO'";
+                $GLOBALS['dbi']->query($sql_set_mode);
+                $GLOBALS['sql_query'] .= "\n\n" . $sql_set_mode . ';';
+            }
 
             $sql_insert_data = 'INSERT INTO ' . $target
                 . ' SELECT * FROM ' . $source;

--- a/libraries/operations.lib.php
+++ b/libraries/operations.lib.php
@@ -336,8 +336,10 @@ function PMA_createDbBeforeCopy()
 
     // Set the SQL mode to NO_AUTO_VALUE_ON_ZERO to prevent MySQL from creating
     // export statements it cannot import
-    $sql_set_mode = "SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO'";
-    $GLOBALS['dbi']->query($sql_set_mode);
+    if (! PMA_DRIZZLE) {
+        $sql_set_mode = "SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO'";
+        $GLOBALS['dbi']->query($sql_set_mode);
+    }
 
     // rebuild the database list because PMA_Table::moveCopy
     // checks in this list if the target db exists


### PR DESCRIPTION
Bug#4975 - Move/ Copy/ Rename operations on Table/ Db fail on Drizzle server

'SQL_MODE' does not exist in Drizzle.
So, the query 'SET SQL_MODE = NO_AUTO_VALUE_ON_ZERO' fails, while we are on Drizzle server.

Related discussion : 
https://lists.launchpad.net/drizzle-discuss/msg04101.html
https://bugs.launchpad.net/drizzle/+bug/314567

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
