### PR TITLE
Fix Issue #11367

### DIFF
--- a/tbl_row_action.php
+++ b/tbl_row_action.php
@@ -56,6 +56,15 @@ case 'edit':
 }
 
 if (!empty($submit_mult)) {
+
+    if (! isset($_REQUEST['rows_to_delete'])
+        || ! is_array($_REQUEST['rows_to_delete'])
+    ) {
+        $response = PMA_Response::getInstance();
+        $response->isSuccess(false);
+        $response->addJSON('message', __('No row selected.'));
+    }
+
     switch($submit_mult) {
     case 'row_edit':
         // As we got the rows to be edited from the


### PR DESCRIPTION
Force the user to select at least one row from the query results if he/she wants to perform an action on some of the rows.

Shows a `No row selected` message if none selected.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
