### PR TITLE
Hide comment field when no table comment is set

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -84,6 +84,7 @@ phpMyAdmin - ChangeLog
 - issue #13000 Align NULL values according to the column alignment
 - issue #13021 Show phpMyAdmin errors even with error_reporting set to 0
 - issue #13020 Removed warning about client and server versions mismatch
+- issue        Hide comments on table Structure tab when no comment is set
 
 4.6.6 (2017-01-23)
 - issue #12759 Fix Notice regarding 'Undefined index: old_usergroup'

--- a/templates/table/structure/display_table_stats.phtml
+++ b/templates/table/structure/display_table_stats.phtml
@@ -1,9 +1,11 @@
 <div id="tablestatistics">
     <fieldset>
         <legend><?= __('Information'); ?></legend>
-        <p> <strong> <?= __('Table comments:') ?> </strong>
-            <?= isset($showtable['TABLE_COMMENT']) ? htmlspecialchars($showtable['TABLE_COMMENT']) : '';?>
-        </p>
+        <?php if($showtable['TABLE_COMMENT'] !== '') { ?>
+            <p> <strong> <?= __('Table comments:') ?> </strong>
+                <?= htmlspecialchars($showtable['TABLE_COMMENT']) ;?>
+            </p>
+        <?php } ?>
         <a id="showusage"></a>
 
         <?php if (! $tbl_is_view && ! $db_is_system_schema): ?>


### PR DESCRIPTION
On the table structure tab, this hide table comments if there is none. See https://github.com/phpmyadmin/phpmyadmin/issues/12961#issuecomment-281040584

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
