### PR TITLE
Deprecation of "referral" directive

### DIFF
--- a/libraries/Header.class.php
+++ b/libraries/Header.class.php
@@ -525,6 +525,9 @@ class PMA_Header
             );
         }
         header(
+            "Referrer-Policy: no-referrer"
+        );
+        header(
             "Content-Security-Policy: default-src 'self' "
             . $captcha_url
             . $GLOBALS['cfg']['CSPAllow'] . ';'
@@ -536,7 +539,6 @@ class PMA_Header
             . $captcha_url
             . $GLOBALS['cfg']['CSPAllow']
             . ";"
-            . "referrer no-referrer;"
             . "img-src 'self' data: "
             . $GLOBALS['cfg']['CSPAllow']
             . $map_tile_urls
@@ -548,7 +550,6 @@ class PMA_Header
             . $captcha_url
             . $GLOBALS['cfg']['CSPAllow'] . ';'
             . "options inline-script eval-script;"
-            . "referrer no-referrer;"
             . "img-src 'self' data: "
             . $GLOBALS['cfg']['CSPAllow']
             . $map_tile_urls
@@ -609,7 +610,7 @@ class PMA_Header
     private function _getMetaTags()
     {
         $retval  = '<meta charset="utf-8" />';
-        $retval .= '<meta name="referrer" content="no-referrer" />';
+        $retval .= '<meta name="Referrer-Policy" content="no-referrer" />';
         $retval .= '<meta name="robots" content="noindex,nofollow" />';
         $retval .= '<meta http-equiv="X-UA-Compatible" content="IE=Edge">';
         if (! $GLOBALS['cfg']['AllowThirdPartyFraming']) {


### PR DESCRIPTION
The "referral" directive in the "Content-Security-Header" has been deprecated in favor of a separate header "Referrer-Policy". Using the legacy setting makes FF/Chrome to display an error in the console.