### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/test/Environment_test.php
+++ b/test/Environment_test.php
@@ -11,12 +11,14 @@
  */
 require_once 'config.sample.inc.php';
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Environment tests
  *
  * @package PhpMyAdmin-test
  */
-class Environment_Test extends PHPUnit_Framework_TestCase
+class Environment_Test extends TestCase
 {
     /**
      * Tests PHP version

--- a/test/classes/BookmarkTest.php
+++ b/test/classes/BookmarkTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Bookmark;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for Bookmark class

--- a/test/classes/BrowseForeignersTest.php
+++ b/test/classes/BrowseForeignersTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\BrowseForeigners;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\BrowseForeigners

--- a/test/classes/CentralColumnsTest.php
+++ b/test/classes/CentralColumnsTest.php
@@ -13,7 +13,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Types;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 $GLOBALS['server'] = 1;
 

--- a/test/classes/CharsetsTest.php
+++ b/test/classes/CharsetsTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Charsets;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for MySQL Charsets

--- a/test/classes/CheckUserPrivilegesTest.php
+++ b/test/classes/CheckUserPrivilegesTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\CheckUserPrivileges;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /*
  * Include to test.

--- a/test/classes/Config/FormDisplayTemplateTest.php
+++ b/test/classes/Config/FormDisplayTemplateTest.php
@@ -10,7 +10,7 @@ namespace PhpMyAdmin\Tests\Config;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\FormDisplayTemplate;
 use PhpMyAdmin\Theme;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for FromDisplay.tpl.php

--- a/test/classes/Database/DesignerTest.php
+++ b/test/classes/Database/DesignerTest.php
@@ -8,7 +8,7 @@ namespace PhpMyAdmin\Tests\Database;
 
 use PhpMyAdmin\Database\Designer;
 use PhpMyAdmin\DatabaseInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\Database\Designer

--- a/test/classes/Display/ChangePasswordTest.php
+++ b/test/classes/Display/ChangePasswordTest.php
@@ -11,7 +11,7 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\Display\ChangePassword;
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Url;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 require_once 'libraries/config.default.php';
 

--- a/test/classes/Display/CreateTableTest.php
+++ b/test/classes/Display/CreateTableTest.php
@@ -11,7 +11,7 @@ use PhpMyAdmin\Display\CreateTable;
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\Display\CreateTableTest class

--- a/test/classes/Display/ExportTest.php
+++ b/test/classes/Display/ExportTest.php
@@ -13,7 +13,7 @@ use PhpMyAdmin\Plugins;
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * class PhpMyAdmin\Tests\Display\ExportTest

--- a/test/classes/EncodingTest.php
+++ b/test/classes/EncodingTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Encoding;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for Charset Conversions

--- a/test/classes/ExportTest.php
+++ b/test/classes/ExportTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Export;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\ExportTest class

--- a/test/classes/Gis/GisFactoryTest.php
+++ b/test/classes/Gis/GisFactoryTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisFactory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for PhpMyAdmin\Gis\GisFactory

--- a/test/classes/Gis/GisGeomTest.php
+++ b/test/classes/Gis/GisGeomTest.php
@@ -7,7 +7,7 @@
  */
 namespace PhpMyAdmin\Tests\Gis;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Abstract parent class for all GIS<Geom_type> test classes

--- a/test/classes/Gis/GisGeometryCollectionTest.php
+++ b/test/classes/Gis/GisGeometryCollectionTest.php
@@ -9,7 +9,7 @@
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisGeometryCollection;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use TCPDF;
 
 /**

--- a/test/classes/Gis/GisGeometryTest.php
+++ b/test/classes/Gis/GisGeometryTest.php
@@ -7,7 +7,7 @@
  */
 namespace PhpMyAdmin\Tests\Gis;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**

--- a/test/classes/ImportTest.php
+++ b/test/classes/ImportTest.php
@@ -11,7 +11,7 @@ use PhpMyAdmin\Import;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /*
  * we must set $GLOBALS['server'] here

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\InsertEdit;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Table;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use stdClass;
 

--- a/test/classes/IpAllowDenyTest.php
+++ b/test/classes/IpAllowDenyTest.php
@@ -9,7 +9,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Core;
 use PhpMyAdmin\IpAllowDeny;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\IpAllowDenyTest class

--- a/test/classes/MimeTest.php
+++ b/test/classes/MimeTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Mime;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test for mime detection.

--- a/test/classes/MultSubmitsTest.php
+++ b/test/classes/MultSubmitsTest.php
@@ -9,7 +9,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\MultSubmits;
 use PhpMyAdmin\Url;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\MultSubmitsTest class

--- a/test/classes/NormalizationTest.php
+++ b/test/classes/NormalizationTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\Normalization;
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Types;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 $GLOBALS['server'] = 1;

--- a/test/classes/OperationsTest.php
+++ b/test/classes/OperationsTest.php
@@ -9,7 +9,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Operations;
 use PhpMyAdmin\Theme;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for operations

--- a/test/classes/PmaTestCase.php
+++ b/test/classes/PmaTestCase.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Response;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 /**

--- a/test/classes/PmdCommonTest.php
+++ b/test/classes/PmdCommonTest.php
@@ -9,7 +9,7 @@ namespace PhpMyAdmin\Tests;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\PmdCommon;
 use PhpMyAdmin\Relation;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\PmdCommon

--- a/test/classes/Properties/Options/Groups/OptionsPropertyMainGroupTest.php
+++ b/test/classes/Properties/Options/Groups/OptionsPropertyMainGroupTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests\Properties\Options\Groups;
 
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup class

--- a/test/classes/Properties/Options/Groups/OptionsPropertyRootGroupTest.php
+++ b/test/classes/Properties/Options/Groups/OptionsPropertyRootGroupTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests\Properties\Options\Groups;
 
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup class

--- a/test/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
+++ b/test/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests\Properties\Options\Groups;
 
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertySubgroup;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for PhpMyAdmin\Properties\Options\Groups\OptionsPropertySubgroup class

--- a/test/classes/Properties/Options/Items/PropertyItemsTest.php
+++ b/test/classes/Properties/Options/Items/PropertyItemsTest.php
@@ -14,7 +14,7 @@ use PhpMyAdmin\Properties\Options\Items\MessageOnlyPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\RadioPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\SelectPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for *PhpMyAdmin\Properties\PropertyItem class

--- a/test/classes/Properties/Options/OptionsPropertyGroupTest.php
+++ b/test/classes/Properties/Options/OptionsPropertyGroupTest.php
@@ -7,7 +7,7 @@
  */
 namespace PhpMyAdmin\Tests\Properties\Options;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 /**

--- a/test/classes/Properties/Options/OptionsPropertyItemTest.php
+++ b/test/classes/Properties/Options/OptionsPropertyItemTest.php
@@ -7,7 +7,7 @@
  */
 namespace PhpMyAdmin\Tests\Properties\Options;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\Properties\Options\OptionsPropertyItem class

--- a/test/classes/Properties/Options/OptionsPropertyOneItemTest.php
+++ b/test/classes/Properties/Options/OptionsPropertyOneItemTest.php
@@ -7,7 +7,7 @@
  */
 namespace PhpMyAdmin\Tests\Properties\Options;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\Properties\Options\OptionsPropertyOneItem class

--- a/test/classes/Properties/Plugins/ImportPluginPropertiesTest.php
+++ b/test/classes/Properties/Plugins/ImportPluginPropertiesTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests\Properties\Plugins;
 
 use PhpMyAdmin\Properties\Plugins\ImportPluginProperties;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for PhpMyAdmin\Properties\Plugins\ImportPluginProperties class

--- a/test/classes/Properties/Plugins/PluginPropertyItemTest.php
+++ b/test/classes/Properties/Plugins/PluginPropertyItemTest.php
@@ -7,7 +7,7 @@
  */
 namespace PhpMyAdmin\Tests\Properties\Plugins;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\Properties\Plugins\PluginPropertyItem class

--- a/test/classes/Properties/PropertyItemTest.php
+++ b/test/classes/Properties/PropertyItemTest.php
@@ -7,7 +7,7 @@
  */
 namespace PhpMyAdmin\Tests\Properties;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\Properties\PropertyItem class

--- a/test/classes/RelationCleanupTest.php
+++ b/test/classes/RelationCleanupTest.php
@@ -11,7 +11,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\RelationCleanup;
 use PhpMyAdmin\Tests\RelationCleanupDbiMock;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\RelationCleanupTest class

--- a/test/classes/RelationTest.php
+++ b/test/classes/RelationTest.php
@@ -9,7 +9,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\Theme;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\Relation

--- a/test/classes/ReplicationGuiTest.php
+++ b/test/classes/ReplicationGuiTest.php
@@ -10,7 +10,7 @@ namespace PhpMyAdmin\Tests;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\ReplicationGui;
 use PhpMyAdmin\Theme;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /*
 * Include to test.

--- a/test/classes/Rte/EventsTest.php
+++ b/test/classes/Rte/EventsTest.php
@@ -9,7 +9,7 @@ namespace PhpMyAdmin\Tests\Rte;
 
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Rte\Events;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * This class is for testing PhpMyAdmin\Rte\Events methods

--- a/test/classes/Rte/RoutinesTest.php
+++ b/test/classes/Rte/RoutinesTest.php
@@ -11,7 +11,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Rte\Routines;
 use PhpMyAdmin\Types;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * This class is for testing PhpMyAdmin\Rte\Routines methods

--- a/test/classes/Rte/TriggersTest.php
+++ b/test/classes/Rte/TriggersTest.php
@@ -9,7 +9,7 @@ namespace PhpMyAdmin\Tests\Rte;
 
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Rte\Triggers;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * This class is for testing PhpMyAdmin\Rte\Triggers methods

--- a/test/classes/SanitizeTest.php
+++ b/test/classes/SanitizeTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Sanitize;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for methods in Sanitize class

--- a/test/classes/Server/PrivilegesTest.php
+++ b/test/classes/Server/PrivilegesTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\Server\Privileges;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\Server\PrivilegesTest class

--- a/test/classes/Server/SelectTest.php
+++ b/test/classes/Server/SelectTest.php
@@ -10,7 +10,7 @@ namespace PhpMyAdmin\Tests\Server;
 use PhpMyAdmin\Server\Select;
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\Server\SelectTest class

--- a/test/classes/Server/Status/AdvisorTest.php
+++ b/test/classes/Server/Status/AdvisorTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Server\Status\Advisor;
 use PhpMyAdmin\Server\Status\Data;
 use PhpMyAdmin\Theme;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\Server\Status\AdvisorTest class

--- a/test/classes/Server/Status/MonitorTest.php
+++ b/test/classes/Server/Status/MonitorTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Server\Status\Monitor;
 use PhpMyAdmin\Server\Status\Data;
 use PhpMyAdmin\Theme;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * this class is for testing PhpMyAdmin\Server\Status\Monitor methods

--- a/test/classes/Server/Status/ProcessesTest.php
+++ b/test/classes/Server/Status/ProcessesTest.php
@@ -11,7 +11,7 @@ use PhpMyAdmin\Core;
 use PhpMyAdmin\Server\Status\Processes;
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Url;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\Server\Status\ProcessesTest class

--- a/test/classes/Server/Status/QueriesTest.php
+++ b/test/classes/Server/Status/QueriesTest.php
@@ -13,7 +13,7 @@ use PhpMyAdmin\Server\Status\Data;
 use PhpMyAdmin\Server\Status\Queries;
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\Server\Status\QueriesTest class

--- a/test/classes/Server/Status/VariablesTest.php
+++ b/test/classes/Server/Status/VariablesTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Server\Status\Data;
 use PhpMyAdmin\Server\Status\Variables;
 use PhpMyAdmin\Theme;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * This class is for testing PhpMyAdmin\Server\Status\Variables methods

--- a/test/classes/Server/StatusTest.php
+++ b/test/classes/Server/StatusTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Server\Status;
 use PhpMyAdmin\Server\Status\Data;
 use PhpMyAdmin\Theme;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\Server\StatusTest class

--- a/test/classes/Server/UserGroupsTest.php
+++ b/test/classes/Server/UserGroupsTest.php
@@ -10,7 +10,7 @@ namespace PhpMyAdmin\Tests\Server;
 use PhpMyAdmin\Server\UserGroups;
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Url;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\Server\UserGroups

--- a/test/classes/Server/UsersTest.php
+++ b/test/classes/Server/UsersTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests\Server;
 
 use PhpMyAdmin\Server\Users;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PhpMyAdmin\Tests\Server\UsersTest class

--- a/test/classes/Setup/IndexTest.php
+++ b/test/classes/Setup/IndexTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests\Setup;
 
 use PhpMyAdmin\Setup\Index as SetupIndex;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for methods under PhpMyAdmin\Setup\Index

--- a/test/classes/SqlQueryFormTest.php
+++ b/test/classes/SqlQueryFormTest.php
@@ -13,7 +13,7 @@ use PhpMyAdmin\SqlQueryForm;
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 //the following definition should be used globally
 $GLOBALS['server'] = 0;

--- a/test/classes/SqlTest.php
+++ b/test/classes/SqlTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Sql;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**

--- a/test/classes/SysInfoTest.php
+++ b/test/classes/SysInfoTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\SysInfo;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for sysinfo library

--- a/test/classes/TrackingTest.php
+++ b/test/classes/TrackingTest.php
@@ -9,7 +9,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Tracking;
 use PhpMyAdmin\Url;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for PhpMyAdmin\Tracking

--- a/test/classes/TransformationsTest.php
+++ b/test/classes/TransformationsTest.php
@@ -9,7 +9,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Theme;
 use PhpMyAdmin\Transformations;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for transformation wrappers

--- a/test/classes/UrlTest.php
+++ b/test/classes/UrlTest.php
@@ -8,7 +8,7 @@
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Url;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for methods in URL class

--- a/test/libraries/Files_test.php
+++ b/test/libraries/Files_test.php
@@ -10,13 +10,14 @@
  * Include to test.
  */
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * tests for bookmark.lib.php
  *
  * @package PhpMyAdmin-test
  */
-class FilesTest extends PHPUnit_Framework_TestCase
+class FilesTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, opens a network connection.

--- a/test/libraries/common/PMA_checkbox_test.php
+++ b/test/libraries/common/PMA_checkbox_test.php
@@ -11,6 +11,7 @@
  * Include to test.
  */
 
+use PHPUnit\Framework\TestCase;
 
 /**
  ** Test for checkbox.phtml
@@ -18,7 +19,7 @@
  * @package PhpMyAdmin-test
  * @group common.lib-tests
  */
-class PMA_GetCheckboxTest extends PHPUnit_Framework_TestCase
+class PMA_GetCheckboxTest extends TestCase
 {
     /**
      * Test for checkbox.phtml

--- a/test/libraries/database_interface_test.php
+++ b/test/libraries/database_interface_test.php
@@ -10,12 +10,14 @@
  * Include to test.
  */
 
+ use PHPUnit\Framework\TestCase;
+
 /**
  * Tests basic functionality of dummy dbi driver
  *
  * @package PhpMyAdmin-test
  */
-class PMA_DBI_Test extends PHPUnit_Framework_TestCase
+class PMA_DBI_Test extends TestCase
 {
     /**
      * Configures test parameters.


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).