### PR TITLE
notice class now appears on top of canvas as expected, …

### DIFF
--- a/themes/pmahomme/css/designer.css.php
+++ b/themes/pmahomme/css/designer.css.php
@@ -290,6 +290,7 @@ canvas.designer * {
     position: absolute;
     background-color: #fff;
     color: #000;
+    margin-top: 50px;
 }
 
 .designer_header {
@@ -476,6 +477,7 @@ a.active.trigger:hover {
     overflow: hidden;
     z-index: 50;
     padding: 2px;
+    margin-top: 50px;
 }
 
 .side-menu.right {


### PR DESCRIPTION
…added top-margin to the osn_tab(canvas) and the side-menu
The notice class is fully visible now.
fixes #14133 
![before](https://user-images.githubusercontent.com/29040076/38781172-167356d2-40ff-11e8-83ff-78b70c77470f.png)
![after](https://user-images.githubusercontent.com/29040076/38781173-16f16694-40ff-11e8-8058-e0ac63173252.png)

Signed-off-by: Amit Pakhare <ampmail1998@gmail.com>
