### PR TITLE
Add PHP Nightly version to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ php:
   - "5.5"
   - "hhvm-3.12"
   - "hhvm-3.18"
+  - "nightly"
 
 sudo: required
 
@@ -80,6 +81,10 @@ matrix:
         - curl https://getcomposer.org/installer | php
         - ln -s "`pwd`/composer.phar" /usr/local/bin/composer
         - mysql.server start
+
+  allow_failures:
+    - php: "nightly"
+      env: CI_MODE=test
 
 cache:
   pip: true


### PR DESCRIPTION
PHP nightly currently corresponds to `PHP 7.3.0-dev`.

Signed-off-by: Maurício Meneghini Fauth <mauriciofauth@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
