### PR TITLE
Fix Export and Copy of Tables with Generated/Virtual columns

### DIFF
--- a/libraries/Table.php
+++ b/libraries/Table.php
@@ -1511,8 +1511,13 @@ class Table
             && $columns_meta_query_result !== false
         ) {
             foreach ($columns_meta_query_result as $column) {
+                $value = $column['Field'];
+                if ($backquoted === true) {
+                    $value = Util::backquote($value);
+                }
+
                 if (strpos($column['Extra'], 'GENERATED') === false) {
-                    array_push($ret, Util::backquote($column['Field']));
+                    array_push($ret, $value);
                 }
             }
         }

--- a/libraries/Table.php
+++ b/libraries/Table.php
@@ -1500,15 +1500,16 @@ class Table
      */
     public function getNonGeneratedColumns($backquoted = true)
     {
-        $columns_meta_query = sprintf(
-            'SHOW COLUMNS FROM %s.%s',
-            Util::backquote($this->_db_name),
-            Util::backquote($this->_name)
-        );
+        $columns_meta_query = 'SHOW COLUMNS FROM ' . $this->getFullName(true);
         $ret = array();
 
-        $columns_meta_query_result = $this->_dbi->tryQuery($columns_meta_query);
-        if ($columns_meta_query_result !== false) {
+        $columns_meta_query_result = $this->_dbi->fetchResult(
+            $columns_meta_query
+        );
+
+        if ($columns_meta_query_result
+            && $columns_meta_query_result !== false
+        ) {
             foreach ($columns_meta_query_result as $column) {
                 if (strpos($column['Extra'], 'GENERATED') === false) {
                     array_push($ret, Util::backquote($column['Field']));

--- a/libraries/export.lib.php
+++ b/libraries/export.lib.php
@@ -682,8 +682,13 @@ function PMA_exportDatabase(
             && in_array($table, $table_data)
             && ! ($is_view)
         ) {
-            $local_query  = 'SELECT * FROM ' . PMA\libraries\Util::backquote($db)
+            $tableObj = new PMA\libraries\Table($table, $db);
+            $nonGeneratedCols = $tableObj->getNonGeneratedColumns(true);
+
+            $local_query  = 'SELECT ' . implode(', ', $nonGeneratedCols)
+                .  ' FROM ' . PMA\libraries\Util::backquote($db)
                 . '.' . PMA\libraries\Util::backquote($table);
+
             if (! $export_plugin->exportData(
                 $db, $table, $crlf, $err_url, $local_query, $aliases
             )) {
@@ -862,7 +867,12 @@ function PMA_exportTable(
             $local_query = $sql_query . $add_query;
             $GLOBALS['dbi']->selectDb($db);
         } else {
-            $local_query  = 'SELECT * FROM ' . PMA\libraries\Util::backquote($db)
+            // Data is exported only for Non-generated columns
+            $tableObj = new PMA\libraries\Table($table, $db);
+            $nonGeneratedCols = $tableObj->getNonGeneratedColumns(true);
+
+            $local_query  = 'SELECT ' . implode(', ', $nonGeneratedCols)
+                .  ' FROM ' . PMA\libraries\Util::backquote($db)
                 . '.' . PMA\libraries\Util::backquote($table) . $add_query;
         }
         if (! $export_plugin->exportData(

--- a/test/classes/TableTest.php
+++ b/test/classes/TableTest.php
@@ -180,6 +180,31 @@ class TableTest extends PMATestCase
                     'ALL'
                 )
             ),
+            array(
+                'SHOW COLUMNS FROM `PMA`.`PMA_BookMark`',
+                null,
+                null,
+                null,
+                0,
+                array(
+                    array(
+                        'Field'=>'COLUMN_NAME1',
+                        'Type'=> 'INT(10)',
+                        'Null'=> 'NO',
+                        'Key'=> '',
+                        'Default'=> NULL,
+                        'Extra'=>''
+                    ),
+                    array(
+                        'Field'=>'COLUMN_NAME2',
+                        'Type'=> 'INT(10)',
+                        'Null'=> 'YES',
+                        'Key'=> '',
+                        'Default'=> NULL,
+                        'Extra'=>'STORED GENERATED'
+                    )
+                )
+            ),
         );
 
         $dbi = $this->getMockBuilder('PMA\libraries\DatabaseInterface')
@@ -1047,7 +1072,8 @@ class TableTest extends PMATestCase
             $expect,
             $return
         );
-        $sql_query = "INSERT INTO `PMA_new`.`PMA_BookMark_new` SELECT * FROM "
+        $sql_query = "INSERT INTO `PMA_new`.`PMA_BookMark_new`(`COLUMN_NAME1`)"
+            . " SELECT `COLUMN_NAME1` FROM "
             . "`PMA`.`PMA_BookMark`";
         $this->assertContains(
             $sql_query,
@@ -1070,8 +1096,9 @@ class TableTest extends PMATestCase
             $expect,
             $return
         );
-        $sql_query = "INSERT INTO `PMA_new`.`PMA_BookMark_new` SELECT * FROM "
-            . "`PMA`.`PMA_BookMark`;";
+        $sql_query = "INSERT INTO `PMA_new`.`PMA_BookMark_new`(`COLUMN_NAME1`)"
+            . " SELECT `COLUMN_NAME1` FROM "
+            . "`PMA`.`PMA_BookMark`";
         $this->assertContains(
             $sql_query,
             $GLOBALS['sql_query']


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

We include only the _non-generated columns_ insert using `INSERT INTO .. SELECT .. FROM ..` while copying data.
In Export too, we export the data of only the non-generated columns
Fix #12221
Fix #12518

Similar [bug](https://bugs.mysql.com/bug.php?id=79148) was present in mysqldump's exports before MySQL version 5.7.9 too. MariaDB allows INSERT with generated columns but generates a warning saying those values were ignored. With the import of our dumps, that warning also would not be generated.

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
