### PR TITLE
Fix more selenium tests

### DIFF
--- a/templates/columns_definitions/column_auto_increment.twig
+++ b/templates/columns_definitions/column_auto_increment.twig
@@ -1,5 +1,5 @@
 <input name="field_extra[{{ column_number }}]"
-    id="field_{{ columnNumber }}_{{ ci - ci_offset }}"
+    id="field_{{ column_number }}_{{ ci - ci_offset }}"
     {% if column_meta['Extra'] is defined and column_meta['Extra']|lower == 'auto_increment' -%}
         checked="checked"
     {%- endif %}

--- a/test/selenium/PmaSeleniumCreateDropDatabaseTest.php
+++ b/test/selenium/PmaSeleniumCreateDropDatabaseTest.php
@@ -51,7 +51,7 @@ class PMA_SeleniumCreateDropDatabaseTest extends PMA_SeleniumBase
         );
 
         $this->waitForElement('byPartialLinkText','Databases')->click();
-        $this->waitForElementNotPresent('byCssSelector', 'div#loading_parent');
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
 
         $element = $this->waitForElement('byId', 'text_create_db');
         $element->clear();
@@ -79,7 +79,7 @@ class PMA_SeleniumCreateDropDatabaseTest extends PMA_SeleniumBase
         $this->gotoHomepage();
 
         $this->byPartialLinkText('Databases')->click();
