### PR TITLE
Remove double escaping

### DIFF
--- a/templates/list/item.twig
+++ b/templates/list/item.twig
@@ -3,7 +3,7 @@
 
     {% if url is defined and url is iterable %}
         <a{% if url['href'] is not empty %} href="{{ url['href'] }}"{% endif -%}
-        {%- if url['target'] is not empty %} target="{{ url['target'] }}"{% endif -%}
+        {%- if url['target'] is not empty %} target="{{ url['target']|raw }}"{% endif -%}
         {%- if url['target'] is not empty and url['target'] == '_blank' %} rel="noopener noreferrer"{% endif -%}
         {%- if url['id'] is not empty %} id="{{ url['id'] }}"{% endif -%}
         {%- if url['class'] is not empty %} class="{{ url['class'] }}"{% endif -%}


### PR DESCRIPTION
The href part of the url is already escaped, double escaping like it's done atm breaks the links on for example these buttons:
![grafik](https://user-images.githubusercontent.com/4395417/27711139-8422a6fe-5d22-11e7-8977-bfa92e9fee8d.png)


Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
