### PR TITLE
Fixup for missing glossary terms

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -229,6 +229,10 @@ From Wikipedia, the free encyclopedia
 
       .. seealso:: <http://www.wikipedia.org/wiki/module>
 
+    mod_proxy_fcgi
+      an Apache module implmenting a Fast CGI interface; PHP can be run as a CGI module, FastCGI, or
+      directly as an Apache module.
+
     MySQL
       a multithreaded, multi-user, SQL (Structured Query Language) Database Management System (DBMS).	
 

--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -606,7 +606,7 @@ HTTP authentication mode
   support using :term:`CGI` PHP see :ref:`faq1_32`, for using with Apache
   :term:`CGI` see :ref:`faq1_35`.
 * When PHP is running under Apache's :term:`mod_proxy_fcgi` (e.g. with PHP-FPM),
-  :term:`Authorization` headers are not passed to the underlying FCGI application,
+  ``Authorization`` headers are not passed to the underlying FCGI application,
   such that your credentials will not reach the application. In this case, you can
   add the following configuration directive:
 


### PR DESCRIPTION
When compiling the documentation for a release, this should fix notices about missing glossary terms for `mod_proxy_fcgi` (which I added) and `Authorization` (which I removed).
