### PR TITLE
Fix double escaping

### DIFF
--- a/templates/database/structure/tracking_icon.twig
+++ b/templates/database/structure/tracking_icon.twig
@@ -1,4 +1,4 @@
-<a href="tbl_tracking.php{{ url_query }}&amp;table={{ truename }}">
+<a href="tbl_tracking.php{{ url_query|raw }}&amp;table={{ truename }}">
     {% if is_tracked -%}
         {{ Util_getImage('eye.png', 'Tracking is active.'|trans) }}
     {%- else -%}

--- a/templates/prefs_autoload.twig
+++ b/templates/prefs_autoload.twig
@@ -3,7 +3,7 @@
         {{ hidden_inputs|raw }}
         <input type="hidden" name="json" value="" />
         <input type="hidden" name="submit_import" value="1" />
-        <input type="hidden" name="return_url" value="{{ return_url }}" />
+        <input type="hidden" name="return_url" value="{{ return_url|raw }}" />
         {% trans %}
             Your browser has phpMyAdmin configuration for this domain. Would you like to import it for current session?
         {% endtrans %}

--- a/templates/table/structure/display_partitions.twig
+++ b/templates/table/structure/display_partitions.twig
@@ -76,7 +76,7 @@
                         <td>{{ partition.getComment() }}</td>
                         {% for action, icon in action_icons %}
                             <td>
-                                <a href="tbl_structure.php{{ url_query -}}
+                                <a href="tbl_structure.php{{ url_query|raw -}}
                                     &amp;partition_maintenance=1&amp;sql_query=
                                     {{- ("ALTER TABLE " ~ Util_backquote(table) ~ action
                                         ~ " PARTITION " ~ partition.getName())|url_encode }}"

--- a/templates/table/structure/display_table_stats.twig
+++ b/templates/table/structure/display_table_stats.twig
@@ -56,7 +56,7 @@
                     or tbl_storage_engine == 'BDB') %}
                     <tr class="tblFooters">
                         <td colspan="3" class="center">
-                            <a href="sql.php{{ url_query }}&amp;pos=0&amp;sql_query=
+                            <a href="sql.php{{ url_query|raw }}&amp;pos=0&amp;sql_query=
                                 {{- ('OPTIMIZE TABLE ' ~ Util_backquote(table))|url_encode }}">
                                 {{ Util_getIcon('b_tbloptimize.png', 'Optimize table'|trans) }}
                             </a>

--- a/templates/table/structure/table_structure_row.twig
+++ b/templates/table/structure/table_structure_row.twig
@@ -43,12 +43,12 @@
 {% if not tbl_is_view and not db_is_system_schema %}
     <td class="edit center print_ignore">
         <a class="change_column_anchor ajax" href="tbl_structure.php
-            {{- url_query }}&amp;field={{ row['Field']|url_encode }}&amp;change_column=1">
+            {{- url_query|raw }}&amp;field={{ row['Field']|url_encode }}&amp;change_column=1">
             {{ titles['Change']|raw }}
         </a>
     </td>
     <td class="drop center print_ignore">
-        <a class="drop_column_anchor ajax" href="sql.php{{ url_query }}&amp;sql_query=
+        <a class="drop_column_anchor ajax" href="sql.php{{ url_query|raw }}&amp;sql_query=
             {{- ('ALTER TABLE ' ~ Util_backquote(table)
                 ~ ' DROP ' ~ Util_backquote(row['Field']) ~ ';')|url_encode -}}
             &amp;dropped_column={{ row['Field']|url_encode }}&amp;purge=1&amp;message_to_show=


### PR DESCRIPTION
Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

Fixes double escaping which for example breaks the "Change" and "Drop" buttons on the table structure view.

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
