### PR TITLE
Fix UTF strings in linter.

### DIFF
--- a/libraries/sql-parser/src/Components/AlterOperation.php
+++ b/libraries/sql-parser/src/Components/AlterOperation.php
@@ -179,7 +179,9 @@ class AlterOperation extends Component
                     } elseif ($token->value === ')') {
                         --$brackets;
                     } elseif ($token->value === ',') {
-                        break;
+                        if ($brackets === 0) {
+                            break;
+                        }
                     }
                 }
                 $ret->unknown[] = $token;

--- a/libraries/sql-parser/src/Context.php
+++ b/libraries/sql-parser/src/Context.php
@@ -297,13 +297,13 @@ abstract class Context
         $len = strlen($str);
         if ($str[0] === '#') {
             return Token::FLAG_COMMENT_BASH;
-        } elseif (($len > 1) && ((($str[0] === '/') && ($str[1] === '*'))
-            || (($str[0] === '*') && ($str[1] === '/')))
-        ) {
+        } elseif (($len > 1) && ($str[0] === '/') && ($str[1] === '*')) {
+            return (($len > 2) && ($str[2] == '!')) ?
+                Token::FLAG_COMMENT_MYSQL_CMD : Token::FLAG_COMMENT_C;
+        } elseif (($len > 1) && ($str[0] === '*') && ($str[1] === '/')) {
             return Token::FLAG_COMMENT_C;
         } elseif (($len > 2) && ($str[0] === '-')
-            && ($str[1] === '-') && ($str[2] !== "\n")
-            && (static::isWhitespace($str[2]))
+            && ($str[1] === '-') && (static::isWhitespace($str[2]))
         ) {
             return Token::FLAG_COMMENT_SQL;
         }
@@ -416,10 +416,6 @@ abstract class Context
      */
     public static function load($context = '')
     {
-        /**
-         * @var Context $context
-         */
-
         if (empty($context)) {
             $context = self::$defaultContext;
         }

--- a/libraries/sql-parser/src/Statement.php
+++ b/libraries/sql-parser/src/Statement.php
@@ -262,7 +262,7 @@ abstract class Statement
                     // this statement it means it is a new statement, but no
                     // delimiter was found between them.
                     $parser->error(
-                        __('A new statement was found, but no delimiter between them.'),
+                        __('A new statement was found, but no delimiter between it and the previous one.'),
                         $token
                     );
                     break;

--- a/libraries/sql-parser/src/Utils/Formatter.php
+++ b/libraries/sql-parser/src/Utils/Formatter.php
@@ -277,7 +277,7 @@ class Formatter
             if ($prev !== null) {
 
                 // Checking if a new clause started.
-                if (static::isClause($prev)) {
+                if (static::isClause($prev) !== false) {
                     $lastClause = $prev->value;
                     $formattedOptions = false;
                 }

--- a/libraries/sql-parser/src/Utils/Query.php
+++ b/libraries/sql-parser/src/Utils/Query.php
@@ -587,6 +587,10 @@ class Query
         for ($i = $statement->first; $i <= $statement->last; ++$i) {
             $token = $list->tokens[$i];
 
+            if ($token->type === Token::TYPE_COMMENT) {
+                continue;
+            }
+
             if ($token->type === Token::TYPE_OPERATOR) {
                 if ($token->value === '(') {
                     ++$brackets;
@@ -707,5 +711,66 @@ class Query
         $ret .= static::getClause($statement, $list, $ops[$count - 1][0], 1);
 
         return $ret;
+    }
+
+    /**
+     * Gets the first full statement in the query.
+     *
+     * @param string $query     The query to be analyzed.
+     * @param string $delimiter The delimiter to be used.
+     *
+     * @return array                Array containing the first full query, the
+     *                              remaining part of the query and the last
+     *                              delimiter.
+     */
+    public static function getFirstStatement($query, $delimiter = null)
+    {
+        $lexer = new Lexer($query, false, $delimiter);
+        $list = $lexer->list;
+
+        /**
+         * Whether a full statement was found.
+         * @var bool
+         */
+        $fullStatement = false;
+
+        /**
+         * The first full statement.
+         * @var string
+         */
+        $statement = '';
+
+        for ($list->idx = 0; $list->idx < $list->count; ++$list->idx) {
+            $token = $list->tokens[$list->idx];
+
+            if (($token->type === Token::TYPE_COMMENT)
+                && (!($token->flags & Token::FLAG_COMMENT_MYSQL_CMD))
+            ) {
+                continue;
+            }
+
+            $statement .= $token->token;
+
+            if (($token->type === Token::TYPE_DELIMITER) && (!empty($token->token))) {
+                $delimiter = $token->token;
+                $fullStatement = true;
+                break;
+            }
+        }
+
+        // No statement was found so we return the entire query as being the
+        // remaining part.
+        if (!$fullStatement) {
+            return array(null, $query, $delimiter);
+        }
+
+        // At least one query was found so we have to build the rest of the
+        // remaining query.
+        $query = '';
+        for (++$list->idx; $list->idx < $list->count; ++$list->idx) {
+            $query .= $list->tokens[$list->idx]->token;
+        }
+
+        return array(trim($statement), $query, $delimiter);
     }
 }


### PR DESCRIPTION
Fix UTF strings in linter.
Updated sql-parser to udan11/sql-parser@8a1011e97497cbecbfb7cf9ef36146aaf81a1486.

The linter miscalculated the positions of each line. You can check the bug using the following query:

``` sql
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";
SELECT * FROM `foo` WHERE `fld` = "фошафщцукщжшрцфгшкрцуг";


CREATE TABLE `tb_` (`rel_uid` BIGINT UNSIGNED NOT NULL ,
`custom_field_uid` INT UNSIGNED NOT NULL ,
`related_object_uid` BIGINT UNSIGNED NOT NULL ,
`value` VARCHAR( 255 ) NOT NULL ,
INDEX ( `related_object_uid` )
) ENGINE = InnoDB;

ALTER TABLE `tb_` ADD PRIMARY KEY ( `rel_uid` , `custom_field_uid` ) ;

ALTER TABLE `tb_` DROP INDEX `w_rel` ,
ADD INDEX `w_rel` ( `w_type_uid` , `related_object_uid` , `w_uid` ); ?
```

Thanks to MaxiBul for reporting.

Signed-off-by: Dan Ungureanu udan1107@gmail.com
