### PR TITLE
$param was not being used in mockResponse()

### DIFF
--- a/test/PMATestCase.php
+++ b/test/PMATestCase.php
@@ -27,7 +27,7 @@ class PMATestCase extends PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function mockResponse($param)
+    public function mockResponse()
     {
         $this->restoreInstance = PMA\libraries\Response::getInstance();
 


### PR DESCRIPTION
There was a parameter ($param) not being used in the mockResponse() method.

https://scrutinizer-ci.com/g/phpmyadmin/phpmyadmin/inspections/173bc2d8-f521-4adf-ad46-0c5f65514a89/issues/files/test/PMATestCase.php?status=new&orderField=path&order=asc&honorSelectedPaths=0
