### PR TITLE
SSL validation flag

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -289,6 +289,20 @@ Server connection settings
     :default: NULL
 
     List of allowable ciphers for SSL connections to the MySQL server.
+    
+.. config:option:: $cfg['Servers'][$i]['ssl_verify']
+
+    :type: boolean
+    :default: true
+
+    If your PHP install uses the MySQL Native Driver (mysqlnd), your
+    MySQL server is 5.6 or later, and your SSL certificate is self-signed, 
+    there is a chance your SSL connection will fail due to validation.
+    Setting this to ``false`` will disable the validation check.
+    
+    .. note::
+    
+        This flag only works with PHP 5.6.16 or later
 
 .. config:option:: $cfg['Servers'][$i]['connect_type']
 

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -181,6 +181,17 @@ $cfg['Servers'][$i]['ssl_ca_path'] = null;
 $cfg['Servers'][$i]['ssl_ciphers'] = null;
 
 /**
+ * MySQL 5.6 or later triggers the mysqlnd driver in PHP to validate the
+ * peer_name of the SSL certifcate
+ * For most self-signed certificates this is a problem. Setting this to false 
+ * will disable the check and allow the connection (PHP 5.6.16 or later)
+ *
+ * @link http://bugs.php.net/68344
+ * @global string $cfg['Servers'][$i]['ssl_verify']
+ */
+$cfg['Servers'][$i]['ssl_verify'] = true;
+
+/**
  * How to connect to MySQL server ('tcp' or 'socket')
  *
  * @global string $cfg['Servers'][$i]['connect_type']

--- a/libraries/dbi/DBIMysqli.php
+++ b/libraries/dbi/DBIMysqli.php
@@ -158,7 +158,16 @@ class DBIMysqli implements DBIExtension
                 $cfg['Server']['ssl_ca_path'],
                 $cfg['Server']['ssl_ciphers']
             );
-            $client_flags |= MYSQLI_CLIENT_SSL;
+            $ssl_flag = MYSQLI_CLIENT_SSL;
+            /*
+             * disables SSL certificate validation on mysqlnd for MySQL 5.6 or later
+             * @link https://bugs.php.net/bug.php?id=68344
+             * @link https://github.com/phpmyadmin/phpmyadmin/pull/11838
+             */
+            if(!$cfg['Server']['ssl_verify'] && defined('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT')) {
+                $ssl_flag = MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
+            }
+            $client_flags |= $ssl_flag;
         }
 
         if (! $server) {


### PR DESCRIPTION
I installed the latest PMA and had to make it work with a remote server running 5.7. The connection had to be encrypted and it conveniently came with its own self-signed certificates so I used them in my PMA setup and I couldn't get it to work. It always returned a 2002 error. I could connect over CLI and Workbench so I dug into it. After some searching I ran across [this PHP bug](https://bugs.php.net/bug.php?id=68344) which described the problem as being due to the following combination
- MySQL 5.6 or later
- PHP using mysqlnd
- A self-signed certificate (with the name not matching the server name)

PHP 5.6.16 introduced a fix as a result of that bug report. They added an additional flag (still not documented yet) that disables the mysqlnd validation. By replacing **MYSQLI_CLIENT_SSL** with **MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT** in my local PMA install I got PMA to finally work over SSL.

This patch adds a new configuration `$cfg['Servers'][$i]['ssl_verify']` which, when set to `false`, will tell PMA to use this new flag (if present).

Signed-off-by: Joel Hutchinson joel.hutchinson@onlinecommercegroup.com
