### PR TITLE
Don't use PMA_DROP_IMPORT on Table insert if it has Blob field 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@ phpMyAdmin - ChangeLog
 - issue #12473 Code can throw unhandled exception
 - issue #12550 Do not try to keep alive session even after expiry
 - issue #12512 Fixed rendering BBCode links in setup
+- issue #12487 Drag and drop import prevents file dropping to blob column file selector on the insert tab
 
 4.6.4 (2016-08-16)
 - issue        [security] Weaknesses with cookie encryption, see PMASA-2016-29

--- a/js/common.js
+++ b/js/common.js
@@ -298,6 +298,11 @@ PMA_DROP_IMPORT = {
      * @return void
      */
     _dragenter : function (event) {
+
+        if ($(".noDragDrop").length !== 0) {
+            return;
+        }
+
         event.stopPropagation();
         event.preventDefault();
         if (!PMA_DROP_IMPORT._hasFiles(event)) {
@@ -333,6 +338,10 @@ PMA_DROP_IMPORT = {
      * @return void
      */
     _dragover: function (event) {
+        if ($(".noDragDrop").length !== 0) {
+            return;
+        }
+
         event.stopPropagation();
         event.preventDefault();
         if (!PMA_DROP_IMPORT._hasFiles(event)) {
@@ -348,6 +357,9 @@ PMA_DROP_IMPORT = {
      * @return void
      */
     _dragleave: function (event) {
+        if ($(".noDragDrop").length !== 0) {
+            return;
+        }
         event.stopPropagation();
         event.preventDefault();
         var $pma_drop_handler = $(".pma_drop_handler");
@@ -408,6 +420,10 @@ PMA_DROP_IMPORT = {
      * @return void
      */
     _drop: function (event) {
+        if ($(".noDragDrop").length !== 0) {
+            return;
+        }
+
         var dbname = PMA_commonParams.get('db');
         var server = PMA_commonParams.get('server');
 

--- a/js/common.js
+++ b/js/common.js
@@ -299,6 +299,8 @@ PMA_DROP_IMPORT = {
      */
     _dragenter : function (event) {
 
+        // We don't want to prevent users from using
+        // browser's default drag-drop feature on some page(s)
         if ($(".noDragDrop").length !== 0) {
             return;
         }
@@ -338,6 +340,8 @@ PMA_DROP_IMPORT = {
      * @return void
      */
     _dragover: function (event) {
+        // We don't want to prevent users from using
+        // browser's default drag-drop feature on some page(s)
         if ($(".noDragDrop").length !== 0) {
             return;
         }
@@ -357,6 +361,8 @@ PMA_DROP_IMPORT = {
      * @return void
      */
     _dragleave: function (event) {
+        // We don't want to prevent users from using
+        // browser's default drag-drop feature on some page(s)
         if ($(".noDragDrop").length !== 0) {
             return;
         }
@@ -420,6 +426,8 @@ PMA_DROP_IMPORT = {
      * @return void
      */
     _drop: function (event) {
+        // We don't want to prevent users from using
+        // browser's default drag-drop feature on some page(s)
         if ($(".noDragDrop").length !== 0) {
             return;
         }

--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -1129,7 +1129,7 @@ function PMA_getBinaryAndBlobColumn(
         $html_output .= '<br />'
             . '<input type="file"'
             . ' name="fields_upload' . $vkey . '[' . $column['Field_md5'] . ']"'
-            . ' class="textfield" id="field_' . $idindex . '_3" size="10"'
+            . ' class="textfield noDragDrop" id="field_' . $idindex . '_3" size="10"'
             . ' ' . $onChangeClause . '/>&nbsp;';
         list($html_out,) = PMA_getMaxUploadSize(
             $column, $biggest_max_file_size

--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -1126,6 +1126,9 @@ function PMA_getBinaryAndBlobColumn(
     $html_output .= sprintf($fields_type_html, $fields_type_val);
 
     if ($is_upload && $column['is_blob'] && !$readOnly) {
+        // We don't want to prevent users from using
+        // browser's default drag-drop feature on some page(s),
+        // so we add noDragDrop class to the input
         $html_output .= '<br />'
             . '<input type="file"'
             . ' name="fields_upload' . $vkey . '[' . $column['Field_md5'] . ']"'

--- a/test/libraries/PMA_insert_edit_test.php
+++ b/test/libraries/PMA_insert_edit_test.php
@@ -1132,7 +1132,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
             . 'name="fieldsb" value="" /><input type="hidden" '
             . 'name="fields_typeb" value="protected" />'
             . '<br /><input type="file" name="fields_uploadfoo[123]" class="text'
-            . 'field" id="field_1_3" size="10" c/>&nbsp;(Max: 64KiB)' . "\n",
+            . 'field noDragDrop" id="field_1_3" size="10" c/>&nbsp;(Max: 64KiB)' . "\n",
             $result
         );
 
@@ -1190,7 +1190,7 @@ class PMA_InsertEditTest extends PHPUnit_Framework_TestCase
             . 'cols="1" dir="/" id="field_1_3" c tabindex="3" data-type="HEX">'
             . '</textarea><input type="hidden" name="fields_typeb" value="hex" />'
             . '<br /><input type="file" name="fields_uploadfoo[123]" class="text'
-            . 'field" id="field_1_3" size="10" c/>&nbsp;(Max: 64KiB)' . "\n",
+            . 'field noDragDrop" id="field_1_3" size="10" c/>&nbsp;(Max: 64KiB)' . "\n",
             $result
         );
 


### PR DESCRIPTION
Don't use PMA_DROP_IMPORT on Table insert if it has Blob field. If we force PMA_DROP_IMPORT on all pages, users can't use Chrome's drag-drop-files feature even on Table Insert page with blob field.

Fix #12487 

Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
