### PR TITLE
Remove connect_type setting

### DIFF
--- a/config.sample.inc.php
+++ b/config.sample.inc.php
@@ -29,7 +29,6 @@ $i++;
 $cfg['Servers'][$i]['auth_type'] = 'cookie';
 /* Server parameters */
 $cfg['Servers'][$i]['host'] = 'localhost';
-$cfg['Servers'][$i]['connect_type'] = 'tcp';
 $cfg['Servers'][$i]['compress'] = false;
 $cfg['Servers'][$i]['AllowNoPassword'] = false;
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -221,7 +221,7 @@ Server connection settings
         The hostname ``localhost`` is handled specially by MySQL and it uses
         the socket based connection protocol. To use TCP/IP networking, use an
         IP address or hostname such as ``127.0.0.1`` or ``db.example.com``. You
-        can configure socket address by
+        can configure the path to the socket with
         :config:option:`$cfg['Servers'][$i]['socket']`.
 
     .. seealso::

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -219,7 +219,9 @@ Server connection settings
     .. note::
 
         The hostname ``localhost`` is handled specially by MySQL and it
-        ignores :config:option:`$cfg['Servers'][$i]['port']` in this case.
+        ignores :config:option:`$cfg['Servers'][$i]['port']` in this case
+        and uses socket based connection. You can configure
+        socket address by :config:option:`$cfg['Servers'][$i]['socket']`.
 
     .. seealso::
 
@@ -255,6 +257,11 @@ Server connection settings
     the correct socket, check your MySQL configuration or, using the
     :command:`mysql` command–line client, issue the ``status`` command. Among the
     resulting information displayed will be the socket used.
+
+    .. note::
+
+        This takes effect only if :config:option:`$cfg['Servers'][$i]['host']` is set
+        to ``localhost``.
 
     .. seealso::
 
@@ -417,6 +424,13 @@ Server connection settings
 
     :type: string
     :default: ``'tcp'``
+
+    .. deprecated:: 4.7.0
+
+       This settings is no longer used as of 4.7.0, the MySQL anyway decides
+       connection type based on host, so it could lead to unexpected results.
+       Please set :config:option:`$cfg['Servers'][$i]['host']` accordingly
+       instead.
 
     What type connection to use with the MySQL server. Your options are
     ``'socket'`` and ``'tcp'``. It defaults to tcp as that is nearly guaranteed

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -218,10 +218,11 @@ Server connection settings
 
     .. note::
 
-        The hostname ``localhost`` is handled specially by MySQL and it
-        ignores :config:option:`$cfg['Servers'][$i]['port']` in this case
-        and uses socket based connection. You can configure
-        socket address by :config:option:`$cfg['Servers'][$i]['socket']`.
+        The hostname ``localhost`` is handled specially by MySQL and it uses
+        the socket based connection protocol. To use TCP/IP networking, use an
+        IP address or hostname such as ``127.0.0.1`` or ``db.example.com``. You
+        can configure socket address by
+        :config:option:`$cfg['Servers'][$i]['socket']`.
 
     .. seealso::
 
@@ -427,7 +428,7 @@ Server connection settings
 
     .. deprecated:: 4.7.0
 
-       This settings is no longer used as of 4.7.0, the MySQL anyway decides
+       This setting is no longer used as of 4.7.0, since MySQL decides the
        connection type based on host, so it could lead to unexpected results.
        Please set :config:option:`$cfg['Servers'][$i]['host']` accordingly
        instead.

