### PR TITLE
Remove no longer needed code in authentication

### DIFF
--- a/libraries/plugins/auth/AuthenticationCookie.php
+++ b/libraries/plugins/auth/AuthenticationCookie.php
@@ -446,23 +446,6 @@ class AuthenticationCookie extends AuthenticationPlugin
     {
         global $cfg;
 
-        // Ensures valid authentication mode, 'only_db', bookmark database and
-        // table names and relation table name are used
-        if (! hash_equals($cfg['Server']['user'], $GLOBALS['PHP_AUTH_USER'])) {
-            foreach ($cfg['Servers'] as $idx => $current) {
-                if ($current['host'] == $cfg['Server']['host']
-                    && $current['port'] == $cfg['Server']['port']
-                    && $current['socket'] == $cfg['Server']['socket']
-                    && $current['ssl'] == $cfg['Server']['ssl']
-                    && hash_equals($current['user'], $GLOBALS['PHP_AUTH_USER'])
-                ) {
-                    $GLOBALS['server'] = $idx;
-                    $cfg['Server']     = $current;
-                    break;
-                }
-            } // end foreach
-        } // end if
-
         if ($GLOBALS['cfg']['AllowArbitraryServer']
             && ! empty($GLOBALS['pma_auth_server'])
         ) {

--- a/libraries/plugins/auth/AuthenticationHttp.php
+++ b/libraries/plugins/auth/AuthenticationHttp.php
@@ -195,22 +195,6 @@ class AuthenticationHttp extends AuthenticationPlugin
         global $cfg, $server;
         global $PHP_AUTH_USER, $PHP_AUTH_PW;
 
-        // Ensures valid authentication mode, 'only_db', bookmark database and
-        // table names and relation table name are used
-        if (! hash_equals($cfg['Server']['user'], $PHP_AUTH_USER)) {
-            $servers_cnt = count($cfg['Servers']);
-            for ($i = 1; $i <= $servers_cnt; $i++) {
-                if (isset($cfg['Servers'][$i])
-                    && ($cfg['Servers'][$i]['host'] == $cfg['Server']['host']
-                    && hash_equals($cfg['Servers'][$i]['user'], $PHP_AUTH_USER))
-                ) {
-                    $server = $i;
-                    $cfg['Server'] = $cfg['Servers'][$i];
-                    break;
-                }
-            } // end for
-        } // end if
-
         $cfg['Server']['user'] = $PHP_AUTH_USER;
         $cfg['Server']['password'] = $PHP_AUTH_PW;
 

--- a/test/classes/plugin/auth/AuthenticationCookieTest.php
+++ b/test/classes/plugin/auth/AuthenticationCookieTest.php
@@ -666,11 +666,11 @@ class AuthenticationCookieTest extends PMATestCase
         $this->object->storeUserCredentials();
 
         $this->assertTrue(
-            isset($_COOKIE['pmaUser-1'])
+            isset($_COOKIE['pmaUser-2'])
         );
 
         $this->assertTrue(
-            isset($_COOKIE['pmaAuth-1'])
+            isset($_COOKIE['pmaAuth-2'])
         );
 
         $arr['password'] = 'testPW';

--- a/test/classes/plugin/auth/AuthenticationHttpTest.php
+++ b/test/classes/plugin/auth/AuthenticationHttpTest.php
@@ -333,13 +333,12 @@ class AuthenticationHttpTest extends PMATestCase
                 'user' => 'testUser',
                 'password' => 'testPass',
                 'host' => 'a',
-                'foo' => 'bar'
             ),
             $GLOBALS['cfg']['Server']
         );
 
         $this->assertEquals(
-            1,
+            2,
             $GLOBALS['server']
         );
 


### PR DESCRIPTION
The code is incosistent between auth methods and I don't see any purpose
for it.

Fixes #12478
Fixes #13003

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
