### PR TITLE
RFE #1396 : Add support for MySQL 5.6.6+ SHA256 Auth plugin

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -4741,3 +4741,25 @@ AJAX.registerOnload('functions.js', function () {
         }
     });
 });
+
+/**
+ * Unbind all event handlers before tearing down a page
+ */
+AJAX.registerTeardown('functions.js', function(){
+    $(document).off('change', 'input[type=radio][name="pw_hash"]');
+});
+
+AJAX.registerOnload('functions.js', function(){
+    /*
+     * Display warning regarding SSL when sha256_password
+     * method is selected
+     * Used in user_password.php (Change Password link on index.php)
+     */
+    $(document).on("change", 'input[type=radio][name="pw_hash"]', function() {
+        if (this.value === 'sha256_password') {
+            $('#ssl_reqd_warning').show();
+        } else {
+            $('#ssl_reqd_warning').hide();
+        }
+    });
+});

--- a/js/server_privileges.js
+++ b/js/server_privileges.js
@@ -61,6 +61,7 @@ AJAX.registerTeardown('server_privileges.js', function () {
     $(document).off("click", ".checkall_box");
     $(document).off('change', '#checkbox_SSL_priv');
     $(document).off('change', 'input[name="ssl_type"]');
+    $(document).off('change', '#select_authentication_plugin');
 });
 
 AJAX.registerOnload('server_privileges.js', function () {
@@ -88,6 +89,18 @@ AJAX.registerOnload('server_privileges.js', function () {
             });
         } else {
             $warning.hide();
+        }
+    });
+
+    /**
+     * Display a notice if sha256_password is selected
+     */
+    $(document).on("change", "#select_authentication_plugin", function () {
+        var selected_plugin = $(this).val();
+        if (selected_plugin === 'sha256_password') {
+            $('#ssl_reqd_warning').show();
+        } else {
+            $('#ssl_reqd_warning').hide();
         }
     });
 

