### PR TITLE
Fix for issues with spatial fields

### DIFF
--- a/libraries/classes/Controllers/Table/TableSearchController.php
+++ b/libraries/classes/Controllers/Table/TableSearchController.php
@@ -1020,7 +1020,10 @@ class TableSearchController extends TableController
         $geom_funcs = Util::getGISFunctions($types, true, false);
 
         // If the function takes multiple parameters
-        if ($geom_funcs[$geom_func]['params'] > 1) {
+        if(strpos($func_type, "IS NULL") !== false || strpos($func_type, "IS NOT NULL") !== false) {
+            $where = Util::backquote($names) . " " . $func_type;
+            return $where;
+        } elseif ($geom_funcs[$geom_func]['params'] > 1) {
             // create gis data from the criteria input
             $gis_data = Util::createGISData($criteriaValues);
             $where = $geom_func . '(' . Util::backquote($names)

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1678,9 +1678,14 @@ class Results
      */
     private function _getOptionsBlock()
     {
+        if(isset($_SESSION['tmpval']['possible_as_geomtery']) && $_SESSION['tmpval']['possible_as_geomtery'] == false) {
+            if($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_GEOM) {
+                $_SESSION['tmpval']['geoOption'] = self::GEOMETRY_DISP_WKT;
+            }
+        }
         return Template::get('display/results/options_block')->render([
             'unique_id' => $this->__get('unique_id'),
-            'geo_option' => ($_SESSION['tmpval']['possible_as_geomtery'] ? $_SESSION['tmpval']['geoOption'] : (self::GEOMETRY_DISP_WKT)),
+            'geo_option' => $_SESSION['tmpval']['geoOption'],
             'hide_transformation' => $_SESSION['tmpval']['hide_transformation'],
             'display_blob' => $_SESSION['tmpval']['display_blob'],
             'display_binary' => $_SESSION['tmpval']['display_binary'],
@@ -3678,7 +3683,7 @@ class Results
         }
 
         // Display as [GEOMETRY - (size)]
-        if ($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_GEOM && $_SESSION['tmpval']['possible_as_geomtery']) {
+        if ($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_GEOM) {
             $geometry_text = $this->_handleNonPrintableContents(
                 strtoupper(self::GEOMETRY_FIELD), $column, $transformation_plugin,
                 $transform_options, $default_function, $meta, $_url_params
@@ -3690,7 +3695,7 @@ class Results
             return $cell;
         }
 
-        if ($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_WKT || !$_SESSION['tmpval']['possible_as_geomtery']) {
+        if ($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_WKT) {
             // Prepare in Well Known Text(WKT) format.
             $where_comparison = ' = ' . $column;
 

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1680,13 +1680,14 @@ class Results
     {
         return Template::get('display/results/options_block')->render([
             'unique_id' => $this->__get('unique_id'),
-            'geo_option' => $_SESSION['tmpval']['geoOption'],
+            'geo_option' => ($_SESSION['tmpval']['possible_as_geomtery'] ? $_SESSION['tmpval']['geoOption'] : (self::GEOMETRY_DISP_WKT)),
             'hide_transformation' => $_SESSION['tmpval']['hide_transformation'],
             'display_blob' => $_SESSION['tmpval']['display_blob'],
             'display_binary' => $_SESSION['tmpval']['display_binary'],
             'relational_display' => $_SESSION['tmpval']['relational_display'],
             'displaywork' => $GLOBALS['cfgRelation']['displaywork'],
             'relwork' => $GLOBALS['cfgRelation']['relwork'],
+            'possible_as_geometry' => $_SESSION['tmpval']['possible_as_geomtery'],
             'pftext' => $_SESSION['tmpval']['pftext'],
             'db' => $this->__get('db'),
             'table' => $this->__get('table'),
@@ -3677,7 +3678,7 @@ class Results
         }
 
         // Display as [GEOMETRY - (size)]
-        if ($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_GEOM) {
+        if ($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_GEOM && $_SESSION['tmpval']['possible_as_geomtery']) {
             $geometry_text = $this->_handleNonPrintableContents(
                 strtoupper(self::GEOMETRY_FIELD), $column, $transformation_plugin,
                 $transform_options, $default_function, $meta, $_url_params
@@ -3689,7 +3690,7 @@ class Results
             return $cell;
         }
 
-        if ($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_WKT) {
+        if ($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_WKT || !$_SESSION['tmpval']['possible_as_geomtery']) {
             // Prepare in Well Known Text(WKT) format.
             $where_comparison = ' = ' . $column;
 

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1678,7 +1678,7 @@ class Results
      */
     private function _getOptionsBlock()
     {
-        if(isset($_SESSION['tmpval']['possible_as_geomtery']) && $_SESSION['tmpval']['possible_as_geomtery'] == false) {
+        if(isset($_SESSION['tmpval']['possible_as_geometry']) && $_SESSION['tmpval']['possible_as_geometry'] == false) {
             if($_SESSION['tmpval']['geoOption'] == self::GEOMETRY_DISP_GEOM) {
                 $_SESSION['tmpval']['geoOption'] = self::GEOMETRY_DISP_WKT;
             }
@@ -1692,7 +1692,7 @@ class Results
             'relational_display' => $_SESSION['tmpval']['relational_display'],
             'displaywork' => $GLOBALS['cfgRelation']['displaywork'],
             'relwork' => $GLOBALS['cfgRelation']['relwork'],
-            'possible_as_geometry' => $_SESSION['tmpval']['possible_as_geomtery'],
+            'possible_as_geometry' => $_SESSION['tmpval']['possible_as_geometry'],
             'pftext' => $_SESSION['tmpval']['pftext'],
             'db' => $this->__get('db'),
             'table' => $this->__get('table'),

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1941,7 +1941,7 @@ EOT;
             || $updatableView)
             && $just_one_table;
 
-        $_SESSION['tmpval']['possible_as_geomtery'] = $editable;
+        $_SESSION['tmpval']['possible_as_geometry'] = $editable;
 
         $displayParts = array(
             'edit_lnk' => $displayResultsObject::UPDATE_ROW,

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1941,6 +1941,8 @@ EOT;
             || $updatableView)
             && $just_one_table;
 
+        $_SESSION['tmpval']['possible_as_geomtery'] = $editable;
+
         $displayParts = array(
             'edit_lnk' => $displayResultsObject::UPDATE_ROW,
             'del_lnk' => $displayResultsObject::DELETE_ROW,

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2974,7 +2974,7 @@ class Util
         }
 
         $wktresult  = $GLOBALS['dbi']->tryQuery(
-            $wktsql, null, DatabaseInterface::QUERY_STORE
+            $wktsql
         );
         $wktarr     = $GLOBALS['dbi']->fetchRow($wktresult, 0);
         $wktval     = $wktarr[0];

--- a/templates/display/results/options_block.twig
+++ b/templates/display/results/options_block.twig
@@ -73,22 +73,40 @@
                 } only %}
             </div>
 
-            <div class="formelement">
-                {{ Util_getRadioFields(
-                    'geoOption',
-                    {
-                        'GEOM': 'Geometry'|trans,
-                        'WKT': 'Well Known Text'|trans,
-                        'WKB': 'Well Known Binary'|trans
-                    },
-                    geo_option,
-                    true,
-                    true,
-                    '',
-                    'geoOption_' ~ unique_id
-                ) }}
-            </div>
 
+            {% if possible_as_geometry %}
+                <div class="formelement">
+                    {{ Util_getRadioFields(
+                        'geoOption',
+                        {
+                            'GEOM': 'Geometry'|trans,
+                            'WKT': 'Well Known Text'|trans,
+                            'WKB': 'Well Known Binary'|trans
+                        },
+                        geo_option,
+                        true,
+                        true,
+                        '',
+                        'geoOption_' ~ unique_id
+                    ) }}
+                </div>
+            {% else %}
+                <div class="formelement">
+                    {{ possible_as_geometry }}
+                    {{ Util_getRadioFields(
+                        'geoOption',
+                        {
+                            'WKT': 'Well Known Text'|trans,
+                            'WKB': 'Well Known Binary'|trans
+                        },
+                        geo_option,
+                        true,
+                        true,
+                        '',
+                        'geoOption_' ~ unique_id
+                    ) }}
+                </div>
+            {% endif %}
             <div class="clearfloat"></div>
         </fieldset>
 

--- a/test/classes/Controllers/Table/TableSearchControllerTest.php
+++ b/test/classes/Controllers/Table/TableSearchControllerTest.php
@@ -319,7 +319,7 @@ class TableSearchControllerTest extends PmaTestCase
             'b', 'a'
         );
         $_POST['criteriaColumnOperators'] = array(
-            '<=', '='
+            '<=', '=', 'IS NULL', 'IS NOT NULL'
         );
         $_POST['criteriaValues'] = array(
             '10', '2'


### PR DESCRIPTION
Fixes the following issues:
1. Fixes #14068 SPATIAL fields with no unique index/autoincrement error when clicking
	This error occurs when there is no unique column to uniquely identify a tuple. I've disabled the geomtery view and made view as wkt the default view in such cases.
2. Fixes #14121 View spatial fields as WKT doesn't work
3. Fixes #14067 IS NULL search operator produces no WHERE SQL with spatial fields
Signed-Off-By: Lakshya arora <arora.lakshya123@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
