### PR TITLE
Fix #12455: Query history stores separate entry for every letter typed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -48,6 +48,7 @@ phpMyAdmin - ChangeLog
 - issue #12508 Remove duplicate code in SQL escaping
 - issue #12475 Cleanup code for getting table information
 - issue #12579 phpMyAdmin's export of a Select statment without a FROM clause generates Wrong SQL
+- issue #12455 Query history stores separate entry for every letter typed
 
 4.6.4 (2016-08-16)
 - issue        [security] Weaknesses with cookie encryption, see PMASA-2016-29

--- a/js/codemirror/addon/lint/sql-lint.js
+++ b/js/codemirror/addon/lint/sql-lint.js
@@ -33,6 +33,7 @@ CodeMirror.sqlLint = function(text, updateLinting, options, cm) {
             token: PMA_commonParams.get('token'),
             server: PMA_commonParams.get('server'),
             options: options.lintOptions,
+            no_history: true,
         },
         success: handleResponse
     });


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

Don't store history when linting, rather store it, only when user has submitted the query and the query has been executed.
