### PR TITLE
Fix double escaping in table structure view

### DIFF
--- a/templates/table/structure/table_structure_row.twig
+++ b/templates/table/structure/table_structure_row.twig
@@ -9,7 +9,7 @@
 </th>
 <td {{ type_nowrap }}>
     <bdo dir="ltr" lang="en">
-        {{ extracted_columnspec['displayed_type'] }}
+        {{ extracted_columnspec['displayed_type']|raw }}
         {% if relation_commwork and relation_mimework and browse_mime
             and mime_map[row['Field']]['mimetype'] is defined %}
             <br />MIME: {{ mime_map[row['Field']]['mimetype']|replace({'_': '/'})|lower }}


### PR DESCRIPTION
Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

`displayed_type` is either just escaped text or html + escaped text [depending on the length of the text](https://github.com/phpmyadmin/phpmyadmin/blob/master/libraries/Util.php#L2983-L2993). To fix the display issue which currently exists we can either use the already escaped content and display it raw as suggested with this commit or we can extract the length depending logic, put it into the template and use the unescaped text (`print_type`) and let the template do the escaping.

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
