### PR TITLE
Warning in ./libraries/sql.lib.php#601

### DIFF
--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -609,8 +609,8 @@ function PMA_isRememberSortingOrder($analyzed_sql_results)
             || $analyzed_sql_results['is_func']
             || $analyzed_sql_results['is_analyse'])
         && $analyzed_sql_results['select_from']
-        && ((empty($analyzed_sql_results['select_expr']))
-            || (count($analyzed_sql_results['select_expr'] == 1)
+        && ((empty($analyzed_sql_results['select_expr'])
+            || (count($analyzed_sql_results['select_expr']) == 1)
                 && ($analyzed_sql_results['select_expr'][0] == '*')))
         && count($analyzed_sql_results['select_tables']) == 1;
 }


### PR DESCRIPTION
When accessing phpMyAdmin I get the following error:

Warning in ./libraries/sql.lib.php#601
count(): Parameter must be an array or an object that implements Countable

Backtrace

./libraries/sql.lib.php#2038: PMA_isRememberSortingOrder(array)
./libraries/sql.lib.php#1984: PMA_executeQueryAndGetQueryResponse(
array,
boolean true,
string 'holding',
string 'users',
NULL,
NULL,
NULL,
NULL,
NULL,
NULL,
string '',
string './themes/pmahomme/img/',
NULL,
NULL,
NULL,
string 'SELECT * FROM `users`',
NULL,
NULL,
)
./sql.php#216: PMA_executeQueryAndSendQueryResponse(
array,
boolean true,
string 'holding',
string 'users',
NULL,
NULL,
NULL,
NULL,
NULL,
NULL,
string '',
string './themes/pmahomme/img/',
NULL,
NULL,
NULL,
string 'SELECT * FROM `users`',
NULL,
NULL,
)

Before submitting pull request, please check that every commit:

- [ ] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
