### PR TITLE
Improved indents, alignment and rtl in Original theme

### DIFF
--- a/index.php
+++ b/index.php
@@ -558,7 +558,7 @@ if ($server > 0) {
             . '%sFind out why%s. '
         );
         if ($cfg['ZeroConf'] == true) {
-            $msg_text .= '<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' .
+            $msg_text .= '<br>' .
                 __(
                     'Or alternately go to \'Operations\' tab of any database '
                     . 'to set it up there.'

--- a/js/ajax.js
+++ b/js/ajax.js
@@ -442,7 +442,7 @@ var AJAX = {
                     msg = data._errSubmitMsg;
                 }
                 if (data._errors) {
-                    $('<div/>', {id : 'pma_errors'})
+                    $('<div/>', {id : 'pma_errors', class : 'clearfloat'})
                         .insertAfter('#selflink')
                         .append(data._errors);
                     // bind for php error reporting forms (bottom)

--- a/libraries/Footer.php
+++ b/libraries/Footer.php
@@ -217,11 +217,10 @@ class Footer
      */
     public function getErrorMessages()
     {
-        $retval = '<div class="clearfloat" id="pma_errors">';
+        $retval = '';
         if ($GLOBALS['error_handler']->hasDisplayErrors()) {
             $retval .= $GLOBALS['error_handler']->getDispErrors();
         }
-        $retval .= '</div>';
 
         /**
          * Report php errors
@@ -341,7 +340,9 @@ class Footer
                 $this->_scripts->addCode(
                     'var debugSQLInfo = ' . $this->getDebugMessage() . ';'
                 );
+                $retval .= '<div class="clearfloat" id="pma_errors">';
                 $retval .= $this->getErrorMessages();
+                $retval .= '</div>';
                 $retval .= $this->_scripts->getDisplay();
                 if ($GLOBALS['cfg']['DBG']['demo']) {
                     $retval .= '<div id="pma_demo">';

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -422,14 +422,21 @@ div.error {
     <?php
     if ($GLOBALS['text_dir'] === 'ltr') { ?>
         background-position: 10px 50%;
-        padding:            0.1em 0.1em 0.1em 36px;
+        padding:            0.1em 0.1em 0.1em 42px;
     <?php
     } else { ?>
         background-position: 99% 50%;
-        padding:            0.1em 46px 0.1em 0.1em;
+        padding:            0.1em 40px 0.1em 0.1em;
         <?php
     }
 ?>
+}
+div.success img.icon,
+div.notice img.icon,
+div.error img.icon {
+    display: block;
+    float:              <?php echo $left; ?>;
+    margin-<?php echo $left; ?>: -22px;
 }
 
 .success {
@@ -1249,7 +1256,7 @@ div#queryboxcontainer div#bookmarkoptions {
 
 li.no_bullets {
     list-style-type:none !important;
-    margin-left: -25px !important;      //align with other list items which have bullets
+    margin-<?php echo $left; ?>: -25px !important;      //align with other list items which have bullets
 }
 
 /* end iconic view for ul items */


### PR DESCRIPTION
- Fixed list items aligment in rtl view
- Fixed notices icon alignment in rtl and ltr views
- Fixed Footer.php getErrorMessages() to avoid `<div id="pma_errors"><div id="pma_errors">....</div></div>` nested blocks.
- Removed indentation by &nbsp;

Issues:
![main-panel-ltr-notice-unaligned](https://cloud.githubusercontent.com/assets/13328211/17281374/10575d58-57c6-11e6-9cf4-06854bf3fe0b.PNG)
![main-panel-notice-en-tight](https://cloud.githubusercontent.com/assets/13328211/17281376/10973612-57c6-11e6-9330-d8704005e98d.PNG)
![main-panel-rtl-bullets-unaligned](https://cloud.githubusercontent.com/assets/13328211/17281375/10928d24-57c6-11e6-9dab-53f01bc47965.PNG)

After patch:

![after-ltr](https://cloud.githubusercontent.com/assets/13328211/17281683/9fdccc8c-57c7-11e6-85fb-d400ddb5b8d9.PNG)
![after-rtl](https://cloud.githubusercontent.com/assets/13328211/17281695/c12fe89c-57c7-11e6-9617-e130c8a21010.PNG)
