### PR TITLE
Fix advisory rule 'Slow launch time'

### DIFF
--- a/libraries/advisory_rules.txt
+++ b/libraries/advisory_rules.txt
@@ -365,7 +365,7 @@ rule 'Threads that are slow to launch' [slow_launch_time > 0]
 rule 'Slow launch time'
 	slow_launch_time
 	value > 2
-	Slow_launch_threads is above 2s.
+	Slow_launch_time is above 2s.
 	Set {slow_launch_time} to 1s or 2s to correctly count threads that are slow to launch.
 	slow_launch_time is set to %s | value
 

--- a/po/af.po
+++ b/po/af.po
@@ -16823,7 +16823,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/ar.po
+++ b/po/ar.po
@@ -17343,7 +17343,7 @@ msgstr ""
 #: libraries/advisory_rules.txt:368
 #, fuzzy
 #| msgid "long_query_time is set to %d second(s)."
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "long_query_time محددة بـ %d ثانية."
 
 #: libraries/advisory_rules.txt:369

--- a/po/az.po
+++ b/po/az.po
@@ -16357,7 +16357,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/be.po
+++ b/po/be.po
@@ -17799,7 +17799,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/be@latin.po
+++ b/po/be@latin.po
@@ -17881,7 +17881,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/bg.po
+++ b/po/bg.po
@@ -16847,9 +16847,9 @@ msgstr "Показване времето за пускане"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads е над 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time е над 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/bn.po
+++ b/po/bn.po
@@ -17248,9 +17248,9 @@ msgstr "ধীর আরম্ভের সময়"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads 2s উপরে"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time 2s উপরে"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/br.po
+++ b/po/br.po
@@ -17069,7 +17069,7 @@ msgstr ""
 #: libraries/advisory_rules.txt:368
 #, fuzzy
 #| msgid "long_query_time is set to %d second(s)."
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "Reizhet eo bet long_query_time da %d eilenn."
 
 #: libraries/advisory_rules.txt:369

--- a/po/brx.po
+++ b/po/brx.po
@@ -15373,7 +15373,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/bs.po
+++ b/po/bs.po
@@ -17143,7 +17143,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/ca.po
+++ b/po/ca.po
@@ -16686,8 +16686,8 @@ msgid "Slow launch time"
 msgstr "Temps d'inici lent"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "{slow_launch_threads} està per sobre de 2s."
+msgid "Slow_launch_time is above 2s."
+msgstr "{slow_launch_time} està per sobre de 2s."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -16283,7 +16283,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/cs.po
+++ b/po/cs.po
@@ -16671,9 +16671,9 @@ msgstr "Dlouhá doba spuštění"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads je nad 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time je nad 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/cy.po
+++ b/po/cy.po
@@ -17322,7 +17322,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/da.po
+++ b/po/da.po
@@ -16981,9 +16981,9 @@ msgstr "Langsom starttid"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads er over 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time er over 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -16850,7 +16850,7 @@ msgid "Slow launch time"
 msgstr "Langsame Startzeit"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "slow_launch_time ist höher als 2 Sekunden."
 
 #: libraries/advisory_rules.txt:369

--- a/po/el.po
+++ b/po/el.po
@@ -16829,8 +16829,8 @@ msgid "Slow launch time"
 msgstr "Αργός χρόνος προσπέλασης"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Το Slow_launch_threads είναι πάνω από 2δ."
+msgid "Slow_launch_time is above 2s."
+msgstr "Το Slow_launch_time είναι πάνω από 2δ."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -17333,9 +17333,9 @@ msgstr "Slow launch time"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads is above 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time is above 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/eo.po
+++ b/po/eo.po
@@ -15376,7 +15376,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/es.po
+++ b/po/es.po
@@ -16859,9 +16859,9 @@ msgstr "Tiempo de inicio lento"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "«slow_launch_threads» es mayor a 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "«Slow_launch_time» es mayor a 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/et.po
+++ b/po/et.po
@@ -16461,8 +16461,8 @@ msgid "Slow launch time"
 msgstr "Aeglane käivitumise aeg"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads on üle 2s."
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time on üle 2s."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -17201,7 +17201,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/fa.po
+++ b/po/fa.po
@@ -17022,7 +17022,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/fi.po
+++ b/po/fi.po
@@ -17325,7 +17325,7 @@ msgstr ""
 #: libraries/advisory_rules.txt:368
 #, fuzzy
 #| msgid "long_query_time is set to %d second(s)."
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "long_query_time on asetettu %d sekuntiin."
 
 #: libraries/advisory_rules.txt:369

