### PR TITLE
Fix for wrong mysql_upgrade message on Users tab with Percona Server 5.7

### DIFF
--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -4739,7 +4739,8 @@ function PMA_getHtmlForUserOverview($pmaThemeImage, $text_dir)
        . '</h2>' . "\n";
 
     $password_column = 'Password';
-    if (Util::getServerType() == 'MySQL'
+	$server_type = Util::getServerType();
+    if (($server_type == 'MySQL' || $server_type == 'Percona Server')
         && PMA_MYSQL_INT_VERSION >= 50706
     ) {
         $password_column = 'authentication_string';

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -4739,7 +4739,7 @@ function PMA_getHtmlForUserOverview($pmaThemeImage, $text_dir)
        . '</h2>' . "\n";
 
     $password_column = 'Password';
-	$server_type = Util::getServerType();
+    $server_type = Util::getServerType();
     if (($server_type == 'MySQL' || $server_type == 'Percona Server')
         && PMA_MYSQL_INT_VERSION >= 50706
     ) {


### PR DESCRIPTION
Fix for false mysql_upgrade message on privileges tab with Percona Server >= 5.7

Signed-off-by: Andre Evertz andre.evertz@devil-coding.de
