### PR TITLE
Home page: Hide languages if only 1 is available

### DIFF
--- a/index.php
+++ b/index.php
@@ -237,11 +237,14 @@ echo '  <ul>';
 
 // Displays language selection combo
 if (empty($cfg['Lang'])) {
-    echo '<li id="li_select_lang" class="no_bullets">';
+    $selector = LanguageManager::getInstance()->getSelectorDisplay();
 
-    echo PMA\libraries\Util::getImage('s_lang.png') , " "
-        , LanguageManager::getInstance()->getSelectorDisplay();
-    echo '</li>';
+    if (!empty(trim($selector))) {
+        echo '<li id="li_select_lang" class="no_bullets">';
+        echo PMA\libraries\Util::getImage('s_lang.png') , ' ' , $selector;
+        echo '</li>';
+    }
+    unset($selector);
 }
 
 // ThemeManager if available


### PR DESCRIPTION
This may happen on the development version when the mo files generator hasn't been run.

<img width="277" alt="bildschirmfoto 2017-02-11 um 16 31 15" src="https://cloud.githubusercontent.com/assets/6348321/22861364/cdcd5e9c-f117-11e6-8f19-a83d1808b708.png">
