### PR TITLE
#14260 Fixed configuration for DefaultLang and Lang

### DIFF
--- a/libraries/classes/LanguageManager.php
+++ b/libraries/classes/LanguageManager.php
@@ -822,8 +822,8 @@ class LanguageManager
     public function selectLanguage()
     {
         // check forced language
-        if (! empty($GLOBALS['cfg']['Lang'])) {
-            $lang = $this->getLanguage($GLOBALS['cfg']['Lang']);
+        if (! empty($GLOBALS['PMA_Config']->get('Lang'))) {
+            $lang = $this->getLanguage($GLOBALS['PMA_Config']->get('Lang'));
             if ($lang !== false) {
                 return $lang;
             }
@@ -883,8 +883,8 @@ class LanguageManager
         }
 
         // Didn't catch any valid lang : we use the default settings
-        if (isset($langs[$GLOBALS['cfg']['DefaultLang']])) {
-            return $langs[$GLOBALS['cfg']['DefaultLang']];
+        if (isset($langs[$GLOBALS['PMA_Config']->get('DefaultLang')])) {
+            return $langs[$GLOBALS['PMA_Config']->get('DefaultLang')];
         }
 
         // Fallback to English

--- a/test/classes/LanguageTest.php
+++ b/test/classes/LanguageTest.php
@@ -158,25 +158,25 @@ class LanguageTest extends PmaTestCase
      */
     public function testSelect($lang, $post, $get, $cookie, $accept, $agent, $default, $expect)
     {
-        $GLOBALS['cfg']['Lang'] = $lang;
+        $GLOBALS['PMA_Config']->set('Lang', $lang);
         $_POST['lang'] = $post;
         $_GET['lang'] = $get;
         $_COOKIE['pma_lang'] = $cookie;
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept;
         $_SERVER['HTTP_USER_AGENT'] = $agent;
-        $GLOBALS['cfg']['DefaultLang'] = $default;
+        $GLOBALS['PMA_Config']->set('DefaultLang', $default);
 
         $lang = $this->manager->selectLanguage();
 
         $this->assertEquals($expect, $lang->getEnglishName());
 
-        $GLOBALS['cfg']['Lang'] = '';
+        $GLOBALS['PMA_Config']->set('Lang', '');
         $_POST['lang'] = '';
         $_GET['lang'] = '';
         $_COOKIE['pma_lang'] = '';
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = '';
         $_SERVER['HTTP_USER_AGENT'] = '';
-        $GLOBALS['cfg']['DefaultLang'] = 'en';
+        $GLOBALS['PMA_Config']->set('DefaultLang', 'en');
     }
 
     /**
@@ -191,6 +191,7 @@ class LanguageTest extends PmaTestCase
             array('', 'cs', '', '' ,'' ,'', '', 'Czech'),
             array('', 'cs', 'en', '' ,'' ,'', '', 'Czech'),
             array('', '', 'cs', '' ,'' ,'', '', 'Czech'),
+            array('', '', '', 'cs' ,'' ,'', '', 'Czech'),
             array('', '', '', '' ,'cs,en-US;q=0.7,en;q=0.3' ,'', '', 'Czech'),
             array(
                 '', '', '', '', '',


### PR DESCRIPTION

`$GLOBALS['cfg']` is not set before :
https://github.com/phpmyadmin/phpmyadmin/blob/bb9fc5d6e970c7a72d8888175074121816cd7792/libraries/common.inc.php#L287
So `$GLOBALS['cfg']` cannot be used in
https://github.com/phpmyadmin/phpmyadmin/blob/bb9fc5d6e970c7a72d8888175074121816cd7792/libraries/common.inc.php#L255

https://github.com/phpmyadmin/phpmyadmin/blob/bb9fc5d6e970c7a72d8888175074121816cd7792/libraries/classes/LanguageManager.php#L822-L831

And

https://github.com/phpmyadmin/phpmyadmin/blob/bb9fc5d6e970c7a72d8888175074121816cd7792/libraries/classes/LanguageManager.php#L886-L892


# Solution
Migrate to `$GLOBALS['PMA_Config']->get('nameofkey')` instead of `$GLOBALS['cfg']['nameofkey']`

# More info

Unit tests never failed because the globals where setup for the test.
I updated the test and added a test case that was not covered (cookie test case)


Closes: #14260