### PR TITLE
Patch - missed instance of 'Avoid passing extension to Util::getImage' and GIS icon

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -5282,7 +5282,7 @@ class Results
                         'tbl_gis_visualization.php'
                         . Url::getCommon($_url_params),
                         Util::getIcon(
-                            'b_globe.gif',
+                            'b_globe',
                             __('Visualize GIS data'),
                             true
                         )

--- a/libraries/classes/Navigation/Navigation.php
+++ b/libraries/classes/Navigation/Navigation.php
@@ -241,7 +241,7 @@ class Navigation
                         $html .= '<td style="width:80px"><a href="navigation.php'
                             . Url::getCommon($params) . '"'
                             . ' class="unhideNavItem ajax">'
-                            . Util::getIcon('show.png', __('Show'))
+                            . Util::getIcon('show', __('Show'))
                             . '</a></td>';
                     }
                     $html .= '</tbody></table>';

--- a/themes/pmahomme/css/icons.css.php
+++ b/themes/pmahomme/css/icons.css.php
@@ -45,6 +45,7 @@ if (! defined('PHPMYADMIN') && ! defined('TESTSUITE')) {
 .ic_b_find_replace { background-image: url('<?= $theme->getImgPath('b_find_replace.png'); ?>'); }
 .ic_b_firstpage { background-image: url('<?= $theme->getImgPath('b_firstpage.png'); ?>'); }
 .ic_b_ftext { background-image: url('<?= $theme->getImgPath('b_ftext.png'); ?>'); }
+.ic_b_globe { background-image: url('<?= $theme->getImgPath('b_globe.gif'); ?>'); }
 .ic_b_group { background-image: url('<?= $theme->getImgPath('b_group.png'); ?>'); }
 .ic_b_help { background-image: url('<?= $theme->getImgPath('b_help.png'); ?>'); }
 .ic_b_home { background-image: url('<?= $theme->getImgPath('b_home.png'); ?>'); }


### PR DESCRIPTION
Patch for commit https://github.com/phpmyadmin/phpmyadmin/commit/bed6fb4ebdc5f83ed30fe3e83e380baf24ed2fa5


Fixes: #14390 "[4.8] Can't unhide tables"
Closes: #14382 "Visualize GIS data" icon missing
