### PR TITLE
Allow vertical scrolling to read longer text values in grid editing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@ phpMyAdmin - ChangeLog
 - issue #12473 Code can throw unhandled exception
 - issue #12550 Do not try to keep alive session even after expiry
 - issue #12512 Fixed rendering BBCode links in setup
+- issue #12554 Absence of scrolling makes it impossible to read longer text values in grid editing
 
 4.6.4 (2016-08-16)
 - issue        [security] Weaknesses with cookie encryption, see PMASA-2016-29

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -2321,7 +2321,8 @@ fieldset .disabled-field td {
 }
 
 .cEdit .edit_box {
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: scroll;
     padding: 0;
 }
 

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2873,7 +2873,8 @@ fieldset .disabled-field td {
 }
 
 .cEdit .edit_box {
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: scroll;
     padding: 0;
     margin: 0;
 }


### PR DESCRIPTION
Fix #12554 

Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
