### PR TITLE
Bug fix for #11746

### DIFF
--- a/templates/table/structure/display_table_stats.phtml
+++ b/templates/table/structure/display_table_stats.phtml
@@ -2,7 +2,9 @@
     <?php $odd_row = false; ?>
     <fieldset>
         <legend><?php echo __('Information'); ?></legend>
-        <p> <strong> <?php echo __('Table comments: ') ?> </strong> <?php echo $showtable['TABLE_COMMENT']; ?></p>
+        <p> <strong> <?php echo __('Table comments: ') ?> </strong>
+            <?php echo isset($showtable['TABLE_COMMENT']) ? $showtable['TABLE_COMMENT'] : '';?>
+        </p>
         <a id="showusage"></a>
 
         <?php if (! $tbl_is_view && ! $db_is_system_schema): ?>


### PR DESCRIPTION
Some times, the key 'TABLE_COMMENT' is not present instead of just being empty string. This fix is for handling such cases.

Signed-off-by: Raghuram Vadapalli raghuram.vadapalli@research.iiit.ac.in
