### PR TITLE
Update ServerConfigChecks.php

### DIFF
--- a/libraries/config/ServerConfigChecks.php
+++ b/libraries/config/ServerConfigChecks.php
@@ -217,7 +217,7 @@ class ServerConfigChecks
     ) {
         if ($cookieAuthServer && $blowfishSecret === null) {
             $blowfishSecret = '';
-            if (! function_exists('openssl_random_pseudo_bytes')) {
+            if (class_exists('phpseclib\Crypt\Random')) {
                 $random_func = 'phpseclib\\Crypt\\Random::string';
             } else {
                 $random_func = 'openssl_random_pseudo_bytes';


### PR DESCRIPTION
Logic here was backwards. We should use phpseclib, which uses random_bytes internally, if phpseclib is available.

https://github.com/phpseclib/phpseclib/blob/813b85b5b2d97c8463d537c251be6fb6f83a7984/phpseclib/Crypt/Random.php#L52

Signed-off-by: Eero Vuojolahti <eero@oittaa.net>

Before submitting pull request, please check that every commit:

- [X] Has proper Signed-Off-By
- [X] Has commit message which describes it
- [X] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [X] Any new functionality is covered by tests
