### PR TITLE
Question-  The mbstring extension is missing

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -2183,4 +2183,3 @@ Synchronization
 
 9.2 (withdrawn).
 ----------------
-


### PR DESCRIPTION
I am getting this sort of error when trying to access localhost/phpmyadmin in my URL
"The mbstring extension is missing. Please check your PHP configuration."
Please somebody help ASAP
