### PR TITLE
fixes broken links to icons in the setup page

### DIFF
--- a/libraries/classes/Config/FormDisplayTemplate.php
+++ b/libraries/classes/Config/FormDisplayTemplate.php
@@ -163,7 +163,7 @@ class FormDisplayTemplate
                 'edit'   => array('b_edit.png',   ''),
                 'help'   => array('b_help.png',   __('Documentation')),
                 'reload' => array('s_reload.png', ''),
-                'tblops' => array('b_tblops.png', '')
+                'tblops' => array('b_tblops', '')
             );
             if ($is_setup_script) {
                 // When called from the setup script, we don't have access to the

--- a/libraries/classes/Config/FormDisplayTemplate.php
+++ b/libraries/classes/Config/FormDisplayTemplate.php
@@ -160,10 +160,10 @@ class FormDisplayTemplate
             // The first element contains the filename and the second
             // element is used for the "alt" and "title" attributes.
             $icon_init = array(
-                'edit'   => array('b_edit',   ''),
-                'help'   => array('b_help',   __('Documentation')),
-                'reload' => array('s_reload', ''),
-                'tblops' => array('b_tblops', '')
+                'edit'   => array('b_edit.png',   ''),
+                'help'   => array('b_help.png',   __('Documentation')),
+                'reload' => array('s_reload.png', ''),
+                'tblops' => array('b_tblops.png', '')
             );
             if ($is_setup_script) {
                 // When called from the setup script, we don't have access to the


### PR DESCRIPTION
fixes broken links to icons in the setup page

- [ ] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests