### PR TITLE
Fix unnecessary escaping of html content

### DIFF
--- a/templates/privileges/privileges_summary_row.twig
+++ b/templates/privileges/privileges_summary_row.twig
@@ -1,6 +1,6 @@
 <tr>
     <td>{{ name }}</td>
-    <td><code>{{ privileges }}</code></td>
+    <td><code>{{ privileges|raw }}</code></td>
     <td>{{ grant ? 'Yes'|trans : 'No'|trans }}</td>
 
     {% if type == 'database' %}


### PR DESCRIPTION
Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

The `privileges` string can contain html content which when escaped looks like this:
![grafik](https://user-images.githubusercontent.com/4395417/28706292-f49fdd9a-7373-11e7-922c-8c6117d6f032.png)


Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
