### PR TITLE
token mismatch error after php session timeout

### DIFF
--- a/libraries/session.lib.php
+++ b/libraries/session.lib.php
@@ -30,7 +30,9 @@ function PMA_secureSession()
  */
 function PMA_generateToken()
 {
-    if (class_exists('phpseclib\Crypt\Random')) {
+    if (32 == PMA_isValid($_REQUEST['token']) && ctype_xdigit($_REQUEST['token'])) {
+        $_SESSION[' PMA_token '] = $_REQUEST['token'];
+    } else if (class_exists('phpseclib\Crypt\Random')) {
         $_SESSION[' PMA_token '] = bin2hex(phpseclib\Crypt\Random::string(16));
     } else {
         $_SESSION[' PMA_token '] = bin2hex(openssl_random_pseudo_bytes(16));


### PR DESCRIPTION
Make sure the security token given by the client is compared only against a valid session token. If the php session no longer exists, use a valid client-provided token.

Many people seem to keep their phpMyAdmin browser windows open, receiving the - really annoying - token error on the first action next day - only because the php session has timed out.
Applying this tiny change transparently creates the new session re-using the old token if the user is (still) correctly signed in.

Signed-off-by: Thomas Horner <github-phpmyadmin@t-horner.com>