### PR TITLE
Fix #12531 : Properly flag queries as DROP DATABASE

### DIFF
--- a/import.php
+++ b/import.php
@@ -797,6 +797,19 @@ if ($go_sql) {
         // @todo: possibly refactor
         extract($analyzed_sql_results);
 
+        // Check if User is allowed to issue a 'DROP DATABASE' Statement
+        if (PMA_hasNoRightsToDropDatabase(
+            $analyzed_sql_results, $cfg['AllowUserDropDatabase'], $GLOBALS['is_superuser']
+        )) {
+            PMA\libraries\Util::mysqlDie(
+                __('"DROP DATABASE" statements are disabled.'),
+                '',
+                false,
+                $_SESSION['Import_message']['go_back_url']
+            );
+            return;
+        } // end if
+
         if ($table != $table_from_sql && !empty($table_from_sql)) {
             $table = $table_from_sql;
         }

--- a/js/functions.js
+++ b/js/functions.js
@@ -629,8 +629,7 @@ function confirmLink(theLink, theSqlQuery)
 } // end of the 'confirmLink()' function
 
 /**
- * Displays an error message if a "DROP DATABASE" statement is submitted
- * while it isn't allowed, else confirms a "DROP/DELETE/ALTER" query before
+ * Confirms a "DROP/DELETE/ALTER" query before
  * submitting it if required.
  * This function is called by the 'checkSqlQuery()' js function.
  *
@@ -648,17 +647,6 @@ function confirmQuery(theForm1, sqlQuery1)
         return true;
     }
 
-    // "DROP DATABASE" statement isn't allowed
-    if (PMA_messages.strNoDropDatabases !== '') {
-        var drop_re = new RegExp('(^|;)\\s*DROP\\s+(IF EXISTS\\s+)?DATABASE\\s', 'i');
-        if (drop_re.test(sqlQuery1.value)) {
-            alert(PMA_messages.strNoDropDatabases);
-            theForm1.reset();
-            sqlQuery1.focus();
-            return false;
-        } // end if
-    } // end if
-
     // Confirms a "DROP/DELETE/ALTER/TRUNCATE" statement
     //
     // TODO: find a way (if possible) to use the parser-analyser
@@ -666,7 +654,7 @@ function confirmQuery(theForm1, sqlQuery1)
     // For now, I just added a ^ to check for the statement at
     // beginning of expression
 
-    var do_confirm_re_0 = new RegExp('^\\s*DROP\\s+(IF EXISTS\\s+)?(TABLE|DATABASE|PROCEDURE)\\s', 'i');
+    var do_confirm_re_0 = new RegExp('^\\s*DROP\\s+(IF EXISTS\\s+)?(TABLE|PROCEDURE)\\s', 'i');
     var do_confirm_re_1 = new RegExp('^\\s*ALTER\\s+TABLE\\s+((`[^`]+`)|([A-Za-z0-9_$]+))\\s+DROP\\s', 'i');
     var do_confirm_re_2 = new RegExp('^\\s*DELETE\\s+FROM\\s', 'i');
     var do_confirm_re_3 = new RegExp('^\\s*TRUNCATE\\s', 'i');

--- a/js/messages.php
+++ b/js/messages.php
@@ -36,11 +36,6 @@ register_shutdown_function(
     }
 );
 
-$js_messages['strNoDropDatabases'] = __('"DROP DATABASE" statements are disabled.');
-if ($cfg['AllowUserDropDatabase']) {
-    $js_messages['strNoDropDatabases'] = '';
-}
-
 /* For confirmations */
 $js_messages['strConfirm'] = __('Confirm');
 $js_messages['strDoYouReally'] = __('Do you really want to execute "%s"?');

