### PR TITLE
Console and Error Report files modularized 

### DIFF
--- a/js/src/classes/Console/PMA_ConsoleResizer.js
+++ b/js/src/classes/Console/PMA_ConsoleResizer.js
@@ -1,0 +1,86 @@
+/**
+ * Resizer object
+ * Careful: this object UI logics highly related with functions under PMA_console
+ * Resizing min-height is 32, if small than it, console will collapse
+ */
+export default class PMA_consoleResizer {
+    constructor (instance) {
+        this._posY = 0;
+        this._height = 0;
+        this._resultHeight = 0;
+        this.pmaConsole = null;
+        this.initialize = this.initialize.bind(this);
+        this._mousedown = this._mousedown.bind(this);
+        this._mousemove = this._mousemove.bind(this);
+        this._mouseup = this._mouseup.bind(this);
+        this.setPmaConsole(instance);
+    }
+    setPmaConsole (instance) {
+        this.pmaConsole = instance;
+        this.initialize();
+    }
+    /**
+     * Mousedown event handler for bind to resizer
+     *
+     * @return void
+     */
+    _mousedown (event) {
+        if (this.pmaConsole.config.Mode !== 'show') {
+            return;
+        }
+        this._posY = event.pageY;
+        this._height = this.pmaConsole.$consoleContent.height();
+        $(document).mousemove(this._mousemove);
+        $(document).mouseup(this._mouseup);
+        // Disable text selection while resizing
+        $(document).on('selectstart', function () {
+            return false;
+        });
+    }
+    /**
+     * Mousemove event handler for bind to resizer
+     *
+     * @return void
+     */
+    _mousemove (event) {
+        if (event.pageY < 35) {
+            event.pageY = 35;
+        }
+        this._resultHeight = this._height + (this._posY - event.pageY);
+        // Content min-height is 32, if adjusting height small than it we'll move it out of the page
+        if (this._resultHeight <= 32) {
+            this.pmaConsole.$consoleAllContents.height(32);
+            this.pmaConsole.$consoleContent.css('margin-bottom', this._resultHeight - 32);
+        } else {
+            // Logic below makes viewable area always at bottom when adjusting height and content already at bottom
+            if (this.pmaConsole.$consoleContent.scrollTop() + this.pmaConsole.$consoleContent.innerHeight() + 16
+                >= this.pmaConsole.$consoleContent.prop('scrollHeight')) {
+                this.pmaConsole.$consoleAllContents.height(this._resultHeight);
+                this.pmaConsole.scrollBottom();
+            } else {
+                this.pmaConsole.$consoleAllContents.height(this._resultHeight);
+            }
+        }
+    }
+    /**
+     * Mouseup event handler for bind to resizer
+     *
+     * @return void
+     */
+    _mouseup () {
+        this.pmaConsole.setConfig('Height', this._resultHeight);
+        this.pmaConsole.show();
+        $(document).off('mousemove');
+        $(document).off('mouseup');
+        $(document).off('selectstart');
+    }
+    /**
+     * Used for console resizer initialize
+     *
+     * @return void
+     */
+    initialize () {
+        $('#pma_console').find('.toolbar').off('mousedown');
+        $('#pma_console').find('.toolbar').mousedown(this._mousedown);
+    }
+}

--- a/js/src/classes/Console/PMA_consoleBookmarks.js
+++ b/js/src/classes/Console/PMA_consoleBookmarks.js
@@ -1,0 +1,97 @@
+/**
+ * Console bookmarks card, and bookmarks items management object
+ */
+export default class PMA_consoleBookmarks {
+    constructor (instance) {
+        this._bookmarks = [];
+        this.pmaConsole = null;
+        this.setPmaConsole = this.setPmaConsole.bind(this);
+        this.addBookmark = this.addBookmark.bind(this);
+        this.refresh = this.refresh.bind(this);
+        this.initialize = this.initialize.bind(this);
+        this.setPmaConsole(instance);
+    }
+    setPmaConsole (instance) {
+        this.pmaConsole = instance;
+        this.initialize();
+    }
+    addBookmark (queryString, targetDb, label, isShared, id) {
+        $('#pma_bookmarks').find('.add [name=shared]').prop('checked', false);
+        $('#pma_bookmarks').find('.add [name=label]').val('');
+        $('#pma_bookmarks').find('.add [name=targetdb]').val('');
+        $('#pma_bookmarks').find('.add [name=id_bookmark]').val('');
+        this.pmaConsole.pmaConsoleInput.setText('', 'bookmark');
+
+        switch (arguments.length) {
+        case 4:
+            $('#pma_bookmarks').find('.add [name=shared]').prop('checked', isShared);
+            break;
+        case 3:
+            $('#pma_bookmarks').find('.add [name=label]').val(label);
+            break;
+        case 2:
+            $('#pma_bookmarks').find('.add [name=targetdb]').val(targetDb);
+            break;
+        case 1:
+            this.pmaConsole.pmaConsoleInput.setText(queryString, 'bookmark');
+            break;
+        default:
+            break;
+        }
+    }
+    refresh () {
+        $.get('import.php',
+            { ajax_request: true,
+                server: PMA_commonParams.get('server'),
+                console_bookmark_refresh: 'refresh' },
+            function (data) {
+                if (data.console_message_bookmark) {
+                    $('#pma_bookmarks').find('.content.bookmark').html(data.console_message_bookmark);
+                    this.pmaConsole.pmaConsoleMessages._msgEventBinds($('#pma_bookmarks').find('.message:not(.binded)'));
+                }
+            }.bind(this));
+    }
+    /**
+     * Used for console bookmarks initialize
+     * message events are already binded by PMA_consoleMsg._msgEventBinds
+     *
+     * @return void
+     */
+    initialize () {
+        var self = this;
+        if ($('#pma_bookmarks').length === 0) {
+            return;
+        }
+        $('#pma_console').find('.button.bookmarks').click(function () {
+            self.pmaConsole.showCard('#pma_bookmarks');
+        });
+        $('#pma_bookmarks').find('.button.add').click(function () {
+            self.pmaConsole.showCard('#pma_bookmarks .card.add');
+        });
+        $('#pma_bookmarks').find('.card.add [name=submit]').click(function () {
+            if ($('#pma_bookmarks').find('.card.add [name=label]').val().length === 0
+                || self.pmaConsole.pmaConsoleInput.getText('bookmark').length === 0) {
+                alert(PMA_messages.strFormEmpty);
+                return;
+            }
+            $(this).prop('disabled', true);
+            $.post('import.php',
+                {
+                    ajax_request: true,
+                    console_bookmark_add: 'true',
+                    label: $('#pma_bookmarks').find('.card.add [name=label]').val(),
+                    server: PMA_commonParams.get('server'),
+                    db: $('#pma_bookmarks').find('.card.add [name=targetdb]').val(),
+                    bookmark_query: self.pmaConsole.pmaConsoleInput.getText('bookmark'),
+                    shared: $('#pma_bookmarks').find('.card.add [name=shared]').prop('checked') },
+                function () {
+                    self.refresh();
+                    $('#pma_bookmarks').find('.card.add [name=submit]').prop('disabled', false);
+                    self.pmaConsole.hideCard($('#pma_bookmarks').find('.card.add'));
+                });
+        });
+        $('#pma_console').find('.button.refresh').click(function () {
+            self.refresh();
+        });
+    }
+}

