### PR TITLE
Restore Overhead column in Server > Databases > Enable Statistics.

### DIFF
--- a/libraries/DatabaseInterface.php
+++ b/libraries/DatabaseInterface.php
@@ -871,7 +871,8 @@ class DatabaseInterface
                     SUM(t.INDEX_LENGTH)    AS SCHEMA_INDEX_LENGTH,
                     SUM(t.DATA_LENGTH + t.INDEX_LENGTH)
                                            AS SCHEMA_LENGTH,
-                    SUM(t.DATA_FREE)       AS SCHEMA_DATA_FREE';
+                    SUM(IF(t.ENGINE <> \'InnoDB\', t.DATA_FREE, 0))
+                                           AS SCHEMA_DATA_FREE';
             }
             $sql .= '
                    FROM `information_schema`.SCHEMATA s';

--- a/libraries/controllers/server/ServerDatabasesController.php
+++ b/libraries/controllers/server/ServerDatabasesController.php
@@ -357,9 +357,11 @@ class ServerDatabasesController extends Controller
             'format'    => 'byte',
             'footer'    => 0,
         );
-        // At this point we were preparing the display of Overhead using DATA_FREE
-        // but its content does not represent the real overhead in the case
-        // of InnoDB
+        $column_order['SCHEMA_DATA_FREE'] = array(
+            'disp_name' => __('Overhead'),
+            'format'    => 'byte',
+            'footer'    => 0,
+        );
 
         return $column_order;
     }

--- a/test/classes/controllers/ServerDatabasesControllerTest.php
+++ b/test/classes/controllers/ServerDatabasesControllerTest.php
@@ -311,6 +311,11 @@ class ServerDatabasesControllerTest extends PMATestCase
                     'disp_name' => __('Total'),
                     'format'    => 'byte',
                     'footer'    => 0
+                ),
+                'SCHEMA_DATA_FREE' => array(
+                    'disp_name' => __('Overhead'),
+                    'format'    => 'byte',
+                    'footer'    => 0
                 )
             ),
             $method->invoke($ctrl)


### PR DESCRIPTION
Restore Overhead column in Server > Databases > Enable Statistics which was removed in 582b02262bcda6edb10ffc6df1b67c47468bbe59.

Similar can also be applied to earlier versions, but I use this on 4.6.3.
