### PR TITLE
Refuse to work with mbstring.func_overload enabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -58,6 +58,7 @@ phpMyAdmin - ChangeLog
 - issue #12419 Wrong description on GRANT OPTION
 - issue #12615 Fixed regexp for matching browser versions
 - issue #12569 Avoid showing import errors twice
+- issue #12616 Refuse to work with mbstring.func_overload enabled
 
 4.6.4 (2016-08-16)
 - issue        [security] Weaknesses with cookie encryption, see PMASA-2016-29

--- a/index.php
+++ b/index.php
@@ -429,21 +429,6 @@ echo '</div>';
 echo '</div>';
 
 /**
- * As we try to handle charsets by ourself, mbstring overloads just
- * break it, see bug 1063821.
- */
-if (@extension_loaded('mbstring') && @ini_get('mbstring.func_overload') > 1) {
-    trigger_error(
-        __(
-            'You have enabled mbstring.func_overload in your PHP '
-            . 'configuration. This option is incompatible with phpMyAdmin '
-            . 'and might cause some data to be corrupted!'
-        ),
-        E_USER_WARNING
-    );
-}
-
-/**
  * mbstring is used for handling multibytes inside parser, so it is good
  * to tell user something might be broken without it, see bug #1063149.
  */

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -530,6 +530,20 @@ if ($GLOBALS['PMA_Config']->error_config_default_file) {
     trigger_error($error, E_USER_ERROR);
 }
 
+/**
+ * As we try to handle charsets by ourself, mbstring overloads just
+ * break it, see bug 1063821.
+ */
+if (@extension_loaded('mbstring') && @ini_get('mbstring.func_overload') != '0') {
+    PMA_fatalError(
+        __(
+            'You have enabled mbstring.func_overload in your PHP '
+            . 'configuration. This option is incompatible with phpMyAdmin '
+            . 'and might cause some data to be corrupted!'
+        )
+    );
+}
+
 
 /******************************************************************************/
 /* setup servers                                       LABEL_setup_servers    */


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

In several places our code assumes that strlen does return length in
bytes and not in chars. This can be different with
mbstring.func_overload and will lead to several hard to debug breakages.
Therefore it's safer to simply deny using phpMyAdmin with this setting.

Signed-off-by: Michal Čihař michal@cihar.com
