### PR TITLE
[doc] Installation with Composer - add --no-dev option

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -100,7 +100,7 @@ The installation is possible by adding our own repository
 
 .. code-block:: sh
 
-    composer create-project phpmyadmin/phpmyadmin --repository-url=https://www.phpmyadmin.net/packages.json
+    composer create-project phpmyadmin/phpmyadmin --repository-url=https://www.phpmyadmin.net/packages.json --no-dev
 
 Installing using Docker
 +++++++++++++++++++++++


### PR DESCRIPTION
Otherwise it installs multiple dependencies not needed for running PhpMyAdmin (phpunit, code sniffer, etc.).

Signed-off-by: Bilal Amarni bilal.amarni@gmail.com
