### PR TITLE
Partitions editor: Allow to edit partition names; Add 'COLUMNS Partitioning' support.

### DIFF
--- a/libraries/Partition.php
+++ b/libraries/Partition.php
@@ -193,7 +193,7 @@ class Partition extends SubPartition
     {
         if (Partition::havePartitioning()) {
             return $GLOBALS['dbi']->fetchResult(
-                "SELECT `PARTITION_NAME` FROM `information_schema`.`PARTITIONS`"
+                "SELECT DISTINCT `PARTITION_NAME` FROM `information_schema`.`PARTITIONS`"
                 . " WHERE `TABLE_SCHEMA` = '" . Util::sqlAddSlashes($db)
                 . "' AND `TABLE_NAME` = '" . Util::sqlAddSlashes($table) . "'"
             );
@@ -217,6 +217,7 @@ class Partition extends SubPartition
                 "SELECT `PARTITION_METHOD` FROM `information_schema`.`PARTITIONS`"
                 . " WHERE `TABLE_SCHEMA` = '" . Util::sqlAddSlashes($db) . "'"
                 . " AND `TABLE_NAME` = '" . Util::sqlAddSlashes($table) . "'"
+                . " LIMIT 1"
             );
             if (! empty($partition_method)) {
                 return $partition_method[0];

--- a/libraries/controllers/table/TableStructureController.php
+++ b/libraries/controllers/table/TableStructureController.php
@@ -602,12 +602,16 @@ class TableStructureController extends TableController
         $partitionDetails['can_have_subpartitions']
             = $partitionDetails['partition_count'] > 1
                 && ($partitionDetails['partition_by'] == 'RANGE'
-                || $partitionDetails['partition_by'] == 'LIST');
+                || $partitionDetails['partition_by'] == 'RANGE COLUMNS'
+                || $partitionDetails['partition_by'] == 'LIST'
+                || $partitionDetails['partition_by'] == 'LIST COLUMNS');
 
         // Values are specified only for LIST and RANGE type partitions
         $partitionDetails['value_enabled'] = isset($partitionDetails['partition_by'])
             && ($partitionDetails['partition_by'] == 'RANGE'
-            || $partitionDetails['partition_by'] == 'LIST');
+            || $partitionDetails['partition_by'] == 'RANGE COLUMNS'
+            || $partitionDetails['partition_by'] == 'LIST'
+            || $partitionDetails['partition_by'] == 'LIST COLUMNS');
 
         $partitionDetails['partitions'] = array();
 
