### PR TITLE
Fix #12814 : Allow length parameter to be specified for DATETIME and TIME

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ phpMyAdmin - ChangeLog
 - issue #12800 Fixed various issues with PHP 7.1
 - issue #11816 Fixed operation with lower_case_table_names=2
 - issue #12813 Fixed stored procedure execution
+- issue #12814 DateTime won't allow to input length in Routine editor
 
 4.6.5.2 (2016-12-05)
 - issue #12765 Fixed SQL export with newlines

--- a/js/rte.js
+++ b/js/rte.js
@@ -792,8 +792,6 @@ RTE.ROUTINE = {
         // Process for parameter length
         switch ($type.val()) {
         case 'DATE':
-        case 'DATETIME':
-        case 'TIME':
         case 'TINYBLOB':
         case 'TINYTEXT':
         case 'BLOB':

--- a/libraries/rte/rte_routines.lib.php
+++ b/libraries/rte/rte_routines.lib.php
@@ -1161,7 +1161,7 @@ function PMA_RTN_getQueryFromRequest()
                 }
                 if ($item_param_length[$i] != ''
                     && !preg_match(
-                        '@^(DATE|DATETIME|TIME|TINYBLOB|TINYTEXT|BLOB|TEXT|'
+                        '@^(DATE|TINYBLOB|TINYTEXT|BLOB|TEXT|'
                         . 'MEDIUMBLOB|MEDIUMTEXT|LONGBLOB|LONGTEXT|'
                         . 'SERIAL|BOOLEAN)$@i',
                         $item_param_type[$i]


### PR DESCRIPTION
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

MySQL allows precision to be specified for DATETIME, TIME type fields too, we should allow it to be specified.

Ref: http://dev.mysql.com/doc/refman/5.7/en/fractional-seconds.html

Fix #12814 
