### PR TITLE
Clean elses

### DIFF
--- a/libraries/classes/CentralColumns.php
+++ b/libraries/classes/CentralColumns.php
@@ -122,9 +122,9 @@ class CentralColumns
         );
         if (isset($res[0])) {
             return $res[0];
-        } else {
-            return 0;
         }
+
+        return 0;
     }
     /**
      * return the existing columns in central list among the given list of columns
@@ -551,9 +551,9 @@ class CentralColumns
         $has_list = self::findExistingColNames($dbi, $user, $db, $cols, $allFields);
         if (! empty($has_list)) {
             return (array)$has_list;
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**

--- a/libraries/classes/Database/Qbe.php
+++ b/libraries/classes/Database/Qbe.php
@@ -1943,10 +1943,10 @@ class Qbe
             $candidate_columns = $where_clause_columns;
             $needsort = 0;
             return array($candidate_columns, $needsort);
-        } else {
-            $candidate_columns = $search_tables;
-            $needsort = 0;
-            return array($candidate_columns, $needsort);
         }
+
+        $candidate_columns = $search_tables;
+        $needsort = 0;
+        return array($candidate_columns, $needsort);
     }
 }

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -1121,90 +1121,90 @@ class DatabaseInterface
                 $sql .= "\n" . ' WHERE ' . implode(' AND ', $sql_wheres);
             }
             return $this->fetchResult($sql, $array_keys, null, $link);
-        } else {
-            $columns = array();
-            if (null === $database) {
-                foreach ($GLOBALS['dblist']->databases as $database) {
-                    $columns[$database] = $this->getColumnsFull(
-                        $database, null, null, $link
-                    );
-                }
-                return $columns;
-            } elseif (null === $table) {
-                $tables = $this->getTables($database);
-                foreach ($tables as $table) {
-                    $columns[$table] = $this->getColumnsFull(
-                        $database, $table, null, $link
-                    );
-                }
-                return $columns;
+        }
+
+        $columns = array();
+        if (null === $database) {
+            foreach ($GLOBALS['dblist']->databases as $database) {
+                $columns[$database] = $this->getColumnsFull(
+                    $database, null, null, $link
+                );
             }
-            $sql = 'SHOW FULL COLUMNS FROM '
-                . Util::backquote($database) . '.' . Util::backquote($table);
-            if (null !== $column) {
-                $sql .= " LIKE '" . $this->escapeString($column, $link) . "'";
+            return $columns;
+        } elseif (null === $table) {
+            $tables = $this->getTables($database);
+            foreach ($tables as $table) {
+                $columns[$table] = $this->getColumnsFull(
+                    $database, $table, null, $link
+                );
             }
-
-            $columns = $this->fetchResult($sql, 'Field', null, $link);
-            $ordinal_position = 1;
-            foreach ($columns as $column_name => $each_column) {
-
-                // Compatibility with INFORMATION_SCHEMA output
-                $columns[$column_name]['COLUMN_NAME']
-                    =& $columns[$column_name]['Field'];
-                $columns[$column_name]['COLUMN_TYPE']
-                    =& $columns[$column_name]['Type'];
-                $columns[$column_name]['COLLATION_NAME']
-                    =& $columns[$column_name]['Collation'];
-                $columns[$column_name]['IS_NULLABLE']
-                    =& $columns[$column_name]['Null'];
-                $columns[$column_name]['COLUMN_KEY']
-                    =& $columns[$column_name]['Key'];
-                $columns[$column_name]['COLUMN_DEFAULT']
-                    =& $columns[$column_name]['Default'];
-                $columns[$column_name]['EXTRA']
-                    =& $columns[$column_name]['Extra'];
-                $columns[$column_name]['PRIVILEGES']
-                    =& $columns[$column_name]['Privileges'];
-                $columns[$column_name]['COLUMN_COMMENT']
-                    =& $columns[$column_name]['Comment'];
-
-                $columns[$column_name]['TABLE_CATALOG'] = null;
-                $columns[$column_name]['TABLE_SCHEMA'] = $database;
-                $columns[$column_name]['TABLE_NAME'] = $table;
-                $columns[$column_name]['ORDINAL_POSITION'] = $ordinal_position;
-                $columns[$column_name]['DATA_TYPE']
-                    = substr(
-                        $columns[$column_name]['COLUMN_TYPE'],
-                        0,
-                        strpos($columns[$column_name]['COLUMN_TYPE'], '(')
-                    );
-                /**
-                 * @todo guess CHARACTER_MAXIMUM_LENGTH from COLUMN_TYPE
-                */
-                $columns[$column_name]['CHARACTER_MAXIMUM_LENGTH'] = null;
-                /**
-                 * @todo guess CHARACTER_OCTET_LENGTH from CHARACTER_MAXIMUM_LENGTH
-                 */
-                $columns[$column_name]['CHARACTER_OCTET_LENGTH'] = null;
-                $columns[$column_name]['NUMERIC_PRECISION'] = null;
-                $columns[$column_name]['NUMERIC_SCALE'] = null;
-                $columns[$column_name]['CHARACTER_SET_NAME']
-                    = substr(
-                        $columns[$column_name]['COLLATION_NAME'],
-                        0,
-                        strpos($columns[$column_name]['COLLATION_NAME'], '_')
-                    );
-
-                $ordinal_position++;
-            }
-
-            if (null !== $column) {
-                return reset($columns);
-            }
-
             return $columns;
         }
