### PR TITLE
Patch for #14257 CodeMirror hints hidden

### DIFF
--- a/themes/metro/css/codemirror.css.php
+++ b/themes/metro/css/codemirror.css.php
@@ -73,5 +73,5 @@ span.cm-number {
     margin-left: 1em;
 }
 .CodeMirror-hints {
-    z-index: 200;
+    z-index: 999;
 }

--- a/themes/pmahomme/css/codemirror.css.php
+++ b/themes/pmahomme/css/codemirror.css.php
@@ -73,7 +73,7 @@ span.cm-number {
     margin-left: 1em;
 }
 .CodeMirror-hints {
-    z-index: 200;
+    z-index: 999;
 }
 .CodeMirror-lint-tooltip {
     z-index: 200;


### PR DESCRIPTION
I have set `z-index` to 999 for `.CodeMirror-hints`
99 was not enough
Closes: #14257 