### PR TITLE
Fix error check of a routine execution

### DIFF
--- a/libraries/rte/rte_routines.lib.php
+++ b/libraries/rte/rte_routines.lib.php
@@ -1416,37 +1416,41 @@ function PMA_RTN_handleExecute()
 
                 $GLOBALS['dbi']->freeResult($result);
 
-            } while ($GLOBALS['dbi']->nextResult());
+            } while ($outcome = $GLOBALS['dbi']->nextResult());
 
-            $output .= "</fieldset>";
+            if ($outcome) {
+                $output .= "</fieldset>";
 
-            $message = __('Your SQL query has been executed successfully.');
-            if ($routine['item_type'] == 'PROCEDURE') {
-                $message .= '<br />';
+                $message = __('Your SQL query has been executed successfully.');
+                if ($routine['item_type'] == 'PROCEDURE') {
+                    $message .= '<br />';
 
-                // TODO : message need to be modified according to the
-                // output from the routine
-                $message .= sprintf(
-                    _ngettext(
-                        '%d row affected by the last statement inside the '
-                        . 'procedure.',
-                        '%d rows affected by the last statement inside the '
-                        . 'procedure.',
+                    // TODO : message need to be modified according to the
+                    // output from the routine
+                    $message .= sprintf(
+                        _ngettext(
+                            '%d row affected by the last statement inside the '
+                            . 'procedure.',
+                            '%d rows affected by the last statement inside the '
+                            . 'procedure.',
+                            $affected
+                        ),
                         $affected
-                    ),
-                    $affected
-                );
-            }
-            $message = Message::success($message);
+                    );
+                }
+                $message = Message::success($message);
 
-            if ($nbResultsetToDisplay == 0) {
-                $notice = __(
-                    'MySQL returned an empty result set (i.e. zero rows).'
-                );
-                $output .= Message::notice($notice)->getDisplay();
+                if ($nbResultsetToDisplay == 0) {
+                    $notice = __(
+                        'MySQL returned an empty result set (i.e. zero rows).'
+                    );
+                    $output .= Message::notice($notice)->getDisplay();
+                }
             }
 
-        } else {
+        } 
+        
+        if (! $outcome) {
             $output = '';
             $message = Message::error(
                 sprintf(

--- a/libraries/rte/rte_routines.lib.php
+++ b/libraries/rte/rte_routines.lib.php
@@ -1417,40 +1417,39 @@ function PMA_RTN_handleExecute()
                 $GLOBALS['dbi']->freeResult($result);
 
             } while ($outcome = $GLOBALS['dbi']->nextResult());
+        }
 
-            if ($outcome) {
-                $output .= "</fieldset>";
+        if ($outcome) {
 
-                $message = __('Your SQL query has been executed successfully.');
-                if ($routine['item_type'] == 'PROCEDURE') {
-                    $message .= '<br />';
+            $output .= "</fieldset>";
 
-                    // TODO : message need to be modified according to the
-                    // output from the routine
-                    $message .= sprintf(
-                        _ngettext(
-                            '%d row affected by the last statement inside the '
-                            . 'procedure.',
-                            '%d rows affected by the last statement inside the '
-                            . 'procedure.',
-                            $affected
-                        ),
+            $message = __('Your SQL query has been executed successfully.');
+            if ($routine['item_type'] == 'PROCEDURE') {
+                $message .= '<br />';
+
+                // TODO : message need to be modified according to the
+                // output from the routine
+                $message .= sprintf(
+                    _ngettext(
+                        '%d row affected by the last statement inside the '
+                        . 'procedure.',
+                        '%d rows affected by the last statement inside the '
+                        . 'procedure.',
                         $affected
-                    );
-                }
-                $message = Message::success($message);
+                    ),
+                    $affected
+                );
+            }
+            $message = Message::success($message);
 
-                if ($nbResultsetToDisplay == 0) {
-                    $notice = __(
-                        'MySQL returned an empty result set (i.e. zero rows).'
-                    );
-                    $output .= Message::notice($notice)->getDisplay();
-                }
+            if ($nbResultsetToDisplay == 0) {
+                $notice = __(
+                    'MySQL returned an empty result set (i.e. zero rows).'
+                );
+                $output .= Message::notice($notice)->getDisplay();
             }
 
-        } 
-        
-        if (! $outcome) {
+        } else {
             $output = '';
             $message = Message::error(
                 sprintf(


### PR DESCRIPTION
Because a routine execution is done by a multi query, all results need to be checked for errors.

Signed-off-by: Thomas Faller tfaller1@gmx.de
