### PR TITLE
Add phpstan / finding errors in php code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ matrix:
       env: CI_MODE=docs
     - php: "7.1"
       env: CI_MODE=apidocs
+    - php: "7.2"
+      env: CI_MODE=phpstan
     - os: osx
       language: generic
       env: CI_MODE=test
@@ -80,6 +82,8 @@ matrix:
   allow_failures:
     - php: "nightly"
       env: CI_MODE=test
+    - php: "7.2"
+      env: CI_MODE=phpstan
 
 cache:
   pip: true

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,8 @@
         "pragmarx/google2fa": "^3.0",
         "bacon/bacon-qr-code": "^1.0",
         "samyoul/u2f-php-server": "^1.1",
-        "phpmyadmin/coding-standard": "^0.3"
+        "phpmyadmin/coding-standard": "^0.3",
+        "phpstan/phpstan": "^0.9.2"
     },
     "extra": {
         "branch-alias": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    bootstrap: %rootDir%/../../../test/bootstrap-phpstan.php
+    ignoreErrors:
+        - '#Unexpected token "&", expected TOKEN_VARIABLE at offset#'
+    excludes_analyse:
+        - %rootDir%/../../../tmp/*
+        - %rootDir%/../../../vendor/*

--- a/test/bootstrap-phpstan.php
+++ b/test/bootstrap-phpstan.php
@@ -1,0 +1,19 @@
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * Bootstrap file for phpstan
+ *
+ * @package PhpMyAdmin-test
+ */
+declare(strict_types=1);
+
+define('PHPMYADMIN', true);
+define('TESTSUITE', true);
+
+require_once 'libraries/config.default.php';
+$GLOBALS['cfg'] = $cfg;
+$GLOBALS['server'] = 0;
+
+\PhpMyAdmin\MoTranslator\Loader::loadFunctions();
+
+\PhpMyAdmin\DatabaseInterface::load();

--- a/test/ci-install-phpstan
+++ b/test/ci-install-phpstan
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+composer install --no-interaction

--- a/test/ci-phpstan
+++ b/test/ci-phpstan
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cd $(dirname $0)/../
+echo "Running in : $(pwd)"
+
+# 1G is a litte high, should use < 512M (less ram + a lot of code = bigger risk of crash)
+./vendor/bin/phpstan analyse ./ --configuration=phpstan.neon --level=0 --memory-limit=1G


### PR DESCRIPTION
# This PR is a proposal

Using `phpstan/phpstan` would help solving issues since strict mode is now enabled.

I intentionally put `--level=max` to show all errors, this mode goes very far in analysis.

Try levels from 0 to 7 or max.

Many errors found by `phpstan` can be fixed (IMO).

Other can be hidden :)

## Manual launch
`./vendor/bin/phpstan analyse ./ --level=max --memory-limit=1G --configuration=phpstan.neon`

`./` can be `./libraries ./test ./*.php` ...

`bootstrap.php` file is needed, otherwise `phpstan` will crash (no time to find why, maybe constants).

`PhpMyAdmin\MoTranslator\Loader::loadFunctions()` is required to avoid having errors for undefined function with code like: `__("blablabla");`

See : https://github.com/phpstan/phpstan