### PR TITLE
Add margin to the "add new column" text in central columns page

### DIFF
--- a/libraries/central_columns.lib.php
+++ b/libraries/central_columns.lib.php
@@ -1259,7 +1259,7 @@ function PMA_handleColumnExtra(&$columns_list)
  */
 function PMA_getHTMLforAddNewColumn($db)
 {
-    $addNewColumn = '<div id="add_col_div"><a href="#">'
+    $addNewColumn = '<div id="add_col_div" class="topmargin"><a href="#">'
         . '<span>+</span> ' . __('Add new column') . '</a>'
         . '<form id="add_new" style="min-width:100%;display:none" '
         . 'method="post" action="db_central_columns.php">'


### PR DESCRIPTION
Closes #12834 

Hello, first time contributor. This PR will add a small top margin to the "add new column" text found in the central columns page. This is done by adding an existing `topmargin` css class found in existing css files. This eliminates the need to modify any CSS files in this PR while achieving the desired effect.

Before:

![before_changes](https://cloud.githubusercontent.com/assets/13433484/21962525/e68c64d4-db62-11e6-86f9-ab251f4bddc6.PNG)

After:

![after_changes](https://cloud.githubusercontent.com/assets/13433484/21962527/f6a67bde-db62-11e6-90f3-01b7c01f4251.PNG)


Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
