### PR TITLE
Fix #11647 Restrict configuration NavigationTreeDbSeparator to strings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ phpMyAdmin - ChangeLog
 + issue #11619 TokuDB Tables Show Size as "unknown"
 + issue #11654 Use a slider for Internal relations
 + issue #11641 Ability to disable the navigationhiding Feature
+- issue #11647 Restrict configuration NavigationTreeDbSeparator to strings
 
 4.5.2.0 (not yet released)
 - issue #11589 Incorrect parameter in mysqli_fetch_fields()

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1507,12 +1507,11 @@ Navigation panel setup
 
 .. config:option:: $cfg['NavigationTreeDbSeparator']
 
-    :type: string or array
+    :type: string
     :default: ``'_'``
 
     The string used to separate the parts of the database name when
-    showing them in a tree. Alternatively you can specify more strings in
-    an array and all of them will be used as a separator.
+    showing them in a tree.
 
 .. config:option:: $cfg['NavigationTreeTableSeparator']
 


### PR DESCRIPTION
I am proposing to restrict the configuration `NavigationTreeDbSeparator` to strings due to the problem highlighted in https://github.com/phpmyadmin/phpmyadmin/issues/11647#issuecomment-155739095
