### PR TITLE
Add source release, strip current ones

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -17,7 +17,7 @@ set -u
 # Fail on failure
 set -e
 
-KITS="all-languages english"
+KITS="all-languages english source"
 COMPRESSIONS="zip-7z txz tgz"
 
 # Process parameters
@@ -183,8 +183,6 @@ if [ -d po ] ; then
         echo "* Removing incomplete translations"
         ./scripts/remove-incomplete-mo
     fi
-    echo "* Removing gettext source files"
-    rm -rf po
 fi
 
 if [ -f ./scripts/line-counts.sh ] ; then
@@ -279,7 +277,25 @@ for kit in $KITS ; do
 
     # Cleanup translations
     cd phpMyAdmin-$version-$kit
-    scripts/lang-cleanup.sh $kit
+    ./scripts/lang-cleanup.sh $kit
+
+    # Remove tests, source code,...
+    if [ $kit != source ] ; then
+        echo "* Removing source files"
+        # Testsuite
+        rm -rf test/
+        rm phpunit.xml.* build.xml
+        # Gettext po files
+        rm -rf po/
+        # Documentation source code
+        mv doc/html htmldoc
+        rm -rf doc
+        mkdir doc
+        mv htmldoc doc/html
+        rm doc/html/.buildinfo doc/html/objects.inv
+        # Javascript sources
+        rm -rf js/jquery/src/ js/openlayers/src/
+    fi
 
     # Remove developer scripts
     rm -rf scripts

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -310,10 +310,6 @@ for kit in $KITS ; do
                     gzip -9c $name.tar > $name.tar.gz
                 fi
                 ;;
-            zip)
-                echo "* Creating $name.zip"
-                zip -q -9 -r $name.zip $name
-                ;;
             zip-7z)
                 echo "* Creating $name.zip"
                 7za a -bd -tzip $name.zip $name > /dev/null

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -199,7 +199,7 @@ rm -rf .github
 rm -rf PMAStandard
 
 # Testsuite setup
-rm -f .travis.yml .coveralls.yml .scrutinizer.yml .jshintrc .weblate
+rm -f .travis.yml .coveralls.yml .scrutinizer.yml .jshintrc .weblate codecov.yml
 
 # Remove readme for github
 rm -f README.rst

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -18,7 +18,7 @@ set -u
 set -e
 
 KITS="all-languages english"
-COMPRESSIONS="zip-7z txz tgz 7z"
+COMPRESSIONS="zip-7z txz tgz"
 
 # Process parameters
 
@@ -310,10 +310,6 @@ for kit in $KITS ; do
                 echo "* Creating $name.zip"
                 7za a -bd -tzip $name.zip $name > /dev/null
                 ;;
-            7z)
-                echo "* Creating $name.7z"
-                7za a -bd $name.7z $name > /dev/null
-                ;;
             *)
                 echo "WARNING: ignoring compression '$comp', not known!"
                 ;;
@@ -333,7 +329,7 @@ git worktree prune
 
 # Signing of files with default GPG key
 echo "* Signing files"
-for file in *.gz *.zip *.xz *.7z ; do
+for file in *.gz *.zip *.xz ; do
     gpg --detach-sign --armor $file
     sha1sum $file > $file.sha1
     sha256sum $file > $file.sha256
@@ -346,7 +342,7 @@ echo ""
 echo "Files:"
 echo "------"
 
-ls -la *.gz *.zip *.xz *.7z
+ls -la *.gz *.zip *.xz
 
 cd ..
 

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -18,7 +18,7 @@ set -u
 set -e
 
 KITS="all-languages english"
-COMPRESSIONS="zip-7z tbz txz tgz 7z"
+COMPRESSIONS="zip-7z txz tgz 7z"
 
 # Process parameters
 
@@ -297,10 +297,6 @@ for kit in $KITS ; do
                     echo "* Creating $name.tar"
                     tar --owner=root --group=root --numeric-owner --sort=name -cf $name.tar $name
                 fi
-                if [ $comp = tbz ] ; then
-                    echo "* Creating $name.tar.bz2"
-                    bzip2 -9k $name.tar
-                fi
                 if [ $comp = txz ] ; then
                     echo "* Creating $name.tar.xz"
                     xz -9k $name.tar
@@ -337,7 +333,7 @@ git worktree prune
 
 # Signing of files with default GPG key
 echo "* Signing files"
-for file in *.gz *.zip *.xz *.bz2 *.7z ; do
+for file in *.gz *.zip *.xz *.7z ; do
     gpg --detach-sign --armor $file
     sha1sum $file > $file.sha1
     sha256sum $file > $file.sha256
@@ -350,7 +346,7 @@ echo ""
 echo "Files:"
 echo "------"
 
-ls -la *.gz *.zip *.xz *.bz2 *.7z
+ls -la *.gz *.zip *.xz *.7z
 
 cd ..
 

--- a/scripts/lang-cleanup.sh
+++ b/scripts/lang-cleanup.sh
@@ -14,6 +14,7 @@ if [ $# -lt 1 ] ; then
     echo "Usage: lang-cleanup.sh type"
     echo "Type can be one of:"
     echo "  all-languages - nothing will be done"
+    echo "  source - nothing will be done"
     echo "  english - no translations will be kept"
     echo "  langcode - keeps language"
     echo
@@ -25,7 +26,7 @@ fi
 match=""
 for type in "$@" ; do
     case $type in
-        all-languages)
+        all-languages|source)
             exit 0
             ;;
         english)

