### PR TITLE
Fix XML Export fatal error and add Move columns preview SQL

### DIFF
--- a/js/tbl_structure.js
+++ b/js/tbl_structure.js
@@ -297,14 +297,12 @@ AJAX.registerOnload('tbl_structure.js', function () {
             var $this = $(this);
             var $form = $this.find('form');
             var serialized = $form.serialize();
-
             // check if any columns were moved at all
             if (serialized === $form.data('serialized-unmoved')) {
                 PMA_ajaxRemoveMessage($msgbox);
                 $this.dialog('close');
                 return;
             }
-
             $.post($form.prop('action'), serialized + PMA_commonParams.get('arg_separator') + 'ajax_request=true', function (data) {
                 if (data.success === false) {
                     PMA_ajaxRemoveMessage($msgbox);
@@ -346,6 +344,11 @@ AJAX.registerOnload('tbl_structure.js', function () {
                     $this.dialog('close');
                 }
             });
+        };
+        button_options[PMA_messages.strPreviewSQL] = function () {
+            // Function for Previewing SQL
+            var $form = $('#move_column_form');
+            PMA_previewSQL($form);
         };
         button_options[PMA_messages.strCancel] = function () {
             $(this).dialog('close');

--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -54,7 +54,7 @@ class ExportXml extends ExportPlugin
     }
 
     /**
-     * Initialize the local variables that are used for export PDF
+     * Initialize the local variables that are used for export XML
      *
      * @return void
      */
@@ -62,7 +62,9 @@ class ExportXml extends ExportPlugin
     {
         global $table, $tables;
         $this->_setTable($table);
-        $this->_setTables($tables);
+        if (is_array($tables)) {
+            $this->_setTables($tables);
+        }
     }
 
     /**

--- a/templates/table/structure/move_columns_dialog.twig
+++ b/templates/table/structure/move_columns_dialog.twig
@@ -1,6 +1,6 @@
 <div id="move_columns_dialog" class="hide" title="{% trans 'Move columns' %}">
     <p>{% trans 'Move the columns by dragging them up and down.' %}</p>
-    <form action="tbl_structure.php">
+    <form action="tbl_structure.php" name="move_column_form" id="move_column_form">
         <div>
             {{ Url_getHiddenInputs(db, table) }}
             <ul></ul>


### PR DESCRIPTION
Signed-off-by: Piyush Vijay <piyushvijay.1997@gmail.com>
XML Export from single table throws fatal error (PHP 7.2): Fixes #14212 
Move columns preview SQL: Resolves #14155
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
