### PR TITLE
Fix PHP Notice 'Undefined index: row_format' when altering table options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ phpMyAdmin - ChangeLog
 - issue #12826 Honor user configured connection collation
 - issue #12293 Correctly report OpenSSL errors from cookie encryption
 - issue #12814 DateTime won't allow to input length in Routine editor
+- issue #12840 Fix Notice regarding 'Undefined index: row_format' when altering table options
 - issue #12841 Fixed moving of columns with whitespace in name
 - issue #12847 Fixed editing of virtual columns
 - issue #12859 Changed WHERE condition to 0 instead of 1 for SQL query window to avoid accidents

--- a/tbl_operations.php
+++ b/tbl_operations.php
@@ -146,13 +146,17 @@ if (isset($_REQUEST['submitoptions'])) {
         $new_tbl_storage_engine = '';
     }
 
+    $row_format = (isset($create_options['row_format']))
+        ? $create_options['row_format']
+        : $pma_table->getStatusInfo('ROW_FORMAT');
+
     $table_alters = PMA_getTableAltersArray(
         $is_myisam_or_aria, $is_isam, $create_options['pack_keys'],
         (empty($create_options['checksum']) ? '0' : '1'),
         $is_aria,
         ((isset($create_options['page_checksum'])) ? $create_options['page_checksum'] : ''),
         (empty($create_options['delay_key_write']) ? '0' : '1'),
-        $is_innodb, $is_pbxt, $create_options['row_format'],
+        $is_innodb, $is_pbxt, $row_format,
         $new_tbl_storage_engine,
         ((isset($create_options['transactional']) && $create_options['transactional'] == '0') ? '0' : '1'),
         $tbl_collation


### PR DESCRIPTION
Issue #12840
Signed-off-by: Tim McLaughlin <tim.j.mclaughlin@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
