### PR TITLE
Fix #11519 Bug while exporting results when a joined table field name is in SELECT query

### DIFF
--- a/libraries/sql-parser/src/Utils/Query.php
+++ b/libraries/sql-parser/src/Utils/Query.php
@@ -32,6 +32,7 @@ use SqlParser\Statements\SelectStatement;
 use SqlParser\Statements\ShowStatement;
 use SqlParser\Statements\TruncateStatement;
 use SqlParser\Statements\UpdateStatement;
+use SqlParser\Components\JoinKeyword;
 
 /**
  * Statement utilities.
@@ -612,11 +613,13 @@ class Query
 
             if ($brackets == 0) {
                 // Checking if the section was changed.
-                if (($token->type === Token::TYPE_KEYWORD)
-                    && (isset($clauses[$token->value]))
-                    && ($clauses[$token->value] >= $currIdx)
+                if ($token->type === Token::TYPE_KEYWORD
+                    && ((isset($clauses[$token->value]) && $clauses[$token->value] >= $currIdx)
+                    || (isset(JoinKeyword::$JOINS[$token->value]) && $clauses['JOIN'] >= $currIdx))
                 ) {
-                    $currIdx = $clauses[$token->value];
+                    $currIdx = isset($clauses[$token->value])
+                        ? $clauses[$token->value]
+                        : $clauses['JOIN'];
                     if (($skipFirst) && ($currIdx == $clauseIdx)) {
                         // This token is skipped (not added to the old
                         // clause) because it will be replaced.


### PR DESCRIPTION
@udan11 
I'd like your opinion on this as well.
The issue was, while the `$clauses` contained `JOIN`, the token had the value `INNER JOIN`. So they did not match.