--- a/js/src/classes/Console/PMA_consoleDebug.js
+++ b/js/src/classes/Console/PMA_consoleDebug.js
@@ -1,0 +1,414 @@
+export default class PMA_consoleDebug {
+    constructor (instance) {
+        this.pmaConsole = null;
+        this._config = {
+            groupQueries: false,
+            orderBy: 'exec', // Possible 'exec' => Execution order, 'time' => Time taken, 'count'
+            order: 'asc' // Possible 'asc', 'desc'
+        };
+        this._lastDebugInfo = {
+            debugInfo: null,
+            url: null
+        };
+        this.initialize = this.initialize.bind(this);
+        this.setPmaConsole = this.setPmaConsole.bind(this);
+        this._formatFunctionCall = this._formatFunctionCall.bind(this);
+        this._formatFunctionArgs = this._formatFunctionArgs.bind(this);
+        this._formatFileName = this._formatFileName.bind(this);
+        this._formatBackTrace = this._formatBackTrace.bind(this);
+        this._formatQueryOrGroup = this._formatQueryOrGroup.bind(this);
+        this._appendQueryExtraInfo = this._appendQueryExtraInfo.bind(this);
+        this.getQueryDetails = this.getQueryDetails.bind(this);
+        this.showLog = this.showLog.bind(this);
+        this.refresh = this.refresh.bind(this);
+        this.setPmaConsole(instance);
+    }
+    setPmaConsole (instance) {
+        this.pmaConsole = instance;
+        this.initialize();
+    }
+    initialize () {
+        var self = this;
+        // Try to get debug info after every AJAX request
+        $(document).ajaxSuccess(function (event, xhr, settings, data) {
+            if (data._debug) {
+                self.showLog(data._debug, settings.url);
+            }
+        });
+
+        if (self.pmaConsole.config.GroupQueries) {
+            $('#debug_console').addClass('grouped');
+        } else {
+            $('#debug_console').addClass('ungrouped');
+            if (self.pmaConsole.config.OrderBy === 'count') {
+                $('#debug_console').find('.button.order_by.sort_exec').addClass('active');
+            }
+        }
+        var orderBy = self.pmaConsole.config.OrderBy;
+        var order = self.pmaConsole.config.Order;
+        $('#debug_console').find('.button.order_by.sort_' + orderBy).addClass('active');
+        $('#debug_console').find('.button.order.order_' + order).addClass('active');
+
+        // Initialize actions in toolbar
+        $('#debug_console').find('.button.group_queries').click(function () {
+            $('#debug_console').addClass('grouped');
+            $('#debug_console').removeClass('ungrouped');
+            self.pmaConsole.setConfig('GroupQueries', true);
+            self.refresh();
+            if (self.pmaConsole.config.OrderBy === 'count') {
+                $('#debug_console').find('.button.order_by.sort_exec').removeClass('active');
+            }
+        });
+        $('#debug_console').find('.button.ungroup_queries').click(function () {
+            $('#debug_console').addClass('ungrouped');
+            $('#debug_console').removeClass('grouped');
+            self.pmaConsole.setConfig('GroupQueries', false);
+            self.refresh();
+            if (self.pmaConsole.config.OrderBy === 'count') {
+                $('#debug_console').find('.button.order_by.sort_exec').addClass('active');
+            }
+        });
+        $('#debug_console').find('.button.order_by').click(function () {
+            var $this = $(this);
+            $('#debug_console').find('.button.order_by').removeClass('active');
+            $this.addClass('active');
+            if ($this.hasClass('sort_time')) {
+                self.pmaConsole.setConfig('OrderBy', 'time');
+            } else if ($this.hasClass('sort_exec')) {
+                self.pmaConsole.setConfig('OrderBy', 'exec');
+            } else if ($this.hasClass('sort_count')) {
+                self.pmaConsole.setConfig('OrderBy', 'count');
+            }
+            self.refresh();
+        });
+        $('#debug_console').find('.button.order').click(function () {
+            var $this = $(this);
+            $('#debug_console').find('.button.order').removeClass('active');
+            $this.addClass('active');
+            if ($this.hasClass('order_asc')) {
+                self.pmaConsole.setConfig('Order', 'asc');
+            } else if ($this.hasClass('order_desc')) {
+                self.pmaConsole.setConfig('Order', 'desc');
+            }
+            self.refresh();
+        });
+
+        // Show SQL debug info for first page load
+        if (typeof debugSQLInfo !== 'undefined' && debugSQLInfo !== 'null') {
+            $('#pma_console').find('.button.debug').removeClass('hide');
+        } else {
+            return;
+        }
+        self.showLog(debugSQLInfo);
+    }
+    _formatFunctionCall (dbgStep) {
+        var functionName = '';
+        if ('class' in dbgStep) {
+            functionName += dbgStep.class;
+            functionName += dbgStep.type;
+        }
+        functionName += dbgStep.function;
+        if (dbgStep.args && dbgStep.args.length) {
+            functionName += '(...)';
+        } else {
+            functionName += '()';
+        }
+        return functionName;
+    }
+    _formatFunctionArgs (dbgStep) {
+        var $args = $('<div>');
+        if (dbgStep.args.length) {
+            $args.append('<div class="message welcome">')
+                .append(
+                    $('<div class="message welcome">')
+                        .text(
+                            PMA_sprintf(
+                                PMA_messages.strConsoleDebugArgsSummary,
+                                dbgStep.args.length
+                            )
+                        )
+                );
+            for (var i = 0; i < dbgStep.args.length; i++) {
+                $args.append(
+                    $('<div class="message">')
+                        .html(
+                            '<pre>' +
+                        escapeHtml(JSON.stringify(dbgStep.args[i], null, '  ')) +
+                        '</pre>'
+                        )
+                );
+            }
+        }
+        return $args;
+    }
+    _formatFileName (dbgStep) {
+        var fileName = '';
+        if ('file' in dbgStep) {
+            fileName += dbgStep.file;
+            fileName += '#' + dbgStep.line;
+        }
+        return fileName;
+    }
+    _formatBackTrace (dbgTrace) {
+        var $traceElem = $('<div class="trace">');
+        $traceElem.append(
+            $('<div class="message welcome">')
+        );
+        var step;
+        var $stepElem;
+        for (var stepId in dbgTrace) {
+            if (dbgTrace.hasOwnProperty(stepId)) {
+                step = dbgTrace[stepId];
+                if (!Array.isArray(step) && typeof step !== 'object') {
+                    $stepElem =
+                        $('<div class="message traceStep collapsed hide_args">')
+                            .append(
+                                $('<span>').text(step)
+                            );
+                } else {
+                    if (typeof step.args === 'string' && step.args) {
+                        step.args = [step.args];
+                    }
+                    $stepElem =
+                        $('<div class="message traceStep collapsed hide_args">')
+                            .append(
+                                $('<span class="function">').text(this._formatFunctionCall(step))
+                            )
+                            .append(
+                                $('<span class="file">').text(this._formatFileName(step))
+                            );
+                    if (step.args && step.args.length) {
+                        $stepElem
+                            .append(
+                                $('<span class="args">').html(this._formatFunctionArgs(step))
+                            )
+                            .prepend(
+                                $('<div class="action_content">')
+                                    .append(
+                                        '<span class="action dbg_show_args">' +
+                                PMA_messages.strConsoleDebugShowArgs +
+                                '</span> '
+                                    )
+                                    .append(
+                                        '<span class="action dbg_hide_args">' +
+                                PMA_messages.strConsoleDebugHideArgs +
+                                '</span> '
+                                    )
+                            );
+                    }
+                }
+                $traceElem.append($stepElem);
+            }
+        }
+        return $traceElem;
+    }
+    _formatQueryOrGroup (queryInfo, totalTime) {
+        var grouped;
+        var queryText;
+        var queryTime;
+        var count;
+        var i;
+        if (Array.isArray(queryInfo)) {
+            // It is grouped
+            grouped = true;
+
+            queryText = queryInfo[0].query;
+
+            queryTime = 0;
+            for (i in queryInfo) {
+                queryTime += queryInfo[i].time;
+            }
+
+            count = queryInfo.length;
+        } else {
+            queryText = queryInfo.query;
+            queryTime = queryInfo.time;
+        }
+
+        var $query = $('<div class="message collapsed hide_trace">')
+            .append(
+                $('#debug_console').find('.templates .debug_query').clone()
+            )
+            .append(
+                $('<div class="query">')
+                    .text(queryText)
+            )
+            .data('queryInfo', queryInfo)
+            .data('totalTime', totalTime);
+        if (grouped) {
+            $query.find('.text.count').removeClass('hide');
+            $query.find('.text.count span').text(count);
+        }
+        $query.find('.text.time span').text(queryTime + 's (' + ((queryTime * 100) / totalTime).toFixed(3) + '%)');
+
+        return $query;
+    }
+    _appendQueryExtraInfo (query, $elem) {
+        if ('error' in query) {
+            $elem.append(
+                $('<div>').html(query.error)
+            );
+        }
+        $elem.append(this._formatBackTrace(query.trace));
+    }
+    getQueryDetails (queryInfo, totalTime, $query) {
+        if (Array.isArray(queryInfo)) {
+            var $singleQuery;
+            for (var i in queryInfo) {
+                $singleQuery = $('<div class="message welcome trace">')
+                    .text((parseInt(i) + 1) + '.')
+                    .append(
+                        $('<span class="time">').text(
+                            PMA_messages.strConsoleDebugTimeTaken +
+                        ' ' + queryInfo[i].time + 's' +
+                        ' (' + ((queryInfo[i].time * 100) / totalTime).toFixed(3) + '%)'
+                        )
+                    );
+                this._appendQueryExtraInfo(queryInfo[i], $singleQuery);
+                $query
+                    .append('<div class="message welcome trace">')
+                    .append($singleQuery);
+            }
+        } else {
+            this._appendQueryExtraInfo(queryInfo, $query);
+        }
+    }
+    showLog (debugInfo, url) {
+        this._lastDebugInfo.debugInfo = debugInfo;
+        this._lastDebugInfo.url = url;
+
+        $('#debug_console').find('.debugLog').empty();
+        $('#debug_console').find('.debug>.welcome').empty();
+
+        var debugJson = false;
+        var i;
+        if (typeof debugInfo === 'object' && 'queries' in debugInfo) {
+            // Copy it to debugJson, so that it doesn't get changed
+            if (!('queries' in debugInfo)) {
+                debugJson = false;
+            } else {
+                debugJson = { queries: [] };
+                for (i in debugInfo.queries) {
+                    debugJson.queries[i] = debugInfo.queries[i];
+                }
+            }
+        } else if (typeof debugInfo === 'string') {
+            try {
+                debugJson = JSON.parse(debugInfo);
+            } catch (e) {
+                debugJson = false;
+            }
+            if (debugJson && !('queries' in debugJson)) {
+                debugJson = false;
+            }
+        }
+        if (debugJson === false) {
+            $('#debug_console').find('.debug>.welcome').text(
+                PMA_messages.strConsoleDebugError
+            );
+            return;
+        }
+        var allQueries = debugJson.queries;
+        var uniqueQueries = {};
+
+        var totalExec = allQueries.length;
+
+        // Calculate total time and make unique query array
+        var totalTime = 0;
+        for (i = 0; i < totalExec; ++i) {
+            totalTime += allQueries[i].time;
+            if (!(allQueries[i].hash in uniqueQueries)) {
+                uniqueQueries[allQueries[i].hash] = [];
+            }
+            uniqueQueries[allQueries[i].hash].push(allQueries[i]);
+        }
+        // Count total unique queries, convert uniqueQueries to Array
+        var totalUnique = 0;
+        var uniqueArray = [];
+        for (var hash in uniqueQueries) {
+            if (uniqueQueries.hasOwnProperty(hash)) {
+                ++totalUnique;
+                uniqueArray.push(uniqueQueries[hash]);
+            }
+        }
+        uniqueQueries = uniqueArray;
+        // Show summary
+        $('#debug_console').find('.debug>.welcome').append(
+            $('<span class="debug_summary">').text(
+                PMA_sprintf(
+                    PMA_messages.strConsoleDebugSummary,
+                    totalUnique,
+                    totalExec,
+                    totalTime
+                )
+            )
+        );
+        if (url) {
+            $('#debug_console').find('.debug>.welcome').append(
+                $('<span class="script_name">').text(url.split('?')[0])
+            );
+        }
+
+        // For sorting queries
+        function sortByTime (a, b) {
+            var order = ((PMA_console.config.Order === 'asc') ? 1 : -1);
+            if (Array.isArray(a) && Array.isArray(b)) {
+                // It is grouped
+                var timeA = 0;
+                var timeB = 0;
+                var i;
+                for (i in a) {
+                    timeA += a[i].time;
+                }
+                for (i in b) {
+                    timeB += b[i].time;
+                }
+                return (timeA - timeB) * order;
+            } else {
+                return (a.time - b.time) * order;
+            }
+        }
+
+        function sortByCount (a, b) {
+            var order = ((PMA_console.config.Oorder === 'asc') ? 1 : -1);
+            return (a.length - b.length) * order;
+        }
+
+        var orderBy = this.pmaConsole.config.OrderBy;
+        var order = this.pmaConsole.config.Order;
+
+        if (this.pmaConsole.config.GroupQueries) {
+            // Sort queries
+            if (orderBy === 'time') {
+                uniqueQueries.sort(sortByTime);
+            } else if (orderBy === 'count') {
+                uniqueQueries.sort(sortByCount);
+            } else if (orderBy === 'exec' && order === 'desc') {
+                uniqueQueries.reverse();
+            }
+            for (i in uniqueQueries) {
+                if (orderBy === 'time') {
+                    uniqueQueries[i].sort(sortByTime);
+                } else if (orderBy === 'exec' && order === 'desc') {
+                    uniqueQueries[i].reverse();
+                }
+                $('#debug_console').find('.debugLog').append(this._formatQueryOrGroup(uniqueQueries[i], totalTime));
+            }
+        } else {
+            if (orderBy === 'time') {
+                allQueries.sort(sortByTime);
+            } else if (order === 'desc') {
+                allQueries.reverse();
+            }
+            for (i = 0; i < totalExec; ++i) {
+                $('#debug_console').find('.debugLog').append(this._formatQueryOrGroup(allQueries[i], totalTime));
+            }
+        }
+
+        this.pmaConsole.pmaConsoleMessages._msgEventBinds($('#debug_console').find('.message:not(.binded)'));
+    }
+    refresh () {
+        var last = this._lastDebugInfo;
+        this.showLog(last.debugInfo, last.url);
+    }
+}

