### PR TITLE
notice class now appears on top of canvas as expected,…

### DIFF
--- a/themes/pmahomme/css/designer.css.php
+++ b/themes/pmahomme/css/designer.css.php
@@ -290,6 +290,7 @@ canvas.designer * {
     position: absolute;
     background-color: #fff;
     color: #000;
+    margin-top: 50px; 
 }
 
 .designer_header {
@@ -476,6 +477,7 @@ a.active.trigger:hover {
     overflow: hidden;
     z-index: 50;
     padding: 2px;
+    margin-top: 50px; 
 }
 
 .side-menu.right {

--- a/themes/pmahomme/css/designer.css.php
+++ b/themes/pmahomme/css/designer.css.php
@@ -290,7 +290,7 @@ canvas.designer * {
     position: absolute;
     background-color: #fff;
     color: #000;
-    margin-top: 50px; 
+    margin-top: 50px;
 }
 
 .designer_header {
@@ -477,7 +477,7 @@ a.active.trigger:hover {
     overflow: hidden;
     z-index: 50;
     padding: 2px;
-    margin-top: 50px; 
+    margin-top: 50px;
 }
 
 .side-menu.right {


### PR DESCRIPTION
… added top-margin to osn_tab(canvas) and the side-menu
The notice class is fully visible now.
fixes #14133 
![before](https://user-images.githubusercontent.com/29040076/38780035-873deec4-40ee-11e8-93b0-07a7ac83ca57.png)
![after](https://user-images.githubusercontent.com/29040076/38780036-878e3654-40ee-11e8-986f-32bf5da44d6d.png)

Signed-off-by: Amit Pakhare <ampmail1998@gmail.com>