+        $sql = 'SHOW FULL COLUMNS FROM '
+            . Util::backquote($database) . '.' . Util::backquote($table);
+        if (null !== $column) {
+            $sql .= " LIKE '" . $this->escapeString($column, $link) . "'";
+        }
+
+        $columns = $this->fetchResult($sql, 'Field', null, $link);
+        $ordinal_position = 1;
+        foreach ($columns as $column_name => $each_column) {
+
+            // Compatibility with INFORMATION_SCHEMA output
+            $columns[$column_name]['COLUMN_NAME']
+                =& $columns[$column_name]['Field'];
+            $columns[$column_name]['COLUMN_TYPE']
+                =& $columns[$column_name]['Type'];
+            $columns[$column_name]['COLLATION_NAME']
+                =& $columns[$column_name]['Collation'];
+            $columns[$column_name]['IS_NULLABLE']
+                =& $columns[$column_name]['Null'];
+            $columns[$column_name]['COLUMN_KEY']
+                =& $columns[$column_name]['Key'];
+            $columns[$column_name]['COLUMN_DEFAULT']
+                =& $columns[$column_name]['Default'];
+            $columns[$column_name]['EXTRA']
+                =& $columns[$column_name]['Extra'];
+            $columns[$column_name]['PRIVILEGES']
+                =& $columns[$column_name]['Privileges'];
+            $columns[$column_name]['COLUMN_COMMENT']
+                =& $columns[$column_name]['Comment'];
+
+            $columns[$column_name]['TABLE_CATALOG'] = null;
+            $columns[$column_name]['TABLE_SCHEMA'] = $database;
+            $columns[$column_name]['TABLE_NAME'] = $table;
+            $columns[$column_name]['ORDINAL_POSITION'] = $ordinal_position;
+            $columns[$column_name]['DATA_TYPE']
+                = substr(
+                    $columns[$column_name]['COLUMN_TYPE'],
+                    0,
+                    strpos($columns[$column_name]['COLUMN_TYPE'], '(')
+                );
+            /**
+             * @todo guess CHARACTER_MAXIMUM_LENGTH from COLUMN_TYPE
+            */
+            $columns[$column_name]['CHARACTER_MAXIMUM_LENGTH'] = null;
+            /**
+             * @todo guess CHARACTER_OCTET_LENGTH from CHARACTER_MAXIMUM_LENGTH
+             */
+            $columns[$column_name]['CHARACTER_OCTET_LENGTH'] = null;
+            $columns[$column_name]['NUMERIC_PRECISION'] = null;
+            $columns[$column_name]['NUMERIC_SCALE'] = null;
+            $columns[$column_name]['CHARACTER_SET_NAME']
+                = substr(
+                    $columns[$column_name]['COLLATION_NAME'],
+                    0,
+                    strpos($columns[$column_name]['COLLATION_NAME'], '_')
+                );
+
+            $ordinal_position++;
+        }
+
+        if (null !== $column) {
+            return reset($columns);
+        }
+
+        return $columns;
     }
 
     /**
@@ -1674,9 +1674,9 @@ class DatabaseInterface
     {
         if (is_null($value)) {
             return $row;
-        } else {
-            return $row[$value];
         }
+
+        return $row[$value];
     }
 
     /**
@@ -2721,9 +2721,9 @@ class DatabaseInterface
 
         if ($get_from_cache) {
             return $GLOBALS['cached_affected_rows'];
-        } else {
-            return $this->_extension->affectedRows($this->_links[$link]);
         }
+
+        return $this->_extension->affectedRows($this->_links[$link]);
     }
 
     /**
@@ -2853,9 +2853,9 @@ class DatabaseInterface
     {
         if ($this->isAmazonRds()) {
             return 'CALL mysql.rds_kill(' . $process . ');';
-        } else {
-            return 'KILL ' . $process . ';';
         }
+
+        return 'KILL ' . $process . ';';
     }
 
     /**
@@ -2902,14 +2902,14 @@ class DatabaseInterface
                 . ' WHERE SCHEMA_NAME = \'' . $this->escapeString($db)
                 . '\' LIMIT 1';
             return $this->fetchValue($sql);
-        } else {
-            $this->selectDb($db);
-            $return = $this->fetchValue('SELECT @@collation_database');
-            if ($db !== $GLOBALS['db']) {
-                $this->selectDb($GLOBALS['db']);
-            }
-            return $return;
         }
+
+        $this->selectDb($db);
+        $return = $this->fetchValue('SELECT @@collation_database');
+        if ($db !== $GLOBALS['db']) {
+            $this->selectDb($GLOBALS['db']);
+        }
+        return $return;
     }
 
     /**

--- a/libraries/classes/Dbi/DbiMysql.php
+++ b/libraries/classes/Dbi/DbiMysql.php
@@ -164,9 +164,9 @@ class DbiMysql implements DbiExtension
             return mysql_query($query, $link);
         } elseif ($options == ($options | DatabaseInterface::QUERY_UNBUFFERED)) {
             return mysql_unbuffered_query($query, $link);
-        } else {
-            return mysql_query($query, $link);
         }
+
+        return mysql_query($query, $link);
     }
 
     /**

--- a/libraries/classes/ErrorHandler.php
+++ b/libraries/classes/ErrorHandler.php
@@ -471,9 +471,9 @@ class ErrorHandler
     {
         if ($GLOBALS['cfg']['SendErrorReports'] != 'never') {
             return $this->countErrors();
-        } else {
-            return $this->countUserErrors();
         }
+
+        return $this->countUserErrors();
     }
 
     /**

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -74,9 +74,9 @@ class Export
             || $chromeAndGreaterThan43)
         ) {
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -1062,9 +1062,9 @@ class Export
     {
         if (in_array($key, $array)) {
             return ' checked="checked"';
-        } else {
-            return '';
         }
+
+        return '';
     }
 
     /**

--- a/libraries/classes/File.php
+++ b/libraries/classes/File.php
@@ -374,9 +374,9 @@ class File
             return $this->setLocalSelectedFile(
                 $_REQUEST['fields_uploadlocal']['multi_edit'][$rownumber][$key]
             );
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -638,10 +638,10 @@ class File
         case 'application/zip':
             if ($GLOBALS['cfg']['ZipDump'] && @function_exists('zip_open')) {
                 return $this->openZip();
-            } else {
-                $this->errorUnsupported();
-                return false;
             }
+
+            $this->errorUnsupported();
+            return false;
         case 'none':
             $this->_handle = @fopen($this->getName(), 'r');
             break;

--- a/libraries/classes/Gis/GisPolygon.php
+++ b/libraries/classes/Gis/GisPolygon.php
@@ -499,9 +499,9 @@ class GisPolygon extends GisGeometry
 
         if ($counter % 2 == 0) {
             return false;
-        } else {
-            return true;
         }
+
+        return true;
     }
 
     /**

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -70,9 +70,9 @@ class Import
         } elseif ((time() - $timestamp) > ($maximum_time - 5)) {
             $timeout_passed = true;
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -305,10 +305,10 @@ class Import
         if (!empty($sql) || !empty($full)) {
             $import_run_buffer = array('sql' => $sql, 'full' => $full);
             return $import_run_buffer;
-        } else {
-            unset($GLOBALS['import_run_buffer']);
-            return $import_run_buffer;
         }
+
+        unset($GLOBALS['import_run_buffer']);
+        return $import_run_buffer;
     }
 
     /**
@@ -605,9 +605,9 @@ class Import
             if ($last_cumulative_type == self::VARCHAR) {
                 if ($curr_size >= $last_cumulative_size) {
                     return $curr_size;
-                } else {
-                    return $last_cumulative_size;
                 }
+
+                return $last_cumulative_size;
             } elseif ($last_cumulative_type == self::DECIMAL) {
                 /**
                  * The last cumulative type was DECIMAL
@@ -616,33 +616,33 @@ class Import
 
                 if ($curr_size >= $oldM) {
                     return $curr_size;
-                } else {
-                    return $oldM;
                 }
+
+                return $oldM;
             } elseif ($last_cumulative_type == self::BIGINT || $last_cumulative_type == self::INT) {
                 /**
                  * The last cumulative type was BIGINT or INT
                  */
                 if ($curr_size >= $last_cumulative_size) {
                     return $curr_size;
-                } else {
-                    return $last_cumulative_size;
                 }
