### PR TITLE
RFE#1163

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,6 +23,8 @@ $drops = array(
     'lang',
     'server',
     'collation_connection',
+    'character_set_client',
+    'character_set_results',
     'db',
     'table'
 );
@@ -198,8 +200,8 @@ if ($server > 0 || count($cfg['Servers']) > 1
                 );
             }
         } // end if
-        echo '    <li id="li_select_mysql_collation" class="no_bullets" >';
-        echo '        <form method="post" action="index.php">' . "\n"
+        echo '    <form method="post" action="index.php">' . "\n";
+        echo '        <li id="li_select_mysql_collation" class="no_bullets" >'
            . PMA_URL_getHiddenInputs(null, null, 4, 'collation_connection')
            . '            <label for="select_collation_connection">' . "\n"
            . '                ' . PMA_Util::getImage('s_asci.png') . " "
@@ -217,8 +219,52 @@ if ($server > 0 || count($cfg['Servers']) > 1
                true,
                true
            )
-           . '        </form>' . "\n"
-           . '    </li>' . "\n";
+           . '        </li>' . "\n";
+
+        echo '        <li id="li_select_client_collation" class="no_bullets" >'
+           . PMA_URL_getHiddenInputs(null, null, 4, 'character_set_results')
+           . '            <label for="select_character_set_results">' . "\n"
+           . '                ' . PMA_Util::getImage('s_asci.png') . " "
+                               . __('Character Set Results') . "\n"
+           . PMA_Util::showMySQLDocu(
+               'server-system-variables', false, 'sysvar_character_set_results',
+               false
+           )
+           . ': ' .  "\n"
+           . '            </label>' . "\n"
+
+           . PMA_generateCharsetDropdownBox(
+               PMA_CSDROPDOWN_CHARSET,
+               'character_set_results',
+               'select_character_set_results',
+               $character_set_results,
+               true,
+               true
+           )
+           . '        </li>' . "\n";
+
+        echo '        <li id="li_select_client_collation" class="no_bullets" >'
+           . PMA_URL_getHiddenInputs(null, null, 4, 'character_set_client')
+           . '            <label for="select_character_set_client">' . "\n"
+           . '                ' . PMA_Util::getImage('s_asci.png') . " "
+                               . __('Character Set Client') . "\n"
+           . PMA_Util::showMySQLDocu(
+               'server-system-variables', false, 'sysvar_character_set_client',
+               false
+           )
+           . ': ' .  "\n"
+           . '            </label>' . "\n"
+
+           . PMA_generateCharsetDropdownBox(
+               PMA_CSDROPDOWN_CHARSET,
+               'character_set_client',
+               'select_character_set_client',
+               $character_set_client,
+               true,
+               true
+           )
+           . '        </li>' . "\n"
+           . '    </form>' . "\n";
     } // end of if ($server > 0 && !PMA_DRIZZLE)
     echo '</ul>';
     echo '</div>';

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -1823,6 +1823,30 @@ class PMA_DatabaseInterface
                     self::QUERY_STORE
                 );
             }
+
+            if (isset($GLOBALS['character_set_results'])
+                && ! empty($GLOBALS['character_set_results'])
+            ) {
+                $this->query(
+                    "SET @@session.character_set_results = '"
+                    . PMA_Util::sqlAddSlashes($GLOBALS['character_set_results'])
+                    . "';",
+                    $link,
+                    self::QUERY_STORE
+                );
+            }
+
+            if (isset($GLOBALS['character_set_client'])
+                && ! empty($GLOBALS['character_set_client'])
+            ) {
+                $this->query(
+                    "SET @@session.character_set_client = '"
+                    . PMA_Util::sqlAddSlashes($GLOBALS['character_set_client'])
+                    . "';",
+                    $link,
+                    self::QUERY_STORE
+                );
+            }
         }
 
         // Cache plugin list for Drizzle

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -51,7 +51,8 @@ if (version_compare(PHP_VERSION, '5.3.0', 'lt')) {
  */
 define('PHPMYADMIN', true);
 
-
+error_reporting(E_ALL);
+ini_set('error_reporting', E_ALL);
 /**
  * String handling (security)
  */
@@ -461,7 +462,8 @@ if (PMA_checkPageValidity($_REQUEST['back'], $goto_whitelist)) {
  * f.e. PMA_Config: fontsize
  *
  * @todo variables should be handled by their respective owners (objects)
- * f.e. lang, server, collation_connection in PMA_Config
+ * f.e. lang, server, collation_connection, character_set_results,
+ * character_set_client in PMA_Config
  */
 $token_mismatch = true;
 $token_provided = false;
@@ -482,7 +484,8 @@ if ($token_mismatch) {
         /* Session ID */
         'phpMyAdmin',
         /* Cookie preferences */
-        'pma_lang', 'pma_collation_connection',
+        'pma_lang', 'pma_collation_connection', 'pma_character_set_results',
+        'pma_character_set_client',
         /* Possible login form */
         'pma_servername', 'pma_username', 'pma_password',
         'g-recaptcha-response',
@@ -814,6 +817,18 @@ if (! defined('PMA_MINIMUM_COMMON')) {
         $GLOBALS['PMA_Config']->setCookie(
             'pma_collation_connection',
             $GLOBALS['collation_connection']
+        );
+    }
+    if (isset($GLOBALS['character_set_client'])) {
+        $GLOBALS['PMA_Config']->setCookie(
+            'pma_character_set_client',
+            $GLOBALS['character_set_client']
+        );
+    }
+    if (isset($GLOBALS['character_set_results'])) {
+        $GLOBALS['PMA_Config']->setCookie(
+            'pma_character_set_results',
+            $GLOBALS['character_set_results']
         );
     }
 


### PR DESCRIPTION
RFE#1163 : This is more of a bug rather than a feature.

In the existing scenario, the variables `character_set_results` and `character_set_client`
are always stuck at `utf8mb4' or`utf8` (for earlier versions of MySQL).

So, we provide 2 more drop-downs on the welcome page (i.e. index.php) similar to the existing one for `collation_connection` to select the values for these 2 variables.

Please suggest changes if needed. Suggestions regarding the complete approach to the problem are welcome as well.

Also, suggestions regarding the icons for these 2 drop-downs are also welcome. Currently I have used the same icons as used for `collation_connection` drop-down.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