@@ -615,6 +619,7 @@ class TableStructureController extends TableController
 
             if (! isset($stmt->partitions[$i])) {
                 $partitionDetails['partitions'][$i] = array(
+                    'name' => 'p' . $i,
                     'value_type' => '',
                     'value' => '',
                     'engine' => '',
@@ -635,6 +640,7 @@ class TableStructureController extends TableController
                     $expr = '';
                 }
                 $partitionDetails['partitions'][$i] = array(
+                    'name' => $p->name,
                     'value_type' => $type,
                     'value' => $expr,
                     'engine' => $p->options->has('ENGINE', true),
@@ -649,7 +655,6 @@ class TableStructureController extends TableController
             }
 
             $partition =& $partitionDetails['partitions'][$i];
-            $partition['name'] = 'p' . $i;
             $partition['prefix'] = 'partitions[' . $i . ']';
 
             if ($partitionDetails['subpartition_count'] > 1) {
@@ -659,6 +664,7 @@ class TableStructureController extends TableController
                 for ($j = 0; $j < intval($partitionDetails['subpartition_count']); $j++) {
                     if (! isset($stmt->partitions[$i]->subpartitions[$j])) {
                         $partition['subpartitions'][$j] = array(
+                            'name' => $partition['name'] . '_s' . $j,
                             'engine' => '',
                             'comment' => '',
                             'data_directory' => '',
@@ -671,6 +677,7 @@ class TableStructureController extends TableController
                     } else {
                         $sp = $stmt->partitions[$i]->subpartitions[$j];
                         $partition['subpartitions'][$j] = array(
+                            'name' => $sp->name,
                             'engine' => $sp->options->has('ENGINE', true),
                             'comment' => trim($sp->options->has('COMMENT', true), "'"),
                             'data_directory' => trim($sp->options->has('DATA DIRECTORY', true), "'"),
@@ -683,7 +690,6 @@ class TableStructureController extends TableController
                     }
 
                     $subpartition =& $partition['subpartitions'][$j];
-                    $subpartition['name'] = 'p' . $i . 's' . $j;
                     $subpartition['prefix'] = 'partitions[' . $i . ']'
                         . '[subpartitions][' . $j . ']';
                 }

--- a/libraries/create_addfield.lib.php
+++ b/libraries/create_addfield.lib.php
@@ -322,7 +322,7 @@ function PMA_getPartitionsDefinition()
         $i = 0;
         $partitions = array();
         foreach ($_REQUEST['partitions'] as $partition) {
-            $partitions[] = PMA_getPartitionDefinition('p' . $i, $partition);
+            $partitions[] = PMA_getPartitionDefinition($partition);
             $i++;
         }
         $sql_query .= " (" . implode(", ", $partitions) . ")";
@@ -334,15 +334,15 @@ function PMA_getPartitionsDefinition()
 /**
  * Returns the definition of a partition/subpartition
  *
- * @param string  $name           name of the partition/subpartition
  * @param array   $partition      array of partition/subpartition detiails
  * @param boolean $isSubPartition whether a subpartition
  *
  * @return string partition/subpartition definition
  */
-function PMA_getPartitionDefinition($name, $partition, $isSubPartition = false)
+function PMA_getPartitionDefinition($partition, $isSubPartition = false)
 {
-    $sql_query = " " . ($isSubPartition ? "SUB" : "") . "PARTITION " . $name;
+    $sql_query = " " . ($isSubPartition ? "SUB" : "") . "PARTITION ";
+    $sql_query .= $partition['name'];
 
     if (! empty($partition['value_type'])) {
         $sql_query .= " VALUES " . $partition['value_type'];
@@ -382,7 +382,6 @@ function PMA_getPartitionDefinition($name, $partition, $isSubPartition = false)
         $subpartitions = array();
         foreach ($partition['subpartitions'] as $subpartition) {
             $subpartitions[] = PMA_getPartitionDefinition(
-                $name . 's' . $j,
                 $subpartition,
                 true
             );

--- a/libraries/operations.lib.php
+++ b/libraries/operations.lib.php
@@ -1588,7 +1588,11 @@ function PMA_getHtmlForPartitionMaintenance($partition_names, $url_params)
         $GLOBALS['db'], $GLOBALS['table']
     );
     // add COALESCE or DROP option to choices array depeding on Partition method
-    if ($partition_method == 'RANGE' || $partition_method == 'LIST') {
+    if ($partition_method == 'RANGE'
+        || $partition_method == 'RANGE COLUMNS'
+        || $partition_method == 'LIST'
+        || $partition_method == 'LIST COLUMNS'
+    ) {
         $choices['DROP'] = __('Drop');
     } else {
         $choices['COALESCE'] = __('Coalesce');

--- a/libraries/tbl_partition_definition.inc.php
+++ b/libraries/tbl_partition_definition.inc.php
@@ -27,12 +27,16 @@ if (!isset($partitionDetails)) {
         && $_REQUEST['partition_count'] > 1
         && isset($_REQUEST['partition_by'])
         && ($_REQUEST['partition_by'] == 'RANGE'
-        || $_REQUEST['partition_by'] == 'LIST');
+        || $_REQUEST['partition_by'] == 'RANGE COLUMNS'
+        || $_REQUEST['partition_by'] == 'LIST'
+        || $_REQUEST['partition_by'] == 'LIST COLUMNS');
 
     // Values are specified only for LIST and RANGE type partitions
     $partitionDetails['value_enabled'] = isset($_REQUEST['partition_by'])
         && ($_REQUEST['partition_by'] == 'RANGE'
-        || $_REQUEST['partition_by'] == 'LIST');
+        || $_REQUEST['partition_by'] == 'RANGE COLUMNS'
+        || $_REQUEST['partition_by'] == 'LIST'
+        || $_REQUEST['partition_by'] == 'LIST COLUMNS');
 
     if (PMA_isValid($_REQUEST['partition_count'], 'numeric')
         && $_REQUEST['partition_count'] > 1
@@ -48,6 +52,7 @@ if (!isset($partitionDetails)) {
         for ($i = 0; $i < $_REQUEST['partition_count']; $i++) {
             if (! isset($partitions[$i])) { // Newly added partition
                 $partitions[$i] = array(
+                    'name' => 'p' . $i,
                     'value_type' => '',
                     'value' => '',
                     'engine' => '',
@@ -62,7 +67,6 @@ if (!isset($partitionDetails)) {
             }
 
             $partition =& $partitions[$i];
-            $partition['name'] = 'p' . $i;
             $partition['prefix'] = 'partitions[' . $i . ']';
 
             // Changing from HASH/KEY to RANGE/LIST
@@ -99,6 +103,7 @@ if (!isset($partitionDetails)) {
                 for ($j = 0; $j < $_REQUEST['subpartition_count']; $j++) {
                     if (! isset($subpartitions[$j])) { // Newly added subpartition
                         $subpartitions[$j] = array(
+                            'name' => $partition['name'] . '_s' . $j,
                             'engine' => '',
                             'comment' => '',
                             'data_directory' => '',
@@ -111,7 +116,6 @@ if (!isset($partitionDetails)) {
                     }
 
                     $subpartition =& $subpartitions[$j];
-                    $subpartition['name'] = 'p' . $i . 's' . $j;
                     $subpartition['prefix'] = 'partitions[' . $i . ']'
                         . '[subpartitions][' . $j . ']';
                 }

--- a/po/ru.po
+++ b/po/ru.po
@@ -15553,7 +15553,7 @@ msgstr "Длина индекса"
 
 #: templates/table/structure/display_partitions.phtml:135
 msgid "Partition table"
-msgstr "Разбить таблицу"
+msgstr "Создать разбиение"
 
 #: templates/table/structure/display_partitions.phtml:138
 #: templates/table/structure/partition_definition_form.phtml:7

--- a/templates/columns_definitions/partitions.phtml
+++ b/templates/columns_definitions/partitions.phtml
@@ -1,5 +1,5 @@
 <?php
-$partitionOptions = array('', 'HASH', 'LINEAR HASH', 'KEY', 'LINEAR KEY', 'RANGE', 'LIST');
+$partitionOptions = array('', 'HASH', 'LINEAR HASH', 'KEY', 'LINEAR KEY', 'RANGE', 'RANGE COLUMNS', 'LIST', 'LIST COLUMNS');
 $subPartitionOptions = array('', 'HASH', 'LINEAR HASH', 'KEY', 'LINEAR KEY');
 $valueTypeOptions = array('', 'LESS THAN', 'LESS THAN MAXVALUE', 'IN');
 ?>
@@ -88,9 +88,10 @@ $valueTypeOptions = array('', 'LESS THAN', 'LESS THAN MAXVALUE', 'IN');
         <?php foreach ($partitionDetails['partitions'] as $partition): ?>
             <?php $rowspan = ! empty($partition['subpartition_count']) ? ($partition['subpartition_count'] + 1) : 2; ?>
             <tr class="<?= ($odd ? 'odd' : 'even'); ?>">
-                <th rowspan="<?= $rowspan; ?>" class="vmiddle">
-                    <?= htmlspecialchars($partition['name']); ?>
-                </th>
+                <td rowspan="<?= $rowspan; ?>">
+                    <input type="text" name="<?= $partition['prefix']; ?>[name]"
+                       value="<?= htmlspecialchars($partition['name']); ?>" />
+                </td>
                 <?php if ($partitionDetails['value_enabled']): ?>
                     <td rowspan="<?= $rowspan; ?>" class="vmiddle">
                         <select class="partition_value"
@@ -123,7 +124,10 @@ $valueTypeOptions = array('', 'LESS THAN', 'LESS THAN MAXVALUE', 'IN');
             <?php foreach ($subpartitions as $subpartition): ?>
                 <tr class="<?= ($odd ? 'odd' : 'even'); ?>">
                     <?php if ($partitionDetails['can_have_subpartitions'] && $partitionDetails['subpartition_count'] > 1): ?>
-                        <th class="vmiddle"><?= htmlspecialchars($subpartition['name']); ?></th>
+                        <td>
+                            <input type="text" name="<?= $subpartition['prefix']; ?>[name]"
+                               value="<?= htmlspecialchars($subpartition['name']); ?>" />
+                        </td>
                     <?php endif; ?>
                     <td>
                         <?= PMA\libraries\StorageEngine::getHtmlSelect(
@@ -135,9 +139,8 @@ $valueTypeOptions = array('', 'LESS THAN', 'LESS THAN MAXVALUE', 'IN');
                         ); ?>
                     </td>
                     <td>
-                        <textarea name="<?= $subpartition['prefix']; ?>[comment]">
-                            <?= htmlspecialchars($subpartition['comment']); ?>
-                        </textarea>
+                        <?php  //Please keep this at one line to avoid extra spaces in textarea value. ?>
+                        <textarea name="<?= $subpartition['prefix']; ?>[comment]"><?= htmlspecialchars($subpartition['comment']); ?></textarea>
                     </td>
                     <td>
                         <input type="text" name="<?= $subpartition['prefix']; ?>[data_directory]"

--- a/templates/table/structure/display_partitions.phtml
+++ b/templates/table/structure/display_partitions.phtml
@@ -22,7 +22,7 @@ use PMA\libraries\Util; ?>
                 <thead>
                     <tr>
                         <th colspan="2">#</th>
-                        <th><?= __('Name'); ?></th>
+                        <th><?= __('Partition'); ?></th>
                         <?php if ($hasDescription): ?>
                             <th><?= __('Expression'); ?></th>
                         <?php endif; ?>
@@ -115,7 +115,7 @@ use PMA\libraries\Util; ?>
                                         <span><?= $value; ?></span>
                                         <span class="unit"><?= $unit; ?></span>
                                     </td>
-                                    <td><?= $subParition->getComment(); ?></td>
+                                    <td><?= htmlspecialchars($subParition->getComment()); ?></td>
                                     <td colspan="<?= $rangeOrList ? '7' : '6'; ?>"></td>
                                 </tr>
                             <?php endforeach; ?>

--- a/templates/table/structure/display_structure.phtml
+++ b/templates/table/structure/display_structure.phtml
@@ -160,7 +160,9 @@ $rownum = 0; $odd_row = true; ?>
         $partitions = Partition::getPartitions($db, $table);
         $firstPartition = $partitions[0];
         $rangeOrList = $firstPartition->getMethod() == 'RANGE'
-            || $firstPartition->getMethod() == 'LIST';
+            || $firstPartition->getMethod() == 'RANGE COLUMNS'
+            || $firstPartition->getMethod() == 'LIST'
+            || $firstPartition->getMethod() == 'LIST COLUMNS';
         $subParitions = $firstPartition->getSubPartitions();
         $hasSubPartitions = $firstPartition->hasSubPartitions();
         if ($hasSubPartitions) {


### PR DESCRIPTION
Fixed issues:
- Table partitions editor does not support 'COLUMNS Partitioning' ('RANGE COLUMNS', 'LIST COLUMNS'). Added in MySQL 5.5 (http://dev.mysql.com/doc/refman/5.5/en/partitioning-columns.html).
- Table partitions editor ignores exising partitions names and overwrites them to 'pXX' on saving.
- The 'Partition maintenance' snippet on 'Operations' tab has duplicate partition names in list when partitioning has subpartitions.
- Partition comment textarea adds extra spaces to value. Caused by word wrap/formatting.

Optimization:
- Optimize Partition::getPartitionMethod() - need only one row, so use 'LIMIT 1' in query to avoid much data transfer from database when table has many partitions/subpartitions.
