### PR TITLE
Fix replication status output in Server > Databases

### DIFF
--- a/libraries/controllers/server/ServerDatabasesController.php
+++ b/libraries/controllers/server/ServerDatabasesController.php
@@ -482,9 +482,7 @@ class ServerDatabasesController extends Controller
                     );
 
                     if (mb_strlen($key) > 0
-                        || (isset($replication_info[$type]['Do_DB'][0])
-                        && $replication_info[$type]['Do_DB'][0] == ""
-                        && count($replication_info[$type]['Do_DB']) == 1)
+                        || count($replication_info[$type]['Do_DB']) == 0
                     ) {
                         // if ($key != null) did not work for index "0"
                         $out = Util::getIcon(


### PR DESCRIPTION
Fix replication status output in Server > Databases

Broken by refactoring done in 829a84b46e101cc5caa3a4252ea6f4453c49528d 
Incorrectly fixed by c4710c3e1d20c95b6cf5081d02ac50eda86d2538

Previously, 'libraries/replication.inc.php' has following code:

```
           ${"server_{$type}_Do_DB"} = explode(
                ",", $server_master_replication[0]["Binlog_Do_DB"]
            );
```

This provide following result on empty value of 'Binlog_Do_DB':

```
# php -r '$v = explode(",",""); print var_export($v);'
array (
  0 => '',
)
```

... and 's_success' displayed as result of condition check.

```
                if (strlen($key) > 0
                    || ($replication_info[$type]['Do_DB'][0] == ""
                    && count($replication_info[$type]['Do_DB']) == 1)
                ) {
                    // if ($key != null) did not work for index "0"
                    $out .= PMA_Util::getIcon('s_success.png', __('Replicated'));
                }
```

Current code (4.6.3) has refactored version

```
function PMA_fillReplicationInfo(
    $type, $replicationInfoKey, $mysqlInfo, $mysqlKey
) {
    $GLOBALS['replication_info'][$type][$replicationInfoKey]
        = empty($mysqlInfo[$mysqlKey])
            ? array()
            : explode(
                ",",
                $mysqlInfo[$mysqlKey]
            );

    return $GLOBALS['replication_info'][$type][$replicationInfoKey];
}
```

and it provides an empty array on empty value of 'Binlog_Do_DB'.

As result, no 's_success' is displayed.

Proposed patch fixed this problem for my phpMyAdmin-4.6.3 setup.
