### PR TITLE
Fix displaying of indexes

### DIFF
--- a/libraries/classes/Controllers/Table/TableStructureController.php
+++ b/libraries/classes/Controllers/Table/TableStructureController.php
@@ -1353,14 +1353,13 @@ class TableStructureController extends TableController
         }
 
         $engine = $this->table_obj->getStorageEngine();
-        $foreignKeySupported = Util::isForeignKeySupported($engine);
         return $this->template->render('table/structure/display_structure', [
             'url_params' => [
                 'db' => $this->db,
                 'table' => $this->table,
             ],
             'is_foreign_key_supported' => Util::isForeignKeySupported($engine),
-            'displayIndexesHtml' => $foreignKeySupported ? Index::getHtmlForDisplayIndexes() : null,
+            'displayIndexesHtml' => Index::getHtmlForDisplayIndexes(),
             'cfg_relation' => $this->relation->getRelationsParam(),
             'hide_structure_actions' => $hideStructureActions,
             'db' => $this->db,


### PR DESCRIPTION
Fixes an issue where you can't see or edit indexes on tables which don't have foreign keys support but support "normal" ones. An example engine like this would be TokuDB.

Before submitting pull request, please check that every commit:

- [x] Has proper Signed-Off-By
- [x] Has commit message which describes it
- [x] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
