### PR TITLE
Fix coding standard errors using vendor/bin/phpcbf

### DIFF
--- a/libraries/central_columns.lib.php
+++ b/libraries/central_columns.lib.php
@@ -825,10 +825,9 @@ function PMA_getHTMLforAddCentralColumn($total_rows, $pos, $db)
 /**
  * build html for a row in central columns table
  *
- * @param array   $row     array contains complete information of
- * a particular row of central list table
- * @param int     $row_num position the row in the table
- * @param string  $db      current database
+ * @param array  $row     array contains complete information of a particular row of central list table
+ * @param int    $row_num position the row in the table
+ * @param string $db      current database
  *
  * @return string html of a particular row in the central columns table.
  */
@@ -996,9 +995,8 @@ function PMA_getHTMLforCentralColumnsTableRow($row, $row_num, $db)
 /**
  * build html for editing a row in central columns table
  *
- * @param array   $row     array contains complete information of
- * a particular row of central list table
- * @param int     $row_num position the row in the table
+ * @param array $row     array contains complete information of a particular row of central list table
+ * @param int   $row_num position the row in the table
  *
  * @return string html of a particular row in the central columns table.
  */

--- a/libraries/config/PageSettings.php
+++ b/libraries/config/PageSettings.php
@@ -102,8 +102,8 @@ class PageSettings
      * @param FormDisplay  &$form_display Form
      * @param ConfigFile   &$cf           Configuration file
      * @param Message|null &$error        Error message
-     * @param FormDisplay $form_display
-     * @param ConfigFile $cf
+     * @param FormDisplay  $form_display
+     * @param ConfigFile   $cf
      *
      * @return void
      */

--- a/libraries/config/Validator.php
+++ b/libraries/config/Validator.php
@@ -162,12 +162,12 @@ class Validator
     /**
      * Test database connection
      *
-     * @param string $host         host name
-     * @param string $port         tcp port to use
-     * @param string $socket       socket to use
-     * @param string $user         username to use
-     * @param string $pass         password to use
-     * @param string $error_key    key to use in return array
+     * @param string $host      host name
+     * @param string $port      tcp port to use
+     * @param string $socket    socket to use
+     * @param string $user      username to use
+     * @param string $pass      password to use
+     * @param string $error_key key to use in return array
      *
      * @return bool|array
      */

--- a/libraries/core.lib.php
+++ b/libraries/core.lib.php
@@ -208,8 +208,8 @@ function PMA_securePath($path)
  *
  * loads language file if not loaded already
  *
- * @param string       $error_message  the error message or named error message
- * @param string|array $message_args   arguments applied to $error_message
+ * @param string       $error_message the error message or named error message
+ * @param string|array $message_args  arguments applied to $error_message
  *
  * @return void
  */

--- a/libraries/insert_edit.lib.php
+++ b/libraries/insert_edit.lib.php
@@ -887,7 +887,7 @@ function PMA_getColumnEnumValues($column, $extracted_columnspec)
  * @param integer $idindex              id index
  * @param string  $data                 data to edit
  * @param array   $column_enum_values   $column['values']
- * @param boolean $readOnly              is column read only or not
+ * @param boolean $readOnly             is column read only or not
  *
  * @return string                       an html snippet
  */
