### PR TITLE
Fix #11724 : live data edit of big sets is not working

### DIFF
--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -795,7 +795,7 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                     }
 
                     // if the select/editor is changed un-check the 'checkbox_null_<field_name>_<row_index>'.
-                    if ($td.is('.enum, .set:not(.truncated)')) {
+                    if ($td.is('.enum, .set')) {
                         $editArea.on('change', 'select', function (e) {
                             $checkbox.prop('checked', false);
                         });
@@ -925,7 +925,7 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                         $(g.cEdit).find('.edit_box').val($(this).val());
                     });
                 }
-                else if ($td.is('.set:not(.truncated)')) {
+                else if ($td.is('.set')) {
                     //handle set fields
                     $editArea.addClass('edit_area_loading');
 
@@ -942,6 +942,12 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                         'token' : g.token,
                         'curr_value' : curr_value
                     };
+
+                    // if the data is truncated, get the full data
+                    if ($td.is('.truncated')) {
+                        post_params.get_full_values = true;
+                        post_params.where_clause = PMA_urldecode(where_clause);
+                    }
 
                     g.lastXHR = $.post('sql.php', post_params, function (data) {
                         g.lastXHR = null;
@@ -1411,7 +1417,7 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
             } else {
                 if ($this_field.is('.bit')) {
                     this_field_params[field_name] = $(g.cEdit).find('.edit_box').val();
-                } else if ($this_field.is('.set:not(.truncated)')) {
+                } else if ($this_field.is('.set')) {
                     $test_element = $(g.cEdit).find('select');
                     this_field_params[field_name] = $test_element.map(function () {
                         return $(this).val();

--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -397,6 +397,24 @@ function PMA_getHtmlForEnumColumnDropdown($db, $table, $column, $curr_value)
 }
 
 /**
+ * Get value of a column for a specific row (marked by $where_clause)
+ *
+ * @param string $db           current database
+ * @param string $table        current table
+ * @param string $column       current column
+ * @param string $where_clause where clause to select a particular row
+ *
+ */
+function PMA_getFullValuesForSetColumn($db, $table, $column, $where_clause)
+{
+    $result = $GLOBALS['dbi']->fetchSingleRow(
+        "SELECT `$column` FROM `$db`.`$table` WHERE $where_clause"
+    );
+
+    return $result[$column];
+}
+
+/**
  * Get the HTML for the set column dropdown
  * During grid edit, if we have a set field, returns the html for the
  * dropdown
@@ -412,6 +430,18 @@ function PMA_getHtmlForSetColumn($db, $table, $column, $curr_value)
 {
     $values = PMA_getValuesForColumn($db, $table, $column);
     $dropdown = '';
+    $full_values =
+        isset($_REQUEST['get_full_values']) ? $_REQUEST['get_full_values'] : false;
+    $where_clause =
+        isset($_REQUEST['where_clause']) ? $_REQUEST['where_clause'] : null;
+
+    // If the $curr_value was truncated, we should
+    // fetch the correct full values from the table
+    if ($full_values && ! empty($where_clause)) {
+        $curr_value = PMA_getFullValuesForSetColumn(
+            $db, $table, $column, $where_clause
+        );
+    }
 
     //converts characters of $curr_value to HTML entities
     $converted_curr_value = htmlentities(
@@ -419,6 +449,7 @@ function PMA_getHtmlForSetColumn($db, $table, $column, $curr_value)
     );
 
     $selected_values = explode(',', $converted_curr_value);
+
     $dropdown .= PMA_getHtmlForOptionsList($values, $selected_values);
 
     $select_size = (sizeof($values) > 10) ? 10 : sizeof($values);
@@ -818,7 +849,9 @@ function PMA_getEnumOrSetValues($db, $table, $columnType)
         );
         $response->addJSON('dropdown', $dropdown);
     } else {
-        $select = PMA_getHtmlForSetColumn($db, $table, $column, $curr_value);
+        $select = PMA_getHtmlForSetColumn(
+            $db, $table, $column, $curr_value
+        );
         $response->addJSON('select', $select);
     }
     exit;


### PR DESCRIPTION
If the data was truncated, we make a query and get the full values of data from the table to avoid the problem mentioned in the issue #11724 .

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
