### PR TITLE
Add 'pageselector' below navigation tree

### DIFF
--- a/libraries/navigation/NavigationTree.php
+++ b/libraries/navigation/NavigationTree.php
@@ -867,6 +867,7 @@ class NavigationTree
                 }
             }
         }
+        $retval .= $this->_getPageSelector($this->_tree);
         $retval .= "</ul></div>";
 
         return $retval;
@@ -905,6 +906,7 @@ class NavigationTree
                     $listContent .= $this->_renderNode($children[$i], true, 'last');
                 }
             }
+            $listContent .= $this->_getPageSelector($node);
             $retval .= $listContent;
             $retval .= "</ul>";
             if (!$GLOBALS['cfg']['ShowDatabasesNavigationAsTree']) {
@@ -1220,6 +1222,7 @@ class NavigationTree
                 $retval .= $this->_fastFilterHtml($node);
                 $retval .= $this->_getPageSelector($node);
                 $retval .= $buffer;
+                $retval .= $this->_getPageSelector($node);
                 if ($wrap) {
                     $retval .= "</ul></div>";
                 }


### PR DESCRIPTION
This is simply to make it easier to navigate between pages of tables
instead of scrolling up again in order to change the page.
