### PR TITLE
Fix Import-related selenium tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ after_script:
   - if [ -f vendor/bin/codacycoverage ] ; then php vendor/bin/codacycoverage clover || true ; fi
   - if [ -f php.log ] ; then cat php.log ; fi
   - if [ -f build/logs/phpunit.json ] ; then ./scripts/phpunit-top-tests build/logs/phpunit.json ; fi
+  - if [ -f config.inc.php ] ; then rm -rf config.inc.php; fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/test/ci-install-selenium
+++ b/test/ci-install-selenium
@@ -2,3 +2,5 @@
 
 ./test/install-browserstack
 composer install --no-interaction
+
+echo -e "<?php\n\$cfg['UploadDir'] = './test/test_data/';" > config.inc.php

--- a/test/selenium/PmaSeleniumImportTest.php
+++ b/test/selenium/PmaSeleniumImportTest.php
@@ -110,15 +110,17 @@ class PMA_SeleniumImportTest extends PMA_SeleniumBase
      */
     private function _doImport($type)
     {
-        /* FIXME: Need to implement file upload compatible with remote Selenium */
-        $this->markTestIncomplete(
-            'File uploading not yet implemented in Selenium test'
-        );
-        $this->waitForElement('byLinkText', "Import")->click();
-        $ele = $this->waitForElement("byId", "input_import_file");
-        $ele->value(
-            dirname(__FILE__) . "/../test_data/" . $type . "_import.sql"
-        );
+        $this->waitForElement('byPartialLinkText', "Import")->click();
+        $this->waitForElementNotPresent('byId', 'ajax_message_num_1');
+        $this->waitForElement("byId", "input_import_file");
+
+        $this->waitForElement('byCssSelector', 'label[for=radio_local_import_file]')->click();
+        $this->select($this->byName("local_import_file"))
+            ->selectOptionByLabel($type . "_import.sql");
+
+        usleep(1000000);
+
+        $this->scrollToBottom();
         $this->byId("buttonGo")->click();
         $this->waitForElement(
             "byXPath",


### PR DESCRIPTION
* Use $cfg['uploadDir'] = "./test/test_data" while importing
* Prevents use of FileDetectors and remote file detectors etc.

Example successful job at : https://travis-ci.org/devenbansod/phpmyadmin/jobs/257735559 (unrelated skipped test)

Signed-off-by: Deven Bansod <devenbansod.bits@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
