### PR TITLE
Fixes #11320.

### DIFF
--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -807,7 +807,7 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                             $checkbox.prop('checked', false);
                         });
                     } else {
-                        $(g.cEdit).on('keypress change', '.edit_box', function (e) {
+                        $(g.cEdit).on('keypress change paste', '.edit_box', function (e) {
                             $checkbox.prop('checked', false);
                         });
                         // Capture ctrl+v (on IE and Chrome)


### PR DESCRIPTION
Any paste event (CTRL + V, SHIFT + INSERT, right click and paste) are now handled and untick the NULL box that caused the bug.

Signed-off-by: Dan Ungureanu udan1107@gmail.com
