### PR TITLE
Prevent reposting of javascript errors

### DIFF
--- a/js/error_report.js
+++ b/js/error_report.js
@@ -15,6 +15,10 @@ var ErrorReport = {
      * @return void
      */
     error_handler: function (exception) {
+        // issue: 14359
+        if (JSON.stringify(ErrorReport._last_exception) === JSON.stringify(exception)) {
+            return;
+        }
         if (exception.name === null || typeof(exception.name) === 'undefined') {
             exception.name = ErrorReport._extractExceptionName(exception);
         }


### PR DESCRIPTION
Prevent reposting of javascript errors.

If an error is from the error handler then it will be caught by the error handler that will re-error and so on, forever.
#infiniteloop
This PR stops that behavior.

Closes: #14359 