### PR TITLE
ascending order of bookmarks list

### DIFF
--- a/libraries/Bookmark.php
+++ b/libraries/Bookmark.php
@@ -277,7 +277,7 @@ class Bookmark
         if ($db !== false) {
             $query .= " AND dbase = '" . $GLOBALS['dbi']->escapeString($db) . "'";
         }
-        $query .= " ORDER BY label";
+        $query .= " ORDER BY label ASC";
 
         $result = $GLOBALS['dbi']->fetchResult(
             $query,


### PR DESCRIPTION
Tested on my mac machine, the list was sorted but in PHPMyAdmin demos ( both 4.7 and 4.6 ), list was unsorted. Therefore added "ASC" to get ascending list of bookmarks.

Fix #12922 

Signed-off-by: Piyush Agrawal <poush12@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
