### PR TITLE
Declare strict type issue in export.php fix

### DIFF
--- a/export.php
+++ b/export.php
@@ -1,11 +1,12 @@
 <?php
+declare(strict_types=1);
 /* vim: set expandtab sw=4 ts=4 sts=4: */
 /**
  * Main export handling code
  *
  * @package PhpMyAdmin
  */
-declare(strict_types=1);
+
 
 use PhpMyAdmin\Core;
 use PhpMyAdmin\Encoding;
@@ -217,7 +218,7 @@ $compression_methods = array(
 /**
  * init and variable checking
  */
-$compression = false;
+$compression = '';
 $onserver = false;
 $save_on_server = false;
 $buffer_needed = false;


### PR DESCRIPTION
While trying to export the following two errors were found in export.php

PHP Fatal error:  Uncaught TypeError: Argument 4 passed to PhpMyAdmin\\Export::getFilenameAndMimetype() must be of the type string, boolean given

PHP Fatal error:  strict_types declaration must be the very first statement in the script

Signed-off-by: Aswani Prakash <aswani15prakash@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
