### PR TITLE
Fixes error in foreign key sql generation + drop foreign key contraint

### DIFF
--- a/templates/table/relation/foreign_key_row.twig
+++ b/templates/table/relation/foreign_key_row.twig
@@ -120,7 +120,7 @@
             {% for foreign_column in one_key['ref_index_list'] %}
                 <span class="formelement clearfloat">
                     {% include 'table/relation/relational_dropdown.twig' with {
-                        'name': 'destination_foreign_column[' ~ i ~ ']',
+                        'name': 'destination_foreign_column[' ~ i ~ '][]',
                         'title': 'Column'|trans,
                         'values': unique_columns,
                         'foreign': foreign_column
@@ -130,7 +130,7 @@
         {% else %}
             <span class="formelement clearfloat">
                 {% include 'table/relation/relational_dropdown.twig' with {
-                    'name': 'destination_foreign_column[' ~ i ~ ']',
+                    'name': 'destination_foreign_column[' ~ i ~ '][]',
                     'title': 'Column'|trans,
                     'values': [],
                     'foreign': ''

--- a/templates/table/relation/foreign_key_row.twig
+++ b/templates/table/relation/foreign_key_row.twig
@@ -4,7 +4,7 @@
         {% set js_msg = '' %}
         {% set this_params = null %}
         {% if one_key['constraint'] is defined %}
-            {% set drop_fk_query = 'ALTER TABLE ' ~ Util_backquote(table)
+            {% set drop_fk_query = 'ALTER TABLE ' ~ Util_backquote(db) ~ '.' ~ Util_backquote(table)
                 ~ ' DROP FOREIGN KEY '
                 ~ Util_backquote(one_key['constraint']) ~ ';'
             %}
@@ -18,7 +18,7 @@
                 )
             } %}
             {% set js_msg = Sanitize_jsFormat(
-                'ALTER TABLE ' ~ table
+                'ALTER TABLE ' ~ db ~ '.' ~ table
                 ~ ' DROP FOREIGN KEY '
                 ~ one_key['constraint'] ~ ';'
             ) %}


### PR DESCRIPTION
Changed:
	templates/table/relation/foreign_key_row.twig
The destination_column_names were getting passed as a 1d array, the names when extracted gave a string. Passing it as a 2d array (see templates/table/relation/foreign_key_row.twig lines 123,133) fixes the issue.

Signed-Off-By: Lakshay arora (b16060@students.iitmandi.ac.in)

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
