### PR TITLE
Fix import tab broken by ImportLdi.

### DIFF
--- a/libraries/plugins/import/ImportLdi.class.php
+++ b/libraries/plugins/import/ImportLdi.class.php
@@ -13,12 +13,6 @@ if (! defined('PHPMYADMIN')) {
 /* Get the import interface */
 require_once 'libraries/plugins/import/AbstractImportCsv.class.php';
 
-// We need relations enabled and we work only on database
-if ($GLOBALS['plugin_param'] !== 'table') {
-    $GLOBALS['skip_import'] = true;
-    return;
-}
-
 /**
  * Handles the import for the CSV format using load data
  *
@@ -32,6 +26,11 @@ class ImportLdi extends AbstractImportCsv
      */
     public function __construct()
     {
+        // We need relations enabled and we work only on database
+        if ($GLOBALS['plugin_param'] !== 'table') {
+            $GLOBALS['skip_import'] = true;
+            return;
+        }
         $this->setProperties();
     }
 


### PR DESCRIPTION
The return before the class would cause the class to not be found, breaking https://github.com/phpmyadmin/phpmyadmin/blob/QA_4_5/libraries/plugin_interface.lib.php#L79
which in turn caused a 500 error. Other importers might need a fix similar.
Can be seen on the demo server, click the import tab.

Signed-off-by: Daniel Rix Drainx1@live.com
