### PR TITLE
GPG sign Git release tags

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -340,7 +340,7 @@ if [ $do_tag -eq 1 ] ; then
     echo "Additional tasks:"
     tagname=RELEASE_`echo $version | tr . _ | tr '[:lower:]' '[:upper:]' | tr -d -`
     echo "* Tagging release as $tagname"
-    git tag -a -m "Released $version" $tagname $branch
+    git tag -s -a -m "Released $version" $tagname $branch
     echo "   Dont forget to push tags using: git push --tags"
 fi
 


### PR DESCRIPTION
This makes it possible to verify that the tag matches what release
manager did release.

Signed-off-by: Michal Čihař michal@cihar.com

I don't think this could cause any problems (as gpg setup is anyway already required for signing releases), but still this is for @ibennetch as a release manager to merge.
