### PR TITLE
Require a polyfill instead of the cytpe extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "ext-xml": "*",
         "ext-pcre": "*",
         "ext-json": "*",
-        "ext-ctype": "*",
         "ext-hash": "*",
         "phpmyadmin/sql-parser": "^4.2.3",
         "phpmyadmin/motranslator": "^4.0",
@@ -55,7 +54,8 @@
         "twig/twig": "^1.34",
         "twig/extensions": "~1.5.1",
         "symfony/expression-language": "^3.2",
-        "symfony/polyfill-mbstring": "^1.3"
+        "symfony/polyfill-mbstring": "^1.3",
+        "symfony/polyfill-ctype": "^1.8"
     },
     "conflict": {
         "phpseclib/phpseclib": "2.0.8",


### PR DESCRIPTION
Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them

Ctype is an indirect dependency due to twig,  and it isn't resolved there until a later version than we require.
By requiring the symfony polyfill for cytpe everything will still run, regardless of the ctype availability. 

Twig will require this polyfill itself in a later version, but this makes sure we still allow earlier versions of twig to be used.

Signed-off-by: Gert de Pagter <BackEndTea@gmail.com>