### PR TITLE
fix brackets

### DIFF
--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -612,7 +612,7 @@ function PMA_isRememberSortingOrder($analyzed_sql_results)
             || $analyzed_sql_results['is_analyse'])
         && $analyzed_sql_results['select_from']
         && ((empty($analyzed_sql_results['select_expr']))
-            || (count($analyzed_sql_results['select_expr'] == 1)
+            || ((count($analyzed_sql_results['select_expr']) == 1)
                 && ($analyzed_sql_results['select_expr'][0] == '*')))
         && count($analyzed_sql_results['select_tables']) == 1;
 }


### PR DESCRIPTION
Found testing PHP 7.2
```
Warning in ./libraries/sql.lib.php#615
count(): Parameter must be an array or an object that implements Countable
```

Brackets are obvious wrong (== in the count argument)