### PR TITLE
The test folder was included in coverage.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,10 +36,13 @@
         <log type="coverage-clover" target="build/logs/clover.xml"/>
         <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
     </logging>
+
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">.</directory>
             <exclude>
+                <!-- excluding the tests from the coverage -->
+                <directory>test/</directory>
                 <!-- we don't care about coverage of embedded libraries -->
                 <directory suffix=".inc">libraries/php-gettext</directory>
                 <directory suffix=".php">libraries/bfShapeFiles</directory>


### PR DESCRIPTION
At this moment the `test` folder is included in the coverage which artificially increases the code coverage.

Signed-off-by: Dan Ungureanu udan1107@gmail.com
