### PR TITLE
Bookmark id that is an auto_increment column can only take positive v…

### DIFF
--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -37,7 +37,7 @@ USE phpmyadmin;
 --
 
 CREATE TABLE IF NOT EXISTS `pma__bookmark` (
-  `id` int(11) NOT NULL auto_increment,
+  `id` int(10) unsigned NOT NULL auto_increment,
   `dbase` varchar(255) NOT NULL default '',
   `user` varchar(255) NOT NULL default '',
   `label` varchar(255) COLLATE utf8_general_ci NOT NULL default '',

--- a/sql/upgrade_column_info_4_6_5+.sql
+++ b/sql/upgrade_column_info_4_6_5+.sql
@@ -1,0 +1,24 @@
+-- -------------------------------------------------------------
+-- SQL Commands to upgrade pmadb.pma__column_info table
+-- for normal phpMyAdmin operation
+--
+-- This file is meant for use with phpMyAdmin 4.6.5 and above!
+-- For older releases, please use create_tables.sql
+--
+-- Please don't forget to set up the table names in config.inc.php
+--
+
+-- --------------------------------------------------------
+
+--
+-- Database : `phpmyadmin`
+--
+USE `phpmyadmin`;
+
+-- --------------------------------------------------------
+
+--
+-- Update table structure for table `pma__bookmark`
+--
+ALTER TABLE `pma__bookmark`
+  CHANGE `id` `id` int( 10 ) unsigned NOT NULL auto_increment;


### PR DESCRIPTION
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

Bookmark ID from MySQL database is an auto_increment column, therefore will only have positive values starting from 1, therefore should be flagged as "unsigned" otherwise half of allowed interval is wasted from start, see [MySQL Integer Types (Exact Value)](https://dev.mysql.com/doc/refman/5.7/en/integer-types.html).
Current changes provide a fix for that and aligned bookmark table with other tables reaching a high consistency with MySQL database being used internally by phpMyAdmin.

Signed-Off-By: Daniel Popiniuc danielpopiniuc@gmail.com