### PR TITLE
Remove direct support for openssl in cookie auth [WIP]

### DIFF
--- a/libraries/plugins/auth/AuthenticationCookie.php
+++ b/libraries/plugins/auth/AuthenticationCookie.php
@@ -689,27 +689,9 @@ class AuthenticationCookie extends AuthenticationPlugin
     private function _getSessionEncryptionSecret()
     {
         if (empty($_SESSION['encryption_key'])) {
-            if (self::useOpenSSL()) {
-                $_SESSION['encryption_key'] = openssl_random_pseudo_bytes(256);
-            } else {
-                $_SESSION['encryption_key'] = Crypt\Random::string(256);
-            }
+            $_SESSION['encryption_key'] = Crypt\Random::string(256);
         }
         return $_SESSION['encryption_key'];
-    }
-
-    /**
-     * Checks whether we should use openssl for encryption.
-     *
-     * @return boolean
-     */
-    public static function useOpenSSL()
-    {
-        return (
-            function_exists('openssl_encrypt')
-            && function_exists('openssl_decrypt')
-            && function_exists('openssl_random_pseudo_bytes')
-        );
     }
 
     /**
@@ -723,20 +705,10 @@ class AuthenticationCookie extends AuthenticationPlugin
      */
     public function cookieEncrypt($data, $secret)
     {
-        if (self::useOpenSSL()) {
-            return openssl_encrypt(
-                $data,
-                'AES-128-CBC',
-                $secret,
-                0,
-                $this->_cookie_iv
-            );
-        } else {
-            $cipher = new Crypt\AES(Crypt\Base::MODE_CBC);
-            $cipher->setIV($this->_cookie_iv);
-            $cipher->setKey($secret);
-            return base64_encode($cipher->encrypt($data));
-        }
+        $cipher = new Crypt\AES(Crypt\Base::MODE_CBC);
+        $cipher->setIV($this->_cookie_iv);
+        $cipher->setKey($secret);
+        return base64_encode($cipher->encrypt($data));
     }
 
     /**
@@ -760,20 +732,10 @@ class AuthenticationCookie extends AuthenticationPlugin
                 $this->createIV();
         }
 
-        if (self::useOpenSSL()) {
-            return openssl_decrypt(
-                $encdata,
-                'AES-128-CBC',
-                $secret,
-                0,
-                $this->_cookie_iv
-            );
-        } else {
-            $cipher = new Crypt\AES(Crypt\Base::MODE_CBC);
-            $cipher->setIV($this->_cookie_iv);
-            $cipher->setKey($secret);
-            return $cipher->decrypt(base64_decode($encdata));
-        }
+        $cipher = new Crypt\AES(Crypt\Base::MODE_CBC);
+        $cipher->setIV($this->_cookie_iv);
+        $cipher->setKey($secret);
+        return $cipher->decrypt(base64_decode($encdata));
     }
 
     /**
@@ -783,9 +745,6 @@ class AuthenticationCookie extends AuthenticationPlugin
      */
     public function getIVSize()
     {
-        if (self::useOpenSSL()) {
-            return openssl_cipher_iv_length('AES-128-CBC');
-        }
         $cipher = new Crypt\AES(Crypt\Base::MODE_CBC);
         return $cipher->block_size;
     }
@@ -800,15 +759,9 @@ class AuthenticationCookie extends AuthenticationPlugin
      */
     public function createIV()
     {
-        if (self::useOpenSSL()) {
-            $this->_cookie_iv = openssl_random_pseudo_bytes(
-                $this->getIVSize()
-            );
-        } else {
-            $this->_cookie_iv = Crypt\Random::string(
-                $this->getIVSize()
-            );
-        }
+        $this->_cookie_iv = Crypt\Random::string(
+            $this->getIVSize()
+        );
         $GLOBALS['PMA_Config']->setCookie(
             'pma_iv-' . $GLOBALS['server'],
             base64_encode($this->_cookie_iv)

--- a/libraries/session.inc.php
+++ b/libraries/session.inc.php
@@ -111,11 +111,7 @@ if (! isset($_COOKIE[$session_name])) {
  * (we use "space PMA_token space" to prevent overwriting)
  */
 if (! isset($_SESSION[' PMA_token '])) {
-    if (! function_exists('openssl_random_pseudo_bytes')) {
-        $_SESSION[' PMA_token '] = bin2hex(phpseclib\Crypt\Random::string(16));
-    } else {
-        $_SESSION[' PMA_token '] = bin2hex(openssl_random_pseudo_bytes(16));
-    }
+    $_SESSION[' PMA_token '] = bin2hex(phpseclib\Crypt\Random::string(16));
 }
 
 require_once 'libraries/session.lib.php';

--- a/libraries/session.lib.php
+++ b/libraries/session.lib.php
@@ -19,9 +19,5 @@ function PMA_secureSession()
     if (session_status() === PHP_SESSION_ACTIVE) {
         session_regenerate_id(true);
     }
-    if (! function_exists('openssl_random_pseudo_bytes')) {
-        $_SESSION[' PMA_token '] = bin2hex(phpseclib\Crypt\Random::string(16));
-    } else {
-        $_SESSION[' PMA_token '] = bin2hex(openssl_random_pseudo_bytes(16));
-    }
+    $_SESSION[' PMA_token '] = bin2hex(phpseclib\Crypt\Random::string(16));
 }


### PR DESCRIPTION
By this code we're duplicating phpseclib functionality with only benefit
of making it's dependency optional.

**This is not for merge right now, it just shows what cleanup could be done if we decide to make phpseclib non optional.**

Signed-off-by: Michal Čihař <michal@cihar.com
