### PR TITLE
Fix buggy sql.lib.php on debian9 with PHP7.2

### DIFF
--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -610,7 +610,7 @@ function PMA_isRememberSortingOrder($analyzed_sql_results)
             || $analyzed_sql_results['is_analyse'])
         && $analyzed_sql_results['select_from']
         && ((empty($analyzed_sql_results['select_expr']))
-            || (count($analyzed_sql_results['select_expr'] == 1)
+            || (count($analyzed_sql_results['select_expr']) == 1
                 && ($analyzed_sql_results['select_expr'][0] == '*')))
         && count($analyzed_sql_results['select_tables']) == 1;
 }


### PR DESCRIPTION
Fixed the exception (Warning in ./libraries/sql.lib.php#613  count(): Parameter must be an array or an object that implements Countable)
bracket at the wrong position

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests

Signed-off-by: Gonzo <info@gonzo-online.de>