--- a/libraries/dbi/DBIDummy.class.php
+++ b/libraries/dbi/DBIDummy.class.php
@@ -601,6 +601,15 @@ $GLOBALS['dummy_queries'] = array(
             . '`host` = "" AND `Db` = "" AND `User` = "" AND `Routine_name` = "" '
             . 'AND `Routine_type` = "" LIMIT 1',
         'result' => true
+    ),
+    array(
+        'query' => 'SELECT `plugin` FROM `mysql`.`user` WHERE '
+            . ' `User` = "pma_username" AND `Host` = "pma_hostname" LIMIT 1',
+        'result' => array()
+    ),
+    array(
+        'query' => 'SHOW VARIABLES like \'default_authentication_plugin\'',
+        'result' => array(array('Variable_name' => 'mysql_native_password'))
     )
 );
 /**

--- a/libraries/display_change_password.lib.php
+++ b/libraries/display_change_password.lib.php
@@ -77,18 +77,64 @@ function PMA_getHtmlForChangePassword($username, $hostname)
         . $chg_evt_handler . '="nopass[1].checked = true" />'
         . '</td>'
         . '</tr>';
+    $default_auth_plugin = PMA_getCurrentAuthenticationPlugin(
+        'change', $username, $hostname
+    );
 
-    if (PMA_MYSQL_INT_VERSION < 50705) {
+    // See http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-5.html
+    if (PMA_MYSQL_INT_VERSION >= 50705) {
+        $html .= '<tr class="vmiddle">'
+            . '<td>' . __('Password Hashing:')
+            . '</td>'
+            . '<td>'
+            . '<input type="radio" name="pw_hash" id="radio_pw_hash_mysql_native" '
+            . 'value="' . 'mysql_native_password"';
+        if ($default_auth_plugin == 'mysql_native_password') {
+            $html .= '" checked="checked"';
+        }
+        $html .= ' />'
+            . '<label for="radio_pw_hash_mysql_native">' . 'mysql_native_password'
+            . '</label>'
+            . '</td>'
+            . '</tr>'
+            . '<tr id="tr_element_before_generate_password">'
+            . '<td>&nbsp;</td>'
+            . '<td>'
+            . '<input type="radio" name="pw_hash" id="radio_pw_hash_sha256" '
+            . 'value="sha256_password"';
+        if ($default_auth_plugin == 'sha256_password') {
+            $html .= '" checked="checked"';
+        }
+        $html .= ' />'
+            . '<label for="radio_pw_hash_sha256">' . 'sha256_password'
+            . '</label>'
+            . '</td>'
+            . '</tr>';
+    } elseif (PMA_MYSQL_INT_VERSION >= 50606) {
+        $html .= '<tr class="vmiddle" id="tr_element_before_generate_password">'
+            . '<td>' . __('Password Hashing:')
+            . '</td>'
+            . '<td>'
+            . '<input type="radio" name="pw_hash" id="radio_pw_hash_new" '
+            . 'value="' . $default_auth_plugin . '"'
+            . ' checked="checked" />'
+            . '<label for="radio_pw_hash_new">' . $default_auth_plugin
+            . '</label>'
+            . '</td>'
+            . '</tr>';
+    } else {
         $html .= '<tr class="vmiddle">'
             . '<td>' . __('Password Hashing:')
             . '</td>'
             . '<td>'
             . '<input type="radio" name="pw_hash" id="radio_pw_hash_new" '
-            . 'value="new" checked="checked" />'
-            . '<label for="radio_pw_hash_new">MySQL&nbsp;4.1+</label>'
+            . 'value="mysql_native_password"'
+            . ' checked="checked" />'
+            . '<label for="radio_pw_hash_new">' . 'mysql_native_password'
+            . '</label>'
             . '</td>'
             . '</tr>'
-            . '<tr id="tr_element_before_generate_password">'
+            . '<tr id="tr_element_before_generate_password" >'
             . '<td>&nbsp;</td>'
             . '<td>'
             . '<input type="radio" name="pw_hash" id="radio_pw_hash_old" '
@@ -97,13 +143,24 @@ function PMA_getHtmlForChangePassword($username, $hostname)
             . '</label>'
             . '</td>'
             . '</tr>';
-    } else {
-        // See http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-5.html
-        $html .= '<input type="hidden" name="pw_hash" value="new" />';
     }
 
-    $html .=  '</table>'
-        . '</fieldset>'
+    $html .=  '</table>';
+
+    $html .= '<div '
+    . ($default_auth_plugin != 'sha256_password' ? 'style="display:none"' : '')
+    . ' id="ssl_reqd_warning">'
+    . PMA_Message::notice(
+        __(
+            'This method requires using an \'<i>SSL connection</i>\' '
+            . 'or an \'<i>unencrypted connection that encrypts the password using RSA</i>\''
+            . '; while connecting to the server.'
+        )
+        . PMA_Util::showMySQLDocu('sha256-authentication-plugin')
+    )->getDisplay()
+    . '</div>';
+
+    $html .= '</fieldset>'
         . '<fieldset id="fieldset_change_password_footer" class="tblFooters">'
         . '<input type="hidden" name="change_pw" value="1" />'
         . '<input type="submit" value="' . __('Go') . '" />'

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -70,6 +70,7 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['NavigationTreeDefaultTabTable'] = "structure";
         $GLOBALS['cfg']['Confirm'] = "Confirm";
         $GLOBALS['cfg']['ShowHint'] = true;
+        $GLOBALS['cfg']['ShowDatabasesNavigationAsTree'] = true;
 
         $GLOBALS['cfgRelation'] = array();
         $GLOBALS['cfgRelation']['menuswork'] = false;
@@ -630,6 +631,8 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
         $_POST['pred_username'] = 'any';
         $_POST['pred_hostname'] = 'localhost';
         $_REQUEST['createdb-3'] = true;
+        $_REQUEST['authentication_plugin'] = 'mysql_native_password';
+
         list($create_user_real, $create_user_show, $real_sql_query, $sql_query)
             = PMA_getSqlQueriesForDisplayAndAddUser(
                 $username, $hostname,
@@ -668,6 +671,7 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
         $_POST['pred_hostname'] = 'localhost';
         $_REQUEST['createdb-3'] = true;
         $_REQUEST['userGroup'] = "username";
+        $_REQUEST['authentication_plugin'] = 'mysql_native_password';
 
         list(
             $ret_message,,, $sql_query,
@@ -1641,7 +1645,7 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
 
         //PMA_getHtmlForLoginInformationFields
         $this->assertContains(
-            PMA_getHtmlForLoginInformationFields('change'),
+            PMA_getHtmlForLoginInformationFields('change', $username, $hostname),
             $html
         );
 

--- a/user_password.php
+++ b/user_password.php
@@ -12,6 +12,11 @@
  */
 require_once './libraries/common.inc.php';
 
