### PR TITLE
Fix errors on zoom search errors, issue #13439

### DIFF
--- a/js/tbl_zoom_plot_jqplot.js
+++ b/js/tbl_zoom_plot_jqplot.js
@@ -182,10 +182,10 @@ AJAX.registerOnload('tbl_zoom_plot_jqplot.js', function () {
             'field' : $('#tableid_1').val(),
             'it' : 1
         }, function (data) {
-            $('#tableFieldsId').find('tr:eq(3) td:eq(0)').html(data.field_type);
-            $('#tableFieldsId').find('tr:eq(3) td:eq(1)').html(data.field_collation);
-            $('#tableFieldsId').find('tr:eq(3) td:eq(2)').html(data.field_operators);
-            $('#tableFieldsId').find('tr:eq(3) td:eq(3)').html(data.field_value);
+            $('#tableFieldsId').find('tr:eq(2) td:eq(0)').html(data.field_type);
+            $('#tableFieldsId').find('tr:eq(2) td:eq(1)').html(data.field_collation);
+            $('#tableFieldsId').find('tr:eq(2) td:eq(2)').html(data.field_operators);
+            $('#tableFieldsId').find('tr:eq(2) td:eq(3)').html(data.field_value);
             yLabel = $('#tableid_1').val();
             $('#types_1').val(data.field_type);
             yType = data.field_type;
@@ -205,10 +205,10 @@ AJAX.registerOnload('tbl_zoom_plot_jqplot.js', function () {
             'field' : $('#tableid_2').val(),
             'it' : 2
         }, function (data) {
-            $('#tableFieldsId').find('tr:eq(6) td:eq(0)').html(data.field_type);
-            $('#tableFieldsId').find('tr:eq(6) td:eq(1)').html(data.field_collation);
-            $('#tableFieldsId').find('tr:eq(6) td:eq(2)').html(data.field_operators);
-            $('#tableFieldsId').find('tr:eq(6) td:eq(3)').html(data.field_value);
+            $('#tableFieldsId').find('tr:eq(4) td:eq(0)').html(data.field_type);
+            $('#tableFieldsId').find('tr:eq(4) td:eq(1)').html(data.field_collation);
+            $('#tableFieldsId').find('tr:eq(4) td:eq(2)').html(data.field_operators);
+            $('#tableFieldsId').find('tr:eq(4) td:eq(3)').html(data.field_value);
             $('#types_2').val(data.field_type);
             $('#collations_2').val(data.field_collations);
             addDateTimePicker();
@@ -226,10 +226,10 @@ AJAX.registerOnload('tbl_zoom_plot_jqplot.js', function () {
             'field' : $('#tableid_3').val(),
             'it' : 3
         }, function (data) {
-            $('#tableFieldsId').find('tr:eq(8) td:eq(0)').html(data.field_type);
-            $('#tableFieldsId').find('tr:eq(8) td:eq(1)').html(data.field_collation);
-            $('#tableFieldsId').find('tr:eq(8) td:eq(2)').html(data.field_operators);
-            $('#tableFieldsId').find('tr:eq(8) td:eq(3)').html(data.field_value);
+            $('#tableFieldsId').find('tr:eq(5) td:eq(0)').html(data.field_type);
+            $('#tableFieldsId').find('tr:eq(5) td:eq(1)').html(data.field_collation);
+            $('#tableFieldsId').find('tr:eq(5) td:eq(2)').html(data.field_operators);
+            $('#tableFieldsId').find('tr:eq(5) td:eq(3)').html(data.field_value);
             $('#types_3').val(data.field_type);
             $('#collations_3').val(data.field_collations);
             addDateTimePicker();

--- a/templates/table/search/rows_zoom.twig
+++ b/templates/table/search/rows_zoom.twig
@@ -56,6 +56,8 @@
         </td>
         {# Inputbox for search criteria value #}
         <td>
+        </td>
+        <td>
             {{ value[i] is defined ? value[i]|raw }}
             {# Displays hidden fields #}
             <input type="hidden"


### PR DESCRIPTION
Problem 1:
The number of td elements in the zoom search form table were insufficient, due to which, the field_type(element #types_$) was getting replaced with field_value(element td:eq(3))(see ./js/tbl_zoom_jqplot.js lines 164, 188, 211, 232). Added a td element in the table for each row.
Problem 2:
The events attached to 'tableid_$' were inserting the values in wrong tr elements(see ./js/tbl_zoom_jqplot.js lines 185-188, 208-211, 229-232), leading to wrong values being passed to the zoom search.
Signed-Off-By: Lakshay arora(b16060@students.iitmandi.ac.in)
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
