### PR TITLE
Search and replace with nothing

### DIFF
--- a/templates/table/search/search_and_replace.phtml
+++ b/templates/table/search/search_and_replace.phtml
@@ -1,7 +1,7 @@
 <?= __('Find:'); ?>
 <input type="text" value="" name="find" required />
 <?= __('Replace with:'); ?>
-<input type="text" value="" name="replaceWith" required />
+<input type="text" value="" name="replaceWith" />
 
 <?= __('Column:'); ?>
 <select name="columnIndex">


### PR DESCRIPTION
This PR removes `required` from search and replace form input#replaceWith to let us delete found values.

PS. Sorry for the latest pull request. I hope it's ok now :)

Signed-off-by: Catalin Zalog catalinzalog@yahoo.com
