### PR TITLE
Proper type support for mysqli_real_connect() parameters

### DIFF
--- a/libraries/dbi/DBIMysqli.php
+++ b/libraries/dbi/DBIMysqli.php
@@ -185,7 +185,7 @@ class DBIMysqli implements DBIExtension
                 $cfg['Server']['host'],
                 $user,
                 $password,
-                false,
+                '',
                 $server_port,
                 $server_socket,
                 $client_flags
@@ -201,7 +201,7 @@ class DBIMysqli implements DBIExtension
                     $cfg['Server']['host'],
                     $user,
                     '',
-                    false,
+                    '',
                     $server_port,
                     $server_socket,
                     $client_flags


### PR DESCRIPTION
HHVM is complaining about argument 4 and 5 of mysqli_real_connect() must be of type string and not boolean.
PHP should not actually be allowing false as a valid alternative for false.
Empty string or null are both valid. I preferred empty string.
This PR is for stable branch.
