### PR TITLE
PHP 7.2 Countable Warning

### DIFF
--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -620,7 +620,7 @@ EOT;
      *
      * @return boolean
      */
-    public static function isRememberSortingOrder($analyzed_sql_results)
+    public static function isRememberSortingOrder(array $analyzed_sql_results)
     {
         return $GLOBALS['cfg']['RememberSorting']
             && ! ($analyzed_sql_results['is_count']

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -620,7 +620,7 @@ EOT;
      *
      * @return boolean
      */
-    public static function isRememberSortingOrder(array $analyzed_sql_results)
+    public static function isRememberSortingOrder($analyzed_sql_results)
     {
         return $GLOBALS['cfg']['RememberSorting']
             && ! ($analyzed_sql_results['is_count']
@@ -628,9 +628,12 @@ EOT;
                 || $analyzed_sql_results['is_func']
                 || $analyzed_sql_results['is_analyse'])
             && $analyzed_sql_results['select_from']
-            && ((empty($analyzed_sql_results['select_expr']))
-                || ((count($analyzed_sql_results['select_expr']) == 1)
-                    && ($analyzed_sql_results['select_expr'][0] == '*')))
+            && (( empty($analyzed_sql_results['select_expr']))
+                || ((is_array($analyzed_sql_results['select_expr']) 
+                || (is_object($analyzed_sql_results['select_expr']) 
+                    && $analyzed_sql_results['select_expr'] instanceof \Countable)
+                && count($analyzed_sql_results['select_expr']) == 1)
+                && ($analyzed_sql_results['select_expr'][0] == '*')))
             && count($analyzed_sql_results['select_tables']) == 1;
     }
 


### PR DESCRIPTION
7.2 throws Warnings if trying to count a non-array, non-object, or object w/o the Countable interface. This adjustment prevents that warning when viewing any table's contents.
Signed-off-by: Zach Mowrey