### PR TITLE
Fixes #12470 Stores tab_id hash into a variable instead of location.hash

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -588,8 +588,9 @@ function setTab(tab_id)
         }
         $this.find('li').removeClass('active').find('a[href=#' + tab_id + ']').parent().addClass('active');
         $this.parent().find('div.tabs_contents fieldset').hide().filter('#' + tab_id).show();
-        location.hash = 'tab_' + tab_id;
-        $this.parent().find('input[name=tab_hash]').val(location.hash);
+        var hashValue = 'tab_' + tab_id;
+        location.hash = hashValue;
+        $this.parent().find('input[name=tab_hash]').val(hashValue);
     });
 }
 


### PR DESCRIPTION
Signed-off-by: Sudheesh Singanamalla sudheesh1995@outlook.com