--- a/js/src/classes/Console/PMA_consoleInput.js
+++ b/js/src/classes/Console/PMA_consoleInput.js
@@ -1,0 +1,259 @@
+/**
+ * Console input object
+ */
+export default class PMA_consoleInput {
+    constructor (pmaConsoleInstance) {
+        /**
+         * @var array, contains Codemirror objects or input jQuery objects
+         * @access private
+         */
+        this._inputs = null;
+        /**
+         * @var bool, if codemirror enabled
+         * @access private
+         */
+        this._codemirror = false;
+        /**
+         * @var int, count for history navigation, 0 for current input
+         * @access private
+         */
+        this._historyCount = 0;
+        /**
+         * @var string, current input when navigating through history
+         * @access private
+         */
+        this._historyPreserveCurrent = null;
+
+        this.pmaConsole = null;
+
+        this.setPmaConsole = this.setPmaConsole.bind(this);
+        this.initialize = this.initialize.bind(this);
+        this._historyNavigate = this._historyNavigate.bind(this);
+        this._keydown = this._keydown.bind(this);
+        this.execute = this.execute.bind(this);
+        this.clear = this.clear.bind(this);
+        this.focus = this.focus.bind(this);
+        this.blur = this.blur.bind(this);
+        this.setText = this.setText.bind(this);
+        this.getText = this.getText.bind(this);
+
+        this.setPmaConsole(pmaConsoleInstance);
+    }
+    setPmaConsole (instance) {
+        this.pmaConsole = instance;
+        this.initialize();
+    }
+    initialize () {
+        // _cm object can't be reinitialize
+        if (this._inputs !== null) {
+            return;
+        }
+        if (typeof CodeMirror !== 'undefined') {
+            this._codemirror = true;
+        }
+        this._inputs = [];
+        if (this._codemirror) {
+            this._inputs.console = CodeMirror($('#pma_console').find('.console_query_input')[0], {
+                theme: 'pma',
+                mode: 'text/x-sql',
+                lineWrapping: true,
+                extraKeys: { 'Ctrl-Space': 'autocomplete' },
+                hintOptions: { 'completeSingle': false, 'completeOnSingleClick': true },
+                gutters: ['CodeMirror-lint-markers'],
+                lint: {
+                    'getAnnotations': CodeMirror.sqlLint,
+                    'async': true,
+                }
+            });
+            this._inputs.console.on('inputRead', codemirrorAutocompleteOnInputRead);
+            this._inputs.console.on('keydown', function (instance, event) {
+                this._historyNavigate(event);
+            }.bind(this));
+            if ($('#pma_bookmarks').length !== 0) {
+                this._inputs.bookmark = CodeMirror($('#pma_console').find('.bookmark_add_input')[0], {
+                    theme: 'pma',
+                    mode: 'text/x-sql',
+                    lineWrapping: true,
+                    extraKeys: { 'Ctrl-Space': 'autocomplete' },
+                    hintOptions: { 'completeSingle': false, 'completeOnSingleClick': true },
+                    gutters: ['CodeMirror-lint-markers'],
+                    lint: {
+                        'getAnnotations': CodeMirror.sqlLint,
+                        'async': true,
+                    }
+                });
+                this._inputs.bookmark.on('inputRead', codemirrorAutocompleteOnInputRead);
+            }
+        } else {
+            this._inputs.console =
+                $('<textarea>').appendTo('#pma_console .console_query_input')
+                    .on('keydown', this._historyNavigate);
+            if ($('#pma_bookmarks').length !== 0) {
+                this._inputs.bookmark =
+                    $('<textarea>').appendTo('#pma_console .bookmark_add_input');
+            }
+        }
+        $('#pma_console').find('.console_query_input').keydown(this._keydown);
+    }
+    _historyNavigate (event) {
+        if (event.keyCode === 38 || event.keyCode === 40) {
+            var upPermitted = false;
+            var downPermitted = false;
+            var editor = this._inputs.console;
+            var cursorLine;
+            var totalLine;
+            if (this._codemirror) {
+                cursorLine = editor.getCursor().line;
+                totalLine = editor.lineCount();
+            } else {
+                // Get cursor position from textarea
+                var text = this.getText();
+                cursorLine = text.substr(0, editor.prop('selectionStart')).split('\n').length - 1;
+                totalLine = text.split(/\r*\n/).length;
+            }
+            if (cursorLine === 0) {
+                upPermitted = true;
+            }
+            if (cursorLine === totalLine - 1) {
+                downPermitted = true;
+            }
+            var nextCount;
+            var queryString = false;
+            if (upPermitted && event.keyCode === 38) {
+                // Navigate up in history
+                if (this._historyCount === 0) {
+                    this._historyPreserveCurrent = this.getText();
+                }
+                nextCount = this._historyCount + 1;
+                queryString = this.pmaConsole.pmaConsoleMessages.getHistory(nextCount);
+            } else if (downPermitted && event.keyCode === 40) {
+                // Navigate down in history
+                if (this._historyCount === 0) {
+                    return;
+                }
+                nextCount = this._historyCount - 1;
+                if (nextCount === 0) {
+                    queryString = this._historyPreserveCurrent;
+                } else {
+                    queryString = this.pmaConsole.pmaConsoleMessages.getHistory(nextCount);
+                }
+            }
+            if (queryString !== false) {
+                this._historyCount = nextCount;
+                this.setText(queryString, 'console');
+                if (this._codemirror) {
+                    editor.setCursor(editor.lineCount(), 0);
+                }
+                event.preventDefault();
+            }
+        }
+    }
+    /**
+     * Mousedown event handler for bind to input
+     * Shortcut is Ctrl+Enter key or just ENTER, depending on console's
+     * configuration.
+     *
+     * @return void
+     */
+    _keydown (event) {
+        if (this.pmaConsole.config.EnterExecutes) {
+            // Enter, but not in combination with Shift (which writes a new line).
+            if (!event.shiftKey && event.keyCode === 13) {
+                this.execute();
+            }
+        } else {
+            // Ctrl+Enter
+            if (event.ctrlKey && event.keyCode === 13) {
+                this.execute();
+            }
+        }
+    }
+    /**
+     * Used for send text to PMA_console.execute()
+     *
+     * @return void
+     */
+    execute () {
+        if (this._codemirror) {
+            this.pmaConsole.execute(this._inputs.console.getValue());
+        } else {
+            this.pmaConsole.execute(this._inputs.console.val());
+        }
+    }
+    /**
+     * Used for clear the input
+     *
+     * @param string target, default target is console input
+     * @return void
+     */
+    clear (target) {
+        this.setText('', target);
+    }
+    /**
+     * Used for set focus to input
+     *
+     * @return void
+     */
+    focus () {
+        this._inputs.console.focus();
+    }
+    /**
+     * Used for blur input
+     *
+     * @return void
+     */
+    blur () {
+        if (this._codemirror) {
+            this._inputs.console.getInputField().blur();
+        } else {
+            this._inputs.console.blur();
+        }
+    }
+    /**
+     * Used for set text in input
+     *
+     * @param string text
+     * @param string target
+     * @return void
+     */
+    setText (text, target) {
+        if (this._codemirror) {
+            switch (target) {
+            case 'bookmark':
+                this.pmaConsole.execute(this._inputs.bookmark.setValue(text));
+                break;
+            default:
+            case 'console':
+                this.pmaConsole.execute(this._inputs.console.setValue(text));
+            }
+        } else {
+            switch (target) {
+            case 'bookmark':
+                this.pmaConsole.execute(this._inputs.bookmark.val(text));
+                break;
+            default:
+            case 'console':
+                this.pmaConsole.execute(this._inputs.console.val(text));
+            }
+        }
+    }
+    getText (target) {
+        if (this._codemirror) {
+            switch (target) {
+            case 'bookmark':
+                return this._inputs.bookmark.getValue();
+            default:
+            case 'console':
+                return this._inputs.console.getValue();
+            }
+        } else {
+            switch (target) {
+            case 'bookmark':
+                return this._inputs.bookmark.val();
+            default:
+            case 'console':
+                return this._inputs.console.val();
+            }
+        }
+    }
+}

