### PR TITLE
Change composer package type to project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "phpmyadmin/phpmyadmin",
-    "type": "application",
+    "type": "project",
     "description": "MySQL web administration tool",
     "keywords": ["phpmyadmin","mysql","web"],
     "homepage": "https://www.phpmyadmin.net/",


### PR DESCRIPTION
Composer doesn't seem to support packages of type application.
Package type library (the default) or project seem to be the most appropriate.