### PR TITLE
Add support for Ctrl + C

### DIFF
--- a/js/db_structure.js
+++ b/js/db_structure.js
@@ -182,6 +182,27 @@ function PMA_fetchRealRowCount($target)
     });
 }
 
+/* Support Ctrl + C event for copying multiple tables */
+$(document).ready(function() {
+    var ctrlDown = false;
+    var ctrlKey = 17, cKey = 67;
+
+    $(document).keydown(function(e) {
+
+        if (e.keyCode == ctrlKey) {
+            ctrlDown = true;
+        }
+        if(ctrlDown==true&&e.keyCode==cKey) {
+            $('select[name=submit_mult]').val('copy_tbl');
+            $('select[name=submit_mult]').trigger('change');
+        }
+    }).keyup(function(e) {
+        if (e.keyCode == ctrlKey) {
+            ctrlDown = false;
+        }
+    });
+});
+
 AJAX.registerOnload('db_structure.js', function () {
 /**
  * function to open the confirmation dialog for making table consistent with central list


### PR DESCRIPTION
Go to database structure of any database, select some tables and press `ctrl + c`. If you like this functionality, we can implement this wherever possible to enhance usability. Shortcuts do increase speed of work.

Signed-off-by: Raghuram Vadapalli raghuram.vadapalli@research.iiit.ac.in
