### PR TITLE
Correct the check for Amazon RDS

### DIFF
--- a/libraries/DatabaseInterface.php
+++ b/libraries/DatabaseInterface.php
@@ -2768,7 +2768,7 @@ class DatabaseInterface
         }
         $sql = 'SELECT @@basedir';
         $result = $this->fetchResult($sql);
-        $rds = ($result[0] == '/rdsdbbin/mysql/');
+        $rds = (substr($result[0], 0, 10) == '/rdsdbbin/');
         Util::cacheSet('is_amazon_rds', $rds);
 
         return $rds;


### PR DESCRIPTION
RDS now uses version specific paths (eg `mysql-5.7.18` instead of just `mysql`), so just match on `rdsdbbin` instead.

Related to #1205