### PR TITLE
Move to html5 history api

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -354,7 +354,7 @@ var AJAX = {
                 if (data._menu) {
                     if (history && history.pushState) {
                         history.replaceState({
-                            menu : data._menu
+                                menu : data._menu
                             },
                             null
                         );
@@ -545,7 +545,7 @@ var AJAX = {
          *
          * @return void
          */
-        load: function (files) {
+        load: function (files, callback) {
             var self = this;
             self._scriptsToBeLoaded = [];
             self._scriptsToBeFired = [];
@@ -572,7 +572,7 @@ var AJAX = {
             if (needRequest) {
                 this.appendScript("js/get_scripts.js.php?" + request.join("&"));
             } else {
-                self.done();
+                self.done(callback);
             }
         },
         /**
@@ -580,7 +580,10 @@ var AJAX = {
          *
          * @return void
          */
-        done: function () {
+        done: function (callback) {
+            if($.isFunction(callback)) {
+                callback();
+            }
             if (typeof ErrorReport !== 'undefined') {
                 ErrorReport.wrap_global_functions();
             }
@@ -714,31 +717,33 @@ $(function () {
         });
         // Add initial menu to history state object
         history.replaceState({
-            menu : menuContent
+                menu : menuContent
             },
             null
         );
     } else {
         // Fallback to microhistory mechanism
-        AJAX.scriptHandler.load([{'name' : 'microhistory.js', 'fire' : 1}]);
-        // The cache primer is set by the footer class
-        if (PMA_MicroHistory.primer.url) {
-            PMA_MicroHistory.menus.add(
-                PMA_MicroHistory.primer.menuHash,
-                menuContent
-            );
-        }
-        $(function () {
-            // Queue up this event twice to make sure that we get a copy
-            // of the page after all other onload events have been fired
-            if (PMA_MicroHistory.primer.url) {
-                PMA_MicroHistory.add(
-                    PMA_MicroHistory.primer.url,
-                    PMA_MicroHistory.primer.scripts,
-                    PMA_MicroHistory.primer.menuHash
-                );
-            }
-        });
+        AJAX.scriptHandler
+            .load([{'name' : 'microhistory.js', 'fire' : 1}], function () {
+                // The cache primer is set by the footer class
+                if (PMA_MicroHistory.primer.url) {
+                    PMA_MicroHistory.menus.add(
+                        PMA_MicroHistory.primer.menuHash,
+                        menuContent
+                    );
+                }
+                $(function () {
+                    // Queue up this event twice to make sure that we get a copy
+                    // of the page after all other onload events have been fired
+                    if (PMA_MicroHistory.primer.url) {
+                        PMA_MicroHistory.add(
+                            PMA_MicroHistory.primer.url,
+                            PMA_MicroHistory.primer.scripts,
+                            PMA_MicroHistory.primer.menuHash
+                        );
+                    }
+                });
+            });
     }
 });
 

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -184,6 +184,15 @@ var AJAX = {
         AJAX.lockedTargets = {};
         $('#lock_page_icon').html('');
     },
+    handleMenu: {
+        replace: function (content) {
+            $('#floating_menubar').html(content)
+                // Remove duplicate wrapper
+                // TODO: don't send it in the response
+                .children().first().remove();
+            $('#topmenu').menuResizer(PMA_mainMenuResizerCallback);
+        }
+    },
     /**
      * Event handler for clicks on links and form submissions
      *
@@ -264,8 +273,10 @@ var AJAX = {
         if (! isLink) {
             params += '&' + $(this).serialize();
         }
-        // Add a list of menu hashes that we have in the cache to the request
-        params += AJAX.cache.menus.getRequestParam();
+        if (! (history && history.pushState)) {
+            // Add a list of menu hashes that we have in the cache to the request
+            params += PMA_MicroHistory.menus.getRequestParam();
+        }
 
         if (AJAX._debug) {
             console.log("Loading: " + url); // no need to translate
@@ -328,10 +339,15 @@ var AJAX = {
                     $('title').replaceWith(data._title);
                 }
                 if (data._menu) {
-                    AJAX.cache.menus.replace(data._menu);
-                    AJAX.cache.menus.add(data._menuHash, data._menu);
+                    
+                    if (! (history && history.pushState)) {
+                        PMA_MicroHistory.menus.replace(data._menu);
+                        PMA_MicroHistory.menus.add(data._menuHash, data._menu);
+                    }
                 } else if (data._menuHash) {
-                    AJAX.cache.menus.replace(AJAX.cache.menus.get(data._menuHash));
+                    if (! (history && history.pushState)) {
+                        PMA_MicroHistory.menus.replace(PMA_MicroHistory.menus.get(data._menuHash));
+                    }
                 }
                 if (data._disableNaviSettings) {
                     PMA_disableNaviSettings();
@@ -382,13 +398,15 @@ var AJAX = {
                     AJAX.scriptHandler.load(data._scripts);
                 }
                 if (data._selflink && data._scripts && data._menuHash && data._params) {
-                    AJAX.cache.add(
-                        data._selflink,
-                        data._scripts,
-                        data._menuHash,
-                        data._params,
-                        AJAX.source.attr('rel')
-                    );
+                    if (! (history && history.pushState)) {
+                        PMA_MicroHistory.add(
+                            data._selflink,
+                            data._scripts,
+                            data._menuHash,
+                            data._params,
+                            AJAX.source.attr('rel')
+                        );
+                    }
                 }
                 if (data._params) {
                     PMA_commonParams.setAll(data._params);
@@ -585,7 +603,9 @@ var AJAX = {
              */
             $(document).off('click', 'a').on('click', 'a', AJAX.requestHandler);
             $(document).off('submit', 'form').on('submit', 'form', AJAX.requestHandler);
-            AJAX.cache.update();
+            if (! (history && history.pushState)) {
+                PMA_MicroHistory.update();
+            }
             callback();
         }
     }
@@ -655,363 +675,37 @@ AJAX.registerOnload('functions.js', function () {
 });
 
 /**
- * An implementation of a client-side page cache.
- * This object also uses the cache to provide a simple microhistory,
- * that is the ability to use the back and forward buttons in the browser
- */
-AJAX.cache = {
-    /**
-     * @var int The maximum number of pages to keep in the cache
-     */
-    MAX: 6,
-    /**
-     * @var object A hash used to prime the cache with data about the initially
-     *             loaded page. This is set in the footer, and then loaded
-     *             by a double-queued event further down this file.
-     */
-    primer: {},
-    /**
-     * @var array Stores the content of the cached pages
-     */
-    pages: [],
-    /**
-     * @var int The index of the currently loaded page
-     *          This is used to know at which point in the history we are
-     */
-    current: 0,
-    /**
-     * Saves a new page in the cache
-     *
-     * @param string hash    The hash part of the url that is being loaded
-     * @param array  scripts A list of scripts that is required for the page
-     * @param string menu    A hash that links to a menu stored
-     *                       in a dedicated menu cache
-     * @param array  params  A list of parameters used by PMA_commonParams()
-     * @param string rel     A relationship to the current page:
-     *                       'samepage': Forces the response to be treated as
-     *                                   the same page as the current one
-     *                       'newpage':  Forces the response to be treated as
-     *                                   a new page
-     *                       undefined:  Default behaviour, 'samepage' if the
-     *                                   selflinks of the two pages are the same.
-     *                                   'newpage' otherwise
-     *
-     * @return void
-     */
-    add: function (hash, scripts, menu, params, rel) {
-        if (this.pages.length > AJAX.cache.MAX) {
-            // Trim the cache, to the maximum number of allowed entries
-            // This way we will have a cached menu for every page
-            for (var i = 0; i < this.pages.length - this.MAX; i++) {
-                delete this.pages[i];
-            }
-        }
-        while (this.current < this.pages.length) {
-            // trim the cache if we went back in the history
-            // and are now going forward again
-            this.pages.pop();
-        }
-        if (rel === 'newpage' ||
-            (
-                typeof rel === 'undefined' && (
-                    typeof this.pages[this.current - 1] === 'undefined' ||
-                    this.pages[this.current - 1].hash !== hash
-                )
-            )
-        ) {
-            this.pages.push({
-                hash: hash,
-                content: $('#page_content').html(),
-                scripts: scripts,
-                selflink: $('#selflink').html(),
-                menu: menu,
-                params: params
-            });
-            AJAX.setUrlHash(this.current, hash);
-            this.current++;
-        }
-    },
-    /**
-     * Restores a page from the cache. This is called when the hash
-     * part of the url changes and it's structure appears to be valid
-     *
-     * @param string index Which page from the history to load
-     *
-     * @return void
-     */
-    navigate: function (index) {
-        if (typeof this.pages[index] === 'undefined' ||
-            typeof this.pages[index].content === 'undefined' ||
-            typeof this.pages[index].menu === 'undefined' ||
-            ! AJAX.cache.menus.get(this.pages[index].menu)
-        ) {
-            PMA_ajaxShowMessage(
-                '<div class="error">' + PMA_messages.strInvalidPage + '</div>',
-                false
-            );
-        } else {
-            AJAX.active = true;
-            var record = this.pages[index];
-            AJAX.scriptHandler.reset(function () {
-                $('#page_content').html(record.content);
-                $('#selflink').html(record.selflink);
-                AJAX.cache.menus.replace(AJAX.cache.menus.get(record.menu));
-                PMA_commonParams.setAll(record.params);
-                AJAX.scriptHandler.load(record.scripts);
-                AJAX.cache.current = ++index;
-            });
-        }
-    },
-    /**
-     * Resaves the content of the current page in the cache.
-     * Necessary in order not to show the user some outdated version of the page
-     *
-     * @return void
-     */
-    update: function () {
-        var page = this.pages[this.current - 1];
-        if (page) {
-            page.content = $('#page_content').html();
-        }
-    },
-    /**
-     * @var object Dedicated menu cache
-     */
-    menus: {
-        /**
-         * Returns the number of items in an associative array
-         *
-         * @return int
-         */
-        size: function (obj) {
-            var size = 0, key;
-            for (key in obj) {
-                if (obj.hasOwnProperty(key)) {
-                    size++;
-                }
-            }
-            return size;
-        },
-        /**
-         * @var hash Stores the content of the cached menus
-         */
-        data: {},
-        /**
-         * Saves a new menu in the cache
-         *
-         * @param string hash    The hash (trimmed md5) of the menu to be saved
-         * @param string content The HTML code of the menu to be saved
-         *
-         * @return void
-         */
-        add: function (hash, content) {
-            if (this.size(this.data) > AJAX.cache.MAX) {
-                // when the cache grows, we remove the oldest entry
-                var oldest, key, init = 0;
-                for (var i in this.data) {
-                    if (this.data[i]) {
-                        if (! init || this.data[i].timestamp.getTime() < oldest.getTime()) {
-                            oldest = this.data[i].timestamp;
-                            key = i;
-                            init = 1;
-                        }
-                    }
-                }
-                delete this.data[key];
-            }
-            this.data[hash] = {
-                content: content,
-                timestamp: new Date()
-            };
-        },
-        /**
-         * Retrieves a menu given its hash
-         *
-         * @param string hash The hash of the menu to be retrieved
-         *
-         * @return string
-         */
-        get: function (hash) {
-            if (this.data[hash]) {
-                return this.data[hash].content;
-            } else {
-                // This should never happen as long as the number of stored menus
-                // is larger or equal to the number of pages in the page cache
-                return '';
-            }
-        },
-        /**
-         * Prepares part of the parameter string used during page requests,
-         * this is necessary to tell the server which menus we have in the cache
-         *
-         * @return string
-         */
-        getRequestParam: function () {
-            var param = '';
-            var menuHashes = [];
-            for (var i in this.data) {
-                menuHashes.push(i);
-            }
-            var menuHashesParam = menuHashes.join('-');
-            if (menuHashesParam) {
-                param = '&menuHashes=' + menuHashesParam;
-            }
-            return param;
-        },
-        /**
-         * Replaces the menu with new content
-         *
-         * @return void
-         */
-        replace: function (content) {
-            $('#floating_menubar').html(content)
-                // Remove duplicate wrapper
-                // TODO: don't send it in the response
-                .children().first().remove();
-            $('#topmenu').menuResizer(PMA_mainMenuResizerCallback);
-        }
-    }
-};
-
-/**
- * URL hash management module.
- * Allows direct bookmarking and microhistory.
- */
-AJAX.setUrlHash = (function (jQuery, window) {
-    "use strict";
-    /**
-     * Indictaes whether we have already completed
-     * the initialisation of the hash
-     *
-     * @access private
-     */
-    var ready = false;
-    /**
-     * Stores a hash that needed to be set when we were not ready
-     *
-     * @access private
-     */
-    var savedHash = "";
-    /**
-     * Flag to indicate if the change of hash was triggered
-     * by a user pressing the back/forward button or if
-     * the change was triggered internally
-     *
-     * @access private
-     */
-    var userChange = true;
-
-    // Fix favicon disappearing in Firefox when setting location.hash
-    function resetFavicon() {
-        if (navigator.userAgent.indexOf('Firefox') > -1) {
-            // Move the link tags for the favicon to the bottom
-            // of the head element to force a reload of the favicon
-            $('head > link[href=favicon\\.ico]').appendTo('head');
-        }
-    }
-
-    /**
-     * Sets the hash part of the URL
-     *
-     * @access public
-     */
-    function setUrlHash(index, hash) {
-        /*
-         * Known problem:
-         * Setting hash leads to reload in webkit:
-         * http://www.quirksmode.org/bugreports/archives/2005/05/Safari_13_visual_anomaly_with_windowlocationhref.html
-         *
-         * so we expect that users are not running an ancient Safari version
-         */
-
-        userChange = false;
-        if (ready) {
-            window.location.hash = "PMAURL-" + index + ":" + hash;
-            resetFavicon();
-        } else {
-            savedHash = "PMAURL-" + index + ":" + hash;
-        }
-    }
-    /**
-     * Start initialisation
-     */
-    if (window.location.hash.substring(0, 8) == '#PMAURL-') {
-        // We have a valid hash, let's redirect the user
-        // to the page that it's pointing to
-        var colon_position = window.location.hash.indexOf(':');
-        var questionmark_position = window.location.hash.indexOf('?');
-        if (colon_position != -1 && questionmark_position != -1 && colon_position < questionmark_position) {
-            var hash_url = window.location.hash.substring(colon_position + 1, questionmark_position);
-            if (PMA_gotoWhitelist.indexOf(hash_url) != -1) {
-                window.location = window.location.hash.substring(
-                    colon_position + 1
-                );
-            }
-        }
-    } else {
-        // We don't have a valid hash, so we'll set it up
-        // when the page finishes loading
-        jQuery(function () {
-            /* Check if we should set URL */
-            if (savedHash !== "") {
-                window.location.hash = savedHash;
-                savedHash = "";
-                resetFavicon();
-            }
-            // Indicate that we're done initialising
-            ready = true;
-        });
-    }
-    /**
-     * Register an event handler for when the url hash changes
-     */
-    jQuery(function () {
-        jQuery(window).hashchange(function () {
-            if (userChange === false) {
-                // Ignore internally triggered hash changes
-                userChange = true;
-            } else if (/^#PMAURL-\d+:/.test(window.location.hash)) {
-                // Change page if the hash changed was triggered by a user action
-                var index = window.location.hash.substring(
-                    8, window.location.hash.indexOf(':')
-                );
-                AJAX.cache.navigate(index);
-            }
-        });
-    });
-    /**
-     * Publicly exposes a reference to the otherwise private setUrlHash function
-     */
-    return setUrlHash;
-})(jQuery, window);
-
-/**
  * Page load event handler
  */
 $(function () {
-    // Add the menu from the initial page into the cache
-    // The cache primer is set by the footer class
-    if (AJAX.cache.primer.url) {
-        AJAX.cache.menus.add(
-            AJAX.cache.primer.menuHash,
-            $('<div></div>')
-                .append('<div></div>')
-                .append($('#serverinfo').clone())
-                .append($('#topmenucontainer').clone())
-                .html()
-        );
-    }
-    $(function () {
-        // Queue up this event twice to make sure that we get a copy
-        // of the page after all other onload events have been fired
-        if (AJAX.cache.primer.url) {
-            AJAX.cache.add(
-                AJAX.cache.primer.url,
-                AJAX.cache.primer.scripts,
-                AJAX.cache.primer.menuHash
+    if (history && history.pushState) {
+        // Add menu and scripts to history state object
+    } else {
+       // AJAX.scriptHandler.load();
+           // Add the menu from the initial page into the cache
+        // The cache primer is set by the footer class
+        if (PMA_MicroHistory.primer.url) {
+            PMA_MicroHistory.menus.add(
+                PMA_MicroHistory.primer.menuHash,
+                $('<div></div>')
+                    .append('<div></div>')
+                    .append($('#serverinfo').clone())
+                    .append($('#topmenucontainer').clone())
+                    .html()
             );
         }
-    });
+        $(function () {
+            // Queue up this event twice to make sure that we get a copy
+            // of the page after all other onload events have been fired
+            if (PMA_MicroHistory.primer.url) {
+                PMA_MicroHistory.add(
+                    PMA_MicroHistory.primer.url,
+                    PMA_MicroHistory.primer.scripts,
+                    PMA_MicroHistory.primer.menuHash
+                );
+            }
+        });
+    }
 });
 
 /**

--- a/js/error_report.js
+++ b/js/error_report.js
@@ -188,37 +188,6 @@ var ErrorReport = {
         ErrorReport._showReportDialog(ErrorReport._last_exception);
     },
     /**
-     * Returns the needed info about stored microhistory
-     *
-     * @return object
-     */
-    _get_microhistory: function () {
-        if (! (history && history.pushState)) {
-            var cached_pages = PMA_MicroHistory.pages.slice(-7);
-            var remove = ["common_query", "table", "db", "token", "pma_absolute_uri"];
-            return {
-                pages: cached_pages.map(function (page) {
-                    var simplepage = {
-                        hash: page.hash
-                    };
-
-                    if (page.params) {
-                        simplepage.params = $.extend({}, page.params);
-                        $.each(simplepage.params, function (param) {
-                            if ($.inArray(param, remove) != -1) {
-                                delete simplepage.params[param];
-                            }
-                        });
-                    }
-
-                    return simplepage;
-                }),
-                current_index: PMA_MicroHistory.current -
-                    (PMA_MicroHistory.pages.length - cached_pages.length)
-            };
-        }
-    },
-    /**
      * Redirects to the settings page containing error report
      * preferences
      *
@@ -240,7 +209,6 @@ var ErrorReport = {
             "token": PMA_commonParams.get('token'),
             "exception": exception,
             "current_url": window.location.href,
-            "microhistory": ErrorReport._get_microhistory(),
             "exception_type": 'js'
         };
         if (AJAX.scriptHandler._scripts.length > 0) {

--- a/js/error_report.js
+++ b/js/error_report.js
@@ -193,28 +193,30 @@ var ErrorReport = {
      * @return object
      */
     _get_microhistory: function () {
-        var cached_pages = AJAX.cache.pages.slice(-7);
-        var remove = ["common_query", "table", "db", "token", "pma_absolute_uri"];
-        return {
-            pages: cached_pages.map(function (page) {
-                var simplepage = {
-                    hash: page.hash
-                };
+        if (! (history && history.pushState)) {
+            var cached_pages = PMA_MicroHistory.pages.slice(-7);
+            var remove = ["common_query", "table", "db", "token", "pma_absolute_uri"];
+            return {
+                pages: cached_pages.map(function (page) {
+                    var simplepage = {
+                        hash: page.hash
+                    };
 
-                if (page.params) {
-                    simplepage.params = $.extend({}, page.params);
-                    $.each(simplepage.params, function (param) {
-                        if ($.inArray(param, remove) != -1) {
-                            delete simplepage.params[param];
-                        }
-                    });
-                }
+                    if (page.params) {
+                        simplepage.params = $.extend({}, page.params);
+                        $.each(simplepage.params, function (param) {
+                            if ($.inArray(param, remove) != -1) {
+                                delete simplepage.params[param];
+                            }
+                        });
+                    }
 
-                return simplepage;
-            }),
-            current_index: AJAX.cache.current -
-                (AJAX.cache.pages.length - cached_pages.length)
-        };
+                    return simplepage;
+                }),
+                current_index: PMA_MicroHistory.current -
+                    (PMA_MicroHistory.pages.length - cached_pages.length)
+            };
+        }
     },
     /**
      * Redirects to the settings page containing error report
@@ -241,8 +243,8 @@ var ErrorReport = {
             "microhistory": ErrorReport._get_microhistory(),
             "exception_type": 'js'
         };
-        if (typeof AJAX.cache.pages[AJAX.cache.current - 1] !== 'undefined') {
-            report_data.scripts = AJAX.cache.pages[AJAX.cache.current - 1].scripts.map(
+        if (AJAX.scriptHandler._scripts.length > 0) {
+            report_data.scripts = AJAX.scriptHandler._scripts.map(
                 function (script) {
                     return script.name;
                 }

--- a/js/functions.js
+++ b/js/functions.js
@@ -2812,7 +2812,9 @@ AJAX.registerOnload('functions.js', function () {
                         PMA_reloadNavigation();
                         // Redirect to table structure page on creation of new table
                         var params_12 = 'ajax_request=true&ajax_page_request=true';
-                        params_12 += AJAX.cache.menus.getRequestParam();
+                        if (! (history && history.pushState)) {
+                            params_12 += PMA_Microhistory.menus.getRequestParam();
+                        }
                         tblStruct_url = 'tbl_structure.php?server=' + data._params.server +
                             '&db='+ data._params.db + '&token=' + data._params.token +
                             '&goto=db_structure.php&table=' + data._params.table + '';

--- a/js/microhistory.js
+++ b/js/microhistory.js
@@ -311,7 +311,7 @@ PMA_SetUrlHash = (function (jQuery, window) {
      * Register an event handler for when the url hash changes
      */
     jQuery(function () {
-        jQuery(window).hashchange(function () { return;
+        jQuery(window).hashchange(function () {
             if (userChange === false) {
                 // Ignore internally triggered hash changes
                 userChange = true;

--- a/js/microhistory.js
+++ b/js/microhistory.js
@@ -1,0 +1,331 @@
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * An implementation of a client-side page cache.
+ * This object also uses the cache to provide a simple microhistory,
+ * that is the ability to use the back and forward buttons in the browser
+ */
+PMA_MicroHistory = {
+    /**
+     * @var int The maximum number of pages to keep in the cache
+     */
+    MAX: 6,
+    /**
+     * @var object A hash used to prime the cache with data about the initially
+     *             loaded page. This is set in the footer, and then loaded
+     *             by a double-queued event further down this file.
+     */
+    primer: {},
+    /**
+     * @var array Stores the content of the cached pages
+     */
+    pages: [],
+    /**
+     * @var int The index of the currently loaded page
+     *          This is used to know at which point in the history we are
+     */
+    current: 0,
+    /**
+     * Saves a new page in the cache
+     *
+     * @param string hash    The hash part of the url that is being loaded
+     * @param array  scripts A list of scripts that is required for the page
+     * @param string menu    A hash that links to a menu stored
+     *                       in a dedicated menu cache
+     * @param array  params  A list of parameters used by PMA_commonParams()
+     * @param string rel     A relationship to the current page:
+     *                       'samepage': Forces the response to be treated as
+     *                                   the same page as the current one
+     *                       'newpage':  Forces the response to be treated as
+     *                                   a new page
+     *                       undefined:  Default behaviour, 'samepage' if the
+     *                                   selflinks of the two pages are the same.
+     *                                   'newpage' otherwise
+     *
+     * @return void
+     */
+    add: function (hash, scripts, menu, params, rel) {
+        if (this.pages.length > PMA_MicroHistory.MAX) {
+            // Trim the cache, to the maximum number of allowed entries
+            // This way we will have a cached menu for every page
+            for (var i = 0; i < this.pages.length - this.MAX; i++) {
+                delete this.pages[i];
+            }
+        }
+        while (this.current < this.pages.length) {
+            // trim the cache if we went back in the history
+            // and are now going forward again
+            this.pages.pop();
+        }
+        if (rel === 'newpage' ||
+            (
+                typeof rel === 'undefined' && (
+                    typeof this.pages[this.current - 1] === 'undefined' ||
+                    this.pages[this.current - 1].hash !== hash
+                )
+            )
+        ) {
+            this.pages.push({
+                hash: hash,
+                content: $('#page_content').html(),
+                scripts: scripts,
+                selflink: $('#selflink').html(),
+                menu: menu,
+                params: params
+            });
+            PMA_SetUrlHash(this.current, hash);
+            this.current++;
+        }
+    },
+    /**
+     * Restores a page from the cache. This is called when the hash
+     * part of the url changes and it's structure appears to be valid
+     *
+     * @param string index Which page from the history to load
+     *
+     * @return void
+     */
+    navigate: function (index) {
+        if (typeof this.pages[index] === 'undefined' ||
+            typeof this.pages[index].content === 'undefined' ||
+            typeof this.pages[index].menu === 'undefined' ||
+            ! PMA_MicroHistory.menus.get(this.pages[index].menu)
+        ) {
+            PMA_ajaxShowMessage(
+                '<div class="error">' + PMA_messages.strInvalidPage + '</div>',
+                false
+            );
+        } else {
+            AJAX.active = true;
+            var record = this.pages[index];
+            AJAX.scriptHandler.reset(function () {
+                $('#page_content').html(record.content);
+                $('#selflink').html(record.selflink);
+                PMA_MicroHistory.menus.replace(PMA_MicroHistory.menus.get(record.menu));
+                PMA_commonParams.setAll(record.params);
+                AJAX.scriptHandler.load(record.scripts);
+                PMA_MicroHistory.current = ++index;
+            });
+        }
+    },
+    /**
+     * Resaves the content of the current page in the cache.
+     * Necessary in order not to show the user some outdated version of the page
+     *
+     * @return void
+     */
+    update: function () {
+        var page = this.pages[this.current - 1];
+        if (page) {
+            page.content = $('#page_content').html();
+        }
+    },
+    /**
+     * @var object Dedicated menu cache
+     */
+    menus: {
+        /**
+         * Returns the number of items in an associative array
+         *
+         * @return int
+         */
+        size: function (obj) {
+            var size = 0, key;
+            for (key in obj) {
+                if (obj.hasOwnProperty(key)) {
+                    size++;
+                }
+            }
+            return size;
+        },
+        /**
+         * @var hash Stores the content of the cached menus
+         */
+        data: {},
+        /**
+         * Saves a new menu in the cache
+         *
+         * @param string hash    The hash (trimmed md5) of the menu to be saved
+         * @param string content The HTML code of the menu to be saved
+         *
+         * @return void
+         */
+        add: function (hash, content) {
+            if (this.size(this.data) > PMA_MicroHistory.MAX) {
+                // when the cache grows, we remove the oldest entry
+                var oldest, key, init = 0;
+                for (var i in this.data) {
+                    if (this.data[i]) {
+                        if (! init || this.data[i].timestamp.getTime() < oldest.getTime()) {
+                            oldest = this.data[i].timestamp;
+                            key = i;
+                            init = 1;
+                        }
+                    }
+                }
+                delete this.data[key];
+            }
+            this.data[hash] = {
+                content: content,
+                timestamp: new Date()
+            };
+        },
+        /**
+         * Retrieves a menu given its hash
+         *
+         * @param string hash The hash of the menu to be retrieved
+         *
+         * @return string
+         */
+        get: function (hash) {
+            if (this.data[hash]) {
+                return this.data[hash].content;
+            } else {
+                // This should never happen as long as the number of stored menus
+                // is larger or equal to the number of pages in the page cache
+                return '';
+            }
+        },
+        /**
+         * Prepares part of the parameter string used during page requests,
+         * this is necessary to tell the server which menus we have in the cache
+         *
+         * @return string
+         */
+        getRequestParam: function () {
+            var param = '';
+            var menuHashes = [];
+            for (var i in this.data) {
+                menuHashes.push(i);
+            }
+            var menuHashesParam = menuHashes.join('-');
+            if (menuHashesParam) {
+                param = '&menuHashes=' + menuHashesParam;
+            }
+            return param;
+        },
+        /**
+         * Replaces the menu with new content
+         *
+         * @return void
+         */
+        replace: function (content) {
+            $('#floating_menubar').html(content)
+                // Remove duplicate wrapper
+                // TODO: don't send it in the response
+                .children().first().remove();
+            $('#topmenu').menuResizer(PMA_mainMenuResizerCallback);
+        }
+    }
+};
+
+/**
+ * URL hash management module.
+ * Allows direct bookmarking and microhistory.
+ */
+PMA_SetUrlHash = (function (jQuery, window) {
+    "use strict";
+    /**
+     * Indictaes whether we have already completed
+     * the initialisation of the hash
+     *
+     * @access private
+     */
+    var ready = false;
+    /**
+     * Stores a hash that needed to be set when we were not ready
+     *
+     * @access private
+     */
+    var savedHash = "";
+    /**
+     * Flag to indicate if the change of hash was triggered
+     * by a user pressing the back/forward button or if
+     * the change was triggered internally
+     *
+     * @access private
+     */
+    var userChange = true;
+
+    // Fix favicon disappearing in Firefox when setting location.hash
+    function resetFavicon() {
+        if (navigator.userAgent.indexOf('Firefox') > -1) {
+            // Move the link tags for the favicon to the bottom
+            // of the head element to force a reload of the favicon
+            $('head > link[href=favicon\\.ico]').appendTo('head');
+        }
+    }
+
+    /**
+     * Sets the hash part of the URL
+     *
+     * @access public
+     */
+    function setUrlHash(index, hash) {
+        /*
+         * Known problem:
+         * Setting hash leads to reload in webkit:
+         * http://www.quirksmode.org/bugreports/archives/2005/05/Safari_13_visual_anomaly_with_windowlocationhref.html
+         *
+         * so we expect that users are not running an ancient Safari version
+         */
+
+        userChange = false;
+        if (ready) {
+            window.location.hash = "PMAURL-" + index + ":" + hash;
+            resetFavicon();
+        } else {
+            savedHash = "PMAURL-" + index + ":" + hash;
+        }
+    }
+    /**
+     * Start initialisation
+     */
+    if (window.location.hash.substring(0, 8) == '#PMAURL-') {
+        // We have a valid hash, let's redirect the user
+        // to the page that it's pointing to
+        var colon_position = window.location.hash.indexOf(':');
+        var questionmark_position = window.location.hash.indexOf('?');
+        if (colon_position != -1 && questionmark_position != -1 && colon_position < questionmark_position) {
+            var hash_url = window.location.hash.substring(colon_position + 1, questionmark_position);
+            if (PMA_gotoWhitelist.indexOf(hash_url) != -1) {
+                window.location = window.location.hash.substring(
+                    colon_position + 1
+                );
+            }
+        }
+    } else {
+        // We don't have a valid hash, so we'll set it up
+        // when the page finishes loading
+        jQuery(function () {
+            /* Check if we should set URL */
+            if (savedHash !== "") {
+                window.location.hash = savedHash;
+                savedHash = "";
+                resetFavicon();
+            }
+            // Indicate that we're done initialising
+            ready = true;
+        });
+    }
+    /**
+     * Register an event handler for when the url hash changes
+     */
+    jQuery(function () {
+        jQuery(window).hashchange(function () { return;
+            if (userChange === false) {
+                // Ignore internally triggered hash changes
+                userChange = true;
+            } else if (/^#PMAURL-\d+:/.test(window.location.hash)) {
+                // Change page if the hash changed was triggered by a user action
+                var index = window.location.hash.substring(
+                    8, window.location.hash.indexOf(':')
+                );
+                PMA_MicroHistory.navigate(index);
+            }
+        });
+    });
+    /**
+     * Publicly exposes a reference to the otherwise private setUrlHash function
+     */
+    return setUrlHash;
+})(jQuery, window);

--- a/js/server_databases.js
+++ b/js/server_databases.js
@@ -130,7 +130,9 @@ AJAX.registerOnload('server_databases.js', function () {
             var dbStruct_url = data.url_query;
             dbStruct_url = dbStruct_url.replace(/amp;/ig, '');
             var params = 'ajax_request=true&ajax_page_request=true';
-            params += AJAX.cache.menus.getRequestParam();
+            if (! (history && history.pushState)) {
+                params += PMA_Microhistory.menus.getRequestParam();
+            }
             $.get(dbStruct_url, params, AJAX.responseHandler);
         }); // end $.post()
     }); // end $(document).on()

--- a/js/sql.js
+++ b/js/sql.js
@@ -390,7 +390,7 @@ AJAX.registerOnload('sql.js', function () {
                 if (data._menu) {
                     if (history && history.pushState) {
                         history.replaceState({
-                            menu : data._menu
+                                menu : data._menu
                             },
                             null
                         );
@@ -399,7 +399,7 @@ AJAX.registerOnload('sql.js', function () {
                         PMA_Microhistory.menus.replace(data._menu);
                         PMA_Microhistory.menus.add(data._menuHash, data._menu);
                     }
-                } else if (data._menuHash) {debugger;
+                } else if (data._menuHash) {
                     if (! (history && history.pushState)) {
                         PMA_Microhistory.menus.replace(PMA_Microhistory.menus.get(data._menuHash));
                     }

--- a/js/sql.js
+++ b/js/sql.js
@@ -399,7 +399,7 @@ AJAX.registerOnload('sql.js', function () {
                         PMA_Microhistory.menus.replace(data._menu);
                         PMA_Microhistory.menus.add(data._menuHash, data._menu);
                     }
-                } else if (data._menuHash) {
+                } else if (data._menuHash) {debugger;
                     if (! (history && history.pushState)) {
                         PMA_Microhistory.menus.replace(PMA_Microhistory.menus.get(data._menuHash));
                     }

--- a/js/sql.js
+++ b/js/sql.js
@@ -388,10 +388,21 @@ AJAX.registerOnload('sql.js', function () {
                 PMA_highlightSQL($sqlqueryresultsouter);
 
                 if (data._menu) {
-                    AJAX.cache.menus.replace(data._menu);
-                    AJAX.cache.menus.add(data._menuHash, data._menu);
+                    if (history && history.pushState) {
+                        history.replaceState({
+                            menu : data._menu
+                            },
+                            null
+                        );
+                        AJAX.handleMenu.replace(data._menu);
+                    } else {
+                        PMA_Microhistory.menus.replace(data._menu);
+                        PMA_Microhistory.menus.add(data._menuHash, data._menu);
+                    }
                 } else if (data._menuHash) {
-                    AJAX.cache.menus.replace(AJAX.cache.menus.get(data._menuHash));
+                    if (! (history && history.pushState)) {
+                        PMA_Microhistory.menus.replace(PMA_Microhistory.menus.get(data._menuHash));
+                    }
                 }
 
                 if (data._params) {

--- a/libraries/Footer.class.php
+++ b/libraries/Footer.class.php
@@ -322,7 +322,7 @@ class PMA_Footer
                     // prime the client-side cache
                     $this->_scripts->addCode(
                         sprintf(
-                            'PMA_Microhistory.primer = {'
+                            'if (! (history && history.pushState)) PMA_Microhistory.primer = {'
                             . ' url: "%s",'
                             . ' scripts: %s,'
                             . ' menuHash: "%s"'

--- a/libraries/Footer.class.php
+++ b/libraries/Footer.class.php
@@ -322,7 +322,7 @@ class PMA_Footer
                     // prime the client-side cache
                     $this->_scripts->addCode(
                         sprintf(
-                            'AJAX.cache.primer = {'
+                            'PMA_Microhistory.primer = {'
                             . ' url: "%s",'
                             . ' scripts: %s,'
                             . ' menuHash: "%s"'


### PR DESCRIPTION
Changes:
- clearer URL with easier manipulation of URL script name or query params to navigate.
- as we use no-cache, so browser now makes new requests on pressing back/forth buttons, under HTML5 API. Earlier with hash microhistory, we were manually caching the no-cache content of pages.
