### PR TITLE
Remove SkipLockedTables settings

### DIFF
--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -706,13 +706,6 @@ $cfg['SessionSavePath'] = '';
 $cfg['MemoryLimit'] = '-1';
 
 /**
- * mark used tables, make possible to show locked tables (since MySQL 3.23.30)
- *
- * @global boolean $cfg['SkipLockedTables']
- */
-$cfg['SkipLockedTables'] = false;
-
-/**
  * show SQL queries as run
  *
  * @global boolean $cfg['ShowSQL']

--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -885,10 +885,6 @@ $strConfigShowStats_desc = __(
     'Allow to display database and table statistics (eg. space usage).'
 );
 $strConfigShowStats_name = __('Show statistics');
-$strConfigSkipLockedTables_desc = __(
-    'Mark used tables and make it possible to show databases with locked tables.'
-);
-$strConfigSkipLockedTables_name = __('Skip locked tables');
 $strConfigSQLQuery_Edit_name = __('Edit');
 $strConfigSQLQuery_Explain_name = __('Explain SQL');
 $strConfigSQLQuery_Refresh_name = __('Refresh');

--- a/libraries/config/setup.forms.php
+++ b/libraries/config/setup.forms.php
@@ -137,7 +137,6 @@ $forms['Features']['Other_core_settings'] = array(
     'PersistentConnections',
     'ExecTimeLimit',
     'MemoryLimit',
-    'SkipLockedTables',
     'DisableMultiTableMaintenance',
     'UseDbSearch',
     'VersionCheck',

--- a/libraries/config/user_preferences.forms.php
+++ b/libraries/config/user_preferences.forms.php
@@ -26,7 +26,6 @@ $forms['Features']['General'] = array(
     'NaturalOrder',
     'InitialSlidersState',
     'LoginCookieValidity',
-    'SkipLockedTables',
     'DisableMultiTableMaintenance',
     'MaxTableList',
     'ShowHint',


### PR DESCRIPTION
**This needs further testing before merging!**

I've tested with following servers and there doesn't seem to be any problem with listing locked tables, so this settings just add code complexity and the only visible effect is that:
1. Loading of tables is way slower due to getting status for every non locked table separately (see #12129)
2. Locked tables do not show any stats.

When this setting is not enabled, the stats for locked tables are shown without any visible blocking.

I've tested with:
- MariaDB 10.0.24
- MariaDB 10.0.22
- MySQL 5.5.46
