### PR TITLE
Fix header display when table contains a long comment

### DIFF
--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -797,6 +797,7 @@ fieldset.confirmation legend {
     font-size: 70%;
     font-weight: normal;
     color: #000099;
+    white-space: nowrap;
 }
 
 .tblHeaders {


### PR DESCRIPTION
When the table contains a long comment, the header will be distorted
