### PR TITLE
Do not delete session on fatal error

### DIFF
--- a/libraries/Util.php
+++ b/libraries/Util.php
@@ -2157,7 +2157,7 @@ class Util
             }
         }
         if ($found_error) {
-            PMA_fatalError($error_message, null, false);
+            PMA_fatalError($error_message);
         }
     } // end function
 

--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -206,13 +206,10 @@ function PMA_securePath($path)
  *
  * @param string       $error_message  the error message or named error message
  * @param string|array $message_args   arguments applied to $error_message
- * @param boolean      $delete_session whether to delete session cookie
  *
  * @return void
  */
-function PMA_fatalError(
-    $error_message, $message_args = null, $delete_session = true
-) {
+function PMA_fatalError($error_message, $message_args = null) {
     /* Use format string if applicable */
     if (is_string($message_args)) {
         $error_message = sprintf($error_message, $message_args);
@@ -248,14 +245,6 @@ function PMA_fatalError(
         }
         $lang = isset($GLOBALS['lang']) ? $GLOBALS['lang'] : 'en';
         $dir = isset($GLOBALS['text_dir']) ? $GLOBALS['text_dir'] : 'ltr';
-
-        // on fatal errors it cannot hurt to always delete the current session
-        if ($delete_session
-            && isset($GLOBALS['session_name'])
-            && isset($_COOKIE[$GLOBALS['session_name']])
-        ) {
-            $GLOBALS['PMA_Config']->removeCookie($GLOBALS['session_name']);
-        }
 
         // Displays the error message
         include './libraries/error.inc.php';


### PR DESCRIPTION
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

I see no reason why this should be done, the fatal error is used
in following cases:

* Very early when there is no session (eg. missing extension)
* Invalid value for parameters
* Invalid invocation like too big request

In neither case session removal will do any good.

Signed-off-by: Michal Čihař <michal@cihar.com>