### PR TITLE
Improved database search to allow search for exact phrase match

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ phpMyAdmin - ChangeLog
 - issue #13087 Offer login as different user on access denied from MySQL
 - issue #13110 Indicate when HTTPS is not properly reported on the server
 - issue #13119 No database selected error when adding foreign key
+- issue #12388 Improved database search to allow search for exact phrase match
 
 4.7.0.0 (not yet released)
 - patch #12233 [Display] Improve message when renaming database to same name

--- a/libraries/DbSearch.php
+++ b/libraries/DbSearch.php
@@ -82,6 +82,13 @@ class DbSearch
     public function __construct($db)
     {
         $this->_db = $db;
+        $this->_searchTypes = array(
+            '1' => __('at least one of the words'),
+            '2' => __('all of the words'),
+            '3' => __('the exact phrase as substring'),
+            '4' => __('the exact phrase as whole field'),
+            '5' => __('as regular expression'),
+        );
         // Sets criteria parameters
         $this->_setSearchParams();
     }
@@ -94,13 +101,6 @@ class DbSearch
     private function _setSearchParams()
     {
         $this->_tables_names_only = $GLOBALS['dbi']->getTables($this->_db);
-
-        $this->_searchTypes = array(
-            '1' => __('at least one of the words'),
-            '2' => __('all words'),
-            '3' => __('the exact phrase'),
-            '4' => __('as regular expression'),
-        );
 
         if (empty($_REQUEST['criteriaSearchType'])
             || ! is_string($_REQUEST['criteriaSearchType'])
@@ -201,9 +201,9 @@ class DbSearch
         $allColumns = $GLOBALS['dbi']->getColumns($GLOBALS['db'], $table);
         $likeClauses = array();
         // Based on search type, decide like/regex & '%'/''
-        $like_or_regex   = (($this->_criteriaSearchType == 4) ? 'REGEXP' : 'LIKE');
-        $automatic_wildcard   = (($this->_criteriaSearchType < 3) ? '%' : '');
-        // For "as regular expression" (search option 4), LIKE won't be used
+        $like_or_regex   = (($this->_criteriaSearchType == 5) ? 'REGEXP' : 'LIKE');
+        $automatic_wildcard   = (($this->_criteriaSearchType < 4) ? '%' : '');
+        // For "as regular expression" (search option 5), LIKE won't be used
         // Usage example: If user is searching for a literal $ in a regexp search,
         // he should enter \$ as the value.
         $criteriaSearchStringEscaped = $GLOBALS['dbi']->escapeString(
@@ -389,16 +389,17 @@ class DbSearch
         $html_output .= '<td class="right vtop">' . __('Find:') . '</td>';
         $html_output .= '<td>';
         $choices = array(
-            '1' => __('at least one of the words')
+            '1' => $this->_searchTypes[1] . ' '
                 . Util::showHint(
                     __('Words are separated by a space character (" ").')
                 ),
-            '2' => __('all words')
+            '2' => $this->_searchTypes[2] . ' '
                 . Util::showHint(
                     __('Words are separated by a space character (" ").')
                 ),
-            '3' => __('the exact phrase'),
-            '4' => __('as regular expression') . ' '
+            '3' => $this->_searchTypes[3],
+            '4' => $this->_searchTypes[4],
+            '5' => $this->_searchTypes[5] . ' '
                 . Util::showMySQLDocu('Regexp')
         );
         // 4th parameter set to true to add line breaks

--- a/test/classes/DbSearchTest.php
+++ b/test/classes/DbSearchTest.php
@@ -49,7 +49,10 @@ class DbSearchTest extends PMATestCase
         $dbi->expects($this->any())
             ->method('getColumns')
             ->with('pma', 'table1')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue(array(
+                array('Field' => 'column1'),
+                array('Field' => 'column2'),
+            )));
 
         $dbi->expects($this->any())
             ->method('escapeString')
@@ -84,6 +87,57 @@ class DbSearchTest extends PMATestCase
         $method = $class->getMethod($name);
         $method->setAccessible(true);
         return $method->invokeArgs($this->object, $params);
+    }
+
+    /**
+     * Test for generating where clause for different search types
+     *
+     * @dataProvider searchTypes
+     */
+    public function testGetWhereClause($type, $expected)
+    {
+        $_REQUEST['criteriaSearchType'] = $type;
+        $_REQUEST['criteriaSearchString'] = 'search string';
+
+        $this->object = new DbSearch('pma_test');
+        $this->assertEquals(
+            $expected,
+            $this->_callProtectedFunction(
+                '_getWhereClause',
+                array('table1')
+            )
+        );
+    }
+
+    /**
+     * Data provider for testGetWhereClause
+     *
+     * @return array
+     */
+    public function searchTypes()
+    {
+        return array(
+            array(
+                '1',
+                " WHERE (CONVERT(`column1` USING utf8) LIKE '%search%' OR CONVERT(`column2` USING utf8) LIKE '%search%')  OR  (CONVERT(`column1` USING utf8) LIKE '%string%' OR CONVERT(`column2` USING utf8) LIKE '%string%')"
+            ),
+            array(
+                '2',
+                " WHERE (CONVERT(`column1` USING utf8) LIKE '%search%' OR CONVERT(`column2` USING utf8) LIKE '%search%')  AND  (CONVERT(`column1` USING utf8) LIKE '%string%' OR CONVERT(`column2` USING utf8) LIKE '%string%')"
+            ),
+            array(
+                '3',
+                " WHERE (CONVERT(`column1` USING utf8) LIKE '%search string%' OR CONVERT(`column2` USING utf8) LIKE '%search string%')"
+            ),
+            array(
+                '4',
+                " WHERE (CONVERT(`column1` USING utf8) LIKE 'search string' OR CONVERT(`column2` USING utf8) LIKE 'search string')"
+            ),
+            array(
+                '5',
+                " WHERE (CONVERT(`column1` USING utf8) REGEXP 'search string' OR CONVERT(`column2` USING utf8) REGEXP 'search string')"
+            ),
+        );
     }
 
     /**
@@ -188,55 +242,10 @@ class DbSearchTest extends PMATestCase
      */
     public function testGetSelectionForm()
     {
-        $this->assertEquals(
-            '<a id="db_search"></a><form id="db_search_form" class="ajax lock-page" '
-            . 'method="post" action="db_search.php" name="db_search">'
-            . '<input type="hidden" name="db" value="pma" />'
-            . '<input type="hidden" name="lang" value="en" />'
-            . '<input type="hidden" name="collation_connection" value="utf-8" />'
-            . '<input type="hidden" name="token" value="token" />'
-            . '<fieldset><legend>Search in database</legend><table class='
-            . '"formlayout"><tr><td>Words or values to search for (wildcard: "%"):'
-            . '</td><td><input type="text" name="criteriaSearchString" size="60" '
-            . 'value="" /></td></tr><tr><td class="right vtop">Find:</td><td><input '
-            . 'type="radio" name="criteriaSearchType" id="criteriaSearchType_1" '
-            . 'value="1" checked="checked" />' . "\n"
-            . '<label for="criteriaSearchType_1">at least one of the words<span '
-            . 'class="pma_hint"><img src="themes/dot.gif" title="" alt="" class="icon ic_b_help" '
-            . '/><span class="hide">Words are separated by a space character (" ").'
-            . '</span></span></label>' . "\n" . '<br />' . "\n"
-            . '<input type="radio" name="criteriaSearchType" id="criteriaSearchType'
-            . '_2" value="2" />' . "\n"
-            . '<label for="criteriaSearchType_2">all words<span class="pma_hint">'
-            . '<img src="themes/dot.gif" title="" alt="" class="icon ic_b_help" /><span class'
-            . '="hide">Words are separated by a space character (" ").</span></span>'
-            . '</label>' . "\n" . '<br />' . "\n"
-            . '<input type="radio" name="criteriaSearchType" id="criteriaSearchType'
-            . '_3" value="3" />' . "\n"
-            . '<label for="criteriaSearchType_3">the exact phrase</label>' . "\n" . '<br />'
-            . "\n" . '<input type="radio" name="criteriaSearchType" id="criteria'
-            . 'SearchType_4" value="4" />' . "\n"
-            . '<label for="criteriaSearchType_4">as regular expression <a href='
-            . '"./url.php?url=https%3A%2F%2Fdev.mysql.com%2Fdoc%2Frefman%2F5.7%2Fen'
-            . '%2Fregexp.html" target='
-            . '"mysql_doc"><img src="themes/dot.gif" title="Documentation"'
-            . ' alt="Documentation" class="icon ic_b_help" /></a></label>' . "\n" . '<br />' . "\n"
-            . '</td></tr><tr><td class="right vtop">Inside tables:</td>'
-            . '<td rowspan="2"><select name="criteriaTables[]" size="6" '
-            . 'multiple="multiple"><option value="table1">table1</option>'
-            . '<option value="table2">table2</option></select></td></tr><tr>'
-            . '<td class="right vbottom"><a href="#" onclick="setSelectOptions'
-            . '(\'db_search\', \'criteriaTables[]\', true); return false;">Select '
-            . 'all</a> &nbsp;/&nbsp;<a href="#" onclick="setSelectOptions'
-            . '(\'db_search\', \'criteriaTables[]\', false); return false;">Unselect'
-            . ' all</a></td></tr><tr><td class="right">Inside column:</td><td>'
-            . '<input type="text" name="criteriaColumnName" size="60"value="" />'
-            . '</td></tr></table></fieldset><fieldset class="tblFooters"><input '
-            . 'type="submit" name="submit_search" value="Go" id="buttonGo" />'
-            . '</fieldset></form><div id="togglesearchformdiv">'
-            . '<a id="togglesearchformlink"></a></div>',
-            $this->object->getSelectionForm()
-        );
+        $form = $this->object->getSelectionForm();
+        $this->assertContains('<form', $form);
+        $this->assertContains('<a id="togglesearchformlink">', $form);
+        $this->assertContains('criteriaSearchType', $form);
     }
 
     /**


### PR DESCRIPTION
Add option to search exact phrase as substring, what was currently
missing.

While doing that, also improve testsuite for generating the clauses.

Fixes #12388

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
