### PR TITLE
Fixes #12380 Refactored http requests into one function "httpRequest" in Util.php

### DIFF
--- a/libraries/Config.php
+++ b/libraries/Config.php
@@ -612,7 +612,7 @@ class Config
         } else {
             $link = 'https://api.github.com/repos/phpmyadmin/phpmyadmin/git/commits/'
                 . $hash;
-            $is_found = $this->checkHTTP($link, ! $commit);
+            $is_found = Util::httpRequest($link, "GET", 5);
             switch($is_found) {
             case false:
                 $is_remote_commit = false;
@@ -641,7 +641,7 @@ class Config
             } else {
                 $link = 'https://api.github.com/repos/phpmyadmin/phpmyadmin'
                     . '/git/trees/' . $branch;
-                $is_found = $this->checkHTTP($link);
+                $is_found = Util::httpRequest($link, "GET", 5,true);
                 switch($is_found) {
                 case true:
                     $is_remote_branch = true;
@@ -704,53 +704,6 @@ class Config
         $this->set('PMA_VERSION_GIT_COMMITTER', $committer);
         $this->set('PMA_VERSION_GIT_ISREMOTECOMMIT', $is_remote_commit);
         $this->set('PMA_VERSION_GIT_ISREMOTEBRANCH', $is_remote_branch);
-    }
-
-    /**
-     * Checks if given URL is 200 or 404, optionally returns data
-     *
-     * @param string  $link     the URL to check
-     * @param boolean $get_body whether to retrieve body of document
-     *
-     * @return string|boolean test result or data
-     */
-    public function checkHTTP($link, $get_body = false)
-    {
-        if (! function_exists('curl_init')) {
-            return null;
-        }
-        $handle = curl_init($link);
-        if ($handle === false) {
-            return null;
-        }
-        Util::configureCurl($handle);
-        curl_setopt($handle, CURLOPT_FOLLOWLOCATION, 0);
-        curl_setopt($handle, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, '2');
-        curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, '1');
-        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, 5);
-        curl_setopt($handle, CURLOPT_TIMEOUT, 5);
-        curl_setopt($handle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
-        if (! defined('TESTSUITE')) {
-            session_write_close();
-        }
-        $data = @curl_exec($handle);
-        if (! defined('TESTSUITE')) {
-            session_start();
-        }
-        if ($data === false) {
-            return null;
-        }
-        $http_status = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-
-        if ($http_status == 200) {
-            return $get_body ? $data : true;
-        }
-
-        if ($http_status == 404) {
-            return false;
-        }
-        return null;
     }
 
     /**

--- a/libraries/VersionInformation.php
+++ b/libraries/VersionInformation.php
@@ -33,11 +33,6 @@ class VersionInformation
             return null;
         }
 
-        // wait 3s at most for server response, it's enough to get information
-        // from a working server
-        $connection_timeout = 3;
-
-        $response = '{}';
         // Get response text from phpmyadmin.net or from the session
         // Update cache every 6 hours
         if (isset($_SESSION['cache']['version_check'])
@@ -47,48 +42,10 @@ class VersionInformation
             $response = $_SESSION['cache']['version_check']['response'];
         } else {
             $save = true;
-            if (! defined('TESTSUITE')) {
-                session_write_close();
-            }
             $file = 'https://www.phpmyadmin.net/home_page/version.json';
-            if (function_exists('curl_init')) {
-                $curl_handle = curl_init($file);
-                if ($curl_handle === false) {
-                    return null;
-                }
-                $curl_handle = Util::configureCurl($curl_handle);
-                curl_setopt(
-                    $curl_handle,
-                    CURLOPT_HEADER,
-                    false
-                );
-                curl_setopt(
-                    $curl_handle,
-                    CURLOPT_RETURNTRANSFER,
-                    true
-                );
-                curl_setopt(
-                    $curl_handle,
-                    CURLOPT_TIMEOUT,
-                    $connection_timeout
-                );
-                $response = curl_exec($curl_handle);
-            } else if (ini_get('allow_url_fopen')) {
-                $context = array(
-                    'http' => array(
-                        'request_fulluri' => true,
-                        'timeout' => $connection_timeout,
-                    )
-                );
-                $context = Util::handleContext($context);
-                $response = file_get_contents(
-                    $file,
-                    false,
-                    stream_context_create($context)
-                );
-            }
+            $response = Util::httpRequest($file,"GET",3);
         }
-
+        $response = $response ? $response : '{}';
         /* Parse response */
         $data = json_decode($response);
 
@@ -102,9 +59,6 @@ class VersionInformation
         }
 
         if ($save) {
-            if (! isset($_SESSION) && ! defined('TESTSUITE')) {
-                session_start();
-            }
             $_SESSION['cache']['version_check'] = array(
                 'response' => $response,
                 'timestamp' => time()

--- a/libraries/error_report.lib.php
+++ b/libraries/error_report.lib.php
@@ -179,41 +179,8 @@ function PMA_sanitizeUrl($url)
 function PMA_sendErrorReport($report)
 {
     $data_string = json_encode($report);
-    if (function_exists('curl_init')) {
-        $curl_handle = curl_init(SUBMISSION_URL);
-        if ($curl_handle === false) {
-            return null;
-        }
-        $curl_handle = PMA\libraries\Util::configureCurl($curl_handle);
-        curl_setopt($curl_handle, CURLOPT_CUSTOMREQUEST, "POST");
-        curl_setopt(
-            $curl_handle, CURLOPT_HTTPHEADER,
-            array('Expect:', 'Content-Type: application/json')
-        );
-        curl_setopt($curl_handle, CURLOPT_POSTFIELDS, $data_string);
-        curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, 1);
-        $response = curl_exec($curl_handle);
-        curl_close($curl_handle);
-
-        return $response;
-    } else if (ini_get('allow_url_fopen')) {
-        $context = array("http" =>
-            array(
-                'method'  => 'POST',
-                'content' => $data_string,
-                'header' => "Content-Type: application/json\r\n",
-            )
-        );
-        $context = PMA\libraries\Util::handleContext($context);
-        $response = @file_get_contents(
-            SUBMISSION_URL,
-            false,
-            stream_context_create($context)
-        );
-        return $response;
-    }
-
-    return null;
+    $response = PMA\libraries\Util::httpRequest(SUBMISSION_URL,"POST", 3,false, $data_string,"Content-Type: application/json\r\n");
+    return $response;
 }
 
 /**

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -14,6 +14,7 @@ use PMA\libraries\Theme;
 
 require_once 'libraries/relation.lib.php';
 require_once 'test/PMATestCase.php';
+require_once 'libraries/Util.php';
 
 /**
  * Tests behaviour of PMA\libraries\Config class
@@ -937,31 +938,29 @@ class ConfigTest extends PMATestCase
     }
 
     /**
-     * Test for Check HTTP
-     *
-     * @group medium
-     *
-     * @return void
-     */
-    public function testCheckHTTP()
+         * Test for http request
+         *
+         * @group medium
+         *
+         * @return void
+         */
+    public function testHttpRequest()
     {
-        if (! function_exists('curl_init')) {
-            $this->markTestSkipped('Missing curl extension!');
-        }
         $this->assertTrue(
-            $this->object->checkHTTP("https://www.phpmyadmin.net/test/data")
-        );
-        $this->assertContains(
-            "TEST DATA",
-            $this->object->checkHTTP("https://www.phpmyadmin.net/test/data", true)
-        );
-        $this->assertFalse(
-            $this->object->checkHTTP("https://www.phpmyadmin.net/test/nothing")
-        );
-        // Use rate limit API as it's not subject to rate limiting
-        $this->assertContains(
-            '"resources"',
-            $this->object->checkHTTP("https://api.github.com/rate_limit", true)
-        );
-    }
+                PMA\libraries\Util::httpRequest("https://www.phpmyadmin.net/test/data", "GET", 5,true)
+            );
+            $this->assertContains(
+                    "TEST DATA",
+                PMA\libraries\Util::httpRequest("https://www.phpmyadmin.net/test/data","GET", 5)
+            );
+         $this->assertFalse(
+                 PMA\libraries\Util::httpRequest("https://www.phpmyadmin.net/test/nothing","GET", 5,true)
+             );
+         // Use rate limit API as it's not subject to rate limiting
+         $this->assertContains(
+                 '"resources"',
+                 PMA\libraries\Util::httpRequest("https://api.github.com/rate_limit","GET", 5)
+         );
+     }
+
 }


### PR DESCRIPTION
Changed below methods to call the same method for httpRequests, which resides in Util class.

Util::httpRequest - new method
Config::checkHTTP - removed
VersionInformation::getLatestVersion - updated
PMA_sendErrorReport - updated

Fixed a couple of issues according to comments in #12457.

Signed-off-by: Volkan Ulukut arthan@gmail.com
