### PR TITLE
Reload Navigation if no previous entry stored

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -552,12 +552,15 @@ $(function () {
         if ($('#pma_navigation_tree_content').length &&
             typeof storage.navTreePaths === 'undefined'
         ) {
-            navTreeStateUpdate();
+            PMA_reloadNavigation();
         } else if (PMA_commonParams.get('server') === storage.server &&
             PMA_commonParams.get('token') === storage.token
         ) {
             // Reload the tree to the state before page refresh
             PMA_reloadNavigation(null, JSON.parse(storage.navTreePaths));
+        } else {
+            // If the user is different
+            navTreeStateUpdate();
         }
     }
 });


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

Reload Navigation if no prev entry stored. This automatically ensures check for url params.
If token does not match, store the current NavTree status in sessionStorage.
Fix #12384

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
