### PR TITLE
Use justBrowsing only if outputting the results from a single table

### DIFF
--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -655,7 +655,7 @@ function PMA_isJustBrowsing($analyzed_sql_results, $find_real_end)
         && empty($analyzed_sql_results['union'])
         && empty($analyzed_sql_results['distinct'])
         && $analyzed_sql_results['select_from']
-        && (count($analyzed_sql_results['select_tables']) <= 1)
+        && (count($analyzed_sql_results['select_tables']) === 1)
         && (empty($analyzed_sql_results['statement']->where)
             || (count($analyzed_sql_results['statement']->where) == 1
                 && $analyzed_sql_results['statement']->where[0]->expr ==='1'))


### PR DESCRIPTION
Before submitting pull request, please check that every commit:
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

The issue #12533 happens because we use countRecords on the parent table since it is incorrectly set,
while actually we should be looking at SQL_CALC_FOUND_ROWS instead.

Fix #12533
Fix #12365 

Signed-off-by: Deven Bansod devenbansod.bits@gmail.com
