### PR TITLE
Also submit inline SQL form when pressing the command key on macOS

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -2087,7 +2087,7 @@ function bindCodeMirrorToInlineEditor() {
 
 function catchKeypressesFromSqlInlineEdit(event) {
     // ctrl-enter is 10 in chrome and ie, but 13 in ff
-    if (event.ctrlKey && (event.keyCode == 13 || event.keyCode == 10)) {
+    if ((event.ctrlKey || event.metaKey) && (event.keyCode == 13 || event.keyCode == 10)) {
         $("#sql_query_edit_save").trigger('click');
     }
 }


### PR DESCRIPTION
Allows for the natural macOS key combination to submit a form (command + enter) to be used in addition to the Windows combination (control + enter).

Signed-off-by: Mike Lewis <mike@mplew.is>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
