### PR TITLE
Fixes cURL timeout.

### DIFF
--- a/libraries/Config.class.php
+++ b/libraries/Config.class.php
@@ -778,6 +778,7 @@ class PMA_Config
         curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, 0);
         curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, 5);
         curl_setopt($handle, CURLOPT_TIMEOUT, 5);
+        curl_setopt($handle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
         if (! defined('TESTSUITE')) {
             session_write_close();
         }


### PR DESCRIPTION
cURL tries to reverse DNS the server and because it cannot it waits for the timeout.
It depends on machine configuration.

Fixes #10250.

Signed-off-by: Dan Ungureanu udan1107@gmail.com
