### PR TITLE
Fix server databases statistics

### DIFF
--- a/libraries/classes/Controllers/Server/ServerDatabasesController.php
+++ b/libraries/classes/Controllers/Server/ServerDatabasesController.php
@@ -270,14 +270,17 @@ class ServerDatabasesController extends Controller
         $first_database = reset($this->_databases);
         // table col order
         $column_order = $this->_getColumnOrder();
+        $dbColumnOrders = [];
 
         // calculate aggregate stats to display in footer
         foreach ($this->_databases as $current) {
+            $dbColumnOrders[$current['SCHEMA_NAME']] = $this->_getColumnOrder();
             foreach ($column_order as $stat_name => $stat) {
                 if (array_key_exists($stat_name, $current)
                     && is_numeric($stat['footer'])
                 ) {
                     $column_order[$stat_name]['footer'] += $current[$stat_name];
+                    $dbColumnOrders[$current['SCHEMA_NAME']][$stat_name]['footer'] = $current[$stat_name];
                 }
             }
         }
@@ -287,7 +290,7 @@ class ServerDatabasesController extends Controller
         foreach ($column_order as $stat_name => $stat) {
             if (array_key_exists($stat_name, $first_database)) {
                 if ($stat['format'] == 'byte') {
-                    $byte_format = Util_formatByteDown($stat['footer'], 3, 1);
+                    $byte_format = Util::formatByteDown($stat['footer'], 3, 1);
                     $values[$stat_name] = $byte_format[0];
                     $units[$stat_name] = $byte_format[1];
                 } elseif ($stat['format'] == 'number') {
@@ -320,7 +323,7 @@ class ServerDatabasesController extends Controller
             'allow_user_drop_database' => $GLOBALS['cfg']['AllowUserDropDatabase'],
         ]);
 
-        $html .= $this->_getHtmlForTableBody($column_order, $replication_types);
+        $html .= $this->_getHtmlForTableBody($dbColumnOrders, $replication_types);
 
         $html .= $this->template->render('server/databases/databases_footer', [
             'column_order' => $column_order,
@@ -396,7 +399,7 @@ class ServerDatabasesController extends Controller
      *
      * @return string
      */
-    private function _getHtmlForTableBody(array $column_order, array $replication_types)
+    private function _getHtmlForTableBody(array $dbColumnOrders, array $replication_types)
     {
         $html = '<tbody>' . "\n";
 
@@ -408,7 +411,7 @@ class ServerDatabasesController extends Controller
 
             $generated_html = $this->_buildHtmlForDb(
                 $current,
-                $column_order,
+                $dbColumnOrders[$current['SCHEMA_NAME']],
                 $replication_types,
                 $GLOBALS['replication_info'],
                 $tr_class
@@ -486,7 +489,7 @@ class ServerDatabasesController extends Controller
                     $values[$stat_name] = $byte_format[0];
                     $units[$stat_name] = $byte_format[1];
                 } elseif ($stat['format'] == 'number') {
-                    $values[$stat_name] = Util_formatNumber($stat['footer'], 0);
+                    $values[$stat_name] = Util::formatNumber($stat['footer'], 0);
                 } else {
                     $values[$stat_name] = htmlentities($stat['footer'], 0);
                 }


### PR DESCRIPTION
Server databases statistics was not working, and the data shown in the table was the sum of all databases, not the real information of each one.

Signed-off-by: Leonardo Strozzi <laps15@inf.ufpr.br>

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [x] Any new functionality is covered by tests
