### PR TITLE
Fix favorite icon escaping

### DIFF
--- a/templates/database/structure/favorite_anchor.twig
+++ b/templates/database/structure/favorite_anchor.twig
@@ -3,5 +3,5 @@
     href="db_structure.php{{ Url_getCommon(fav_params) }}"
     title="{{ already_favorite ? 'Remove from Favorites'|trans : 'Add to Favorites'|trans }}"
     data-favtargets="{{ db_table_name_hash }}" >
-    {{ already_favorite ? titles['Favorite'] : titles['NoFavorite'] }}
+    {{ already_favorite ? titles['Favorite']|raw : titles['NoFavorite']|raw }}
 </a>


### PR DESCRIPTION
Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

Both `titles['Favorite']` and `titles['NoFavorite']` are HTML img tags defined here: https://github.com/phpmyadmin/phpmyadmin/blob/master/libraries/classes/Util.php#L3449-L3450 . In order to not return them as text but rather render them as an image we need to output them `raw`. 

This fixes this:
![grafik](https://user-images.githubusercontent.com/4395417/31570731-66e8b566-b087-11e7-84d9-795e59478cc7.png)


Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
