### PR TITLE
Move Theme object out of session

### DIFF
--- a/js/get_image.js.php
+++ b/js/get_image.js.php
@@ -32,7 +32,7 @@ if (!defined('TESTSUITE')) {
 }
 
 // Get the data for the sprites, if it's available
-$sprites = $_SESSION['PMA_Theme']->getSpriteData();
+$sprites = $GLOBALS['PMA_Theme']->getSpriteData();
 
 // We only need the keys from the array of sprites data,
 // since they contain the (partial) class names
@@ -130,7 +130,7 @@ function PMA_getImage(image, alternate, attributes) {
         retval.isSprite = false;
         retval.attr(
             'src',
-            "<?php echo $_SESSION['PMA_Theme']->getImgPath(); ?>" + image
+            "<?php echo $GLOBALS['PMA_Theme']->getImgPath(); ?>" + image
         );
     }
     // set all other attrubutes

--- a/js/messages.php
+++ b/js/messages.php
@@ -706,7 +706,7 @@ $js_messages['phpErrorsBeingSubmitted'] = '<div class="error">'
     )
     . '<br/>'
     . '<img src="'
-    . ($_SESSION['PMA_Theme']->getImgPath('ajax_clock_small.gif'))
+    . ($GLOBALS['PMA_Theme']->getImgPath('ajax_clock_small.gif'))
     . '" width="16" height="16" alt="ajax clock"/>'
     . '</div>';
 

--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -1252,8 +1252,8 @@ class Config
             $this->source_mtime +
             $this->default_source_mtime +
             $this->get('user_preferences_mtime') +
-            $_SESSION['PMA_Theme']->mtime_info +
-            $_SESSION['PMA_Theme']->filesize_info);
+            $GLOBALS['PMA_Theme']->mtime_info +
+            $GLOBALS['PMA_Theme']->filesize_info);
     }
 
     /**

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -187,8 +187,8 @@ class Header
         // Append the theme id to this url to invalidate
         // the cache on a theme change. Though this might be
         // unavailable for fatal errors.
-        if (isset($_SESSION['PMA_Theme'])) {
-            $theme_id = urlencode($_SESSION['PMA_Theme']->getId());
+        if (isset($GLOBALS['PMA_Theme'])) {
+            $theme_id = urlencode($GLOBALS['PMA_Theme']->getId());
         } else {
             $theme_id = 'default';
         }

--- a/libraries/classes/ThemeManager.php
+++ b/libraries/classes/ThemeManager.php
@@ -498,32 +498,32 @@ class ThemeManager
         /**
          * the theme object
          *
-         * @global Theme $_SESSION['PMA_Theme']
+         * @global Theme $GLOBALS['PMA_Theme']
          */
-        $_SESSION['PMA_Theme'] = $tmanager->theme;
+        $GLOBALS['PMA_Theme'] = $tmanager->theme;
 
         // BC
         /**
          * the active theme
          * @global string $GLOBALS['theme']
          */
-        $GLOBALS['theme']           = $_SESSION['PMA_Theme']->getName();
+        $GLOBALS['theme']           = $GLOBALS['PMA_Theme']->getName();
         /**
          * the theme path
          * @global string $GLOBALS['pmaThemePath']
          */
-        $GLOBALS['pmaThemePath']    = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath']    = $GLOBALS['PMA_Theme']->getPath();
         /**
          * the theme image path
          * @global string $GLOBALS['pmaThemeImage']
          */
-        $GLOBALS['pmaThemeImage']   = $_SESSION['PMA_Theme']->getImgPath();
+        $GLOBALS['pmaThemeImage']   = $GLOBALS['PMA_Theme']->getImgPath();
 
         /**
          * load layout file if exists
          */
