### PR TITLE
Fix order of testing DBConnection with different parameters in Config method

### DIFF
--- a/libraries/config/ConfigFile.php
+++ b/libraries/config/ConfigFile.php
@@ -416,7 +416,9 @@ class ConfigFile
         $dsn = 'mysqli://';
         if ($this->getValue("$path/auth_type") == 'config') {
             $dsn .= $this->getValue("$path/user");
-            if (! $this->getValue("$path/nopassword")) {
+            if (! $this->getValue("$path/nopassword")
+                || ! empty($this->getValue("$path/password"))
+            ) {
                 $dsn .= ':***';
             }
             $dsn .= '@';

--- a/libraries/config/Validator.php
+++ b/libraries/config/Validator.php
@@ -271,8 +271,10 @@ class Validator
         }
 
         if (! $error && $values['Servers/1/auth_type'] == 'config') {
-            $password = !empty($values['Servers/1/nopassword']) && $values['Servers/1/nopassword'] ? null
-                : (empty($values['Servers/1/password']) ? '' : $values['Servers/1/password']);
+            $password = '';
+            if (! empty($values['Servers/1/password'])) {
+                $password = $values['Servers/1/password'];
+            }
             $test = static::testDBConnection(
                 empty($values['Servers/1/connect_type']) ? '' : $values['Servers/1/connect_type'],
                 empty($values['Servers/1/host']) ? '' : $values['Servers/1/host'],
@@ -282,6 +284,24 @@ class Validator
                 $password,
                 'Server'
             );
+
+            // If failed 'with' password, try 'without' password
+            if ($test !== true
+                && !empty($values['Servers/1/nopassword'])
+                && $values['Servers/1/nopassword']
+            ) {
+                $password = '';
+                $test = static::testDBConnection(
+                    empty($values['Servers/1/connect_type']) ? '' : $values['Servers/1/connect_type'],
+                    empty($values['Servers/1/host']) ? '' : $values['Servers/1/host'],
+                    empty($values['Servers/1/port']) ? '' : $values['Servers/1/port'],
+                    empty($values['Servers/1/socket']) ? '' : $values['Servers/1/socket'],
+                    empty($values['Servers/1/user']) ? '' : $values['Servers/1/user'],
+                    $password,
+                    'Server'
+                );
+            }
+
             if ($test !== true) {
                 $result = array_merge($result, $test);
             }

--- a/test/classes/config/ConfigFileTest.php
+++ b/test/classes/config/ConfigFileTest.php
@@ -529,6 +529,26 @@ class ConfigFileTest extends PMATestCase
             "mysqli://testUser@123",
             $this->object->getServerDSN(1)
         );
+
+        $this->object->updateWithGlobalConfig(
+            array(
+                'Servers' => array(
+                    1 => array(
+                        "auth_type" => "config",
+                        "user" => "testUser",
+                        "connect_type" => "tcp",
+                        "host" => "example.com",
+                        "port" => "21",
+                        "nopassword" => "yes",
+                        "password" => "testPass"
+                    )
+                )
+            )
+        );
+        $this->assertEquals(
+            "mysqli://testUser:***@example.com:21",
+            $this->object->getServerDSN(1)
+        );
     }
 
     /**


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

In setup, try to follow what the [docs](https://docs.phpmyadmin.net/en/latest/config.html#cfg_Servers_nopassword) say.
'Password login is still tried first, but as fallback, no password method is tried.'

Fix #12472

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