+/**
+ * Libraries needed for some functions
+ */
+require_once './libraries/server_privileges.lib.php';
+
 $response = PMA_Response::getInstance();
 $header   = $response->getHeader();
 $scripts  = $header->getScripts();
@@ -62,6 +67,7 @@ if (isset($msg)) {
 }
 
 require_once './libraries/display_change_password.lib.php';
+
 echo PMA_getHtmlForChangePassword($username, $hostname);
 exit;
 
@@ -131,15 +137,48 @@ function PMA_changePassword($password, $message, $change_password_message)
     global $auth_plugin;
 
     $hashing_function = PMA_changePassHashingFunction();
+
+    $orig_auth_plugin = null;
+
+    $row = $GLOBALS['dbi']->fetchSingleRow('SELECT CURRENT_USER() as user');
+    $curr_user = $row['user'];
+    list($username, $hostname) = explode('@', $curr_user);
+
     if (PMA_Util::getServerType() === 'MySQL' && PMA_MYSQL_INT_VERSION >= 50706) {
-        $sql_query = 'ALTER USER USER() IDENTIFIED BY '
+
+        if (isset($_REQUEST['pw_hash']) && ! empty($_REQUEST['pw_hash'])) {
+            $orig_auth_plugin = $_REQUEST['pw_hash'];
+        } else {
+            $orig_auth_plugin = PMA_getCurrentAuthenticationPlugin(
+                'change', $username, $hostname
+            );
+        }
+
+        $sql_query = 'ALTER USER \'' . $username . '\'@\'' . $hostname . '\' IDENTIFIED WITH '
+            . $orig_auth_plugin . ' BY '
             . (($password == '') ? '\'\'' : '\'***\'');
     } else {
+        // For MySQL versions 5.6.6+,
+        // explicitly set value of `old_passwords` so that
+        // it does not give an error while using
+        // the PASSWORD() function
+        if (PMA_MYSQL_INT_VERSION >= 50606) {
+            $orig_auth_plugin = PMA_getCurrentAuthenticationPlugin(
+                'change', $username, $hostname
+            );
+            if ($orig_auth_plugin == 'sha256_password') {
+                $value = 2;
+            } else {
+                $value = 0;
+            }
+            $GLOBALS['dbi']->tryQuery('SET `old_passwords` = ' . $value . ';');
+        }
         $sql_query = 'SET password = '
             . (($password == '') ? '\'\'' : $hashing_function . '(\'***\')');
     }
     PMA_changePassUrlParamsAndSubmitQuery(
-        $password, $sql_query, $hashing_function
+        $username, $hostname, $password,
+        $sql_query, $hashing_function, $orig_auth_plugin
     );
 
     $auth_plugin->handlePasswordChange($password);
@@ -165,18 +204,23 @@ function PMA_changePassHashingFunction()
 /**
  * Generate the error url and submit the query
  *
+ * @param string $username         Username
+ * @param string $hostname         Hostname
  * @param string $password         Password
  * @param string $sql_query        SQL query
  * @param string $hashing_function Hashing function
+ * @param string $auth_plugin      Authentication Plugin
  *
  * @return void
  */
 function PMA_changePassUrlParamsAndSubmitQuery(
-    $password, $sql_query, $hashing_function
+    $username, $hostname, $password, $sql_query, $hashing_function, $auth_plugin
 ) {
     $err_url = 'user_password.php' . PMA_URL_getCommon();
     if (PMA_Util::getServerType() === 'MySQL' && PMA_MYSQL_INT_VERSION >= 50706) {
-        $local_query = 'ALTER USER USER() IDENTIFIED BY ' . (($password == '')
+        $local_query = 'ALTER USER \'' . $username . '\'@\'' . $hostname . '\''
+            . ' IDENTIFIED with ' . $auth_plugin . ' BY '
+            . (($password == '')
             ? '\'\''
             : '\'' . PMA_Util::sqlAddSlashes($password) . '\'');
     } else {


### PR DESCRIPTION
RFE#1396 : Add support for MySQL 5.6.6+ SHA256 Auth plugin

For relevant versions, changes made are:
1. While adding an user, provide an option to select the authentication plugin to be used (5.6.6+)
2. While editing/ copying an user, provide an option to change the authentication plugin to be used (5.7.6+) (Not 5.6.6+ as it does not support syntax like : ALTER USER 'bob'@'localhost' IDENTIFIED **WITH** ...)
3. Make similar changes in Change Password form (opened from index.php)

Since this involves a lot of different versions, please report any issue with any of the versions.
