### PR TITLE
Make ThemeManager a singleton instead of storing it in the session

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,6 +9,7 @@ use PMA\libraries\RecentFavoriteTable;
 use PMA\libraries\URL;
 use PMA\libraries\Sanitize;
 use PMA\libraries\Charsets;
+use PMA\libraries\ThemeManager;
 
 /**
  * Gets some core libraries and displays a top message if required
@@ -246,7 +247,7 @@ if (empty($cfg['Lang'])) {
 if ($GLOBALS['cfg']['ThemeManager']) {
     echo '<li id="li_select_theme" class="no_bullets">';
     echo PMA\libraries\Util::getImage('s_theme.png') , " "
-            ,  $_SESSION['PMA_Theme_Manager']->getHtmlSelectBox();
+            ,  ThemeManager::getInstance()->getHtmlSelectBox();
     echo '</li>';
 }
 echo '<li id="li_select_fontsize">';

--- a/libraries/Config.php
+++ b/libraries/Config.php
@@ -9,6 +9,7 @@ namespace PMA\libraries;
 
 use DirectoryIterator;
 use PMA\libraries\URL;
+use PMA\libraries\ThemeManager;
 
 /**
  * Indication for error handler (see end of this file).
@@ -985,7 +986,7 @@ class Config
 
         // save theme
         /** @var ThemeManager $tmanager */
