### PR TITLE
Force PHP platform in composer to oldest supported version

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -220,12 +220,18 @@ rm -f .travis.yml .coveralls.yml .scrutinizer.yml .jshintrc .weblate codecov.yml
 rm -f README.rst
 
 if [ ! -d libraries/tcpdf ] ; then
-    echo "* Running composer"
-    composer update --no-dev
+    PHP_REQ=`sed -n '/"php"/ s/.*">=\([0-9]\.[0-9]\).*/\1/p' composer.json`
+    if [ -z "$PHP_REQ" ] ; then
+        echo "Failed to figure out required PHP version from composer.json"
+        exit 2
+    fi
     # Okay, there is no way to tell composer to install
     # suggested package. Let's require it and then revert
     # composer.json to original state.
     cp composer.json composer.json.backup
+    echo "* Running composer"
+    composer config platform.php "$PHP_REQ"
+    composer update --no-dev
     composer require --update-no-dev tecnickcom/tcpdf
     mv composer.json.backup composer.json
     echo "* Cleanup of composer packages"


### PR DESCRIPTION
This way the packages should be compatible with all versions we support
regardless PHP version used to build the release.

Fixes #13831

Signed-off-by: Michal Čihař <michal@cihar.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
