### PR TITLE
Changes to make Get auto saved query and show this query here again button functional

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -245,10 +245,17 @@ var AJAX = {
         // the click event is not triggered by script
         if (typeof event !== 'undefined' && event.type === 'click' &&
             event.isTrigger !== true &&
-            !jQuery.isEmptyObject(AJAX.lockedTargets) &&
-            confirm(PMA_messages.strConfirmNavigation) === false
+            !jQuery.isEmptyObject(AJAX.lockedTargets)
         ) {
-            return false;
+            if (confirm(PMA_messages.strConfirmNavigation) === false) {
+                return false;
+            } else {
+                if (isStorageSupported('localStorage')) {
+                    window.localStorage.removeItem('auto_saved_sql');
+                } else {
+                    Cookies.set('auto_saved_sql', '');
+                }
+            }
         }
         AJAX.resetLock();
         var isLink = !! href || false;

--- a/js/messages.php
+++ b/js/messages.php
@@ -421,7 +421,8 @@ $js_messages['strEdit'] = __('Edit');
 $js_messages['strDelete'] = __('Delete');
 $js_messages['strNotValidRowNumber'] = __('%d is not valid row number.');
 $js_messages['strBrowseForeignValues'] = __('Browse foreign values');
-$js_messages['strNoAutoSavedQuery'] = __('No auto-saved query');
+$js_messages['strNoAutoSavedQuery'] = __('No previously auto-saved query. Loading default query.');
+$js_messages['strPreviousSaveQuery'] = __('You have previously saved query. Click Get auto-saved query to get query.');
 $js_messages['strBookmarkVariable'] = __('Variable %d:');
 
 /* For Central list of columns */

--- a/js/sql.js
+++ b/js/sql.js
@@ -88,7 +88,7 @@ function setShowThisQuery () {
             if (db === stored_db && table === stored_table) {
                 if (codemirror_editor) {
                     codemirror_editor.setValue(stored_query);
-                } else {
+                } else if (document.sqlform) {
                     document.sqlform.sql_query.value = stored_query;
                 }
             }
@@ -950,7 +950,9 @@ AJAX.registerOnload('sql.js', function () {
     /**
      * Check if there is any saved query
      */
-    checkSavedQuery();
+    if (codemirror_editor || document.sqlform) {
+        checkSavedQuery();
+    }
 });
 
 /*

--- a/js/sql.js
+++ b/js/sql.js
@@ -72,6 +72,30 @@ function PMA_showThisQuery (db, table, query) {
 }
 
 /**
+ * Set query to codemirror if show this query is
+ * checked and query for the db and table pair exists
+ */
+function setShowThisQuery () {
+    if (isStorageSupported('localStorage')
+        && window.localStorage.show_this_query !== undefined
+        && window.localStorage.show_this_query === '1') {
+        $('input[name="show_query"]').prop('checked', true);
+        var db = $('input[name="db"]').val();
+        var table = $('input[name="table"]').val();
+        if (db === JSON.parse(window.localStorage.show_this_query_object).db
+            && table === JSON.parse(window.localStorage.show_this_query_object).table) {
+            if (codemirror_editor) {
+                codemirror_editor.setValue(JSON.parse(window.localStorage.show_this_query_object).query);
+            } else {
+                $('#sqlquery').val = JSON.parse(window.localStorage.show_this_query_object).query;
+            }
+        }
+    } else {
+        $('input[name="show_query"]').prop('checked', false);
+    }
+}
+
+/**
  * Saves SQL query with sort in local storage or cookie
  *
  * @param string SQL query
@@ -180,13 +204,7 @@ AJAX.registerTeardown('sql.js', function () {
  * @memberOf    jQuery
  */
 AJAX.registerOnload('sql.js', function () {
-    if (isStorageSupported('localStorage')
-        && window.localStorage.show_this_query !== undefined
-        && window.localStorage.show_this_query === '1') {
-        $('input[name="show_query"]').prop('checked', true);
-    } else {
-        $('input[name="show_query"]').prop('checked', false);
-    }
+    setShowThisQuery();
     $(function () {
         if (codemirror_editor) {
             codemirror_editor.on('change', function () {

--- a/js/sql.js
+++ b/js/sql.js
@@ -79,9 +79,11 @@ function setShowThisQuery () {
     var db = $('input[name="db"]').val();
     var table = $('input[name="table"]').val();
     if (isStorageSupported('localStorage')) {
-        var stored_db = JSON.parse(window.localStorage.show_this_query_object).db;
-        var stored_table = JSON.parse(window.localStorage.show_this_query_object).table;
-        var stored_query = JSON.parse(window.localStorage.show_this_query_object).query;
+        if (window.localStorage.show_this_query_object !== undefined) {
+            var stored_db = JSON.parse(window.localStorage.show_this_query_object).db;
+            var stored_table = JSON.parse(window.localStorage.show_this_query_object).table;
+            var stored_query = JSON.parse(window.localStorage.show_this_query_object).query;
+        }
         if (window.localStorage.show_this_query !== undefined
             && window.localStorage.show_this_query === '1') {
             $('input[name="show_query"]').prop('checked', true);
@@ -207,7 +209,9 @@ AJAX.registerTeardown('sql.js', function () {
  * @memberOf    jQuery
  */
 AJAX.registerOnload('sql.js', function () {
-    setShowThisQuery();
+    if (codemirror_editor || document.sqlform) {
+        setShowThisQuery();
+    }
     $(function () {
         if (codemirror_editor) {
             codemirror_editor.on('change', function () {

--- a/js/sql.js
+++ b/js/sql.js
@@ -842,6 +842,12 @@ function browseForeignDialog ($this_a) {
     });
 }
 
+function checkSavedQuery () {
+    if (isStorageSupported('localStorage') && window.localStorage.auto_saved_sql !== undefined) {
+        PMA_ajaxShowMessage(PMA_messages.strPreviousSaveQuery);
+    }
+}
+
 AJAX.registerOnload('sql.js', function () {
     $('body').on('click', 'a.browse_foreign', function (e) {
         e.preventDefault();
@@ -871,11 +877,9 @@ AJAX.registerOnload('sql.js', function () {
     $('.sqlqueryresults').trigger('makegrid').trigger('stickycolumns');
 
     /**
-     * Restores SQL query after timeout login
+     * Check if there is any saved query
      */
-    if (codemirror_editor || document.sqlform) {
-        insertQuery('saved');
-    }
+    checkSavedQuery();
 });
 
 /*

--- a/js/sql.js
+++ b/js/sql.js
@@ -76,22 +76,25 @@ function PMA_showThisQuery (db, table, query) {
  * checked and query for the db and table pair exists
  */
 function setShowThisQuery () {
-    if (isStorageSupported('localStorage')
-        && window.localStorage.show_this_query !== undefined
-        && window.localStorage.show_this_query === '1') {
-        $('input[name="show_query"]').prop('checked', true);
-        var db = $('input[name="db"]').val();
-        var table = $('input[name="table"]').val();
-        if (db === JSON.parse(window.localStorage.show_this_query_object).db
-            && table === JSON.parse(window.localStorage.show_this_query_object).table) {
-            if (codemirror_editor) {
-                codemirror_editor.setValue(JSON.parse(window.localStorage.show_this_query_object).query);
-            } else {
-                $('#sqlquery').val = JSON.parse(window.localStorage.show_this_query_object).query;
+    var db = $('input[name="db"]').val();
+    var table = $('input[name="table"]').val();
+    if (isStorageSupported('localStorage')) {
+        var stored_db = JSON.parse(window.localStorage.show_this_query_object).db;
+        var stored_table = JSON.parse(window.localStorage.show_this_query_object).table;
+        var stored_query = JSON.parse(window.localStorage.show_this_query_object).query;
+        if (window.localStorage.show_this_query !== undefined
+            && window.localStorage.show_this_query === '1') {
+            $('input[name="show_query"]').prop('checked', true);
+            if (db === stored_db && table === stored_table) {
+                if (codemirror_editor) {
+                    codemirror_editor.setValue(stored_query);
+                } else {
+                    document.sqlform.sql_query.value = stored_query;
+                }
             }
+        } else {
+            $('input[name="show_query"]').prop('checked', false);
         }
-    } else {
-        $('input[name="show_query"]').prop('checked', false);
     }
 }
 
@@ -445,6 +448,11 @@ AJAX.registerOnload('sql.js', function () {
         // import.php about what needs to be done
         $form.find('select[name=id_bookmark]').val('');
         // let normal event propagation happen
+        if (isStorageSupported('localStorage')) {
+            window.localStorage.removeItem('auto_saved_sql');
+        } else {
+            Cookies.set('auto_saved_sql', '');
+        }
         var isShowQuery =  $('input[name="show_query"').is(':checked');
         if (isShowQuery) {
             window.localStorage.show_this_query = '1';

--- a/libraries/classes/SqlQueryForm.php
+++ b/libraries/classes/SqlQueryForm.php
@@ -342,7 +342,7 @@ class SqlQueryForm
 
         $html .= '<div class="formelement">';
         $html .= '<input type="checkbox" name="show_query" value="1" '
-            . 'id="checkbox_show_query" tabindex="132" checked="checked" />'
+            . 'id="checkbox_show_query" tabindex="132"/>'
             . '<label for="checkbox_show_query">' . __('Show this query here again')
             . '</label>';
         $html .= '</div>';


### PR DESCRIPTION
No auto saved query everytime new sql page is loaded: fixes #14093
Fix bugs in SQL query restore after session expire: closes #14094
SQL tab already has a query loaded: fixes #14118
"Show this query here again" checkbox does not work: fixes #14144
Not showing previous query on clearing Codemirror and then clicking get saved query: fixes #14148
Not showing default query on changing table: fixes #14163
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
