### PR TITLE
Fix handling of databases with dot in a name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ phpMyAdmin - ChangeLog
 - issue        Undefined index: host
 - issue #11810 'Add to central columns' (per column button) does nothing
 - issue #11727 SQL duplicate entry error trying to INSERT in designer_settings table
+- issue #11798 Fix handling of databases with dot in a name
 
 4.5.3.1 (2015-12-25)
 - issue #11774 Undefined offset 2

--- a/libraries/DatabaseInterface.class.php
+++ b/libraries/DatabaseInterface.class.php
@@ -99,8 +99,8 @@ class PMA_DatabaseInterface
     /**
      * Get a cached value from table cache.
      *
-     * @param string $contentPath Dot notation of the target value
-     * @param mixed  $default     Return value on cache miss
+     * @param array $contentPath Array of the name of the target value
+     * @param mixed $default     Return value on cache miss
      *
      * @return mixed cached value or default
      */
@@ -112,8 +112,8 @@ class PMA_DatabaseInterface
     /**
      * Set an item in table cache using dot notation.
      *
-     * @param string $contentPath Dot notation of the target path
-     * @param mixed  $value       Target value
+     * @param array $contentPath Array with the target path
+     * @param mixed $value       Target value
      *
      * @return void
      */
@@ -126,10 +126,8 @@ class PMA_DatabaseInterface
             return;
         }
 
