### PR TITLE
Updated sql-parser library.

### DIFF
--- a/libraries/sql-parser/src/Component.php
+++ b/libraries/sql-parser/src/Component.php
@@ -70,12 +70,13 @@ namespace SqlParser {
          * `static::parse`.
          *
          * @param mixed $component The component to be built.
+         * @param array $options   Parameters for building.
          *
          * @throws \Exception Not implemented yet.
          *
          * @return string
          */
-        public static function build($component)
+        public static function build($component, array $options = array())
         {
             // This method should be abstract, but it can't be both static and
             // abstract.

--- a/libraries/sql-parser/src/Components/AlterOperation.php
+++ b/libraries/sql-parser/src/Components/AlterOperation.php
@@ -202,7 +202,6 @@ class AlterOperation extends Component
                 __('Unrecognized alter operation.'),
                 $list->tokens[$list->idx]
             );
-            return null;
         }
 
         --$list->idx;
@@ -211,14 +210,15 @@ class AlterOperation extends Component
 
     /**
      * @param AlterOperation $component The component to be built.
+     * @param array          $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
-        $ret = OptionsArray::build($component->options) . ' ';
-        if (!empty($component->field)) {
-            $ret .= Expression::build($component->field) . ' ';
+        $ret = $component->options . ' ';
+        if ((isset($component->field)) && ($component->field !== '')) {
+            $ret .= $component->field . ' ';
         }
         $ret .= TokensList::build($component->unknown);
         return $ret;

--- a/libraries/sql-parser/src/Components/Array2d.php
+++ b/libraries/sql-parser/src/Components/Array2d.php
@@ -124,10 +124,11 @@ class Array2d extends Component
 
     /**
      * @param ArrayObj[] $component The component to be built.
+     * @param array      $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         return ArrayObj::build($component);
     }

--- a/libraries/sql-parser/src/Components/ArrayObj.php
+++ b/libraries/sql-parser/src/Components/ArrayObj.php
@@ -136,7 +136,6 @@ class ArrayObj extends Component
                     break;
                 }
             }
-
         }
 
         return $ret;
@@ -144,27 +143,18 @@ class ArrayObj extends Component
 
     /**
      * @param ArrayObj|ArrayObj[] $component The component to be built.
+     * @param array               $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         if (is_array($component)) {
-            $values = array();
-            foreach ($component as $c) {
-                $values[] = static::build($c);
-            }
-            return implode(', ', $values);
+            return implode(', ', $component);
+        } elseif (!empty($component->raw)) {
+            return '(' . implode(', ', $component->raw) . ')';
         } else {
-            $values = array();
-            if (!empty($component->raw)) {
-                $values = $component->raw;
-            } else {
-                foreach ($component->values as $value) {
-                    $values[] = $value;
-                }
-            }
-            return '(' . implode(', ', $values) . ')';
+            return '(' . implode(', ', $component->values) . ')';
         }
     }
 }

--- a/libraries/sql-parser/src/Components/Condition.php
+++ b/libraries/sql-parser/src/Components/Condition.php
@@ -197,15 +197,16 @@ class Condition extends Component
 
     /**
      * @param Condition[] $component The component to be built.
+     * @param array       $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
-        $ret = array();
-        foreach ($component as $c) {
-            $ret[] = $c->expr;
+        if (is_array($component)) {
+            return implode(' ', $component);
+        } else {
+            return $component->expr;
         }
-        return implode(' ', $ret);
     }
 }

--- a/libraries/sql-parser/src/Components/CreateDefinition.php
+++ b/libraries/sql-parser/src/Components/CreateDefinition.php
@@ -272,17 +272,14 @@ class CreateDefinition extends Component
 
     /**
      * @param CreateDefinition|CreateDefinition[] $component The component to be built.
+     * @param array                               $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         if (is_array($component)) {
-            $ret = array();
-            foreach ($component as $c) {
-                $ret[] = static::build($c);
-            }
-            return "(\n  " . implode(",\n  ", $ret) . "\n)";
+            return "(\n  " . implode(",\n  ", $component) . "\n)";
         } else {
             $tmp = '';
 
@@ -290,23 +287,26 @@ class CreateDefinition extends Component
                 $tmp .= 'CONSTRAINT ';
             }
 
-            if (isset($component->name) && strlen($component->name)) {
+            if ((isset($component->name)) && ($component->name !== '')) {
                 $tmp .= Context::escape($component->name) . ' ';
             }
 
             if (!empty($component->type)) {
-                $tmp .= DataType::build($component->type) . ' ';
+                $tmp .= DataType::build(
+                    $component->type,
+                    array('lowercase' => true)
+                ) . ' ';
             }
 
             if (!empty($component->key)) {
-                $tmp .= Key::build($component->key) . ' ';
+                $tmp .= $component->key . ' ';
             }
 
             if (!empty($component->references)) {
-                $tmp .= 'REFERENCES ' . Reference::build($component->references) . ' ';
+                $tmp .= 'REFERENCES ' . $component->references . ' ';
             }
 
-            $tmp .= OptionsArray::build($component->options);
+            $tmp .= $component->options;
 
             return trim($tmp);
         }

--- a/libraries/sql-parser/src/Components/DataType.php
+++ b/libraries/sql-parser/src/Components/DataType.php
@@ -151,18 +151,20 @@ class DataType extends Component
 
     /**
      * @param DataType $component The component to be built.
+     * @param array    $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
-        $tmp = '';
+        $name = (empty($options['lowercase'])) ?
+            $component->name : strtolower($component->name);
+
+        $parameters = '';
         if (!empty($component->parameters)) {
-            $tmp = '(' . implode(',', $component->parameters) . ')';
+            $parameters = '(' . implode(',', $component->parameters) . ')';
         }
-        return trim(
-            strtolower($component->name) . $tmp . ' '
-            . OptionsArray::build($component->options)
-        );
+
+        return trim($name . $parameters . ' ' . $component->options);
     }
 }

--- a/libraries/sql-parser/src/Components/Expression.php
+++ b/libraries/sql-parser/src/Components/Expression.php
@@ -350,32 +350,37 @@ class Expression extends Component
     }
 
     /**
-     * @param Expression $component The component to be built.
+     * @param Expression|Expression[] $component The component to be built.
+     * @param array                   $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
-        if (!empty($component->expr)) {
-            $ret = $component->expr;
+        if (is_array($component)) {
+            return implode($component, ', ');
         } else {
-            $fields = array();
-            if (!empty($component->database)) {
-                $fields[] = $component->database;
+            if (!empty($component->expr)) {
+                $ret = $component->expr;
+            } else {
+                $fields = array();
+                if ((isset($component->database)) && ($component->database !== '')) {
+                    $fields[] = $component->database;
+                }
+                if ((isset($component->table)) && ($component->table !== '')) {
+                    $fields[] = $component->table;
+                }
+                if ((isset($component->column)) && ($component->column !== '')) {
+                    $fields[] = $component->column;
+                }
+                $ret = implode('.', Context::escape($fields));
             }
-            if (!empty($component->table)) {
-                $fields[] = $component->table;
-            }
-            if (!empty($component->column)) {
-                $fields[] = $component->column;
-            }
-            $ret = implode('.', Context::escape($fields));
-        }
 
-        if (!empty($component->alias)) {
-            $ret .= ' AS ' . Context::escape($component->alias);
-        }
+            if (!empty($component->alias)) {
+                $ret .= ' AS ' . Context::escape($component->alias);
+            }
 
-        return $ret;
+            return $ret;
+        }
     }
 }

--- a/libraries/sql-parser/src/Components/ExpressionArray.php
+++ b/libraries/sql-parser/src/Components/ExpressionArray.php
@@ -106,10 +106,11 @@ class ExpressionArray extends Component
 
     /**
      * @param Expression[] $component The component to be built.
+     * @param array        $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         $ret = array();
         foreach ($component as $frag) {

--- a/libraries/sql-parser/src/Components/FunctionCall.php
+++ b/libraries/sql-parser/src/Components/FunctionCall.php
@@ -115,11 +115,12 @@ class FunctionCall extends Component
 
     /**
      * @param FunctionCall $component The component to be built.
+     * @param array        $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
-        return $component->name . ArrayObj::build($component->parameters);
+        return $component->name . $component->parameters;
     }
 }

--- a/libraries/sql-parser/src/Components/IntoKeyword.php
+++ b/libraries/sql-parser/src/Components/IntoKeyword.php
@@ -133,15 +133,16 @@ class IntoKeyword extends Component
 
     /**
      * @param IntoKeyword $component The component to be built.
+     * @param array       $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         if ($component->dest instanceof Expression) {
             $columns = !empty($component->columns) ?
                 '(' . implode(', ', $component->columns) . ')' : '';
-            return Expression::build($component->dest) . $columns;
+            return $component->dest . $columns;
         } else {
             return 'OUTFILE "' . $component->dest . '"';
         }

--- a/libraries/sql-parser/src/Components/JoinKeyword.php
+++ b/libraries/sql-parser/src/Components/JoinKeyword.php
@@ -151,15 +151,16 @@ class JoinKeyword extends Component
 
     /**
      * @param JoinKeyword[] $component The component to be built.
+     * @param array         $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         $ret = array();
         foreach ($component as $c) {
-            $ret[] = (($c->type === 'JOIN') ? 'JOIN ' : ($c->type . ' JOIN ')) .
-                Expression::build($c->expr) . ' ON ' . Condition::build($c->on);
+            $ret[] = (($c->type === 'JOIN') ? 'JOIN ' : ($c->type . ' JOIN '))
+               . $c->expr . ' ON ' . Condition::build($c->on);
         }
         return implode(' ', $ret);
     }

--- a/libraries/sql-parser/src/Components/Key.php
+++ b/libraries/sql-parser/src/Components/Key.php
@@ -145,7 +145,6 @@ class Key extends Component
                 ++$list->idx;
                 break;
             }
-
         }
 
         --$list->idx;
@@ -153,18 +152,19 @@ class Key extends Component
     }
 
     /**
-     * @param Key $component The component to be built.
+     * @param Key   $component The component to be built.
+     * @param array $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         $ret = $component->type . ' ';
         if (!empty($component->name)) {
             $ret .= Context::escape($component->name) . ' ';
         }
-        $ret .= '(' . implode(',', Context::escape($component->columns)) . ')';
-        $ret .= OptionsArray::build($component->options);
+        $ret .= '(' . implode(',', Context::escape($component->columns)) . ') '
+            . $component->options;
         return trim($ret);
     }
 }

--- a/libraries/sql-parser/src/Components/Limit.php
+++ b/libraries/sql-parser/src/Components/Limit.php
@@ -122,10 +122,11 @@ class Limit extends Component
 
     /**
      * @param Limit $component The component to be built.
+     * @param array $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         if (empty($component->offset)) {
             return $component->rowCount;

--- a/libraries/sql-parser/src/Components/OptionsArray.php
+++ b/libraries/sql-parser/src/Components/OptionsArray.php
@@ -251,14 +251,16 @@ class OptionsArray extends Component
 
     /**
      * @param OptionsArray $component The component to be built.
+     * @param array        $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
-        if ((empty($component)) || (!is_array($component->options))) {
+        if (empty($component->options)) {
             return '';
         }
+
         $options = array();
         foreach ($component->options as $option) {
             if (!is_array($option)) {
@@ -266,9 +268,7 @@ class OptionsArray extends Component
             } else {
                 $options[] = $option['name']
                     . (!empty($option['equals']) ? '=' : ' ')
-                    . (!empty($option['expr']) ? ((string) $option['expr']) : $option['value']);
-                // If `$option['expr']` happens to be a component, the magic
-                // method will build it automatically.
+                    . (!empty($option['expr']) ? $option['expr'] : $option['value']);
             }
         }
         return implode(' ', $options);

--- a/libraries/sql-parser/src/Components/OrderKeyword.php
+++ b/libraries/sql-parser/src/Components/OrderKeyword.php
@@ -126,20 +126,17 @@ class OrderKeyword extends Component
     }
 
     /**
-     * @param OrderKeyword $component The component to be built.
+     * @param OrderKeyword|OrderKeyword[] $component The component to be built.
+     * @param array                       $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         if (is_array($component)) {
-            $ret = array();
-            foreach ($component as $c) {
-                $ret[] = static::build($c);
-            }
-            return implode(", ", $ret);
+            return implode(', ', $component);
         } else {
-            return Expression::build($component->expr) . ' ' . $component->type;
+            return $component->expr . ' ' . $component->type;
         }
     }
 }

--- a/libraries/sql-parser/src/Components/ParameterDefinition.php
+++ b/libraries/sql-parser/src/Components/ParameterDefinition.php
@@ -130,7 +130,7 @@ class ParameterDefinition extends Component
         }
 
         // Last iteration was not saved.
-        if (!empty($expr->name)) {
+        if ((isset($expr->name)) && ($expr->name !== '')) {
             $ret[] = $expr;
         }
 
@@ -140,23 +140,23 @@ class ParameterDefinition extends Component
 
     /**
      * @param ParameterDefinition[] $component The component to be built.
+     * @param array                 $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
-        $ret = array();
-        foreach ($component as $c) {
+        if (is_array($component)) {
+            return '(' . implode(', ', $component) . ')';
+        } else {
             $tmp = '';
-            if (!empty($c->inOut)) {
-                $tmp .= $c->inOut . ' ';
+            if (!empty($component->inOut)) {
+                $tmp .= $component->inOut . ' ';
             }
 
-            $ret[] = trim(
-                $tmp . Context::escape($c->name) . ' ' .
-                DataType::build($c->type)
+            return trim(
+                $tmp . Context::escape($component->name) . ' ' . $component->type
             );
         }
-        return '(' . implode(', ', $ret) . ')';
     }
 }

--- a/libraries/sql-parser/src/Components/PartitionDefinition.php
+++ b/libraries/sql-parser/src/Components/PartitionDefinition.php
@@ -192,17 +192,14 @@ class PartitionDefinition extends Component
 
     /**
      * @param PartitionDefinition|PartitionDefinition[] $component The component to be built.
+     * @param array                                     $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         if (is_array($component)) {
-            $ret = array();
-            foreach ($component as $c) {
-                $ret[] = static::build($c);
-            }
-            return "(\n" . implode(",\n", $ret) . "\n)";
+            return "(\n" . implode(",\n", $component) . "\n)";
         } else {
             if ($component->isSubpartition) {
                 return 'SUBPARTITION ' . $component->name;
@@ -213,7 +210,6 @@ class PartitionDefinition extends Component
                     . ' VALUES ' . $component->type . ' ' . $component->expr
                     . $subpartitions;
             }
-
         }
     }
 }

--- a/libraries/sql-parser/src/Components/Reference.php
+++ b/libraries/sql-parser/src/Components/Reference.php
@@ -137,15 +137,16 @@ class Reference extends Component
 
     /**
      * @param Reference $component The component to be built.
+     * @param array     $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         return trim(
             Context::escape($component->table)
             . ' (' . implode(', ', Context::escape($component->columns)) . ') '
-            . OptionsArray::build($component->options)
+            . $component->options
         );
     }
 }

--- a/libraries/sql-parser/src/Components/RenameOperation.php
+++ b/libraries/sql-parser/src/Components/RenameOperation.php
@@ -162,20 +162,16 @@ class RenameOperation extends Component
 
     /**
      * @param RenameOperation $component The component to be built.
+     * @param array           $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         if (is_array($component)) {
-            $values = array();
-            foreach ($component as $c) {
-                $values[] = static::build($c);
-            }
-            return implode(', ', $values);
+            return implode(', ', $component);
         } else {
-            return Expression::build($component->old) . ' TO '
-                . Expression::build($component->new);
+            return $component->old . ' TO ' . $component->new;
         }
     }
 }

--- a/libraries/sql-parser/src/Components/SetOperation.php
+++ b/libraries/sql-parser/src/Components/SetOperation.php
@@ -122,17 +122,14 @@ class SetOperation extends Component
 
     /**
      * @param SetOperation|SetOperation[] $component The component to be built.
+     * @param array                       $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
         if (is_array($component)) {
-            $ret = array();
-            foreach ($component as $c) {
-                $ret[] = static::build($c);
-            }
-            return implode(", ", $ret);
+            return implode(', ', $component);
         } else {
             return $component->column . ' = ' . $component->value;
         }

--- a/libraries/sql-parser/src/Components/UnionKeyword.php
+++ b/libraries/sql-parser/src/Components/UnionKeyword.php
@@ -25,15 +25,12 @@ class UnionKeyword extends Component
 
     /**
      * @param SelectStatement[] $component The component to be built.
+     * @param array             $options   Parameters for building.
      *
      * @return string
      */
