### PR TITLE
Fix bugs in SQL query restore after session expire

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -245,10 +245,18 @@ var AJAX = {
         // the click event is not triggered by script
         if (typeof event !== 'undefined' && event.type === 'click' &&
             event.isTrigger !== true &&
-            !jQuery.isEmptyObject(AJAX.lockedTargets) &&
-            confirm(PMA_messages.strConfirmNavigation) === false
+            !jQuery.isEmptyObject(AJAX.lockedTargets)
         ) {
-            return false;
+            if (confirm(PMA_messages.strConfirmNavigation) === false) {
+                return false;
+            } else {
+                // If user goes to another page the localStorage data should be discarded
+                if (isStorageSupported('localStorage')) {
+                    window.localStorage.auto_saved_sql = "";
+                } else {
+                    Cookies.set('auto_saved_sql', "");
+                }
+            }
         }
         AJAX.resetLock();
         var isLink = !! href || false;

--- a/js/functions.js
+++ b/js/functions.js
@@ -1182,8 +1182,6 @@ function insertQuery (queryType) {
             setQuery(window.localStorage.auto_saved_sql);
         } else if (Cookies.get('auto_saved_sql')) {
             setQuery(Cookies.get('auto_saved_sql'));
-        } else {
-            PMA_ajaxShowMessage(PMA_messages.strNoAutoSavedQuery);
         }
         return;
     }

--- a/js/messages.php
+++ b/js/messages.php
@@ -421,7 +421,6 @@ $js_messages['strEdit'] = __('Edit');
 $js_messages['strDelete'] = __('Delete');
 $js_messages['strNotValidRowNumber'] = __('%d is not valid row number.');
 $js_messages['strBrowseForeignValues'] = __('Browse foreign values');
-$js_messages['strNoAutoSavedQuery'] = __('No auto-saved query');
 $js_messages['strBookmarkVariable'] = __('Variable %d:');
 
 /* For Central list of columns */

--- a/js/sql.js
+++ b/js/sql.js
@@ -41,10 +41,12 @@ function PMA_urlencode (str) {
  * @return void
  */
 function PMA_autosaveSQL (query) {
-    if (isStorageSupported('localStorage')) {
-        window.localStorage.auto_saved_sql = query;
-    } else {
-        Cookies.set('auto_saved_sql', query);
+    if (query) {
+        if (isStorageSupported('localStorage')) {
+            window.localStorage.auto_saved_sql = query;
+        } else {
+            Cookies.set('auto_saved_sql', query);
+        }
     }
 }
 

--- a/js/sql.js
+++ b/js/sql.js
@@ -387,7 +387,7 @@ AJAX.registerOnload('sql.js', function () {
      * @memberOf    jQuery
      */
     $(document).on('click', '#button_submit_query', function (event) {
-        window.localStorage.auto_saved_sql="";
+        window.localStorage.auto_saved_sql = "";
         // Remove auto_saved_sql on submission of sql
         $('.success,.error').hide();
         // hide already existing error or success message

--- a/js/sql.js
+++ b/js/sql.js
@@ -381,13 +381,14 @@ AJAX.registerOnload('sql.js', function () {
         });
     }
 
-
     /**
      * Event handler for sqlqueryform.ajax button_submit_query
      *
      * @memberOf    jQuery
      */
     $(document).on('click', '#button_submit_query', function (event) {
+        window.localStorage.auto_saved_sql="";
+        // Remove auto_saved_sql on submission of sql
         $('.success,.error').hide();
         // hide already existing error or success message
         var $form = $(this).closest('form');

--- a/libraries/classes/SqlQueryForm.php
+++ b/libraries/classes/SqlQueryForm.php
@@ -82,7 +82,6 @@ class SqlQueryForm
         // start output
         $html .= '<form method="post" action="import.php" ' . $enctype;
         $html .= ' class="ajax lock-page"';
-        $html .= ' onsubmit=window.localStorage.auto_saved_sql=""';
         $html .= ' id="sqlqueryform" name="sqlform">' . "\n";
 
         $html .= '<input type="hidden" name="is_js_confirmed" value="0" />'

--- a/libraries/classes/SqlQueryForm.php
+++ b/libraries/classes/SqlQueryForm.php
@@ -82,6 +82,7 @@ class SqlQueryForm
         // start output
         $html .= '<form method="post" action="import.php" ' . $enctype;
         $html .= ' class="ajax lock-page"';
+        $html .= ' onsubmit=window.localStorage.auto_saved_sql=""';
         $html .= ' id="sqlqueryform" name="sqlform">' . "\n";
 
         $html .= '<input type="hidden" name="is_js_confirmed" value="0" />'


### PR DESCRIPTION
Fixes: https://github.com/phpmyadmin/phpmyadmin/issues/14093
Also, the sql query was getting stored in the browser indefinetly even after visiting another page and then coming back. So it had to be cleared from localstorage on page change.

Signed-off-by: Saksham Gupta <shucon01@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
