### PR TITLE
Avoid caching JS and CSS files across phpMyAdmin versions

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -571,6 +571,7 @@ var AJAX = {
                 }
             }
             request.push("call_done=1");
+            request.push("v=" + encodeURIComponent(PMA_commonParams.get('PMA_VERSION')));
             // Download the composite js file, if necessary
             if (needRequest) {
                 this.appendScript("js/get_scripts.js.php?" + request.join("&"));

--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -257,6 +257,7 @@ class PMA_Header
             'confirm' => $GLOBALS['cfg']['Confirm'],
             'LoginCookieValidity' => $GLOBALS['cfg']['LoginCookieValidity'],
             'logged_in' => isset($GLOBALS['userlink']) ? true : false,
+            'PMA_VERSION' => PMA_VERSION
         );
         if (isset($GLOBALS['cfg']['Server'])
             && isset($GLOBALS['cfg']['Server']['auth_type'])
@@ -649,27 +650,28 @@ class PMA_Header
         $basedir    = defined('PMA_PATH_TO_BASEDIR') ? PMA_PATH_TO_BASEDIR : '';
         $theme_id   = $GLOBALS['PMA_Config']->getThemeUniqueValue();
         $theme_path = $GLOBALS['pmaThemePath'];
+        $v          = self::getVersionParameter();
 
         if ($this->_isPrintView) {
             $retval .= '<link rel="stylesheet" type="text/css" href="'
-                . $basedir . 'print.css" />';
+                . $basedir . 'print.css?' . $v . '" />';
         } else {
             // load jQuery's CSS prior to our theme's CSS, to let the theme
             // override jQuery's CSS
             $retval .= '<link rel="stylesheet" type="text/css" href="'
                 . $theme_path . '/jquery/jquery-ui-1.11.2.css" />';
             $retval .= '<link rel="stylesheet" type="text/css" href="'
-                . $basedir . 'js/codemirror/lib/codemirror.css" />';
+                . $basedir . 'js/codemirror/lib/codemirror.css?' . $v . '" />';
             $retval .= '<link rel="stylesheet" type="text/css" href="'
-                . $basedir . 'js/codemirror/addon/hint/show-hint.css" />';
+                . $basedir . 'js/codemirror/addon/hint/show-hint.css?' . $v . '" />';
             $retval .= '<link rel="stylesheet" type="text/css" href="'
-                . $basedir . 'js/codemirror/addon/lint/lint.css" />';
+                . $basedir . 'js/codemirror/addon/lint/lint.css?' . $v . '" />';
             $retval .= '<link rel="stylesheet" type="text/css" href="'
                 . $basedir . 'phpmyadmin.css.php?'
                 . 'nocache=' . $theme_id . $GLOBALS['text_dir'] . '" />';
             // load Print view's CSS last, so that it overrides all other CSS while 'printing'
             $retval .= '<link rel="stylesheet" type="text/css" href="'
-                . $theme_path . '/css/printview.css" />';
+                . $theme_path . '/css/printview.css?' . $v . '" />';
         }
 
         return $retval;
@@ -776,6 +778,17 @@ class PMA_Header
             }
         }
         return $retval;
+    }
+
+    /**
+     * Returns the phpMyAdmin version to be appended to the url to avoid caching
+     * between versions
+     *
+     * @return string urlenocded pma version as a parameter
+     */
+    public static function getVersionParameter()
+    {
+        return "v=" . urlencode(PMA_VERSION);
     }
 }
 

--- a/libraries/Scripts.class.php
+++ b/libraries/Scripts.class.php
@@ -53,15 +53,18 @@ class PMA_Scripts
         $first_dynamic_scripts = "";
         $dynamic_scripts = "";
         $scripts = array();
+        $separator = PMA_URL_getArgSeparator();
         foreach ($files as $value) {
             if (/*overload*/mb_strpos($value['filename'], "?") !== false) {
+                $file_name = $value['filename'] . $separator
+                    . PMA_Header::getVersionParameter();
                 if ($value['before_statics'] === true) {
                     $first_dynamic_scripts
                         .= "<script data-cfasync='false' type='text/javascript' src='js/"
-                        . $value['filename'] . "'></script>";
+                        . $file_name . "'></script>";
                 } else {
                     $dynamic_scripts .= "<script data-cfasync='false' type='text/javascript' src='js/"
-                        . $value['filename'] . "'></script>";
+                        . $file_name . "'></script>";
                 }
                 continue;
             }
@@ -81,8 +84,8 @@ class PMA_Scripts
                 $scripts[] = "scripts%5B%5D=" . $value['filename'];
             }
         }
-        $separator = PMA_URL_getArgSeparator();
-        $url = 'js/get_scripts.js.php?' . implode($separator, $scripts);
+        $url = 'js/get_scripts.js.php?' . implode($separator, $scripts)
+            . $separator . PMA_Header::getVersionParameter();
 
         $static_scripts = sprintf(
             '<script data-cfasync="false" type="text/javascript" src="%s"></script>',

--- a/test/classes/PMA_Scripts_test.php
+++ b/test/classes/PMA_Scripts_test.php
@@ -81,7 +81,7 @@ class PMA_Scripts_Test extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             '<script data-cfasync="false" type="text/javascript" '
             . 'src="js/get_scripts.js.php?'
-            . 'scripts%5B%5D=common.js"></script>',
+            . 'scripts%5B%5D=common.js&amp;v=' . PMA_VERSION . '"></script>',
             $this->_callPrivateFunction(
                 '_includeFiles',
                 array(
@@ -111,7 +111,7 @@ class PMA_Scripts_Test extends PHPUnit_Framework_TestCase
         $this->assertRegExp(
             '@<script data-cfasync="false" type="text/javascript" '
             . 'src="js/get_scripts.js.php\\?'
-            . 'scripts%5B%5D=common.js"></script>'
+            . 'scripts%5B%5D=common.js&amp;v=' . PMA_VERSION . '"></script>'
             . '<script data-cfasync="false" type="text/'
             . 'javascript">// <!\\[CDATA\\[' . "\n"
             . 'AJAX.scriptHandler.add\\("common.js",1\\);' . "\n"


### PR DESCRIPTION
We can see quite a lot of JS errors in our error reporting server mainly due to not clearing browser cache upon version upgrade. This patch avoid caching upon version upgrade by appending version as a parameter.
