### PR TITLE
Don't destroy the session if logins are still present. fixes #12301

### DIFF
--- a/libraries/plugins/AuthenticationPlugin.php
+++ b/libraries/plugins/AuthenticationPlugin.php
@@ -74,9 +74,17 @@ abstract class AuthenticationPlugin
         $PHP_AUTH_USER = '';
         $PHP_AUTH_PW = '';
 
+        /* Get a logged-in server count */
+        $servers = 0;
+        foreach ($GLOBALS['cfg']['Servers'] as $key => $val) {
+            if (isset($_COOKIE['pmaAuth-' . $key])) {
+                $servers++;
+            }
+        }
+
         /* delete user's choices that were stored in session */
-        $_SESSION = array();
-        if (!defined('TESTSUITE')) {
+        if ($servers === 0 and ! defined('TESTSUITE')) {
+            $_SESSION = array();
             session_destroy();
         }
 


### PR DESCRIPTION
If you are logged-in into multiple database servers, logOut() logs you out of all of them. This fix will prevent that, and will only destroy the session when you log out of the last server.

Before submitting pull request, please check that every commit:

- [ ] Has proper Signed-Off-By
- [ ] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