--- a/libraries/import.lib.php
+++ b/libraries/import.lib.php
@@ -19,11 +19,6 @@ if (! defined('PHPMYADMIN')) {
 require_once './libraries/check_user_privileges.lib.php';
 
 /**
- * We do this check, DROP DATABASE does not need to be confirmed elsewhere
- */
-define('PMA_CHK_DROP', 1);
-
-/**
  * Checks whether timeout is getting close
  *
  * @return boolean true if timeout is close
@@ -189,7 +184,6 @@ function PMA_importRunQuery($sql = '', $full = '', &$sql_data = array())
     if (! empty($import_run_buffer['sql'])
         && trim($import_run_buffer['sql']) != ''
     ) {
-
         $max_sql_len = max(
             $max_sql_len,
             mb_strlen($import_run_buffer['sql'])
@@ -197,63 +191,53 @@ function PMA_importRunQuery($sql = '', $full = '', &$sql_data = array())
         if (! $sql_query_disabled) {
             $sql_query .= $import_run_buffer['full'];
         }
-        $pattern = '@^[[:space:]]*DROP[[:space:]]+(IF EXISTS[[:space:]]+)?'
-            . 'DATABASE @i';
-        if (! $cfg['AllowUserDropDatabase']
-            && ! $is_superuser
-            && preg_match($pattern, $import_run_buffer['sql'])
-        ) {
-            $GLOBALS['message'] = Message::error(
-                __('"DROP DATABASE" statements are disabled.')
+
+        $executed_queries++;
+
+        if ($run_query && $executed_queries < 50) {
+            $go_sql = true;
+
+            if (! $sql_query_disabled) {
+                $complete_query = $sql_query;
+                $display_query = $sql_query;
+            } else {
+                $complete_query = '';
+                $display_query = '';
+            }
+            $sql_query = $import_run_buffer['sql'];
+            $sql_data['valid_sql'][] = $import_run_buffer['sql'];
+            $sql_data['valid_full'][] = $import_run_buffer['full'];
+            if (! isset($sql_data['valid_queries'])) {
+                $sql_data['valid_queries'] = 0;
+            }
+            $sql_data['valid_queries']++;
+        } elseif ($run_query) {
+
+            /* Handle rollback from go_sql */
+            if ($go_sql && isset($sql_data['valid_full'])) {
+                $queries = $sql_data['valid_sql'];
+                $fulls = $sql_data['valid_full'];
+                $count = $sql_data['valid_queries'];
+                $go_sql = false;
+
+                $sql_data['valid_sql'] = array();
+                $sql_data['valid_queries'] = 0;
+                unset($sql_data['valid_full']);
+                for ($i = 0; $i < $count; $i++) {
+                    PMA_executeQuery(
+                        $queries[$i],
+                        $fulls[$i],
+                        $sql_data
+                    );
+                }
+            }
+
+            PMA_executeQuery(
+                $import_run_buffer['sql'],
+                $import_run_buffer['full'],
+                $sql_data
             );
-            $error = true;
-        } else {
-            $executed_queries++;
-
-            if ($run_query && $executed_queries < 50) {
-                $go_sql = true;
-                if (! $sql_query_disabled) {
-                    $complete_query = $sql_query;
-                    $display_query = $sql_query;
-                } else {
-                    $complete_query = '';
-                    $display_query = '';
-                }
-                $sql_query = $import_run_buffer['sql'];
-                $sql_data['valid_sql'][] = $import_run_buffer['sql'];
-                $sql_data['valid_full'][] = $import_run_buffer['full'];
-                if (! isset($sql_data['valid_queries'])) {
-                    $sql_data['valid_queries'] = 0;
-                }
-                $sql_data['valid_queries']++;
-            } elseif ($run_query) {
-
-                /* Handle rollback from go_sql */
-                if ($go_sql && isset($sql_data['valid_full'])) {
-                    $queries = $sql_data['valid_sql'];
-                    $fulls = $sql_data['valid_full'];
-                    $count = $sql_data['valid_queries'];
-                    $go_sql = false;
-
-                    $sql_data['valid_sql'] = array();
-                    $sql_data['valid_queries'] = 0;
-                    unset($sql_data['valid_full']);
-                    for ($i = 0; $i < $count; $i++) {
-                        PMA_executeQuery(
-                            $queries[$i],
-                            $fulls[$i],
-                            $sql_data
-                        );
-                    }
-                }
-
-                PMA_executeQuery(
-                    $import_run_buffer['sql'],
-                    $import_run_buffer['full'],
-                    $sql_data
-                );
-            } // end run query
-        } // end if not DROP DATABASE
+        } // end run query
         // end non empty query
     } elseif (! empty($import_run_buffer['full'])) {
         if ($go_sql) {

--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -687,8 +687,7 @@ function PMA_isDeleteTransformationInfo($analyzed_sql_results)
 function PMA_hasNoRightsToDropDatabase($analyzed_sql_results,
     $allowUserDropDatabase, $is_superuser
 ) {
-    return ! defined('PMA_CHK_DROP')
-        && ! $allowUserDropDatabase
+    return ! $allowUserDropDatabase
         && isset($analyzed_sql_results['drop_database'])
         && $analyzed_sql_results['drop_database']
         && ! $is_superuser;

--- a/test/libraries/PMA_sql_test.php
+++ b/test/libraries/PMA_sql_test.php
@@ -172,7 +172,7 @@ class PMA_SqlTest extends PHPUnit_Framework_TestCase
     public function testHasNoRightsToDropDatabase()
     {
         $this->assertEquals(
-            !defined('PMA_CHK_DROP'),
+            true,
             PMA_hasNoRightsToDropDatabase(
                 PMA_parseAndAnalyze('DROP DATABASE db'),
                 false,
@@ -181,7 +181,7 @@ class PMA_SqlTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            !defined('PMA_CHK_DROP'),
+            false,
             PMA_hasNoRightsToDropDatabase(
                 PMA_parseAndAnalyze('DROP TABLE tbl'),
                 false,
@@ -190,7 +190,7 @@ class PMA_SqlTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            !defined('PMA_CHK_DROP'),
+            false,
             PMA_hasNoRightsToDropDatabase(
                 PMA_parseAndAnalyze('SELECT * from tbl'),
                 false,


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

Parser recognizes various DROP statements correctly, but the flags set by SQL Parser are incorrectly used.
In js/functions.js, removed the Regex-based matching, rather handle it in PHP as we have correct flags available from SQL Parser

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