-        if (@file_exists($_SESSION['PMA_Theme']->getLayoutFile())) {
-            include $_SESSION['PMA_Theme']->getLayoutFile();
+        if (@file_exists($GLOBALS['PMA_Theme']->getLayoutFile())) {
+            include $GLOBALS['PMA_Theme']->getLayoutFile();
         }
     }
 }

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -130,8 +130,8 @@ class Util
         if (! isset($sprites)) {
             $sprites = array();
             // Try to load the list of sprites
-            if (isset($_SESSION['PMA_Theme'])) {
-                $sprites = $_SESSION['PMA_Theme']->getSpriteData();
+            if (isset($GLOBALS['PMA_Theme'])) {
+                $sprites = $GLOBALS['PMA_Theme']->getSpriteData();
             }
         }
 

--- a/templates/database/designer/database_tables.phtml
+++ b/templates/database/designer/database_tables.phtml
@@ -33,7 +33,7 @@
                 </td>
                 <td class="small_tab_pref small_tab_pref_1"
                     table_name_small="<?= htmlspecialchars($GLOBALS['PMD_URL']["TABLE_NAME_SMALL"][$i]); ?>">
-                    <img src="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/exec_small.png'); ?>"
+                    <img src="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/exec_small.png'); ?>"
                          title="<?= __('See table structure'); ?>" />
                 </td>
                 <td id="id_zag_<?= htmlspecialchars($t_n_url); ?>"
@@ -89,7 +89,7 @@
                     <td width="10px" colspan="3" id="<?= $t_n_url; ?>.<?= urlencode($tab_column[$t_n]["COLUMN_NAME"][$j]); ?>">
                         <div class="nowrap">
                             <?php if (isset($tables_pk_or_unique_keys[$t_n . "." . $tab_column[$t_n]["COLUMN_NAME"][$j]])) : ?>
-                                <img src="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/FieldKey_small.png'); ?>" alt="*" />
+                                <img src="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/FieldKey_small.png'); ?>" alt="*" />
                             <?php else :
                                 $type = 'pmd/Field_small';
                                 if (strstr($tab_column[$t_n]["TYPE"][$j], 'char')
@@ -109,7 +109,7 @@
                                     $type .= '_date';
                                 }
                                 ?>
-                                <img src="<?= $_SESSION['PMA_Theme']->getImgPath($type); ?>.png" alt="*" />
+                                <img src="<?= $GLOBALS['PMA_Theme']->getImgPath($type); ?>.png" alt="*" />
                             <?php endif; ?>
                             <?= htmlspecialchars(
                                 $tab_column[$t_n]["COLUMN_NAME"][$j] . " : "
@@ -121,7 +121,7 @@
                     <?php if (isset($_REQUEST['query'])) : ?>
                         <td class="small_tab_pref small_tab_pref_click_opt"
                             Click_option_param="pmd_optionse,<?= urlencode($tab_column[$t_n]['COLUMN_NAME'][$j]); ?>,<?= $GLOBALS['PMD_OUT']['TABLE_NAME_SMALL'][$i]; ?>" >
-                            <img src="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/exec_small.png'); ?>" title="options" />
+                            <img src="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/exec_small.png'); ?>" title="options" />
                         </td>
                     <?php endif; ?>
                 </tr>

--- a/templates/database/designer/side_menu.phtml
+++ b/templates/database/designer/side_menu.phtml
@@ -1,7 +1,7 @@
 <?php
 function getImg($path)
 {
-    return $_SESSION['PMA_Theme']->getImgPath($path);
+    return $GLOBALS['PMA_Theme']->getImgPath($path);
 }
 ?>
 <?php if (!$visualBuilder) : ?>

--- a/templates/database/designer/table_list.phtml
+++ b/templates/database/designer/table_list.phtml
@@ -4,17 +4,17 @@
             <img title="<?= __('Hide/Show all'); ?>"
                  alt="v"
                  id="key_HS_all"
-                 src="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/downarrow1.png'); ?>"
-                 data-down="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/downarrow1.png'); ?>"
-                 data-right="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/rightarrow1.png'); ?>" />
+                 src="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/downarrow1.png'); ?>"
+                 data-down="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/downarrow1.png'); ?>"
+                 data-right="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/rightarrow1.png'); ?>" />
         </a>
         <a href="#" class="M_butt" target="_self" >
             <img alt="v"
                  id="key_HS"
                  title="<?= __('Hide/Show Tables with no relationship'); ?>"
-                 src="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/downarrow2.png'); ?>"
-                 data-down="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/downarrow2.png'); ?>"
-                 data-right="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/rightarrow2.png'); ?>" />
+                 src="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/downarrow2.png'); ?>"
+                 data-down="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/downarrow2.png'); ?>"
+                 data-right="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/rightarrow2.png'); ?>" />
         </a>
     </div>
     <div id="id_scroll_tab" class="scroll_tab">
@@ -31,7 +31,7 @@
                         <img alt=""
                              table_name="<?= htmlspecialchars($GLOBALS['PMD_URL']['TABLE_NAME_SMALL'][$i]); ?>"
                              class="scroll_tab_struct"
-                             src="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/exec.png'); ?>"/>
+                             src="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/exec.png'); ?>"/>
                     </td>
                     <td width="1px">
                         <input class="scroll_tab_checkbox"
@@ -57,8 +57,8 @@
     <div id="layer_menu_sizer">
         <div class="floatleft">
             <img class="icon"
-                 data-right="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/resizeright.png'); ?>"
-                 src="<?= $_SESSION['PMA_Theme']->getImgPath('pmd/resize.png'); ?>"/>
+                 data-right="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/resizeright.png'); ?>"
+                 src="<?= $GLOBALS['PMA_Theme']->getImgPath('pmd/resize.png'); ?>"/>
         </div>
     </div>
 </div>

--- a/test/bootstrap-dist.php
+++ b/test/bootstrap-dist.php
@@ -87,7 +87,7 @@ session_start();
 
 // Standard environment for tests
 $_SESSION[' PMA_token '] = 'token';
-$_SESSION['PMA_Theme'] = PhpMyAdmin\Theme::load('./themes/pmahomme');
+$GLOBALS['PMA_Theme'] = PhpMyAdmin\Theme::load('./themes/pmahomme');
 $_SESSION['tmpval']['pftext'] = 'F';
 $GLOBALS['lang'] = 'en';
 $GLOBALS['cell_align_left'] = 'left';

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -839,8 +839,8 @@ class ConfigTest extends PMATestCase
                 'default_source_mtime'
             ) +
             $this->object->get('user_preferences_mtime') +
-            $_SESSION['PMA_Theme']->mtime_info +
-            $_SESSION['PMA_Theme']->filesize_info
+            $GLOBALS['PMA_Theme']->mtime_info +
+            $GLOBALS['PMA_Theme']->filesize_info
         );
 
         $this->object->set('fontsize', 10);