--- a/po/fr.po
+++ b/po/fr.po
@@ -16775,8 +16775,8 @@ msgid "Slow launch time"
 msgstr "Durée d'un lancement considéré comme lent"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads dépasse 2s."
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time dépasse 2s."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/fy.po
+++ b/po/fy.po
@@ -15637,7 +15637,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/gl.po
+++ b/po/gl.po
@@ -17309,9 +17309,9 @@ msgstr "Tempo de inicio lento"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads é superior a 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time é superior a 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/gu.po
+++ b/po/gu.po
@@ -15375,7 +15375,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/he.po
+++ b/po/he.po
@@ -17135,7 +17135,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/hi.po
+++ b/po/hi.po
@@ -17578,7 +17578,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/hr.po
+++ b/po/hr.po
@@ -17815,7 +17815,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/hu.po
+++ b/po/hu.po
@@ -17011,9 +17011,9 @@ msgstr "Lassú indítási idő"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads 2s felett van"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time 2s felett van"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/hy.po
+++ b/po/hy.po
@@ -15734,8 +15734,8 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads 2s-ից բարձր է։"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time 2s-ից բարձր է։"
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/ia.po
+++ b/po/ia.po
@@ -16238,7 +16238,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/id.po
+++ b/po/id.po
@@ -18018,9 +18018,9 @@ msgstr "Waktu peluncuran lambat"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads diatas 2 detik"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time diatas 2 detik"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -16823,8 +16823,8 @@ msgid "Slow launch time"
 msgstr "Tempo di avvio lento"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Il valore di Slow_launch_threads è superiore a 2 secondi."
+msgid "Slow_launch_time is above 2s."
+msgstr "Il valore di Slow_launch_time è superiore a 2 secondi."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -18007,9 +18007,9 @@ msgstr "遅い起動時間"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads が 2 秒を超えています"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time が 2 秒を超えています"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/ka.po
+++ b/po/ka.po
@@ -17756,7 +17756,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/kk.po
+++ b/po/kk.po
@@ -16288,7 +16288,7 @@ msgstr ""
 #: libraries/advisory_rules.txt:368
 #, fuzzy
 #| msgid "Set long_query_time to %ds"
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "long_query_time орнату %d сек"
 
 #: libraries/advisory_rules.txt:369

--- a/po/km.po
+++ b/po/km.po
@@ -15710,7 +15710,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/kn.po
+++ b/po/kn.po
@@ -15411,7 +15411,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/ko.po
+++ b/po/ko.po
@@ -16459,8 +16459,8 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads가 2 초를 초과함."
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time가 2 초를 초과함."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/ksh.po
+++ b/po/ksh.po
@@ -15469,7 +15469,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/ky.po
+++ b/po/ky.po
@@ -15582,7 +15582,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/li.po
+++ b/po/li.po
@@ -15373,7 +15373,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/lt.po
+++ b/po/lt.po
@@ -17825,7 +17825,7 @@ msgstr ""
 #: libraries/advisory_rules.txt:368
 #, fuzzy
 #| msgid "long_query_time is set to %d second(s)."
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "long_query_time yra nustatytas į %d sekundė(-es/-žių)."
 
 #: libraries/advisory_rules.txt:369

--- a/po/lv.po
+++ b/po/lv.po
@@ -17194,7 +17194,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/mk.po
+++ b/po/mk.po
@@ -17355,7 +17355,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/ml.po
+++ b/po/ml.po
@@ -15795,7 +15795,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/mn.po
+++ b/po/mn.po
@@ -17537,7 +17537,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/ms.po
+++ b/po/ms.po
@@ -16896,7 +16896,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/nb.po
+++ b/po/nb.po
@@ -17915,7 +17915,7 @@ msgstr ""
 #: libraries/advisory_rules.txt:368
 #, fuzzy
 #| msgid "long_query_time is set to %d second(s)."
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "long_query_time er satt til %d sekund(er)."
 
 #: libraries/advisory_rules.txt:369

--- a/po/ne.po
+++ b/po/ne.po
@@ -15471,7 +15471,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/nl.po
+++ b/po/nl.po
@@ -16770,8 +16770,8 @@ msgid "Slow launch time"
 msgstr "Trage lanceertijd"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads is hoger dan 2sec."
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time is hoger dan 2sec."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -15477,7 +15477,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/phpmyadmin.pot
+++ b/po/phpmyadmin.pot
@@ -15228,7 +15228,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/pl.po
+++ b/po/pl.po
@@ -17440,9 +17440,9 @@ msgstr "Powolny czas uruchamiania"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads jest ponad 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time jest ponad 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/pt.po
+++ b/po/pt.po
@@ -17241,9 +17241,9 @@ msgstr "Tempo de inícios lentos"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads está acima de 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time está acima de 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -17091,8 +17091,8 @@ msgstr "Tempo de inícios lentos"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
 msgstr "Slow_launch_time está acima de 2s"
 
 #: libraries/advisory_rules.txt:369

