### PR TITLE
Fix #11757

### DIFF
--- a/libraries/mysql_charsets.lib.php
+++ b/libraries/mysql_charsets.lib.php
@@ -92,7 +92,7 @@ function PMA_generateCharsetQueryPart($collation)
 {
     if (!PMA_DRIZZLE) {
         list($charset) = explode('_', $collation);
-        return ' CHARACTER SET ' . $charset
+        return ' CHARSET=' . $charset
             . ($charset == $collation ? '' : ' COLLATE ' . $collation);
     } else {
         return ' COLLATE ' . $collation;

--- a/test/classes/PMA_Table_test.php
+++ b/test/classes/PMA_Table_test.php
@@ -713,8 +713,8 @@ class PMA_Table_Test extends PHPUnit_Framework_TestCase
                 . "COLLATE charset1 NULL DEFAULT 'VARCHAR' "
                 . "AUTO_INCREMENT COMMENT 'PMA comment' AFTER `new_name`";
         } else {
-            $expect = "`name` `new_name` VARCHAR(2) new_name CHARACTER "
-                . "SET charset1 NULL DEFAULT 'VARCHAR' "
+            $expect = "`name` `new_name` VARCHAR(2) new_name CHARSET="
+                . "charset1 NULL DEFAULT 'VARCHAR' "
                 . "AUTO_INCREMENT COMMENT 'PMA comment' AFTER `new_name`";
         }
 

--- a/test/libraries/PMA_mysql_charsets_test.php
+++ b/test/libraries/PMA_mysql_charsets_test.php
@@ -69,9 +69,9 @@ class PMA_MySQL_Charsets_Test extends PHPUnit_Framework_TestCase
     public function charsetQueryData()
     {
         return array(
-            array(false, "a_b_c_d", " CHARACTER SET a COLLATE a_b_c_d"),
-            array(false, "a_", " CHARACTER SET a COLLATE a_"),
-            array(false, "a", " CHARACTER SET a"),
+            array(false, "a_b_c_d", " CHARSET=a COLLATE a_b_c_d"),
+            array(false, "a_", " CHARSET=a COLLATE a_"),
+            array(false, "a", " CHARSET=a"),
             array(true, "a_b_c_d", " COLLATE a_b_c_d")
         );
     }


### PR DESCRIPTION
Export and preview show different SQL for character set. 

Changed the preview query to have `CHARSET` instead of `CHARACTER SET` so as to match the export query as well as the `SHOW CREATE ...` generated query.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