-        $this->waitForElementNotPresent('byCssSelector', 'div#loading_parent');
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
 
         $this->scrollIntoView('tableslistcontainer');
         $this->byCssSelector(

--- a/test/selenium/PmaSeleniumDbEventsTest.php
+++ b/test/selenium/PmaSeleniumDbEventsTest.php
@@ -123,9 +123,11 @@ class PMA_SeleniumDbEventsTest extends PMA_SeleniumBase
 
         $this->byName("item_starts")
             ->value(date('Y-m-d H:i:s', strtotime('-1 day')));
+        usleep(1000000);
 
         $this->byName("item_ends")
             ->value(date('Y-m-d H:i:s', strtotime('+1 day')));
+        usleep(1000000);
 
         $proc = "UPDATE " . $this->database_name . ".`test_table` SET val=val+1";
         $this->typeInTextArea($proc, 2);
@@ -136,6 +138,10 @@ class PMA_SeleniumDbEventsTest extends PMA_SeleniumBase
             "byXPath",
             "//div[@class='success' and contains(., "
             . "'Event `test_event` has been created')]"
+        );
+        $this->waitForElementNotPresent(
+            'byXPath',
+            '//div[@id=\'alertLabel\' and not(contains(@style,\'display: none;\'))]'
         );
 
         $this->assertTrue(

--- a/test/selenium/PmaSeleniumDbOperationsTest.php
+++ b/test/selenium/PmaSeleniumDbOperationsTest.php
@@ -123,6 +123,7 @@ class PMA_SeleniumDbOperationsTest extends PMA_SeleniumBase
         $this->byCssSelector("form#copy_db_form input[name=newname]")
             ->value($new_db_name);
 
+        $this->scrollIntoView('copy_db_form', -150);
         $this->byCssSelector("form#copy_db_form input[type='submit']")->click();
 
         $this->waitForElement(

--- a/test/selenium/PmaSeleniumDbProceduresTest.php
+++ b/test/selenium/PmaSeleniumDbProceduresTest.php
@@ -209,6 +209,8 @@ class PMA_SeleniumDbProceduresTest extends PMA_SeleniumBase
         $this->waitForElement("byPartialLinkText", "Execute")->click();
         $this->waitForElement("byName", "params[inp]")->value($text);
         $this->byCssSelector("div.ui-dialog-buttonset button:nth-child(1)")->click();
+
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement(
             "byCssSelector",
             "span#PMA_slidingMessage table tbody"

--- a/test/selenium/PmaSeleniumExportTest.php
+++ b/test/selenium/PmaSeleniumExportTest.php
@@ -83,6 +83,10 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
      */
     public function testDbExport($plugin, $expected)
     {
+        // Go to server databases
+        $this->waitForElement('byPartialLinkText','Databases')->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+
         $this->waitForElement("byPartialLinkText", $this->database_name)->click();
         $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement(
@@ -140,7 +144,7 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
                 array(
                     "CREATE TABLE IF NOT EXISTS `test_table`",
                     "INSERT INTO `test_table` (`id`, `val`) VALUES",
-                    "(1, 2);",
+                    "(1, 2)",
                 )
             ),
             array(
@@ -169,26 +173,32 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
 
         $this->waitForElement("byId", "quick_or_custom");
         $this->byCssSelector("label[for=radio_custom_export]")->click();
-        $this->sleep();
+        usleep(1000000);
 
-        if ($type == 'server') {
-            $this->byLinkText('Unselect all')->click();
-            $this->byCssSelector(
+        $this->select($this->byId("plugins"))->selectOptionByLabel($plugin);
+        usleep(1000000);
+
+        if ($type === 'server') {
+            $this->scrollIntoView('databases_and_tables', 200);
+            $this->waitForElement('byPartialLinkText', 'Unselect all')->click();
+            usleep(1000000);
+
+            $this->waitForElement(
+                'byCssSelector',
                 "option[value=" . $this->database_name . "]"
             )->click();
         }
 
-        if ($type == 'table') {
+        if ($type === 'table') {
             $this->byCssSelector("label[for=radio_allrows_0]")->click();
             $this->sleep();
             $this->byName("limit_to")->clear();
             $this->byName("limit_to")->value("1");
         }
 
-        $this->select($this->byId("plugins"))->selectOptionByLabel($plugin);
-        usleep(1000000);
-        $this->scrollIntoView('output', 0);
+        $this->scrollIntoView('output', -150);
         $this->waitForElement('byCssSelector', "label[for=radio_view_as_text]")->click();
+        usleep(1000000);
 
         if ($plugin == "SQL") {
             if ($type !== 'db') {
@@ -201,11 +211,11 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
             }
 
             if ($type === 'server') {
-                $this->scrollIntoView('sql_data', -600);
+                $this->scrollIntoView('sql_data', -650);
             } elseif ($type === 'db') {
-                $this->scrollIntoView('sql_data', -200);
+                $this->scrollIntoView('sql_data', -250);
             } elseif ($type === 'table') {
-                $this->scrollIntoView('sql_data', -300);
+                $this->scrollIntoView('sql_data', -350);
             }
 
             $ele = $this->waitForElement('byId', 'checkbox_sql_if_not_exists');
@@ -216,6 +226,8 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
         }
 
         $this->scrollToBottom();
+        usleep(1000000);
+
         $this->waitForElement('byId', "buttonGo")->click();
 
         $text = $this->waitForElement("byId", "textSQLDUMP")->text();

--- a/test/selenium/PmaSeleniumExportTest.php
+++ b/test/selenium/PmaSeleniumExportTest.php
@@ -45,6 +45,7 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
      */
     public function setUpPage()
     {
+        parent::setUpPage();
         $this->login();
     }
 
@@ -59,7 +60,7 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
      *
      * @group large
      */
-    public function testServerImport($plugin, $expected)
+    public function testServerExport($plugin, $expected)
     {
         $text = $this->_doExport('server', $plugin);
 
@@ -82,7 +83,8 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
      */
     public function testDbExport($plugin, $expected)
     {
-        $this->waitForElement("byLinkText", $this->database_name)->click();
+        $this->waitForElement("byPartialLinkText", $this->database_name)->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement(
             "byXPath",
             "//a[@class='item' and contains(., 'Database: "
@@ -138,12 +140,12 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
                 array(
                     "CREATE TABLE IF NOT EXISTS `test_table`",
                     "INSERT INTO `test_table` (`id`, `val`) VALUES",
-                    "(1, 2);"
+                    "(1, 2);",
                 )
             ),
             array(
                 'JSON',
-                array('[{"id":"1","val":"2"}]')
+                array('{"id":"1","val":"2"}')
             )
         );
     }
@@ -160,15 +162,14 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
     {
         $this->expandMore();
 
-        $this->waitForElement('byLinkText', "Export")->click();
+        $this->waitForElement('byPartialLinkText', "Export")->click();
         $this->sleep();
 
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+
         $this->waitForElement("byId", "quick_or_custom");
-        /*
-         * FIXME: There should be better way to wait for javascript to be executed
-         */
-        $this->sleep();
         $this->byCssSelector("label[for=radio_custom_export]")->click();
+        $this->sleep();
 
         if ($type == 'server') {
             $this->byLinkText('Unselect all')->click();
@@ -185,24 +186,39 @@ class PMA_SeleniumExportTest extends PMA_SeleniumBase
         }
 
         $this->select($this->byId("plugins"))->selectOptionByLabel($plugin);
-        $this->byCssSelector("label[for=radio_view_as_text]")->click();
+        usleep(1000000);
+        $this->scrollIntoView('output', 0);
+        $this->waitForElement('byCssSelector', "label[for=radio_view_as_text]")->click();
 
         if ($plugin == "SQL") {
-            $this->byCssSelector(
-                "label[for=radio_sql_structure_or_data_structure_and_data]"
-            )->click();
-
-            if ($type != "table") {
-                $this->byCssSelector(
-                    "label[for=checkbox_sql_create_database]"
+            if ($type !== 'db') {
+                $this->scrollIntoView('sql_structure', -200);
+                $this->waitForElement(
+                    'byCssSelector',
+                    "label[for=radio_sql_structure_or_data_structure_and_data]"
                 )->click();
+                usleep(1000000);
+            }
+
+            if ($type === 'server') {
+                $this->scrollIntoView('sql_data', -600);
+            } elseif ($type === 'db') {
+                $this->scrollIntoView('sql_data', -200);
+            } elseif ($type === 'table') {
+                $this->scrollIntoView('sql_data', -300);
+            }
+
+            $ele = $this->waitForElement('byId', 'checkbox_sql_if_not_exists');
+            if (! $ele->selected()) {
+                $this->moveto($ele);
+                $this->click();
             }
         }
 
-        $this->byId("buttonGo")->click();
+        $this->scrollToBottom();
+        $this->waitForElement('byId', "buttonGo")->click();
 
         $text = $this->waitForElement("byId", "textSQLDUMP")->text();
-
         return $text;
     }
 }

--- a/test/selenium/PmaSeleniumImportTest.php
+++ b/test/selenium/PmaSeleniumImportTest.php
@@ -25,6 +25,7 @@ class PMA_SeleniumImportTest extends PMA_SeleniumBase
      */
     public function setUpPage()
     {
+        parent::setUpPage();
         $this->login();
     }
 
@@ -55,8 +56,14 @@ class PMA_SeleniumImportTest extends PMA_SeleniumBase
      */
     public function testDbImport()
     {
+        // Go to server databases
+        $this->waitForElement('byPartialLinkText','Databases')->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+
         $this->dbQuery("CREATE DATABASE " . $this->database_name);
-        $this->waitForElement("byLinkText", $this->database_name)->click();
+        $this->waitForElement("byPartialLinkText", $this->database_name)->click();
+
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement(
             "byXPath",
             "//a[@class='item' and contains(., 'Database: "

--- a/test/selenium/PmaSeleniumTableBrowseTest.php
+++ b/test/selenium/PmaSeleniumTableBrowseTest.php
@@ -65,6 +65,7 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
     public function testSortRecords()
     {
         $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        usleep(1000000); // let the page load
 
         // case 1
         $this->byPartialLinkText("name")->click();
@@ -286,12 +287,13 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
             $this->byId("field_3_3")->value()
         );
 
-        $this->byId("field_2_3")->clear();
-        $this->byId("field_2_3")->value("ABCDEFG");
         $this->byId("field_3_3")->clear();
+        $this->byId("field_2_3")->clear();
         $this->byId("field_3_3")->value("2012-01-20 02:05:02");
+        $this->byId("field_2_3")->value("ABCDEFG");
+        usleep(1000000); // longer string takes longer to type
 
-        $this->byId("buttonYes")->click();
+        $this->waitForElement('byId', "buttonYes")->click();
 
         $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $success = $this->waitForElement("byClassName", "success");
@@ -357,6 +359,7 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
     public function testDeleteRecords()
     {
         $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        usleep(1000000);
 
         $this->byId("id_rows_to_delete1_left")->click();
         $this->byId("id_rows_to_delete2_left")->click();

--- a/test/selenium/PmaSeleniumTableBrowseTest.php
+++ b/test/selenium/PmaSeleniumTableBrowseTest.php
@@ -49,6 +49,8 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
      */
     public function setUpPage()
     {
+        parent::setUpPage();
+
         $this->login();
         $this->navigateTable('test_table');
     }
@@ -62,14 +64,12 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
      */
     public function testSortRecords()
     {
-        /* TODO: needs to be fixed */
-        $this->markTestIncomplete(
-            'Does not work with multi column sorting.'
-        );
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+
         // case 1
-        $this->byLinkText("name")->click();
-        $this->waitForElementNotPresent("byId", "loading_parent");
-        $this->sleep();
+        $this->byPartialLinkText("name")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        usleep(1000000);
 
         $this->assertEquals(
             "1",
@@ -87,9 +87,9 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
         );
 
         // case 2
-        $this->byLinkText("name")->click();
-        $this->waitForElementNotPresent("byId", "loading_parent");
-        $this->sleep();
+        $this->byPartialLinkText("name")->click();
+        $this->waitForElementNotPresent("byId", "ajax_message_num_1");
+        usleep(1000000);
 
         $this->assertEquals(
             "2",
@@ -108,9 +108,10 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
 
         // case 2
         $this->byLinkText("datetimefield")->click();
-        $this->waitForElementNotPresent("byId", "loading_parent");
-        $this->sleep();
+        $this->waitForElementNotPresent("byId", "ajax_message_num_1");
+        usleep(1000000);
 
+        $this->getCellByTableClass('table_results', 1, 5);
         $this->assertEquals(
             "3",
             $this->getCellByTableClass('table_results', 1, 5)
@@ -127,9 +128,9 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
         );
 
         // case 4
-        $this->byLinkText("datetimefield")->click();
-        $this->waitForElementNotPresent("byId", "loading_parent");
-        $this->sleep();
+        $this->byPartialLinkText("datetimefield")->click();
+        $this->waitForElementNotPresent("byId", "ajax_message_num_1");
+        usleep(1000000);
 
         $this->assertEquals(
             "2",
@@ -156,12 +157,19 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
      */
     public function testChangeRecords()
     {
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->sleep();
-        $this->byCssSelector(
-            "table.table_results tbody tr:nth-child(2) td:nth-child(2) a"
-        )->click();
-        $this->sleep();
-        /* TODO: this occasionally fails, so there is probably something wrong */
+
+        $ele = $this->byCssSelector(
+            "table.table_results tbody tr:nth-child(2) td:nth-child(2)"
+        );
+        usleep(1000000);
+        $this->moveto($ele);
+        $this->click();
+
+        $this->waitForElement("byId", "insertForm");
+
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement("byId", "insertForm");
 
         $this->assertEquals(
@@ -181,11 +189,15 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
 
         $this->byId("field_2_3")->clear();
         $this->byId("field_2_3")->value("foobar");
+
+        $this->sleep();
         $this->byId("field_3_3")->clear();
         $this->byId("field_3_3")->value("2009-01-20 02:00:02");
 
+        $this->sleep();
         $this->byId("buttonYes")->click();
 
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $success = $this->waitForElement("byClassName", "success");
         $this->assertContains("1 row affected", $success->text());
 
@@ -209,22 +221,30 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
      */
     public function testChangeRecordsByDoubleClick()
     {
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $element = $this->byCssSelector(
             "table.table_results tbody tr:nth-child(1) td:nth-child(6)"
         );
+        usleep(1000000);
 
         $this->moveto($element);
         $this->doubleclick();
 
         $this->assertEquals(
-            $this->byCssSelector("textarea.edit_box")->value(),
+            $this->waitForElement(
+                'byXPath',
+                "//div[not(contains(@style,'display: none;'))]//textarea[contains(@class, 'edit_box')]"
+            )->value(),
             "abcd"
         );
 
         $this->byCssSelector("textarea.edit_box")->clear();
         $this->byCssSelector("textarea.edit_box")->value("abcde");
+
+        $this->sleep();
         $this->keys(PHPUnit_Extensions_Selenium2TestCase_Keys::RETURN_);
 
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $success = $this->waitForElement(
             "byCssSelector", "span.ajax_notification div.success"
         );
@@ -245,11 +265,15 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
      */
     public function testCopyRecords()
     {
-        $this->byCssSelector(
-            "table.table_results tbody tr:nth-child(3) td:nth-child(3) a"
-        )->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        $this->sleep();
 
-        /* TODO: this occasionally fails, so there is probably something wrong */
+        $ele = $this->byCssSelector(
+            "table.table_results tbody tr:nth-child(3) td:nth-child(3)"
+        );
+        usleep(1000000);
+        $this->moveto($ele);
+        $this->click();
         $this->waitForElement("byId", "insertForm");
 
         $this->assertEquals(
@@ -268,6 +292,8 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
         $this->byId("field_3_3")->value("2012-01-20 02:05:02");
 
         $this->byId("buttonYes")->click();
+
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $success = $this->waitForElement("byClassName", "success");
         $this->assertContains("1 row inserted", $success->text());
 
@@ -291,16 +317,22 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
      */
     public function testSearchRecords()
     {
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->expandMore();
 
-        $this->byLinkText("Search")->click();
+        $this->byPartialLinkText("Search")->click();
         $this->waitForElement("byId", "tbl_search_form");
 
         $this->byId("fieldID_1")->value("abcd");
         $select = $this->select($this->byName("criteriaColumnOperators[1]"));
         $select->selectOptionByLabel("LIKE %...%");
 
-        $this->byName("submit")->click();
+        $this->scrollToBottom();
+        $elem = $this->waitForElement('byCssSelector', ".tblFooters input[name=submit]");
+        $this->moveto($elem);
+        $elem->click();
+
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $success = $this->waitForElement("byClassName", "success");
         $this->assertContains("Showing rows", $success->text());
 
@@ -324,6 +356,8 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
      */
     public function testDeleteRecords()
     {
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+
         $this->byId("id_rows_to_delete1_left")->click();
         $this->byId("id_rows_to_delete2_left")->click();
 
@@ -331,6 +365,8 @@ class PMA_SeleniumTableBrowseTest extends PMA_SeleniumBase
         $this->waitForElement("byCssSelector", "fieldset.confirmation");
 
         $this->byId("buttonYes")->click();
+
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $success = $this->waitForElement("byClassName", "success");
         $this->assertContains("Showing rows", $success->text());
 

--- a/test/selenium/PmaSeleniumTableCreateTest.php
+++ b/test/selenium/PmaSeleniumTableCreateTest.php
@@ -18,6 +18,19 @@ require_once 'TestBase.php';
  */
 class PMA_SeleniumTableCreateTest extends PMA_SeleniumBase
 {
+
+    public function setUpPage()
+    {
+        parent::setUpPage();
+
+        $this->login();
+        $this->waitForElement('byPartialLinkText','Databases')->click();
+        $this->waitForElementNotPresent('byCssSelector', 'div#loading_parent');
+
+        // go to specific database page
+        $this->waitForElement("byPartialLinkText", $this->database_name)->click();
+    }
+
     /**
      * Creates a table
      *
@@ -27,51 +40,78 @@ class PMA_SeleniumTableCreateTest extends PMA_SeleniumBase
      */
     public function testCreateTable()
     {
-        $this->login();
-        $this->waitForElement('byLinkText', $this->database_name)->click();
+        $this->waitForElementNotPresent('byCssSelector', 'div#loading_parent');
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
 
         $this->waitForElement('byId', 'create_table_form_minimal');
         $this->byCssSelector(
             "form#create_table_form_minimal input[name=table]"
         )->value("test_table");
+        $this->byName("num_fields")->clear();
         $this->byName("num_fields")->value("4");
         $this->byCssSelector('input[value=Go]')->click();
+
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement('byName', 'do_save_data');
 
         // column details
         $column_text_details = array(
             "field_0_1" => "test_id",
             "field_0_3" => "14",
-            "field_0_10" => "comm1",
+            "field_0_9" => "comm1",
             "field_1_1" => "test_column",
             "field_1_3" => "10",
-            "field_1_10" => "comm2",
+            "field_1_9" => "comm2",
         );
 
         foreach ($column_text_details as $field => $val) {
             $this->byId($field)->value($val);
         }
 
+        $this->byId("field_0_8")->click(); // auto increment
+        $this->byId("field_1_6")->click(); // null
+
+        $this->sleep();
+
         $column_dropdown_details = array(
-            "field_0_6" => "UNSIGNED",
-            "field_0_8" => "PRIMARY",
+            "field_0_5" => "UNSIGNED",
             "field_1_2" => "VARCHAR",
             "field_1_5" => "utf8_general_ci",
             "field_1_4" => "As defined:"
         );
 
         foreach ($column_dropdown_details as $selector => $value) {
-            $sel = $this->select($this->byId($selector));
-            $sel->selectOptionByLabel($value);
+            $this->waitForElement(
+                'byXPath',
+                '//select[@id=\'' . $selector . '\']//option[contains(text(), \'' . $value . '\')]'
+            )->click();
         }
 
-        $this->byName("field_default_value[1]")->value("def");
-        $this->byId("field_0_9")->click(); // auto increment
-        $this->byId("field_1_7")->click(); // null
+        // Do this separately since this opens a dialog
+        $this->waitForElement(
+            'byXPath',
+            '//select[@id=\'field_0_7\']//option[contains(text(), \'PRIMARY\')]'
+        )->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        $this->waitForElement('byXPath', '//button[contains(text(), \'Go\')]')->click();
 
+        $this->sleep();
+        $this->byName("field_default_value[1]")->value("def");
+
+        $this->scrollToBottom();
+        $ele = $this->waitForElement('byName', "do_save_data");
+        $this->moveto($ele);
         // post
-        $this->byName("do_save_data")->click();
-        $this->waitForElement("byLinkText", "test_table");
+        $ele->click();
+        $this->waitForElement(
+            'byCssSelector',
+            'li.last.table'
+        );
+
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        $this->waitForElementNotPresent('byId', 'loading_parent');
+
+        $this->waitForElement("byPartialLinkText", "test_table");
 
         $this->_tableStructureAssertions();
     }
@@ -83,9 +123,18 @@ class PMA_SeleniumTableCreateTest extends PMA_SeleniumBase
      */
     private function _tableStructureAssertions()
     {
+        $this->gotoHomepage();
+        $this->waitForElementNotPresent('byId', 'loading_parent');
+
+        $this->navigateTable('test_table');
+
+        $this->waitForElementNotPresent('byId', 'loading_parent');
+
         // go to structure page
-        $this->byLinkText("Structure")->click();
+        $this->waitForElement('byPartialLinkText', "Structure")->click();
+
         $this->waitForElement("byId", "tablestructure");
+        $this->waitForElement('byId', 'table_strucuture_id');
 
         // make assertions for first row
         $this->assertContains(
@@ -109,13 +158,17 @@ class PMA_SeleniumTableCreateTest extends PMA_SeleniumBase
         );
 
         $this->assertEquals(
-            "None",
+            "",
             $this->getCellByTableId('tablestructure', 1, 8)
+        );
+        $this->assertEquals(
+            "comm1",
+            $this->getCellByTableId('tablestructure', 1, 9)
         );
 
         $this->assertEquals(
             "AUTO_INCREMENT",
-            $this->getCellByTableId('tablestructure', 1, 9)
+            $this->getCellByTableId('tablestructure', 1, 10)
         );
 
         $this->assertFalse(

--- a/test/selenium/PmaSeleniumTableCreateTest.php
+++ b/test/selenium/PmaSeleniumTableCreateTest.php
@@ -54,6 +54,14 @@ class PMA_SeleniumTableCreateTest extends PMA_SeleniumBase
         $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement('byName', 'do_save_data');
 
+        $this->waitForElement('byId', "field_1_6")->click(); // null
+        $this->waitForElement('byId', "field_0_8")->click(); // auto increment
+
+        // Do this separately since this opens a dialog
+        // Since auto-increment auto sets a PRIMARY key since no key present
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        $this->waitForElement('byXPath', '//button[contains(text(), \'Go\')]')->click();
+
         // column details
         $column_text_details = array(
             "field_0_1" => "test_id",
@@ -67,11 +75,6 @@ class PMA_SeleniumTableCreateTest extends PMA_SeleniumBase
         foreach ($column_text_details as $field => $val) {
             $this->byId($field)->value($val);
         }
-
-        $this->byId("field_0_8")->click(); // auto increment
-        $this->byId("field_1_6")->click(); // null
-
-        $this->sleep();
 
         $column_dropdown_details = array(
             "field_0_5" => "UNSIGNED",
@@ -87,14 +90,6 @@ class PMA_SeleniumTableCreateTest extends PMA_SeleniumBase
             )->click();
         }
 
-        // Do this separately since this opens a dialog
-        $this->waitForElement(
-            'byXPath',
-            '//select[@id=\'field_0_7\']//option[contains(text(), \'PRIMARY\')]'
-        )->click();
-        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
-        $this->waitForElement('byXPath', '//button[contains(text(), \'Go\')]')->click();
-
         $this->sleep();
         $this->byName("field_default_value[1]")->value("def");
 
@@ -109,7 +104,6 @@ class PMA_SeleniumTableCreateTest extends PMA_SeleniumBase
         );
 
         $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
-        $this->waitForElementNotPresent('byId', 'loading_parent');
 
         $this->waitForElement("byPartialLinkText", "test_table");
 

--- a/test/selenium/PmaSeleniumTableInsertTest.php
+++ b/test/selenium/PmaSeleniumTableInsertTest.php
@@ -68,40 +68,54 @@ class PMA_SeleniumTableInsertTest extends PMA_SeleniumBase
         $this->expandMore();
 
         $this->byPartialLinkText("Insert")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement("byId", "insertForm");
+        usleep(1000000);
 
+        $this->byId("field_3_3")->value("2011-01-20 02:00:02");
         $this->byId("field_1_3")->value("1");
         $this->byId("field_2_3")->value("abcd");
-        $this->byId("field_3_3")->value("2011-01-20 02:00:02");
-        $this->sleep();
+        usleep(1000000);
 
-        $this->byId("field_5_3")->value("foo");
         $this->byId("field_6_3")->value("2010-01-20 02:00:02");
-        $this->sleep();
+        $this->byId("field_5_3")->value("foo");
+        usleep(1000000);
 
         $select = $this->select($this->byName("after_insert"));
         $select->selectOptionByLabel("Insert another new row");
-        $this->sleep();
-
+        usleep(1000000);
         // post
         $this->byId("buttonYes")->click();
+        $this->waitForElementNotPresent("byId", "ajax_message_num_1");
+
         $ele = $this->waitForElement("byClassName", "success");
         $this->assertContains("2 rows inserted", $ele->text());
+        usleep(1000000);
 
-        $this->byId("field_2_3")->value("Abcd");
         $this->byId("field_3_3")->value("2012-01-20 02:00:02");
-        $this->sleep();
+        $this->byId("field_2_3")->value("Abcd");
+        usleep(1000000);
 
         // post
         $this->byCssSelector(
             "input[value=Go]"
         )->click();
 
-        $this->waitForElementNotPresent("byId", "loading_parent");
-        $ele = $this->waitForElement("byClassName", "success");
+        $this->waitForElementNotPresent("byId", "ajax_message_num_1");
+        // Old success message should not be present
+        $this->waitForElementNotPresent(
+            'byXPath',
+            "//div[not(contains(., '2 rows inserted')) and contains(@class, 'success') and not(contains(@class, 'message'))]"
+        );
+        usleep(1000000);
+
+        // New message
+        $ele = $this->waitForElement(
+            'byXPath',
+            "//div[contains(@class, 'success') and not(contains(@class, 'message'))]"
+        );
         $this->assertContains("1 row inserted", $ele->text());
 
-        $this->sleep();
         $this->_assertDataPresent();
     }
 

--- a/test/selenium/PmaSeleniumTableInsertTest.php
+++ b/test/selenium/PmaSeleniumTableInsertTest.php
@@ -45,6 +45,8 @@ class PMA_SeleniumTableInsertTest extends PMA_SeleniumBase
      */
     public function setUpPage()
     {
+        parent::setUpPage();
+
         $this->login();
         $this->navigateTable('test_table');
     }
@@ -62,19 +64,24 @@ class PMA_SeleniumTableInsertTest extends PMA_SeleniumBase
             /* TODO: this should be fixed, but the cause is unclear to me */
             $this->markTestIncomplete('Fails with Safari');
         }
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->expandMore();
 
-        $this->byLinkText("Insert")->click();
+        $this->byPartialLinkText("Insert")->click();
         $this->waitForElement("byId", "insertForm");
 
         $this->byId("field_1_3")->value("1");
         $this->byId("field_2_3")->value("abcd");
         $this->byId("field_3_3")->value("2011-01-20 02:00:02");
+        $this->sleep();
+
         $this->byId("field_5_3")->value("foo");
         $this->byId("field_6_3")->value("2010-01-20 02:00:02");
+        $this->sleep();
 
         $select = $this->select($this->byName("after_insert"));
         $select->selectOptionByLabel("Insert another new row");
+        $this->sleep();
 
         // post
         $this->byId("buttonYes")->click();
@@ -83,6 +90,7 @@ class PMA_SeleniumTableInsertTest extends PMA_SeleniumBase
 
         $this->byId("field_2_3")->value("Abcd");
         $this->byId("field_3_3")->value("2012-01-20 02:00:02");
+        $this->sleep();
 
         // post
         $this->byCssSelector(
@@ -92,6 +100,8 @@ class PMA_SeleniumTableInsertTest extends PMA_SeleniumBase
         $this->waitForElementNotPresent("byId", "loading_parent");
         $ele = $this->waitForElement("byClassName", "success");
         $this->assertContains("1 row inserted", $ele->text());
+
+        $this->sleep();
         $this->_assertDataPresent();
     }
 
@@ -102,8 +112,10 @@ class PMA_SeleniumTableInsertTest extends PMA_SeleniumBase
      */
     private function _assertDataPresent()
     {
-        $this->byLinkText("Browse")->click();
-        $this->waitForElement("byId", "table_results");
+        $this->byPartialLinkText("Browse")->click();
+
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        $this->waitForElement("byCssSelector", "table.table_results");
 
         $this->assertEquals(
             "1",

--- a/test/selenium/PmaSeleniumTableStructureTest.php
+++ b/test/selenium/PmaSeleniumTableStructureTest.php
@@ -53,7 +53,9 @@ class PMA_SeleniumTableStructureTest extends PMA_SeleniumBase
             "(//a[contains(., 'Structure')])"
         )->click();
 
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement("byId", "tablestructure");
+        usleep(1000000);
     }
 
     /**
@@ -110,7 +112,7 @@ class PMA_SeleniumTableStructureTest extends PMA_SeleniumBase
         $this->byCssSelector(
             "#tablestructure tbody tr:nth-child(2) td:nth-child(11)"
         )->click();
-        $this->waitForElementNotPresent('byId', 'loading_parent');
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
 
         $this->waitForElement("byClassName", "append_fields_form");
 
@@ -130,10 +132,9 @@ class PMA_SeleniumTableStructureTest extends PMA_SeleniumBase
 
         $this->waitForElement("byId", "tablestructure");
 
-        var_dump($this->byCssSelector('label[for=checkbox_row_2]')->text());
         $this->assertEquals(
             "val3",
-            $this->byCssSelector('label[for=checkbox_row_2]')->text()
+            $this->waitForElement('byCssSelector', 'label[for=checkbox_row_2]')->text()
         );
     }
 
@@ -146,8 +147,8 @@ class PMA_SeleniumTableStructureTest extends PMA_SeleniumBase
      */
     public function testDropColumns()
     {
-        $this->byCssSelector('label[for=checkbox_row_2]')->click();
-        $this->byCssSelector('label[for=checkbox_row_3]')->click();
+        $this->waitForElement('byCssSelector', 'label[for=checkbox_row_2]')->click();
+        $this->waitForElement('byCssSelector', 'label[for=checkbox_row_3]')->click();
         $this->byXPath(
             "//button[@class='mult_submit' and contains(., 'Drop')]"
         )->click();
@@ -161,6 +162,7 @@ class PMA_SeleniumTableStructureTest extends PMA_SeleniumBase
             "//div[@class='success' and contains(., "
             . "'Your SQL query has been executed successfully')]"
         );
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
 
         $this->assertFalse(
             $this->isElementPresent(

--- a/test/selenium/PmaSeleniumTableStructureTest.php
+++ b/test/selenium/PmaSeleniumTableStructureTest.php
@@ -43,9 +43,9 @@ class PMA_SeleniumTableStructureTest extends PMA_SeleniumBase
      */
     public function setUpPage()
     {
-        $this->login();
-        $this->waitForElement('byLinkText', $this->database_name)->click();
+        parent::setUpPage();
 
+        $this->login();
         $this->navigateTable('test_table');
 
         $this->waitForElement(
@@ -65,31 +65,36 @@ class PMA_SeleniumTableStructureTest extends PMA_SeleniumBase
      */
     public function testAddColumn()
     {
-        $this->byCssSelector("label[for='field_where_after']")->click();
-        $this->byCssSelector("input[value='Go']")->click();
+        $this->waitForElement(
+            'byCssSelector',
+            "#addColumns > input[value='Go']"
+        )->click();
+        $this->waitForElementNotPresent('byId', 'loading_parent');
 
         $this->waitForElement("byClassName", "append_fields_form");
 
         $this->byId("field_0_1")->value('val3');
         $this->byCssSelector("input[name='do_save_data']")->click();
 
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement(
             "byXPath",
             "//div[@class='success' and contains(., "
             . "'Table test_table has been altered successfully')]"
         );
 
-        $this->byLinkText("Structure")->click();
+        $this->byPartialLinkText("Structure")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement("byId", "tablestructure");
 
         $this->assertEquals(
             "val3",
-            $this->byCssSelector('label[for=checkbox_row_2]')->text()
+            $this->byCssSelector('label[for=checkbox_row_4]')->text()
         );
 
         $this->assertEquals(
             "int(11)",
-            $this->getCellByTableId('tablestructure', 2, 4)
+            $this->getCellByTableId('tablestructure', 4, 4)
         );
     }
 
@@ -102,7 +107,10 @@ class PMA_SeleniumTableStructureTest extends PMA_SeleniumBase
      */
     public function testChangeColumn()
     {
-        $this->byXPath("(//a[contains(., 'Change')])[2]")->click();
+        $this->byCssSelector(
+            "#tablestructure tbody tr:nth-child(2) td:nth-child(11)"
+        )->click();
+        $this->waitForElementNotPresent('byId', 'loading_parent');
 
         $this->waitForElement("byClassName", "append_fields_form");
 
@@ -117,9 +125,12 @@ class PMA_SeleniumTableStructureTest extends PMA_SeleniumBase
             . "'Table test_table has been altered successfully')]"
         );
 
-        $this->byLinkText("Structure")->click();
+        $this->byPartialLinkText("Structure")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+
         $this->waitForElement("byId", "tablestructure");
 
+        var_dump($this->byCssSelector('label[for=checkbox_row_2]')->text());
         $this->assertEquals(
             "val3",
             $this->byCssSelector('label[for=checkbox_row_2]')->text()

--- a/test/selenium/PmaSeleniumTrackingTest.php
+++ b/test/selenium/PmaSeleniumTrackingTest.php
@@ -63,13 +63,17 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
             "//a[@class='item' and contains(., 'Database: "
             . $this->database_name . "')]"
         );
-        $this->waitForElementNotPresent('byId', 'loading_parent');
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->expandMore();
 
         $this->waitForElement('byPartialLinkText', "Tracking")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+
+        usleep(1000000);
         $this->waitForElement("byPartialLinkText", "Track table");
         $this->byXPath("(//a[contains(., 'Track table')])[1]")->click();
 
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement("byName", "delete")->click();
         $this->byCssSelector("input[value='Create version']")->click();
         $this->waitForElement("byId", "versions");
@@ -134,11 +138,12 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
         );
 
         // only data
-        $this->select($this->byName("logtype"))
+        $this->select($this->waitForElement('byName', "logtype"))
             ->selectOptionByLabel("Data only");
         $this->byCssSelector("input[value='Go']")->click();
 
         $this->waitForElementNotPresent("byId", "ajax_message_num_1");
+        usleep(1000000);
 
         $this->assertFalse(
             $this->isElementPresent("byId", "ddl_versions")
@@ -183,11 +188,16 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
      */
     public function testDropTracking()
     {
-        $this->byPartialLinkText("Database: " . $this->database_name)->click();
-        $this->waitForElement("byCssSelector", "table.data");
-
+        $this->waitForElement(
+            'byPartialLinkText',
+            "Database: " . $this->database_name
+        )->click();
         $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        $this->waitForElement("byId", "structureTable");
+
         $this->expandMore();
+        usleep(1000000);
+
         $this->byPartialLinkText("Tracking")->click();
 
         $this->waitForElementNotPresent('byId', 'loading_parent');
@@ -273,6 +283,9 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
     private function _executeSqlAndReturnToTableTracking()
     {
         $this->byPartialLinkText("SQL")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+
+        usleep(1000000);
         $this->waitForElement("byId", "queryfieldscontainer");
         $this->typeInTextArea(
             ";UPDATE test_table SET val = val + 1; "
@@ -280,10 +293,12 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
             2
         );
         $this->byCssSelector("input[value='Go']")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement("byClassName", "success");
 
         $this->expandMore();
         $this->byPartialLinkText("Tracking")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement("byId", "versions");
     }
 }

--- a/test/selenium/PmaSeleniumTrackingTest.php
+++ b/test/selenium/PmaSeleniumTrackingTest.php
@@ -52,19 +52,22 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
      */
     public function setUpPage()
     {
-        $this->login();
+        parent::setUpPage();
 
+        $this->login();
         $this->skipIfNotPMADB();
 
-        $this->waitForElement('byLinkText', $this->database_name)->click();
+        $this->waitForElement('byPartialLinkText', $this->database_name)->click();
         $this->waitForElement(
             "byXPath",
             "//a[@class='item' and contains(., 'Database: "
             . $this->database_name . "')]"
         );
+        $this->waitForElementNotPresent('byId', 'loading_parent');
         $this->expandMore();
-        $this->byLinkText("Tracking")->click();
-        $this->waitForElement("byLinkText", "Track table");
+
+        $this->waitForElement('byPartialLinkText', "Tracking")->click();
+        $this->waitForElement("byPartialLinkText", "Track table");
         $this->byXPath("(//a[contains(., 'Track table')])[1]")->click();
 
         $this->waitForElement("byName", "delete")->click();
@@ -83,7 +86,7 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
     {
         $this->_executeSqlAndReturnToTableTracking();
 
-        $this->byLinkText("Tracking report")->click();
+        $this->byPartialLinkText("Tracking report")->click();
         $this->waitForElement(
             "byXPath",
             "//h3[contains(., 'Tracking report')]"
@@ -135,7 +138,7 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
             ->selectOptionByLabel("Data only");
         $this->byCssSelector("input[value='Go']")->click();
 
-        $this->waitForElementNotPresent("byId", "loading_parent");
+        $this->waitForElementNotPresent("byId", "ajax_message_num_1");
 
         $this->assertFalse(
             $this->isElementPresent("byId", "ddl_versions")
@@ -180,33 +183,52 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
      */
     public function testDropTracking()
     {
-        $this->byLinkText("Database: " . $this->database_name)->click();
+        $this->byPartialLinkText("Database: " . $this->database_name)->click();
         $this->waitForElement("byCssSelector", "table.data");
-        usleep(1000000);
-        $this->expandMore();
-        $this->byLinkText("Tracking")->click();
-        $this->waitForElement("byId", "versions");
-        $this->byLinkText("Drop")->click();
 
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        $this->expandMore();
+        $this->byPartialLinkText("Tracking")->click();
+
+        $this->waitForElementNotPresent('byId', 'loading_parent');
+        $this->waitForElement("byId", "versions");
+
+        $ele = $this->waitForElement(
+            'byCssSelector',
+            'table#versions tbody tr:nth-child(1) td:nth-child(7)'
+        );
+        $this->moveto($ele);
+        $this->sleep();
+        $this->click();
+
+        $this->sleep();
         $this->waitForElement(
-            "byXPath",
-            "//button[contains(., 'OK')]"
+            "byCssSelector",
+            "button.submitOK"
         )->click();
 
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement(
             "byXPath",
             "//div[@class='success' and contains(., "
-            . "'Your SQL query has been executed')]"
+            . "'Tracking data deleted successfully.')]"
         );
 
+        // Can not use getCellByTableId,
+        // since this is under 'th' and not 'td'
         $this->assertContains(
-            "test_table",
-            $this->getCellByTableId('noversions', 1, 1)
+            'test_table',
+            $this->waitForElement(
+                'byCssSelector',
+                'table#noversions tbody tr:nth-child(1) th:nth-child(2)'
+            )->text()
         );
-
         $this->assertContains(
-            "test_table_2",
-            $this->getCellByTableId('noversions', 2, 1)
+            'test_table_2',
+            $this->waitForElement(
+                'byCssSelector',
+                'table#noversions tbody tr:nth-child(2) th:nth-child(2)'
+            )->text()
         );
     }
 
@@ -219,17 +241,17 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
      */
     public function testStructureSnapshot()
     {
-        $this->byLinkText("Structure snapshot")->click();
+        $this->byPartialLinkText("Structure snapshot")->click();
         $this->waitForElement("byId", "tablestructure");
 
         $this->assertContains(
             "id",
-            $this->getCellByTableId('tablestructure', 1, 1)
+            $this->getCellByTableId('tablestructure', 1, 2)
         );
 
         $this->assertContains(
             "val",
-            $this->getCellByTableId('tablestructure', 2, 1)
+            $this->getCellByTableId('tablestructure', 2, 2)
         );
 
         $this->assertContains(
@@ -250,17 +272,18 @@ class PMA_SeleniumTrackingTest extends PMA_SeleniumBase
      */
     private function _executeSqlAndReturnToTableTracking()
     {
-        $this->byLinkText("SQL")->click();
+        $this->byPartialLinkText("SQL")->click();
         $this->waitForElement("byId", "queryfieldscontainer");
         $this->typeInTextArea(
             ";UPDATE test_table SET val = val + 1; "
-            . "DELETE FROM test_table WHERE val = 3"
+            . "DELETE FROM test_table WHERE val = 3",
+            2
         );
         $this->byCssSelector("input[value='Go']")->click();
         $this->waitForElement("byClassName", "success");
 
         $this->expandMore();
-        $this->byLinkText("Tracking")->click();
+        $this->byPartialLinkText("Tracking")->click();
         $this->waitForElement("byId", "versions");
     }
 }

--- a/test/selenium/PmaSeleniumXssTest.php
+++ b/test/selenium/PmaSeleniumXssTest.php
@@ -18,6 +18,11 @@ require_once 'TestBase.php';
  */
 class PMA_SeleniumXSSTest extends PMA_SeleniumBase
 {
+    public function setUpPage()
+    {
+        parent::setUpPage();
+        $this->login();
+    }
     /**
      * Tests the SQL query tab with a null query
      *
@@ -30,8 +35,7 @@ class PMA_SeleniumXSSTest extends PMA_SeleniumBase
         if (mb_strtolower($this->getBrowser()) == 'safari') {
             $this->markTestSkipped('Alerts not supported on Safari browser.');
         }
-        $this->login();
-        $this->waitForElement('byLinkText', "SQL")->click();
+        $this->waitForElement('byPartialLinkText', "SQL")->click();
         $this->waitForElement("byId", "queryboxf");
         $this->byId("button_submit_query")->click();
         $this->assertEquals("Missing value in the form!", $this->alertText());

--- a/test/selenium/PmaSeleniumXssTest.php
+++ b/test/selenium/PmaSeleniumXssTest.php
@@ -36,6 +36,7 @@ class PMA_SeleniumXSSTest extends PMA_SeleniumBase
             $this->markTestSkipped('Alerts not supported on Safari browser.');
         }
         $this->waitForElement('byPartialLinkText', "SQL")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
         $this->waitForElement("byId", "queryboxf");
         $this->byId("button_submit_query")->click();
         $this->assertEquals("Missing value in the form!", $this->alertText());

--- a/test/selenium/TestBase.php
+++ b/test/selenium/TestBase.php
@@ -57,11 +57,12 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
             self::$_selenium_enabled = true;
 
             $strategy = 'shared';
-            $build_local = false;
+            $build_local = true;
             $build_id = 'Manual';
             $project_name = 'phpMyAdmin';
             if (getenv('BUILD_TAG')) {
                 $build_id = getenv('BUILD_TAG');
+                $build_local = false;
                 $strategy = 'isolated';
                 $project_name = 'phpMyAdmin (Jenkins)';
             } elseif (getenv('TRAVIS_JOB_NUMBER')) {
@@ -464,7 +465,9 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
         $element = $this->byCssSelector(
             $sel
         );
-        return $element->text();
+        $text = $element->attribute('innerText');
+
+        return ($text && is_string($text)) ? trim($text) : '';
     }
 
     /**
@@ -483,7 +486,9 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
         $element = $this->byCssSelector(
             $sel
         );
-        return $element->text();
+        $text = $element->attribute('innerText');
+
+        return ($text && is_string($text)) ? trim($text) : '';
     }
 
     /**
@@ -626,12 +631,13 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
      * Scrolls to a coordinate such that the element with given id is visible
      *
      * @param string $element_id Id of the element
+     * @param int    $offset     Offset from Y-coordinate of element
      *
      * @return void
      */
-    public function scrollIntoView($element_id)
+    public function scrollIntoView($element_id, $offset = 70)
     {
-        // 70pt offset so that the topmenu does not cover the element
+        // 70pt offset by-default so that the topmenu does not cover the element
         $this->execute(
             array(
                 'script' => 'var element = document.getElementById("'
@@ -639,11 +645,11 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
                             . 'var position = element.getBoundingClientRect();'
                             . 'var x = position.left;'
                             . 'var y = position.top;'
-                            . 'window.scrollTo(x, y-70);',
+                            . 'window.scrollTo(x, y-(' . $offset . '));',
                 'args'   => array()
             )
         );
-        usleep(10000);
+        usleep(1000000);
     }
 
     /**
@@ -659,6 +665,6 @@ abstract class PMA_SeleniumBase extends PHPUnit_Extensions_Selenium2TestCase
                 'args' => array()
             )
         );
-        usleep(10000);
+        usleep(1000000);
     }
 }

--- a/test/start-local-server
+++ b/test/start-local-server
@@ -13,5 +13,5 @@ if [ "$CI_MODE" != "selenium" -o -z "$TESTSUITE_BROWSERSTACK_KEY" ] ; then
     exit 0
 fi
 
-php --server 127.0.0.1:8000 > php.log &
+php --server 127.0.0.1:8000 >& php.log &
 ~/browserstack/BrowserStackLocal -localIdentifier "travis-$TRAVIS_JOB_NUMBER" -onlyAutomate "$TESTSUITE_BROWSERSTACK_KEY" 127.0.0.1,8000,0 & 

--- a/test/start-local-server
+++ b/test/start-local-server
@@ -13,5 +13,5 @@ if [ "$CI_MODE" != "selenium" -o -z "$TESTSUITE_BROWSERSTACK_KEY" ] ; then
     exit 0
 fi
 
-php --server 127.0.0.1:8000 &> php.log &
+php --server 127.0.0.1:8000 > php.log 2>&1 &
 ~/browserstack/BrowserStackLocal -localIdentifier "travis-$TRAVIS_JOB_NUMBER" -onlyAutomate "$TESTSUITE_BROWSERSTACK_KEY" 127.0.0.1,8000,0 & 

--- a/test/start-local-server
+++ b/test/start-local-server
@@ -13,5 +13,5 @@ if [ "$CI_MODE" != "selenium" -o -z "$TESTSUITE_BROWSERSTACK_KEY" ] ; then
     exit 0
 fi
 
-php --server 127.0.0.1:8000 >& php.log &
+php --server 127.0.0.1:8000 &> php.log &
 ~/browserstack/BrowserStackLocal -localIdentifier "travis-$TRAVIS_JOB_NUMBER" -onlyAutomate "$TESTSUITE_BROWSERSTACK_KEY" 127.0.0.1,8000,0 & 


### PR DESCRIPTION
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

The selenium tests in the following files should be fixed by this:
* PmaSeleniumExportTest
* PmaSeleniumTableBrowse
* PmaSeleniumTableCreate
* PmaSeleniumTableInsert
* PmaSeleniumTableOperations
* PmaSeleniumTableStructure
* PmaSeleniumTracking
* PmaSeleniumXSS

Along with the above ones, this also fixes possible failures in some other selenium tests. It also makes the selenium job on travis have a slightly more cleaner log. 

The sleeps are introduced for the timing issues with phpMyAdmin, which I was unable to circumvent around. I would be making a different commit to move this `usleep` calls to `sleep` and some other refactoring later.

This finally leads to a successful selenium job on Travis (ex.https://travis-ci.org/devenbansod/phpmyadmin/jobs/257207731) (with Import tests being marked as incomplete for now).