--- a/test/classes/HeaderTest.php
+++ b/test/classes/HeaderTest.php
@@ -35,7 +35,7 @@ class HeaderTest extends PMATestCase
         }
         $GLOBALS['server'] = 0;
         $GLOBALS['message'] = 'phpmyadminmessage';
-        $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
         $GLOBALS['PMA_PHP_SELF'] = Core::getenv('PHP_SELF');
         $GLOBALS['server'] = 'server';
         $GLOBALS['db'] = 'pma_test';

--- a/test/classes/MenuTest.php
+++ b/test/classes/MenuTest.php
@@ -37,7 +37,7 @@ class MenuTest extends PMATestCase
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['Server']['verbose'] = 'verbose host';
-        $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
         $GLOBALS['PMA_PHP_SELF'] = Core::getenv('PHP_SELF');
         $GLOBALS['server'] = 'server';
         $GLOBALS['db'] = 'pma_test';

--- a/test/classes/ThemeTest.php
+++ b/test/classes/ThemeTest.php
@@ -35,8 +35,8 @@ class ThemeTest extends PMATestCase
     protected function setUp()
     {
         $this->object = new Theme();
-        $this->backup = $_SESSION['PMA_Theme'];
-        $_SESSION['PMA_Theme'] = $this->object;
+        $this->backup = $GLOBALS['PMA_Theme'];
+        $GLOBALS['PMA_Theme'] = $this->object;
         $GLOBALS['PMA_Config'] = new PhpMyAdmin\Config();
         $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['text_dir'] = 'ltr';
@@ -53,7 +53,7 @@ class ThemeTest extends PMATestCase
      */
     protected function tearDown()
     {
-        $_SESSION['PMA_Theme'] = $this->backup;
+        $GLOBALS['PMA_Theme'] = $this->backup;
     }
 
     /**

--- a/test/classes/config/FormDisplayTest.php
+++ b/test/classes/config/FormDisplayTest.php
@@ -34,7 +34,7 @@ class FormDisplayTest extends PMATestCase
      */
     function setup()
     {
-        $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
         $GLOBALS['PMA_Config'] = new Config();
         $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['server'] = 0;

--- a/test/classes/config/FormTest.php
+++ b/test/classes/config/FormTest.php
@@ -32,7 +32,7 @@ class FormTest extends PMATestCase
      */
     function setup()
     {
-        $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
         $GLOBALS['PMA_Config'] = new Config();
         $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['server'] = 0;

--- a/test/classes/navigation/NodeDatabaseChildTest.php
+++ b/test/classes/navigation/NodeDatabaseChildTest.php
@@ -34,7 +34,7 @@ class NodeDatabaseChildTest extends PMATestCase
      */
     protected function setUp()
     {
-        $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
         $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
         $GLOBALS['server'] = 1;
         $GLOBALS['cfg']['ServerDefault'] = 1;

--- a/test/libraries/PMA_relation_test.php
+++ b/test/libraries/PMA_relation_test.php
@@ -43,7 +43,7 @@ class PMA_Relation_Test extends PHPUnit_Framework_TestCase
         $_SESSION['relation'][$GLOBALS['server']] = "PMA_relation";
         $_SESSION['relation'] = array();
 
-        $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
         $GLOBALS['cfg']['ServerDefault'] = 0;
 
         include_once 'libraries/relation.lib.php';

--- a/test/libraries/common/PMA_checkParameters_test.php
+++ b/test/libraries/common/PMA_checkParameters_test.php
@@ -41,7 +41,7 @@ class PMA_CheckParameters_Test extends PHPUnit_Framework_TestCase
     function testCheckParameterMissing()
     {
         $GLOBALS['PMA_PHP_SELF'] = Core::getenv('PHP_SELF');
-        $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
 
         $this->expectOutputRegex("/Missing parameter: field/");
 
@@ -58,7 +58,7 @@ class PMA_CheckParameters_Test extends PHPUnit_Framework_TestCase
     function testCheckParameter()
     {
         $GLOBALS['PMA_PHP_SELF'] = Core::getenv('PHP_SELF');
-        $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
         $GLOBALS['db'] = "dbDatabase";
         $GLOBALS['table'] = "tblTable";
         $GLOBALS['field'] = "test_field";

--- a/test/libraries/rte/PMA_RTN_getEditorForm_test.php
+++ b/test/libraries/rte/PMA_RTN_getEditorForm_test.php
@@ -40,7 +40,7 @@ class PMA_RTN_GetEditorForm_Test extends PHPUnit_Framework_TestCase
         $cfg['ServerDefault'] = 1;
 
         $GLOBALS['PMA_Types'] = new TypesMySQL();
-        $GLOBALS['pmaThemePath'] = $_SESSION['PMA_Theme']->getPath();
+        $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
 
     }
 


### PR DESCRIPTION
Honestly I don't see good reason for storing Theme in session as loading
it from the session will take about same time as loading it from the
disk.

Additionally it seems that current code really didn't really use the
object stored in session, it was constructed with every request anyway
(by ThemeManager::initializeTheme).

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
