### PR TITLE
enhancing server variables table view

### DIFF
--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -1095,7 +1095,9 @@ div#logTable table {
     text-overflow: ellipsis;
     line-height: 2em;
 }
-
+#serverVariables .var-row > td:last-child {
+    text-align: center;
+}
 #serverVariables .var-header {
     font-weight:        bold;
     color:              <?php echo $GLOBALS['cfg']['ThColor']; ?>;

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -1433,6 +1433,9 @@ div#queryAnalyzerDialog table.queryNums {
     text-overflow: ellipsis;
     line-height: 2em;
 }
+#serverVariables .var-row > td:last-child {
+    text-align: center;
+}
 #serverVariables .var-header {
     color: <?php echo $GLOBALS['cfg']['ThColor']; ?>;
     background: #f3f3f3;


### PR DESCRIPTION
Fixes: #12899 

Set text-align to center, looks like this:
<img width="1199" alt="screen shot 2017-02-01 at 11 53 29 am" src="https://cloud.githubusercontent.com/assets/1812082/22497135/60203f40-e875-11e6-8742-7cdde79f32c6.png">

Please provide me any suggestions to improve it more.

Signed-off-by: Piyush Agrawal <poush12@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
