### PR TITLE
Create an autoload.php in the root directory and tell libraries/common.inc.php to require it

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -8,4 +8,4 @@
  * @see libraries/common.inc.php
  */
 
-require __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';

--- a/autoload.php
+++ b/autoload.php
@@ -8,4 +8,4 @@
  * @see libraries/common.inc.php
  */
 
-return require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @file
+ * Includes the autoloader created by Composer.
+ *
+ * @see composer.json
+ * @see libraries/common.inc.php
+ */
+
+return require __DIR__ . '/vendor/autoload.php';

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -75,14 +75,14 @@ require_once './libraries/vendor_config.php';
 /**
  * Activate autoloader
  */
-if (! @is_readable('/../autoload.php')) {
+if (! @is_readable(__DIR__ . '/../autoload.php')) {
     die(
         'File <tt>/../autoload.php</tt> missing or not readable. <br />'
         . 'Most likely you did not run Composer to '
         . '<a href="https://docs.phpmyadmin.net/en/latest/setup.html#installing-from-git">install library files</a>.'
     );
 }
-require_once '/../autoload.php';
+require_once __DIR__ . '/../autoload.php';
 
 /**
  * Load gettext functions.

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -75,14 +75,14 @@ require_once './libraries/vendor_config.php';
 /**
  * Activate autoloader
  */
-if (! @is_readable('./vendor/autoload.php')) {
+if (! @is_readable('/../autoload.php')) {
     die(
-        'File <tt>./vendor/autoload.php</tt> missing or not readable. <br />'
+        'File <tt>/../autoload.php</tt> missing or not readable. <br />'
         . 'Most likely you did not run Composer to '
         . '<a href="https://docs.phpmyadmin.net/en/latest/setup.html#installing-from-git">install library files</a>.'
     );
 }
-require_once './vendor/autoload.php';
+require_once '/../autoload.php';
 
 /**
  * Load gettext functions.


### PR DESCRIPTION
Hello

Currently an **autoloader** is implemented via `vendor/autoload.php`, which is then loaded into `libraries/common.inc.php`.

Although easy to change where this autoloader lives, this involves patching `common.inc.php`, making it a little less easier than it could be if the autoloader was instead loaded by an additional file, which could be easily replaced or edited.

# Why?
To support installing the phpmyadmin vendor dependencies inside the root project directory, that is, outside of phpmyadmin directory structure, being no longer visible to the world, and being updatable by an upper composer project - currently detailed [here](https://github.com/solsoft/phpmyadmin-boilerplate) and on issue #13200 .

# How?
The provided patch solves this by creating an `autoload.php` at the root of the directory project which then includes the `vendor/autoload.php` file.
The file `libraries/common.inc.php` will load this root autoload.php instead of the one inside the vendor directory.