### PR TITLE
Warning "PHP 5.5+ is required" changed in common.inc.php 

### DIFF
--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -56,7 +56,7 @@ if (getcwd() == dirname(__FILE__)) {
  * PHP 5 function, so cannot easily localize this message.
  */
 if (version_compare(PHP_VERSION, '5.5.0', 'lt')) {
-    die('PHP 5.5+ is required');
+    die('PHP 5.5+ is required.<br/> Currently Installed version is : '.phpversion() .'<br/><a href="http://php.net/downloads.php" target="_blank">*Click Here</a> To Download Latest version of PHP');
 }
 
 /**

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -56,7 +56,7 @@ if (getcwd() == dirname(__FILE__)) {
  * PHP 5 function, so cannot easily localize this message.
  */
 if (version_compare(PHP_VERSION, '5.5.0', 'lt')) {
-    die('PHP 5.5+ is required.<br/> Currently Installed version is : '.phpversion() .'<br/><a href="http://php.net/downloads.php" target="_blank">*Click Here</a> To Download Latest version of PHP');
+    die('PHP 5.5+ is required.<br/> Currently Installed version is : '.phpversion() .'<br/><a href="http://php.net/downloads.php" target="_blank">*Click Here</a> to download latest version of PHP');
 }
 
 /**


### PR DESCRIPTION
The warning " PHP 5.5+ is required " has been replaced with the new warning which indicates the current version installed in the user's system and also provided a link to download the latest version of PHP. This provides a basic idea to the user about what PHP version is running on their system and provides a link to update the same.
Signed-off-by: Abhishek kanojia abhishekka3193@gmail.com
