### PR TITLE
Fix table horizontal scrolling

### DIFF
--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -3324,7 +3324,7 @@ body .ui-dialog .ui-button-text-only .ui-button-text {
 }
 
 .responsivetable {
-    overflow-x: auto !important;
+    overflow-x: auto;
 }
 
 @media only screen and (max-width: 768px) {

--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -3323,6 +3323,10 @@ body .ui-dialog .ui-button-text-only .ui-button-text {
     display: none;
 }
 
+.responsivetable {
+    overflow-x: auto !important;
+}
+
 @media only screen and (max-width: 768px) {
     /* For mobile phones: */
     #main_pane_left {

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -3570,6 +3570,9 @@ body .ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset {
 }
 /* end of styles for jQuery-ui to support rtl languages */
 
+.responsivetable {
+    overflow-x: auto !important;
+}
 @media only screen and (max-width: 768px) {
     /* For mobile phones: */
     #main_pane_left {

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -3571,7 +3571,7 @@ body .ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset {
 /* end of styles for jQuery-ui to support rtl languages */
 
 .responsivetable {
-    overflow-x: auto !important;
+    overflow-x: auto;
 }
 @media only screen and (max-width: 768px) {
     /* For mobile phones: */


### PR DESCRIPTION
Changed files:
	themes/original/css/common.css.php
	themes/pmahomme/css/common.css.php
Added style definition for .responsivetable element to prevent horizontal overflow
Signed-Off-By: Lakshay arora (b16060@students.iitmandi.ac.in)

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
