### PR TITLE
Be a bit more consistent in using full stop

### DIFF
--- a/libraries/advisory_rules.txt
+++ b/libraries/advisory_rules.txt
@@ -115,7 +115,7 @@ rule 'Minor Version' [! fired('Release Series')]
 	version
 	substr(value,0,1) == 5 && substr(value,2,1) == 5 && substr(value,4,2) < 8
 	Version less than 5.5.8 (the first GA release of 5.5).
-	You should upgrade, to a stable version of MySQL 5.5
+	You should upgrade, to a stable version of MySQL 5.5.
 	Current version: %s | value
 
 rule 'Distribution'
@@ -205,21 +205,21 @@ rule 'Percentage of sorts that cause temporary tables' [Sort_scan + Sort_range >
 	Sort_merge_passes / (Sort_scan + Sort_range) * 100
 	value > 10
 	Too many sorts are causing temporary tables.
-	Consider increasing {sort_buffer_size} and/or {read_rnd_buffer_size}, depending on your system memory limits
+	Consider increasing {sort_buffer_size} and/or {read_rnd_buffer_size}, depending on your system memory limits.
 	%s% of all sorts cause temporary tables, this value should be lower than 10%. | round(value,1)
 
 rule 'Rate of sorts that cause temporary tables'
 	Sort_merge_passes / Uptime
 	value * 60 * 60 > 1
 	Too many sorts are causing temporary tables.
-	Consider increasing {sort_buffer_size} and/or {read_rnd_buffer_size}, depending on your system memory limits
+	Consider increasing {sort_buffer_size} and/or {read_rnd_buffer_size}, depending on your system memory limits.
 	Temporary tables average: %s, this value should be less than 1 per hour. | ADVISOR_bytime(value,2)
 
 rule 'Sort rows'
 	Sort_rows / Uptime
 	value * 60 >= 1
 	There are lots of rows being sorted.
-	While there is nothing wrong with a high amount of row sorting, you might want to make sure that the queries which require a lot of sorting use indexed columns in the ORDER BY clause, as this will result in much faster sorting
+	While there is nothing wrong with a high amount of row sorting, you might want to make sure that the queries which require a lot of sorting use indexed columns in the ORDER BY clause, as this will result in much faster sorting.
 	Sorted rows average: %s | ADVISOR_bytime(value,2)
 
 # Joins, scans
@@ -227,7 +227,7 @@ rule 'Rate of joins without indexes'
 	(Select_range_check + Select_scan + Select_full_join) / Uptime
 	value * 60 * 60 > 1
 	There are too many joins without indexes.
-	This means that joins are doing full table scans. Adding indexes for the columns being used in the join conditions will greatly speed up table joins
+	This means that joins are doing full table scans. Adding indexes for the columns being used in the join conditions will greatly speed up table joins.
 	Table joins average: %s, this value should be less than 1 per hour | ADVISOR_bytime(value,2)
 
 rule 'Rate of reading first index entry'
@@ -376,8 +376,8 @@ rule 'Threads that are slow to launch' [slow_launch_time > 0]
 rule 'Slow launch time'
 	slow_launch_time
 	value > 2
-	Slow_launch_threads is above 2s
-	Set {slow_launch_time} to 1s or 2s to correctly count threads that are slow to launch
+	Slow_launch_threads is above 2s.
+	Set {slow_launch_time} to 1s or 2s to correctly count threads that are slow to launch.
 	slow_launch_time is set to %s | value
 
 #

--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -1539,7 +1539,7 @@ function PMA_getSubmitAndResetButtonForActionsPanel($tabindex, $tabindex_for_val
     . PMA\libraries\Util::showHint(
         __(
             'Use TAB key to move from value to value,'
-            . ' or CTRL+arrows to move anywhere'
+            . ' or CTRL+arrows to move anywhere.'
         )
     )
     . '</td>'

--- a/libraries/normalization.lib.php
+++ b/libraries/normalization.lib.php
@@ -147,7 +147,7 @@ function PMA_getHtmlFor1NFStep1($db, $table, $normalizedTo)
         ) . " </a>)</h4>"
         . "<p class='cm-em'>" . __(
             'Select a column which can be split into more '
-            . 'than one. (on select of \'no such column\', it\'ll move to next step)'
+            . 'than one (on select of \'no such column\', it\'ll move to next step).'
         )
         . "</p>"
         . "<div id='extra'>"


### PR DESCRIPTION
Move full stop to end of sentence or add it to sentences where it is
missing. This just fixes common places where translators tend to use
sentence with full stop but we don't.

Signed-off-by: Michal Čihař michal@cihar.com
