### PR TITLE
Use correct-case table name in message for successful rename

### DIFF
--- a/libraries/operations.lib.php
+++ b/libraries/operations.lib.php
@@ -2083,8 +2083,15 @@ function PMA_moveOrCopyTable($db, $table)
             $old = Util::backquote($db) . '.'
                 . Util::backquote($table);
             $message->addParam($old);
+
+
+            $new_name = $_REQUEST['new_name'];
+            if ($GLOBALS['dbi']->getLowerCaseNames() === '1') {
+                $new_name = strtolower($new_name);
+            }
+
             $new = Util::backquote($_REQUEST['target_db']) . '.'
-                . Util::backquote($_REQUEST['new_name']);
+                . Util::backquote($new_name);
             $message->addParam($new);
 
             /* Check: Work on new table or on old table? */


### PR DESCRIPTION
Previously, the name returned was the name used in the request, rather than the name after the correcting for the server’s `lower_case_table_names` setting.

Following up on issue #12901 and @b2e2e77.

Signed-off-by: Mike Lewis <mike@mplew.is>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests