### PR TITLE
Minimum supported PHP version is now 5.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "source": "https://github.com/phpmyadmin/phpmyadmin"
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.5.0"
     },
     "require-dev": {
         "satooshi/php-coveralls": "~0.6",


### PR DESCRIPTION
Signed-off-by: Florian Rey florian.rey@elao.com

Related to https://github.com/phpmyadmin/phpmyadmin/pull/11427
