### PR TITLE
Fix dropdown selector

### DIFF
--- a/templates/dropdown.twig
+++ b/templates/dropdown.twig
@@ -1,4 +1,4 @@
-<select name="{{ select_name }}" id="{{ id }}"{{ class ? ' class="' ~ class ~ '"' }}>
+<select name="{{ select_name }}"{% if id is not empty %} id="{{ id }}"{% endif %}{% if class is not empty %} class="{{ class }}"{% endif %}>
 {% if placeholder is not empty %}
     <option value="" disabled="disabled"
     {%- if not selected %} selected="selected"{% endif %}>{{ placeholder }}</option>


### PR DESCRIPTION
Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

The previous syntax escaped the " of the class part which resulted in html code like this `class=&quot;autosubmit&quot;`
I also added a check for the id part so we don't have things like `id=""`

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
