### PR TITLE
Share TempDir for Twig and other uses

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -2955,13 +2955,15 @@ the files.
 .. config:option:: $cfg['TempDir']
 
     :type: string
-    :default: ``''``
+    :default: ``'./tmp/'``
 
-    The name of the directory where temporary files can be stored.
+    The name of the directory where temporary files can be stored. It is used
+    for several purposes, currently:
 
-    This is needed for importing ESRI Shapefiles, see :ref:`faq6_30` and to
-    work around limitations of ``open_basedir`` for uploaded files, see
-    :ref:`faq1_11`.
+    * The templates cache which speeds up page loading.
+    * ESRI Shapefiles import, see :ref:`faq6_30`.
+    * To work around limitations of ``open_basedir`` for uploaded files, see
+      :ref:`faq1_11`.
 
     This directory should have as strict permissions as possible as the only
     user required to access this directory is the one who runs the webserver.

--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -994,6 +994,8 @@ are always ways to make your installation more secure:
   scripting vulnerabilities that might happen to be found in that code. For the
   Apache webserver, this is often accomplished with a :term:`.htaccess` file in
   those directories.
+* Deny access to temporary files, see :config:option:`$cfg['TempDir']` (if that
+  is placed inside your web root, see also :ref:`web-dirs`.
 * It is generally a good idea to protect a public phpMyAdmin installation
   against access by robots as they usually can not do anything good there. You
   can do this using ``robots.txt`` file in root of your webserver or limit

--- a/index.php
+++ b/index.php
@@ -601,6 +601,17 @@ if ($cfg['SuhosinDisableWarning'] == false
     );
 }
 
+/* Missing template cache */
+if (is_null($GLOBALS['PMA_Config']->getTempDir('twig'))) {
+    trigger_error(
+        sprintf(
+            __('The $cfg[\'TempDir\'] (%s) is not accessible. phpMyAdmin is not able to cache templates and will be slow because of this.'),
+            $GLOBALS['PMA_Config']->get('TempDir')
+        ),
+        E_USER_WARNING
+    );
+}
+
 /**
  * Warning about incomplete translations.
  *

--- a/libraries/Config.php
+++ b/libraries/Config.php
@@ -1744,6 +1744,54 @@ class Config
     {
         return self::_renderCustom(CUSTOM_HEADER_FILE, 'pma_header');
     }
+
+    /**
+     * Returns temporary dir path
+     *
+     * @param string $name Directory name
+     *
+     * @return string|null
+     */
+    public function getTempDir($name)
+    {
+        $path = $this->get('TempDir');
+        if (empty($path)) {
+            return null;
+        }
+
+        $path .= '/' . $name;
+        if (! @is_dir($path)) {
+            @mkdir($path, 0770, true);
+        }
+        if (! @is_dir($path) || ! @is_writable($path)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    /**
+     * Returns temporary directory
+     *
+     * @return string
+     */
+    public function getUploadTempDir()
+    {
+        // First try configured temp dir
+        $path = $this->getTempDir('upload');
+
+        // Fallback to PHP upload_tmp_dir
+        if (is_null($path)) {
+            $path = ini_get('upload_tmp_dir');
+        }
+
+        // Last resort is systemp temporary directory
+        if (empty($path)) {
+            $path = sys_get_temp_dir();
+        }
+
+        return rtrim($path, DIRECTORY_SEPARATOR);
+    }
 }
 
 if (!defined('TESTSUITE')) {

--- a/libraries/Encoding.php
+++ b/libraries/Encoding.php
@@ -285,7 +285,7 @@ class Encoding
         if ($enc == '' && $kana == '') {
             return $file;
         }
-        $tmpfname = tempnam(ConfigFile::getDefaultTempDirectory(), $enc);
+        $tmpfname = tempnam($GLOBALS['PMA_Config']->getUploadTempDir(), $enc);
         $fpd      = fopen($tmpfname, 'wb');
         $fps      = fopen($file, 'r');
         self::kanjiChangeOrder();

--- a/libraries/File.php
+++ b/libraries/File.php
@@ -483,7 +483,7 @@ class File
             return true;
         }
 
-        $tmp_subdir = ConfigFile::getDefaultTempDirectory();
+        $tmp_subdir = $GLOBALS['PMA_Config']->getUploadTempDir();
         if (@is_writable($tmp_subdir)) {
             // cannot create directory or access, point user to FAQ 1.11
             $this->_error_message = Message::error(__(

--- a/libraries/Template.php
+++ b/libraries/Template.php
@@ -61,7 +61,7 @@ class Template
         $loader = new Twig_Loader_Filesystem(static::BASE_PATH);
         $this->twig = new Twig_Environment($loader, array(
             'auto_reload' => true,
-            'cache' => CACHE_DIR . 'twig',
+            'cache' => $GLOBALS['PMA_Config']->getTempDir('twig'),
             'debug' => false,
         ));
         $this->twig->addExtension(new I18nExtension());

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -2934,7 +2934,11 @@ $cfg['SaveDir'] = '';
  *
  * @global string $cfg['TempDir']
  */
-$cfg['TempDir'] = '';
+if (defined('TEMP_DIR')) {
+    $cfg['TempDir'] = TEMP_DIR;
+} else {
+    $cfg['TempDir'] = './tmp/';
+}
 
 
 /**

--- a/libraries/config/ConfigFile.php
+++ b/libraries/config/ConfigFile.php
@@ -527,24 +527,4 @@ class ConfigFile
         }
         return $c;
     }
-
-    /**
-     * Returns temporary directory
-     *
-     * @return string
-     */
-    public static function getDefaultTempDirectory()
-    {
-        $tmp_subdir = null;
-        if (! empty($GLOBALS['cfg']['TempDir']) && @is_writable($GLOBALS['cfg']['TempDir'])) {
-            $tmp_subdir = $GLOBALS['cfg']['TempDir'];
-        } else {
-            $tmp_subdir = ini_get('upload_tmp_dir');
-            if (empty($tmp_subdir)) {
-                $tmp_subdir = sys_get_temp_dir();
-            }
-            $tmp_subdir = rtrim($tmp_subdir, DIRECTORY_SEPARATOR);
-        }
-        return $tmp_subdir;
-    }
 }

--- a/libraries/plugins/import/ImportShp.php
+++ b/libraries/plugins/import/ImportShp.php
@@ -85,12 +85,10 @@ class ImportShp extends ImportPlugin
         $temp_dbf_file = false;
         // We need dbase extension to handle .dbf file
         if (extension_loaded('dbase')) {
+            $temp = $GLOBALS['PMA_Config']->getTempDir('shp');
             // If we can extract the zip archive to 'TempDir'
             // and use the files in it for import
-            if ($compression == 'application/zip'
-                && !empty($GLOBALS['cfg']['TempDir'])
-                && @is_writable($GLOBALS['cfg']['TempDir'])
-            ) {
+            if ($compression == 'application/zip' && ! is_null($temp)) {
                 $dbf_file_name = PMA_findFileFromZipArchive(
                     '/^.*\.dbf$/i',
                     $import_file
@@ -103,8 +101,7 @@ class ImportShp extends ImportPlugin
                         $dbf_file_name
                     );
                     if ($extracted !== false) {
-                        $dbf_file_path = realpath($GLOBALS['cfg']['TempDir'])
-                            . (PMA_IS_WINDOWS ? '\\' : '/')
+                        $dbf_file_path = $temp . (PMA_IS_WINDOWS ? '\\' : '/')
                             . Sanitize::sanitizeFilename($dbf_file_name, true);
                         $handle = fopen($dbf_file_path, 'wb');
                         if ($handle !== false) {

--- a/libraries/vendor_config.php
+++ b/libraries/vendor_config.php
@@ -22,7 +22,7 @@ define('AUTOLOAD_FILE', './vendor/autoload.php');
 /**
  * Directory where cache files are stored.
  */
-define('CACHE_DIR', './cache/');
+define('TEMP_DIR', './tmp/');
 
 /**
  * Path to changelog file, can be gzip compressed. Useful when you want to

--- a/scripts/generate-twig-cache
+++ b/scripts/generate-twig-cache
@@ -10,7 +10,7 @@ use PMA\libraries\twig\UrlExtension;
 use PMA\libraries\twig\UtilExtension;
 
 $tplDir = dirname(__FILE__) . '/../templates';
-$tmpDir = dirname(__FILE__) . '/../' . CACHE_DIR . 'twig';
+$tmpDir = dirname(__FILE__) . '/../' . TEMP_DIR . 'twig';
 $loader = new Twig_Loader_Filesystem($tplDir);
 
 // force auto-reload to always have the latest version of the template


### PR DESCRIPTION
I think setting up just one folder for all the features is better approach than having separate folder for Twig cache and other temporary data.

Fixes #13226 and #13225 (also #13231).

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
