### PR TITLE
Fix for wrong mysql_upgrade message on Users tab with Percona Server

### DIFF
--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -4739,7 +4739,8 @@ function PMA_getHtmlForUserOverview($pmaThemeImage, $text_dir)
        . '</h2>' . "\n";
 
     $password_column = 'Password';
-    if (Util::getServerType() == 'MySQL'
+    $serverType = Util::getServerType();
+    if (($serverType == 'MySQL' || $serverType == 'Percona Server')
         && PMA_MYSQL_INT_VERSION >= 50706
     ) {
         $password_column = 'authentication_string';


### PR DESCRIPTION
Simple fix for Percona Server 5.7 "Your privilege table structure seems to be older than MySQL version!" message
