### PR TITLE
login form style fix, sprites css caching fix and extended security-related HTTP headers

### DIFF
--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -593,6 +593,22 @@ class PMA_Header
             . $captcha_url
             . ";"
         );
+        // Re-enable possible disabled XSS filters
+        // see https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+        header(
+            'X-XSS-Protection: 1; mode=block'
+        );
+        // "nosniff", prevents Internet Explorer and Google Chrome from MIME-sniffing a
+        // response away from the declared content-type
+        /// see https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+        header(
+            'X-Content-Type-Options: nosniff'
+        );
+        // Adobe cross-domain-policies
+        // see http://www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html
+        header(
+            'X-Permitted-Cross-Domain-Policies: none'
+        );
         PMA_noCacheHeader();
         if (! defined('IS_TRANSFORMATION_WRAPPER')) {
             // Define the charset to be used

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -894,6 +894,7 @@ form.login label {
 form.login input[type=text],
 form.login input[type=password],
 form.login select {
+    box-sizing: border-box;
     width: 14em;
 }
 

--- a/themes/sprites.css.php
+++ b/themes/sprites.css.php
@@ -11,7 +11,7 @@ if (! defined('PMA_MINIMUM_COMMON')) {
     exit();
 }
 
-$bg = $_SESSION['PMA_Theme']->getImgPath() . 'sprites.png';
+$bg = $_SESSION['PMA_Theme']->getImgPath() . 'sprites.png?v=' . urlencode(PMA_VERSION);
 /* Check if there is a valid data file for sprites */
 if (is_readable($_SESSION['PMA_Theme']->getPath() . '/sprites.lib.php')) {
 


### PR DESCRIPTION
Just a bunch of smaller changes we're using locally and thought would be useful to have upstream.

The CSS "box-sizing" feature fixes the width differences of the input and select elements on the login page. It is in our instance since a few months and should be compatible with all major browsers according to http://caniuse.com/#search=box-sizing
see before [1] and after [2]

We're using the modified CSS sprites URL even longer and it made phpMyAdmin upgrades easier (no cached sprites file which results in different images and needing to tell customers to press CTRL-F5 or smth. like that). I just updated the fix to match the method used in cd76cb6acc1af19331dc543db45aa0f60eaaefe6

The security-related HTTP headers are something we're using on different products since almost a year or so. The "X-XSS-Protection" re-enables user disabled XSS filters (they should be on by default), "X-Content-Type-Options" should prevent mime type sniffing attacks on IE and Chrom(e|ium) and "X-Permitted-Cross-Domain-Policies" seems to be an Adobe specific header that prevents clients like e.g. Flash from getting content from phpMyAdmin. It does NOT interfere with "X-Content-Security-Policy". More information to those headers are in [3] and [4].

Signed-off-by: Martin Herndl martin.herndl@world4you.com

[1] 
![image](https://cloud.githubusercontent.com/assets/5738896/9521928/ee1bfe7e-4cd1-11e5-85b4-19cd08f0580e.png)

[2] 
![image](https://cloud.githubusercontent.com/assets/5738896/9521903/c79e7eb6-4cd1-11e5-94c0-9fc49a0bde46.png)

[3] https://www.owasp.org/index.php/List_of_useful_HTTP_headers
[4] http://www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html
