### PR TITLE
Better rendering of icons in modern browsers

### DIFF
--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -388,6 +388,7 @@ img.lightbulb {
 
 /* leave some space between icons and text */
 .icon {
+    image-rendering: pixelated;
     vertical-align:     middle;
     margin-<?php echo $left; ?>:        0.3em;
 }

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -684,6 +684,7 @@ img.lightbulb {
 
 /* no extra space in table cells */
 td .icon {
+    image-rendering: pixelated;
     margin: 0;
 }
 


### PR DESCRIPTION
This PR allows for icons to be rendered without antialiasing in modern browsers which support the `image-rendering` CSS rule.

This looks significantly better than before, especially with the original theme.

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By (I am not sure how to do this, I used the GitHub web interface to make these commits)
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests (no new functionality)
