### PR TITLE
When editing table records, display readonly inputs for fields without write access.

### DIFF
--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -379,12 +379,13 @@ function PMA_getEnumSetAndTimestampColumns($column, $timestamp_seen)
  * @param integer $tabindex              tab index
  * @param integer $idindex               id index
  * @param boolean $insert_mode           insert mode or edit mode
+ * @param boolean $readOnly              is column read only or not
  *
  * @return string                           an html snippet
  */
 function PMA_getFunctionColumn($column, $is_upload, $column_name_appendix,
     $onChangeClause, $no_support_types, $tabindex_for_function,
-    $tabindex, $idindex, $insert_mode
+    $tabindex, $idindex, $insert_mode, $readOnly
 ) {
     $html_output = '';
     if (($GLOBALS['cfg']['ProtectBinary'] === 'blob'
@@ -395,7 +396,8 @@ function PMA_getFunctionColumn($column, $is_upload, $column_name_appendix,
         && $column['is_binary'])
     ) {
         $html_output .= '<td class="center">' . __('Binary') . '</td>' . "\n";
-    } elseif (mb_strstr($column['True_Type'], 'enum')
+    } elseif ($readOnly
+        || mb_strstr($column['True_Type'], 'enum')
         || mb_strstr($column['True_Type'], 'set')
         || in_array($column['pma_type'], $no_support_types)
     ) {
@@ -430,13 +432,15 @@ function PMA_getFunctionColumn($column, $is_upload, $column_name_appendix,
  * @param string  $vkey                 [multi_edit]['row_id']
  * @param array   $foreigners           keys into foreign fields
  * @param array   $foreignData          data about the foreign keys
+ * @param boolean $readOnly             is column read only or not
  *
  * @return string                       an html snippet
  */
 function PMA_getNullColumn($column, $column_name_appendix, $real_null_value,
-    $tabindex, $tabindex_for_null, $idindex, $vkey, $foreigners, $foreignData
+    $tabindex, $tabindex_for_null, $idindex, $vkey, $foreigners, $foreignData,
+    $readOnly
 ) {
-    if ($column['Null'] != 'YES') {
+    if ($column['Null'] != 'YES' || $readOnly) {
         return "<td></td>\n";
     }
     $html_output = '';
@@ -544,6 +548,7 @@ function PMA_getNullifyCodeForNullColumn($column, $foreigners, $foreignData)
  * @param array   $extracted_columnspec  associative array containing type,
  *                                       spec_in_brackets and possibly
  *                                       enum_set_values (another array)
+ * @param boolean $readOnly              is column read only or not
  *
  * @return string an html snippet
  */
@@ -552,7 +557,8 @@ function PMA_getValueColumn($column, $backup_field, $column_name_appendix,
     $special_chars, $foreignData, $odd_row, $paramTableDbArray, $rownumber,
     $titles, $text_dir, $special_chars_encoded, $vkey,
     $is_upload, $biggest_max_file_size,
-    $default_char_editing, $no_support_types, $gis_data_types, $extracted_columnspec
+    $default_char_editing, $no_support_types, $gis_data_types, $extracted_columnspec,
+    $readOnly
 ) {
     // HTML5 data-* attribute data-type
     $data_type = $GLOBALS['PMA_Types']->getTypeClass($column['True_Type']);
@@ -562,14 +568,14 @@ function PMA_getValueColumn($column, $backup_field, $column_name_appendix,
         $html_output .= PMA_getForeignLink(
             $column, $backup_field, $column_name_appendix,
             $onChangeClause, $tabindex, $tabindex_for_value, $idindex, $data,
-            $paramTableDbArray, $rownumber, $titles
+            $paramTableDbArray, $rownumber, $titles, $readOnly
         );
 
     } elseif (is_array($foreignData['disp_row'])) {
         $html_output .= PMA_dispRowForeignData(
             $backup_field, $column_name_appendix,
             $onChangeClause, $tabindex, $tabindex_for_value,
-            $idindex, $data, $foreignData
+            $idindex, $data, $foreignData, $readOnly
         );
 
     } elseif ($GLOBALS['cfg']['LongtextDoubleTextarea']
@@ -582,7 +588,7 @@ function PMA_getValueColumn($column, $backup_field, $column_name_appendix,
         $html_output .= PMA_getTextarea(
             $column, $backup_field, $column_name_appendix, $onChangeClause,
             $tabindex, $tabindex_for_value, $idindex, $text_dir,
-            $special_chars_encoded, $data_type
+            $special_chars_encoded, $data_type, $readOnly
         );
 
     } elseif (mb_strstr($column['pma_type'], 'text')) {
@@ -590,7 +596,7 @@ function PMA_getValueColumn($column, $backup_field, $column_name_appendix,
         $html_output .= PMA_getTextarea(
             $column, $backup_field, $column_name_appendix, $onChangeClause,
             $tabindex, $tabindex_for_value, $idindex, $text_dir,
-            $special_chars_encoded, $data_type
+            $special_chars_encoded, $data_type, $readOnly
         );
         $html_output .= "\n";
         if (mb_strlen($special_chars) > 32000) {
@@ -603,14 +609,15 @@ function PMA_getValueColumn($column, $backup_field, $column_name_appendix,
     } elseif ($column['pma_type'] == 'enum') {
         $html_output .= PMA_getPmaTypeEnum(
             $column, $backup_field, $column_name_appendix, $extracted_columnspec,
-            $onChangeClause, $tabindex, $tabindex_for_value, $idindex, $data
+            $onChangeClause, $tabindex, $tabindex_for_value, $idindex, $data,
+            $readOnly
         );
 
     } elseif ($column['pma_type'] == 'set') {
         $html_output .= PMA_getPmaTypeSet(
             $column, $extracted_columnspec, $backup_field,
             $column_name_appendix, $onChangeClause, $tabindex,
-            $tabindex_for_value, $idindex, $data
+            $tabindex_for_value, $idindex, $data, $readOnly
         );
 
     } elseif ($column['is_binary'] || $column['is_blob']) {
@@ -618,7 +625,7 @@ function PMA_getValueColumn($column, $backup_field, $column_name_appendix,
             $column, $data, $special_chars, $biggest_max_file_size,
             $backup_field, $column_name_appendix, $onChangeClause, $tabindex,
             $tabindex_for_value, $idindex, $text_dir, $special_chars_encoded,
-            $vkey, $is_upload
+            $vkey, $is_upload, $readOnly
         );
 
     } elseif (! in_array($column['pma_type'], $no_support_types)) {
@@ -626,7 +633,7 @@ function PMA_getValueColumn($column, $backup_field, $column_name_appendix,
             $column, $default_char_editing, $backup_field,
             $column_name_appendix, $onChangeClause, $tabindex, $special_chars,
             $tabindex_for_value, $idindex, $text_dir, $special_chars_encoded,
-            $data, $extracted_columnspec
+            $data, $extracted_columnspec, $readOnly
         );
     }
 
@@ -653,12 +660,13 @@ function PMA_getValueColumn($column, $backup_field, $column_name_appendix,
  * @param array   $titles               An HTML IMG tag for a particular icon from
  *                                      a theme, which may be an actual file or
  *                                      an icon from a sprite
+ * @param boolean $readOnly             is column read only or not
  *
  * @return string                       an html snippet
  */
 function PMA_getForeignLink($column, $backup_field, $column_name_appendix,
     $onChangeClause, $tabindex, $tabindex_for_value, $idindex, $data,
-    $paramTableDbArray, $rownumber, $titles
+    $paramTableDbArray, $rownumber, $titles, $readOnly
 ) {
     list($table, $db) = $paramTableDbArray;
     $html_output = '';
@@ -670,6 +678,7 @@ function PMA_getForeignLink($column, $backup_field, $column_name_appendix,
     $html_output .= '<input type="text" name="fields' . $column_name_appendix . '" '
         . 'class="textfield" '
         . $onChangeClause . ' '
+        . ($readOnly ? 'readonly="readonly" ' : '')
         . 'tabindex="' . ($tabindex + $tabindex_for_value) . '" '
         . 'id="field_' . ($idindex) . '_3" '
         . 'value="' . htmlspecialchars($data) . '" />';
@@ -699,12 +708,13 @@ function PMA_getForeignLink($column, $backup_field, $column_name_appendix,
  * @param integer $idindex              id index
  * @param string  $data                 data to edit
  * @param array   $foreignData          data about the foreign keys
+ * @param boolean $readOnly             is display read only or not
  *
  * @return string                       an html snippet
  */
 function PMA_dispRowForeignData($backup_field, $column_name_appendix,
     $onChangeClause, $tabindex, $tabindex_for_value, $idindex, $data,
-    $foreignData
+    $foreignData, $readOnly
 ) {
     $html_output = '';
     $html_output .= $backup_field . "\n";
@@ -715,6 +725,7 @@ function PMA_dispRowForeignData($backup_field, $column_name_appendix,
     $html_output .= '<select name="fields' . $column_name_appendix . '"'
         . ' ' . $onChangeClause
         . ' class="textfield"'
+        . ($readOnly ? ' disabled' : '')
         . ' tabindex="' . ($tabindex + $tabindex_for_value) . '"'
         . ' id="field_' . $idindex . '_3">';
     $html_output .= PMA_foreignDropdown(
@@ -723,6 +734,12 @@ function PMA_dispRowForeignData($backup_field, $column_name_appendix,
         $GLOBALS['cfg']['ForeignKeyMaxLimit']
     );
     $html_output .= '</select>';
+
+    //Add hidden input, as disabled <select> input does not included in POST.
+    if ($readOnly) {
+        $html_output .= '<input name="fields' . $column_name_appendix . '"'
+            . ' type="hidden" value="' . htmlspecialchars($data) . '">';
+    }
 
     return $html_output;
 }
@@ -741,12 +758,13 @@ function PMA_dispRowForeignData($backup_field, $column_name_appendix,
  * @param string  $special_chars_encoded replaced char if the string starts
  *                                       with a \r\n pair (0x0d0a) add an extra \n
  * @param string  $data_type             the html5 data-* attribute type
+ * @param boolean $readOnly              is column read only or not
  *
  * @return string                       an html snippet
  */
 function PMA_getTextarea($column, $backup_field, $column_name_appendix,
     $onChangeClause, $tabindex, $tabindex_for_value, $idindex,
-    $text_dir, $special_chars_encoded, $data_type
+    $text_dir, $special_chars_encoded, $data_type, $readOnly
 ) {
     $the_class = '';
     $textAreaRows = $GLOBALS['cfg']['TextareaRows'];
@@ -773,6 +791,7 @@ function PMA_getTextarea($column, $backup_field, $column_name_appendix,
     $html_output = $backup_field . "\n"
         . '<textarea name="fields' . $column_name_appendix . '"'
         . ' class="' . $the_class . '"'
+        . ($readOnly ? ' readonly="readonly"' : '')
         . (isset($maxlength) ? ' data-maxlength="' . $maxlength . '"' : '')
         . ' rows="' . $textAreaRows . '"'
         . ' cols="' . $textareaCols . '"'
@@ -801,12 +820,13 @@ function PMA_getTextarea($column, $backup_field, $column_name_appendix,
  * @param integer $tabindex_for_value   offset for the values tabindex
  * @param integer $idindex              id index
  * @param mixed   $data                 data to edit
+ * @param boolean $readOnly             is column read only or not
  *
  * @return string an html snippet
  */
 function PMA_getPmaTypeEnum($column, $backup_field, $column_name_appendix,
     $extracted_columnspec, $onChangeClause, $tabindex, $tabindex_for_value,
-    $idindex, $data
+    $idindex, $data, $readOnly
 ) {
     $html_output = '';
     if (! isset($column['values'])) {
@@ -821,13 +841,14 @@ function PMA_getPmaTypeEnum($column, $backup_field, $column_name_appendix,
     if (mb_strlen($column['Type']) > 20) {
         $html_output .= PMA_getDropDownDependingOnLength(
             $column, $column_name_appendix, $onChangeClause,
-            $tabindex, $tabindex_for_value, $idindex, $data, $column_enum_values
+            $tabindex, $tabindex_for_value,
+            $idindex, $data, $column_enum_values, $readOnly
         );
     } else {
         $html_output .= PMA_getRadioButtonDependingOnLength(
             $column_name_appendix, $onChangeClause,
             $tabindex, $column, $tabindex_for_value,
-            $idindex, $data, $column_enum_values
+            $idindex, $data, $column_enum_values, $readOnly
         );
     }
     return $html_output;
@@ -871,15 +892,18 @@ function PMA_getColumnEnumValues($column, $extracted_columnspec)
  */
 function PMA_getDropDownDependingOnLength(
     $column, $column_name_appendix, $onChangeClause,
-    $tabindex, $tabindex_for_value, $idindex, $data, $column_enum_values
+    $tabindex, $tabindex_for_value, $idindex, $data, $column_enum_values,
+    $readOnly
 ) {
     $html_output = '<select name="fields' . $column_name_appendix . '"'
         . ' ' . $onChangeClause
         . ' class="textfield"'
         . ' tabindex="' . ($tabindex + $tabindex_for_value) . '"'
+        . ($readOnly ? ' disabled' : '')
         . ' id="field_' . ($idindex) . '_3">';
     $html_output .= '<option value="">&nbsp;</option>' . "\n";
 
+    $selected_html = '';
     foreach ($column_enum_values as $enum_value) {
         $html_output .= '<option value="' . $enum_value['html'] . '"';
         if ($data == $enum_value['plain']
@@ -889,10 +913,17 @@ function PMA_getDropDownDependingOnLength(
             && $enum_value['plain'] == $column['Default'])
         ) {
             $html_output .= ' selected="selected"';
+            $selected_html = $enum_value['html'];
         }
         $html_output .= '>' . $enum_value['html'] . '</option>' . "\n";
     }
     $html_output .= '</select>';
+
+    //Add hidden input, as disabled <select> input does not included in POST.
+    if ($readOnly) {
+        $html_output .= '<input name="fields' . $column_name_appendix . '"'
+            . ' type="hidden" value="' . $selected_html . '">';
+    }
     return $html_output;
 }
 
@@ -912,7 +943,8 @@ function PMA_getDropDownDependingOnLength(
  */
 function PMA_getRadioButtonDependingOnLength(
     $column_name_appendix, $onChangeClause,
-    $tabindex, $column, $tabindex_for_value, $idindex, $data, $column_enum_values
+    $tabindex, $column, $tabindex_for_value, $idindex, $data,
+    $column_enum_values, $readOnly
 ) {
     $j = 0;
     $html_output = '';
@@ -930,6 +962,9 @@ function PMA_getRadioButtonDependingOnLength(
             && $enum_value['plain'] == $column['Default'])
         ) {
             $html_output .= ' checked="checked"';
+        }
+        elseif ($readOnly) {
+            $html_output .= ' disabled';
         }
         $html_output .= ' tabindex="' . ($tabindex + $tabindex_for_value) . '" />';
         $html_output .= '<label for="field_' . $idindex . '_3_' . $j . '">'
@@ -953,13 +988,14 @@ function PMA_getRadioButtonDependingOnLength(
  * @param integer $tabindex_for_value   offset for the values tabindex
  * @param integer $idindex              id index
  * @param string  $data                 description of the column field
+ * @param boolean $readOnly             is column read only or not
  *
  * @return string                       an html snippet
  */
 function PMA_getPmaTypeSet(
     $column, $extracted_columnspec, $backup_field,
     $column_name_appendix, $onChangeClause, $tabindex,
-    $tabindex_for_value, $idindex, $data
+    $tabindex_for_value, $idindex, $data, $readOnly
 ) {
     list($column_set_values, $select_size) = PMA_getColumnSetValueAndSelectSize(
         $column, $extracted_columnspec
@@ -970,19 +1006,29 @@ function PMA_getPmaTypeSet(
         . $column_name_appendix . '" value="set" />';
     $html_output .= '<select name="fields' . $column_name_appendix . '[]' . '"'
         . ' class="textfield"'
+        . ($readOnly ? ' disabled' : '')
         . ' size="' . $select_size . '"'
         . ' multiple="multiple"'
         . ' ' . $onChangeClause
         . ' tabindex="' . ($tabindex + $tabindex_for_value) . '"'
         . ' id="field_' . ($idindex) . '_3">';
+
+    $selected_html = '';
     foreach ($column_set_values as $column_set_value) {
         $html_output .= '<option value="' . $column_set_value['html'] . '"';
         if (isset($vset[$column_set_value['plain']])) {
             $html_output .= ' selected="selected"';
+            $selected_html = $column_set_value['html'];
         }
         $html_output .= '>' . $column_set_value['html'] . '</option>' . "\n";
     }
     $html_output .= '</select>';
+
+    //Add hidden input, as disabled <select> input does not included in POST.
+    if ($readOnly) {
+        $html_output .= '<input name="fields' . $column_name_appendix . '[]' . '"'
+            . ' type="hidden" value="' . $selected_html . '">';
+    }
     return $html_output;
 }
 
@@ -1029,6 +1075,7 @@ function PMA_getColumnSetValueAndSelectSize($column, $extracted_columnspec)
  *                                       with a \r\n pair (0x0d0a) add an extra \n
  * @param string  $vkey                  [multi_edit]['row_id']
  * @param boolean $is_upload             is upload or not
+ * @param boolean $readOnly              is column read only or not
  *
  * @return string                           an html snippet
  */
@@ -1036,7 +1083,7 @@ function PMA_getBinaryAndBlobColumn(
     $column, $data, $special_chars, $biggest_max_file_size,
     $backup_field, $column_name_appendix, $onChangeClause, $tabindex,
     $tabindex_for_value, $idindex, $text_dir, $special_chars_encoded,
-    $vkey, $is_upload
+    $vkey, $is_upload, $readOnly
 ) {
     $html_output = '';
     // Add field type : Protected or Hexadecimal
@@ -1065,19 +1112,20 @@ function PMA_getBinaryAndBlobColumn(
         $html_output .= "\n" . PMA_getTextarea(
             $column, $backup_field, $column_name_appendix, $onChangeClause,
             $tabindex, $tabindex_for_value, $idindex, $text_dir,
-            $special_chars_encoded, 'HEX'
+            $special_chars_encoded, 'HEX', $readOnly
         );
     } else {
         // field size should be at least 4 and max $GLOBALS['cfg']['LimitChars']
         $fieldsize = min(max($column['len'], 4), $GLOBALS['cfg']['LimitChars']);
         $html_output .= "\n" . $backup_field . "\n" . PMA_getHTMLinput(
             $column, $column_name_appendix, $special_chars, $fieldsize,
-            $onChangeClause, $tabindex, $tabindex_for_value, $idindex, 'HEX'
+            $onChangeClause, $tabindex, $tabindex_for_value, $idindex, 'HEX',
+            $readOnly
         );
     }
     $html_output .= sprintf($fields_type_html, $fields_type_val);
 
-    if ($is_upload && $column['is_blob']) {
+    if ($is_upload && $column['is_blob'] && !$readOnly) {
         $html_output .= '<br />'
             . '<input type="file"'
             . ' name="fields_upload' . $vkey . '[' . $column['Field_md5'] . ']"'
@@ -1089,7 +1137,7 @@ function PMA_getBinaryAndBlobColumn(
         $html_output .= $html_out;
     }
 
-    if (!empty($GLOBALS['cfg']['UploadDir'])) {
+    if (!empty($GLOBALS['cfg']['UploadDir']) && !$readOnly) {
         $html_output .= PMA_getSelectOptionForUpload($vkey, $column);
     }
 
@@ -1108,12 +1156,13 @@ function PMA_getBinaryAndBlobColumn(
  * @param integer $tabindex_for_value   offset for the values tabindex
  * @param integer $idindex              id index
  * @param string  $data_type            the html5 data-* attribute type
+ * @param boolean $readOnly             is column read only or not
  *
  * @return string                       an html snippet
  */
 function PMA_getHTMLinput(
     $column, $column_name_appendix, $special_chars, $fieldsize, $onChangeClause,
-    $tabindex, $tabindex_for_value, $idindex, $data_type
+    $tabindex, $tabindex_for_value, $idindex, $data_type, $readOnly
 ) {
     $input_type = 'text';
     // do not use the 'date' or 'time' types here; they have no effect on some
@@ -1121,7 +1170,9 @@ function PMA_getHTMLinput(
 
     $the_class = 'textfield';
     // verify True_Type which does not contain the parentheses and length
-    if ($column['True_Type'] === 'date') {
+    if ($readOnly) {
+        //NOOP. Disable date/timepicker
+    } else if ($column['True_Type'] === 'date') {
         $the_class .= ' datefield';
     } else if ($column['True_Type'] === 'time') {
         $the_class .= ' timefield';
@@ -1149,6 +1200,7 @@ function PMA_getHTMLinput(
         . ((isset($column['is_char']) && $column['is_char'])
         ? ' data-maxlength="' . $fieldsize . '"'
         : '')
+        . ($readOnly ? ' readonly="readonly"' : '')
         . ($input_min_max !== false ? ' ' . $input_min_max : '')
         . ' data-type="' . $data_type . '"'
         . ($input_type === 'time' ? ' step="1"' : '')
@@ -1248,6 +1300,7 @@ function PMA_getMaxUploadSize($column, $biggest_max_file_size)
  * @param array   $extracted_columnspec  associative array containing type,
  *                                       spec_in_brackets and possibly
  *                                       enum_set_values (another array)
+ * @param boolean $readOnly              is column read only or not
  *
  * @return string an html snippet
  */
@@ -1255,7 +1308,7 @@ function PMA_getValueColumnForOtherDatatypes($column, $default_char_editing,
     $backup_field,
     $column_name_appendix, $onChangeClause, $tabindex, $special_chars,
     $tabindex_for_value, $idindex, $text_dir, $special_chars_encoded, $data,
-    $extracted_columnspec
+    $extracted_columnspec, $readOnly
 ) {
     // HTML5 data-* attribute data-type
     $data_type = $GLOBALS['PMA_Types']->getTypeClass($column['True_Type']);
@@ -1270,12 +1323,13 @@ function PMA_getValueColumnForOtherDatatypes($column, $default_char_editing,
         $html_output .= PMA_getTextarea(
             $column, $backup_field, $column_name_appendix, $onChangeClause,
             $tabindex, $tabindex_for_value, $idindex, $text_dir,
-            $special_chars_encoded, $data_type
+            $special_chars_encoded, $data_type, $readOnly
         );
     } else {
         $html_output .= PMA_getHTMLinput(
             $column, $column_name_appendix, $special_chars, $fieldsize,
-            $onChangeClause, $tabindex, $tabindex_for_value, $idindex, $data_type
+            $onChangeClause, $tabindex, $tabindex_for_value, $idindex,
+            $data_type, $readOnly
         );
 
         $virtual = array(
@@ -2700,6 +2754,11 @@ function PMA_getHtmlForInsertEditFormColumn($table_columns, $column_number,
     $text_dir, $repopulate, $column_mime, $where_clause
 ) {
     $column = $table_columns[$column_number];
+    $readOnly = false;
+    if (! PMA_userHasColumnPrivileges($column, $insert_mode)) {
+        $readOnly = true;
+    }
+
     if (! isset($column['processed'])) {
         $column = PMA_analyzeTableColumnsArray(
             $column, $comments_map, $timestamp_seen
@@ -2794,7 +2853,7 @@ function PMA_getHtmlForInsertEditFormColumn($table_columns, $column_number,
         $html_output .= PMA_getFunctionColumn(
             $column, $is_upload, $column_name_appendix,
             $onChangeClause, $no_support_types, $tabindex_for_function,
-            $tabindex, $idindex, $insert_mode
+            $tabindex, $idindex, $insert_mode, $readOnly
         );
     }
 
@@ -2806,7 +2865,7 @@ function PMA_getHtmlForInsertEditFormColumn($table_columns, $column_number,
     $html_output .= PMA_getNullColumn(
         $column, $column_name_appendix, $real_null_value,
         $tabindex, $tabindex_for_null, $idindex, $vkey, $foreigners,
-        $foreignData
+        $foreignData, $readOnly
     );
 
     // The value column (depends on type)
@@ -2875,7 +2934,7 @@ function PMA_getHtmlForInsertEditFormColumn($table_columns, $column_number,
             $foreignData, $odd_row, array($table, $db), $row_id, $titles,
             $text_dir, $special_chars_encoded, $vkey, $is_upload,
             $biggest_max_file_size, $default_char_editing,
-            $no_support_types, $gis_data_types, $extracted_columnspec
+            $no_support_types, $gis_data_types, $extracted_columnspec, $readOnly
         );
     }
     $html_output .= '</td>'
@@ -2936,10 +2995,6 @@ function PMA_getHtmlForInsertEditRow($url_params, $table_columns,
     }
     for ($column_number = 0; $column_number < $columns_cnt; $column_number++) {
         $table_column = $table_columns[$column_number];
-        // skip this column if user does not have necessary column privilges
-        if (! PMA_userHasColumnPrivileges($table_column, $insert_mode)) {
-            continue;
-        }
         $column_mime = array();
         if (isset($mime_map[$table_column['Field']])) {
             $column_mime = $mime_map[$table_column['Field']];

--- a/test/libraries/PMA_insert_edit_test.php
+++ b/test/libraries/PMA_insert_edit_test.php
@@ -561,34 +561,44 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $column['is_blob'] = true;
         $this->assertContains(
             '<td class="center">Binary</td>',
-            PMA_getFunctionColumn($column, false, '', '', array(), 0, 0, 0, false)
+            PMA_getFunctionColumn(
+                $column, false, '', '', array(), 0, 0, 0, false, false
+            )
         );
 
         $GLOBALS['cfg']['ProtectBinary'] = 'all';
         $column['is_binary'] = true;
         $this->assertContains(
             '<td class="center">Binary</td>',
-            PMA_getFunctionColumn($column, true, '', '', array(), 0, 0, 0, false)
+            PMA_getFunctionColumn(
+                $column, true, '', '', array(), 0, 0, 0, false, false
+            )
         );
 
         $GLOBALS['cfg']['ProtectBinary'] = 'noblob';
         $column['is_blob'] = false;
         $this->assertContains(
             '<td class="center">Binary</td>',
-            PMA_getFunctionColumn($column, true, '', '', array(), 0, 0, 0, false)
+            PMA_getFunctionColumn(
+                $column, true, '', '', array(), 0, 0, 0, false, false
+            )
         );
 
         $GLOBALS['cfg']['ProtectBinary'] = false;
         $column['True_Type'] = 'enum';
         $this->assertContains(
             '<td class="center">--</td>',
-            PMA_getFunctionColumn($column, true, '', '', array(), 0, 0, 0, false)
+            PMA_getFunctionColumn(
+                $column, true, '', '', array(), 0, 0, 0, false, false
+            )
         );
 
         $column['True_Type'] = 'set';
         $this->assertContains(
             '<td class="center">--</td>',
-            PMA_getFunctionColumn($column, true, '', '', array(), 0, 0, 0, false)
+            PMA_getFunctionColumn(
+                $column, true, '', '', array(), 0, 0, 0, false, false
+            )
         );
 
         $column['True_Type'] = '';
@@ -596,7 +606,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $this->assertContains(
             '<td class="center">--</td>',
             PMA_getFunctionColumn(
-                $column, true, '', '', array('int'), 0, 0, 0, false
+                $column, true, '', '', array('int'), 0, 0, 0, false, false
             )
         );
 
@@ -605,7 +615,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $this->assertContains(
             '<select name="funcsa" b tabindex="5" id="field_3_1"',
             PMA_getFunctionColumn(
-                $column, true, 'a', 'b', array(), 2, 3, 3, false
+                $column, true, 'a', 'b', array(), 2, 3, 3, false, false
             )
         );
     }
@@ -628,7 +638,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         );
 
         $result = PMA_getNullColumn(
-            $column, 'a', true, 2, 0, 1, "<script>", $foreigners, array()
+            $column, 'a', true, 2, 0, 1, "<script>", $foreigners, array(), false
         );
 
         $this->assertContains(
@@ -663,7 +673,18 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         // case 2
         $column['Null'] = 'NO';
         $result = PMA_getNullColumn(
-            $column, 'a', true, 2, 0, 1, "<script>", array(), array()
+            $column, 'a', true, 2, 0, 1, "<script>", array(), array(), false
+        );
+
+        $this->assertEquals(
+            "<td></td>\n",
+            $result
+        );
+
+        // case 3
+        $column['Null'] = 'YES';
+        $result = PMA_getNullColumn(
+            $column, 'a', true, 2, 0, 1, "<script>", array(), array(), true
         );
 
         $this->assertEquals(
@@ -725,7 +746,8 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $titles['Browse'] = "'";
         $GLOBALS['cfg']['ServerDefault'] = 2;
         $result = PMA_getForeignLink(
-            $column, 'a', 'b', 'd', 2, 0, 1, "abc", array('tbl', 'db'), 8, $titles
+            $column, 'a', 'b', 'd', 2, 0, 1, "abc", array('tbl', 'db'), 8,
+            $titles, false
         );
 
         $this->assertContains(
@@ -762,7 +784,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $GLOBALS['cfg']['ForeignKeyMaxLimit'] = 1;
         $GLOBALS['cfg']['NaturalOrder'] = false;
         $result = PMA_dispRowForeignData(
-            'a', 'b', 'd', 2, 0, 1, "<s>", $foreignData
+            'a', 'b', 'd', 2, 0, 1, "<s>", $foreignData, false
         );
 
         $this->assertContains(
@@ -800,7 +822,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $column['Type'] = 'char(10)';
         $column['True_Type'] = 'char';
         $result = PMA_getTextarea(
-            $column, 'a', 'b', '', 2, 0, 1, "abc/", 'foobar', 'CHAR'
+            $column, 'a', 'b', '', 2, 0, 1, "abc/", 'foobar', 'CHAR', false
         );
 
         $this->assertContains(
@@ -828,7 +850,8 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
             )
         );
         $result = PMA_getPmaTypeEnum(
-            $column, 'a', 'b', $extracted_columnspec, 'd', 2, 0, 1, 'foobar'
+            $column, 'a', 'b', $extracted_columnspec, 'd', 2, 0, 1,
+            'foobar', false
         );
 
         $this->assertContains(
@@ -843,7 +866,8 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
 
         $column['Type'] = 'ababababababababababa';
         $result = PMA_getPmaTypeEnum(
-            $column, 'a', 'b', $extracted_columnspec, 'd', 2, 0, 1, 'foobar'
+            $column, 'a', 'b', $extracted_columnspec, 'd', 2, 0, 1,
+            'foobar', false
         );
 
         $this->assertContains(
@@ -901,7 +925,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         );
 
         $result = PMA_getDropDownDependingOnLength(
-            array(), 'a', 'b', 2, 0, 1, 'data', $column_enum_values
+            array(), 'a', 'b', 2, 0, 1, 'data', $column_enum_values, false
         );
 
         $this->assertContains(
@@ -932,7 +956,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $column['Default'] = 'data';
         $column['Null'] = 'YES';
         $result = PMA_getDropDownDependingOnLength(
-            $column, 'a', 'b', 2, 0, 1, '', $column_enum_values
+            $column, 'a', 'b', 2, 0, 1, '', $column_enum_values, false
         );
 
         $this->assertContains(
@@ -960,7 +984,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         );
 
         $result = PMA_getRadioButtonDependingOnLength(
-            'a', 'b', 2, array(), 0, 1, 'data', $column_enum_values
+            'a', 'b', 2, array(), 0, 1, 'data', $column_enum_values, false
         );
 
         $this->assertContains(
@@ -997,7 +1021,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $column['Default'] = 'data';
         $column['Null'] = 'YES';
         $result = PMA_getRadioButtonDependingOnLength(
-            'a', 'b', 2, $column, 0, 1, '', $column_enum_values
+            'a', 'b', 2, $column, 0, 1, '', $column_enum_values, false
         );
 
         $this->assertContains(
@@ -1025,7 +1049,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $column['select_size'] = 1;
 
         $result = PMA_getPmaTypeSet(
-            $column, array(), 'a', 'b', 'c', 2, 0, 1, 'data,<'
+            $column, array(), 'a', 'b', 'c', 2, 0, 1, 'data,<', false
         );
 
         $this->assertContains("a\n", $result);
@@ -1100,7 +1124,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
 
         $result = PMA_getBinaryAndBlobColumn(
             $column, '12\\"23', null, 20, 'a', 'b', 'c', 2, 1, 1, '/', null,
-            'foo', true
+            'foo', true, false
         );
 
         $this->assertEquals(
@@ -1118,7 +1142,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
 
         $result = PMA_getBinaryAndBlobColumn(
             $column, '1223', null, 20, 'a', 'b', 'c', 2, 1, 1, '/', null,
-            'foo', false
+            'foo', false, false
         );
 
         $this->assertEquals(
@@ -1134,7 +1158,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
 
         $result = PMA_getBinaryAndBlobColumn(
             $column, '1223', null, 20, 'a', 'b', 'c', 2, 1, 1, '/', null,
-            'foo', true
+            'foo', true, false
         );
 
         $this->assertEquals(
@@ -1157,7 +1181,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
 
         $result = PMA_getBinaryAndBlobColumn(
             $column, '1223', null, 20, 'a', 'b', 'c', 2, 1, 1, '/', null,
-            'foo', true
+            'foo', true, false
         );
 
         $this->assertEquals(
@@ -1182,7 +1206,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
 
         $result = PMA_getBinaryAndBlobColumn(
             $column, '1223', null, 20, 'a', 'b', 'c', 2, 1, 1, '/', null,
-            'foo', true
+            'foo', true, false
         );
 
         $this->assertEquals(
@@ -1208,7 +1232,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
 
         $result = PMA_getBinaryAndBlobColumn(
             $column, '1223', null, 20, 'a', 'b', 'c', 2, 1, 1, '/', null,
-            'foo', true
+            'foo', true, false
         );
 
         $this->assertEquals(
@@ -1231,7 +1255,9 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $column = array();
         $column['pma_type'] = 'date';
         $column['True_Type'] = 'date';
-        $result = PMA_getHTMLinput($column, 'a', 'b', 30, 'c', 23, 2, 0, 'DATE');
+        $result = PMA_getHTMLinput(
+            $column, 'a', 'b', 30, 'c', 23, 2, 0, 'DATE', false
+        );
 
         $this->assertEquals(
             '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
@@ -1242,7 +1268,9 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         // case 2 datetime
         $column['pma_type'] = 'datetime';
         $column['True_Type'] = 'datetime';
-        $result = PMA_getHTMLinput($column, 'a', 'b', 30, 'c', 23, 2, 0, 'DATE');
+        $result = PMA_getHTMLinput(
+            $column, 'a', 'b', 30, 'c', 23, 2, 0, 'DATE', false
+        );
         $this->assertEquals(
             '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
             . ' class="textfield datetimefield" c tabindex="25" id="field_0_3" />',
@@ -1252,7 +1280,9 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         // case 3 timestamp
         $column['pma_type'] = 'timestamp';
         $column['True_Type'] = 'timestamp';
-        $result = PMA_getHTMLinput($column, 'a', 'b', 30, 'c', 23, 2, 0, 'DATE');
+        $result = PMA_getHTMLinput(
+            $column, 'a', 'b', 30, 'c', 23, 2, 0, 'DATE', false
+        );
         $this->assertEquals(
             '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
             . ' class="textfield datetimefield" c tabindex="25" id="field_0_3" />',
@@ -1314,7 +1344,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $extracted_columnspec['spec_in_brackets'] = 25;
         $result = PMA_getValueColumnForOtherDatatypes(
             $column, 'defchar', 'a', 'b', 'c', 22, '&lt;', 12, 1, "/", "&lt;",
-            "foo\nbar", $extracted_columnspec
+            "foo\nbar", $extracted_columnspec, false
         );
 
         $this->assertEquals(
@@ -1333,7 +1363,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $column['True_Type'] = 'timestamp';
         $result = PMA_getValueColumnForOtherDatatypes(
             $column, 'defchar', 'a', 'b', 'c', 22, '&lt;', 12, 1, "/", "&lt;",
-            "foo\nbar", $extracted_columnspec
+            "foo\nbar", $extracted_columnspec, false
         );
 
         $this->assertEquals(
@@ -1349,7 +1379,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         $column['pma_type'] = 'datetime';
         $result = PMA_getValueColumnForOtherDatatypes(
             $column, 'defchar', 'a', 'b', 'c', 22, '&lt;', 12, 1, "/", "&lt;",
-            "foo\nbar", $extracted_columnspec
+            "foo\nbar", $extracted_columnspec, false
         );
 
         $this->assertContains(
@@ -2849,6 +2879,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
                 'Field' => 'col',
                 'Type' => 'varchar(20)',
                 'Null' => 'Yes',
+                'Privileges' => 'insert,update,select'
             )
         );
         $repopulate = array(
@@ -2909,7 +2940,8 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
                 'Null' => 'Yes',
                 'Key' => '',
                 'Extra' => '',
-                'Default' => null
+                'Default' => null,
+                'Privileges' => 'insert,update,select'
             )
         );
         $repopulate = array(
@@ -3065,7 +3097,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
         );
         $actual = PMA_getHtmlForInsertEditRow(
             array(), $table_columns, array(), false, array(), '', '',
-            '', true, array(), $o_rows, $tabindex, 1, false, 0,
+            '', true, array(), $o_rows, $tabindex, 2, false, 0,
             array(), 0, 0, 'table', 'db', 0, array(), 0, '',
             array(), array('wc')
         );
@@ -3073,8 +3105,9 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
             'foo',
             $actual
         );
-        $this->assertNotContains(
-            'bar',
+        $this->assertContains(
+            '<textarea name="fields[37b51d194a7513e45b56f6524f2d51f2]" '
+            .'class="" readonly="readonly"',
             $actual
         );
     }


### PR DESCRIPTION
The problem:

While editing records, user with limited privileges does not see all fields, which he has read access.
Only fields with write access are displayed.

Expected behaviour:

The edit form should display all fields which user has read access. 
Fields, for which user have no write access, should be displayed as read-only.

Details:

We have users with limited privileges. They have SELECT privilege to all table fields, but only some of fields are accessible for insert/update. While table browsing and making decision to edit record, user see all available fields. When table row edit form opened, user see only fields, which he has insert/update access. In our case that means what user has only one field (while it has SELECT privilege to many fields) on the edit form, which makes is completely unuseable - other fields are the record editing context. We caught this after our Debian-based installation upgrade to 4.6.3.

Problem caused by rfe # 689 / ff1592483a9befbe93db30b766f4b38da4c775f1 commit.
