### PR TITLE
[5.0.0-dev] export default value vars type

### DIFF
--- a/export.php
+++ b/export.php
@@ -517,10 +517,10 @@ do {
             $allrows = '';
         }
         if (! isset($limit_to)) {
-            $limit_to = 0;
+            $limit_to = '0';
         }
         if (! isset($limit_from)) {
-            $limit_from = 0;
+            $limit_from = '0';
         }
         if (isset($lock_tables)) {
             try {


### PR DESCRIPTION
Fatal error: Uncaught TypeError: Argument 13 passed to PhpMyAdmin\Export::exportTable() must be of the type string, integer given, called in \myadmin\export.php on line 566 and defined in \myadmin\libraries\classes\Export.php:893

limit_to and limit_from require string in Export class

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
