### PR TITLE
Additional type check for db_export.php

### DIFF
--- a/db_export.php
+++ b/db_export.php
@@ -110,7 +110,7 @@ foreach ($tables as $each_table) {
     } else {
         $structure_checked = $is_checked;
     }
-    if (isset($_GET['table_data'])) {
+    if (isset($_GET['table_data']) && is_array($_GET['table_data'])) {
         $data_checked = PMA_getCheckedClause(
             $each_table['Name'], $_GET['table_data']
         );


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

Hello. Just a quick one.

File: db_export.php.
- `$_GET['table_data']` in `db_export.php` was accepting both strings and arrays.
- How ever: function `PMA_getCheckedClause()` does accept only arrays.

This clearly creates a bug risk. In order to amend, I added additional `is_array()` check to make sure that only arrays get through. 

Thank you.

Signed-Off-By: Juha Remes jremes@outlook.com.
