### PR TITLE
Fix #11777: While 'changing a column', query fails with a syntax error after the 'CHARSET=' keyword

### DIFF
--- a/libraries/Table.class.php
+++ b/libraries/Table.class.php
@@ -410,7 +410,7 @@ class PMA_Table
                 $type
             );
             if (! empty($collation) && $collation != 'NULL' && $matches) {
-                $query .= PMA_generateCharsetQueryPart($collation);
+                $query .= PMA_generateCharsetQueryPart($collation, true);
             }
 
             if ($null !== false) {

--- a/libraries/mysql_charsets.lib.php
+++ b/libraries/mysql_charsets.lib.php
@@ -84,15 +84,21 @@ function PMA_generateCharsetDropdownBox($type = PMA_CSDROPDOWN_COLLATION,
 /**
  * Generate the charset query part
  *
- * @param string $collation Collation
+ * @param string           $collation Collation
+ * @param boolean optional $override  force 'CHARACTER SET' keyword
  *
  * @return string
  */
-function PMA_generateCharsetQueryPart($collation)
+function PMA_generateCharsetQueryPart($collation, $override = false)
 {
     if (!PMA_DRIZZLE) {
         list($charset) = explode('_', $collation);
-        return ' CHARSET=' . $charset
+        $keyword = ' CHARSET=';
+
+        if ($override) {
+            $keyword = ' CHARACTER SET ';
+        }
+        return $keyword . $charset
             . ($charset == $collation ? '' : ' COLLATE ' . $collation);
     } else {
         return ' COLLATE ' . $collation;

--- a/test/classes/PMA_Table_test.php
+++ b/test/classes/PMA_Table_test.php
@@ -713,7 +713,7 @@ class PMA_Table_Test extends PHPUnit_Framework_TestCase
                 . "COLLATE charset1 NULL DEFAULT 'VARCHAR' "
                 . "AUTO_INCREMENT COMMENT 'PMA comment' AFTER `new_name`";
         } else {
-            $expect = "`name` `new_name` VARCHAR(2) new_name CHARSET="
+            $expect = "`name` `new_name` VARCHAR(2) new_name CHARACTER SET "
                 . "charset1 NULL DEFAULT 'VARCHAR' "
                 . "AUTO_INCREMENT COMMENT 'PMA comment' AFTER `new_name`";
         }


### PR DESCRIPTION
Fix error in commit : a4f02ca

See the error description in this comment : https://github.com/phpmyadmin/phpmyadmin/issues/11777#issuecomment-167289216

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
