### PR TITLE
Fix bad callers to getError where null was being passed.

### DIFF
--- a/libraries/classes/Rte/Events.php
+++ b/libraries/classes/Rte/Events.php
@@ -179,7 +179,7 @@ class Events
                             htmlspecialchars($drop_item)
                         )
                         . '<br />'
-                        . __('MySQL said: ') . $this->dbi->getError(null);
+                        . __('MySQL said: ') . $this->dbi->getError();
                     } else {
                         $result = $this->dbi->tryQuery($item_query);
                         if (! $result) {
@@ -188,7 +188,7 @@ class Events
                                 htmlspecialchars($item_query)
                             )
                             . '<br />'
-                            . __('MySQL said: ') . $this->dbi->getError(null);
+                            . __('MySQL said: ') . $this->dbi->getError();
                             // We dropped the old item, but were unable to create
                             // the new one. Try to restore the backup query
                             $result = $this->dbi->tryQuery($create_item);
@@ -219,7 +219,7 @@ class Events
                             htmlspecialchars($item_query)
                         )
                         . '<br /><br />'
-                        . __('MySQL said: ') . $this->dbi->getError(null);
+                        . __('MySQL said: ') . $this->dbi->getError();
                     } else {
                         $message = Message::success(
                             __('Event %1$s has been created.')

--- a/libraries/classes/Rte/General.php
+++ b/libraries/classes/Rte/General.php
@@ -63,7 +63,7 @@ class General
         $errors[] = $error . '<br />'
             . __('The backed up query was:')
             . "\"" . htmlspecialchars($createStatement) . "\"" . '<br />'
-            . __('MySQL said: ') . $this->dbi->getError(null);
+            . __('MySQL said: ') . $this->dbi->getError();
 
         return $errors;
     }

--- a/libraries/classes/Rte/Routines.php
+++ b/libraries/classes/Rte/Routines.php
@@ -295,7 +295,7 @@ class Routines
                             htmlspecialchars($drop_routine)
                         )
                         . '<br />'
-                        . __('MySQL said: ') . $this->dbi->getError(null);
+                        . __('MySQL said: ') . $this->dbi->getError();
                     } else {
                         list($newErrors, $message) = $this->create(
                             $routine_query,
@@ -322,7 +322,7 @@ class Routines
                         htmlspecialchars($routine_query)
                     )
                     . '<br /><br />'
-                    . __('MySQL said: ') . $this->dbi->getError(null);
+                    . __('MySQL said: ') . $this->dbi->getError();
                 } else {
                     $message = Message::success(
                         __('Routine %1$s has been created.')
@@ -436,7 +436,7 @@ class Routines
                 htmlspecialchars($routine_query)
             )
             . '<br />'
-            . __('MySQL said: ') . $this->dbi->getError(null);
+            . __('MySQL said: ') . $this->dbi->getError();
             // We dropped the old routine,
             // but were unable to create the new one
             // Try to restore the backup query
@@ -1544,7 +1544,7 @@ class Routines
                         htmlspecialchars($multiple_query)
                     )
                     . '<br /><br />'
-                    . __('MySQL said: ') . $this->dbi->getError(null)
+                    . __('MySQL said: ') . $this->dbi->getError()
                 );
             }
 

--- a/libraries/classes/Rte/Triggers.php
+++ b/libraries/classes/Rte/Triggers.php
@@ -150,7 +150,7 @@ class Triggers
                             htmlspecialchars($drop_item)
                         )
                         . '<br />'
-                        . __('MySQL said: ') . $this->dbi->getError(null);
+                        . __('MySQL said: ') . $this->dbi->getError();
                     } else {
                         $result = $this->dbi->tryQuery($item_query);
                         if (! $result) {
@@ -159,7 +159,7 @@ class Triggers
                                 htmlspecialchars($item_query)
                             )
                             . '<br />'
-                            . __('MySQL said: ') . $this->dbi->getError(null);
+                            . __('MySQL said: ') . $this->dbi->getError();
                             // We dropped the old item, but were unable to create the
                             // new one. Try to restore the backup query.
                             $result = $this->dbi->tryQuery($create_item);
@@ -191,7 +191,7 @@ class Triggers
                             htmlspecialchars($item_query)
                         )
                         . '<br /><br />'
-                        . __('MySQL said: ') . $this->dbi->getError(null);
+                        . __('MySQL said: ') . $this->dbi->getError();
                     } else {
                         $message = Message::success(
                             __('Trigger %1$s has been created.')


### PR DESCRIPTION
Fixes #14552: Considering how function signatures work in PHP, this should
be a reltatively 'safe' change, as the mysqli lib currently would still
do a check for cases where the passed in $link was either null or false.
Otherwise the bug's source appears to be a common mistake in PHP:
null != undefined

Signed-off-by: Andy Baugh <thomas.baugh@cpanel.net>

Before submitting pull request, please check that every commit:

- [ ] Has proper Signed-Off-By
- [ ] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
