### PR TITLE
Fix several issues with table headers in Safari

### DIFF
--- a/js/sql.js
+++ b/js/sql.js
@@ -1056,14 +1056,18 @@ function rearrangeStickyColumns ($sticky_columns, $table_results) {
     var $originalHeader = $table_results.find('thead');
     var $originalColumns = $originalHeader.find('tr:first').children();
     var $clonedHeader = $originalHeader.clone();
+    var is_firefox = navigator.userAgent.indexOf('Firefox') > -1;
+    var is_safari = navigator.userAgent.indexOf('Safari') > -1;
     // clone width per cell
-    $clonedHeader.find('tr:first').children().width(function (i,val) {
+    $clonedHeader.find('tr:first').children().each(function (i) {
         var width = $originalColumns.eq(i).width();
-        var is_firefox = navigator.userAgent.indexOf('Firefox') > -1;
-        if (! is_firefox) {
+        if (! is_firefox && ! is_safari) {
             width += 1;
         }
-        return width;
+        $(this).width(width);
+        if (is_safari) {
+            $(this).css('min-width', width).css('max-width', width);
+        }
     });
     $sticky_columns.empty().append($clonedHeader);
 }

--- a/templates/display/results/comment_for_row.twig
+++ b/templates/display/results/comment_for_row.twig
@@ -1,6 +1,6 @@
 {% if comments_map[fields_meta.table] is defined
     and comments_map[fields_meta.table][fields_meta.name] is defined %}
-    <span class="tblcomment" title="{{ comments_map[fields_meta.table][fields_meta.name] }}">
+    <br><span class="tblcomment" title="{{ comments_map[fields_meta.table][fields_meta.name] }}">
         {% if comments_map[fields_meta.table][fields_meta.name]|length > limit_chars %}
             {{ comments_map[fields_meta.table][fields_meta.name]|slice(0, limit_chars) }}…
         {% else %}


### PR DESCRIPTION
The width += 1 does not apply to Safari, either.

Safari requires min-width and max-width to be set. “width” is not honored.

Add a line break to template so comments stay on separate line.

Moved browser checks to higher scope; the user agent only needs to be checked once, not once per cell.

Before submitting pull request, please check that every commit:

- [ ] Has proper Signed-Off-By
- [ ] Has commit message which describes it
- [ ] Is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any new functionality is covered by tests
