### PR TITLE
MariaDB 10.0.21 does not support sha256_password auth plugin

### DIFF
--- a/libraries/display_change_password.lib.php
+++ b/libraries/display_change_password.lib.php
@@ -82,7 +82,9 @@ function PMA_getHtmlForChangePassword($username, $hostname)
     );
 
     // See http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-5.html
-    if (PMA_MYSQL_INT_VERSION >= 50705) {
+    if (PMA_Util::getServerType() == 'MySQL'
+        && PMA_MYSQL_INT_VERSION >= 50705
+    ) {
         $html .= '<tr class="vmiddle">'
             . '<td>' . __('Password Hashing:') . '</td>'
             . '<td>'
@@ -111,7 +113,9 @@ function PMA_getHtmlForChangePassword($username, $hostname)
             . '</label>'
             . '</td>'
             . '</tr>';
-    } elseif (PMA_MYSQL_INT_VERSION >= 50606) {
+    } elseif (PMA_Util::getServerType() == 'MySQL'
+        && PMA_MYSQL_INT_VERSION >= 50606
+    ) {
         $html .= '<tr class="vmiddle" id="tr_element_before_generate_password">'
             . '<td>' . __('Password Hashing:') . '</td>'
             . '<td>'

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -1700,7 +1700,9 @@ function PMA_getHtmlForLoginInformationFields(
         . '>' . __('MySQL native password') . '</option>';
 
     // sha256 auth plugin exists only for 5.6.6+
-    if (PMA_MYSQL_INT_VERSION >= 50606) {
+    if (PMA_Util::getServerType() == 'MySQL'
+        && PMA_MYSQL_INT_VERSION >= 50606
+    ) {
         $html_output .= '<option value="sha256_password" '
         . ($orig_auth_plugin == 'sha256_password' ? ' selected ' : '')
         . ' >' . __('SHA256 password') . '</option>';
@@ -5016,7 +5018,9 @@ function PMA_getSqlQueriesForDisplayAndAddUser($username, $hostname, $password)
         $sql_query = '';
     }
 
-    if (PMA_MYSQL_INT_VERSION >= 50700) {
+    if (PMA_Util::getServerType() == 'MySQL'
+        && PMA_MYSQL_INT_VERSION >= 50700
+    ) {
         $password_set_real = null;
         $password_set_show = null;
     } else {

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -689,6 +689,7 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals(
             "CREATE USER ''@'localhost';GRANT USAGE ON *.* TO ''@'localhost' REQUIRE NONE;"
+            . "SET PASSWORD FOR ''@'localhost' =  PASSWORD('***');"
             . "GRANT ALL PRIVILEGES ON `pma_dbname`.* TO ''@'localhost';",
             $sql_query
         );


### PR DESCRIPTION
MariaDB 10.0.21 (latest stable version) also does not support sha256_password auth plugin.

I could not pin point a documentation reference but the latest version on the demo server as well as my local instance does not list `sha256_password` in the `SHOW PLUGINS;` query results.

Even if the newest beta version(10.1.6) adds the required support (could not find a docu. ref. again), we would to have a different condition to check which can be added later. 
So, this PR can surely be merged for now.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
