### PR TITLE
Fixes JavaScript error when editing rows with Internet Explorer

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ phpMyAdmin - ChangeLog
 - issue #13931 Fixed browsing tables with more results
 - issue #13927 "Not an integer" when browsing a table
 - issue #13887 "Input variables exceeded 1000" error relating to PHP's max_input_vars directive
+- issue #14060 Can't edit rows in Internet Explorer
+- issue #14096 Internet Explorer compatibility; fixes JavaScript error Object doesn't support property or method 'startsWith'
 
 4.7.8 (2018-02-20)
 - issue #13914 Fixed resetting default setting values.

--- a/js/functions.js
+++ b/js/functions.js
@@ -1846,7 +1846,7 @@ function getJSConfirmCommonParam (elem, params) {
     var $elem = $(elem);
     if (params) {
         // Strip possible leading ?
-        if (params.startsWith('?')) {
+        if (params.substring(0,1) == '?') {
             params = params.substr(1);
         }
         params += '&';
@@ -4980,7 +4980,7 @@ AJAX.registerOnload('functions.js', function(){
 jQuery.fn.getPostData = function() {
     var dataPost = this.attr('data-post');
     // Strip possible leading ?
-    if (dataPost !== undefined && dataPost.startsWith('?')) {
+    if (dataPost !== undefined && dataPost.substring(0,1) == '?') {
         dataPost = dataPost.substr(1);
     }
     return dataPost;


### PR DESCRIPTION
Fixes JavaScript error when editing rows with Internet Explorer

Fixes #14060
Fixes #14096

Internet Explorer does not support StartsWith()

See the comments by
tm8544 at https://github.com/phpmyadmin/phpmyadmin/issues/14096#issue-306243721
and qcybb at https://github.com/phpmyadmin/phpmyadmin/issues/14060#issuecomment-374730276


Signed-off-by: Isaac Bennetch <bennetch@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
