### PR TITLE
Only convert table name to lower-case when installation forces it

### DIFF
--- a/libraries/Table.php
+++ b/libraries/Table.php
@@ -1316,7 +1316,7 @@ class Table
                 );
             }
         );
-        if ($lowerCaseTableNames) {
+        if ($lowerCaseTableNames === '1') {
             $new_name = strtolower($new_name);
         }
 


### PR DESCRIPTION
Issue #12861

A `lower_case_table_names` setting of `2` does not mean that the table needs to be forced to lower-case.
This preserves case unless the `lower_case_table_names` setting is `1`, implying that lower-case should be forced.

Signed-off-by: Mike Lewis <mike@mplew.is>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests


I left the last checkbox above blank because I have no idea if you all want tests for table renaming under different `lower_case_table_names` settings (currently, from [your table testing file](https://github.com/phpmyadmin/phpmyadmin/blob/b40e9c13f285be626de972e6414416a4f047f757/test/classes/TableTest.php#L745) you only run your tests with `lower_case_table_names=0`). I can definitely add some tests to this PR if you want or need them.