### PR TITLE
Fix missing include_once

### DIFF
--- a/libraries/plugin_interface.lib.php
+++ b/libraries/plugin_interface.lib.php
@@ -83,6 +83,7 @@ function PMA_getPlugins($plugin_type, $plugins_dir, $plugin_param)
             )
         ) {
             $GLOBALS['skip_import'] = false;
+            include_once $plugins_dir . $file;
             if (! $GLOBALS['skip_import']) {
                 $class_name = $prefix_class_name . $matches[1];
                 $plugin = new $class_name;


### PR DESCRIPTION
Originally removed by: 0680c243d196a8695e68546d07195558eb9a6388

Signed-off-by: Daniel Rix Drainx1@live.com
