### PR TITLE
Remove ServerLibraryDifference_DisableWarning setting

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -108,6 +108,10 @@ Basic settings
     :type: boolean
     :default: false
 
+    .. deprecated:: 4.7.0
+
+        This setting was removed as the warning has been removed as well.
+
     A warning is displayed on the main page if there is a difference
     between the MySQL library and server version.
 

--- a/index.php
+++ b/index.php
@@ -575,48 +575,6 @@ if ($server > 0) {
 }
 
 /**
- * Warning about different MySQL library and server version
- * (a difference on the third digit does not count).
- * If someday there is a constant that we can check about mysqlnd,
- * we can use it instead of strpos().
- * If no default server is set, $GLOBALS['dbi'] is not defined yet.
- * We also do not warn if MariaDB is detected, as it has its own version
- * numbering.
- */
-if (isset($GLOBALS['dbi'])
-    && $cfg['ServerLibraryDifference_DisableWarning'] == false
-) {
-    $_client_info = $GLOBALS['dbi']->getClientInfo();
-    if ($server > 0
-        && mb_strpos($_client_info, 'mysqlnd') === false
-        && mb_strpos(PMA_MYSQL_STR_VERSION, 'MariaDB') === false
-        && substr(PMA_MYSQL_CLIENT_API, 0, 3) != substr(
-            PMA_MYSQL_INT_VERSION, 0, 3
-        )
-    ) {
-        trigger_error(
-            Sanitize::sanitize(
-                sprintf(
-                    __(
-                        'Your PHP MySQL library version %s differs from your ' .
-                        'MySQL server version %s. This may cause unpredictable ' .
-                        'behavior.'
-                    ),
-                    $_client_info,
-                    substr(
-                        PMA_MYSQL_STR_VERSION,
-                        0,
-                        strpos(PMA_MYSQL_STR_VERSION . '-', '-')
-                    )
-                )
-            ),
-            E_USER_NOTICE
-        );
-    }
-    unset($_client_info);
-}
-
-/**
  * Warning about Suhosin only if its simulation mode is not enabled
  */
 if ($cfg['SuhosinDisableWarning'] == false

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -62,14 +62,6 @@ $cfg['SuhosinDisableWarning'] = false;
 $cfg['LoginCookieValidityDisableWarning'] = false;
 
 /**
- * Disable the default warning that is displayed if a difference between
- * the MySQL library and server is detected.
- *
- * @global boolean $cfg['['ServerLibraryDifference_DisableWarning']']
- */
-$cfg['ServerLibraryDifference_DisableWarning'] = false;
-
-/**
  * Disable the default warning about MySQL reserved words in column names
  *
  * @global boolean $cfg['ReservedWordDisableWarning']

--- a/libraries/config/messages.inc.php
+++ b/libraries/config/messages.inc.php
@@ -568,12 +568,6 @@ $strConfigPmaNoRelation_DisableWarning_desc = __(
 );
 $strConfigPmaNoRelation_DisableWarning_name
     = __('Missing phpMyAdmin configuration storage tables');
-$strConfigServerLibraryDifference_DisableWarning_desc = __(
-    'Disable the default warning that is displayed if a difference between the '
-    . 'MySQL library and server is detected.'
-);
-$strConfigServerLibraryDifference_DisableWarning_name
-    = __('Server/library difference warning');
 $strConfigReservedWordDisableWarning_desc = __(
     'Disable the default warning that is displayed on the Structure page if column '
     . 'names in a table are reserved MySQL words.'

--- a/libraries/config/setup.forms.php
+++ b/libraries/config/setup.forms.php
@@ -117,7 +117,6 @@ $forms['Features']['Page_titles'] = array(
     'TitleDatabase',
     'TitleServer');
 $forms['Features']['Warnings'] = array(
-    'ServerLibraryDifference_DisableWarning',
     'PmaNoRelation_DisableWarning',
     'SuhosinDisableWarning',
     'LoginCookieValidityDisableWarning');

--- a/libraries/config/user_preferences.forms.php
+++ b/libraries/config/user_preferences.forms.php
@@ -53,7 +53,6 @@ $forms['Features']['Page_titles'] = array(
     'TitleDatabase',
     'TitleServer');
 $forms['Features']['Warnings'] = array(
-    'ServerLibraryDifference_DisableWarning',
     'PmaNoRelation_DisableWarning',
     'SuhosinDisableWarning',
     'LoginCookieValidityDisableWarning',


### PR DESCRIPTION
This is getting more and more problematic these days as most of Linux
distributions ship MariaDB libraries, while many people run MySQL
servers. As MariaDB claims the protocol compatibility should stay, we
should not warn in this case.

Of course there is option to add this exception to the warning (so far
the exception is there only other way - when using MySQL libraries to
connect to MariaDB server), but we would be ignoring most cases already
and I think complete removal is better than adding exceptions.

Overall I don't think this warning is doing any good these days.

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
