### PR TITLE
Make grid editor NULL checkbox text clickable

### DIFF
--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -785,7 +785,7 @@ function PMA_makegrid(t, enableResize, enableReorder, enableVisib, enableGridEdi
                 g.wasEditedCellNull = false;
                 if ($td.is(':not(.not_null)')) {
                     // append a null checkbox
-                    $editArea.append('<div class="null_div">Null:<input type="checkbox"></div>');
+                    $editArea.append('<div class="null_div"><label>Null:<input type="checkbox"></label></div>');
 
                     var $checkbox = $editArea.find('.null_div input');
                     // check if current <td> is NULL


### PR DESCRIPTION
So you can click the text "NULL" in addition to the checkbox itself.