### PR TITLE
Composer install instead of update

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -114,14 +114,14 @@ Additionally you need to install dependencies using the `Composer tool`_:
 
 .. code-block:: sh
 
-    composer update
+    composer install
 
 If you do not intend to develop, you can skip the installation of developer tools
 by invoking:
 
 .. code-block:: sh
 
-    composer update --no-dev
+    composer install --no-dev
 
 .. _composer:
 


### PR DESCRIPTION
I suggest to use `composer install` here. With `composer update`, last versions of dependencies will be installed and it could potentially break something into the code that is actually incompatible with latest versions of some of those dependencies.

https://getcomposer.org/doc/03-cli.md#install


Signed-off-by: Simeon Bobylev <simeon.bobylev@gmail.com>