### PR TITLE
Fix PHP 7.3 warning: "continue" in "switch" is equal to "break"

### DIFF
--- a/libraries/classes/Config/FormDisplay.php
+++ b/libraries/classes/Config/FormDisplay.php
@@ -686,7 +686,8 @@ class FormDisplay
                         if (! $successfullyValidated) {
                             $this->_errors[$workPath][] = __('Incorrect value!');
                             $result = false;
-                            continue;
+                            // "continue" for the $form->fields foreach-loop
+                            continue 2;
                         }
                         break;
                     case 'string':


### PR DESCRIPTION
Fixes #14525