### PR TITLE
patch fixed for the datepickerui broken #14199

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -115,6 +115,8 @@ function PMA_addDatepicker ($this_element, type, options) {
         altFieldTimeOnly: false,
         showAnim: '',
         beforeShow: function (input, inst) {
+            //temporary adding the class for visible datepicker
+            $( ".responsivetable" ).removeClass('responsivetable').addClass('temp');
             // Remember that we came from the datepicker; this is used
             // in tbl_change.js by verificationsAfterFieldChange()
             $this_element.data('comes_from', 'datepicker');

--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -730,6 +730,8 @@ function PMA_makegrid (t, enableResize, enableReorder, enableVisib, enableGridEd
                 // change the cursor in edit box back to normal
                 // (the cursor become a hand pointer when we add datepicker)
                 $(g.cEdit).find('.edit_box').css('cursor', 'inherit');
+                // remvoing the temp class and adding table responsive back
+                $( ".temp" ).removeClass('temp').addClass('responsivetable');
             }
         },
 


### PR DESCRIPTION
Fixes #14199 
It is not a permanent solution but as of now, I could think of this option to make it go.

Implementation:
Removed the scroll frame when clicked on the date picker and add it back as soon as date picker is destroyed.

Signed-off-by: Akshil Shah <akshilshah4444@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
