### PR TITLE
Fix typo in Greek translation

### DIFF
--- a/po/el.po
+++ b/po/el.po
@@ -7066,7 +7066,7 @@ msgstr "Περιήγηση"
 
 #: libraries/classes/DbSearch.php:377
 msgid "Search in database"
-msgstr "Αναζήτηση στη βάση δεδπμένων"
+msgstr "Αναζήτηση στη βάση δεδομένων"
 
 #: libraries/classes/DbSearch.php:381
 msgid "Words or values to search for (wildcard: \"%\"):"


### PR DESCRIPTION
Signed-off-by: Nikos Grigoriadis <grrnikos@yahoo.gr>

There is a typo when searching the database in the Greek language, so it's frequently seen by many users.
