### PR TITLE
Use assertNotSame instead of comparison in test

### DIFF
--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -853,7 +853,7 @@ class ConfigTest extends PmaTestCase
 
         //if the above assertion is false then applying further assertions
         if (!($perms === false) && ($perms & 2)) {
-            $this->assertFalse($this->permTestObj->get('PMA_IS_WINDOWS') == 0);
+            $this->assertNotSame(0, $this->permTestObj->get('PMA_IS_WINDOWS'));
         }
     }
 


### PR DESCRIPTION
- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