+
+                return $last_cumulative_size;
             } elseif (! isset($last_cumulative_type) || $last_cumulative_type == self::NONE) {
                 /**
                  * This is the first row to be analyzed
                  */
                 return $curr_size;
-            } else {
-                /**
-                 * An error has DEFINITELY occurred
-                 */
-                /**
-                 * TODO: Handle this MUCH more elegantly
-                 */
-
-                return -1;
             }
+
+            /**
+             * An error has DEFINITELY occurred
+             */
+            /**
+             * TODO: Handle this MUCH more elegantly
+             */
+
+            return -1;
         } elseif ($curr_type == self::DECIMAL) {
             /**
              * What to do if the current cell is of type DECIMAL
@@ -656,9 +656,9 @@ class Import
 
                 if ($size[self::M] >= $last_cumulative_size) {
                     return $size[self::M];
-                } else {
-                    return $last_cumulative_size;
                 }
+
+                return $last_cumulative_size;
             } elseif ($last_cumulative_type == self::DECIMAL) {
                 /**
                  * The last cumulative type was DECIMAL
@@ -673,9 +673,9 @@ class Import
                     /* Take the largest of both types */
                     return (string) ((($size[self::M] > $oldM) ? $size[self::M] : $oldM)
                         . "," . (($size[self::D] > $oldD) ? $size[self::D] : $oldD));
-                } else {
-                    return $last_cumulative_size;
                 }
+
+                return $last_cumulative_size;
             } elseif ($last_cumulative_type == self::BIGINT || $last_cumulative_type == self::INT) {
                 /**
                  * The last cumulative type was BIGINT or INT
@@ -685,9 +685,9 @@ class Import
 
                 if ($size[self::M] >= $last_cumulative_size) {
                     return $size[self::FULL];
-                } else {
-                    return ($last_cumulative_size . "," . $size[self::D]);
                 }
+
+                return ($last_cumulative_size . "," . $size[self::D]);
             } elseif (! isset($last_cumulative_type) || $last_cumulative_type == self::NONE) {
                 /**
                  * This is the first row to be analyzed
@@ -696,16 +696,16 @@ class Import
                 $size = self::getDecimalSize($cell);
 
                 return $size[self::FULL];
-            } else {
-                /**
-                 * An error has DEFINITELY occurred
-                 */
-                /**
-                 * TODO: Handle this MUCH more elegantly
-                 */
-
-                return -1;
             }
