### PR TITLE
Removed maximum height parameter of ServerInfo bar

### DIFF
--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -1132,7 +1132,6 @@ div#tablestatistics table {
     padding-<?php echo $left; ?>: 2.2em;
     text-shadow: 0 1px 0 #000;
     max-width: 100%;
-    max-height: 16px;
     overflow: hidden;
 }
 


### PR DESCRIPTION
To fix issue #13738
Signed-off-by: Anant Jain <anantjain60@gmail.com>

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
