### PR TITLE
Remove extra spacing when navbar is not displayed

### DIFF
--- a/libraries/DisplayResults.php
+++ b/libraries/DisplayResults.php
@@ -4351,8 +4351,6 @@ class DisplayResults
                 $pos_next, $pos_prev, self::PLACE_TOP_DIRECTION_DROPDOWN,
                 $is_innodb
             );
-        } elseif (! isset($printview) || ($printview != '1')) {
-            $table_html .= "\n" . '<br /><br />' . "\n";
         }
 
         // 2b ----- Get field references from Database -----


### PR DESCRIPTION
Not showing navbar is not reason for adding extra whitespace, there is
already enough whitespace arround.

Issue #11507

Signed-off-by: Michal Čihař michal@cihar.com