-        $keys = explode('.', $contentPath);
-
-        while (count($keys) > 1) {
-            $key = array_shift($keys);
+        while (count($contentPath) > 1) {
+            $key = array_shift($contentPath);
 
             // If the key doesn't exist at this depth, we will just create an empty array
             // to hold the next value, allowing us to create the arrays to hold final
@@ -140,7 +138,7 @@ class PMA_DatabaseInterface
             $loc = &$loc[$key];
         }
 
-        $loc[array_shift($keys)] = $value;
+        $loc[array_shift($contentPath)] = $value;
     }
 
     /**

--- a/libraries/Table.class.php
+++ b/libraries/Table.class.php
@@ -169,7 +169,7 @@ class PMA_Table
         }
 
         // use cached data or load information with SHOW command
-        if ($this->_dbi->getCachedTableContent("${db}.${table}") != null
+        if ($this->_dbi->getCachedTableContent(array($db, $table)) != null
             || $GLOBALS['cfg']['Server']['DisableIS']
         ) {
             $type = $this->getStatusInfo('TABLE_TYPE');
@@ -314,14 +314,14 @@ class PMA_Table
 
         // sometimes there is only one entry (ExactRows) so
         // we have to get the table's details
-        if ($this->_dbi->getCachedTableContent("${db}.${table}") == null
+        if ($this->_dbi->getCachedTableContent(array($db, $table)) == null
             || $force_read
-            || count($this->_dbi->getCachedTableContent("${db}.${table}")) == 1
+            || count($this->_dbi->getCachedTableContent(array($db, $table))) == 1
         ) {
             $this->_dbi->getTablesFull($db, $table);
         }
 
-        if ($this->_dbi->getCachedTableContent("${db}.${table}") == null) {
+        if ($this->_dbi->getCachedTableContent(array($db, $table)) == null) {
             // happens when we enter the table creation dialog
             // or when we really did not get any status info, for example
             // when $table == 'TABLE_NAMES' after the user tried SHOW TABLES
@@ -329,12 +329,12 @@ class PMA_Table
         }
 
         if (null === $info) {
-            return $this->_dbi->getCachedTableContent("${db}.${table}");
+            return $this->_dbi->getCachedTableContent(array($db, $table));
         }
 
         // array_key_exists allows for null values
         if (!array_key_exists(
-            $info, $this->_dbi->getCachedTableContent("${db}.${table}")
+            $info, $this->_dbi->getCachedTableContent(array($db, $table))
         )
         ) {
             if (! $disable_error) {
@@ -346,7 +346,7 @@ class PMA_Table
             return false;
         }
 
-        return $this->_dbi->getCachedTableContent("${db}.${table}.${info}");
+        return $this->_dbi->getCachedTableContent(array($db, $table, $info));
     }
 
     /**
@@ -495,29 +495,29 @@ class PMA_Table
         $db = $this->_db_name;
         $table = $this->_name;
 
-        if ($this->_dbi->getCachedTableContent("${db}.${table}.ExactRows") != null) {
+        if ($this->_dbi->getCachedTableContent(array($db, $table, 'ExactRows')) != null) {
             $row_count = $this->_dbi->getCachedTableContent(
-                "${db}.${table}.ExactRows"
+                array($db, $table, 'ExactRows')
             );
             return $row_count;
         }
         $row_count = false;
 
         if (! $force_exact) {
-            if (($this->_dbi->getCachedTableContent("${db}.${table}.Rows") == null)
+            if (($this->_dbi->getCachedTableContent(array($db, $table, 'Rows')) == null)
                 && !$is_view
             ) {
                 $tmp_tables = $this->_dbi->getTablesFull($db, $table);
                 if (isset($tmp_tables[$table])) {
                     $this->_dbi->cacheTableContent(
-                        "${db}.${table}",
+                        array($db, $table),
                         $tmp_tables[$table]
                     );
                 }
             }
-            if ($this->_dbi->getCachedTableContent("${db}.${table}.Rows") != null) {
+            if ($this->_dbi->getCachedTableContent(array($db, $table, 'Rows')) != null) {
                 $row_count = $this->_dbi->getCachedTableContent(
-                    "${db}.${table}.Rows"
+                    array($db, $table, 'Rows')
                 );
             } else {
                 $row_count = false;
@@ -567,7 +567,7 @@ class PMA_Table
             }
         }
         if ($row_count) {
-            $this->_dbi->cacheTableContent("${db}.${table}.ExactRows", $row_count);
+            $this->_dbi->cacheTableContent(array($db, $table, 'ExactRows'), $row_count);
         }
 
         return $row_count;

--- a/libraries/db_table_exists.lib.php
+++ b/libraries/db_table_exists.lib.php
@@ -57,7 +57,7 @@ if (empty($is_table)
     // Not a valid table name -> back to the db_sql.php
 
     if (/*overload*/mb_strlen($table)) {
-        $is_table = $GLOBALS['dbi']->getCachedTableContent("${db}.${table}", false);
+        $is_table = $GLOBALS['dbi']->getCachedTableContent(array($db, $table), false);
 
         if (! $is_table) {
             $_result = $GLOBALS['dbi']->tryQuery(

--- a/test/classes/PMA_Table_test.php
+++ b/test/classes/PMA_Table_test.php
@@ -620,8 +620,8 @@ class PMA_Table_Test extends PHPUnit_Framework_TestCase
     public function testIsMergeCase2()
     {
         $map = array(
-            array('PMA.PMA_BookMark', null, array('ENGINE' => "MERGE")),
-            array('PMA.PMA_BookMark.ENGINE', null, "MERGE")
+            array(array('PMA', 'PMA_BookMark'), null, array('ENGINE' => "MERGE")),
+            array(array('PMA', 'PMA_BookMark', 'ENGINE'), null, "MERGE")
         );
         $GLOBALS['dbi']->expects($this->any())
             ->method('getCachedTableContent')
@@ -642,8 +642,8 @@ class PMA_Table_Test extends PHPUnit_Framework_TestCase
     public function testIsMergeCase3()
     {
         $map = array(
-            array('PMA.PMA_BookMark', null, array('ENGINE' => "MRG_MYISAM")),
-            array('PMA.PMA_BookMark.ENGINE', null, "MRG_MYISAM")
+            array(array('PMA', 'PMA_BookMark'), null, array('ENGINE' => "MRG_MYISAM")),
+            array(array('PMA', 'PMA_BookMark', 'ENGINE'), null, "MRG_MYISAM")
         );
         $GLOBALS['dbi']->expects($this->any())
             ->method('getCachedTableContent')
@@ -664,8 +664,8 @@ class PMA_Table_Test extends PHPUnit_Framework_TestCase
     public function testIsMergeCase4()
     {
         $map = array(
-            array('PMA.PMA_BookMark', null, array('ENGINE' => "ISDB")),
-            array('PMA.PMA_BookMark.ENGINE', null, "ISDB")
+            array(array('PMA', 'PMA_BookMark'), null, array('ENGINE' => "ISDB")),
+            array(array('PMA', 'PMA_BookMark', 'ENGINE'), null, "ISDB")
         );
         $GLOBALS['dbi']->expects($this->any())
             ->method('getCachedTableContent')
@@ -988,11 +988,11 @@ class PMA_Table_Test extends PHPUnit_Framework_TestCase
     {
         $map = array(
             array(
-                'PMA.PMA_BookMark',
+                array('PMA', 'PMA_BookMark'),
                 null,
                 array('Comment' => "Comment222", 'TABLE_TYPE' => "VIEW"),
             ),
-            array('PMA.PMA_BookMark.TABLE_TYPE', null, 'VIEW'),
+            array(array('PMA', 'PMA_BookMark', 'TABLE_TYPE'), null, 'VIEW'),
         );
         $GLOBALS['dbi']->expects($this->any())
             ->method('getCachedTableContent')

--- a/test/libraries/PMA_display_export_test.php
+++ b/test/libraries/PMA_display_export_test.php
@@ -139,7 +139,7 @@ class PMA_DisplayExport_Test extends PHPUnit_Framework_TestCase
         $num_tables_str = "10";
         $unlim_num_rows_str = "unlim_num_rows_str";
         $single_table = "single_table";
-        $GLOBALS['dbi']->cacheTableContent("${db}.${table}.ENGINE", 'MERGE');
+        $GLOBALS['dbi']->cacheTableContent(array($db, $table, 'ENGINE'), 'MERGE');
 
         $columns_info = array(
             'test_column1' => array(


### PR DESCRIPTION
We do not need to concatenate and parse the items, the cache backend
accepts array directly.

Fixes #11798

Signed-off-by: Michal Čihař michal@cihar.com
