### PR TITLE
notice class now appears on top of canvas as expected, …

### DIFF
--- a/themes/pmahomme/css/designer.css.php
+++ b/themes/pmahomme/css/designer.css.php
@@ -290,6 +290,7 @@ canvas.designer * {
     position: absolute;
     background-color: #fff;
     color: #000;
+    margin-top: 50px;
 }
 
 .designer_header {
@@ -476,6 +477,7 @@ a.active.trigger:hover {
     overflow: hidden;
     z-index: 50;
     padding: 2px;
+    margin-top: 50px;
 }
 
 .side-menu.right {


### PR DESCRIPTION
…added top-margin to osn_tab(canvas) and side-menu.

The notice class is fully visible now.
fixes #14133
  
![before](https://user-images.githubusercontent.com/29040076/38779647-e326b0aa-40e8-11e8-80a9-ea5e88a4febe.png)
![after](https://user-images.githubusercontent.com/29040076/38779648-e376b53c-40e8-11e8-9020-1bf53d5936af.png)



Signed-off-by: Amit Pakhare <ampmail1998@gmail.com>
