### PR TITLE
Patch for issue #14246

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -1577,6 +1577,11 @@ class DatabaseInterface
     {
         // If Zero configuration mode enabled, check PMA tables in current db.
         if ($GLOBALS['cfg']['ZeroConf'] == true) {
+            /**
+             * the DatabaseList class as a stub for the ListDatabase class
+             */
+            $GLOBALS['dblist'] = new DatabaseList();
+
             if (strlen($GLOBALS['db'])) {
                 $cfgRelation = $this->relation->getRelationsParam();
                 if (empty($cfgRelation['db'])) {

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -150,6 +150,20 @@ class DatabaseInterfaceTest extends PmaTestCase
     }
 
     /**
+     * Tests for DBI::postConnectControl() method.
+     *
+     * @return void
+     * @test
+     */
+    public function testPostConnectControl()
+    {
+        $GLOBALS['db'] = '';
+        $GLOBALS['cfg']['Server']['only_db'] = array();
+        $this->_dbi->postConnectControl();
+        $this->assertInstanceOf('PhpMyAdmin\Database\DatabaseList', $GLOBALS['dblist']);
+    }
+
+    /**
      * Test for getDbCollation
      *
      * @return void


### PR DESCRIPTION
```php
$GLOBALS['dblist']->databases->exists('phpmyadmin')
```
Is used but ```$GLOBALS['dblist']``` is not initialized.
I added in `postConnectControl()` :
```php
$GLOBALS['dblist'] = new DatabaseList();
```
Like it is done in `postConnect()`

This PR closes issue #14246 