### PR TITLE
make PMA_isAllowedDomain case insensitive, fix links on home page

### DIFF
--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -765,7 +765,7 @@ function PMA_isAllowedDomain($url)
             return false;
         }
     }
-    $domain = $arr["host"];
+    $domain = strtolower($arr["host"]);
     $domainWhiteList = array(
         /* Include current domain */
         $_SERVER['SERVER_NAME'],


### PR DESCRIPTION
On home page, external link are broken.

Ex: http://localhost/phpMyAdmin/url.php?url=https%3A%2F%2Fwww.phpMyAdmin.net%2F

phpMyAdmin is not in the allowed domain list, only phpmyadmin.net.

Signed-off-by: Remi Collet <fedora@famillecollet.com>