### PR TITLE
Fix PMA_token generation

### DIFF
--- a/libraries/session.lib.php
+++ b/libraries/session.lib.php
@@ -31,7 +31,7 @@ function PMA_secureSession()
  */
 function PMA_generateToken()
 {
-    $_SESSION[' PMA_token '] = Util::generateRandom(16);
+    $_SESSION[' PMA_token '] = bin2hex(Util::generateRandom(16));
 
     /**
      * Check if token is properly generated (the generation can fail, for example


### PR DESCRIPTION
The PMA_token is used in Javascript and HTML without escaping in most places.
If the token has ', ", < or > in it it can break the Javascript or the HTML on the page.

Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
