### PR TITLE
Using number_format parameters instead of Util::localizeNumber

### DIFF
--- a/libraries/Util.php
+++ b/libraries/Util.php
@@ -1475,26 +1475,6 @@ class Util
         return array(trim($return_value), $unit);
     } // end of the 'formatByteDown' function
 
-    /**
-     * Changes thousands and decimal separators to locale specific values.
-     *
-     * @param string $value the value
-     *
-     * @return string
-     */
-    public static function localizeNumber($value)
-    {
-        return str_replace(
-            array(',', '.'),
-            array(
-                /* l10n: Thousands separator */
-                __(','),
-                /* l10n: Decimal separator */
-                __('.'),
-            ),
-            $value
-        );
-    }
 
     /**
      * Formats $value to the given length and appends SI prefixes
@@ -1536,11 +1516,18 @@ class Util
         $originalValue = $value;
         //number_format is not multibyte safe, str_replace is safe
         if ($digits_left === 0) {
-            $value = number_format($value, $digits_right);
+            $value = number_format(
+                $value,
+                $digits_right,
+                /* l10n: Decimal separator */
+                __('.'),
+                /* l10n: Thousands separator */
+                __(',')
+            );
             if (($originalValue != 0) && (floatval($value) == 0)) {
                 $value = ' <' . (1 / self::pow(10, $digits_right));
             }
-            return self::localizeNumber($value);
+            return $value;
         }
 
         // this units needs no translation, ISO
@@ -1597,19 +1584,32 @@ class Util
         $unit = $units[$d];
 
         // number_format is not multibyte safe, str_replace is safe
-        $formattedValue = number_format($value, $digits_right);
+        $formattedValue = number_format(
+            $value,
+            $digits_right,
+            /* l10n: Decimal separator */
+            __('.'),
+            /* l10n: Thousands separator */
+            __(',')
+        );
         // If we don't want any zeros, remove them now
         if ($noTrailingZero && strpos($formattedValue, '.') !== false) {
             $formattedValue = preg_replace('/\.?0+$/', '', $formattedValue);
         }
-        $localizedValue = self::localizeNumber($formattedValue);
 
         if ($originalValue != 0 && floatval($value) == 0) {
-            return ' <' . self::localizeNumber((1 / self::pow(10, $digits_right)))
+            return ' <' . number_format(
+                (1 / self::pow(10, $digits_right)),
+                $digits_right,
+                /* l10n: Decimal separator */
+                __('.'),
+                /* l10n: Thousands separator */
+                __(',')
+            )
             . ' ' . $unit;
         }
 
-        return $sign . $localizedValue . ' ' . $unit;
+        return $sign . $formattedValue . ' ' . $unit;
     } // end of the 'formatNumber' function
 
     /**

--- a/test/libraries/common/PMA_formatNumberByteDown_test.php
+++ b/test/libraries/common/PMA_formatNumberByteDown_test.php
@@ -73,6 +73,9 @@ class PMA_FormatNumberByteDown_Test extends PHPUnit_Framework_TestCase
             array(21010101, 0, 2, '21,010,101.00'),
             array(20000, 2, 2, '20 k'),
             array(20011, 2, 2, '20.01 k'),
+            array(123456789, 6, 0, '123,457 k'),
+            array(-123456789, 4, 2, '-123.46 M'),
+            array(0, 6, 0, '0')
         );
     }
 


### PR DESCRIPTION
Fixing issue #12302. Util::localizeNumber is no longer needed due to new multibyte feature of number_format on php 5.4
Removed localizeNumber and converted the parts to use number_format decimal and thousand seperator parameters. 
Added tests to UtilTest. 
