### PR TITLE
add warning if no user selected

### DIFF
--- a/js/server_privileges.js
+++ b/js/server_privileges.js
@@ -292,6 +292,7 @@ AJAX.registerOnload('server_privileges.js', function () {
         event.preventDefault();
         // can't export if no users checked
         if ($(this.form).find("input:checked").length === 0) {
+            PMA_ajaxShowMessage('No User Account Selected',3000,'success');
             return;
         }
         var $msgbox = PMA_ajaxShowMessage();

--- a/js/server_privileges.js
+++ b/js/server_privileges.js
@@ -292,7 +292,7 @@ AJAX.registerOnload('server_privileges.js', function () {
         event.preventDefault();
         // can't export if no users checked
         if ($(this.form).find("input:checked").length === 0) {
-            PMA_ajaxShowMessage('No User Account Selected',3000,'success');
+            PMA_ajaxShowMessage('No User Account Selected', 3000, 'success');
             return;
         }
         var $msgbox = PMA_ajaxShowMessage();


### PR DESCRIPTION
The Export button on User Accounts now gives a warning similar to Databases Drop button without selecting any Database.

Signed-off-by: codehimanshu <himanshuagrawal1998@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [ ] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
