### PR TITLE
Add method getHtmlForColumnDropdown in CentralColumns.php

### DIFF
--- a/libraries/classes/CentralColumns.php
+++ b/libraries/classes/CentralColumns.php
@@ -1079,6 +1079,33 @@ class CentralColumns
     }
 
     /**
+     * build dropdown select html to select column in selected table,
+     * include only columns which are not already in central list
+     *
+     * @param string $db           current database to which selected table belongs
+     * @param string $selected_tbl selected table
+     *
+     * @return string html to select column
+     */
+    public function getHtmlForColumnDropdown($db, $selected_tbl)
+    {
+        $existing_cols = $this->getFromTable($db, $selected_tbl);
+        $this->dbi->selectDb($db);
+        $columns = (array) $this->dbi->getColumnNames(
+            $db, $selected_tbl
+        );
+        $selectColHtml = "";
+        foreach ($columns as $column) {
+            if (!in_array($column, $existing_cols)) {
+                $selectColHtml .= '<option value="' . htmlspecialchars($column) . '">'
+                    . htmlspecialchars($column)
+                    . '</option>';
+            }
+        }
+        return $selectColHtml;
+    }
+
+    /**
      * build html for adding a new user defined column to central list
      *
      * @param string $db            current database

--- a/test/classes/CentralColumnsTest.php
+++ b/test/classes/CentralColumnsTest.php
@@ -715,4 +715,24 @@ class CentralColumnsTest extends TestCase
             $result
         );
     }
+
+    /**
+     * Test for getHtmlForColumnDropdown
+     *
+     * @return void
+     */
+    public function testGetHtmlForColumnDropdown()
+    {
+        $db = 'PMA_db';
+        $selected_tbl = 'PMA_table';
+        $result = $this->centralColumns->getHtmlForColumnDropdown(
+            $db,
+            $selected_tbl
+        );
+        $this->assertEquals(
+            '<option value="id">id</option><option value="col1">col1</option>'
+            . '<option value="col2">col2</option>',
+            $result
+        );
+    }
 }


### PR DESCRIPTION
Missing method from CentralColumns.php class: Fixes #14530.

Before submitting pull request, please check that every commit:

- [ ] Has proper Signed-Off-By
- [ ] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
