### PR TITLE
RFC: Add configuration for Probot Stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 7
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking as stale
+staleLabel: wontfix
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: false
+# Limit to only `issues` or `pulls`
+only: pulls


### PR DESCRIPTION
See https://github.com/probot/stale/

We have quite some pull requests which did not receive attention for quite some time and are not ready to be merged. This enables Probot Stale to label those as wontfix after 60 days and close them after additional 7 days without activity.

I think it's better to having a bot do the work because it, to some degree, is less personal and it can avoid bad feelings from the contributors as it's bureaucracy that closed your pull request.