### PR TITLE
Fix #12433 : Copy table with prefix does not copy the indexes

### DIFF
--- a/libraries/mult_submits.lib.php
+++ b/libraries/mult_submits.lib.php
@@ -259,15 +259,18 @@ function PMA_buildOrExecuteQueryForMulti(
             break;
 
         case 'copy_tbl_change_prefix':
+            $run_parts = true;
+            $copy_tbl = true;
+
             $current = $selected[$i];
             $newtablename = $to_prefix .
                 mb_substr($current, mb_strlen($from_prefix));
+
             // COPY TABLE AND CHANGE PREFIX PATTERN
-            $a_query = 'CREATE TABLE '
-                . PMA\libraries\Util::backquote($newtablename)
-                . ' SELECT * FROM '
-                . PMA\libraries\Util::backquote($selected[$i]);
-            $run_parts = true;
+            Table::moveCopy(
+                $db, $current, $db, $newtablename,
+                'data', false, 'one_table'
+            );
             break;
 
         case 'copy_tbl':


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

Change the query "CREATE TABLE $newtablename SELECT \* FROM $old" to using Table::moveCopy

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
