### PR TITLE
Scroll (using Animate) only when result div is visible

### DIFF
--- a/js/db_search.js
+++ b/js/db_search.js
@@ -48,16 +48,16 @@ function loadResult(result_path, table_name, link)
         $.get(url, {'ajax_request': true, 'is_js_confirmed': true}, function (data) {
             if (typeof data !== 'undefined' && data.success) {
                 $('#browse-results').html(data.message);
-                $('html, body')
-                    .animate({
-                        scrollTop: $("#browse-results").offset().top
-                    }, 1000);
                 PMA_ajaxRemoveMessage($msg);
                 $('.table_results').each(function () {
                     PMA_makegrid(this, true, true, true, true);
                 });
                 $('#browse-results').show();
                 PMA_highlightSQL($('#browse-results'));
+                $('html, body')
+                    .animate({
+                        scrollTop: $("#browse-results").offset().top
+                    }, 1000);
             } else {
                 PMA_ajaxShowMessage(data.error, false);
             }


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

We load the result div using data from AJAX request and make the div visible.
So, we should scroll down once the div is visible and loaded with the appropriate data.

Fix #12375

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
