### PR TITLE
Fix unexpected behaviour of Processlist filter

### DIFF
--- a/libraries/server_status_processes.lib.php
+++ b/libraries/server_status_processes.lib.php
@@ -238,7 +238,6 @@ function PMA_getHtmlForProcessListFilter()
     }
 
     $url_params = array(
-        'showExecuting' => 1,
         'ajax_request' => true
     );
 


### PR DESCRIPTION
Removed the unnecessary and problem-causing URL parameter for `showExecuting` as there is already a checkbox input related to it in the form and the checked property for that is properly set, keeping in mind the submitted request parameters.

Moreover, this extra url param causes a problem in the behavior that, once checked, the checkbox always remains checked as $_REQUEST['showExecuting'] was always 1.

This PR should fix the above issue.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
