### PR TITLE
config.inc.php add more server,host not current

### DIFF
--- a/libraries/DatabaseInterface.php
+++ b/libraries/DatabaseInterface.php
@@ -2262,8 +2262,13 @@ class DatabaseInterface
 
         if ($mode == DatabaseInterface::CONNECT_USER) {
             $user = $cfg['Server']['user'];
-            $password = $cfg['Server']['password'];
+            $password = !$cfg['Server']['password'] ? $cfg['Server']['controlpass'] : $cfg['Server']['password'];
             $server = $cfg['Server'];
+            if (! empty($cfg['Server']['controlhost'])) {
+                $server['host'] = $cfg['Server']['controlhost'];
+            } else {
+                $server['host'] = $cfg['Server']['host'];
+            }
         } elseif ($mode == DatabaseInterface::CONNECT_CONTROL) {
             $user = $cfg['Server']['controluser'];
             $password = $cfg['Server']['controlpass'];


### PR DESCRIPTION
```
$i++;
/* Authentication type */
$cfg['Servers'][$i]['auth_type'] = 'config';
/* Server parameters */
$cfg['Servers'][$i]['host'] = 'test';
$cfg['Servers'][$i]['compress'] = false;
$cfg['Servers'][$i]['AllowNoPassword'] = false;

/**
 * phpMyAdmin configuration storage settings.
 */

/* User used to manipulate with storage */
 $cfg['Servers'][$i]['controlhost'] = '';
 $cfg['Servers'][$i]['controlport'] = '';
 $cfg['Servers'][$i]['controluser'] = 'pma';
 $cfg['Servers'][$i]['controlpass'] = 'pmapass';

```

use config.inc.php autologin,
```
$cfg['Servers'][$i]['controlhost'] 
```
 not used and can't login 

edit the code to autologin more database server


Before submitting pull request, please check that every commit:

- [ ] Has proper Signed-Off-By
- [+] Has commit message which describes it
- [+] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [+] Any new functionality is covered by tests
