### PR TITLE
Fixes #12514 - Uses sys_get_temp_dir in place of empty string for temporary file creation

### DIFF
--- a/libraries/Encoding.php
+++ b/libraries/Encoding.php
@@ -280,7 +280,7 @@ class Encoding
             return $file;
         }
 
-        $tmpfname = tempnam('', $enc);
+        $tmpfname = tempnam(sys_get_temp_dir(), $enc);
         $fpd      = fopen($tmpfname, 'wb');
         $fps      = fopen($file, 'r');
         self::kanjiChangeOrder();


### PR DESCRIPTION
Fix for #12514
