### PR TITLE
Fix #11519. Bug while exporting results when a joined table field name is in SELECT query.

### DIFF
--- a/libraries/sql-parser/src/Statements/SelectStatement.php
+++ b/libraries/sql-parser/src/Statements/SelectStatement.php
@@ -83,22 +83,30 @@ class SelectStatement extends Statement
      * @var array
      */
     public static $CLAUSES = array(
-        'SELECT'                        => array('SELECT',      2),
+        'SELECT'                        => array('SELECT',              2),
         // Used for options.
-        '_OPTIONS'                      => array('_OPTIONS',    1),
+        '_OPTIONS'                      => array('_OPTIONS',            1),
         // Used for selected expressions.
-        '_SELECT'                       => array('SELECT',      1),
-        'FROM'                          => array('FROM',        3),
-        'PARTITION'                     => array('PARTITION',   3),
-        'JOIN'                          => array('JOIN',        1),
-        'WHERE'                         => array('WHERE',       3),
-        'GROUP BY'                      => array('GROUP BY',    3),
-        'HAVING'                        => array('HAVING',      3),
-        'ORDER BY'                      => array('ORDER BY',    3),
-        'LIMIT'                         => array('LIMIT',       3),
-        'PROCEDURE'                     => array('PROCEDURE',   3),
-        'INTO'                          => array('INTO',        3),
-        'UNION'                         => array('UNION',       3),
+        '_SELECT'                       => array('SELECT',              1),
+        'FROM'                          => array('FROM',                3),
+        'PARTITION'                     => array('PARTITION',           3),
+
+        'JOIN'                          => array('JOIN',                1),
+        'FULL JOIN'                     => array('FULL JOIN',           1),
+        'INNER JOIN'                    => array('INNER JOIN',          1),
+        'LEFT JOIN'                     => array('LEFT JOIN',           1),
+        'LEFT OUTER JOIN'               => array('LEFT OUTER JOIN',     1),
+        'RIGHT JOIN'                    => array('RIGHT JOIN',          1),
+        'RIGHT OUTER JOIN'              => array('RIGHT OUTER JOIN',    1),
+
+        'WHERE'                         => array('WHERE',               3),
+        'GROUP BY'                      => array('GROUP BY',            3),
+        'HAVING'                        => array('HAVING',              3),
+        'ORDER BY'                      => array('ORDER BY',            3),
+        'LIMIT'                         => array('LIMIT',               3),
+        'PROCEDURE'                     => array('PROCEDURE',           3),
+        'INTO'                          => array('INTO',                3),
+        'UNION'                         => array('UNION',               3),
         // These are available only when `UNION` is present.
         // 'ORDER BY'                      => array('ORDER BY',    3),
         // 'LIMIT'                         => array('LIMIT',       3),


### PR DESCRIPTION
Fix #11519. Bug while exporting results when a joined table field name is in SELECT query.

Instead of #11530.

Signed-off-by: Dan Ungureanu udan1107@gmail.com
