### PR TITLE
Remove undocumented caching for table status

### DIFF
--- a/libraries/DatabaseInterface.php
+++ b/libraries/DatabaseInterface.php
@@ -542,38 +542,7 @@ class DatabaseInterface
                         . Util::backquote($each_database);
                 }
 
-                $useStatusCache = false;
-
-                if (extension_loaded('apc')
-                    && isset($GLOBALS['cfg']['Server']['StatusCacheDatabases'])
-                    && ! empty($GLOBALS['cfg']['Server']['StatusCacheLifetime'])
-                ) {
-                    $statusCacheDatabases
-                        = (array) $GLOBALS['cfg']['Server']['StatusCacheDatabases'];
-                    if (in_array($each_database, $statusCacheDatabases)) {
-                        $useStatusCache = true;
-                    }
-                }
-
-                $each_tables = null;
-
-                if ($useStatusCache) {
-                    $cacheKey = 'phpMyAdmin_tableStatus_'
-                        . sha1($GLOBALS['cfg']['Server']['host'] . '_' . $sql);
-
-                    $each_tables = apc_fetch($cacheKey);
-                }
-
-                if (! $each_tables) {
-                    $each_tables = $this->fetchResult($sql, 'Name', null, $link);
-                }
-
-                if ($useStatusCache) {
-                    apc_store(
-                        $cacheKey, $each_tables,
-                        $GLOBALS['cfg']['Server']['StatusCacheLifetime']
-                    );
-                }
+                $each_tables = $this->fetchResult($sql, 'Name', null, $link);
 
                 // Sort naturally if the config allows it and we're sorting
                 // the Name column.


### PR DESCRIPTION
This feature is not documented, not in the default config, so probably
not used at all.

This was introduced in revert commit
19432a02cc218e7469dc8c123f73b10ab47c872c, so I believe it was not
intentional.

Alternatively we could properly document it, so feedback is welcome. Especially from @madhuracj :-).
