### PR TITLE
Add hhvm 3.21 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ php:
   - "5.5"
   - "hhvm-3.12"
   - "hhvm-3.18"
+  - "hhvm-3.21"
 
 sudo: required
 


### PR DESCRIPTION
This is another LTS reease for hhvm.

Signed-off-by: Michal Čihař <michal@cihar.com>

This needs LTS packages to appear on http://dl.hhvm.com/ubuntu/dists/ first...

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
