### PR TITLE
ServerConfigChecks.php, try to use phpseclib first

### DIFF
--- a/libraries/config/ServerConfigChecks.php
+++ b/libraries/config/ServerConfigChecks.php
@@ -218,7 +218,7 @@ class ServerConfigChecks
         if ($cookieAuthServer && $blowfishSecret === null) {
             $blowfishSecret = '';
             while (strlen($blowfishSecret) < 32) {
-                if (class_exists('phpseclib\Crypt\Random')) {
+                if (is_callable(array('phpseclib\Crypt\Random', 'string'))) {
                     $byte = phpseclib\Crypt\Random::string(1);
                 } else {
                     $byte = openssl_random_pseudo_bytes(1);

--- a/libraries/config/ServerConfigChecks.php
+++ b/libraries/config/ServerConfigChecks.php
@@ -7,6 +7,7 @@
  */
 namespace PMA\libraries\config;
 
+use phpseclib\Crypt;
 use PMA\libraries\URL;
 
 /**
@@ -218,8 +219,8 @@ class ServerConfigChecks
         if ($cookieAuthServer && $blowfishSecret === null) {
             $blowfishSecret = '';
             while (strlen($blowfishSecret) < 32) {
-                if (is_callable('random_bytes')) {
-                    $byte = random_bytes(1);
+                if (is_callable('Crypt\Random::string')) {
+                    $byte = Crypt\Random::string(1);
                 } else {
                     $byte = openssl_random_pseudo_bytes(1);
                 }

--- a/libraries/config/ServerConfigChecks.php
+++ b/libraries/config/ServerConfigChecks.php
@@ -218,8 +218,8 @@ class ServerConfigChecks
         if ($cookieAuthServer && $blowfishSecret === null) {
             $blowfishSecret = '';
             while (strlen($blowfishSecret) < 32) {
-                if (is_callable(array('phpseclib\Crypt\Random', 'string'))) {
-                    $byte = phpseclib\Crypt\Random::string(1);
+                if (is_callable('random_bytes')) {
+                    $byte = random_bytes(1);
                 } else {
                     $byte = openssl_random_pseudo_bytes(1);
                 }

--- a/libraries/config/ServerConfigChecks.php
+++ b/libraries/config/ServerConfigChecks.php
@@ -217,16 +217,16 @@ class ServerConfigChecks
     ) {
         if ($cookieAuthServer && $blowfishSecret === null) {
             $blowfishSecret = '';
-            if (! function_exists('openssl_random_pseudo_bytes')) {
-                $random_func = 'phpseclib\\Crypt\\Random::string';
-            } else {
-                $random_func = 'openssl_random_pseudo_bytes';
-            }
             while (strlen($blowfishSecret) < 32) {
-                $byte = $random_func(1);
+                if (class_exists('phpseclib\Crypt\Random')) {
+                    $byte = phpseclib\Crypt\Random::string(1);
+                } else {
+                    $byte = openssl_random_pseudo_bytes(1);
+                }
                 // We want only ASCII chars
-                if (ord($byte) > 32 && ord($byte) < 127) {
-                    $blowfishSecret .= $byte;
+                $byte = ord($byte) >> 1;
+                if ($byte > 32 && $byte < 127) {
+                    $blowfishSecret .= chr($byte);
                 }
             }
 


### PR DESCRIPTION
Logic here was backwards. We should use phpseclib, which uses random_bytes internally, if phpseclib is available. Refactored a bit, because the previous (and simpler) pull request #13307 failed on Travis with the following error:
"PHP Fatal error:  Call to undefined function phpseclib\Crypt\Random::string()"
https://travis-ci.org/phpmyadmin/phpmyadmin/builds/236686976?utm_source=github_status&utm_medium=notification

Additionally reduce the number of retries by discarding the highest bit. The byte's range changes from 0-255 to 0-127.

Signed-off-by: Eero Vuojolahti <eero@oittaa.net>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [X] Any new functionality is covered by tests

`testServerConfigChecksPerformConfigChecks()` in [test/libraries/PMA_SetupIndex_test.php](https://github.com/phpmyadmin/phpmyadmin/blob/d6b198e3fafcb6ce1a81db32d5b903c240c3f65a/test/libraries/PMA_SetupIndex_test.php#L167) should cover the changes.