### PR TITLE
Refactor getHTML for auth plugins dropdown

### DIFF
--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -1577,9 +1577,9 @@ function PMA_getActiveAuthPlugins()
 
     while ($row = $GLOBALS['dbi']->fetchAssoc($resultset)) {
         // if description is known, enable its translation
-        if ('Native MySQL authentication' == $row['PLUGIN_DESCRIPTION']) {
+        if ('mysql_native_password' == $row['PLUGIN_NAME']) {
             $row['PLUGIN_DESCRIPTION'] = __('Native MySQL authentication');
-        } elseif ('SHA256 password authentication' == $row['PLUGIN_DESCRIPTION']) {
+        } elseif ('sha256_password' == $row['PLUGIN_NAME']) {
             $row['PLUGIN_DESCRIPTION'] = __('SHA256 password authentication');
         }
 

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -1547,7 +1547,7 @@ function PMA_getHtmlForAuthPluginsDropdown(
         }
     } else {
         $active_auth_plugins = array(
-            'mysql_native_password' => __('Native MySQL Authentication')
+            'mysql_native_password' => __('Native MySQL authentication')
         );
     }
 

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -2301,6 +2301,77 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test for PMA_getHtmlForAuthPluginsDropdown()
+     *
+     * @return void
+     */
+    function testPMAGetHtmlForAuthPluginsDropdown()
+    {
+        $oldDbi = $GLOBALS['dbi'];
+
+        //Mock DBI
+        $dbi = $this->getMockBuilder('PMA\libraries\DatabaseInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dbi->expects($this->any())
+            ->method('query')
+            ->will($this->onConsecutiveCalls(true, true));
+
+        $plugins = array(
+            array(
+                'PLUGIN_NAME'=>'mysql_native_password',
+                'PLUGIN_DESCRIPTION' => 'Native MySQL authentication'
+            ),
+            array(
+                'PLUGIN_NAME' => 'sha256_password',
+                'PLUGIN_DESCRIPTION' => 'SHA256 password authentication'
+            )
+        );
+        $dbi->expects($this->any())
+            ->method('fetchAssoc')
+            ->will(
+                $this->onConsecutiveCalls(
+                    $plugins[0], $plugins[1], null, /* For Assertion 1 */
+                    $plugins[0], $plugins[1], null  /* For Assertion 2 */
+                )
+            );
+        $GLOBALS['dbi'] = $dbi;
+
+        /* Assertion 1 */
+        $actualHtml = PMA_getHtmlForAuthPluginsDropdown(
+            'mysql_native_password',
+            'new',
+            'new'
+        );
+        $this->assertEquals(
+            '<select name="authentication_plugin" id="select_authentication_plugin">'
+            . '<option value="mysql_native_password" selected="selected">'
+            . 'Native MySQL authentication</option><option value="sha256_password">'
+            . 'SHA256 password authentication</option></select>',
+            $actualHtml
+        );
+
+        /* Assertion 2 */
+        $actualHtml = PMA_getHtmlForAuthPluginsDropdown(
+            'mysql_native_password',
+            'change_pw',
+            'new'
+        );
+        $this->assertEquals(
+            '<select name="authentication_plugin" '
+            . 'id="select_authentication_plugin_cp"><option '
+            . 'value="mysql_native_password" selected="selected">'
+            . 'Native MySQL authentication</option><option value="sha256_password">'
+            . 'SHA256 password authentication</option></select>',
+            $actualHtml
+        );
+
+
+        $GLOBALS['dbi'] = $oldDbi;
+
+    }
+
+    /**
      * Tests for PMA_deleteUser
      *
      * @return void

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -2366,9 +2366,37 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
             $actualHtml
         );
 
+        /* Assertion 3 */
+        $actualHtml = PMA_getHtmlForAuthPluginsDropdown(
+            'mysql_native_password',
+            'new',
+            'old'
+        );
+        $this->assertEquals(
+            '<select name="authentication_plugin" '
+            . 'id="select_authentication_plugin"><option '
+            . 'value="mysql_native_password" selected="selected">'
+            . 'Native MySQL authentication</option></select>',
+            $actualHtml
+        );
 
+
+        /* Assertion 4 */
+        $actualHtml = PMA_getHtmlForAuthPluginsDropdown(
+            'mysql_native_password',
+            'change_pw',
+            'old'
+        );
+        $this->assertEquals(
+            '<select name="authentication_plugin" '
+            . 'id="select_authentication_plugin_cp"><option '
+            . 'value="mysql_native_password" selected="selected">'
+            . 'Native MySQL authentication</option></select>',
+            $actualHtml
+        );
+
+        // Restore old DBI
         $GLOBALS['dbi'] = $oldDbi;
-
     }
 
     /**


### PR DESCRIPTION
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

 Refactor the function `PMA_getHtmlForAuthPluginsDropdown` to use Util::getDropdown