### PR TITLE
Export Error while join on same table

### DIFF
--- a/tbl_export.php
+++ b/tbl_export.php
@@ -57,8 +57,7 @@ if (! empty($sql_query)) {
         $aliases = array();
         foreach ($parser->statements[0]->from as $from) {
             if ((!empty($from->table)) && (!empty($from->alias))) {
-                $aliases[$from->alias] = $from->table;
-                
+                $aliases[$from->alias] = $from->table;         
                 $from->expr = null; // Force rebuild.
             }
         }

--- a/tbl_export.php
+++ b/tbl_export.php
@@ -58,9 +58,7 @@ if (! empty($sql_query)) {
         foreach ($parser->statements[0]->from as $from) {
             if ((!empty($from->table)) && (!empty($from->alias))) {
                 $aliases[$from->alias] = $from->table;
-                // We remove the alias of the table because they are going to
-                // be replaced anyway.
-                $from->alias = null;
+                
                 $from->expr = null; // Force rebuild.
             }
         }
@@ -94,28 +92,6 @@ if (! empty($sql_query)) {
             $parser->list,
             $replaces
         );
-
-        // Removing the aliases by finding the alias followed by a dot.
-        $tokens = PhpMyAdmin\SqlParser\Lexer::getTokens($sql_query);
-        foreach ($aliases as $alias => $table) {
-            $tokens = PhpMyAdmin\SqlParser\Utils\Tokens::replaceTokens(
-                $tokens,
-                array(
-                    array(
-                        'value_str' => $alias,
-                    ),
-                    array(
-                        'type' => PhpMyAdmin\SqlParser\Token::TYPE_OPERATOR,
-                        'value_str' => '.',
-                    )
-                ),
-                array(
-                    new PhpMyAdmin\SqlParser\Token($table),
-                    new PhpMyAdmin\SqlParser\Token('.',PhpMyAdmin\SqlParser\Token::TYPE_OPERATOR)
-                )
-            );
-        }
-        $sql_query = PhpMyAdmin\SqlParser\TokensList::build($tokens);
     }
 
     echo PMA\libraries\Util::getMessage(PMA\libraries\Message::success());


### PR DESCRIPTION
Fix for bug #13187 reported-
Whenever we execute a query like this 
`select A.id,B.id from table A,table B where A.id=B.id;`

Query gets executed correctly, but on clicking EXPORT button(in Query Result Operation Widget) and then clicking on GO, gives us file with error """"1066 - Not unique table/alias: 'table'""""
**Actual Flow-**
1- Query get Parsed
2- Alias replaced by table name for every column.  
       _Example_- `A.id,B.id` =changes to=> `table.id,table.id` - _Cant identify Which column from which table_
3- Alias gets removed for table name. 
       _Example_ - `from table A,table B` =Changes to=> `from table, table` - _Cant differentiate between table_ 

This flow got failed for Queries have joins on same table, and working fine for rest cases.
**Conclusion and Changes Made-**
Step 2 and 3 were not required and hence removed those steps.

_**Now export is working fine in all the tested cases.**_