### PR TITLE
Fix tbl_url_query escaping for tables containing +

### DIFF
--- a/libraries/controllers/database/DatabaseStructureController.php
+++ b/libraries/controllers/database/DatabaseStructureController.php
@@ -420,7 +420,7 @@ class DatabaseStructureController extends DatabaseController
             $table_is_view = false;
             // Sets parameters for links
             $tbl_url_query = $this->_url_query
-                . '&amp;table=' . htmlspecialchars($current_table['TABLE_NAME']);
+                . '&amp;table=' . rawurlencode($current_table['TABLE_NAME']);
             // do not list the previous table's size info for a view
 
             list($current_table, $formatted_size, $unit, $formatted_overhead,


### PR DESCRIPTION
Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

Fixes an issue where the links to browse, view the structure or modifiy a table are not working because for example `+` chars in a table name are not properly escaped, at least not to work in an `<a>` html tag. This has been broken by / since https://github.com/phpmyadmin/phpmyadmin/commit/c36d0001f93e2883faecbeaf07c25c2140f4500a . 

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
