### PR TITLE
Fix for issue #13959.

### DIFF
--- a/js/tbl_select.js
+++ b/js/tbl_select.js
@@ -278,7 +278,7 @@ AJAX.registerOnload('tbl_select.js', function () {
     /**
      * Ajax event handler for Range-Search.
      */
-    $('body').on('click', 'select[name*="criteriaColumnOperators"]', function () {
+    $('body').on('change', 'select[name*="criteriaColumnOperators"]', function () {
         $source_select = $(this);
         // Get the column name.
         var column_name = $(this)

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -3316,6 +3316,9 @@ body .ui-dialog .ui-button-text-only .ui-button-text {
 .scrollindicator {
     display: none;
 }
+.responsivetable {
+    overflow-x: auto !important;
+}
 
 @media only screen and (max-width: 768px) {
     /* For mobile phones: */
@@ -3348,7 +3351,7 @@ body .ui-dialog .ui-button-text-only .ui-button-text {
     }
 
     .responsivetable {
-        overflow-x: auto;
+        overflow-x: auto !important;
     }
 
     body#loginform div.container {

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -3566,6 +3566,9 @@ body .ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset {
 }
 /* end of styles for jQuery-ui to support rtl languages */
 
+.responsivetable {
+    overflow-x: auto !important;
+}
 @media only screen and (max-width: 768px) {
     /* For mobile phones: */
     #main_pane_left {
@@ -3597,7 +3600,7 @@ body .ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset {
     }
 
     .responsivetable {
-        overflow-x: auto;
+        overflow-x: auto !important;
     }
 
     body#loginform div.container {


### PR DESCRIPTION
Changes made in ./themes/original/css/commons.css.php
		./themes/pmahomme/css/commons.css.php
Added a style definition to prevent overflow in .responsivetable div element when the table has numerous fields(see issue #13959 ).
Signed-off-by: Lakshay arora (b16060@students.iitmandi.ac.in)

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
