### PR TITLE
Do not hide errors from database connection attempts

### DIFF
--- a/libraries/DatabaseInterface.php
+++ b/libraries/DatabaseInterface.php
@@ -2351,9 +2351,21 @@ class DatabaseInterface
         $user, $password, $is_controluser = false, $server = null,
         $auxiliary_connection = false
     ) {
+        $error_count = $GLOBALS['error_handler']->countErrors();
         $result = $this->_extension->connect(
             $user, $password, $is_controluser, $server, $auxiliary_connection
         );
+
+        /* Any errors from connection? */
+        if ($GLOBALS['error_handler']->countErrors() > $error_count) {
+            $errors = $GLOBALS['error_handler']->sliceErrors($error_count);
+            foreach ($errors as $error) {
+                trigger_error(
+                    $error->getMessage(),
+                    E_USER_ERROR
+                );
+            }
+        }
 
         if ($result) {
             if (! $auxiliary_connection && ! $is_controluser) {

--- a/libraries/ErrorHandler.php
+++ b/libraries/ErrorHandler.php
@@ -82,7 +82,7 @@ class ErrorHandler
      *
      * @return Error[]
      */
-    protected function getErrors()
+    public function getErrors()
     {
         $this->checkSavedErrors();
         return $this->errors;
@@ -97,6 +97,20 @@ class ErrorHandler
     public function getCurrentErrors()
     {
         return $this->errors;
+    }
+
+    /**
+     * Pops recent erros from the storage
+     *
+     * @param int $count Old error count
+     *
+     * @return Error[]
+     */
+    public function sliceErrors($count)
+    {
+        $errors = $this->getErrors();
+        $this->errors = array_splice($errors, 0, $count);
+        return array_splice($errors, $count);
     }
 
     /**

--- a/libraries/dbi/DBIMysqli.php
+++ b/libraries/dbi/DBIMysqli.php
@@ -84,7 +84,7 @@ class DBIMysqli implements DBIExtension
         }
 
         if ($client_flags === null) {
-            return @mysqli_real_connect(
+            return mysqli_real_connect(
                 $link,
                 $host,
                 $user,
@@ -94,7 +94,7 @@ class DBIMysqli implements DBIExtension
                 $server_socket
             );
         } else {
-            return @mysqli_real_connect(
+            return mysqli_real_connect(
                 $link,
                 $host,
                 $user,

--- a/test/classes/ErrorHandlerTest.php
+++ b/test/classes/ErrorHandlerTest.php
@@ -194,6 +194,40 @@ class ErrorHandlerTest extends PMATestCase
     }
 
     /**
+     * Test for sliceErrors
+     *
+     * @return void
+     *
+     * @group medium
+     */
+    public function testSliceErrors()
+    {
+        $this->object->addError(
+            'Compile Error', E_WARNING, 'error.txt', 15
+        );
+        $this->assertEquals(
+            1,
+            $this->object->countErrors()
+        );
+        $this->assertEquals(
+            array(),
+            $this->object->sliceErrors(1)
+        );
+        $this->assertEquals(
+            1,
+            $this->object->countErrors()
+        );
+        $this->assertEquals(
+            1,
+            count($this->object->sliceErrors(0))
+        );
+        $this->assertEquals(
+            0,
+            $this->object->countErrors()
+        );
+    }
+
+    /**
      * Test for countUserErrors
      *
      * @return void

--- a/test/classes/ErrorHandlerTest.php
+++ b/test/classes/ErrorHandlerTest.php
@@ -184,16 +184,11 @@ class ErrorHandlerTest extends PMATestCase
      */
     public function testCountErrors()
     {
-
-        $err = array();
-        $err[] = new PMA\libraries\Error('256', 'Compile Error', 'error.txt', 15);
-        $errHandler = $this->getMock('PMA\libraries\ErrorHandler');
-        $errHandler->expects($this->any())
-            ->method('getErrors')
-            ->will($this->returnValue($err));
-
+        $this->object->addError(
+            'Compile Error', E_WARNING, 'error.txt', 15
+        );
         $this->assertEquals(
-            0,
+            1,
             $this->object->countErrors()
         );
     }
@@ -205,16 +200,18 @@ class ErrorHandlerTest extends PMATestCase
      */
     public function testCountUserErrors()
     {
-
-        $err = array();
-        $err[] = new PMA\libraries\Error('256', 'Compile Error', 'error.txt', 15);
-        $errHandler = $this->getMock('PMA\libraries\ErrorHandler');
-        $errHandler->expects($this->any())
-            ->method('countErrors', 'getErrors')
-            ->will($this->returnValue(1, $err));
-
+        $this->object->addError(
+            'Compile Error', E_WARNING, 'error.txt', 15
+        );
         $this->assertEquals(
             0,
+            $this->object->countUserErrors()
+        );
+        $this->object->addError(
+            'Compile Error', E_USER_WARNING, 'error.txt', 15
+        );
+        $this->assertEquals(
+            1,
             $this->object->countUserErrors()
         );
     }


### PR DESCRIPTION
Without these errors it's impossible to figure out what went wrong in
the SSL negotiation. All you get is error 2002 without any means to
diagnose and all important information is issued as PHP warnings.

Issue #12146

I'm not sure this is best approach as the errors look quite ugly in the end, but we really need to find way to pass the information to the user. What is however annoying is that the SSL setup error leads to at least four warnings:

![phpmyadmin_-_2016-04-18_12 25 45](https://cloud.githubusercontent.com/assets/212189/14601147/c0ca35ba-0560-11e6-81e1-53e094a97883.png)
