### PR TITLE
make navigation database name and icon are in the same horizontal line

### DIFF
--- a/themes/original/css/navigation.css.php
+++ b/themes/original/css/navigation.css.php
@@ -155,6 +155,7 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
 #pma_navigation_tree_content a.hover_show_full {
     position: relative;
     z-index: 100;
+    vertical-align: sub;
 }
 #pma_navigation_tree a {
     color: <?php echo $GLOBALS['cfg']['NaviColor']; ?>;

--- a/themes/pmahomme/css/navigation.css.php
+++ b/themes/pmahomme/css/navigation.css.php
@@ -140,6 +140,7 @@ if (! defined('PMA_MINIMUM_COMMON') && ! defined('TESTSUITE')) {
 #pma_navigation_tree_content a.hover_show_full {
     position: relative;
     z-index: 100;
+    vertical-align: sub;
 }
 #pma_navigation_tree a {
     color: <?php echo $GLOBALS['cfg']['NaviColor']; ?>;


### PR DESCRIPTION
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests

This pr make navigation database name and icon are in same horizontal line.

before:

chrome safari firefox
<img width="185" alt="chrome-before" src="https://user-images.githubusercontent.com/8221099/32094024-09d33932-bb31-11e7-9902-098c50b2fd15.png">　<img width="185" alt="safari-before" src="https://user-images.githubusercontent.com/8221099/32094025-0a18b3c2-bb31-11e7-84f3-380675054162.png">　<img width="185" alt="firefox-before" src="https://user-images.githubusercontent.com/8221099/32094110-46735c0a-bb31-11e7-8af5-4b25aaa1f0f9.png">

after:

chrome safari firefox
<img width="185" alt="chrome-after" src="https://user-images.githubusercontent.com/8221099/32094035-117cbf00-bb31-11e7-9651-018589b45df2.png">　<img width="185" alt="safari-after" src="https://user-images.githubusercontent.com/8221099/32094036-11cafbfc-bb31-11e7-9403-60d2b34205c5.png">　<img width="185" alt="firefox-after" src="https://user-images.githubusercontent.com/8221099/32094281-c9654d30-bb31-11e7-90a5-b2e9c23bc4d9.png">