--- a/js/src/classes/Console/PMA_consoleMessages.js
+++ b/js/src/classes/Console/PMA_consoleMessages.js
@@ -1,0 +1,299 @@
+/**
+ * Console messages, and message items management object
+ */
+export default class PMA_consoleMessages {
+    constructor (instance) {
+        this.pmaConsole = null;
+        this.clear = this.clear.bind(this);
+        this.showHistory = this.showHistory.bind(this);
+        this.getHistory = this.getHistory.bind(this);
+        this.showInstructions = this.showInstructions.bind(this);
+        this.append = this.append.bind(this);
+        this.appendQuery = this.appendQuery.bind(this);
+        this._msgEventBinds = this._msgEventBinds.bind(this);
+        this.msgAppend = this.msgAppend.bind(this);
+        this.updateQuery = this.updateQuery.bind(this);
+        this.initialize = this.initialize.bind(this);
+        this.setPmaConsole = this.setPmaConsole.bind(this);
+        this.setPmaConsole(instance);
+    }
+    setPmaConsole (instance) {
+        this.pmaConsole = instance;
+        this.initialize();
+    }
+    /**
+     * Used for clear the messages
+     *
+     * @return void
+     */
+    clear () {
+        $('#pma_console').find('.content .console_message_container .message:not(.welcome)').addClass('hide');
+        $('#pma_console').find('.content .console_message_container .message.failed').remove();
+        $('#pma_console').find('.content .console_message_container .message.expanded').find('.action.collapse').click();
+    }
+    /**
+     * Used for show history messages
+     *
+     * @return void
+     */
+    showHistory () {
+        $('#pma_console').find('.content .console_message_container .message.hide').removeClass('hide');
+    }
+    /**
+     * Used for getting a perticular history query
+     *
+     * @param int nthLast get nth query message from latest, i.e 1st is last
+     * @return string message
+     */
+    getHistory (nthLast) {
+        var $queries = $('#pma_console').find('.content .console_message_container .query');
+        var length = $queries.length;
+        var $query = $queries.eq(length - nthLast);
+        if (!$query || (length - nthLast) < 0) {
+            return false;
+        } else {
+            return $query.text();
+        }
+    }
+    /**
+     * Used to show the correct message depending on which key
+     * combination executes the query (Ctrl+Enter or Enter).
+     *
+     * @param bool enterExecutes Only Enter has to be pressed to execute query.
+     * @return void
+     */
+    showInstructions (enterExecutes) {
+        enterExecutes = +enterExecutes || 0; // conversion to int
+        var $welcomeMsg = $('#pma_console').find('.content .console_message_container .message.welcome span');
+        $welcomeMsg.children('[id^=instructions]').hide();
+        $welcomeMsg.children('#instructions-' + enterExecutes).show();
+    }
+    /**
+     * Used for log new message
+     *
+     * @param string msgString Message to show
+     * @param string msgType Message type
+     * @return object, {message_id, $message}
+     */
+    append (msgString, msgType) {
+        if (typeof(msgString) !== 'string') {
+            return false;
+        }
+        // Generate an ID for each message, we can find them later
+        var msgId = Math.round(Math.random() * (899999999999) + 100000000000);
+        var now = new Date();
+        var $newMessage =
+            $('<div class="message ' +
+                (this.pmaConsole.config.AlwaysExpand ? 'expanded' : 'collapsed') +
+                '" msgid="' + msgId + '"><div class="action_content"></div></div>');
+        switch (msgType) {
+        case 'query':
+            $newMessage.append('<div class="query highlighted"></div>');
+            if (this.pmaConsole.pmaConsoleInput._codemirror) {
+                CodeMirror.runMode(msgString,
+                    'text/x-sql', $newMessage.children('.query')[0]);
+            } else {
+                $newMessage.children('.query').text(msgString);
+            }
+            $newMessage.children('.action_content')
+                .append(this.pmaConsole.$consoleTemplates.children('.query_actions').html());
+            break;
+        default:
+        case 'normal':
+            $newMessage.append('<div>' + msgString + '</div>');
+        }
+        this._msgEventBinds($newMessage);
+        $newMessage.find('span.text.query_time span')
+            .text(now.getHours() + ':' + now.getMinutes() + ':' + now.getSeconds())
+            .parent().attr('title', now);
+        return { message_id: msgId,
+            $message: $newMessage.appendTo('#pma_console .content .console_message_container') };
+    }
+    /**
+     * Used for log new query
+     *
+     * @param string queryData Struct should be
+     * {sql_query: "Query string", db: "Target DB", table: "Target Table"}
+     * @param string state Message state
+     * @return object, {message_id: string message id, $message: JQuery object}
+     */
+    appendQuery (queryData, state) {
+        var targetMessage = this.append(queryData.sql_query, 'query');
+        if (! targetMessage) {
+            return false;
+        }
+        if (queryData.db && queryData.table) {
+            targetMessage.$message.attr('targetdb', queryData.db);
+            targetMessage.$message.attr('targettable', queryData.table);
+            targetMessage.$message.find('.text.targetdb span').text(queryData.db);
+        }
+        if (this.pmaConsole.isSelect(queryData.sql_query)) {
+            targetMessage.$message.addClass('select');
+        }
+        switch (state) {
+        case 'failed':
+            targetMessage.$message.addClass('failed');
+            break;
+        case 'successed':
+            targetMessage.$message.addClass('successed');
+            break;
+        default:
+        case 'pending':
+            targetMessage.$message.addClass('pending');
+        }
+        return targetMessage;
+    }
+    _msgEventBinds ($targetMessage) {
+        var self = this;
+        // Leave unbinded elements, remove binded.
+        $targetMessage = $targetMessage.filter(':not(.binded)');
+        if ($targetMessage.length === 0) {
+            return;
+        }
+        $targetMessage.addClass('binded');
+
+        $targetMessage.find('.action.expand').click(function () {
+            $(this).closest('.message').removeClass('collapsed');
+            $(this).closest('.message').addClass('expanded');
+        });
+        $targetMessage.find('.action.collapse').click(function () {
+            $(this).closest('.message').addClass('collapsed');
+            $(this).closest('.message').removeClass('expanded');
+        });
+        $targetMessage.find('.action.edit').click(function () {
+            self.pmaConsole.pmaConsoleInput.setText($(this).parent().siblings('.query').text());
+            self.pmaConsole.pmaConsoleInput.focus();
+        });
+        $targetMessage.find('.action.requery').click(function () {
+            var query = $(this).parent().siblings('.query').text();
+            var $message = $(this).closest('.message');
+            if (confirm(PMA_messages.strConsoleRequeryConfirm + '\n' +
+                (query.length < 100 ? query : query.slice(0, 100) + '...'))
+            ) {
+                self.pmaConsole.execute(query, { db: $message.attr('targetdb'), table: $message.attr('targettable') });
+            }
+        });
+        $targetMessage.find('.action.bookmark').click(function () {
+            var query = $(this).parent().siblings('.query').text();
+            var $message = $(this).closest('.message');
+            self.pmaConsole.pmaConsoleBookmarks.addBookmark(query, $message.attr('targetdb'));
+            self.pmaConsole.showCard('#pma_bookmarks .card.add');
+        });
+        $targetMessage.find('.action.edit_bookmark').click(function () {
+            var query = $(this).parent().siblings('.query').text();
+            var $message = $(this).closest('.message');
+            var isShared = $message.find('span.bookmark_label').hasClass('shared');
+            var label = $message.find('span.bookmark_label').text();
+            self.pmaConsole.pmaConsoleBookmarks.addBookmark(query, $message.attr('targetdb'), label, isShared);
+            self.pmaConsole.showCard('#pma_bookmarks .card.add');
+        });
+        $targetMessage.find('.action.delete_bookmark').click(function () {
+            var $message = $(this).closest('.message');
+            if (confirm(PMA_messages.strConsoleDeleteBookmarkConfirm + '\n' + $message.find('.bookmark_label').text())) {
+                $.post('import.php',
+                    {
+                        server: PMA_commonParams.get('server'),
+                        action_bookmark: 2,
+                        ajax_request: true,
+                        id_bookmark: $message.attr('bookmarkid') },
+                    function () {
+                        self.pmaConsole.pmaConsoleBookmarks.refresh();
+                    });
+            }
+        });
+        $targetMessage.find('.action.profiling').click(function () {
+            var $message = $(this).closest('.message');
+            self.pmaConsole.execute($(this).parent().siblings('.query').text(),
+                { db: $message.attr('targetdb'),
+                    table: $message.attr('targettable'),
+                    profiling: true });
+        });
+        $targetMessage.find('.action.explain').click(function () {
+            var $message = $(this).closest('.message');
+            self.pmaConsole.execute('EXPLAIN ' + $(this).parent().siblings('.query').text(),
+                { db: $message.attr('targetdb'),
+                    table: $message.attr('targettable') });
+        });
+        $targetMessage.find('.action.dbg_show_trace').click(function () {
+            var $message = $(this).closest('.message');
+            if (!$message.find('.trace').length) {
+                self.pmaConsole.pmaConsoleDebug.getQueryDetails(
+                    $message.data('queryInfo'),
+                    $message.data('totalTime'),
+                    $message
+                );
+                self._msgEventBinds($message.find('.message:not(.binded)'));
+            }
+            $message.addClass('show_trace');
+            $message.removeClass('hide_trace');
+        });
+        $targetMessage.find('.action.dbg_hide_trace').click(function () {
+            var $message = $(this).closest('.message');
+            $message.addClass('hide_trace');
+            $message.removeClass('show_trace');
+        });
+        $targetMessage.find('.action.dbg_show_args').click(function () {
+            var $message = $(this).closest('.message');
+            $message.addClass('show_args expanded');
+            $message.removeClass('hide_args collapsed');
+        });
+        $targetMessage.find('.action.dbg_hide_args').click(function () {
+            var $message = $(this).closest('.message');
+            $message.addClass('hide_args collapsed');
+            $message.removeClass('show_args expanded');
+        });
+        if (self.pmaConsole.pmaConsoleInput._codemirror) {
+            $targetMessage.find('.query:not(.highlighted)').each(function (index, elem) {
+                CodeMirror.runMode($(elem).text(),
+                    'text/x-sql', elem);
+                $(this).addClass('highlighted');
+            });
+        }
+    }
+    msgAppend (msgId, msgString, msgType) {
+        var $targetMessage = $('#pma_console').find('.content .console_message_container .message[msgid=' + msgId + ']');
+        if ($targetMessage.length === 0 || isNaN(parseInt(msgId)) || typeof(msgString) !== 'string') {
+            return false;
+        }
+        $targetMessage.append('<div>' + msgString + '</div>');
+    }
+    updateQuery (msgId, isSuccessed, queryData) {
+        var $targetMessage = $('#pma_console').find('.console_message_container .message[msgid=' + parseInt(msgId) + ']');
+        if ($targetMessage.length === 0 || isNaN(parseInt(msgId))) {
+            return false;
+        }
+        $targetMessage.removeClass('pending failed successed');
+        if (isSuccessed) {
+            $targetMessage.addClass('successed');
+            if (queryData) {
+                $targetMessage.children('.query').text('');
+                $targetMessage.removeClass('select');
+                if (this.pmaConsole.isSelect(queryData.sql_query)) {
+                    $targetMessage.addClass('select');
+                }
+                if (this.pmaConsole.pmaConsoleInput._codemirror) {
+                    CodeMirror.runMode(queryData.sql_query, 'text/x-sql', $targetMessage.children('.query')[0]);
+                } else {
+                    $targetMessage.children('.query').text(queryData.sql_query);
+                }
+                $targetMessage.attr('targetdb', queryData.db);
+                $targetMessage.attr('targettable', queryData.table);
+                $targetMessage.find('.text.targetdb span').text(queryData.db);
+            }
+        } else {
+            $targetMessage.addClass('failed');
+        }
+    }
+    /**
+     * Used for console messages initialize
+     *
+     * @return void
+     */
+    initialize () {
+        this._msgEventBinds($('#pma_console').find('.message:not(.binded)'));
+        if (this.pmaConsole.config.StartHistory) {
+            this.showHistory();
+        }
+        this.showInstructions(this.pmaConsole.config.EnterExecutes);
+    }
+}

