### PR TITLE
Addapt getHtmlForAddColumn to use twig template

### DIFF
--- a/libraries/classes/CentralColumns.php
+++ b/libraries/classes/CentralColumns.php
@@ -875,39 +875,24 @@ class CentralColumns
      *
      * @return string html to add a column in the central list
      */
-    public function getHtmlForAddColumn(
-        $total_rows,
-        $pos,
-        $db
-    ) {
-        $columnAdd = '<table class="central_columns_add_column" '
-            . 'class="navigation nospacing nopadding">'
-            . '<tr>'
-            . '<td class="navigation_separator largescreenonly"></td>'
-            . '<td class="central_columns_navigation">'
-            . Util::getIcon(
-                'centralColumns_add',
-                __('Add column')
-            )
-            . '<form id="add_column" action="db_central_columns.php" method="post">'
-            . Url::getHiddenInputs(
-                $db
-            )
-            . '<input type="hidden" name="add_column" value="add">'
-            . '<input type="hidden" name="pos" value="' . $pos . '" />'
-            . '<input type="hidden" name="total_rows" value="' . $total_rows . '"/>'
-            . $this->getHtmlForTableDropdown($db)
-            . '<select name="column-select" id="column-select">'
-            . '<option value="" selected="selected">'
-            . __('Select a column.') . '</option>'
-            . '</select></form>'
-            . '</td>'
-            . '<td class="navigation_separator largescreenonly"></td>'
-            . '</tr>'
-            . '</table>';
-
-        return $columnAdd;
-    }
+     public function getHtmlForAddColumn(
+         $total_rows,
+         $pos,
+         $db
+     ) {
+         $icon = Util::getIcon(
+             'centralColumns_add',
+             __('Add column')
+         );
+         $table_drop_down = $this->getHtmlForTableDropdown($db);
+         return Template::get('database/central_columns/add_column')->render(array(
+             'icon' => $icon,
+             'pos' => $pos,
+             'db' => $db,
+             'total_rows' => $total_rows,
+             'table_drop_down' => $table_drop_down,
+         ));
+     }
 
     /**
      * build html for a row in central columns table

--- a/templates/database/central_columns/add_column.twig
+++ b/templates/database/central_columns/add_column.twig
@@ -1,0 +1,19 @@
+<table class="central_columns_add_column" class="navigation nospacing nopadding">
+    <tr>
+        <td class="navigation_separator largescreenonly"></td>
+        <td class="central_columns_navigation">
+            {{ icon|raw }}
+            <form id="add_column" action="db_central_columns.php" method="post">
+                {{ Url_getHiddenInputs(db)}}
+                <input type="hidden" name="add_column" value="add">
+                <input type="hidden" name="pos" value="{{ pos }}" />
+                <input type="hidden" name="total_rows" value="{{ total_rows }}"/>
+                {{ table_drop_down|raw }}
+                <select name="column-select" id="column-select">
+                    <option value="" selected="selected">{% trans 'Select a column.' %}</option>
+                </select>
+            </form>
+        </td>
+        <td class="navigation_separator largescreenonly"></td>
+    </tr>
+</table>

--- a/test/classes/CentralColumnsTest.php
+++ b/test/classes/CentralColumnsTest.php
@@ -730,10 +730,19 @@ class CentralColumnsTest extends TestCase
             $result
         );
         $this->assertContains(
-            Url::getHiddenInputs('phpmyadmin')
-            . '<input type="hidden" name="add_column" value="add">'
-            . '<input type="hidden" name="pos" value="0" />'
-            . '<input type="hidden" name="total_rows" value="20"/>',
+            Url::getHiddenInputs('phpmyadmin'),
+            $result
+        );
+        $this->assertContains(
+            '<input type="hidden" name="add_column" value="add">',
+            $result
+        );
+        $this->assertContains(
+            '<input type="hidden" name="pos" value="0" />',
+            $result
+        );
+        $this->assertContains(
+            '<input type="hidden" name="total_rows" value="20"/>',
             $result
         );
     }


### PR DESCRIPTION
I started to adapt some functions that returns html string and are not yet using Twig templates.

Signed-off-by: Leonardo Strozzi <laps15@inf.ufpr.br>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