--- a/po/ro.po
+++ b/po/ro.po
@@ -17794,7 +17794,7 @@ msgstr ""
 #: libraries/advisory_rules.txt:368
 #, fuzzy
 #| msgid "long_query_time is set to %d second(s)."
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "long_query_time este setat la %d secunde."
 
 #: libraries/advisory_rules.txt:369

--- a/po/ru.po
+++ b/po/ru.po
@@ -16863,9 +16863,9 @@ msgstr "Время медленного запуска"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads больше 2 сек."
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time больше 2 сек."
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/si.po
+++ b/po/si.po
@@ -17036,7 +17036,7 @@ msgstr ""
 #: libraries/advisory_rules.txt:368
 #, fuzzy
 #| msgid "long_query_time is set to %d second(s)."
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "long_query_time තත්පර %d කට සිටුවා ඇත."
 
 #: libraries/advisory_rules.txt:369

--- a/po/sk.po
+++ b/po/sk.po
@@ -16219,9 +16219,9 @@ msgstr ""
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads je viac ako 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time je viac ako 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/sl.po
+++ b/po/sl.po
@@ -16589,8 +16589,8 @@ msgid "Slow launch time"
 msgstr "Čas počasnega zagona"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads je nad 2 s."
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time je nad 2 s."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -16700,8 +16700,8 @@ msgid "Slow launch time"
 msgstr "Koha e lëshimit e ngadaltë"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads është mbi 2s."
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time është mbi 2s."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -17671,7 +17671,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -17443,9 +17443,9 @@ msgstr "Predugo vreme pokretanja"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads je iznad 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time je iznad 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -16639,9 +16639,9 @@ msgstr "Långsam uppstartstid"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads är över 2s"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time är över 2s"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/ta.po
+++ b/po/ta.po
@@ -16004,7 +16004,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/te.po
+++ b/po/te.po
@@ -16819,7 +16819,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/th.po
+++ b/po/th.po
@@ -17176,7 +17176,7 @@ msgstr ""
 #: libraries/advisory_rules.txt:368
 #, fuzzy
 #| msgid "long_query_time is set to %d second(s)."
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr "long_query_time ถูกตั้งไว้ที่ %d วินาที"
 
 #: libraries/advisory_rules.txt:369

--- a/po/tk.po
+++ b/po/tk.po
@@ -15530,7 +15530,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/tr.po
+++ b/po/tr.po
@@ -16596,8 +16596,8 @@ msgid "Slow launch time"
 msgstr "Yavaş çalıştırma zamanı"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads 2s üzerindedir."
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time 2s üzerindedir."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/tt.po
+++ b/po/tt.po
@@ -17421,7 +17421,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/ug.po
+++ b/po/ug.po
@@ -16956,7 +16956,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/uk.po
+++ b/po/uk.po
@@ -17196,9 +17196,9 @@ msgstr "Повільний час запуску"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads перевищує 2 с"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time перевищує 2 с"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/ur.po
+++ b/po/ur.po
@@ -17431,7 +17431,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/uz.po
+++ b/po/uz.po
@@ -18662,7 +18662,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/uz@latin.po
+++ b/po/uz@latin.po
@@ -18741,7 +18741,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/vi.po
+++ b/po/vi.po
@@ -15843,8 +15843,8 @@ msgid "Slow launch time"
 msgstr "Thời gian khởi chạy chậm"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads là trên 2giây."
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time là trên 2giây."
 
 #: libraries/advisory_rules.txt:369
 msgid ""

--- a/po/vls.po
+++ b/po/vls.po
@@ -15381,7 +15381,7 @@ msgid "Slow launch time"
 msgstr ""
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
+msgid "Slow_launch_time is above 2s."
 msgstr ""
 
 #: libraries/advisory_rules.txt:369

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -16394,9 +16394,9 @@ msgstr "慢启动时间"
 
 #: libraries/advisory_rules.txt:368
 #, fuzzy
-#| msgid "Slow_launch_threads is above 2s"
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads 大于 2 秒"
+#| msgid "Slow_launch_time is above 2s"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time 大于 2 秒"
 
 #: libraries/advisory_rules.txt:369
 #, fuzzy

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -15892,8 +15892,8 @@ msgid "Slow launch time"
 msgstr "緩慢啟動時間"
 
 #: libraries/advisory_rules.txt:368
-msgid "Slow_launch_threads is above 2s."
-msgstr "Slow_launch_threads 已超過 2 秒。"
+msgid "Slow_launch_time is above 2s."
+msgstr "Slow_launch_time 已超過 2 秒。"
 
 #: libraries/advisory_rules.txt:369
 msgid ""


### PR DESCRIPTION
Issue string 'Slow_launch_thread' in advisory rule should be changed to 'Slow_launch_time' to match checked variable. 