--- a/js/src/classes/ErrorReport.js
+++ b/js/src/classes/ErrorReport.js
@@ -1,0 +1,338 @@
+/**
+ * general function, usually for data manipulation pages
+ *
+ */
+import { AJAX } from '../ajax';
+import { PMA_Messages as PMA_messages } from '../variables/export_variables';
+import { PMA_commonParams } from '../variables/common_params';
+import { PMA_ajaxShowMessage } from '../utils/show_ajax_messages';
+import { PMA_getImage } from '../functions/get_image';
+import TraceKit from 'tracekit';
+import { jQuery as $ } from '../utils/extend_jquery';
+
+/**
+ * This Object uses the library TraceKit to generate the backtrace of the
+ * error but since we are using webpack and the development and production
+ * mode have different url leading to cross origin query, the error
+ * report cannot be generated in development mode with context.
+ * The context will be null in deveopment mode.
+ *
+ * @see TraceKit url checking implemented to avoid Cross Origin
+ * https://github.com/csnover/TraceKit/blob/d38d48765f089309e4f4c7a1baacd96dd0534187/tracekit.js#L445
+ *
+ * @see TraceKit How context of the error is being gennerated
+ * https://github.com/csnover/TraceKit/blob/d38d48765f089309e4f4c7a1baacd96dd0534187/tracekit.js#L499
+ *
+ * Due to usage of webpack, the production output is creating backtrace context
+ * containing single line only and that single line is the complete generated
+ * webpack bundle in the uglify mode.
+ */
+
+var ErrorReport = {
+    /**
+     * @var object stores the last exception info
+     */
+    _last_exception: null,
+    /**
+     * handles thrown error exceptions based on user preferences
+     *
+     * @return void
+     */
+    error_handler: function (exception) {
+        if (exception.name === null || typeof(exception.name) === 'undefined') {
+            exception.name = ErrorReport._extractExceptionName(exception);
+        }
+        ErrorReport._last_exception = exception;
+        $.get('error_report.php', {
+            ajax_request: true,
+            server: PMA_commonParams.get('server'),
+            get_settings: true,
+            exception_type: 'js'
+        }, function (data) {
+            if (data.success !== true) {
+                PMA_ajaxShowMessage(data.error, false);
+                return;
+            }
+            if (data.report_setting === 'ask') {
+                ErrorReport._showErrorNotification();
+            } else if (data.report_setting === 'always') {
+                var report_data = ErrorReport._get_report_data(exception);
+                var post_data = $.extend(report_data, {
+                    send_error_report: true,
+                    automatic: true
+                });
+                $.post('error_report.php', post_data, function (data) {
+                    if (data.success === false) {
+                        // in the case of an error, show the error message returned.
+                        PMA_ajaxShowMessage(data.error, false);
+                    } else {
+                        PMA_ajaxShowMessage(data.message, false);
+                    }
+                });
+            }
+        });
+    },
+    /**
+     * Shows the modal dialog previewing the report
+     *
+     * @param exception object error report info
+     *
+     * @return void
+     */
+    _showReportDialog: function (exception) {
+        var report_data = ErrorReport._get_report_data(exception);
+
+        /* Remove the hidden dialogs if there are*/
+        if ($('#error_report_dialog').length !== 0) {
+            $('#error_report_dialog').remove();
+        }
+        var $div = $('<div id="error_report_dialog"></div>');
+        $div.css('z-index', '1000');
+
+        var button_options = {};
+        button_options[PMA_messages.strSendErrorReport] = function () {
+            var $dialog = $(this);
+            var post_data = $.extend(report_data, {
+                send_error_report: true,
+                description: $('#report_description').val(),
+                always_send: $('#always_send_checkbox')[0].checked
+            });
+            $.post('error_report.php', post_data, function (data) {
+                $dialog.dialog('close');
+                if (data.success === false) {
+                    // in the case of an error, show the error message returned.
+                    PMA_ajaxShowMessage(data.error, false);
+                } else {
+                    PMA_ajaxShowMessage(data.message, 3000);
+                }
+            });
+        };
+
+        button_options[PMA_messages.strCancel] = function () {
+            $(this).dialog('close');
+        };
+
+        $.post('error_report.php', report_data, function (data) {
+            if (data.success === false) {
+                // in the case of an error, show the error message returned.
+                PMA_ajaxShowMessage(data.error, false);
+            } else {
+                // Show dialog if the request was successful
+                $div
+                    .append(data.message)
+                    .dialog({
+                        title: PMA_messages.strSubmitErrorReport,
+                        width: 650,
+                        modal: true,
+                        buttons: button_options,
+                        close: function () {
+                            $(this).remove();
+                        }
+                    });
+            }
+        }); // end $.get()
+    },
+    /**
+     * Shows the small notification that asks for user permission
+     *
+     * @return void
+     */
+    _showErrorNotification: function () {
+        ErrorReport._removeErrorNotification();
+
+        var $div = $(
+            '<div style="position:fixed;bottom:0;left:0;right:0;margin:0;' +
+            'z-index:1000" class="error" id="error_notification"></div>'
+        ).append(
+            PMA_getImage('s_error') + PMA_messages.strErrorOccurred
+        );
+
+        var $buttons = $('<div class="floatright"></div>');
+
+        var button_html  = '<button id="show_error_report">';
+        button_html += PMA_messages.strShowReportDetails;
+        button_html += '</button>';
+
+        button_html += '<a id="change_error_settings">';
+        button_html += PMA_getImage('s_cog', PMA_messages.strChangeReportSettings);
+        button_html += '</a>';
+
+        button_html += '<a href="#" id="ignore_error">';
+        button_html += PMA_getImage('b_close', PMA_messages.strIgnore);
+        button_html += '</a>';
+
+        $buttons.html(button_html);
+
+        $div.append($buttons);
+        $div.appendTo(document.body);
+        $(document).on('click', '#change_error_settings', ErrorReport._redirect_to_settings);
+        $(document).on('click', '#show_error_report', ErrorReport._createReportDialog);
+        $(document).on('click', '#ignore_error', ErrorReport._removeErrorNotification);
+    },
+    /**
+     * Removes the notification if it was displayed before
+     *
+     * @return void
+     */
+    _removeErrorNotification: function (e) {
+        if (e) {
+            // don't remove the hash fragment by navigating to #
+            e.preventDefault();
+        }
+        $('#error_notification').fadeOut(function () {
+            $(this).remove();
+        });
+    },
+    /**
+     * Extracts Exception name from message if it exists
+     *
+     * @return String
+     */
+    _extractExceptionName: function (exception) {
+        if (exception.message === null || typeof(exception.message) === 'undefined') {
+            return '';
+        }
+
+        var reg = /([a-zA-Z]+):/;
+        var regex_result = reg.exec(exception.message);
+        if (regex_result && regex_result.length === 2) {
+            return regex_result[1];
+        }
+
+        return '';
+    },
+    /**
+     * Shows the modal dialog previewing the report
+     *
+     * @return void
+     */
+    _createReportDialog: function () {
+        ErrorReport._removeErrorNotification();
+        ErrorReport._showReportDialog(ErrorReport._last_exception);
+    },
+    /**
+     * Redirects to the settings page containing error report
+     * preferences
+     *
+     * @return void
+     */
+    _redirect_to_settings: function () {
+        window.location.href = 'prefs_forms.php?form=Features';
+    },
+    /**
+     * Returns the report data to send to the server
+     *
+     * @param exception object exception info
+     *
+     * @return object
+     */
+    _get_report_data: function (exception) {
+        var report_data = {
+            'ajax_request': true,
+            'exception': exception,
+            'current_url': window.location.href,
+            'exception_type': 'js'
+        };
+        if (AJAX.scriptHandler._scripts.length > 0) {
+            report_data.scripts = AJAX.scriptHandler._scripts.map(
+                function (script) {
+                    return script;
+                }
+            );
+        }
+        return report_data;
+    },
+    /**
+     * Wraps all global functions that start with PMA_
+     *
+     * @return void
+     *
+     * This function needs to be changes as no objects are available
+     * in the global scope so window does not contain any function
+     */
+    wrap_global_functions: function () {
+        for (var key in window) {
+            if (key.indexOf('PMA_') === 0) {
+                var global = window[key];
+                if (typeof(global) === 'function') {
+                    window[key] = ErrorReport.wrap_function(global);
+                }
+            }
+        }
+    },
+    /**
+     * Wraps given function in error reporting code and returns wrapped function
+     *
+     * @param func function to be wrapped
+     *
+     * @return function
+     */
+    wrap_function: function (func) {
+        // console.log(func.wrapped);
+        if (!func.wrapped) {
+            var new_func = function () {
+                try {
+                    return func.apply(this, arguments);
+                } catch (x) {
+                    // console.log(new Error(x));
+                    TraceKit.report(x);
+                }
+            };
+            new_func.wrapped = true;
+            // Set guid of wrapped function same as original function, so it can be removed
+            // See bug#4146 (problem with jquery draggable and sortable)
+            new_func.guid = func.guid = func.guid || new_func.guid || jQuery.guid++;
+            return new_func;
+        } else {
+            // console.log(func);
+            return func;
+        }
+    },
+    /**
+     * Automatically wraps the callback in AJAX.registerOnload
+     *
+     * @return void
+     */
+    _wrap_ajax_onload_callback: function () {
+        var oldOnload = AJAX.registerOnload;
+        AJAX.registerOnload = function (file, func) {
+            func = ErrorReport.wrap_function(func);
+            oldOnload.call(this, file, func);
+        };
+    },
+    /**
+     * Automatically wraps the callback in $.fn.on
+     *
+     * @return void
+     *
+     * Since we are exporting the instance of jQuery from
+     * '/util/extend_jquery', therefore this method will work
+     * fine and wrap the callback of $.fn.on of jQuery instance.
+     */
+    _wrap_$_on_callback: function () {
+        var oldOn = $.fn.on;
+        $.fn.on = function () {
+            for (var i = 1; i <= 3; i++) {
+                if (typeof(arguments[i]) === 'function') {
+                    arguments[i] = ErrorReport.wrap_function(arguments[i]);
+                    break;
+                }
+            }
+            return oldOn.apply(this, arguments);
+        };
+    },
+    /**
+     * Wraps all global functions that start with PMA_
+     * also automatically wraps the callback in AJAX.registerOnload
+     *
+     * @return void
+     */
+    set_up_error_reporting: function () {
+        ErrorReport.wrap_global_functions();
+        ErrorReport._wrap_ajax_onload_callback();
+        ErrorReport._wrap_$_on_callback();
+    }
+
+};
+
+export default ErrorReport;

