### PR TITLE
Fix error in Designer saved default state of all tables

### DIFF
--- a/js/pmd/move.js
+++ b/js/pmd/move.js
@@ -1263,6 +1263,7 @@ function Small_tab_all(id_this) // max/min all tables
     var icon = id_this.children[0];
     var key;
     var value_sent = '';
+
     if (icon.alt == "v") {
         for (key in j_tabs) {
             if (document.getElementById('id_hide_tbody_' + key).innerHTML == "v") {
@@ -1309,7 +1310,6 @@ function Small_tab_refresh()
 {
     for (var key in j_tabs) {
         if (document.getElementById('id_hide_tbody_' + key).innerHTML != "v") {
-            Small_tab(key, 0);
             Small_tab(key, 0);
         }
     }


### PR DESCRIPTION
Fixes the incorrect behavior of default saved state of all tables (Hidden/Shown). Saved state was being remembered but incorrectly set after retrieving the stored value.  

Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
