### PR TITLE
Fixed the invalid link which was suggested after an import timeout.

### DIFF
--- a/import.php
+++ b/import.php
@@ -610,7 +610,8 @@ if (! empty($id_bookmark) && $_REQUEST['action_bookmark'] == 2) {
 
 // Did we hit timeout? Tell it user.
 if ($timeout_passed) {
-    $importUrl = $err_url .= '&timeout_passed=1&offset=' . urlencode(
+    $divider = parse_url($url, PHP_URL_QUERY) ? '&' : '?';
+    $importUrl = $err_url .= $divider . 'timeout_passed=1&offset=' . urlencode(
         $GLOBALS['offset']
     );
     if (isset($local_import_file)) {


### PR DESCRIPTION
Fixes #13189.

The faulty line here is [this](https://github.com/phpmyadmin/phpmyadmin/blob/QA_4_7/import.php#L613). `&timeout_passed=1&offset=Z` is being appended to one the following possible values of `$err_url`: `tbl_import.php?db=X&table=Y`, `db_import.php?db=X` or `server_import.php` is appended. This causes an issue when `$err_url` is simply `server_import.php`.

Signed-off-by: Dan Ungureanu <udan1107@gmail.com>