-    public static function build($component)
+    public static function build($component, array $options = array())
     {
-        $ret = array();
-        foreach ($component as $c) {
-            $ret[] = $c->build();
-        }
-        return implode(" UNION ", $ret);
+        return implode(' UNION ', $component);
     }
 }

--- a/libraries/sql-parser/src/Lexer.php
+++ b/libraries/sql-parser/src/Lexer.php
@@ -331,7 +331,7 @@ namespace SqlParser {
                     $pos = $this->last + 1;
 
                     // Parsing the delimiter.
-                    $this->delimiter = '';
+                    $this->delimiter = null;
                     while ((++$this->last < $this->len) && (!Context::isWhitespace($this->str[$this->last]))) {
                         $this->delimiter .= $this->str[$this->last];
                     }

--- a/libraries/sql-parser/src/Statements/CreateStatement.php
+++ b/libraries/sql-parser/src/Statements/CreateStatement.php
@@ -343,7 +343,7 @@ class CreateStatement extends Statement
             )
         );
 
-        if (empty($this->name)) {
+        if ((!isset($this->name)) || ($this->name === '')) {
             $parser->error(
                 __('The name of the entity was expected.'),
                 $list->tokens[$list->idx]

--- a/libraries/sql-parser/src/Utils/Formatter.php
+++ b/libraries/sql-parser/src/Utils/Formatter.php
@@ -80,7 +80,7 @@ class Formatter
                  *
                  * @var string
                  */
-                'indentation' => "    ",
+                'indentation' => "  ",
 
                 /**
                  * Whether comments should be removed or not.

--- a/libraries/sql-parser/src/Utils/Misc.php
+++ b/libraries/sql-parser/src/Utils/Misc.php
@@ -60,11 +60,12 @@ class Misc
         }
 
         foreach ($expressions as $expr) {
-            if (empty($expr->table)) {
+            if ((!isset($expr->table)) || ($expr->table === '')) {
                 continue;
             }
 
-            $thisDb = empty($expr->database) ? $database : $expr->database;
+            $thisDb = ((isset($expr->database)) && ($expr->database !== '')) ?
+                $expr->database : $database;
 
             if (!isset($retval[$thisDb])) {
                 $retval[$thisDb] = array(
@@ -75,7 +76,8 @@ class Misc
 
             if (!isset($retval[$thisDb]['tables'][$expr->table])) {
                 $retval[$thisDb]['tables'][$expr->table] = array(
-                    'alias' => empty($expr->alias) ? null : $expr->alias,
+                    'alias' => ((isset($expr->alias)) && ($expr->alias !== '')) ?
+                        $expr->alias : null,
                     'columns' => array(),
                 );
             }
@@ -87,20 +89,23 @@ class Misc
         }
 
         foreach ($statement->expr as $expr) {
-            if ((empty($expr->column)) || (empty($expr->alias))) {
+            if ((!isset($expr->column)) || ($expr->column === '')
+                || (!isset($expr->alias)) || ($expr->alias === '')
+            ) {
                 continue;
             }
 
-            $thisDb = empty($expr->database) ? $database : $expr->database;
+            $thisDb = ((isset($expr->database)) && ($expr->database !== '')) ?
+                $expr->database : $database;
 
-            if (empty($expr->table)) {
-                foreach ($retval[$thisDb]['tables'] as &$table) {
-                    $table['columns'][$expr->column] = $expr->alias;
-                }
-            } else {
+            if ((isset($expr->table)) && ($expr->table !== '')) {
                 $thisTable = isset($tables[$thisDb][$expr->table]) ?
                     $tables[$thisDb][$expr->table] : $expr->table;
                 $retval[$thisDb]['tables'][$thisTable]['columns'][$expr->column] = $expr->alias;
+            } else {
+                foreach ($retval[$thisDb]['tables'] as &$table) {
+                    $table['columns'][$expr->column] = $expr->alias;
+                }
             }
         }
 

--- a/libraries/sql-parser/src/Utils/Query.php
+++ b/libraries/sql-parser/src/Utils/Query.php
@@ -372,7 +372,7 @@ class Query
     {
         $parser = new Parser($query);
 
-        if (!isset($parser->statements[0])) {
+        if (empty($parser->statements[0])) {
             return array();
         }
 
@@ -390,10 +390,12 @@ class Query
             // Finding tables' aliases and their associated real names.
             $tableAliases = array();
             foreach ($statement->from as $expr) {
-                if ((!empty($expr->table)) && (!empty($expr->alias))) {
+                if ((isset($expr->table)) && ($expr->table !== '')
+                    && (isset($expr->alias)) && ($expr->alias !== '')
+                ) {
                     $tableAliases[$expr->alias] = array(
                         $expr->table,
-                        !empty($expr->database) ? $expr->database : null
+                        isset($expr->database) ? $expr->database : null
                     );
                 }
             }
@@ -402,14 +404,15 @@ class Query
             // Sometimes, this is not possible because the tables aren't defined
             // explicitly (e.g. SELECT * FROM film, SELECT film_id FROM film).
             foreach ($statement->expr as $expr) {
-                if (!empty($expr->table)) {
-                    if (empty($tableAliases[$expr->table])) {
+                if ((isset($expr->table)) && ($expr->table !== '')) {
+                    if (isset($tableAliases[$expr->table])) {
+                        $arr = $tableAliases[$expr->table];
+                    } else {
                         $arr = array(
                             $expr->table,
-                            !empty($expr->database) ? $expr->database : null
+                            ((isset($expr->database)) && ($expr->database !== '')) ?
+                                $expr->database : null
                         );
-                    } else {
-                        $arr = $tableAliases[$expr->table];
                     }
                     if (!in_array($arr, $ret['select_tables'])) {
                         $ret['select_tables'][] = $arr;
@@ -424,10 +427,11 @@ class Query
             // extracted from the FROM clause.
             if (empty($ret['select_tables'])) {
                 foreach ($statement->from as $expr) {
-                    if (!empty($expr->table)) {
+                    if ((isset($expr->table)) && ($expr->table !== '')) {
                         $arr = array(
                             $expr->table,
-                            !empty($expr->database) ? $expr->database : null
+                            ((isset($expr->database)) && ($expr->database !== '')) ?
+                                $expr->database : null
                         );
                         if (!in_array($arr, $ret['select_tables'])) {
                             $ret['select_tables'][] = $arr;
@@ -607,7 +611,7 @@ class Query
             }
 
             if ($brackets == 0) {
-                // Checking if we changed sections.
+                // Checking if the section was changed.
                 if (($token->type === Token::TYPE_KEYWORD)
                     && (isset($clauses[$token->value]))
                     && ($clauses[$token->value] >= $currIdx)


### PR DESCRIPTION
Fixed minor formatting issues.
Updated sql-parser library to udan11/sql-parser@1b2988f296611f7294593fd1fff07c70ac514e2a.

Data type should be lowercase just in `CREATE TABLE` statements. See commit aed8527845a25141f436e503a7d48103dada1677 (especially comments).

Also, some fields were considered invalid (e.g. `0`, `0.0`, etc.). A partial fix was implemented in 5568970c857180fec26d2af5ea064cb0d2004118. This is completely fixed now.

Signed-off-by: Dan Ungureanu udan1107@gmail.com
