### PR TITLE
Fix for #14295

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,6 +21,7 @@ use PhpMyAdmin\Server\Select;
 use PhpMyAdmin\ThemeManager;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
+use PhpMyAdmin\UserPreferences;
 
 /**
  * Gets some core libraries and displays a top message if required
@@ -73,6 +74,12 @@ if (isset($_POST['set_theme'])) {
     $tmanager = ThemeManager::getInstance();
     $tmanager->setActiveTheme($_POST['set_theme']);
     $tmanager->setThemeCookie();
+
+    $userPreferences = new UserPreferences();
+    $prefs = $userPreferences->load();
+    $prefs["config_data"]["ThemeDefault"] = $_POST['set_theme'];
+    $userPreferences->save($prefs["config_data"]);
+
     header('Location: index.php' . Url::getCommonRaw());
     exit();
 }


### PR DESCRIPTION
Fixes: #14295

This is not the best way of fixing this issue.

Concurrent browsers keep overwriting the phpmyadmin config, the last to refresh has it's config written to phpmyadmin config database.

It is not clear what must be the last one to decide in theme selection. Cookie, PMA DB ?

Why the theme cookie is deleted if the theme is the default one, and why the theme it is not written into PMA DB if default one ?

**I need clarifications on theme selection process ...**

Why `original`, what if `original` is deleted in theme folder ?
https://github.com/phpmyadmin/phpmyadmin/blob/2a34c018633764ab0149d453dd2c8bfc8e79396f/libraries/classes/Config.php#L956-L970