### PR TITLE
Fix error message in sql-parser.

### DIFF
--- a/libraries/sql-parser/src/Components/OptionsArray.php
+++ b/libraries/sql-parser/src/Components/OptionsArray.php
@@ -145,7 +145,9 @@ class OptionsArray extends Component
                         $parser->error(
                             sprintf(
                                 __('This option conflicts with "%1$s".'),
-                                $ret->options[$lastOptionId]
+                                is_array($ret->options[$lastOptionId])
+                                    ? $ret->options[$lastOptionId]['name']
+                                    : $ret->options[$lastOptionId]
                             ),
                             $token
                         );


### PR DESCRIPTION
Fix error message in sql-parser (fixes #11590).
Updated sql-parser to udan11/sql-parser@3d73f3877a7c471aa2754b3553bcfa3c73d31aa2 (v3.0.4).

Signed-off-by: Dan Ungureanu udan1107@gmail.com

Query for testing:

```
CREATE TABLE test ( id INT ) CHARSET='a' DEFAULT CHARSET='a';
```
