### PR TITLE
Fix input value escaping

### DIFF
--- a/templates/table/search/input_box.twig
+++ b/templates/table/search/input_box.twig
@@ -44,7 +44,7 @@
 {% elseif column_type starts with 'enum'
     or (column_type starts with 'set' and in_zoom_search_edit) %}
     {% set in_zoom_search_edit = false %}
-    {% set value = column_type|e|slice(5, -1)|replace({"'": ''})|split(', ') %}
+    {% set value = column_type|e|slice(5, -1)|replace({'&#039;': ''})|split(', ') %}
     {% set cnt_value = value|length %}
     {#
     Enum in edit mode   --> dropdown


### PR DESCRIPTION
Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

The value string is HTML escaped at this point so to get the desired effect we need to replace the HTML value for `'` which is `&#039;` instead of `'` directly.

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