--- a/js/src/classes/ErrorReport.js
+++ b/js/src/classes/ErrorReport.js
@@ -8,7 +8,7 @@ import { PMA_commonParams } from '../variables/common_params';
 import { PMA_ajaxShowMessage } from '../utils/show_ajax_messages';
 import { PMA_getImage } from '../functions/get_image';
 import TraceKit from 'tracekit';
-import { jQuery as $ } from '../utils/extend_jquery';
+import { jQuery as $ } from '../utils/JqueryExtended';
 
 /**
  * This Object uses the library TraceKit to generate the backtrace of the

--- a/js/src/console.js
+++ b/js/src/console.js
@@ -1,0 +1,417 @@
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * Used in or for console
+ *
+ * @package phpMyAdmin-Console
+ */
+import PMA_consoleBookmarks from './classes/Console/PMA_consoleBookmarks';
+import PMA_consoleDebug from './classes/Console/PMA_consoleDebug';
+import PMA_consoleInput from './classes/Console/PMA_consoleInput';
+import PMA_consoleMessages from './classes/Console/PMA_consoleMessages';
+import PMA_consoleResizer from './classes/Console/PMA_ConsoleResizer';
+/**
+ * Console object
+ */
+export var PMA_console = {
+    /**
+     * @var object, jQuery object, selector is '#pma_console>.content'
+     * @access private
+     */
+    $consoleContent: null,
+    /**
+     * @var object, jQuery object, selector is '#pma_console .content',
+     *  used for resizer
+     * @access private
+     */
+    $consoleAllContents: null,
+    /**
+     * @var object, jQuery object, selector is '#pma_console .toolbar'
+     * @access private
+     */
+    $consoleToolbar: null,
+    /**
+     * @var object, jQuery object, selector is '#pma_console .template'
+     * @access private
+     */
+    $consoleTemplates: null,
+    /**
+     * @var object, jQuery object, form for submit
+     * @access private
+     */
+    $requestForm: null,
+    /**
+     * @var object, contain console config
+     * @access private
+     */
+    config: null,
+    /**
+     * @var bool, if console element exist, it'll be true
+     * @access public
+     */
+    isEnabled: false,
+    /**
+     * @var bool, make sure console events bind only once
+     * @access private
+     */
+    isInitialized: false,
+    pmaConsoleResizer: null,
+    pmaConsoleInput: null,
+    pmaConsoleMessages: null,
+    pmaConsoleBookmarks: null,
+    pmaConsoleDebug: null,
+    /**
+     * Used for console initialize, reinit is ok, just some variable assignment
+     *
+     * @return void
+     */
+    initialize: function () {
+        if ($('#pma_console').length === 0) {
+            return;
+        }
+
+        PMA_console.config = configGet('Console', false);
+
+        PMA_console.isEnabled = true;
+
+        // Vars init
+        PMA_console.$consoleToolbar = $('#pma_console').find('>.toolbar');
+        PMA_console.$consoleContent = $('#pma_console').find('>.content');
+        PMA_console.$consoleAllContents = $('#pma_console').find('.content');
+        PMA_console.$consoleTemplates = $('#pma_console').find('>.templates');
+
+        // Generate a from for post
+        PMA_console.$requestForm = $('<form method="post" action="import.php">' +
+            '<input name="is_js_confirmed" value="0">' +
+            '<textarea name="sql_query"></textarea>' +
+            '<input name="console_message_id" value="0">' +
+            '<input name="server" value="">' +
+            '<input name="db" value="">' +
+            '<input name="table" value="">' +
+            '<input name="token" value="">' +
+            '</form>'
+        );
+        PMA_console.$requestForm.children('[name=token]').val(PMA_commonParams.get('token'));
+        PMA_console.$requestForm.on('submit', AJAX.requestHandler);
+
+        // Event binds shouldn't run again
+        if (PMA_console.isInitialized === false) {
+            // Load config first
+            if (PMA_console.config.AlwaysExpand === true) {
+                $('#pma_console_options input[name=always_expand]').prop('checked', true);
+            }
+            if (PMA_console.config.StartHistory === true) {
+                $('#pma_console_options').find('input[name=start_history]').prop('checked', true);
+            }
+            if (PMA_console.config.CurrentQuery === true) {
+                $('#pma_console_options').find('input[name=current_query]').prop('checked', true);
+            }
+            if (PMA_console.config.EnterExecutes === true) {
+                $('#pma_console_options').find('input[name=enter_executes]').prop('checked', true);
+            }
+            if (PMA_console.config.DarkTheme === true) {
+                $('#pma_console_options').find('input[name=dark_theme]').prop('checked', true);
+                $('#pma_console').find('>.content').addClass('console_dark_theme');
+            }
+
+            PMA_console.pmaConsoleResizer = new PMA_consoleResizer(PMA_console);
+            PMA_console.pmaConsoleInput = new PMA_consoleInput(PMA_console);
+            PMA_console.pmaConsoleMessages = new PMA_consoleMessages(PMA_console);
+            PMA_console.pmaConsoleBookmarks = new PMA_consoleBookmarks(PMA_console);
+            PMA_console.pmaConsoleDebug = new PMA_consoleDebug(PMA_console);
+
+            PMA_console.$consoleToolbar.children('.console_switch').click(PMA_console.toggle);
+
+            $('#pma_console').find('.toolbar').children().mousedown(function (event) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            });
+
+            $('#pma_console').find('.button.clear').click(function () {
+                PMA_console.pmaConsoleMessages.clear();
+            });
+
+            $('#pma_console').find('.button.history').click(function () {
+                PMA_console.pmaConsoleMessages.showHistory();
+            });
+
+            $('#pma_console').find('.button.options').click(function () {
+                PMA_console.showCard('#pma_console_options');
+            });
+
+            $('#pma_console').find('.button.debug').click(function () {
+                PMA_console.showCard('#debug_console');
+            });
+
+            PMA_console.$consoleContent.click(function (event) {
+                if (event.target === this) {
+                    PMA_console.pmaConsoleInput.focus();
+                }
+            });
+
+            $('#pma_console').find('.mid_layer').click(function () {
+                PMA_console.hideCard($(this).parent().children('.card'));
+            });
+            $('#debug_console').find('.switch_button').click(function () {
+                PMA_console.hideCard($(this).closest('.card'));
+            });
+            $('#pma_bookmarks').find('.switch_button').click(function () {
+                PMA_console.hideCard($(this).closest('.card'));
+            });
+            $('#pma_console_options').find('.switch_button').click(function () {
+                PMA_console.hideCard($(this).closest('.card'));
+            });
+
+            $('#pma_console_options').find('input[type=checkbox]').change(function () {
+                PMA_console.updateConfig();
+            });
+
+            $('#pma_console_options').find('.button.default').click(function () {
+                $('#pma_console_options input[name=always_expand]').prop('checked', false);
+                $('#pma_console_options').find('input[name=start_history]').prop('checked', false);
+                $('#pma_console_options').find('input[name=current_query]').prop('checked', true);
+                $('#pma_console_options').find('input[name=enter_executes]').prop('checked', false);
+                $('#pma_console_options').find('input[name=dark_theme]').prop('checked', false);
+                PMA_console.updateConfig();
+            });
+
+            $('#pma_console_options').find('input[name=enter_executes]').change(function () {
+                PMA_console.pmaConsoleMessages.showInstructions(PMA_console.config.EnterExecutes);
+            });
+
+            $(document).ajaxComplete(function (event, xhr, ajaxOptions) {
+                if (ajaxOptions.dataType && ajaxOptions.dataType.indexOf('json') !== -1) {
+                    return;
+                }
+                if (xhr.status !== 200) {
+                    return;
+                }
+                try {
+                    var data = JSON.parse(xhr.responseText);
+                    PMA_console.ajaxCallback(data);
+                } catch (e) {
+                    console.trace();
+                    console.log('Failed to parse JSON: ' + e.message);
+                }
+            });
+
+            PMA_console.isInitialized = true;
+        }
+
+        // Change console mode from cookie
+        switch (PMA_console.config.Mode) {
+        case 'collapse':
+            PMA_console.collapse();
+            break;
+            /* jshint -W086 */// no break needed in default section
+        case 'info':
+            /* jshint +W086 */
+            PMA_console.info();
+            break;
+        case 'show':
+            PMA_console.show(true);
+            PMA_console.scrollBottom();
+            break;
+        default:
+            PMA_console.setConfig('Mode', 'info');
+        }
+    },
+    /**
+     * Execute query and show results in console
+     *
+     * @return void
+     */
+    execute: function (queryString, options) {
+        if (typeof(queryString) !== 'string' || ! /[a-z]|[A-Z]/.test(queryString)) {
+            return;
+        }
+        PMA_console.$requestForm.children('textarea').val(queryString);
+        PMA_console.$requestForm.children('[name=server]').attr('value', PMA_commonParams.get('server'));
+        if (options && options.db) {
+            PMA_console.$requestForm.children('[name=db]').val(options.db);
+            if (options.table) {
+                PMA_console.$requestForm.children('[name=table]').val(options.table);
+            } else {
+                PMA_console.$requestForm.children('[name=table]').val('');
+            }
+        } else {
+            PMA_console.$requestForm.children('[name=db]').val(
+                (PMA_commonParams.get('db').length > 0 ? PMA_commonParams.get('db') : ''));
+        }
+        PMA_console.$requestForm.find('[name=profiling]').remove();
+        if (options && options.profiling === true) {
+            PMA_console.$requestForm.append('<input name="profiling" value="on">');
+        }
+        if (! confirmQuery(PMA_console.$requestForm[0], PMA_console.$requestForm.children('textarea')[0].value)) {
+            return;
+        }
+        PMA_console.$requestForm.children('[name=console_message_id]')
+            .val(PMA_console.pmaConsoleMessages.appendQuery({ sql_query: queryString }).message_id);
+        PMA_console.$requestForm.trigger('submit');
+        PMA_console.pmaConsoleInput.clear();
+        PMA_reloadNavigation();
+    },
+    ajaxCallback: function (data) {
+        if (data && data.console_message_id) {
+            PMA_console.pmaConsoleMessages.updateQuery(data.console_message_id, data.success,
+                (data._reloadQuerywindow ? data._reloadQuerywindow : false));
+        } else if (data && data._reloadQuerywindow) {
+            if (data._reloadQuerywindow.sql_query.length > 0) {
+                PMA_console.pmaConsoleMessages.appendQuery(data._reloadQuerywindow, 'successed')
+                    .$message.addClass(PMA_console.config.CurrentQuery ? '' : 'hide');
+            }
+        }
+    },
+    /**
+     * Change console to collapse mode
+     *
+     * @return void
+     */
+    collapse: function () {
+        PMA_console.setConfig('Mode', 'collapse');
+        var pmaConsoleHeight = Math.max(92, PMA_console.config.Height);
+
+        PMA_console.$consoleToolbar.addClass('collapsed');
+        PMA_console.$consoleAllContents.height(pmaConsoleHeight);
+        PMA_console.$consoleContent.stop();
+        PMA_console.$consoleContent.animate({ 'margin-bottom': -1 * PMA_console.$consoleContent.outerHeight() + 'px' },
+            'fast', 'easeOutQuart', function () {
+                PMA_console.$consoleContent.css({ display:'none' });
+                $(window).trigger('resize');
+            });
+        PMA_console.hideCard();
+    },
+    /**
+     * Show console
+     *
+     * @param bool inputFocus If true, focus the input line after show()
+     * @return void
+     */
+    show: function (inputFocus) {
+        PMA_console.setConfig('Mode', 'show');
+
+        var pmaConsoleHeight = Math.max(92, PMA_console.config.Height);
+        pmaConsoleHeight = Math.min(PMA_console.config.Height, (window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight)-25);
+        PMA_console.$consoleContent.css({ display:'block' });
+        if (PMA_console.$consoleToolbar.hasClass('collapsed')) {
+            PMA_console.$consoleToolbar.removeClass('collapsed');
+        }
+        PMA_console.$consoleAllContents.height(pmaConsoleHeight);
+        PMA_console.$consoleContent.stop();
+        PMA_console.$consoleContent.animate({ 'margin-bottom': 0 },
+            'fast', 'easeOutQuart', function () {
+                $(window).trigger('resize');
+                if (inputFocus) {
+                    PMA_console.pmaConsoleInput.focus();
+                }
+            });
+    },
+    /**
+     * Change console to SQL information mode
+     * this mode shows current SQL query
+     * This mode is the default mode
+     *
+     * @return void
+     */
+    info: function () {
+        // Under construction
+        PMA_console.collapse();
+    },
+    /**
+     * Toggle console mode between collapse/show
+     * Used for toggle buttons and shortcuts
+     *
+     * @return void
+     */
+    toggle: function () {
+        switch (PMA_console.config.Mode) {
+        case 'collapse':
+        case 'info':
+            PMA_console.show(true);
+            break;
+        case 'show':
+            PMA_console.collapse();
+            break;
+        default:
+            PMA_consoleInitialize();
+        }
+    },
+    /**
+     * Scroll console to bottom
+     *
+     * @return void
+     */
+    scrollBottom: function () {
+        PMA_console.$consoleContent.scrollTop(PMA_console.$consoleContent.prop('scrollHeight'));
+    },
+    /**
+     * Show card
+     *
+     * @param string cardSelector Selector, select string will be "#pma_console " + cardSelector
+     * this param also can be JQuery object, if you need.
+     *
+     * @return void
+     */
+    showCard: function (cardSelector) {
+        var $card = null;
+        if (typeof(cardSelector) !== 'string') {
+            if (cardSelector.length > 0) {
+                $card = cardSelector;
+            } else {
+                return;
+            }
+        } else {
+            $card = $('#pma_console ' + cardSelector);
+        }
+        if ($card.length === 0) {
+            return;
+        }
+        $card.parent().children('.mid_layer').show().fadeTo(0, 0.15);
+        $card.addClass('show');
+        PMA_console.pmaConsoleInput.blur();
+        if ($card.parents('.card').length > 0) {
+            PMA_console.showCard($card.parents('.card'));
+        }
+    },
+    /**
+     * Scroll console to bottom
+     *
+     * @param object $targetCard Target card JQuery object, if it's empty, function will hide all cards
+     * @return void
+     */
+    hideCard: function ($targetCard) {
+        if (! $targetCard) {
+            $('#pma_console').find('.mid_layer').fadeOut(140);
+            $('#pma_console').find('.card').removeClass('show');
+        } else if ($targetCard.length > 0) {
+            $targetCard.parent().find('.mid_layer').fadeOut(140);
+            $targetCard.find('.card').removeClass('show');
+            $targetCard.removeClass('show');
+        }
+    },
+    /**
+     * Used for update console config
+     *
+     * @return void
+     */
+    updateConfig: function () {
+        PMA_console.setConfig('AlwaysExpand', $('#pma_console_options input[name=always_expand]').prop('checked'));
+        PMA_console.setConfig('StartHistory', $('#pma_console_options').find('input[name=start_history]').prop('checked'));
+        PMA_console.setConfig('CurrentQuery', $('#pma_console_options').find('input[name=current_query]').prop('checked'));
+        PMA_console.setConfig('EnterExecutes', $('#pma_console_options').find('input[name=enter_executes]').prop('checked'));
+        PMA_console.setConfig('DarkTheme', $('#pma_console_options').find('input[name=dark_theme]').prop('checked'));
+        /* Setting the dark theme of the console*/
+        if (PMA_console.config.DarkTheme) {
+            $('#pma_console').find('>.content').addClass('console_dark_theme');
+        } else {
+            $('#pma_console').find('>.content').removeClass('console_dark_theme');
+        }
+    },
+    setConfig: function (key, value) {
+        PMA_console.config[key] = value;
+        configSet('Console/' + key, value);
+    },
+    isSelect: function (queryString) {
+        var reg_exp = /^SELECT\s+/i;
+        return reg_exp.test(queryString);
+    }
+}

