### PR TITLE
Properly fix #13420

### DIFF
--- a/templates/list/item.twig
+++ b/templates/list/item.twig
@@ -2,8 +2,8 @@
     {%- if class is not empty %} class="{{ class }}"{% endif %}>
 
     {% if url is defined and url is iterable %}
-        <a{% if url['href'] is not empty %} href="{{ url['href'] }}"{% endif -%}
-        {%- if url['target'] is not empty %} target="{{ url['target']|raw }}"{% endif -%}
+        <a{% if url['href'] is not empty %} href="{{ url['href']|raw }}"{% endif -%}
+        {%- if url['target'] is not empty %} target="{{ url['target'] }}"{% endif -%}
         {%- if url['target'] is not empty and url['target'] == '_blank' %} rel="noopener noreferrer"{% endif -%}
         {%- if url['id'] is not empty %} id="{{ url['id'] }}"{% endif -%}
         {%- if url['class'] is not empty %} class="{{ url['class'] }}"{% endif -%}


### PR DESCRIPTION
I edited the wrong row in GitHub after fixing #13420 in my local installation and testing that it worked. My bad. This is the correct fix for the double escaping of the href part of the url.

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
