### PR TITLE
Assign LIMIT clause only to syntactically correct queries

### DIFF
--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -2131,9 +2131,16 @@ function PMA_executeQueryAndGetQueryResponse($analyzed_sql_results,
     // assign default full_sql_query
     $full_sql_query = $sql_query;
 
-    // Do append a "LIMIT" clause?
-    if (PMA_isAppendLimitClause($analyzed_sql_results)) {
-        $full_sql_query = PMA_getSqlWithLimitClause($analyzed_sql_results);
+    // Assigning LIMIT clause to an syntactically-wrong query
+    // is not needed. Also we would want to show the true query
+    // and the true error message to the query executor
+    if (isset($analyzed_sql_results['parser'])
+        && count($analyzed_sql_results['parser']->errors) === 0
+    ) {
+        // Do append a "LIMIT" clause?
+        if (PMA_isAppendLimitClause($analyzed_sql_results)) {
+            $full_sql_query = PMA_getSqlWithLimitClause($analyzed_sql_results);
+        }
     }
 
     $GLOBALS['reload'] = PMA_hasCurrentDbChanged($db);


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

Assigning LIMIT clause to an syntactically-wrong query is not needed.
Also we would want to show the true query and the true error message to the query executor

Fix #12321

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