+
+            /**
+             * An error has DEFINITELY occurred
+             */
+            /**
+             * TODO: Handle this MUCH more elegantly
+             */
+
+            return -1;
         } elseif ($curr_type == self::BIGINT || $curr_type == self::INT) {
             /**
              * What to do if the current cell is of type BIGINT or INT
@@ -716,9 +716,9 @@ class Import
             if ($last_cumulative_type == self::VARCHAR) {
                 if ($curr_size >= $last_cumulative_size) {
                     return $curr_size;
-                } else {
-                    return $last_cumulative_size;
                 }
+
+                return $last_cumulative_size;
             } elseif ($last_cumulative_type == self::DECIMAL) {
                 /**
                  * The last cumulative type was DECIMAL
@@ -732,35 +732,26 @@ class Import
                 if ($oldInt >= $newInt) {
                     /* Use old decimal size */
                     return $last_cumulative_size;
-                } else {
-                    /* Use $newInt + $oldD as new M */
-                    return (($newInt + $oldD) . "," . $oldD);
                 }
+
+                /* Use $newInt + $oldD as new M */
+                return (($newInt + $oldD) . "," . $oldD);
             } elseif ($last_cumulative_type == self::BIGINT || $last_cumulative_type == self::INT) {
                 /**
                  * The last cumulative type was BIGINT or INT
                  */
                 if ($curr_size >= $last_cumulative_size) {
                     return $curr_size;
-                } else {
-                    return $last_cumulative_size;
                 }
+
+                return $last_cumulative_size;
             } elseif (! isset($last_cumulative_type) || $last_cumulative_type == self::NONE) {
                 /**
                  * This is the first row to be analyzed
                  */
                 return $curr_size;
-            } else {
-                /**
-                 * An error has DEFINITELY occurred
-                 */
-                /**
-                 * TODO: Handle this MUCH more elegantly
-                 */
-
-                return -1;
             }
-        } else {
+
             /**
              * An error has DEFINITELY occurred
              */
@@ -770,6 +761,15 @@ class Import
 
             return -1;
         }
