### PR TITLE
Fix typo

### DIFF
--- a/po/el.po
+++ b/po/el.po
@@ -7066,7 +7066,7 @@ msgstr "Περιήγηση"
 
 #: libraries/classes/DbSearch.php:377
 msgid "Search in database"
-msgstr "Αναζήτηση στη βάση δεδπμένων"
+msgstr "Αναζήτηση στη βάση δεδoμένων"
 
 #: libraries/classes/DbSearch.php:381
 msgid "Words or values to search for (wildcard: \"%\"):"


### PR DESCRIPTION
There is a typo when searching the database for the Greek language, so it's frequently seen by many users.

Signed-off-by: Nikos Grigoriadis <grrnikos@yahoo.gr>