### PR TITLE
Remove confusing second inline edit window (bug #4826)

### DIFF
--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -995,21 +995,10 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                             if (typeof data !== 'undefined' && data.success === true) {
                                 $td.data('original_data', data.value);
                                 $(g.cEdit).find('.edit_box').val(data.value);
-                                $editArea.append('<textarea></textarea>');
-                                $editArea.find('textarea').val(data.value);
-                                $editArea
-                                    .on('keyup', 'textarea', function (e) {
-                                        $(g.cEdit).find('.edit_box').val($(this).val());
-                                    });
-                                $(g.cEdit).on('keyup', '.edit_box', function (e) {
-                                    $editArea.find('textarea').val($(this).val());
-                                });
-                                $editArea.append('<div class="cell_edit_hint">' + g.cellEditHint + '</div>');
                             } else {
                                 PMA_ajaxShowMessage(data.error, false);
                             }
                         }); // end $.post()
-                        $editArea.show();
                     }
                     g.isEditCellTextEditable = true;
                 } else if ($td.is('.timefield, .datefield, .datetimefield, .timestampfield')) {


### PR DESCRIPTION
When a long truncated text field is being inline edited it pops up a second edit window which could be confusing. Removed it.