+
+        /**
+         * An error has DEFINITELY occurred
+         */
+        /**
+         * TODO: Handle this MUCH more elegantly
+         */
+
+        return -1;
     }
 
     /**
@@ -1689,8 +1689,8 @@ class Import
 
         if ($GLOBALS['dbi']->numRows($result) == 1) {
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 }

--- a/libraries/classes/Index.php
+++ b/libraries/classes/Index.php
@@ -140,9 +140,9 @@ class Index
                 Index::$_registry[$schema][$table][$index->getName()] = $index;
             }
             return $index;
-        } else {
-            return Index::$_registry[$schema][$table][$index_name];
         }
+
+        return Index::$_registry[$schema][$table][$index_name];
     }
 
     /**
@@ -159,9 +159,9 @@ class Index
 
         if (isset(Index::$_registry[$schema][$table])) {
             return Index::$_registry[$schema][$table];
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**
@@ -220,9 +220,9 @@ class Index
 
         if (isset(Index::$_registry[$schema][$table]['PRIMARY'])) {
             return Index::$_registry[$schema][$table]['PRIMARY'];
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**

--- a/libraries/classes/IndexColumn.php
+++ b/libraries/classes/IndexColumn.php
@@ -139,12 +139,12 @@ class IndexColumn
         if ($as_text) {
             if (!$this->_null || $this->_null == 'NO') {
                 return __('No');
-            } else {
-                return __('Yes');
             }
-        } else {
-            return $this->_null;
+
+            return __('Yes');
         }
+
+        return $this->_null;
     }
 
     /**

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -321,9 +321,9 @@ class InsertEdit
             return '<span style="border-bottom: 1px dashed black;" title="'
                 . htmlspecialchars($comments_map[$column['Field']]) . '">'
                 . $column['Field_html'] . '</span>';
-        } else {
-                return $column['Field_html'];
         }
+
+        return $column['Field_html'];
     }
 
      /**
@@ -1966,9 +1966,9 @@ class InsertEdit
     {
         if (isset($_REQUEST['err_url'])) {
             return $_REQUEST['err_url'];
-        } else {
-            return 'tbl_change.php' . Url::getCommon($url_params);
         }
+
+        return 'tbl_change.php' . Url::getCommon($url_params);
     }
 
     /**
@@ -2277,12 +2277,12 @@ class InsertEdit
             ) {
                 return $multi_edit_funcs[$key] . '(' . $current_value . ",'"
                     . $GLOBALS['dbi']->escapeString($multi_edit_salt[$key]) . "')";
-            } else {
-                return $multi_edit_funcs[$key] . '(' . $current_value . ')';
             }
-        } else {
-            return $multi_edit_funcs[$key] . '()';
+
+            return $multi_edit_funcs[$key] . '(' . $current_value . ')';
         }
+
+        return $multi_edit_funcs[$key] . '()';
     }
 
     /**

--- a/libraries/classes/Language.php
+++ b/libraries/classes/Language.php
@@ -73,9 +73,9 @@ class Language
     {
         if (! empty($this->native)) {
             return $this->native . ' - ' . $this->name;
-        } else {
-            return $this->name;
         }
+
+        return $this->name;
     }
 
     /**

--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -1521,16 +1521,17 @@ class NavigationTree
     {
         if ($a->isNew) {
             return -1;
-        } else {
-            if ($b->isNew) {
-                return 1;
-            }
         }
+
+        if ($b->isNew) {
+            return 1;
+        }
+
         if ($GLOBALS['cfg']['NaturalOrder']) {
             return strnatcasecmp($a->name, $b->name);
-        } else {
-            return strcasecmp($a->name, $b->name);
         }
+
+        return strcasecmp($a->name, $b->name);
     }
 
     /**

--- a/libraries/classes/Navigation/Nodes/Node.php
+++ b/libraries/classes/Navigation/Nodes/Node.php
@@ -796,9 +796,9 @@ class Node
             $this->visible = true;
 
             return Util::getImage('b_minus');
-        } else {
-            return Util::getImage('b_plus', __('Expand/Collapse'));
         }
+
+        return Util::getImage('b_plus', __('Expand/Collapse'));
     }
 
     /**

--- a/libraries/classes/Partition.php
+++ b/libraries/classes/Partition.php
@@ -86,13 +86,13 @@ class Partition extends SubPartition
     {
         if (empty($this->subPartitions)) {
             return $this->rows;
-        } else {
-            $rows = 0;
-            foreach ($this->subPartitions as $subPartition) {
-                $rows += $subPartition->rows;
-            }
-            return $rows;
         }
+
+        $rows = 0;
+        foreach ($this->subPartitions as $subPartition) {
+            $rows += $subPartition->rows;
+        }
+        return $rows;
     }
 
     /**
@@ -104,13 +104,13 @@ class Partition extends SubPartition
     {
         if (empty($this->subPartitions)) {
             return $this->dataLength;
-        } else {
-            $dataLength = 0;
-            foreach ($this->subPartitions as $subPartition) {
-                $dataLength += $subPartition->dataLength;
-            }
-            return $dataLength;
         }
+
+        $dataLength = 0;
+        foreach ($this->subPartitions as $subPartition) {
+            $dataLength += $subPartition->dataLength;
+        }
+        return $dataLength;
     }
 
     /**
@@ -122,13 +122,13 @@ class Partition extends SubPartition
     {
         if (empty($this->subPartitions)) {
             return $this->indexLength;
-        } else {
-            $indexLength = 0;
-            foreach ($this->subPartitions as $subPartition) {
-                $indexLength += $subPartition->indexLength;
-            }
-            return $indexLength;
         }
+
+        $indexLength = 0;
+        foreach ($this->subPartitions as $subPartition) {
+            $indexLength += $subPartition->indexLength;
+        }
+        return $indexLength;
     }
 
     /**
@@ -177,9 +177,9 @@ class Partition extends SubPartition
                 return array_values($partitionMap);
             }
             return array();
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**
@@ -199,9 +199,9 @@ class Partition extends SubPartition
                 . " WHERE `TABLE_SCHEMA` = '" . $GLOBALS['dbi']->escapeString($db)
                 . "' AND `TABLE_NAME` = '" . $GLOBALS['dbi']->escapeString($table) . "'"
             );
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**

--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -596,9 +596,9 @@ class AuthenticationCookie extends AuthenticationPlugin
     {
         if (empty($GLOBALS['cfg']['blowfish_secret'])) {
             return $this->_getSessionEncryptionSecret();
-        } else {
-            return $GLOBALS['cfg']['blowfish_secret'];
         }
+
+        return $GLOBALS['cfg']['blowfish_secret'];
     }
 
     /**
@@ -813,11 +813,11 @@ class AuthenticationCookie extends AuthenticationPlugin
             return openssl_random_pseudo_bytes(
                 $this->getIVSize()
             );
-        } else {
-            return Crypt\Random::string(
-                $this->getIVSize()
-            );
         }
+
+        return Crypt\Random::string(
+            $this->getIVSize()
+        );
     }
 
     /**

--- a/libraries/classes/Plugins/Auth/AuthenticationHttp.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationHttp.php
@@ -183,9 +183,9 @@ class AuthenticationHttp extends AuthenticationPlugin
         // Returns whether we get authentication settings or not
         if (empty($this->user)) {
             return false;
-        } else {
-            return true;
         }
+
+        return true;
     }
 
     /**

--- a/libraries/classes/Plugins/Auth/AuthenticationSignon.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationSignon.php
@@ -192,11 +192,11 @@ class AuthenticationSignon extends AuthenticationPlugin
             unset($_SESSION['LAST_SIGNON_URL']);
 
             return false;
-        } else {
-            $_SESSION['LAST_SIGNON_URL'] = $GLOBALS['cfg']['Server']['SignonURL'];
-
-            return true;
         }
+
+        $_SESSION['LAST_SIGNON_URL'] = $GLOBALS['cfg']['Server']['SignonURL'];
+
+        return true;
     }
 
     /**

--- a/libraries/classes/Plugins/AuthenticationPlugin.php
+++ b/libraries/classes/Plugins/AuthenticationPlugin.php
@@ -174,17 +174,17 @@ abstract class AuthenticationPlugin
                 __('No activity within %s seconds; please log in again.'),
                 intval($GLOBALS['cfg']['LoginCookieValidity'])
             );
-        } else {
-            $dbi_error = $GLOBALS['dbi']->getError();
-            if (!empty($dbi_error)) {
-                return htmlspecialchars($dbi_error);
-            } elseif (isset($GLOBALS['errno'])) {
-                return '#' . $GLOBALS['errno'] . ' '
-                . __('Cannot log in to the MySQL server');
-            } else {
-                return __('Cannot log in to the MySQL server');
-            }
         }
+
+        $dbi_error = $GLOBALS['dbi']->getError();
+        if (!empty($dbi_error)) {
+            return htmlspecialchars($dbi_error);
+        } elseif (isset($GLOBALS['errno'])) {
+            return '#' . $GLOBALS['errno'] . ' '
+            . __('Cannot log in to the MySQL server');
+        }
+
+        return __('Cannot log in to the MySQL server');
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -581,9 +581,9 @@ class ExportSql extends ExportPlugin
 
         if (!empty($text)) {
             return Export::outputHandler($text);
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -601,17 +601,17 @@ class ExportSql extends ExportPlugin
             // see https://dev.mysql.com/doc/refman/5.0/en/ansi-diff-comments.html
             if (empty($text)) {
                 return '--' . $GLOBALS['crlf'];
-            } else {
-                $lines = preg_split("/\\r\\n|\\r|\\n/", $text);
-                $result = array();
-                foreach ($lines as $line) {
-                    $result[] = '-- ' . $line . $GLOBALS['crlf'];
-                }
-                return implode('', $result);
             }
-        } else {
-            return '';
+
+            $lines = preg_split("/\\r\\n|\\r|\\n/", $text);
+            $result = array();
+            foreach ($lines as $line) {
+                $result[] = '-- ' . $line . $GLOBALS['crlf'];
+            }
+            return implode('', $result);
         }
+
+        return '';
     }
 
     /**
@@ -625,9 +625,9 @@ class ExportSql extends ExportPlugin
             && $GLOBALS['sql_include_comments']
         ) {
             return $GLOBALS['crlf'];
-        } else {
-            return '';
         }
+
+        return '';
     }
 
     /**
@@ -979,9 +979,9 @@ class ExportSql extends ExportPlugin
 
         if (!empty($text)) {
             return Export::outputHandler($text);
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -408,9 +408,9 @@ class ExportXml extends ExportPlugin
                 . htmlspecialchars($db_alias) . '">' . $crlf;
 
             return Export::outputHandler($head);
-        } else {
-            return true;
         }
+
+        return true;
     }
 
     /**
@@ -428,9 +428,9 @@ class ExportXml extends ExportPlugin
             && $GLOBALS['xml_export_contents']
         ) {
             return Export::outputHandler('    </database>' . $crlf);
-        } else {
-            return true;
         }
+
+        return true;
     }
 
     /**

--- a/libraries/classes/Plugins/Import/ImportOds.php
+++ b/libraries/classes/Plugins/Import/ImportOds.php
@@ -408,15 +408,15 @@ class ImportOds extends ImportPlugin
             $value = (double)$cell_attrs['value'];
 
             return $value;
-        } else {
-            /* We need to concatenate all paragraphs */
-            $values = array();
-            foreach ($text as $paragraph) {
-                $values[] = (string)$paragraph;
-            }
-            $value = implode("\n", $values);
-
-            return $value;
         }
