### PR TITLE
Reinitialize configuration values to their defaults for each test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ before_script:
 
 script:
   - ant clean
-  - ant locales
-  - if [ -z "$SELENIUM" ] ; then ant lint ; fi
   - set -e;
     if [ $TRAVIS_PHP_VERSION == "hhvm" ] ; then
     ant phpunit-hhvm ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ before_script:
 
 script:
   - ant clean
+  - ant locales
+  - if [ -z "$SELENIUM" ] ; then ant lint ; fi
   - set -e;
     if [ $TRAVIS_PHP_VERSION == "hhvm" ] ; then
     ant phpunit-hhvm ;

--- a/test/PMATestCase.php
+++ b/test/PMATestCase.php
@@ -1,0 +1,21 @@
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * Base class for phpMyAdmin tests
+ *
+ * @package PhpMyAdmin-test
+ */
+
+/**
+ * Base class for phpMyAdmin tests.
+ *
+ * @package PhpMyAdmin-test
+ */
+class PMATestCase extends PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        require 'libraries/config.default.php';
+        $GLOBALS['cfg'] = $cfg;
+    }
+}

--- a/test/classes/StorageEngineTest.php
+++ b/test/classes/StorageEngineTest.php
@@ -1,15 +1,16 @@
 <?php
-use PMA\libraries\StorageEngine;
 /**
  * Tests for StorageEngine.php
  *
  * @package PhpMyAdmin-test
  */
 
+use PMA\libraries\StorageEngine;
+
+require_once 'test/PMATestCase.php';
 /*
  * Include to test.
  */
-
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/config.default.php';
 require_once 'libraries/database_interface.inc.php';
@@ -19,7 +20,7 @@ require_once 'libraries/database_interface.inc.php';
  *
  * @package PhpMyAdmin-test
  */
-class StorageEngineTest extends PHPUnit_Framework_TestCase
+class StorageEngineTest extends PMATestCase
 {
     /**
      * @access protected

--- a/test/classes/config/ConfigFileTest.php
+++ b/test/classes/config/ConfigFileTest.php
@@ -11,6 +11,7 @@
  */
 use PMA\libraries\config\ConfigFile;
 
+require_once 'test/PMATestCase.php';
 require_once 'libraries/php-gettext/gettext.inc';
 
 /**
@@ -18,7 +19,7 @@ require_once 'libraries/php-gettext/gettext.inc';
  *
  * @package PhpMyAdmin-test
  */
-class ConfigFileTest extends PHPUnit_Framework_TestCase
+class ConfigFileTest extends PMATestCase
 {
     /**
      * Any valid key that exists in config.default.php and isn't empty
@@ -41,7 +42,6 @@ class ConfigFileTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $GLOBALS['server'] = 1;
-        $GLOBALS['cfg']['AvailableCharsets'] = array();
         $this->object = new ConfigFile();
     }
 

--- a/test/classes/config/FormDisplayTest.php
+++ b/test/classes/config/FormDisplayTest.php
@@ -11,6 +11,7 @@ use PMA\libraries\config\ConfigFile;
 use PMA\libraries\config\FormDisplay;
 use PMA\libraries\Theme;
 
+require_once 'test/PMATestCase.php';
 require_once 'libraries/config/config_functions.lib.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/user_preferences.lib.php';
@@ -20,7 +21,7 @@ require_once 'libraries/user_preferences.lib.php';
  *
  * @package PhpMyAdmin-test
  */
-class FormDisplayTest extends PHPUnit_Framework_TestCase
+class FormDisplayTest extends PMATestCase
 {
     /**
      * @var FormDisplay

--- a/test/classes/config/FormTest.php
+++ b/test/classes/config/FormTest.php
@@ -11,6 +11,7 @@ use PMA\libraries\config\ConfigFile;
 use PMA\libraries\config\Form;
 use PMA\libraries\Theme;
 
+require_once 'test/PMATestCase.php';
 require_once 'libraries/php-gettext/gettext.inc';
 
 /**
@@ -18,7 +19,7 @@ require_once 'libraries/php-gettext/gettext.inc';
  *
  * @package PhpMyAdmin-test
  */
-class FormTest extends PHPUnit_Framework_TestCase
+class FormTest extends PMATestCase
 {
     /**
      * @var Form

--- a/test/classes/config/PageSettingsTest.php
+++ b/test/classes/config/PageSettingsTest.php
@@ -7,6 +7,7 @@
  */
 use PMA\libraries\config\PageSettings;
 
+require_once 'test/PMATestCase.php';
 require_once 'libraries/config/user_preferences.forms.php';
 require_once 'libraries/config/page_settings.forms.php';
 
@@ -15,7 +16,7 @@ require_once 'libraries/config/page_settings.forms.php';
  *
  * @package PhpMyAdmin-test
  */
-class PageSettingsTest extends PHPUnit_Framework_TestCase
+class PageSettingsTest extends PMATestCase
 {
     /**
      * Setup tests
@@ -24,7 +25,6 @@ class PageSettingsTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $GLOBALS['cfg']['ServerDefault'] = 1;
         $GLOBALS['server'] = 1;
         $GLOBALS['db'] = 'db';
     }

--- a/test/classes/controllers/DatabaseStructureControllerTest.php
+++ b/test/classes/controllers/DatabaseStructureControllerTest.php
@@ -16,6 +16,7 @@ use PMA\libraries\di\Container;
 use PMA\libraries\Table;
 use PMA\libraries\Theme;
 
+require_once 'test/PMATestCase.php';
 require_once 'libraries/database_interface.inc.php';
 require_once 'test/libraries/stubs/ResponseStub.php';
 
@@ -26,7 +27,7 @@ require_once 'test/libraries/stubs/ResponseStub.php';
  *
  * @package PhpMyAdmin-test
  */
-class DatabaseStructureControllerTest extends PHPUnit_Framework_TestCase
+class DatabaseStructureControllerTest extends PMATestCase
 {
     /**
      * @var \PMA\Test\Stubs\Response
@@ -45,15 +46,7 @@ class DatabaseStructureControllerTest extends PHPUnit_Framework_TestCase
         $_REQUEST['pos'] = 3;
 
         //$GLOBALS
-        $GLOBALS['cfg']['MaxRows'] = 10;
         $GLOBALS['server'] = 1;
-        $GLOBALS['cfg']['ServerDefault'] = "server";
-        $GLOBALS['cfg']['RememberSorting'] = true;
-        $GLOBALS['cfg']['SQP'] = array();
-        $GLOBALS['cfg']['MaxCharactersInDisplayedSQL'] = 1000;
-        $GLOBALS['cfg']['ShowSQL'] = true;
-        $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
-        $GLOBALS['cfg']['LimitChars'] = 100;
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $GLOBALS['table'] = "table";

--- a/test/classes/controllers/ServerCollationsControllerTest.php
+++ b/test/classes/controllers/ServerCollationsControllerTest.php
@@ -24,7 +24,6 @@ $GLOBALS['available_languages']= array(
     "ch" => array("Chinese", "TW-Chinese")
 );
 $GLOBALS['text_dir'] = "text_dir";
-$GLOBALS['cfg']['DBG']['sql'] = false;
 $GLOBALS['cfg']['Server'] = array(
     'DisableIS' => false
 );
@@ -42,13 +41,14 @@ require_once 'libraries/js_escape.lib.php';
 require_once 'libraries/database_interface.inc.php';
 require_once 'libraries/server_common.inc.php';
 require_once 'libraries/mysql_charsets.inc.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for ServerCollationsController class
  *
  * @package PhpMyAdmin-test
  */
-class ServerCollationsControllerTest extends PHPUnit_Framework_TestCase
+class ServerCollationsControllerTest extends PMATestCase
 {
     /**
      * Prepares environment for the test.
@@ -62,16 +62,7 @@ class ServerCollationsControllerTest extends PHPUnit_Framework_TestCase
         $_REQUEST['pos'] = 3;
 
         //$GLOBALS
-        $GLOBALS['cfg']['MaxRows'] = 10;
         $GLOBALS['is_ajax_request'] = true;
-        $GLOBALS['cfg']['ServerDefault'] = "server";
-        $GLOBALS['cfg']['RememberSorting'] = true;
-        $GLOBALS['cfg']['SQP'] = array();
-        $GLOBALS['cfg']['MaxCharactersInDisplayedSQL'] = 1000;
-        $GLOBALS['cfg']['ShowSQL'] = true;
-        $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
-        $GLOBALS['cfg']['LimitChars'] = 100;
-
         $GLOBALS['table'] = "table";
         $GLOBALS['pmaThemeImage'] = 'image';
     }

--- a/test/classes/controllers/ServerDatabasesControllerTest.php
+++ b/test/classes/controllers/ServerDatabasesControllerTest.php
@@ -43,7 +43,7 @@ class ServerDatabasesControllerTest extends PMATestCase
         //$GLOBALS
         $GLOBALS['PMA_Config'] = new PMA\libraries\Config();
         $GLOBALS['PMA_Config']->enableBc();
-        $GLOBALS['is_superuser'] = false;
+        $GLOBALS['is_superuser'] = true;
 
         $GLOBALS['table'] = "table";
         $GLOBALS['replication_info']['master']['status'] = false;

--- a/test/classes/controllers/ServerDatabasesControllerTest.php
+++ b/test/classes/controllers/ServerDatabasesControllerTest.php
@@ -18,7 +18,8 @@ require_once 'libraries/database_interface.inc.php';
 require_once 'libraries/sanitizing.lib.php';
 require_once 'libraries/js_escape.lib.php';
 
-require_once 'libraries/config.default.php';
+require_once 'test/libraries/stubs/ResponseStub.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for ServerDatabasesController class
@@ -26,7 +27,7 @@ require_once 'libraries/config.default.php';
  * @package PhpMyAdmin-test
  */
 
-class ServerDatabasesControllerTest extends PHPUnit_Framework_TestCase
+class ServerDatabasesControllerTest extends PMATestCase
 {
     /**
      * Prepares environment for the test.
@@ -42,18 +43,7 @@ class ServerDatabasesControllerTest extends PHPUnit_Framework_TestCase
         //$GLOBALS
         $GLOBALS['PMA_Config'] = new PMA\libraries\Config();
         $GLOBALS['PMA_Config']->enableBc();
-        $GLOBALS['cfg']['MaxRows'] = 10;
-        $GLOBALS['cfg']['MaxDbList'] = 100;
-        $GLOBALS['cfg']['ServerDefault'] = "server";
-        $GLOBALS['cfg']['RememberSorting'] = true;
-        $GLOBALS['cfg']['SQP'] = array();
-        $GLOBALS['cfg']['MaxCharactersInDisplayedSQL'] = 1000;
-        $GLOBALS['cfg']['ShowSQL'] = true;
-        $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
-        $GLOBALS['cfg']['LimitChars'] = 100;
-        $GLOBALS['cfg']['DBG']['sql'] = false;
-        $GLOBALS['cfg']['ActionLinksMode'] = "both";
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
+        $GLOBALS['is_superuser'] = false;
 
         $GLOBALS['table'] = "table";
         $GLOBALS['replication_info']['master']['status'] = false;

--- a/test/classes/controllers/ServerEnginesControllerTest.php
+++ b/test/classes/controllers/ServerEnginesControllerTest.php
@@ -17,13 +17,14 @@ require_once 'libraries/database_interface.inc.php';
 
 require_once 'libraries/sanitizing.lib.php';
 require_once 'libraries/js_escape.lib.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for ServerEnginesController class
  *
  * @package PhpMyAdmin-test
  */
-class ServerEnginesControllerTest extends PHPUnit_Framework_TestCase
+class ServerEnginesControllerTest extends PMATestCase
 {
     /**
      * Prepares environment for the test.
@@ -38,16 +39,6 @@ class ServerEnginesControllerTest extends PHPUnit_Framework_TestCase
 
         //$GLOBALS
         $GLOBALS['server'] = 0;
-        $GLOBALS['cfg']['MaxRows'] = 10;
-        $GLOBALS['cfg']['ServerDefault'] = "server";
-        $GLOBALS['cfg']['RememberSorting'] = true;
-        $GLOBALS['cfg']['SQP'] = array();
-        $GLOBALS['cfg']['MaxCharactersInDisplayedSQL'] = 1000;
-        $GLOBALS['cfg']['ShowSQL'] = true;
-        $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
-        $GLOBALS['cfg']['LimitChars'] = 100;
-        $GLOBALS['cfg']['DBG']['sql'] = false;
-
         $GLOBALS['table'] = "table";
         $GLOBALS['pmaThemeImage'] = 'image';
 

--- a/test/classes/controllers/ServerPluginsControllerTest.php
+++ b/test/classes/controllers/ServerPluginsControllerTest.php
@@ -17,13 +17,14 @@ require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/database_interface.inc.php';
 require_once 'libraries/sanitizing.lib.php';
 require_once 'libraries/js_escape.lib.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for ServerPluginsController class
  *
  * @package PhpMyAdmin-test
  */
-class ServerPluginsControllerTest extends PHPUnit_Framework_TestCase
+class ServerPluginsControllerTest extends PMATestCase
 {
     /**
      * Prepares environment for the test.
@@ -37,16 +38,6 @@ class ServerPluginsControllerTest extends PHPUnit_Framework_TestCase
         $_REQUEST['pos'] = 3;
 
         //$GLOBALS
-        $GLOBALS['cfg']['MaxRows'] = 10;
-        $GLOBALS['cfg']['ServerDefault'] = "server";
-        $GLOBALS['cfg']['RememberSorting'] = true;
-        $GLOBALS['cfg']['SQP'] = array();
-        $GLOBALS['cfg']['MaxCharactersInDisplayedSQL'] = 1000;
-        $GLOBALS['cfg']['ShowSQL'] = true;
-        $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
-        $GLOBALS['cfg']['LimitChars'] = 100;
-        $GLOBALS['cfg']['DBG']['sql'] = false;
-
         $GLOBALS['table'] = "table";
         $GLOBALS['pmaThemeImage'] = 'image';
 

--- a/test/classes/controllers/ServerVariablesControllerTest.php
+++ b/test/classes/controllers/ServerVariablesControllerTest.php
@@ -14,6 +14,7 @@ require_once 'libraries/url_generating.lib.php';
 
 require_once 'libraries/database_interface.inc.php';
 require_once 'test/libraries/stubs/ResponseStub.php';
+require_once 'test/PMATestCase.php';
 
 require_once 'libraries/sanitizing.lib.php';
 require_once 'libraries/js_escape.lib.php';
@@ -23,7 +24,7 @@ require_once 'libraries/js_escape.lib.php';
  *
  * @package PhpMyAdmin-test
  */
-class ServerVariablesControllerTest extends PHPUnit_Framework_TestCase
+class ServerVariablesControllerTest extends PMATestCase
 {
     /**
      * @var \PMA\Test\Stubs\Response
@@ -42,17 +43,6 @@ class ServerVariablesControllerTest extends PHPUnit_Framework_TestCase
         $_REQUEST['pos'] = 3;
 
         //$GLOBALS
-        $GLOBALS['cfg']['MaxRows'] = 10;
-        $GLOBALS['cfg']['ServerDefault'] = "server";
-        $GLOBALS['cfg']['RememberSorting'] = true;
-        $GLOBALS['cfg']['SQP'] = array();
-        $GLOBALS['cfg']['MaxCharactersInDisplayedSQL'] = 1000;
-        $GLOBALS['cfg']['ShowSQL'] = true;
-        $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
-        $GLOBALS['cfg']['LimitChars'] = 100;
-        $GLOBALS['cfg']['DBG']['sql'] = false;
-        $GLOBALS['cfg']['Server']['host'] = "localhost";
-        $GLOBALS['cfg']['ActionLinksMode'] = 'icons';
         $GLOBALS['PMA_PHP_SELF'] = PMA_getenv('PHP_SELF');
         $GLOBALS['server'] = 1;
         $GLOBALS['table'] = "table";

--- a/test/classes/controllers/TableIndexesControllerTest.php
+++ b/test/classes/controllers/TableIndexesControllerTest.php
@@ -48,8 +48,6 @@ class TableIndexesControllerTest extends PMATestCase
         $GLOBALS['server'] = 1;
         $GLOBALS['cfg']['Server']['pmadb'] = '';
         $GLOBALS['pmaThemeImage'] = 'theme/';
-        $GLOBALS['cfg']['ServerDefault'] = "server";
-        $GLOBALS['cfg']['ShowHint'] = true;
         $GLOBALS['url_params'] = array(
             'db' => 'db',
             'server' => 1

--- a/test/classes/controllers/TableIndexesControllerTest.php
+++ b/test/classes/controllers/TableIndexesControllerTest.php
@@ -25,13 +25,14 @@ require_once 'libraries/url_generating.lib.php';
 
 require_once 'libraries/sanitizing.lib.php';
 require_once 'test/libraries/stubs/ResponseStub.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for libraries/controllers/TableIndexesController.php
  *
  * @package PhpMyAdmin-test
  */
-class TableIndexesControllerTest extends PHPUnit_Framework_TestCase
+class TableIndexesControllerTest extends PMATestCase
 {
     /**
      * Setup function for test cases

--- a/test/classes/controllers/TableRelationControllerTest.php
+++ b/test/classes/controllers/TableRelationControllerTest.php
@@ -17,13 +17,14 @@ require_once 'libraries/database_interface.inc.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/relation.lib.php';
 require_once 'test/libraries/stubs/ResponseStub.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for libraries/controllers/TableRelationController.php
  *
  * @package PhpMyAdmin-test
  */
-class TableRelationControllerTest extends PHPUnit_Framework_TestCase
+class TableRelationControllerTest extends PMATestCase
 {
     /**
      * @var \PMA\Test\Stubs\Response
@@ -39,7 +40,6 @@ class TableRelationControllerTest extends PHPUnit_Framework_TestCase
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['pmaThemeImage'] = 'theme/';
-        $GLOBALS['cfg']['ShowHint'] = true;
         //$_SESSION
         $_SESSION['PMA_Theme'] = Theme::load('./themes/pmahomme');
         $_SESSION['PMA_Theme'] = new Theme();

--- a/test/classes/controllers/TableSearchControllerTest.php
+++ b/test/classes/controllers/TableSearchControllerTest.php
@@ -15,13 +15,14 @@ use PMA\libraries\Theme;
 use PMA\libraries\TypesMySQL;
 
 require_once 'test/libraries/stubs/ResponseStub.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA_TableSearch
  *
  * @package PhpMyAdmin-test
  */
-class TableSearchControllerTest extends PHPUnit_Framework_TestCase
+class TableSearchControllerTest extends PMATestCase
 {
     /**
      * @var PMA\Test\Stubs\Response
@@ -48,16 +49,7 @@ class TableSearchControllerTest extends PHPUnit_Framework_TestCase
         $GLOBALS['is_ajax_request'] = false;
         $GLOBALS['cfgRelation'] = PMA_getRelationsParam();
         $GLOBALS['PMA_Types'] = new TypesMySQL();
-
-        $GLOBALS['cfg']['ServerDefault'] = 1;
-        $GLOBALS['cfg']['maxRowPlotLimit'] = 500;
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
-        $GLOBALS['cfg']['ServerDefault'] = 1;
-        $GLOBALS['cfg']['ActionLinksMode'] = 'both';
-        $GLOBALS['cfg']['ForeignKeyMaxLimit'] = 100;
-        $GLOBALS['cfg']['InitialSlidersState'] = 'closed';
-        $GLOBALS['cfg']['MaxRows'] = 25;
-        $GLOBALS['cfg']['TabsMode'] = 'text';
 
         $dbi = $this->getMockBuilder('PMA\libraries\DatabaseInterface')
             ->disableOriginalConstructor()

--- a/test/classes/controllers/TableStructureControllerTest.php
+++ b/test/classes/controllers/TableStructureControllerTest.php
@@ -16,6 +16,7 @@ use PMA\libraries\Theme;
 
 require_once 'libraries/database_interface.inc.php';
 require_once 'test/libraries/stubs/ResponseStub.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * TableStructureController_Test class
@@ -24,7 +25,7 @@ require_once 'test/libraries/stubs/ResponseStub.php';
  *
  * @package PhpMyAdmin-test
  */
-class TableStructureControllerTest extends PHPUnit_Framework_TestCase
+class TableStructureControllerTest extends PMATestCase
 {
     /**
      * @var \PMA\Test\Stubs\Response
@@ -43,15 +44,7 @@ class TableStructureControllerTest extends PHPUnit_Framework_TestCase
         $_REQUEST['pos'] = 3;
 
         //$GLOBALS
-        $GLOBALS['cfg']['MaxRows'] = 10;
         $GLOBALS['server'] = 1;
-        $GLOBALS['cfg']['ServerDefault'] = "server";
-        $GLOBALS['cfg']['RememberSorting'] = true;
-        $GLOBALS['cfg']['SQP'] = array();
-        $GLOBALS['cfg']['MaxCharactersInDisplayedSQL'] = 1000;
-        $GLOBALS['cfg']['ShowSQL'] = true;
-        $GLOBALS['cfg']['TableNavigationLinksMode'] = 'icons';
-        $GLOBALS['cfg']['LimitChars'] = 100;
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $GLOBALS['table'] = "table";

--- a/test/classes/dbi/DBIMysqlTest.php
+++ b/test/classes/dbi/DBIMysqlTest.php
@@ -14,6 +14,7 @@ use PMA\libraries\dbi\DBIMysql;
 require_once 'libraries/relation.lib.php';
 require_once 'libraries/url_generating.lib.php';
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 require_once 'libraries/database_interface.inc.php';
 
@@ -22,7 +23,7 @@ require_once 'libraries/database_interface.inc.php';
  *
  * @package PhpMyAdmin-test
  */
-class DBIMysqlTest extends PHPUnit_Framework_TestCase
+class DBIMysqlTest extends PMATestCase
 {
     /**
      * @access protected
@@ -42,7 +43,6 @@ class DBIMysqlTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('The MySQL extension is not available.');
         }
         $GLOBALS['cfg']['Server']['ssl'] = true;
-        $GLOBALS['cfg']['PersistentConnections'] = false;
         $GLOBALS['cfg']['Server']['compress'] = true;
         $this->object = new DBIMysql();
     }
@@ -173,7 +173,6 @@ class DBIMysqlTest extends PHPUnit_Framework_TestCase
             $ret
         );
 
-        $GLOBALS['cfg']['PersistentConnections'] = true;
         $ret = $this->object->connect(
             $user, $password, $is_controluser,
             $server, $auxiliary_connection

--- a/test/classes/dbi/DBIMysqlTest.php
+++ b/test/classes/dbi/DBIMysqlTest.php
@@ -173,6 +173,7 @@ class DBIMysqlTest extends PMATestCase
             $ret
         );
 
+        $GLOBALS['cfg']['PersistentConnections'] = true;
         $ret = $this->object->connect(
             $user, $password, $is_controluser,
             $server, $auxiliary_connection

--- a/test/classes/dbi/DBIMysqliTest.php
+++ b/test/classes/dbi/DBIMysqliTest.php
@@ -15,13 +15,14 @@ require_once 'libraries/relation.lib.php';
 require_once 'libraries/url_generating.lib.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/database_interface.inc.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\dbi\DBIMysqli class
  *
  * @package PhpMyAdmin-test
  */
-class DBIMysqliTest extends PHPUnit_Framework_TestCase
+class DBIMysqliTest extends PMATestCase
 {
     /**
      * @access protected
@@ -38,10 +39,7 @@ class DBIMysqliTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $GLOBALS['cfg']['Server']['ssl'] = false;
-        $GLOBALS['cfg']['PersistentConnections'] = false;
         $GLOBALS['cfg']['Server']['compress'] = true;
-        $GLOBALS['cfg']['MaxCharactersInDisplayedSQL'] = 1000;
-        $GLOBALS['cfg']['ActionLinksMode'] = "both";
         $GLOBALS['pmaThemeImage'] = 'image';
 
         //$_SESSION

--- a/test/classes/engines/BdbTest.php
+++ b/test/classes/engines/BdbTest.php
@@ -13,14 +13,14 @@ use PMA\libraries\engines\Bdb;
 
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/database_interface.inc.php';
-
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\engines\Bdb
  *
  * @package PhpMyAdmin-test
  */
-class BdbTest extends PHPUnit_Framework_TestCase
+class BdbTest extends PMATestCase
 {
     /**
      * @access protected
@@ -36,7 +36,6 @@ class BdbTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['server'] = 0;
         $this->object = new Bdb('bdb');
     }

--- a/test/classes/engines/BinlogTest.php
+++ b/test/classes/engines/BinlogTest.php
@@ -12,14 +12,14 @@
 use PMA\libraries\engines\Binlog;
 
 require_once 'libraries/database_interface.inc.php';
-
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\engines\Binlog
  *
  * @package PhpMyAdmin-test
  */
-class BinlogTest extends PHPUnit_Framework_TestCase
+class BinlogTest extends PMATestCase
 {
     /**
      * @access protected
@@ -35,7 +35,6 @@ class BinlogTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['server'] = 0;
         $this->object = new Binlog('binlog');
     }

--- a/test/classes/engines/InnodbTest.php
+++ b/test/classes/engines/InnodbTest.php
@@ -13,13 +13,14 @@ use PMA\libraries\engines\Innodb;
 
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/database_interface.inc.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\engines\Innodb
  *
  * @package PhpMyAdmin-test
  */
-class InnodbTest extends PHPUnit_Framework_TestCase
+class InnodbTest extends PMATestCase
 {
     /**
      * @access protected
@@ -35,7 +36,6 @@ class InnodbTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['server'] = 0;
         $this->object = new Innodb('innodb');
     }

--- a/test/classes/engines/MemoryTest.php
+++ b/test/classes/engines/MemoryTest.php
@@ -13,14 +13,14 @@ use PMA\libraries\engines\Memory;
 
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/database_interface.inc.php';
-
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\engines\Memory
  *
  * @package PhpMyAdmin-test
  */
-class MemoryTest extends PHPUnit_Framework_TestCase
+class MemoryTest extends PMATestCase
 {
     /**
      * @access protected
@@ -36,7 +36,6 @@ class MemoryTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['server'] = 0;
         $this->object = new Memory('memory');
     }

--- a/test/classes/engines/Mrg_MyisamTest.php
+++ b/test/classes/engines/Mrg_MyisamTest.php
@@ -12,13 +12,14 @@
 use PMA\libraries\engines\Mrg_Myisam;
 
 require_once 'libraries/database_interface.inc.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\engines\Mrg_Myisam
  *
  * @package PhpMyAdmin-test
  */
-class Mrg_MyisamTest extends PHPUnit_Framework_TestCase
+class Mrg_MyisamTest extends PMATestCase
 {
     /**
      * @access protected
@@ -34,7 +35,6 @@ class Mrg_MyisamTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['server'] = 0;
         $this->object = new Mrg_Myisam('mrg_myisam');
     }

--- a/test/classes/engines/MyisamTest.php
+++ b/test/classes/engines/MyisamTest.php
@@ -13,13 +13,14 @@ use PMA\libraries\engines\Myisam;
 
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/database_interface.inc.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\engines\Myisam
  *
  * @package PhpMyAdmin-test
  */
-class MyisamTest extends PHPUnit_Framework_TestCase
+class MyisamTest extends PMATestCase
 {
     /**
      * @access protected
@@ -35,7 +36,6 @@ class MyisamTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['server'] = 0;
         $this->object = new Myisam('myisam');
     }

--- a/test/classes/engines/NdbclusterTest.php
+++ b/test/classes/engines/NdbclusterTest.php
@@ -13,13 +13,14 @@ use PMA\libraries\engines\Ndbcluster;
 
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/database_interface.inc.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\engines\Ndbcluster
  *
  * @package PhpMyAdmin-test
  */
-class NdbclusterTest extends PHPUnit_Framework_TestCase
+class NdbclusterTest extends PMATestCase
 {
     /**
      * @access protected
@@ -35,7 +36,6 @@ class NdbclusterTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['server'] = 0;
         $this->object = new Ndbcluster('nbdcluster');
     }

--- a/test/classes/engines/PbxtTest.php
+++ b/test/classes/engines/PbxtTest.php
@@ -15,13 +15,14 @@ use PMA\libraries\engines\Pbxt;
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/core.lib.php';
 require_once 'libraries/database_interface.inc.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\engines\Pbxt;
  *
  * @package PhpMyAdmin-test
  */
-class PbxtTest extends PHPUnit_Framework_TestCase
+class PbxtTest extends PMATestCase
 {
     /**
      * @access protected
@@ -37,7 +38,6 @@ class PbxtTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['server'] = 0;
         $this->object = new Pbxt('pbxt');
     }

--- a/test/classes/navigation/NavigationTest.php
+++ b/test/classes/navigation/NavigationTest.php
@@ -12,13 +12,14 @@ require_once 'libraries/database_interface.inc.php';
 require_once 'libraries/relation.lib.php';
 require_once 'libraries/url_generating.lib.php';
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\Navigation class
  *
  * @package PhpMyAdmin-test
  */
-class NavigationTest extends PHPUnit_Framework_TestCase
+class NavigationTest extends PMATestCase
 {
     /**
      * @var PMA\libraries\navigation\Navigation

--- a/test/classes/navigation/NavigationTreeTest.php
+++ b/test/classes/navigation/NavigationTreeTest.php
@@ -21,13 +21,14 @@ require_once 'libraries/relation.lib.php';
 require_once 'libraries/url_generating.lib.php';
 require_once 'libraries/php-gettext/gettext.inc';
 require_once 'libraries/check_user_privileges.lib.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\NavigationTree class
  *
  * @package PhpMyAdmin-test
  */
-class NavigationTreeTest extends PHPUnit_Framework_TestCase
+class NavigationTreeTest extends PMATestCase
 {
     /**
      * @var NavigationTree

--- a/test/classes/navigation/NodeColumnContainerTest.php
+++ b/test/classes/navigation/NodeColumnContainerTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeColumnContainer class
  *
  * @package PhpMyAdmin-test
  */
-class NodeColumnContainerTest extends PHPUnit_Framework_TestCase
+class NodeColumnContainerTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeColumnTest.php
+++ b/test/classes/navigation/NodeColumnTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeColumn class
  *
  * @package PhpMyAdmin-test
  */
-class NodeColumnTest extends PHPUnit_Framework_TestCase
+class NodeColumnTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeDatabaseChildTest.php
+++ b/test/classes/navigation/NodeDatabaseChildTest.php
@@ -13,13 +13,14 @@ use PMA\libraries\Theme;
 require_once 'libraries/url_generating.lib.php';
 require_once 'libraries/relation.lib.php';
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeDatabaseChild class
  *
  * @package PhpMyAdmin-test
  */
-class NodeDatabaseChildTest extends PHPUnit_Framework_TestCase
+class NodeDatabaseChildTest extends PMATestCase
 {
     /**
      * @var NodeDatabaseChild

--- a/test/classes/navigation/NodeDatabaseTest.php
+++ b/test/classes/navigation/NodeDatabaseTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeDatabase class
  *
  * @package PhpMyAdmin-test
  */
-class NodeDatabaseTest extends PHPUnit_Framework_TestCase
+class NodeDatabaseTest extends PMATestCase
 {
     /**
      * SetUp for test cases
@@ -33,8 +32,6 @@ class NodeDatabaseTest extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['MaxNavigationItems'] = 250;
         $GLOBALS['cfg']['Server'] = array();
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
-        $GLOBALS['cfg']['DBG'] = array();
-        $GLOBALS['cfg']['DBG']['sql'] = false;
         $_SESSION['PMA_Theme'] = Theme::load('./themes/pmahomme');
     }
 

--- a/test/classes/navigation/NodeEventContainerTest.php
+++ b/test/classes/navigation/NodeEventContainerTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeEventContainer class
  *
  * @package PhpMyAdmin-test
  */
-class NodeEventContainerTest extends PHPUnit_Framework_TestCase
+class NodeEventContainerTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeEventTest.php
+++ b/test/classes/navigation/NodeEventTest.php
@@ -10,15 +10,14 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeEvent class
  *
  * @package PhpMyAdmin-test
  */
-class NodeEventTest extends PHPUnit_Framework_TestCase
+class NodeEventTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeFactoryTest.php
+++ b/test/classes/navigation/NodeFactoryTest.php
@@ -11,16 +11,15 @@ use PMA\libraries\navigation\nodes\Node;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for NodeFactory class
  *
  * @package PhpMyAdmin-test
  */
-class NodeFactoryTest extends PHPUnit_Framework_TestCase
+class NodeFactoryTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeFunctionContainerTest.php
+++ b/test/classes/navigation/NodeFunctionContainerTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeFunctionContainer class
  *
  * @package PhpMyAdmin-test
  */
-class NodeFunctionContainerTest extends PHPUnit_Framework_TestCase
+class NodeFunctionContainerTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeFunctionTest.php
+++ b/test/classes/navigation/NodeFunctionTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeFunction class
  *
  * @package PhpMyAdmin-test
  */
-class NodeFunctionTest extends PHPUnit_Framework_TestCase
+class NodeFunctionTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeIndexContainerTest.php
+++ b/test/classes/navigation/NodeIndexContainerTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeIndexContainer class
  *
  * @package PhpMyAdmin-test
  */
-class NodeIndexContainerTest extends PHPUnit_Framework_TestCase
+class NodeIndexContainerTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeIndexTest.php
+++ b/test/classes/navigation/NodeIndexTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeIndex class
  *
  * @package PhpMyAdmin-test
  */
-class NodeIndexTest extends PHPUnit_Framework_TestCase
+class NodeIndexTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeProcedureContainerTest.php
+++ b/test/classes/navigation/NodeProcedureContainerTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeProcedureContainer class
  *
  * @package PhpMyAdmin-test
  */
-class NodeProcedureContainerTest extends PHPUnit_Framework_TestCase
+class NodeProcedureContainerTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeProcedureTest.php
+++ b/test/classes/navigation/NodeProcedureTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeProcedure class
  *
  * @package PhpMyAdmin-test
  */
-class NodeProcedureTest extends PHPUnit_Framework_TestCase
+class NodeProcedureTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeTableContainerTest.php
+++ b/test/classes/navigation/NodeTableContainerTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeTableContainer class
  *
  * @package PhpMyAdmin-test
  */
-class NodeTableContainerTest extends PHPUnit_Framework_TestCase
+class NodeTableContainerTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeTableTest.php
+++ b/test/classes/navigation/NodeTableTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeTable class
  *
  * @package PhpMyAdmin-test
  */
-class NodeTableTest extends PHPUnit_Framework_TestCase
+class NodeTableTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeTest.php
+++ b/test/classes/navigation/NodeTest.php
@@ -11,16 +11,15 @@ use PMA\libraries\navigation\nodes\Node;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/database_interface.inc.php';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for Node class
  *
  * @package PhpMyAdmin-test
  */
-class NodeTest extends PHPUnit_Framework_TestCase
+class NodeTest extends PMATestCase
 {
     /**
      * SetUp for test cases
@@ -300,9 +299,6 @@ class NodeTest extends PHPUnit_Framework_TestCase
             $method->invoke($node, 'SCHEMA_NAME', 'schemaName')
         );
 
-        if (! isset($GLOBALS['cfg'])) {
-            $GLOBALS['cfg'] = array();
-        }
         if (! isset($GLOBALS['cfg']['Server'])) {
             $GLOBALS['cfg']['Server'] = array();
         }
@@ -344,9 +340,6 @@ class NodeTest extends PHPUnit_Framework_TestCase
     {
         $pos = 10;
         $limit = 20;
-        if (! isset($GLOBALS['cfg'])) {
-            $GLOBALS['cfg'] = array();
-        }
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['NavigationTreeEnableGrouping'] = true;
         $GLOBALS['cfg']['FirstLevelNavigationItems'] = $limit;
@@ -395,9 +388,6 @@ class NodeTest extends PHPUnit_Framework_TestCase
     {
         $pos = 10;
         $limit = 20;
-        if (! isset($GLOBALS['cfg'])) {
-            $GLOBALS['cfg'] = array();
-        }
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['cfg']['NavigationTreeEnableGrouping'] = false;
         $GLOBALS['cfg']['FirstLevelNavigationItems'] = $limit;
@@ -433,9 +423,6 @@ class NodeTest extends PHPUnit_Framework_TestCase
     {
         $pos = 0;
         $limit = 10;
-        if (! isset($GLOBALS['cfg'])) {
-            $GLOBALS['cfg'] = array();
-        }
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['dbs_to_test'] = false;
         $GLOBALS['cfg']['NavigationTreeEnableGrouping'] = true;

--- a/test/classes/navigation/NodeTriggerContainerTest.php
+++ b/test/classes/navigation/NodeTriggerContainerTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeTrigger class
  *
  * @package PhpMyAdmin-test
  */
-class NodeTriggerContainerTest extends PHPUnit_Framework_TestCase
+class NodeTriggerContainerTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeTriggerTest.php
+++ b/test/classes/navigation/NodeTriggerTest.php
@@ -10,15 +10,14 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeTrigger class
  *
  * @package PhpMyAdmin-test
  */
-class NodeTriggerTest extends PHPUnit_Framework_TestCase
+class NodeTriggerTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeViewContainerTest.php
+++ b/test/classes/navigation/NodeViewContainerTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeViewContainer class
  *
  * @package PhpMyAdmin-test
  */
-class NodeViewContainerTest extends PHPUnit_Framework_TestCase
+class NodeViewContainerTest extends PMATestCase
 {
     /**
      * SetUp for test cases

--- a/test/classes/navigation/NodeViewTest.php
+++ b/test/classes/navigation/NodeViewTest.php
@@ -10,16 +10,15 @@ use PMA\libraries\navigation\NodeFactory;
 use PMA\libraries\Theme;
 
 require_once 'libraries/navigation/NodeFactory.php';
-
-
 require_once 'libraries/php-gettext/gettext.inc';
+require_once 'test/PMATestCase.php';
 
 /**
  * Tests for PMA\libraries\navigation\nodes\NodeView class
  *
  * @package PhpMyAdmin-test
  */
-class NodeViewTest extends PHPUnit_Framework_TestCase
+class NodeViewTest extends PMATestCase
 {
     /**
      * SetUp for test cases


### PR DESCRIPTION
Currently, our test cases are dependent on each other and change of GLOBALS in one can break the other. Here I have introduced a new parent class, `PMATestCase`, and reinitialized configuration to their default for each test case. Now, each test case can set their required values for configurations.

I did not want to break all the test cases at once, so I am slowly moving test cases to be a child class of `PMATestCase`. And, it might make sense to reset other GLOBALS set in tests as well.
