### PR TITLE
Fix #14323, Parse type error when exporting

### DIFF
--- a/export.php
+++ b/export.php
@@ -217,7 +217,7 @@ $compression_methods = array(
 /**
  * init and variable checking
  */
-$compression = false;
+$compression = '';
 $onserver = false;
 $save_on_server = false;
 $buffer_needed = false;


### PR DESCRIPTION
This FIX an error exporting databases, bug #14323.

libraries/clases/Export.php::getFilenameAndMimetype():278

Before submitting pull request, please check that every commit:
Signed-off-by: Dave Macías Hurtado<TheDave86@hotmail.com>

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