+
+        /* We need to concatenate all paragraphs */
+        $values = array();
+        foreach ($text as $paragraph) {
+            $values[] = (string)$paragraph;
+        }
+        $value = implode("\n", $values);
+
+        return $value;
     }
 }

--- a/libraries/classes/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
+++ b/libraries/classes/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
@@ -142,9 +142,9 @@ abstract class DateFormatTransformationsPlugin extends TransformationsPlugin
             }
             return '<dfn onclick="alert(\'' . Sanitize::jsFormat($source, false) . '\');" title="'
                 . htmlspecialchars($source) . '">' . htmlspecialchars($text) . '</dfn>';
-        } else {
-            return htmlspecialchars($buffer);
         }
+
+        return htmlspecialchars($buffer);
     }
 
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */

--- a/libraries/classes/Relation.php
+++ b/libraries/classes/Relation.php
@@ -63,9 +63,9 @@ class Relation
 
         if ($result) {
             return $result;
-        } else {
-            return false;
         }
+
+        return false;
     } // end of the "self::queryAsControlUser()" function
 
     /**
@@ -709,34 +709,34 @@ class Relation
             if ($rows === 2) {
                 return true;
                 // try silent upgrade without disturbing the user
-            } else {
-                // read upgrade query file
-                $query = @file_get_contents(SQL_DIR . 'upgrade_column_info_4_3_0+.sql');
-                // replace database name from query to with set in config.inc.php
-                $query = str_replace(
-                    '`phpmyadmin`',
-                    Util::backquote($GLOBALS['cfg']['Server']['pmadb']),
-                    $query
-                );
-                // replace pma__column_info table name from query
-                // to with set in config.inc.php
-                $query = str_replace(
-                    '`pma__column_info`',
-                    Util::backquote(
-                        $GLOBALS['cfg']['Server']['column_info']
-                    ),
-                    $query
-                );
-                $GLOBALS['dbi']->tryMultiQuery($query, DatabaseInterface::CONNECT_CONTROL);
-                // skips result sets of query as we are not interested in it
-                while ($GLOBALS['dbi']->moreResults(DatabaseInterface::CONNECT_CONTROL)
-                    && $GLOBALS['dbi']->nextResult(DatabaseInterface::CONNECT_CONTROL)
-                ) {
-                }
-                $error = $GLOBALS['dbi']->getError(DatabaseInterface::CONNECT_CONTROL);
-                // return true if no error exists otherwise false
-                return empty($error);
             }
+
+            // read upgrade query file
+            $query = @file_get_contents(SQL_DIR . 'upgrade_column_info_4_3_0+.sql');
+            // replace database name from query to with set in config.inc.php
+            $query = str_replace(
+                '`phpmyadmin`',
+                Util::backquote($GLOBALS['cfg']['Server']['pmadb']),
+                $query
+            );
+            // replace pma__column_info table name from query
+            // to with set in config.inc.php
+            $query = str_replace(
+                '`pma__column_info`',
+                Util::backquote(
+                    $GLOBALS['cfg']['Server']['column_info']
+                ),
+                $query
+            );
+            $GLOBALS['dbi']->tryMultiQuery($query, DatabaseInterface::CONNECT_CONTROL);
+            // skips result sets of query as we are not interested in it
+            while ($GLOBALS['dbi']->moreResults(DatabaseInterface::CONNECT_CONTROL)
+                && $GLOBALS['dbi']->nextResult(DatabaseInterface::CONNECT_CONTROL)
+            ) {
+            }
+            $error = $GLOBALS['dbi']->getError(DatabaseInterface::CONNECT_CONTROL);
+            // return true if no error exists otherwise false
+            return empty($error);
         }
         // some failure, either in upgrading or something else
         // make some noise, time to wake up user.
@@ -1826,27 +1826,27 @@ class Relation
     {
         if (isset($foreigners[$column])) {
             return $foreigners[$column];
-        } else {
-            $foreigner = array();
-            foreach ($foreigners['foreign_keys_data'] as $one_key) {
-                $column_index = array_search($column, $one_key['index_list']);
-                if ($column_index !== false) {
-                    $foreigner['foreign_field']
-                        = $one_key['ref_index_list'][$column_index];
-                    $foreigner['foreign_db'] = isset($one_key['ref_db_name'])
-                        ? $one_key['ref_db_name']
-                        : $GLOBALS['db'];
-                    $foreigner['foreign_table'] = $one_key['ref_table_name'];
-                    $foreigner['constraint'] = $one_key['constraint'];
-                    $foreigner['on_update'] = isset($one_key['on_update'])
-                        ? $one_key['on_update']
-                        : 'RESTRICT';
-                    $foreigner['on_delete'] = isset($one_key['on_delete'])
-                        ? $one_key['on_delete']
-                        : 'RESTRICT';
+        }
 
-                    return $foreigner;
-                }
+        $foreigner = array();
+        foreach ($foreigners['foreign_keys_data'] as $one_key) {
+            $column_index = array_search($column, $one_key['index_list']);
+            if ($column_index !== false) {
+                $foreigner['foreign_field']
+                    = $one_key['ref_index_list'][$column_index];
+                $foreigner['foreign_db'] = isset($one_key['ref_db_name'])
+                    ? $one_key['ref_db_name']
+                    : $GLOBALS['db'];
+                $foreigner['foreign_table'] = $one_key['ref_table_name'];
+                $foreigner['constraint'] = $one_key['constraint'];
+                $foreigner['on_update'] = isset($one_key['on_update'])
+                    ? $one_key['on_update']
+                    : 'RESTRICT';
+                $foreigner['on_delete'] = isset($one_key['on_delete'])
+                    ? $one_key['on_delete']
+                    : 'RESTRICT';
+
+                return $foreigner;
             }
         }
 
@@ -2090,9 +2090,9 @@ class Relation
             || empty($GLOBALS['cfg']['Server']['export_templates'])
         ) {
             return false;
-        } else {
-            return true;
         }
+
+        return true;
     }
 
     /**

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -118,9 +118,9 @@ class Privileges
         if ($html) {
             return '<dfn title="' . $privilege[2] . '">'
                 . $privilege[1] . '</dfn>';
-        } else {
-            return $privilege[1];
         }
+
+        return $privilege[1];
     }
 
     /**

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -1705,9 +1705,9 @@ class Table
         $row = $this->_dbi->fetchArray(Relation::queryAsControlUser($sql_query));
         if (isset($row[0])) {
             return json_decode($row[0], true);
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**

--- a/libraries/classes/ThemeManager.php
+++ b/libraries/classes/ThemeManager.php
@@ -199,9 +199,9 @@ class ThemeManager
         // Allow different theme per server
         if (isset($GLOBALS['server']) && $this->per_server) {
             return $this->cookie_name . '-' . $GLOBALS['server'];
-        } else {
-            return $this->cookie_name;
         }
+
+        return $this->cookie_name;
     }
 
     /**

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -80,9 +80,9 @@ class Tracker
         $pma_table = self::_getTrackingTable();
         if (isset($pma_table)) {
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**

--- a/libraries/classes/Tracking.php
+++ b/libraries/classes/Tracking.php
@@ -1121,9 +1121,9 @@ class Tracking
     {
         if ($version['tracking_active'] == 1) {
             return __('active');
-        } else {
-            return __('not active');
         }
+
+        return __('not active');
     }
 
     /**

--- a/libraries/classes/Transformations.php
+++ b/libraries/classes/Transformations.php
@@ -410,9 +410,9 @@ class Transformations
 
         if (isset($upd_query)) {
             return Relation::queryAsControlUser($upd_query);
-        } else {
-            return false;
         }
+
+        return false;
     } // end of 'setMIME()' function
 
 

--- a/libraries/classes/Twig/I18n/NodeTrans.php
+++ b/libraries/classes/Twig/I18n/NodeTrans.php
@@ -162,8 +162,8 @@ class NodeTrans extends TransNode
     {
         if ($hasMsgContext) {
             return $plural ? '_ngettext' : '_pgettext';
-        } else {
-            return $plural ? '_ngettext' : '_gettext';
         }
+
+        return $plural ? '_ngettext' : '_gettext';
     }
 }

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -308,11 +308,11 @@ class Util
     {
         if($bbcode){
             return "[a@$link@$target][dochelpicon][/a]";
-        }else{
-            return '<a href="' . $link . '" target="' . $target . '">'
-                . self::getImage('b_help', __('Documentation'))
-                . '</a>';
         }
+
+        return '<a href="' . $link . '" target="' . $target . '">'
+            . self::getImage('b_help', __('Documentation'))
+            . '</a>';
     } // end of the 'showDocLink()' function
 
     /**
@@ -379,9 +379,9 @@ class Util
         } elseif ($big_icon) {
             return $open_link
                 . self::getImage('b_sqlhelp', __('Documentation')) . '</a>';
-        } else {
-            return self::showDocLink($url, 'mysql_doc');
         }
+
+        return self::showDocLink($url, 'mysql_doc');
     } // end of the 'showMySQLDocu()' function
 
     /**
@@ -406,12 +406,12 @@ class Util
         if (! defined('TESTSUITE') && @file_exists('doc/html/index.html')) {
             if ($GLOBALS['PMA_Config']->get('is_setup')) {
                 return '../doc/html/' . $url;
-            } else {
-                return './doc/html/' . $url;
             }
-        } else {
-            return Core::linkURL('https://docs.phpmyadmin.net/en/latest/' . $url);
+
+            return './doc/html/' . $url;
         }
+
+        return Core::linkURL('https://docs.phpmyadmin.net/en/latest/' . $url);
     }
 
     /**
@@ -846,9 +846,9 @@ class Util
         // '0' is also empty for php :-(
         if (strlen($a_name) > 0 && $a_name !== '*') {
             return '`' . str_replace('`', '``', $a_name) . '`';
-        } else {
-            return $a_name;
         }
+
+        return $a_name;
     } // end of the 'backquote()' function
 
     /**
@@ -903,9 +903,9 @@ class Util
         // '0' is also empty for php :-(
         if (strlen($a_name) > 0 && $a_name !== '*') {
             return $quote . $a_name . $quote;
-        } else {
-            return $a_name;
         }
+
+        return $a_name;
     } // end of the 'backquoteCompat()' function
 
     /**
@@ -1804,9 +1804,9 @@ class Util
 
         if (! empty($url_parts['query'])) {
             return explode($separator, $url_parts['query']);
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**
@@ -2623,9 +2623,9 @@ class Util
     {
         if (isset($GLOBALS['cfg']['Server']['user'])) {
             return 'server_' . $GLOBALS['server'] . '_' . $GLOBALS['cfg']['Server']['user'];
-        } else {
-            return 'server_' . $GLOBALS['server'];
         }
+
+        return 'server_' . $GLOBALS['server'];
     }
 
     /**
@@ -2652,14 +2652,14 @@ class Util
     {
         if (self::cacheExists($var)) {
             return $_SESSION['cache'][self::cacheKey()][$var];
-        } else {
-            if ($callback) {
-                $val = $callback();
-                self::cacheSet($var, $val);
-                return $val;
-            }
-            return null;
         }
+
+        if ($callback) {
+            $val = $callback();
+            self::cacheSet($var, $val);
+            return $val;
+        }
+        return null;
     }
 
     /**
@@ -2889,9 +2889,9 @@ class Util
                 $ndbver = substr($ndbver, 4);
             }
             return version_compare($ndbver, 7.3, '>=');
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -3470,9 +3470,9 @@ class Util
             return 'GeomFromText(' . $gis_string . ')';
         } elseif (preg_match("/^" . $geom_types . "\(.*\)$/i", $gis_string)) {
             return "GeomFromText('" . $gis_string . "')";
-        } else {
-            return $gis_string;
         }
+
+        return $gis_string;
     }
 
     /**
@@ -4008,9 +4008,9 @@ class Util
             return $tabList;
         } elseif (array_key_exists($level, $tabList)) {
             return $tabList[$level];
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

I've removed the `else`s when we have already returned something :put_litter_in_its_place: