### PR TITLE
Set console max height, issue #14022

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -281,7 +281,7 @@ var PMA_console = {
         PMA_console.setConfig('Mode', 'show');
 
         var pmaConsoleHeight = Math.max(92, PMA_console.config.Height);
-
+        pmaConsoleHeight = Math.min(PMA_console.config.Height, (window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight)-25);
         PMA_console.$consoleContent.css({ display:'block' });
         if (PMA_console.$consoleToolbar.hasClass('collapsed')) {
             PMA_console.$consoleToolbar.removeClass('collapsed');


### PR DESCRIPTION
Changed:
	js/console.js
Before showing the console, set the height to minimum between current set height and height of the display window.
Signed-Off-By: Lakshay arora (b16060@students.iitmandi.ac.in)

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
