### PR TITLE
Fixed error in PR : 11569

### DIFF
--- a/libraries/display_change_password.lib.php
+++ b/libraries/display_change_password.lib.php
@@ -12,12 +12,14 @@ if (! defined('PHPMYADMIN')) {
 /**
   * Get HTML for the Change password dialog
   *
+  * @param string $mode     where is the function being called?
+  *                         values : 'change_pw' or 'edit_other'
   * @param string $username username
   * @param string $hostname hostname
   *
   * @return string html snippet
   */
-function PMA_getHtmlForChangePassword($username, $hostname)
+function PMA_getHtmlForChangePassword($mode, $username, $hostname)
 {
     /**
      * autocomplete feature of IE kills the "onchange" event handler and it
@@ -78,48 +80,60 @@ function PMA_getHtmlForChangePassword($username, $hostname)
         . '</td>'
         . '</tr>';
 
-    $html .= '<tr class="vmiddle">'
-        . '<td>' . __('Password Hashing:') . '</td><td>';
-
     $serverType = PMA_Util::getServerType();
     $orig_auth_plugin = PMA_getCurrentAuthenticationPlugin(
         'change',
         $username,
         $hostname
     );
+    $is_superuser = $GLOBALS['dbi']->isSuperuser();
 
     if (($serverType == 'MySQL'
         && PMA_MYSQL_INT_VERSION >= 50507)
         || ($serverType == 'MariaDB'
         && PMA_MYSQL_INT_VERSION >= 50200)
     ) {
-        $auth_plugin_dropdown = PMA_getHtmlForAuthPluginsDropdown(
-            $username, $hostname, $orig_auth_plugin, 'change_pw', 'new'
-        );
+        // Provide this option only for 5.7.6+
+        // OR for privileged users in 5.5.7+
+        if (($serverType == 'MySQL'
+            && PMA_MYSQL_INT_VERSION >= 50706)
+            || ($is_superuser && $mode == 'edit_other')
+        ) {
+            $auth_plugin_dropdown = PMA_getHtmlForAuthPluginsDropdown(
+                $username, $hostname, $orig_auth_plugin, 'change_pw', 'new'
+            );
 
-        $html .= $auth_plugin_dropdown;
-        $html .= '</td></tr>';
-        $html .= '<tr id="tr_element_before_generate_password"></tr>';
-        $html .=  '</table>';
+            $html .= '<tr class="vmiddle">'
+                . '<td>' . __('Password Hashing:') . '</td><td>';
+            $html .= $auth_plugin_dropdown;
+            $html .= '</td></tr>'
+                . '<tr id="tr_element_before_generate_password"></tr>'
+                . '</table>';
 
-        $html .= '<div '
-            . ($orig_auth_plugin != 'sha256_password' ? 'style="display:none"' : '')
-            . ' id="ssl_reqd_warning_cp">'
-            . PMA_Message::notice(
-                __(
-                    'This method requires using an \'<i>SSL connection</i>\' '
-                    . 'or an \'<i>unencrypted connection that encrypts the password '
-                    . 'using RSA</i>\'; while connecting to the server.'
+            $html .= '<div '
+                . ($orig_auth_plugin != 'sha256_password' ? 'style="display:none"' : '')
+                . ' id="ssl_reqd_warning_cp">'
+                . PMA_Message::notice(
+                    __(
+                        'This method requires using an \'<i>SSL connection</i>\' '
+                        . 'or an \'<i>unencrypted connection that encrypts the password '
+                        . 'using RSA</i>\'; while connecting to the server.'
+                    )
+                    . PMA_Util::showMySQLDocu('sha256-authentication-plugin')
                 )
-                . PMA_Util::showMySQLDocu('sha256-authentication-plugin')
-            )
-                ->getDisplay()
-            . '</div>';
+                    ->getDisplay()
+                . '</div>';
+        } else {
+            $html .= '<tr id="tr_element_before_generate_password"></tr>'
+                . '</table>';
+        }
     } else {
         $auth_plugin_dropdown = PMA_getHtmlForAuthPluginsDropdown(
             $username, $hostname, $orig_auth_plugin, 'change_pw', 'old'
         );
 
+        $html .= '<tr class="vmiddle">'
+            . '<td>' . __('Password Hashing:') . '</td><td>';
         $html .= $auth_plugin_dropdown . '</td></tr>'
             . '<tr id="tr_element_before_generate_password"></tr>'
             . '</table>';

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -1932,6 +1932,7 @@ function PMA_updatePassword($err_url, $username, $hostname)
 {
     // similar logic in user_password.php
     $message = '';
+    $is_superuser = $GLOBALS['dbi']->isSuperuser();
 
     if (empty($_REQUEST['nopass'])
         && isset($_POST['pma_pw'])
@@ -1947,8 +1948,9 @@ function PMA_updatePassword($err_url, $username, $hostname)
     // here $nopass could be == 1
     if (empty($message)) {
         $hashing_function = 'PASSWORD';
+        $serverType = PMA_Util::getServerType();
 
-        if (PMA_Util::getServerType() == 'MySQL'
+        if ($serverType == 'MySQL'
             && PMA_MYSQL_INT_VERSION >= 50706
         ) {
             if (isset($_REQUEST['authentication_plugin'])
@@ -1972,16 +1974,32 @@ function PMA_updatePassword($err_url, $username, $hostname)
 
             $local_query = $query_prefix
                 . PMA_Util::sqlAddSlashes($_POST['pma_pw']) . "'";
-        } else if ((PMA_Util::getServerType() == 'MySQL'
+        } else if (($serverType == 'MySQL'
             && PMA_MYSQL_INT_VERSION >= 50507)
-            || (PMA_Util::getServerType() == 'MariaDB'
+            || ($serverType == 'MariaDB'
             && PMA_MYSQL_INT_VERSION >= 50200)
+            && $is_superuser
         ) {
             // Backup the old value, to be reset later
             $row = $GLOBALS['dbi']->fetchSingleRow(
                 'SELECT @@old_passwords;'
             );
             $orig_value = $row['@@old_passwords'];
+
+            $update_plugin_query = "UPDATE `mysql`.`user` SET"
+                . " `plugin` = '" . $_REQUEST['authentication_plugin'] . "'"
+                . " WHERE `User` = '" . $username . "' AND Host = '"
+                . $hostname . "';";
+
+            // Update the plugin for the user
+            $GLOBALS['dbi']->tryQuery($update_plugin_query)
+                or PMA_Util::mysqlDie(
+                    $GLOBALS['dbi']->getError(),
+                    $update_plugin_query,
+                    false, $err_url
+                );
+
+            $GLOBALS['dbi']->tryQuery("FLUSH PRIVILEGES;");
 
             if (isset($_REQUEST['authentication_plugin'])
                 && $_REQUEST['authentication_plugin'] == 'mysql_native_password'
@@ -1997,19 +2015,6 @@ function PMA_updatePassword($err_url, $username, $hostname)
                 // to be 'sha256_password' type
                 $GLOBALS['dbi']->tryQuery('SET `old_passwords` = 2;');
             }
-
-            $update_plugin_query = "UPDATE `mysql`.`user` SET"
-                . " `plugin` = '" . $_REQUEST['authentication_plugin'] . "'"
-                . " WHERE `User` = '" . $username . "' AND Host = '"
-                . $hostname . "';";
-
-            // Update the plugin for the user
-            $GLOBALS['dbi']->tryQuery($update_plugin_query)
-                or PMA_Util::mysqlDie(
-                    $GLOBALS['dbi']->getError(),
-                    $update_plugin_query,
-                    false, $err_url
-                );
 
             $sql_query        = 'SET PASSWORD FOR \''
                 . PMA_Util::sqlAddSlashes($username)
@@ -4721,7 +4726,6 @@ function PMA_getHtmlForUserProperties($dbname_is_wildcard,$url_dbname,
             __('The selected user was not found in the privilege table.')
         )->getDisplay();
         $html_output .= PMA_getHtmlForLoginInformationFields();
-            //exit;
     }
 
     $_params = array(
@@ -4793,7 +4797,7 @@ function PMA_getHtmlForUserProperties($dbname_is_wildcard,$url_dbname,
         && ! $user_does_not_exists
     ) {
         //change login information
-        $html_output .= PMA_getHtmlForChangePassword($username, $hostname);
+        $html_output .= PMA_getHtmlForChangePassword('edit_other', $username, $hostname);
         $html_output .= PMA_getChangeLoginInformationHtmlForm($username, $hostname);
     }
     $html_output .= '</div>';

--- a/test/libraries/PMA_display_change_password_test.php
+++ b/test/libraries/PMA_display_change_password_test.php
@@ -48,6 +48,7 @@ class PMA_DisplayChangePassword_Test extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['Server']['user'] = "pma_user";
         $GLOBALS['cfg']['ShowHint'] = true;
         $GLOBALS['cfg']['ActionLinksMode'] = 'icons';
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['PMA_PHP_SELF'] = "server_privileges.php";
         $GLOBALS['server'] = 0;
         $GLOBALS['pmaThemeImage'] = 'image';
@@ -69,7 +70,7 @@ class PMA_DisplayChangePassword_Test extends PHPUnit_Framework_TestCase
         $hostname = "pma_hostname";
 
         //Call the test function
-        $html = PMA_getHtmlForChangePassword($username, $hostname);
+        $html = PMA_getHtmlForChangePassword('change_pw', $username, $hostname);
 
         //PMA_PHP_SELF
         $this->assertContains(

--- a/user_password.php
+++ b/user_password.php
@@ -68,7 +68,7 @@ if (isset($msg)) {
 
 require_once './libraries/display_change_password.lib.php';
 
-echo PMA_getHtmlForChangePassword($username, $hostname);
+echo PMA_getHtmlForChangePassword('change_pw', $username, $hostname);
 exit;
 
 /**
@@ -146,46 +146,40 @@ function PMA_changePassword($password, $message, $change_password_message)
 
     $serverType = PMA_Util::getServerType();
 
+    if (isset($_REQUEST['authentication_plugin'])
+        && ! empty($_REQUEST['authentication_plugin'])
+    ) {
+        $orig_auth_plugin = $_REQUEST['authentication_plugin'];
+    } else {
+        $orig_auth_plugin = PMA_getCurrentAuthenticationPlugin(
+            'change', $username, $hostname
+        );
+    }
+
     if ($serverType === 'MySQL'
         && PMA_MYSQL_INT_VERSION >= 50706
     ) {
-
-        if (isset($_REQUEST['authentication_plugin'])
-            && ! empty($_REQUEST['authentication_plugin'])
-        ) {
-            $orig_auth_plugin = $_REQUEST['authentication_plugin'];
-        } else {
-            $orig_auth_plugin = PMA_getCurrentAuthenticationPlugin(
-                'change', $username, $hostname
-            );
-        }
-
         $sql_query = 'ALTER USER \'' . $username . '\'@\'' . $hostname
             . '\' IDENTIFIED WITH ' . $orig_auth_plugin . ' BY '
             . (($password == '') ? '\'\'' : '\'***\'');
-    } else {
+    } else if (($serverType == 'MySQL'
+        && PMA_MYSQL_INT_VERSION >= 50507)
+        || ($serverType == 'MariaDB'
+        && PMA_MYSQL_INT_VERSION >= 50200)
+    ) {
         // For MySQL versions 5.5.7+ and MariaDB versions 5.2+,
         // explicitly set value of `old_passwords` so that
         // it does not give an error while using
         // the PASSWORD() function
-        if (($serverType == 'MySQL'
-            && PMA_MYSQL_INT_VERSION >= 50507)
-            || ($serverType == 'MariaDB'
-            && PMA_MYSQL_INT_VERSION >= 50200)
-        ) {
-            $orig_auth_plugin = PMA_getCurrentAuthenticationPlugin(
-                'change', $username, $hostname
-            );
-            if ($orig_auth_plugin == 'sha256_password') {
-                $value = 2;
-            } else {
-                $value = 0;
-            }
-            $GLOBALS['dbi']->tryQuery('SET `old_passwords` = ' . $value . ';');
+        if ($orig_auth_plugin == 'sha256_password') {
+            $value = 2;
+        } else {
+            $value = 0;
         }
+        $GLOBALS['dbi']->tryQuery('SET `old_passwords` = ' . $value . ';');
+    }
         $sql_query = 'SET password = '
             . (($password == '') ? '\'\'' : $hashing_function . '(\'***\')');
-    }
     PMA_changePassUrlParamsAndSubmitQuery(
         $username, $hostname, $password,
         $sql_query, $hashing_function, $orig_auth_plugin
@@ -203,7 +197,9 @@ function PMA_changePassword($password, $message, $change_password_message)
  */
 function PMA_changePassHashingFunction()
 {
-    if (PMA_isValid($_REQUEST['pw_hash'], 'identical', 'old')) {
+    if (PMA_isValid(
+        $_REQUEST['authentication_plugin'], 'identical', 'mysql_old_password'
+    )) {
         $hashing_function = 'OLD_PASSWORD';
     } else {
         $hashing_function = 'PASSWORD';


### PR DESCRIPTION
I need a slight advice/help here. The problem is mainly for MySQL versions 5.5.7 -> 5.7.5.

MySQL introduced ALTER USER syntax in 5.6.6, but only from 5.7.6, it can be used to change the authentication_plugin used to authenticate an user. But, as a GUI tool, we should be able to provide it. 

So in Edit Privileges > Change Password, we provide the logged-in user with different options to change the user's(i.e. user being edited) plugin to along with changing the user being edited's password. This is done by Updating the `plugin` field in `mysql`.`user`, flushing the privileges, setting the old_passwords value (0 for mysql_native and 2 for sha256) and then running the SET PASSWORD query.
This works as expected.

And, for the main page's 'Change Password', we do the same thing, but here the currently logged-in user and user being edited is same.

Now, the only problem here is that for changing passwords anywhere, we would require update_priv for `mysql.user`, the `FLUSH` priv as well. So the users which don't have this privileges would not be able to change their passwords at all (atleast not using PMA).

What I suggest we do ?
We keep the above explained method in Edit Privileges > Change Password, as we expect that if the user who is changing credentials for some other user must be privileged enough and his/her actions would go through. So, no problem.
For main page's Change Password, I think we remove the plugin changing options altogether and just provide for changing password. 

Currently this PR implements the privileged user version for both Change Password in Edit Privileges as well as on the main page. I will make the changes as we decide.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
