### PR TITLE
Fix PHP Notice 'Undefined index: row_format' when altering table options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -71,6 +71,7 @@ phpMyAdmin - ChangeLog
 - issue #12859 Changed WHERE condition to 0 instead of 1 for SQL query window to avoid accidents
 - issue #12872 Use same query for display and execution when dropping index
 - issue #12868 Fix check for user groups freatures being enabled
+- issue #12840 Fix Notice regarding 'Undefined index: row_format' when altering table options
 
 4.6.5.2 (2016-12-05)
 - issue #12765 Fixed SQL export with newlines

--- a/tbl_operations.php
+++ b/tbl_operations.php
@@ -134,13 +134,17 @@ if (isset($_REQUEST['submitoptions'])) {
         $new_tbl_storage_engine = '';
     }
 
+    $row_format = (isset($create_options['row_format']))
+        ? $create_options['row_format']
+        : $pma_table->getStatusInfo('ROW_FORMAT');
+
     $table_alters = PMA_getTableAltersArray(
         $pma_table,
         $create_options['pack_keys'],
         (empty($create_options['checksum']) ? '0' : '1'),
         ((isset($create_options['page_checksum'])) ? $create_options['page_checksum'] : ''),
         (empty($create_options['delay_key_write']) ? '0' : '1'),
-        $create_options['row_format'],
+        $row_format,
         $new_tbl_storage_engine,
         ((isset($create_options['transactional']) && $create_options['transactional'] == '0') ? '0' : '1'),
         $tbl_collation


### PR DESCRIPTION
Issue #12840
Signed-off-by: Tim McLaughlin <tim.j.mclaughlin@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