@@ -939,7 +939,7 @@ function PMA_getDropDownDependingOnLength(
  * @param integer $idindex              id index
  * @param string  $data                 data to edit
  * @param array   $column_enum_values   $column['values']
- * @param boolean $readOnly              is column read only or not
+ * @param boolean $readOnly             is column read only or not
  *
  * @return string                       an html snippet
  */

--- a/libraries/operations.lib.php
+++ b/libraries/operations.lib.php
@@ -872,16 +872,16 @@ function PMA_getHtmlForMoveTable()
 /**
  * Get the HTML div for Table option
  *
- * @param Table   $pma_table          Table object
- * @param string  $comment            Comment
- * @param array   $tbl_collation      table collation
- * @param string  $tbl_storage_engine table storage engine
- * @param string  $pack_keys          pack keys
- * @param string  $auto_increment     value of auto increment
- * @param string  $delay_key_write    delay key write
- * @param string  $transactional      value of transactional
- * @param string  $page_checksum      value of page checksum
- * @param string  $checksum           the checksum
+ * @param Table  $pma_table          Table object
+ * @param string $comment            Comment
+ * @param array  $tbl_collation      table collation
+ * @param string $tbl_storage_engine table storage engine
+ * @param string $pack_keys          pack keys
+ * @param string $auto_increment     value of auto increment
+ * @param string $delay_key_write    delay key write
+ * @param string $transactional      value of transactional
+ * @param string $page_checksum      value of page checksum
+ * @param string $checksum           the checksum
  *
  * @return string $html_output
  */
@@ -1011,16 +1011,16 @@ function PMA_getHtmlForPackKeys($current_value)
 /**
  * Get HTML fieldset for Table option, it contains HTML table for options
  *
- * @param Table   $pma_table          Table object
- * @param string  $comment            Comment
- * @param array   $tbl_collation      table collation
- * @param string  $tbl_storage_engine table storage engine
- * @param string  $pack_keys          pack keys
- * @param string  $delay_key_write    delay key write
- * @param string  $auto_increment     value of auto increment
- * @param string  $transactional      value of transactional
- * @param string  $page_checksum      value of page checksum
- * @param string  $checksum           the checksum
+ * @param Table  $pma_table          Table object
+ * @param string $comment            Comment
+ * @param array  $tbl_collation      table collation
+ * @param string $tbl_storage_engine table storage engine
+ * @param string $pack_keys          pack keys
+ * @param string $delay_key_write    delay key write
+ * @param string $auto_increment     value of auto increment
+ * @param string $transactional      value of transactional
+ * @param string $page_checksum      value of page checksum
+ * @param string $checksum           the checksum
  *
  * @return string $html_output
  */
@@ -1323,8 +1323,8 @@ function PMA_getHtmlForCopytable()
 /**
  * Get HTML snippet for table maintenance
  *
- * @param Table   $pma_table  Table object
- * @param array   $url_params array of URL parameters
+ * @param Table $pma_table  Table object
+ * @param array $url_params array of URL parameters
  *
  * @return string $html_output
  */
@@ -1348,8 +1348,8 @@ function PMA_getHtmlForTableMaintenance($pma_table, $url_params)
 /**
  * Get HTML 'li' having a link of maintain action
  *
- * @param Table   $pma_table  Table object
- * @param array   $url_params Array of URL parameters
+ * @param Table $pma_table  Table object
+ * @param array $url_params Array of URL parameters
  *
  * @return string $html_output
  */
@@ -1726,15 +1726,15 @@ function PMA_getQueryAndResultForReorderingTable()
 /**
  * Get table alters array
  *
- * @param Table   $pma_table           The Table object
- * @param string  $pack_keys           pack keys
- * @param string  $checksum            value of checksum
- * @param string  $page_checksum       value of page checksum
- * @param string  $delay_key_write     delay key write
- * @param string  $row_format          row format
- * @param string  $newTblStorageEngine table storage engine
- * @param string  $transactional       value of transactional
- * @param string  $tbl_collation       collation of the table
+ * @param Table  $pma_table           The Table object
+ * @param string $pack_keys           pack keys
+ * @param string $checksum            value of checksum
+ * @param string $page_checksum       value of page checksum
+ * @param string $delay_key_write     delay key write
+ * @param string $row_format          row format
+ * @param string $newTblStorageEngine table storage engine
+ * @param string $transactional       value of transactional
+ * @param string $tbl_collation       collation of the table
  *
  * @return array  $table_alters
  */
@@ -2085,7 +2085,6 @@ function PMA_moveOrCopyTable($db, $table)
             $old = Util::backquote($db) . '.'
                 . Util::backquote($table);
             $message->addParam($old);
-
 
             $new_name = $_REQUEST['new_name'];
             if ($GLOBALS['dbi']->getLowerCaseNames() === '1') {

--- a/libraries/rte/rte_routines.lib.php
+++ b/libraries/rte/rte_routines.lib.php
@@ -564,10 +564,9 @@ function PMA_RTN_getDataFromRequest()
  * This function will generate the values that are required to complete
  * the "Edit routine" form given the name of a routine.
  *
- * @param string $name    The name of the routine.
- * @param string $type    Type of routine (ROUTINE|PROCEDURE)
- * @param bool   $all     Whether to return all data or just
- *                        the info about parameters.
+ * @param string $name The name of the routine.
+ * @param string $type Type of routine (ROUTINE|PROCEDURE)
+ * @param bool   $all  Whether to return all data or just the info about parameters.
  *
  * @return array    Data necessary to create the routine editor.
  */
@@ -1700,4 +1699,3 @@ function PMA_RTN_getExecuteForm($routine)
 
     return $retval;
 } // end PMA_RTN_getExecuteForm()
-

--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -2625,10 +2625,10 @@ function PMA_getHtmlTableBodyForSpecificDbOrTablePrivs($privMap, $db)
 /**
  * Get HTML to display privileges
  *
- * @param string  $db                 Database name
- * @param array   $current_privileges List of privileges
- * @param string  $current_user       Current user
- * @param string  $current_host       Current host
+ * @param string $db                 Database name
+ * @param array  $current_privileges List of privileges
+ * @param string $current_user       Current user
+ * @param string $current_host       Current host
  *
  * @return string HTML to display privileges
  */

--- a/libraries/tracking.lib.php
+++ b/libraries/tracking.lib.php
@@ -910,8 +910,8 @@ function PMA_getHtmlForColumns($columns)
 /**
  * Function to get html for field
  *
- * @param int    $index index
- * @param array  $field field
+ * @param int   $index index
+ * @param array $field field
  *
  * @return string
  */
@@ -996,7 +996,7 @@ function PMA_getHtmlForIndexes($indexes)
 /**
  * Function to get html for an index in schema snapshot
  *
- * @param array  $index index
+ * @param array $index index
  *
  * @return string
  */

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -834,7 +834,6 @@ class ConfigTest extends PMATestCase
     public function testGetThemeUniqueValue()
     {
 
-
         $partial_sum = (
             PHPUnit_Framework_Assert::readAttribute($this->object, 'source_mtime') +
             PHPUnit_Framework_Assert::readAttribute(

--- a/test/classes/plugin/export/ExportXmlTest.php
+++ b/test/classes/plugin/export/ExportXmlTest.php
@@ -345,7 +345,6 @@ class ExportXmlTest extends PMATestCase
             't2' => array(null, '"tbl"')
         );
 
-
         $dbi->expects($this->exactly(5))
             ->method('fetchResult')
             ->willReturnOnConsecutiveCalls(

--- a/test/libraries/PMA_server_privileges_test.php
+++ b/test/libraries/PMA_server_privileges_test.php
@@ -876,7 +876,6 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
             runkit_constant_redefine('PMA_MYSQL_INT_VERSION', $restoreMySQLVersion);
         }
 
-
         // Case 2 : Test with older versions
         $restoreMySQLVersion = "PMANORESTORE";
         if (! PMA_HAS_RUNKIT) {
@@ -1319,7 +1318,6 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
         $dbi->expects($this->any())
             ->method('escapeString')
             ->will($this->returnArgument(0));
-
 
         $GLOBALS['dbi'] = $dbi;
 
@@ -2570,7 +2568,6 @@ class PMA_ServerPrivileges_Test extends PHPUnit_Framework_TestCase
             . 'Native MySQL authentication</option>'. "\n" .'</select>',
             $actualHtml
         );
-
 
         /* Assertion 4 */
         $actualHtml = PMA_getHtmlForAuthPluginsDropdown(


### PR DESCRIPTION
I ran the command `vendor/bin/phpcbf --standard=PMAStandard` to automatically fix these problems.

Signed-off-by: Maurício Meneghini Fauth <mauriciofauth@gmail.com>