--- a/scripts/upload-release
+++ b/scripts/upload-release
@@ -35,32 +35,24 @@ put phpMyAdmin-$REL-all-languages.tar.gz
 put phpMyAdmin-$REL-english.tar.gz
 put phpMyAdmin-$REL-all-languages.zip
 put phpMyAdmin-$REL-english.zip
-put phpMyAdmin-$REL-all-languages.7z
-put phpMyAdmin-$REL-english.7z
 put phpMyAdmin-$REL-all-languages.tar.xz.asc
 put phpMyAdmin-$REL-english.tar.xz.asc
 put phpMyAdmin-$REL-all-languages.tar.gz.asc
 put phpMyAdmin-$REL-english.tar.gz.asc
 put phpMyAdmin-$REL-all-languages.zip.asc
 put phpMyAdmin-$REL-english.zip.asc
-put phpMyAdmin-$REL-all-languages.7z.asc
-put phpMyAdmin-$REL-english.7z.asc
 put phpMyAdmin-$REL-all-languages.tar.xz.sha256
 put phpMyAdmin-$REL-english.tar.xz.sha256
 put phpMyAdmin-$REL-all-languages.tar.gz.sha256
 put phpMyAdmin-$REL-english.tar.gz.sha256
 put phpMyAdmin-$REL-all-languages.zip.sha256
 put phpMyAdmin-$REL-english.zip.sha256
-put phpMyAdmin-$REL-all-languages.7z.sha256
-put phpMyAdmin-$REL-english.7z.sha256
 put phpMyAdmin-$REL-all-languages.tar.xz.sha1
 put phpMyAdmin-$REL-english.tar.xz.sha1
 put phpMyAdmin-$REL-all-languages.tar.gz.sha1
 put phpMyAdmin-$REL-english.tar.gz.sha1
 put phpMyAdmin-$REL-all-languages.zip.sha1
 put phpMyAdmin-$REL-english.zip.sha1
-put phpMyAdmin-$REL-all-languages.7z.sha1
-put phpMyAdmin-$REL-english.7z.sha1
 put phpMyAdmin-$REL-notes.html
 EOT
 

--- a/scripts/upload-release
+++ b/scripts/upload-release
@@ -54,6 +54,10 @@ put phpMyAdmin-$REL-english.tar.gz.sha1
 put phpMyAdmin-$REL-all-languages.zip.sha1
 put phpMyAdmin-$REL-english.zip.sha1
 put phpMyAdmin-$REL-notes.html
+put phpMyAdmin-$REL-source.tar.xz
+put phpMyAdmin-$REL-source.tar.xz.asc
+put phpMyAdmin-$REL-source.tar.xz.sha256
+put phpMyAdmin-$REL-source.tar.xz.sha1
 EOT
 
 # Upload to our file server

--- a/scripts/upload-release
+++ b/scripts/upload-release
@@ -29,8 +29,6 @@ cat > $BATCH <<EOT
 cd /mnt/storage/files/phpMyAdmin
 mkdir $REL
 cd $REL
-put phpMyAdmin-$REL-all-languages.tar.bz2
-put phpMyAdmin-$REL-english.tar.bz2
 put phpMyAdmin-$REL-all-languages.tar.xz
 put phpMyAdmin-$REL-english.tar.xz
 put phpMyAdmin-$REL-all-languages.tar.gz
@@ -39,8 +37,6 @@ put phpMyAdmin-$REL-all-languages.zip
 put phpMyAdmin-$REL-english.zip
 put phpMyAdmin-$REL-all-languages.7z
 put phpMyAdmin-$REL-english.7z
-put phpMyAdmin-$REL-all-languages.tar.bz2.asc
-put phpMyAdmin-$REL-english.tar.bz2.asc
 put phpMyAdmin-$REL-all-languages.tar.xz.asc
 put phpMyAdmin-$REL-english.tar.xz.asc
 put phpMyAdmin-$REL-all-languages.tar.gz.asc
@@ -49,8 +45,6 @@ put phpMyAdmin-$REL-all-languages.zip.asc
 put phpMyAdmin-$REL-english.zip.asc
 put phpMyAdmin-$REL-all-languages.7z.asc
 put phpMyAdmin-$REL-english.7z.asc
-put phpMyAdmin-$REL-all-languages.tar.bz2.sha256
-put phpMyAdmin-$REL-english.tar.bz2.sha256
 put phpMyAdmin-$REL-all-languages.tar.xz.sha256
 put phpMyAdmin-$REL-english.tar.xz.sha256
 put phpMyAdmin-$REL-all-languages.tar.gz.sha256
@@ -59,8 +53,6 @@ put phpMyAdmin-$REL-all-languages.zip.sha256
 put phpMyAdmin-$REL-english.zip.sha256
 put phpMyAdmin-$REL-all-languages.7z.sha256
 put phpMyAdmin-$REL-english.7z.sha256
-put phpMyAdmin-$REL-all-languages.tar.bz2.sha1
-put phpMyAdmin-$REL-english.tar.bz2.sha1
 put phpMyAdmin-$REL-all-languages.tar.xz.sha1
 put phpMyAdmin-$REL-english.tar.xz.sha1
 put phpMyAdmin-$REL-all-languages.tar.gz.sha1


### PR DESCRIPTION
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

See https://github.com/phpmyadmin/phpmyadmin/issues/12348 for discussion which lead to writing this code.

This add source release and removes many files from the standard releases, the outcome is:

* smaller default download size (around 2 MB saved on every single file)
* less chance for exploits for normal users as they don't get testsuite (they don't need)
* there is one more download kit including sources, it is quite big as it includes po files we did not ship before at all (strictly speaking this violates GPL)
* to reduce number of download options, I've disabled 7z and tar.bz2 compressions