### PR TITLE
Fix replication status output in database tables list.

### DIFF
--- a/libraries/controllers/database/DatabaseStructureController.php
+++ b/libraries/controllers/database/DatabaseStructureController.php
@@ -790,7 +790,7 @@ class DatabaseStructureController extends DatabaseController
 
             $do = strlen($searchDoDBInTruename) > 0
                 || strlen($searchDoDBInDB) > 0
-                || ($nbServSlaveDoDb == 1 && $nbServSlaveIgnoreDb == 1)
+                || ($nbServSlaveDoDb == 0 && $nbServSlaveIgnoreDb == 0)
                 || $this->hasTable(
                     $GLOBALS['replication_info']['slave']['Wild_Do_Table'],
                     $table


### PR DESCRIPTION
Issue: Empty replication status column with no icon displayed in database tables list on slave MySQL server database.
Expected: Status icon.

Problem reasons are the same as for #12416

Please, review this PR.
