### PR TITLE
Refactoring tests

### DIFF
--- a/test/classes/CoreTest.php
+++ b/test/classes/CoreTest.php
@@ -256,7 +256,7 @@ class CoreTest extends PmaTestCase
      */
     function testGotoNowhere($page, $whiteList, $expected)
     {
-        $this->assertTrue($expected === Core::checkPageValidity($page, $whiteList));
+        $this->assertSame($expected, Core::checkPageValidity($page, $whiteList));
     }
 
     /**
@@ -605,7 +605,7 @@ class CoreTest extends PmaTestCase
     {
         // $in is not set!
         $out = Core::ifSetOr($in);
-        $this->assertEquals($out, null);
+        $this->assertNull($out);
     }
 
     /**

--- a/test/classes/ErrorHandlerTest.php
+++ b/test/classes/ErrorHandlerTest.php
@@ -164,7 +164,7 @@ class ErrorHandlerTest extends PmaTestCase
             'checkSavedErrors',
             array()
         );
-        $this->assertTrue(!isset($_SESSION['errors']));
+        $this->assertArrayNotHasKey('errors', $_SESSION);
     }
 
     /**
@@ -209,9 +209,9 @@ class ErrorHandlerTest extends PmaTestCase
             1,
             $this->object->countErrors()
         );
-        $this->assertEquals(
+        $this->assertCount(
             1,
-            count($this->object->sliceErrors(0))
+            $this->object->sliceErrors(0)
         );
         $this->assertEquals(
             0,

--- a/test/classes/ErrorTest.php
+++ b/test/classes/ErrorTest.php
@@ -174,9 +174,9 @@ class ErrorTest extends PmaTestCase
         $this->object->setBacktrace($bt);
 
         // case: full backtrace
-        $this->assertEquals(4, count($this->object->getBacktrace()));
+        $this->assertCount(4, $this->object->getBacktrace());
 
         // case: first 2 frames
-        $this->assertEquals(2, count($this->object->getBacktrace(2)));
+        $this->assertCount(2, $this->object->getBacktrace(2));
     }
 }

--- a/test/classes/IndexTest.php
+++ b/test/classes/IndexTest.php
@@ -104,10 +104,7 @@ class IndexTest extends PmaTestCase
     public function testGetIndexChoices()
     {
         $index_choices = Index::getIndexChoices();
-        $this->assertEquals(
-            5,
-            count($index_choices)
-        );
+        $this->assertCount(5, $index_choices);
         $this->assertEquals(
             'PRIMARY,INDEX,UNIQUE,SPATIAL,FULLTEXT',
             implode(",", $index_choices)

--- a/test/classes/LanguageTest.php
+++ b/test/classes/LanguageTest.php
@@ -50,7 +50,7 @@ class LanguageTest extends PmaTestCase
 
         $langs = $this->manager->availableLocales();
 
-        $this->assertEquals(2, count($langs));
+        $this->assertCount(2, $langs);
         $this->assertContains('cs', $langs);
         $GLOBALS['cfg']['FilterLanguages'] = '';
     }
@@ -106,11 +106,11 @@ class LanguageTest extends PmaTestCase
     public function testMySQLLocale()
     {
         $czech = $this->manager->getLanguage('cs');
-        $this->assertNotEquals($czech, false);
+        $this->assertNotFalse($czech);
         $this->assertEquals('cs_CZ', $czech->getMySQLLocale());
 
         $azerbaijani = $this->manager->getLanguage('az');
-        $this->assertNotEquals($azerbaijani, false);
+        $this->assertNotFalse($azerbaijani);
         $this->assertEquals('', $azerbaijani->getMySQLLocale());
     }
 

--- a/test/classes/Navigation/Nodes/NodeDatabaseTest.php
+++ b/test/classes/Navigation/Nodes/NodeDatabaseTest.php
@@ -108,10 +108,7 @@ class NodeDatabaseTest extends PmaTestCase
             'testFunction',
             $functions
         );
-        $this->assertEquals(
-            1,
-            count($functions)
-        );
+        $this->assertCount(1, $functions);
 
         $this->assertEmpty($parent->getData('procedures', 0));
         $this->assertEmpty($parent->getData('events', 0));

--- a/test/classes/Navigation/Nodes/NodeTest.php
+++ b/test/classes/Navigation/Nodes/NodeTest.php
@@ -194,7 +194,7 @@ class NodeTest extends PmaTestCase
     public function testRealParent()
     {
         $parent = NodeFactory::getInstance();
-        $this->assertEquals($parent->realParent(), false);
+        $this->assertFalse($parent->realParent());
 
         $child = NodeFactory::getInstance();
         $parent->addChild($child);

--- a/test/classes/Plugins/Auth/AuthenticationCookieTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -419,8 +419,9 @@ class AuthenticationCookieTest extends PmaTestCase
 
         $this->object->logOut();
 
-        $this->assertFalse(
-            isset($_COOKIE['pmaAuth-0'])
+        $this->assertArrayNotHasKey(
+            'pmaAuth-0',
+            $_COOKIE
         );
     }
 
@@ -445,8 +446,9 @@ class AuthenticationCookieTest extends PmaTestCase
 
         $this->object->logOut();
 
-        $this->assertFalse(
-            isset($_COOKIE['pmaAuth-1'])
+        $this->assertArrayNotHasKey(
+            'pmaAuth-1',
+            $_COOKIE
         );
     }
 
@@ -484,8 +486,9 @@ class AuthenticationCookieTest extends PmaTestCase
             $GLOBALS['pma_auth_server']
         );
 
-        $this->assertFalse(
-            isset($_COOKIE['pmaAuth-1'])
+        $this->assertArrayNotHasKey(
+            'pmaAuth-1',
+            $_COOKIE
         );
     }
 
@@ -680,12 +683,14 @@ class AuthenticationCookieTest extends PmaTestCase
 
         $this->object->rememberCredentials();
 
-        $this->assertTrue(
-            isset($_COOKIE['pmaUser-2'])
+        $this->assertArrayHasKey(
+            'pmaUser-2',
+            $_COOKIE
         );
 
-        $this->assertTrue(
-            isset($_COOKIE['pmaAuth-2'])
+        $this->assertArrayHasKey(
+            'pmaAuth-2',
+            $_COOKIE
         );
 
         $arr['password'] = 'testPW';

--- a/test/classes/Plugins/Auth/AuthenticationHttpTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationHttpTest.php
@@ -295,8 +295,9 @@ class AuthenticationHttpTest extends PmaTestCase
             $GLOBALS['cfg']['Server']['password']
         );
 
-        $this->assertFalse(
-            isset($_SERVER['PHP_AUTH_PW'])
+        $this->assertArrayNotHasKey(
+            'PHP_AUTH_PW',
+            $_SERVER
         );
 
         $this->assertEquals(

--- a/test/classes/Plugins/Auth/AuthenticationSignonTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationSignonTest.php
@@ -196,8 +196,9 @@ class AuthenticationSignonTest extends PmaTestCase
             session_id()
         );
 
-        $this->assertFalse(
-            isset($_SESSION['LAST_SIGNON_URL'])
+        $this->assertArrayNotHasKey(
+            'LAST_SIGNON_URL',
+            $_SESSION
         );
     }
 

--- a/test/classes/Plugins/Export/ExportOdsTest.php
+++ b/test/classes/Plugins/Export/ExportOdsTest.php
@@ -176,8 +176,9 @@ class ExportOdsTest extends PmaTestCase
      */
     public function testExportHeader()
     {
-        $this->assertTrue(
-            isset($GLOBALS['ods_buffer'])
+        $this->assertArrayHasKey(
+            'ods_buffer',
+            $GLOBALS
         );
 
         $this->assertTrue(

--- a/test/classes/Properties/Options/Groups/OptionsPropertyRootGroupTest.php
+++ b/test/classes/Properties/Options/Groups/OptionsPropertyRootGroupTest.php
@@ -59,9 +59,9 @@ class OptionsPropertyRootGroupTest extends TestCase
      */
     public function testCountable()
     {
-        $this->assertEquals(
+        $this->assertCount(
             0,
-            count($this->object)
+            $this->object
         );
     }
 

--- a/test/classes/Rte/EventsTest.php
+++ b/test/classes/Rte/EventsTest.php
@@ -410,7 +410,7 @@ class EventsTest extends TestCase
         $GLOBALS['dbi'] = $dbi;
 
         $this->assertEquals($query, Events::getQueryFromRequest());
-        $this->assertEquals($num_err, count($errors));
+        $this->assertCount($num_err, $errors);
     }
 
     /**

--- a/test/classes/Rte/RoutinesTest.php
+++ b/test/classes/Rte/RoutinesTest.php
@@ -1117,7 +1117,7 @@ class RoutinesTest extends TestCase
         unset($_REQUEST);
         $_REQUEST = $request;
         $this->assertEquals($query, Routines::getQueryFromRequest());
-        $this->assertEquals($num_err, count($errors));
+        $this->assertCount($num_err, $errors);
 
         // reset
         $GLOBALS['dbi'] = $old_dbi;

--- a/test/classes/Rte/TriggersTest.php
+++ b/test/classes/Rte/TriggersTest.php
@@ -336,7 +336,7 @@ class TriggersTest extends TestCase
         $GLOBALS['server'] = 1;
 
         $this->assertEquals($query, Triggers::getQueryFromRequest());
-        $this->assertEquals($num_err, count($errors));
+        $this->assertCount($num_err, $errors);
     }
 
     /**

--- a/test/classes/SanitizeTest.php
+++ b/test/classes/SanitizeTest.php
@@ -280,9 +280,9 @@ class SanitizeTest extends TestCase
         $_REQUEST['second'] = 1;
         $allow_list = array('allow', 'second');
         Sanitize::removeRequestVars($allow_list);
-        $this->assertFalse(isset($_REQUEST['foo']));
-        $this->assertFalse(isset($_REQUEST['second']));
-        $this->assertTrue(isset($_REQUEST['allow']));
+        $this->assertArrayNotHasKey('foo', $_REQUEST);
+        $this->assertArrayNotHasKey('second', $_REQUEST);
+        $this->assertArrayHasKey('allow', $_REQUEST);
     }
 
 }

--- a/test/classes/TwoFactorTest.php
+++ b/test/classes/TwoFactorTest.php
@@ -247,9 +247,9 @@ class TwoFactorTest extends PmaTestCase
         $GLOBALS['cfg']['DBG']['simple2fa'] = true;
         $object = new TwoFactor('user');
         $backends = $object->getAllBackends();
-        $this->assertEquals(
+        $this->assertCount(
             count($object->available) + 1,
-            count($backends)
+            $backends
         );
         $GLOBALS['cfg']['DBG']['simple2fa'] = false;
     }


### PR DESCRIPTION
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertSame` instead of strict comparison `===`;
- `assertNull` instead of comparison with `null` keyword;
- `assertFalse` and `assertNotFalse` instead of comparison with `false` keyword;
- `assertArrayHasKey` and `assertArrayNotHasKey` instead of `isset` function.