### PR TITLE
Fix case in which Config::checkServers is never called

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -833,8 +833,6 @@ class Config
 
         $this->settings = array_replace_recursive($this->settings, $cfg);
 
-        $this->checkServers();
-
         return true;
     }
 

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -277,6 +277,8 @@ Core::checkRequest();
 /******************************************************************************/
 /* setup servers                                       LABEL_setup_servers    */
 
+$GLOBALS['PMA_Config']->checkServers();
+
 /**
  * current server
  * @global integer $GLOBALS['server']


### PR DESCRIPTION
If there is no configuration file, the `Config::checkServers()` method will never be called.

Fix #13769

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