--- a/examples/config.manyhosts.inc.php
+++ b/examples/config.manyhosts.inc.php
@@ -22,7 +22,6 @@ foreach ($hosts as $host) {
     $cfg['Servers'][$i]['host']     = $host;
     $cfg['Servers'][$i]['port']     = '';
     $cfg['Servers'][$i]['socket']   = '';
-    $cfg['Servers'][$i]['connect_type']     = 'tcp';
     $cfg['Servers'][$i]['compress'] = false;
     $cfg['Servers'][$i]['controluser']      = 'pma';
     $cfg['Servers'][$i]['controlpass']      = 'pmapass';

--- a/libraries/DatabaseInterface.php
+++ b/libraries/DatabaseInterface.php
@@ -2278,7 +2278,7 @@ class DatabaseInterface
             // Share the settings if the host is same
             if ($server['host'] == $cfg['Server']['host']) {
                 $shared = array(
-                    'port', 'socket', 'connect_type', 'compress',
+                    'port', 'socket', 'compress',
                     'ssl', 'ssl_key', 'ssl_cert', 'ssl_ca',
                     'ssl_ca_path',  'ssl_ciphers', 'ssl_verify',
                 );

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -495,29 +495,12 @@ if (! isset($cfg['Servers']) || count($cfg['Servers']) == 0) {
 
         $each_server = array_merge($default_server, $each_server);
 
-        // Don't use servers with no hostname
-        if ($each_server['connect_type'] == 'tcp' && empty($each_server['host'])) {
-            trigger_error(
-                sprintf(
-                    __(
-                        'Invalid hostname for server %1$s. '
-                        . 'Please review your configuration.'
-                    ),
-                    $server_index
-                ),
-                E_USER_ERROR
-            );
-        }
-
         // Final solution to bug #582890
         // If we are using a socket connection
         // and there is nothing in the verbose server name
         // or the host field, then generate a name for the server
         // in the form of "Server 2", localized of course!
-        if ($each_server['connect_type'] == 'socket'
-            && empty($each_server['host'])
-            && empty($each_server['verbose'])
-        ) {
+        if (empty($each_server['host']) && empty($each_server['verbose'])) {
             $each_server['verbose'] = sprintf(__('Server %d'), $server_index);
         }
 
@@ -719,11 +702,6 @@ if (! defined('PMA_MINIMUM_COMMON')) {
             $login_without_password_is_forbidden = true;
             Logging::logUser($cfg['Server']['user'], 'empty-denied');
             $auth_plugin->authFails();
-        }
-
-        // if using TCP socket is not needed
-        if (mb_strtolower($cfg['Server']['connect_type']) == 'tcp') {
-            $cfg['Server']['socket'] = '';
         }
 
         // Try to connect MySQL with the control user profile (will be used to

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -192,13 +192,6 @@ $cfg['Servers'][$i]['ssl_ciphers'] = null;
 $cfg['Servers'][$i]['ssl_verify'] = true;
 
 /**
- * How to connect to MySQL server ('tcp' or 'socket')
- *
- * @global string $cfg['Servers'][$i]['connect_type']
- */
-$cfg['Servers'][$i]['connect_type'] = 'tcp';
-
-/**
  * Use compressed protocol for the MySQL connection
  *
  * @global boolean $cfg['Servers'][$i]['compress']

--- a/libraries/config.values.php
+++ b/libraries/config.values.php
@@ -23,7 +23,6 @@ $cfg_db = array();
 $cfg_db['Servers'] = array(
     1 => array(
         'port'         => 'integer',
-        'connect_type' => array('tcp', 'socket'),
         'auth_type'    => array('config', 'http', 'signon', 'cookie'),
         'AllowDeny'    => array(
             'order' => array('', 'deny,allow', 'allow,deny', 'explicit')

--- a/libraries/config/ConfigFile.php
+++ b/libraries/config/ConfigFile.php
@@ -421,7 +421,7 @@ class ConfigFile
             }
             $dsn .= '@';
         }
-        if ($this->getValue("$path/connect_type") == 'tcp') {
+        if ($this->getValue("$path/host") != 'localhost') {
             $dsn .= $this->getValue("$path/host");
             $port = $this->getValue("$path/port");
             if ($port) {

--- a/libraries/config/Validator.php
+++ b/libraries/config/Validator.php
@@ -162,7 +162,6 @@ class Validator
     /**
      * Test database connection
      *
-     * @param string $connect_type 'tcp' or 'socket'
      * @param string $host         host name
      * @param string $port         tcp port to use
      * @param string $socket       socket to use
@@ -173,7 +172,6 @@ class Validator
      * @return bool|array
      */
     public static function testDBConnection(
-        $connect_type,
         $host,
         $port,
         $socket,
@@ -186,14 +184,12 @@ class Validator
         $host = PMA_sanitizeMySQLHost($host);
 
         if (DatabaseInterface::checkDbExtension('mysqli')) {
-            $socket = empty($socket) || $connect_type == 'tcp' ? null : $socket;
-            $port = empty($port) || $connect_type == 'socket' ? null : $port;
+            $socket = empty($socket) ? null : $socket;
+            $port = empty($port) ? null : $port;
             $extension = 'mysqli';
         } else {
-            $socket = empty($socket) || $connect_type == 'tcp'
-                ? null
-                : ':' . ($socket[0] == '/' ? '' : '/') . $socket;
-            $port = empty($port) || $connect_type == 'socket' ? null : ':' . $port;
+            $socket = empty($socket) ? null : ':' . ($socket[0] == '/' ? '' : '/') . $socket;
+            $port = empty($port) ? null : ':' . $port;
             $extension = 'mysql';
         }
 
@@ -276,7 +272,6 @@ class Validator
                 $password = $values['Servers/1/password'];
             }
             $test = static::testDBConnection(
-                empty($values['Servers/1/connect_type']) ? '' : $values['Servers/1/connect_type'],
                 empty($values['Servers/1/host']) ? '' : $values['Servers/1/host'],
                 empty($values['Servers/1/port']) ? '' : $values['Servers/1/port'],
                 empty($values['Servers/1/socket']) ? '' : $values['Servers/1/socket'],
@@ -332,7 +327,6 @@ class Validator
         }
         if (! $error) {
             $test = static::testDBConnection(
-                empty($values['Servers/1/connect_type']) ? '' : $values['Servers/1/connect_type'],
                 empty($values['Servers/1/host']) ? '' : $values['Servers/1/host'],
                 empty($values['Servers/1/port']) ? '' : $values['Servers/1/port'],
                 empty($values['Servers/1/socket']) ? '' : $values['Servers/1/socket'],

--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -642,9 +642,6 @@ $strConfigServers_column_info_desc = __(
 $strConfigServers_column_info_name = __('Column information table');
 $strConfigServers_compress_desc = __('Compress connection to MySQL server.');
 $strConfigServers_compress_name = __('Compress connection');
-$strConfigServers_connect_type_desc
-    = __('How to connect to server, keep [kbd]tcp[/kbd] if unsure.');
-$strConfigServers_connect_type_name = __('Connection type');
 $strConfigServers_controlpass_name = __('Control user password');
 $strConfigServers_controluser_desc = __(
     'A special MySQL user configured with limited permissions, more information '

--- a/libraries/config/setup.forms.php
+++ b/libraries/config/setup.forms.php
@@ -32,7 +32,6 @@ $forms['Servers']['Server'] = array('Servers' => array(1 => array(
     'port',
     'socket',
     'ssl',
-    'connect_type',
     'compress')));
 $forms['Servers']['Server_auth'] = array('Servers' => array(1 => array(
     'auth_type',

--- a/libraries/plugins/auth/AuthenticationCookie.php
+++ b/libraries/plugins/auth/AuthenticationCookie.php
@@ -446,7 +446,6 @@ class AuthenticationCookie extends AuthenticationPlugin
                     && $current['port'] == $cfg['Server']['port']
                     && $current['socket'] == $cfg['Server']['socket']
                     && $current['ssl'] == $cfg['Server']['ssl']
-                    && $current['connect_type'] == $cfg['Server']['connect_type']
                     && hash_equals($current['user'], $GLOBALS['PHP_AUTH_USER'])
                 ) {
                     $GLOBALS['server'] = $idx;

--- a/setup/lib/common.inc.php
+++ b/setup/lib/common.inc.php
@@ -41,7 +41,6 @@ $GLOBALS['ConfigFile']->setPersistKeys(
         'Servers/1/host',
         'Servers/1/port',
         'Servers/1/socket',
-        'Servers/1/connect_type',
         'Servers/1/auth_type',
         'Servers/1/user',
         'Servers/1/password'

--- a/test/classes/config/ConfigFileTest.php
+++ b/test/classes/config/ConfigFileTest.php
@@ -498,7 +498,6 @@ class ConfigFileTest extends PMATestCase
                     1 => array(
                         "auth_type" => "config",
                         "user" => "testUser",
-                        "connect_type" => "tcp",
                         "host" => "example.com",
                         "port" => "21"
                     )
@@ -516,8 +515,7 @@ class ConfigFileTest extends PMATestCase
                     1 => array(
                         "auth_type" => "config",
                         "user" => "testUser",
-                        "connect_type" => "socket",
-                        "host" => "example.com",
+                        "host" => "localhost",
                         "port" => "21",
                         "socket" => "123",
                         "password" => "",
@@ -536,7 +534,6 @@ class ConfigFileTest extends PMATestCase
                     1 => array(
                         "auth_type" => "config",
                         "user" => "testUser",
-                        "connect_type" => "tcp",
                         "host" => "example.com",
                         "port" => "21",
                         "password" => "testPass"

--- a/test/classes/config/FormDisplayTest.php
+++ b/test/classes/config/FormDisplayTest.php
@@ -224,7 +224,7 @@ class FormDisplayTest extends PMATestCase
         );
 
         $sysArr = array(
-            "Servers/1/test" => "Servers/1/connect_type"
+            "Servers/1/test" => "Servers/1/host"
         );
 
         $attrSystemPaths = $reflection->getProperty('_systemPaths');
@@ -239,7 +239,7 @@ class FormDisplayTest extends PMATestCase
             array(
                 'Servers' => array(
                     '1' => array(
-                        'test' => 'tcp'
+                        'test' => 'localhost'
                     )
                 )
             ),

--- a/test/classes/config/FormTest.php
+++ b/test/classes/config/FormTest.php
@@ -249,7 +249,7 @@ class FormTest extends PMATestCase
 
         $this->object->fields = array(
             "pma_form1" => "Servers/1/port",
-            "pma_form2" => "Servers/1/connect_type",
+            "pma_form2" => "Servers/1/auth_type",
             ":group:end:0" => "preffoo/foo/bar/test",
             "1" => "preffoo/foo/bar/:group:end:0"
         );

--- a/test/classes/plugin/auth/AuthenticationCookieTest.php
+++ b/test/classes/plugin/auth/AuthenticationCookieTest.php
@@ -640,7 +640,6 @@ class AuthenticationCookieTest extends PMATestCase
             'port' => 1,
             'socket' => true,
             'ssl' => true,
-            'connect_type' => 'port',
             'user' => 'pmaUser2'
         );
 
@@ -697,7 +696,6 @@ class AuthenticationCookieTest extends PMATestCase
             'port' => 1,
             'socket' => true,
             'ssl' => true,
-            'connect_type' => 'port',
             'user' => 'pmaUser2'
         );
 

--- a/test/test_data/config.inc.php
+++ b/test/test_data/config.inc.php
@@ -12,5 +12,4 @@ $cfg['Servers'][$i]['verbose'] = '';
 $cfg['Servers'][$i]['host'] = 'localhost';
 $cfg['Servers'][$i]['port'] = '';
 $cfg['Servers'][$i]['socket'] = '';
-$cfg['Servers'][$i]['connect_type'] = 'tcp';
 $cfg['Servers'][$i]['auth_type'] = 'cookie';


### PR DESCRIPTION
It is really not necessary as MySQL decides connection type rather based
on hostname than on anything else.

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