--- a/js/src/console.js
+++ b/js/src/console.js
@@ -12,7 +12,7 @@ import PMA_consoleResizer from './classes/Console/PMA_ConsoleResizer';
 /**
  * Console object
  */
-export var PMA_console = {
+var PMA_console = {
     /**
      * @var object, jQuery object, selector is '#pma_console>.content'
      * @access private
@@ -290,7 +290,7 @@ export var PMA_console = {
         PMA_console.setConfig('Mode', 'show');
 
         var pmaConsoleHeight = Math.max(92, PMA_console.config.Height);
-        pmaConsoleHeight = Math.min(PMA_console.config.Height, (window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight)-25);
+        pmaConsoleHeight = Math.min(PMA_console.config.Height, (window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight) - 25);
         PMA_console.$consoleContent.css({ display:'block' });
         if (PMA_console.$consoleToolbar.hasClass('collapsed')) {
             PMA_console.$consoleToolbar.removeClass('collapsed');
@@ -414,4 +414,6 @@ export var PMA_console = {
         var reg_exp = /^SELECT\s+/i;
         return reg_exp.test(queryString);
     }
-}
+};
+
+export default PMA_console;

--- a/js/src/error_report.js
+++ b/js/src/error_report.js
@@ -1,0 +1,8 @@
+import ErrorReport from './classes/ErrorReport';
+import TraceKit from 'tracekit';
+
+export function onload1 () {
+    TraceKit.report.subscribe(ErrorReport.error_handler);
+    ErrorReport.set_up_error_reporting();
+    ErrorReport.wrap_global_functions();
+}

--- a/js/src/functions/navigation.js
+++ b/js/src/functions/navigation.js
@@ -146,7 +146,7 @@ export function PMA_showCurrentNavigation () {
 
     function isItemInContainer ($container, name, clazz) {
         var $whichItem = null;
-        $items = $container.find(clazz);
+        var $items = $container.find(clazz);
         var found = false;
         $items.each(function () {
             if ($(this).children('a').text() === name) {

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -2,6 +2,7 @@ import { AJAX } from './ajax';
 import './variables/import_variables';
 import { jQuery as $ } from './utils/JqueryExtended';
 import files from './consts/files';
+import Console from './console';
 
 /**
  * Page load event handler
@@ -84,3 +85,7 @@ if (typeof files[firstPage] !== 'undefined' && firstPage.toLocaleLowerCase() !==
         AJAX.scriptHandler.add(files[indexPage][i], 1);
     }
 }
+
+$(function () {
+    Console.initialize();
+});

--- a/libraries/classes/Console.php
+++ b/libraries/classes/Console.php
@@ -124,7 +124,7 @@ class Console
      */
     public function getScripts(): array
     {
-        return ['console.js'];
+        return ['console'];
     }
 
     /**


### PR DESCRIPTION
This pr contains the PMA Console and PMA Error Report code in the modular form. The old files were split into multiple files to separate out functions required for base functionality.
There is some issue with this pr.
1). Earlier all the global functions were wrapped in the context of ErrorReport but now due to js modules it will not be possible to wrap all the imports in the context of ErrorReport.
2). Cross-origin files are now not allowed in Tracekit so stacktrace cannot be generated in developer mode.
3). The stack trace generated will contain a single line with column number because of uglified js file as output. See Tracekit Issue: https://github.com/occ/TraceKit/issues/61

This pr is in continuations of Mod_Js_Server_Privileges. Before reviewing this pr, review Mod_Js_Server_Privileges and merge and then compare with this pr.

Before submitting pull request, please check that every commit:

- [ ] Has proper Signed-Off-By
- [ ] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