-        $tmanager = $_SESSION['PMA_Theme_Manager'];
+        $tmanager = ThemeManager::getInstance();
         if ($tmanager->getThemeCookie() || isset($_REQUEST['set_theme'])) {
             if ((! isset($config_data['ThemeDefault'])
                 && $tmanager->theme->getId() != 'original')

--- a/libraries/ThemeManager.php
+++ b/libraries/ThemeManager.php
@@ -17,6 +17,15 @@ use PMA\libraries\URL;
 class ThemeManager
 {
     /**
+     * ThemeManager instance
+     *
+     * @access private
+     * @static
+     * @var ThemeManager
+     */
+    private static $_instance;
+
+    /**
      * @var string path to theme folder
      * @access protected
      */
@@ -65,6 +74,19 @@ class ThemeManager
     public function __construct()
     {
         $this->init();
+    }
+
+    /**
+     * Returns the singleton Response object
+     *
+     * @return Response object
+     */
+    public static function getInstance()
+    {
+        if (empty(self::$_instance)) {
+            self::$_instance = new ThemeManager();
+        }
+        return self::$_instance;
     }
 
     /**
@@ -453,41 +475,31 @@ class ThemeManager
      */
     public static function initializeTheme()
     {
-        /**
-         * @global ThemeManager $_SESSION['ThemeManager']
-         */
-        if (! isset($_SESSION['PMA_Theme_Manager'])) {
-            $_SESSION['PMA_Theme_Manager'] = new ThemeManager;
-        } else {
-            /**
-             * @todo move all __wakeup() functionality into session.inc.php
-             */
-            $_SESSION['PMA_Theme_Manager']->checkConfig();
-        }
+        $tmanager = self::getInstance();
 
         // for the theme per server feature
         if (isset($_REQUEST['server']) && ! isset($_REQUEST['set_theme'])) {
             $GLOBALS['server'] = $_REQUEST['server'];
-            $tmp = $_SESSION['PMA_Theme_Manager']->getThemeCookie();
+            $tmp = $tmanager->getThemeCookie();
             if (empty($tmp)) {
-                $tmp = $_SESSION['PMA_Theme_Manager']->theme_default;
+                $tmp = $tmanager->theme_default;
             }
-            $_SESSION['PMA_Theme_Manager']->setActiveTheme($tmp);
+            $tmanager->setActiveTheme($tmp);
         }
         /**
          * @todo move into ThemeManager::__wakeup()
          */
         if (isset($_REQUEST['set_theme'])) {
             // if user selected a theme
-            $_SESSION['PMA_Theme_Manager']->setActiveTheme($_REQUEST['set_theme']);
+            $tmanager->setActiveTheme($_REQUEST['set_theme']);
         }
 
         /**
          * the theme object
          *
-        *@global Theme $_SESSION['PMA_Theme']
+         * @global Theme $_SESSION['PMA_Theme']
          */
-        $_SESSION['PMA_Theme'] = $_SESSION['PMA_Theme_Manager']->theme;
+        $_SESSION['PMA_Theme'] = $tmanager->theme;
 
         // BC
         /**

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -624,7 +624,7 @@ if (! defined('PMA_MINIMUM_COMMON')) {
         );
     }
 
-    $_SESSION['PMA_Theme_Manager']->setThemeCookie();
+    ThemeManager::getInstance()->setThemeCookie();
 
     if (! empty($cfg['Server'])) {
 

--- a/phpmyadmin.css.php
+++ b/phpmyadmin.css.php
@@ -5,7 +5,8 @@
  *
  * @package PhpMyAdmin
  */
- use PMA\libraries\OutputBuffering;
+use PMA\libraries\OutputBuffering;
+use PMA\libraries\ThemeManager;
 
 /**
  *
@@ -30,4 +31,4 @@ header('Content-Type: text/css; charset=UTF-8');
 // file is reloaded when config changes
 header('Expires: ' . gmdate('D, d M Y H:i:s', time() + 3600) . ' GMT');
 
-$_SESSION['PMA_Theme_Manager']->printCss();
+ThemeManager::getInstance()->printCss();

--- a/prefs_manage.php
+++ b/prefs_manage.php
@@ -12,6 +12,7 @@ use PMA\libraries\Response;
 use PMA\libraries\Util;
 use PMA\libraries\URL;
 use PMA\libraries\Sanitize;
+use PMA\libraries\ThemeManager;
 
 /**
  * Gets some core libraries and displays a top message if required
@@ -148,12 +149,13 @@ if (isset($_POST['submit_export'])
 
         // check for ThemeDefault and fontsize
         $params = array();
+        $tmanager = ThemeManager::getInstance();
         if (isset($config['ThemeDefault'])
-            && $_SESSION['PMA_Theme_Manager']->theme->getId() != $config['ThemeDefault']
-            && $_SESSION['PMA_Theme_Manager']->checkTheme($config['ThemeDefault'])
+            && $tmanager->theme->getId() != $config['ThemeDefault']
+            && $tmanager->checkTheme($config['ThemeDefault'])
         ) {
-            $_SESSION['PMA_Theme_Manager']->setActiveTheme($config['ThemeDefault']);
-            $_SESSION['PMA_Theme_Manager']->setThemeCookie();
+            $tmanager->setActiveTheme($config['ThemeDefault']);
+            $tmanager->setThemeCookie();
         }
         if (isset($config['fontsize'])
             && $config['fontsize'] != $GLOBALS['PMA_Config']->get('fontsize')

--- a/themes.php
+++ b/themes.php
@@ -5,11 +5,13 @@
  *
  * @package PhpMyAdmin
  */
+use PMA\libraries\ThemeManager;
 
 /**
  * get some globals
  */
 require './libraries/common.inc.php';
+
 $response = PMA\libraries\Response::getInstance();
 $response->getFooter()->setMinimal();
 $header = $response->getHeader();
@@ -25,6 +27,6 @@ $output .= '<a href="' . $url . '" class="_blank">';
 $output .= __('Get more themes!');
 $output .= '</a>';
 $output .= '</p>';
-$output .= $_SESSION['PMA_Theme_Manager']->getPrintPreviews();
+$output .= ThemeManager::getInstance()->getPrintPreviews();
 
 $response->addHTML($output);


### PR DESCRIPTION
I believe this is better approach and in my tests there is no performance difference between these two usages. Storing the data in session can cause problems on restoring in case API of the object has changed meanwhile.

Please review, if no negative feedback appears I'm going to merge this in a week or so.
