### PR TITLE
fixed use zh_CN lead to error _lang_failed_cookie or _lang_failed_cfg or _lang_failed_request

### DIFF
--- a/libraries/LanguageManager.php
+++ b/libraries/LanguageManager.php
@@ -827,7 +827,7 @@ class LanguageManager
         if ($accepted_languages && false === mb_strpos($accepted_languages, '<')) {
             foreach (explode(',', $accepted_languages) as $header) {
                 foreach ($langs as $language) {
-                    if ($language->matchesAcceptLanguage($header)) {
+                    if ($language->matchesAcceptLanguage(strtolower($header))) {
                         return $language;
                     }
                 }
@@ -838,7 +838,7 @@ class LanguageManager
         $user_agent = PMA_getenv('HTTP_USER_AGENT');
         if (! empty($user_agent)) {
             foreach ($langs as $language) {
-                if ($language->matchesUserAgent($user_agent)) {
+                if ($language->matchesUserAgent(strtolower($user_agent))) {
                     return $language;
                 }
             }

--- a/libraries/LanguageManager.php
+++ b/libraries/LanguageManager.php
@@ -845,8 +845,8 @@ class LanguageManager
         }
 
         // Didn't catch any valid lang : we use the default settings
-        if (isset($langs[$GLOBALS['cfg']['DefaultLang']])) {
-            return $langs[$GLOBALS['cfg']['DefaultLang']];
+        if (isset($langs[strtolower($GLOBALS['cfg']['DefaultLang'])])) {
+            return $langs[strtolower($GLOBALS['cfg']['DefaultLang'])];
         }
 
         // Fallback to English

--- a/libraries/LanguageManager.php
+++ b/libraries/LanguageManager.php
@@ -790,8 +790,8 @@ class LanguageManager
 
         // check forced language
         if (! empty($GLOBALS['cfg']['Lang'])) {
-            if (isset($langs[$GLOBALS['cfg']['Lang']])) {
-                return $langs[$GLOBALS['cfg']['Lang']];
+            if (isset($langs[strtolower($GLOBALS['cfg']['Lang'])])) {
+                return $langs[strtolower($GLOBALS['cfg']['Lang'])];
             }
             $this->_lang_failed_cfg = true;
         }
@@ -799,24 +799,24 @@ class LanguageManager
         // Don't use REQUEST in following code as it might be confused by cookies
         // with same name. Check user requested language (POST)
         if (! empty($_POST['lang'])) {
-            if (isset($langs[$_POST['lang']])) {
-                return $langs[$_POST['lang']];
+            if (isset($langs[strtolower($_POST['lang'])])) {
+                return $langs[strtolower($_POST['lang'])];
             }
             $this->_lang_failed_request = true;
         }
 
         // check user requested language (GET)
         if (! empty($_GET['lang'])) {
-            if (isset($langs[$_GET['lang']])) {
-                return $langs[$_GET['lang']];
+            if (isset($langs[strtolower($_GET['lang'])])) {
+                return $langs[strtolower($_GET['lang'])];
             }
             $this->_lang_failed_request = true;
         }
 
         // check previous set language
         if (! empty($_COOKIE['pma_lang'])) {
-            if (isset($langs[$_COOKIE['pma_lang']])) {
-                return $langs[$_COOKIE['pma_lang']];
+            if (isset($langs[strtolower($_COOKIE['pma_lang'])])) {
+                return $langs[strtolower($_COOKIE['pma_lang'])];
             }
             $this->_lang_failed_cookie = true;
         }


### PR DESCRIPTION
i use phpMyadmin 4.6.1 on CentOS6.4, in setup/index.php i can't change language to zh_CN, it almost jump to en, i check the source code, find, $lang is be to lower in function availableLanguages(), but in function getCurrentLanguage() not use strtolower, it  will be cause error.
