### PR TITLE
Typographical quotes

### DIFF
--- a/libraries/Menu.php
+++ b/libraries/Menu.php
@@ -270,9 +270,11 @@ class Menu
                         );
                     }
                     $retval .= '<span class="table_comment"';
-                    $retval .= ' id="span_table_comment">&quot;';
-                    $retval .= htmlspecialchars($show_comment);
-                    $retval .= '&quot;</span>';
+                    $retval .= ' id="span_table_comment">';
+                    $retval .= sprintf(
+                        __('&ldquo;%s&rdquo;'), htmlspecialchars($show_comment)
+                    );
+                    $retval .= '</span>';
                 } // end if
             } else {
                 // no table selected, display database comment if present
@@ -287,9 +289,12 @@ class Menu
                      */
                     if (! empty($comment)) {
                         $retval .= '<span class="table_comment"'
-                            . ' id="span_table_comment">&quot;'
-                            . htmlspecialchars($comment)
-                            . '&quot;</span>';
+                            . ' id="span_table_comment">'
+                            . sprintf(
+                                __('&ldquo;%s&rdquo;'),
+                                htmlspecialchars($comment)
+                            )
+                            . '</span>';
                     } // end if
                 }
             }

--- a/libraries/Util.php
+++ b/libraries/Util.php
@@ -2547,7 +2547,7 @@ class Util
             . URL::getCommon(array('db' => $database)) . '" title="'
             . htmlspecialchars(
                 sprintf(
-                    __('Jump to database "%s".'),
+                    __('Jump to database “%s”.'),
                     $database
                 )
             )

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -4665,8 +4665,8 @@ function PMA_getHtmlForUserOverview($pmaThemeImage, $text_dir)
             if ($GLOBALS['is_reload_priv']) {
                 $flushnote = new Message(
                     __(
-                        'Note: phpMyAdmin gets the users\' privileges directly '
-                        . 'from MySQL\'s privilege tables. The content of these '
+                        'Note: phpMyAdmin gets the users’ privileges directly '
+                        . 'from MySQL’s privilege tables. The content of these '
                         . 'tables may differ from the privileges the server uses, '
                         . 'if they have been changed manually. In this case, '
                         . 'you should %sreload the privileges%s before you continue.'
@@ -4682,8 +4682,8 @@ function PMA_getHtmlForUserOverview($pmaThemeImage, $text_dir)
             } else {
                 $flushnote = new Message(
                     __(
-                        'Note: phpMyAdmin gets the users\' privileges directly '
-                        . 'from MySQL\'s privilege tables. The content of these '
+                        'Note: phpMyAdmin gets the users’ privileges directly '
+                        . 'from MySQL’s privilege tables. The content of these '
                         . 'tables may differ from the privileges the server uses, '
                         . 'if they have been changed manually. In this case, '
                         . 'the privileges have to be reloaded but currently, you '

--- a/libraries/sql_query_form.lib.php
+++ b/libraries/sql_query_form.lib.php
@@ -137,11 +137,14 @@ function PMA_initQueryForm($query)
         // prepare for server related
         $legend = sprintf(
             __('Run SQL query/queries on server %s'),
-            '&quot;' . htmlspecialchars(
-                ! empty($GLOBALS['cfg']['Servers'][$GLOBALS['server']]['verbose'])
-                ? $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['verbose']
-                : $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['host']
-            ) . '&quot;'
+            sprintf(
+                __('&ldquo;%s&rdquo;'),
+                htmlspecialchars(
+                    ! empty($GLOBALS['cfg']['Servers'][$GLOBALS['server']]['verbose'])
+                    ? $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['verbose']
+                    : $GLOBALS['cfg']['Servers'][$GLOBALS['server']]['host']
+                )
+            )
         );
     } elseif (strlen($GLOBALS['table']) === 0) {
         // prepare for db related

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -2365,8 +2365,8 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
             'Note: MySQL privilege names are expressed in English.', $actual
         );
         $this->assertContains(
-            'Note: phpMyAdmin gets the users\' privileges directly '
-            . 'from MySQL\'s privilege tables.',
+            'Note: phpMyAdmin gets the users’ privileges directly '
+            . 'from MySQL’s privilege tables.',
             $actual
         );
     }

--- a/test/libraries/common/PMA_getDbLink_test.php
+++ b/test/libraries/common/PMA_getDbLink_test.php
@@ -59,8 +59,8 @@ class PMA_GetDbLink_Test extends PHPUnit_Framework_TestCase
             )
             . '?db=' . $database
             . '&amp;server=99&amp;lang=en" '
-            . 'title="Jump to database &ldquo;'
-            . htmlspecialchars($database) . '&rdquo;.">'
+            . 'title="Jump to database “'
+            . htmlspecialchars($database) . '”.">'
             . htmlspecialchars($database) . '</a>',
             PMA\libraries\Util::getDbLink()
         );
@@ -80,8 +80,8 @@ class PMA_GetDbLink_Test extends PHPUnit_Framework_TestCase
                 $GLOBALS['cfg']['DefaultTabDatabase'], 'database'
             )
             . '?db=' . $database
-            . '&amp;server=99&amp;lang=en" title="Jump to database &quot;'
-            . htmlspecialchars($database) . '&quot;.">'
+            . '&amp;server=99&amp;lang=en" title="Jump to database “'
+            . htmlspecialchars($database) . '”.">'
             . htmlspecialchars($database) . '</a>',
             PMA\libraries\Util::getDbLink($database)
         );
@@ -103,8 +103,8 @@ class PMA_GetDbLink_Test extends PHPUnit_Framework_TestCase
             )
             . '?db='
             . htmlspecialchars(urlencode($database))
-            . '&amp;server=99&amp;lang=en" title="Jump to database &quot;'
-            . htmlspecialchars($database) . '&quot;.">'
+            . '&amp;server=99&amp;lang=en" title="Jump to database “'
+            . htmlspecialchars($database) . '”.">'
             . htmlspecialchars($database) . '</a>',
             PMA\libraries\Util::getDbLink($database)
         );

--- a/test/libraries/common/PMA_getDbLink_test.php
+++ b/test/libraries/common/PMA_getDbLink_test.php
@@ -59,8 +59,8 @@ class PMA_GetDbLink_Test extends PHPUnit_Framework_TestCase
             )
             . '?db=' . $database
             . '&amp;server=99&amp;lang=en" '
-            . 'title="Jump to database &quot;'
-            . htmlspecialchars($database) . '&quot;.">'
+            . 'title="Jump to database &ldquo;'
+            . htmlspecialchars($database) . '&rdquo;.">'
             . htmlspecialchars($database) . '</a>',
             PMA\libraries\Util::getDbLink()
         );


### PR DESCRIPTION
Using typographical, localisable quotes (`“` and `”`) instead of plain ones.

<img width="521" alt="bildschirmfoto 2017-02-11 um 16 58 31" src="https://cloud.githubusercontent.com/assets/6348321/22861382/03239a20-f118-11e6-8189-81f50ab90c47.png">
