### PR TITLE
New features for csv import plugin

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -1005,6 +1005,29 @@ AJAX.registerOnload('functions.js', function () {
 AJAX.registerTeardown('functions.js', function () {
     $(document).off('click', 'input:checkbox.checkall');
 });
+AJAX.registerOnload('functions.js', function(){
+    if($("#new_csv_db_name").length > 0) {
+        var params = {
+            'ajax_request' : true,
+            'server' : PMA_commonParams.get('server'),
+            'db' : $("#new_csv_db_name").val(),
+            'table' : $("#new_csv_tbl_name").val(),
+            'table_type' : 'table',
+            'selected_fld' : $("#new_csv_tblcol_names").val().split(","),
+            'submit_mult' : 'change'
+        };
+        $.ajax({
+            type: 'POST',
+            url: 'tbl_structure.php',
+            data: params,
+            success: function (data) {
+                if (data.success) {
+                    $("<h3>You can change the table structure here</h3>" + data.message).insertAfter($("#new_csv_db_name").parent());
+                }
+            }
+        });
+    }
+});
 AJAX.registerOnload('functions.js', function () {
     /**
      * Row marking in horizontal mode (use "on" so that it works also for

--- a/js/functions.js
+++ b/js/functions.js
@@ -1005,29 +1005,7 @@ AJAX.registerOnload('functions.js', function () {
 AJAX.registerTeardown('functions.js', function () {
     $(document).off('click', 'input:checkbox.checkall');
 });
-AJAX.registerOnload('functions.js', function(){
-    if($("#new_csv_db_name").length > 0) {
-        var params = {
-            'ajax_request' : true,
-            'server' : PMA_commonParams.get('server'),
-            'db' : $("#new_csv_db_name").val(),
-            'table' : $("#new_csv_tbl_name").val(),
-            'table_type' : 'table',
-            'selected_fld' : $("#new_csv_tblcol_names").val().split(","),
-            'submit_mult' : 'change'
-        };
-        $.ajax({
-            type: 'POST',
-            url: 'tbl_structure.php',
-            data: params,
-            success: function (data) {
-                if (data.success) {
-                    $("<h3>You can change the table structure here</h3>" + data.message).insertAfter($("#new_csv_db_name").parent());
-                }
-            }
-        });
-    }
-});
+
 AJAX.registerOnload('functions.js', function () {
     /**
      * Row marking in horizontal mode (use "on" so that it works also for

--- a/js/import.js
+++ b/js/import.js
@@ -60,6 +60,8 @@ AJAX.registerOnload('import.js', function () {
         var radioLocalImport = $('#radio_local_import_file');
         var radioImport = $('#radio_import_file');
         var fileMsg = '<div class="error"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error" /> ' + PMA_messages.strImportDialogMessage + '</div>';
+        var wrongTblNameMsg = '<div class="error"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error" />Please enter a valid table name</div>';
+        var wrongDBNameMsg = '<div class="error"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error" />Please enter a valid database name</div>';
 
         if (radioLocalImport.length !== 0) {
             // remote upload.
@@ -88,6 +90,20 @@ AJAX.registerOnload('import.js', function () {
                 $('#input_import_file').trigger('focus');
                 PMA_ajaxShowMessage(fileMsg, false);
                 return false;
+            }
+            if($("#text_csv_new_tbl_name").length > 0) {
+                var newTblName = $("#text_csv_new_tbl_name").val();
+                if(newTblName.length > 0 && $.trim(newTblName).length === 0) {
+                    PMA_ajaxShowMessage(wrongTblNameMsg, false);
+                    return false;
+                }
+            }
+            if($("#text_csv_new_db_name").length > 0) {
+                var newDBName = $("#text_csv_new_db_name").val();
+                if(newDBName.length > 0 && $.trim(newDBName).length === 0) {
+                    PMA_ajaxShowMessage(wrongDBNameMsg, false);
+                    return false;
+                }
             }
         }
 

--- a/js/import.js
+++ b/js/import.js
@@ -91,16 +91,16 @@ AJAX.registerOnload('import.js', function () {
                 PMA_ajaxShowMessage(fileMsg, false);
                 return false;
             }
-            if($("#text_csv_new_tbl_name").length > 0) {
-                var newTblName = $("#text_csv_new_tbl_name").val();
-                if(newTblName.length > 0 && $.trim(newTblName).length === 0) {
+            if ($('#text_csv_new_tbl_name').length > 0) {
+                var newTblName = $('#text_csv_new_tbl_name').val();
+                if (newTblName.length > 0 && $.trim(newTblName).length === 0) {
                     PMA_ajaxShowMessage(wrongTblNameMsg, false);
                     return false;
                 }
             }
-            if($("#text_csv_new_db_name").length > 0) {
-                var newDBName = $("#text_csv_new_db_name").val();
-                if(newDBName.length > 0 && $.trim(newDBName).length === 0) {
+            if ($('#text_csv_new_db_name').length > 0) {
+                var newDBName = $('#text_csv_new_db_name').val();
+                if (newDBName.length > 0 && $.trim(newDBName).length === 0) {
                     PMA_ajaxShowMessage(wrongDBNameMsg, false);
                     return false;
                 }

--- a/js/import.js
+++ b/js/import.js
@@ -60,8 +60,8 @@ AJAX.registerOnload('import.js', function () {
         var radioLocalImport = $('#radio_local_import_file');
         var radioImport = $('#radio_import_file');
         var fileMsg = '<div class="error"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error" /> ' + PMA_messages.strImportDialogMessage + '</div>';
-        var wrongTblNameMsg = '<div class="error"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error" />Please enter a valid table name</div>';
-        var wrongDBNameMsg = '<div class="error"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error" />Please enter a valid database name</div>';
+        var wrongTblNameMsg = '<div class="error"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error" />' + PMA_messages.strTableNameDialogMessage + '</div>';
+        var wrongDBNameMsg = '<div class="error"><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error" />' + PMA_messages.strDBNameDialogMessage + '</div>';
 
         if (radioLocalImport.length !== 0) {
             // remote upload.

--- a/js/messages.php
+++ b/js/messages.php
@@ -329,6 +329,10 @@ $js_messages['strImport'] = __('Import');
 $js_messages['strImportDialogTitle'] = __('Import monitor configuration');
 $js_messages['strImportDialogMessage']
     = __('Please select the file you want to import.');
+$js_messages['strTableNameDialogMessage']
+    = __('Please enter a valid table name.');
+$js_messages['strDBNameDialogMessage']
+    = __('Please enter a valid database name.');
 $js_messages['strNoImportFile'] = __('No files available on server for import!');
 
 $js_messages['strAnalyzeQuery'] = __('Analyse query');

--- a/libraries/classes/Plugins.php
+++ b/libraries/classes/Plugins.php
@@ -497,10 +497,10 @@ class Plugins
                     }
                     $ret .= '>' . self::getString($val) . '</option>';
                 }
+
                 $ret .= '</select>';
                 break;
             case 'PhpMyAdmin\Properties\Options\Items\TextPropertyItem':
-            case 'PhpMyAdmin\Properties\Options\Items\NumberPropertyItem':
                 $ret .= '<li>' . "\n";
                 $ret .= '<label for="text_' . $plugin_name . '_'
                 . $propertyItem->getName() . '" class="desc">'
@@ -519,6 +519,22 @@ class Plugins
                     . ($propertyItem->getLen() != null
                     ? ' maxlength="' . $propertyItem->getLen() . '"'
                     : '')
+                    . ' />';
+                break;
+            case 'PhpMyAdmin\Properties\Options\Items\NumberPropertyItem':
+                $ret .= '<li>' . "\n";
+                $ret .= '<label for="number_' . $plugin_name . '_'
+                    . $propertyItem->getName() . '" class="desc">'
+                    . self::getString($propertyItem->getText()) . '</label>';
+                $ret .= '<input type="number" name="' . $plugin_name . '_'
+                    . $propertyItem->getName() . '"'
+                    . ' value="' . self::getDefault(
+                        $section,
+                        $plugin_name . '_' . $propertyItem->getName()
+                    ) . '"'
+                    . ' id="number_' . $plugin_name . '_'
+                    . $propertyItem->getName() . '"'
+                    . ' min="0"'
                     . ' />';
                 break;
             default:

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -624,12 +624,12 @@ class ImportCsv extends AbstractImportCsv
                     $i = 0;
                     $lasti = -1;
                     $ch = mb_substr($buffer, 0, 1);
-                    if($max_lines > 0 && $line == $max_lines_constraint){
+                    if($max_lines > 0 && $line == $max_lines_constraint) {
                         break;
                     }
                 }
             } // End of parser loop
-            if($max_lines > 0 && $line == $max_lines_constraint){
+            if($max_lines > 0 && $line == $max_lines_constraint) {
                 break;
             }
         } // End of import loop

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -60,6 +60,24 @@ class ImportCsv extends AbstractImportCsv
         $this->properties->setExtension('csv');
 
         if ($GLOBALS['plugin_param'] !== 'table') {
+            $leaf = new TextPropertyItem(
+                "new_tbl_name",
+                __(
+                    'Name of the new table: '
+                )
+            );
+            $generalOptions->addProperty($leaf);
+
+            if($GLOBALS['plugin_param'] === 'server') {
+                $leaf = new TextPropertyItem(
+                    "new_db_name",
+                    __(
+                        'Name of the new database: '
+                    )
+                );
+            }
+
+            $generalOptions->addProperty($leaf);
             $leaf = new BoolPropertyItem(
                 "col_names",
                 __(
@@ -617,7 +635,11 @@ class ImportCsv extends AbstractImportCsv
                 }
             }
 
-            if (mb_strlen((string) $db)) {
+            if (isset($_REQUEST['csv_new_tbl_name'])
+                && strlen($_REQUEST['csv_new_tbl_name']) > 0
+            ) {
+                $tbl_name = $_REQUEST['csv_new_tbl_name'];
+            } else if (mb_strlen($db)) {
                 $result = $GLOBALS['dbi']->fetchResult('SHOW TABLES');
                 $tbl_name = 'TABLE ' . (count($result) + 1);
             } else {
@@ -644,8 +666,19 @@ class ImportCsv extends AbstractImportCsv
              * array $options = an associative array of options
              */
 
-            /* Set database name to the currently selected one, if applicable */
-            list($db_name, $options) = $this->getDbnameAndOptions($db, 'CSV_DB');
+            /* Set database name to the currently selected one, if applicable,
+             * Otherwise, check if user provided the database name in the request,
+             * if not, set the default name
+             */
+            if(isset($_REQUEST['csv_new_db_name'])
+                && strlen($_REQUEST['csv_new_db_name']) > 0
+            ) {
+                $newDb = $_REQUEST['csv_new_db_name'];
+            } else {
+                $result = $GLOBALS['dbi']->fetchResult('SHOW DATABASES');
+                $newDb = 'CSV_DB ' . (count($result) + 1);
+            }
+            list($db_name, $options) = $this->getDbnameAndOptions($db, $newDb);
 
             /* Non-applicable parameters */
             $create = null;

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -97,6 +97,14 @@ class ImportCsv extends AbstractImportCsv
             );
             $generalOptions->addProperty($leaf);
         } else {
+            $leaf = new NumberPropertyItem(
+                "partial_import",
+                __(
+                    'Import these many number of rows(optional): '
+                )
+            );
+            $generalOptions->addProperty($leaf);
+
             $hint = new Message(
                 __(
                     'If the data in each row of the file is not'
@@ -625,11 +633,13 @@ class ImportCsv extends AbstractImportCsv
                     $lasti = -1;
                     $ch = mb_substr($buffer, 0, 1);
                     if($max_lines > 0 && $line == $max_lines_constraint) {
+                        $finished = 1;
                         break;
                     }
                 }
             } // End of parser loop
             if($max_lines > 0 && $line == $max_lines_constraint) {
+                $finished = 1;
                 break;
             }
         } // End of import loop

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -713,6 +713,7 @@ class ImportCsv extends AbstractImportCsv
                 $newDb = $_REQUEST['csv_new_db_name'];
             } else {
                 $result = $GLOBALS['dbi']->fetchResult('SHOW DATABASES');
+                if(! is_array($result)) $result = [];
                 $newDb = 'CSV_DB ' . (count($result) + 1);
             }
             list($db_name, $options) = $this->getDbnameAndOptions($db, $newDb);

--- a/test/classes/Plugins/Import/ImportCsvTest.php
+++ b/test/classes/Plugins/Import/ImportCsvTest.php
@@ -120,11 +120,48 @@ class ImportCsvTest extends PmaTestCase
 
         //asset that all sql are executed
         $this->assertContains(
-            'CREATE DATABASE IF NOT EXISTS `CSV_DB` DEFAULT CHARACTER',
+            'CREATE DATABASE IF NOT EXISTS `CSV_DB 1` DEFAULT CHARACTER',
             $sql_query
         );
         $this->assertContains(
-            'CREATE TABLE IF NOT EXISTS `CSV_DB`.`TBL_NAME`',
+            'CREATE TABLE IF NOT EXISTS `CSV_DB 1`.`TBL_NAME`',
+            $sql_query
+        );
+
+        $this->assertEquals(
+            true,
+            $GLOBALS['finished']
+        );
+    }
+
+    /**
+     * Test for partial import/setting table and database names in doImport
+     *
+     * @return void
+     *
+     * @group medium
+     */
+    public function testDoPartialImport()
+    {
+        //$sql_query_disabled will show the import SQL detail
+        global $sql_query, $sql_query_disabled;
+        $sql_query_disabled = false;
+
+        $GLOBALS['import_file'] = 'test/test_data/db_test_partial_import.csv';
+        $_REQUEST['csv_new_tbl_name'] = 'ImportTestTable';
+        $_REQUEST['csv_new_db_name'] = 'ImportTestDb';
+        $_REQUEST['csv_partial_import'] = 5;
+
+        //Test function called
+        $this->object->doImport();
+
+        //asset that all sql are executed
+        $this->assertContains(
+            'CREATE DATABASE IF NOT EXISTS `ImportTestDb` DEFAULT CHARACTER',
+            $sql_query
+        );
+        $this->assertContains(
+            'CREATE TABLE IF NOT EXISTS `ImportTestDb`.`ImportTestTable`',
             $sql_query
         );
 
@@ -174,12 +211,12 @@ class ImportCsvTest extends PmaTestCase
 
         //asset that all sql are executed
         $this->assertContains(
-            'CREATE DATABASE IF NOT EXISTS `CSV_DB` DEFAULT CHARACTER',
+            'CREATE DATABASE IF NOT EXISTS `CSV_DB 1` DEFAULT CHARACTER',
             $sql_query
         );
 
         $this->assertContains(
-            'CREATE TABLE IF NOT EXISTS `CSV_DB`.`TBL_NAME`',
+            'CREATE TABLE IF NOT EXISTS `CSV_DB 1`.`TBL_NAME`',
             $sql_query
         );
 


### PR DESCRIPTION
Following new features have been added in the csv import plugin:
1. For a new import, user can now directly enter the table or database name at the time of import
2. Partial import. User can enter how many rows they want to import.
Signed-Off-By: Lakshay arora <arora.lakshya123@gmail.com>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
