### PR TITLE
Simplify Template API

### DIFF
--- a/templates/test/set_helper.phtml
+++ b/templates/test/set_helper.phtml
@@ -1,1 +1,0 @@
-<?= $this->hello($variable);

--- a/test/classes/TemplateTest.php
+++ b/test/classes/TemplateTest.php
@@ -29,13 +29,12 @@ class TemplateTest extends PmaTestCase
     public function testSet($data)
     {
         $template = Template::get($data);
-        $template->set('variable1', 'value1');
-        $template->set(
+        $result = $template->render(
             array(
-                'variable2' => 'value2'
+                'variable1' => 'value1',
+                'variable2' => 'value2',
             )
         );
-        $result = $template->render();
         $this->assertContains('value1', $result);
         $this->assertContains('value2', $result);
     }
@@ -51,53 +50,6 @@ class TemplateTest extends PmaTestCase
             ['test/add_data'],
             ['test/add_data_twig'],
         ];
-    }
-
-    /**
-     * Test for setHelper
-     *
-     * @return void
-     */
-    public function testSetHelper()
-    {
-        $template = Template::get('test/set_helper');
-        $template->setHelper('hello', function ($string) {
-            return 'hello ' . $string;
-        });
-        $template->set(['variable' => 'world']);
-        $this->assertEquals('hello world', $template->render());
-
-        $this->setExpectedException('LogicException');
-        $template->setHelper('hello', 'again');
-    }
-
-    /**
-     * Test for removeHelper
-     *
-     * @return void
-     */
-    public function testRemoveHelper()
-    {
-        $template = Template::get('test/set_helper');
-        $template->setHelper('hello', function ($string) {
-            return 'hello ' . $string;
-        });
-        $template->set(['variable' => 'world']);
-        $template->removeHelper('hello');
-        $this->setExpectedException('LogicException');
-        $template->render();
-    }
-
-    /**
-     * Test for removeHelper
-     *
-     * @return void
-     */
-    public function testRemoveHelperNotFound()
-    {
-        $template = Template::get('test/set_helper');
-        $this->setExpectedException('LogicException');
-        $template->removeHelper('not found');
     }
 
     /**


### PR DESCRIPTION
Remove some features we do not seem to use:

- helper functions (this never worked with Twig)
- per class context, it now has to be passed to render
- this avoids need of array_merge call on every render

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
