### PR TITLE
Alphabetic sorting of Export dropdown

### DIFF
--- a/libraries/plugin_interface.lib.php
+++ b/libraries/plugin_interface.lib.php
@@ -96,8 +96,8 @@ function PMA_getPlugins($plugin_type, $plugins_dir, $plugin_param)
     }
 
     usort($plugin_list, function($cmp_name_1, $cmp_name_2) {
-		return strcmp($cmp_name_1->getProperties()->getText(), $cmp_name_2->getProperties()->getText());
-	});
+        return strcmp($cmp_name_1->getProperties()->getText(), $cmp_name_2->getProperties()->getText());
+    });
     return $plugin_list;
 }
 

--- a/libraries/plugin_interface.lib.php
+++ b/libraries/plugin_interface.lib.php
@@ -95,7 +95,9 @@ function PMA_getPlugins($plugin_type, $plugins_dir, $plugin_param)
         }
     }
 
-    ksort($plugin_list);
+    usort($plugin_list, function($cmp_name_1, $cmp_name_2) {
+		return strcmp($cmp_name_1->getProperties()->getText(), $cmp_name_2->getProperties()->getText());
+	});
     return $plugin_list;
 }
 


### PR DESCRIPTION
Made the Export dropdown menu alphabetically sorted, related to this issue https://github.com/phpmyadmin/phpmyadmin/issues/13425

Signed-off-by: Victor Gomez <victor.gomez.spain@gmail.com>

Before submitting pull request, please check that every commit:

- [ ] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
