### PR TITLE
Implement AUTOLOAD_FILE constant

### DIFF
--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -75,14 +75,14 @@ require_once './libraries/vendor_config.php';
 /**
  * Activate autoloader
  */
-if (! @is_readable('./vendor/autoload.php')) {
+if (! @is_readable(AUTOLOAD_FILE)) {
     die(
-        'File <tt>./vendor/autoload.php</tt> missing or not readable. <br />'
+        'File <tt>' . AUTOLOAD_FILE . '</tt> missing or not readable. <br />'
         . 'Most likely you did not run Composer to '
         . '<a href="https://docs.phpmyadmin.net/en/latest/setup.html#installing-from-git">install library files</a>.'
     );
 }
-require_once './vendor/autoload.php';
+require_once AUTOLOAD_FILE;
 
 /**
  * Load gettext functions.

--- a/libraries/vendor_config.php
+++ b/libraries/vendor_config.php
@@ -14,6 +14,12 @@ if (! defined('PHPMYADMIN')) {
 }
 
 /**
+ * Path to vendor autoload file. Useful when you want to
+ * have have vendor dependencies somewhere else.
+ */
+define('AUTOLOAD_FILE', './../vendor/autoload.php');
+
+/**
  * Directory where cache files are stored.
  */
 define('CACHE_DIR', './cache/');

--- a/libraries/vendor_config.php
+++ b/libraries/vendor_config.php
@@ -17,7 +17,7 @@ if (! defined('PHPMYADMIN')) {
  * Path to vendor autoload file. Useful when you want to
  * have have vendor dependencies somewhere else.
  */
-define('AUTOLOAD_FILE', './../vendor/autoload.php');
+define('AUTOLOAD_FILE', './vendor/autoload.php');
 
 /**
  * Directory where cache files are stored.

--- a/scripts/advisor2po
+++ b/scripts/advisor2po
@@ -50,8 +50,9 @@ function print_message($idx) {
 }
 
 define('PHPMYADMIN', 1);
-require_once 'vendor/autoload.php';
-require_once 'libraries/core.lib.php';
+require_once './../libraries/vendor_config.php';
+require_once './../' . AUTOLOAD_FILE;
+require_once './../libraries/core.lib.php';
 
 $rules = PMA\libraries\Advisor::parseRulesFile();
 

--- a/scripts/advisor2po
+++ b/scripts/advisor2po
@@ -50,9 +50,9 @@ function print_message($idx) {
 }
 
 define('PHPMYADMIN', 1);
-require_once './../libraries/vendor_config.php';
-require_once './../' . AUTOLOAD_FILE;
-require_once './../libraries/core.lib.php';
+require_once 'libraries/vendor_config.php';
+require_once AUTOLOAD_FILE;
+require_once 'libraries/core.lib.php';
 
 $rules = PMA\libraries\Advisor::parseRulesFile();
 

--- a/scripts/generate-twig-cache
+++ b/scripts/generate-twig-cache
@@ -1,8 +1,8 @@
 <?php
 /* vim: set expandtab sw=4 ts=4 sts=4 ft=php: */
 define('PHPMYADMIN', 1);
-require_once 'vendor/autoload.php';
-require_once 'libraries/vendor_config.php';
+require_once './../libraries/vendor_config.php';
+require_once './../' . AUTOLOAD_FILE;
 
 use PMA\libraries\twig\I18nExtension;
 use PMA\libraries\twig\UrlExtension;

--- a/scripts/generate-twig-cache
+++ b/scripts/generate-twig-cache
@@ -1,8 +1,8 @@
 <?php
 /* vim: set expandtab sw=4 ts=4 sts=4 ft=php: */
 define('PHPMYADMIN', 1);
-require_once './../libraries/vendor_config.php';
-require_once './../' . AUTOLOAD_FILE;
+require_once 'libraries/vendor_config.php';
+require_once AUTOLOAD_FILE;
 
 use PMA\libraries\twig\I18nExtension;
 use PMA\libraries\twig\UrlExtension;

--- a/test/bootstrap-dist.php
+++ b/test/bootstrap-dist.php
@@ -58,9 +58,9 @@ if (PHP_SAPI == 'cli') {
     }
 }
 
-require_once 'libraries/vendor_config.php';
-require_once 'vendor/autoload.php';
-require_once 'libraries/core.lib.php';
+require_once './../libraries/vendor_config.php';
+require_once './../' . AUTOLOAD_FILE;
+require_once './../libraries/core.lib.php';
 PhpMyAdmin\MoTranslator\Loader::loadFunctions();
 $CFG = new PMA\libraries\Config();
 // Initialize PMA_VERSION variable

--- a/test/bootstrap-dist.php
+++ b/test/bootstrap-dist.php
@@ -58,9 +58,9 @@ if (PHP_SAPI == 'cli') {
     }
 }
 
-require_once './../libraries/vendor_config.php';
-require_once './../' . AUTOLOAD_FILE;
-require_once './../libraries/core.lib.php';
+require_once 'libraries/vendor_config.php';
+require_once AUTOLOAD_FILE;
+require_once 'libraries/core.lib.php';
 PhpMyAdmin\MoTranslator\Loader::loadFunctions();
 $CFG = new PMA\libraries\Config();
 // Initialize PMA_VERSION variable


### PR DESCRIPTION
This change implements AUTOLOAD_FILE constant to allow changing the autoload.php file being used by phpMyAdmin.

See obsolete pull request #13212  