### PR TITLE
Remove md5 twig extension

### DIFF
--- a/libraries/classes/Controllers/Database/DatabaseStructureController.php
+++ b/libraries/classes/Controllers/Database/DatabaseStructureController.php
@@ -659,6 +659,8 @@ class DatabaseStructureController extends DatabaseController
                 Template::get('database/structure/structure_table_row')
                     ->render(
                         array(
+                            'table_name_hash'       => md5($current_table['TABLE_NAME']),
+                            'db_table_name_hash'    => md5($this->db . '.' . $current_table['TABLE_NAME']),
                             'db'                    => $this->db,
                             'curr'                  => $i,
                             'input_class'           => implode(' ', $input_class),

--- a/libraries/classes/Controllers/Table/TableRelationController.php
+++ b/libraries/classes/Controllers/Table/TableRelationController.php
@@ -189,6 +189,7 @@ class TableRelationController extends TableController
                 || ! empty($column['Key'])
             ) {
                 $column_array[$column['Field']] = $column['Field'];
+                $column_array[$column['Field'] . '_hash'] = md5($column['Field']);
             }
         }
         if ($GLOBALS['cfg']['NaturalOrder']) {

--- a/libraries/classes/Controllers/Table/TableSearchController.php
+++ b/libraries/classes/Controllers/Table/TableSearchController.php
@@ -371,11 +371,18 @@ class TableSearchController extends TableController
                 __('Browse foreign values')
             )
         );
+        $column_names_hashes = [];
+
+        foreach ($this->_columnNames as $columnName) {
+            $column_names_hashes[$columnName] = md5($columnName);
+        }
+
         $this->response->addHTML(
             Template::get('table/search/zoom_result_form')->render([
                 'db' => $this->db,
                 'table' => $this->table,
                 'column_names' => $this->_columnNames,
+                'column_names_hashes' => $column_names_hashes,
                 'foreigners' => $this->_foreigners,
                 'column_null_flags' => $this->_columnNullFlags,
                 'column_types' => $this->_columnTypes,

--- a/libraries/classes/Twig/PhpFunctionsExtension.php
+++ b/libraries/classes/Twig/PhpFunctionsExtension.php
@@ -30,7 +30,6 @@ class PhpFunctionsExtension extends AbstractExtension
             new TwigFunction('array_search', 'array_search'),
             new TwigFunction('bin2hex', 'bin2hex'),
             new TwigFunction('htmlentities', 'htmlentities'),
-            new TwigFunction('md5', 'md5'),
             new TwigFunction('preg_quote', 'preg_quote'),
             new TwigFunction('preg_replace', 'preg_replace'),
             new TwigFunction('strpos', 'strpos'),

--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -28,8 +28,8 @@
                 ((already_favorite ? 'remove' : 'add') ~ '_favorite'): true
             } %}
             {% include 'database/structure/favorite_anchor.twig' with {
-                'table_name_hash': md5(current_table['TABLE_NAME']),
-                'db_table_name_hash': md5(db ~ '.' ~ current_table['TABLE_NAME']),
+                'table_name_hash': table_name_hash,
+                'db_table_name_hash': db_table_name_hash,
                 'fav_params': fav_params,
                 'already_favorite': already_favorite,
                 'titles': titles
@@ -184,28 +184,6 @@
         {% endif %}
 
     {% else %}
-        {% set count = 0 %}
-        {% if properties_num_columns %}
-            {% set count = count + 2 %}
-        {% endif %}
-        {% if is_show_stats %}
-            {% set count = count + 2 %}
-        {% endif %}
-        {% if show_charset %}
-            {% set count = count + 1 %}
-        {% endif %}
-        {% if show_comment %}
-            {% set count = count + 1 %}
-        {% endif %}
-        {% if show_creation %}
-            {% set count = count + 1 %}
-        {% endif %}
-        {% if show_last_update %}
-            {% set count = count + 1 %}
-        {% endif %}
-        {% if show_last_check %}
-            {% set count = count + 1 %}
-        {% endif %}
 
         {% if db_is_system_schema %}
             {% set action_colspan = 3 %}

--- a/templates/table/relation/common_form.twig
+++ b/templates/table/relation/common_form.twig
@@ -117,7 +117,7 @@
                         {% set myfield = save_row[i]['Field'] %}
                         {# Use an md5 as array index to avoid having special characters
                            in the name attribute (see bug #1746964 ) #}
-                        {% set myfield_md5 = md5(myfield) %}
+                        {% set myfield_md5 = column_array[myfield ~ '_hash'] %}
 
                         {% set foreign_table = false %}
                         {% set foreign_column = false %}

--- a/templates/table/search/zoom_result_form.twig
+++ b/templates/table/search/zoom_result_form.twig
@@ -65,7 +65,7 @@
                                 'in_zoom_search_edit': true,
                                 'foreigners': foreigners,
                                 'column_name': field_popup,
-                                'column_name_hash': md5(field_popup),
+                                'column_name_hash': column_name_hashes[field_popup],
                                 'foreign_data': foreign_data,
                                 'table': table,
                                 'column_index': column_index,


### PR DESCRIPTION
Adapt templates to remove md5 from PhpFuncionsExtension.php

Signed-off-by: Leonardo Strozzi <laps15@inf.ufpr.br>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
