### PR TITLE
Fix unwanted escaping

### DIFF
--- a/templates/database/structure/browse_table.twig
+++ b/templates/database/structure/browse_table.twig
@@ -1,3 +1,3 @@
-<a href="sql.php{{ tbl_url_query }}&amp;pos=0">
+<a href="sql.php{{ tbl_url_query|raw }}&amp;pos=0">
     {{ title|raw }}
 </a>

--- a/templates/database/structure/browse_table_label.twig
+++ b/templates/database/structure/browse_table_label.twig
@@ -1,3 +1,3 @@
-<a href="sql.php{{ tbl_url_query }}&amp;pos=0" title="{{ title }}">
+<a href="sql.php{{ tbl_url_query|raw }}&amp;pos=0" title="{{ title }}">
     {{ truename }}
 </a>

--- a/templates/database/structure/empty_table.twig
+++ b/templates/database/structure/empty_table.twig
@@ -1,4 +1,4 @@
-<a class="truncate_table_anchor ajax" href="sql.php{{ tbl_url_query }}&amp;sql_query=
+<a class="truncate_table_anchor ajax" href="sql.php{{ tbl_url_query|raw }}&amp;sql_query=
 {{- sql_query }}&amp;message_to_show={{ message_to_show }}">
     {{ title|raw }}
 </a>

--- a/templates/database/structure/search_table.twig
+++ b/templates/database/structure/search_table.twig
@@ -1,3 +1,3 @@
-<a href="tbl_select.php{{ tbl_url_query }}">
+<a href="tbl_select.php{{ tbl_url_query|raw }}">
     {{ title|raw }}
 </a>


### PR DESCRIPTION
Fixes unwanted double escaping as "tbl_url_query" is already escaped before going into the Twig templates.

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
