### PR TITLE
Shapefile.lib extension

### DIFF
--- a/libraries/bfShapeFiles/ShapeFile.lib.php
+++ b/libraries/bfShapeFiles/ShapeFile.lib.php
@@ -126,6 +126,12 @@
       $this->records[] = $record;
       $this->records[count($this->records) - 1]->recordNumber = count($this->records);
 
+      if ($this->boundingBox["xmin"]==0.0 || ($this->boundingBox["xmin"]>$record->SHPData["xmin"])) $this->boundingBox["xmin"] = $record->SHPData["xmin"];
+      if ($this->boundingBox["xmax"]==0.0 || ($this->boundingBox["xmax"]<$record->SHPData["xmax"])) $this->boundingBox["xmax"] = $record->SHPData["xmax"];
+
+      if ($this->boundingBox["ymin"]==0.0 || ($this->boundingBox["ymin"]>$record->SHPData["ymin"])) $this->boundingBox["ymin"] = $record->SHPData["ymin"];
+      if ($this->boundingBox["ymax"]==0.0 || ($this->boundingBox["ymax"]<$record->SHPData["ymax"])) $this->boundingBox["ymax"] = $record->SHPData["ymax"];
+
       return (count($this->records) - 1);
     }
 

--- a/libraries/bfShapeFiles/ShapeFile.lib.php
+++ b/libraries/bfShapeFiles/ShapeFile.lib.php
@@ -531,7 +531,7 @@
       fwrite($this->SHPFile, pack("VV", $this->SHPData["numparts"], $this->SHPData["numpoints"]));
 
       for ($i = 0; $i < $this->SHPData["numparts"]; $i++) {
-        fwrite($this->SHPFile, pack("V", count($this->SHPData["parts"][$i])));
+        fwrite($this->SHPFile, pack("V", count($this->SHPData["parts"][$i])-1));
       }
 
       foreach ($this->SHPData["parts"] as $partData){


### PR DESCRIPTION
Fixed a bug regarding the part index. It's now in line with the specification from http://dl.maptools.org/dl/shapelib/shapefile.pdf

Added M and Z coordinates, that means the library now covers the most shape types (except 31 MultiPatch) for loading and saving.

Signed-off-by: Johannes Vockeroth vockeroth@nextbike.net
