### PR TITLE
Add optional column 'Charset' on Database structure page

### DIFF
--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -1071,6 +1071,12 @@ $cfg['ShowCreateDb'] = true;
  * Database structure
  */
 
+/** show charset column in database structure (true|false)?
+ *
+ * @global boolean $cfg['ShowDbStructureCharset']
+ */
+$cfg['ShowDbStructureCharset'] = false;
+
 /**
  * show comment column in database structure (true|false)?
  *

--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -856,6 +856,10 @@ $strConfigShowDbStructureLastCheck_desc = __(
     'Show or hide a column displaying the Last check timestamp for all tables.'
 );
 $strConfigShowDbStructureLastCheck_name = __('Show last check timestamp');
+$strConfigShowDbStructureCharset_desc = __(
+    'Show or hide a column displaying the charset for all tables.'
+);
+$strConfigShowDbStructureCharset_name = __('Show table charset');
 $strConfigShowFieldTypesInDataEditView_desc = __(
     'Defines whether or not type fields should be initially displayed in ' .
     'edit/insert mode.'

--- a/libraries/config/setup.forms.php
+++ b/libraries/config/setup.forms.php
@@ -207,6 +207,7 @@ $forms['Main_panel']['Startup'] = array(
     'ShowPhpInfo',
     'ShowChgPassword');
 $forms['Main_panel']['DbStructure'] = array(
+    'ShowDbStructureCharset',
     'ShowDbStructureComment',
     'ShowDbStructureCreation',
     'ShowDbStructureLastUpdate',

--- a/libraries/config/user_preferences.forms.php
+++ b/libraries/config/user_preferences.forms.php
@@ -114,6 +114,7 @@ $forms['Main_panel']['Startup'] = array(
     'ShowStats',
     'ShowServerInfo');
 $forms['Main_panel']['DbStructure'] = array(
+    'ShowDbStructureCharset',
     'ShowDbStructureComment',
     'ShowDbStructureCreation',
     'ShowDbStructureLastUpdate',

--- a/libraries/controllers/database/DatabaseStructureController.php
+++ b/libraries/controllers/database/DatabaseStructureController.php
@@ -435,7 +435,6 @@ class DatabaseStructureController extends DatabaseController
                 }
             } // end if
 
-            
             if ($GLOBALS['cfg']['ShowDbStructureCharset']) {
                 if (isset($current_table['Collation'])) {
                     $charset = mb_substr($collation, 0, mb_strpos($collation, "_"));

--- a/libraries/controllers/database/DatabaseStructureController.php
+++ b/libraries/controllers/database/DatabaseStructureController.php
@@ -435,6 +435,15 @@ class DatabaseStructureController extends DatabaseController
                 }
             } // end if
 
+            
+            if ($GLOBALS['cfg']['ShowDbStructureCharset']) {
+                if (isset($current_table['Collation'])) {
+                    $charset = mb_substr($collation, 0, mb_strpos($collation, "_"));
+                } else {
+                    $charset = '';
+                }
+            }
+
             if ($GLOBALS['cfg']['ShowDbStructureCreation']) {
                 $create_time = isset($current_table['Create_time'])
                     ? $current_table['Create_time'] : '';
@@ -631,6 +640,8 @@ class DatabaseStructureController extends DatabaseController
                                 ? $update_time : '',
                             'check_time'            => isset($check_time)
                                 ? $check_time : '',
+                            'charset'               => isset($charset)
+                                ? $charset : '',
                             'is_show_stats'         => $this->_is_show_stats,
                             'ignored'               => $ignored,
                             'do'                    => $do,
@@ -651,6 +662,7 @@ class DatabaseStructureController extends DatabaseController
         $this->response->addHTML('</tbody>');
 
         $db_collation = $this->dbi->getDbCollation($this->db);
+        $db_charset = mb_substr($db_collation, 0, mb_strpos($db_collation, "_"));
 
         // Show Summary
         $this->response->addHTML(
@@ -662,6 +674,7 @@ class DatabaseStructureController extends DatabaseController
                     'sum_entries' => $sum_entries,
                     'db_collation' => $db_collation,
                     'is_show_stats' => $this->_is_show_stats,
+                    'db_charset' => $db_charset,
                     'sum_size' => $sum_size,
                     'overhead_size' => $overhead_size,
                     'create_time_all' => $create_time_all,

--- a/templates/database/structure/body_for_table_summary.phtml
+++ b/templates/database/structure/body_for_table_summary.phtml
@@ -58,6 +58,7 @@ $cell_text = ($approx_rows)
         <?php endif; ?>
     </th>
 <?php endif; ?>
+
 <?php if ($is_show_stats): ?>
     <?php
         list($sum_formatted, $unit) = PMA\libraries\Util::formatByteDown(
@@ -68,6 +69,12 @@ $cell_text = ($approx_rows)
     ?>
     <th class="value tbl_size"><?= $sum_formatted , ' ' , $unit; ?></th>
     <th class="value tbl_overhead"><?= $overhead_formatted , ' ' , $overhead_unit; ?></th>
+<?php endif; ?>
+
+<?php if ($GLOBALS['cfg']['ShowDbStructureCharset']): ?>
+    <th>
+        <?= $db_charset; ?>
+    </th>
 <?php endif; ?>
 <?php if ($GLOBALS['cfg']['ShowDbStructureComment']): ?>
     <th></th>

--- a/templates/database/structure/structure_table_row.phtml
+++ b/templates/database/structure/structure_table_row.phtml
@@ -116,6 +116,14 @@
             </td>
         <?php endif; ?>
 
+        <?php if (!($GLOBALS['cfg']['ShowDbStructureCharset'] > 1)): ?>
+            <?php if (strlen($charset)): ?>
+                <td class="nowrap">
+                    <?= $charset; ?>
+                </td>
+            <?php endif; ?>
+        <?php endif; ?>
+
         <?php if ($GLOBALS['cfg']['ShowDbStructureComment']): ?>
             <?php $comment = $current_table['Comment']; ?>
             <td>
@@ -162,6 +170,9 @@
         <?php if ($is_show_stats): ?>
             <td class="value tbl_size">-</td>
             <td class="value tbl_overhead">-</td>
+        <?php endif; ?>
+        <?php if ($GLOBALS['cfg']['ShowDbStructureCharset']): ?>
+            <td></td>
         <?php endif; ?>
         <?php if ($GLOBALS['cfg']['ShowDbStructureComment']): ?>
             <td></td>

--- a/templates/database/structure/table_header.phtml
+++ b/templates/database/structure/table_header.phtml
@@ -78,6 +78,16 @@ if ($GLOBALS['cfg']['NumFavoriteTables'] > 0) {
                     ); $cnt++; ?></th>
             <?php endif; ?>
 
+            <?php if ($GLOBALS['cfg']['ShowDbStructureCharset']): ?>
+                <th><?= PMA\libraries\Template::get('database/structure/sortable_header')->render(
+                        array(
+                            'title' => __('Charset'),
+                            'sort' => 'charset',
+                            'initial_sort_order' => 'ASC'
+                        )
+                    ); $cnt++; ?></th>
+            <?php endif; ?>
+
             <?php if ($GLOBALS['cfg']['ShowDbStructureComment']): ?>
                 <th><?= PMA\libraries\Template::get('database/structure/sortable_header')->render(
                         array(


### PR DESCRIPTION
Fix #12162 

Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

Add an option to add a Column on Database structure page which shows the charset of each table/view

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
