### PR TITLE
Proposal to fix HTTPS/HTTP cookie separation issue

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -1432,6 +1432,20 @@ class Config
     }
 
     /**
+     * removes cookie
+     *
+     * @param string $cookieName name of cookie to remove
+     *
+     * @return void
+     */
+    public function unsetCookie(string $cookieName): void
+    {
+        if ($this->issetCookie($cookieName)) {
+            unset($_COOKIE[$this->getCookieName($cookieName)]);
+        }
+    }
+
+    /**
      * sets cookie if value is different from current cookie value,
      * or removes if value is equal to default
      *
@@ -1482,7 +1496,7 @@ class Config
                 return true;
             }
             return setcookie(
-                $cookie,
+                $this->getCookieName($cookie),
                 $value,
                 $validity,
                 $this->getRootPath(),
@@ -1496,6 +1510,37 @@ class Config
         return true;
     }
 
+    /**
+     * get cookie
+     *
+     * @param string $cookieName   name of cookie to get
+     *
+     * @return mixed result of getCookie()
+     */
+    public function getCookie(string $cookieName) {
+        return @$_COOKIE[$this->getCookieName($cookieName)];
+    }
+
+    /**
+     * Get the real cookie name
+     *
+     * @param string $cookieName The name of the cookie
+     * @return string
+     */
+    public function getCookieName(string $cookieName): string {
+        return $cookieName.( ($this->isHttps()) ? 'Secure' : '' );
+    }
+
+    /**
+     * isset cookie
+     *
+     * @param string $cookieName   name of cookie to get
+     *
+     * @return mixed result of issetCookie()
+     */
+    public function issetCookie(string $cookieName) {
+        return isset($_COOKIE[$this->getCookieName($cookieName)]);
+    }
 
     /**
      * Error handler to catch fatal errors when loading configuration

--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -357,12 +357,12 @@ class AuthenticationCookie extends AuthenticationPlugin
         // and $this->password variables from cookies
 
         // check cookies
-        if (empty($_COOKIE['pmaUser-' . $GLOBALS['server']])) {
+        if (empty($GLOBALS['PMA_Config']->getCookie('pmaUser-' . $GLOBALS['server']))) {
             return false;
         }
 
         $value = $this->cookieDecrypt(
-            $_COOKIE['pmaUser-' . $GLOBALS['server']],
+            $GLOBALS['PMA_Config']->getCookie('pmaUser-' . $GLOBALS['server']),
             $this->_getEncryptionSecret()
         );
 
@@ -404,11 +404,11 @@ class AuthenticationCookie extends AuthenticationPlugin
         }
 
         // check password cookie
-        if (empty($_COOKIE['pmaAuth-' . $GLOBALS['server']])) {
+        if (empty($GLOBALS['PMA_Config']->getCookie('pmaAuth-' . $GLOBALS['server']))) {
             return false;
         }
         $value = $this->cookieDecrypt(
-            $_COOKIE['pmaAuth-' . $GLOBALS['server']],
+            $GLOBALS['PMA_Config']->getCookie('pmaAuth-' . $GLOBALS['server']),
             $this->_getSessionEncryptionSecret()
         );
         if ($value === false) {
@@ -872,17 +872,13 @@ class AuthenticationCookie extends AuthenticationPlugin
         if ($GLOBALS['cfg']['LoginCookieDeleteAll']) {
             foreach ($GLOBALS['cfg']['Servers'] as $key => $val) {
                 $GLOBALS['PMA_Config']->removeCookie('pmaAuth-' . $key);
-                if (isset($_COOKIE['pmaAuth-' . $key])) {
-                    unset($_COOKIE['pmaAuth-' . $key]);
-                }
+                $GLOBALS['PMA_Config']->unsetCookie('pmaAuth-' . $key);
             }
         } else {
             $GLOBALS['PMA_Config']->removeCookie(
                 'pmaAuth-' . $GLOBALS['server']
             );
-            if (isset($_COOKIE['pmaAuth-' . $GLOBALS['server']])) {
-                unset($_COOKIE['pmaAuth-' . $GLOBALS['server']]);
-            }
+            $GLOBALS['PMA_Config']->unsetCookie('pmaAuth-' . $GLOBALS['server']);
         }
         parent::logOut();
     }

--- a/libraries/classes/Plugins/Auth/AuthenticationSignon.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationSignon.php
@@ -98,7 +98,7 @@ class AuthenticationSignon extends AuthenticationPlugin
 
             list ($this->user, $this->password)
                 = get_login_credentials($GLOBALS['cfg']['Server']['user']);
-        } elseif (isset($_COOKIE[$session_name])) { /* Does session exist? */
+        } elseif ($GLOBALS['PMA_Config']->issetCookie($session_name)) { /* Does session exist? */
             /* End current session */
             $old_session = session_name();
             $old_id = session_id();
@@ -132,8 +132,8 @@ class AuthenticationSignon extends AuthenticationPlugin
             /* Load single signon session */
             if (!defined('TESTSUITE')) {
                 session_set_cookie_params($session_cookie_params['lifetime'], $session_cookie_params['path'], $session_cookie_params['domain'], $session_cookie_params['secure'], $session_cookie_params['httponly']);
-                session_name($session_name);
-                session_id($_COOKIE[$session_name]);
+                session_name($GLOBALS['PMA_Config']->getCookieName($session_name));
+                session_id($GLOBALS['PMA_Config']->getCookie($session_name));
                 session_start();
             }
 
@@ -230,14 +230,14 @@ class AuthenticationSignon extends AuthenticationPlugin
         $session_name = $GLOBALS['cfg']['Server']['SignonSession'];
 
         /* Does session exist? */
-        if (isset($_COOKIE[$session_name])) {
+        if ($GLOBALS['PMA_Config']->issetCookie($session_name)) {
             if (!defined('TESTSUITE')) {
                 /* End current session */
                 session_write_close();
 
                 /* Load single signon session */
-                session_name($session_name);
-                session_id($_COOKIE[$session_name]);
+                session_name($GLOBALS['PMA_Config']->getCookieName($session_name));
+                session_id($GLOBALS['PMA_Config']->getCookie($session_name));
                 session_start();
             }
 

--- a/libraries/classes/Plugins/AuthenticationPlugin.php
+++ b/libraries/classes/Plugins/AuthenticationPlugin.php
@@ -140,7 +140,7 @@ abstract class AuthenticationPlugin
             && $GLOBALS['cfg']['Server']['auth_type'] == 'cookie'
         ) {
             foreach ($GLOBALS['cfg']['Servers'] as $key => $val) {
-                if (isset($_COOKIE['pmaAuth-' . $key])) {
+                if ($GLOBALS['PMA_Config']->issetCookie('pmaAuth-' . $key)) {
                     $server = $key;
                 }
             }

--- a/libraries/classes/Session.php
+++ b/libraries/classes/Session.php
@@ -179,12 +179,12 @@ class Session
         // proxy servers
         session_cache_limiter('private');
 
-        $session_name = 'phpMyAdmin';
+        $session_name = $config->getCookieName('phpMyAdmin');
         @session_name($session_name);
 
         // Restore correct sesion ID (it might have been reset by auto started session
-        if (isset($_COOKIE['phpMyAdmin'])) {
-            session_id($_COOKIE['phpMyAdmin']);
+        if ($config->issetCookie($session_name)) {
+            session_id($config->getCookie($session_name));
         }
 
         // on first start of session we check for errors

--- a/libraries/classes/ThemeManager.php
+++ b/libraries/classes/ThemeManager.php
@@ -217,8 +217,8 @@ class ThemeManager
     public function getThemeCookie()
     {
         $name = $this->getThemeCookieName();
-        if (isset($_COOKIE[$name])) {
-            return $_COOKIE[$name];
+        if ($GLOBALS['PMA_Config']->issetCookie($name)) {
+            return $GLOBALS['PMA_Config']->getCookie($name);
         }
 
         return false;

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -145,7 +145,8 @@ if (isset($_REQUEST['goto']) && Core::checkPageValidity($_REQUEST['goto'])) {
     $GLOBALS['goto'] = $_REQUEST['goto'];
     $GLOBALS['url_params']['goto'] = $_REQUEST['goto'];
 } else {
-    unset($_REQUEST['goto'], $_GET['goto'], $_POST['goto'], $_COOKIE['goto']);
+    $GLOBALS['PMA_Config']->unsetCookie('goto');
+    unset($_REQUEST['goto'], $_GET['goto'], $_POST['goto']);
 }
 
 /**
@@ -155,7 +156,8 @@ if (isset($_REQUEST['goto']) && Core::checkPageValidity($_REQUEST['goto'])) {
 if (isset($_REQUEST['back']) && Core::checkPageValidity($_REQUEST['back'])) {
     $GLOBALS['back'] = $_REQUEST['back'];
 } else {
-    unset($_REQUEST['back'], $_GET['back'], $_POST['back'], $_COOKIE['back']);
+    $GLOBALS['PMA_Config']->unsetCookie('back');
+    unset($_REQUEST['back'], $_GET['back'], $_POST['back']);
 }
 
 /**


### PR DESCRIPTION
I am trying to fix the issue with login.
**This PR fixes 1/2 of the issue.**

@ibennetch @nijel @mauriciofauth I want to separate cookie names like in screenshot, please _approve_ or not the proposal code of this PR :)

Tests are failing, I will correct them if this PR seems OK for you.

![It works !](https://user-images.githubusercontent.com/7784660/41804256-7420af40-7693-11e8-83b3-21d82c90022e.jpg)


See issue #14184
- REPO: https://github.com/williamdes/issue-14184-pma-login

### Follow instructions below
Do the following :
- Open a **private browser**
- Login on **https** version
- It works !
- Login on **http** version
- Does not work
- **Close the browser**
- Open a **private browser**
- Login on **http** version
- It works !
- Login on **https** version
- It works !

This is exactly what happens on phpMyAdmin (excluding the cookie token/expire bug).

### RTFM
```
4.1.2.5.  The Secure Attribute

   The Secure attribute limits the scope of the cookie to "secure"
   channels (where "secure" is defined by the user agent).  When a
   cookie has the Secure attribute, the user agent will include the
   cookie in an HTTP request only if the request is transmitted over a
   secure channel (typically HTTP over Transport Layer Security (TLS)
   [RFC2818]).

   Although seemingly useful for protecting cookies from active network
   attackers, the Secure attribute protects only the cookie's
   confidentiality.  An active network attacker can overwrite Secure
   cookies from an insecure channel, disrupting their integrity (see
   Section 8.6 for more details).
```
> The Secure attribute **limits the scope** of the cookie to "secure"
   channels

> the user agent will include the
   cookie in an HTTP request **only** if the request is transmitted over a
   **secure channel**

> An active network attacker can **overwrite Secure
   cookies from an insecure channel**

