### PR TITLE
Fix for password change on Galera cluster

### DIFF
--- a/libraries/server_privileges.lib.php
+++ b/libraries/server_privileges.lib.php
@@ -1905,7 +1905,19 @@ function PMA_updatePassword($err_url, $username, $hostname)
 
             $local_query = $query_prefix
                 . $GLOBALS['dbi']->escapeString($_POST['pma_pw']) . "'";
-        } else if ($serverType == 'MariaDB'
+        } // MariaDB uses "SET PASSWORD" syntax to change user password.
+          // On Galera cluster only DDL queries are replicated, since
+          // users are stored in MyISAM storage engine.
+            else if ($serverType == 'MariaDB'
+                   && PMA_MYSQL_INT_VERSION >= 10000
+            ) {
+                $query_prefix = "SET PASSWORD FOR  '"
+                    . $GLOBALS['dbi']->escapeString($username)
+                    . "'@'" . $GLOBALS['dbi']->escapeString($hostname) . "'"
+                    . " = PASSWORD ('";
+                $local_query = $query_prefix
+                    . $GLOBALS['dbi']->escapeString($_POST['pma_pw']) . "')";
+            } else if ($serverType == 'MariaDB'
             && PMA_MYSQL_INT_VERSION >= 50200
             && $is_superuser
         ) {


### PR DESCRIPTION
Hello,
this patch fixes issue with changing passwords on Galera cluster.
The problem is, that user tables are stored in MyISAM storage engine, so changing password with
ordinary "UPDATE" queries will not be replicated. MariaDB uses "SET PASSWORD" command to update user credentials, which is a DDL command. DDL commands are replicated, thus phpMyAdmin should use "SET PASSWORD" on MariaDB versions 10 and above.

Signed-off-by: Tadas Ustinavičius <tadas@ring.lt>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
