### PR TITLE
PMA-Version Stripped-Inconsistent useragent in httpRequest #12708

### DIFF
--- a/libraries/Util.php
+++ b/libraries/Util.php
@@ -4740,7 +4740,7 @@ class Util
                 );
             }
         }
-        $curl_status &= curl_setopt($curl_handle, CURLOPT_USERAGENT, 'phpMyAdmin/' . PMA_VERSION);
+        $curl_status &= curl_setopt($curl_handle, CURLOPT_USERAGENT, 'phpMyAdmin');
 
         if ($method != "GET") {
             $curl_status &= curl_setopt($curl_handle, CURLOPT_CUSTOMREQUEST, $method);


### PR DESCRIPTION
PMA Version stripped from curl user-agent to increase consistency and improve security. 
#12708 
