### PR TITLE
#14452 Remove hash param in edit query URL

### DIFF
--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1072,7 +1072,7 @@ class Util
             if (! empty($cfg['SQLQuery']['Edit'])
                 && empty($GLOBALS['show_as_php'])
             ) {
-                $edit_link .= Url::getCommon($url_params) . '#querybox';
+                $edit_link .= Url::getCommon($url_params);
                 $edit_link = ' [&nbsp;'
                     . self::linkOrButton($edit_link, __('Edit'))
                     . '&nbsp;]';


### PR DESCRIPTION
Remove the hash param that is posted as part of the last field instead of an anchor when in Ajax POSTs. Fixes #14452 