### PR TITLE
Fix left menu not showing on Opera 12.16

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1270,9 +1270,12 @@ var ResizeHandler = function () {
         var $nav_tree   = $('#pma_navigation_tree');
         var $nav_header = $('#pma_navigation_header');
         var $nav_tree_content = $('#pma_navigation_tree_content');
-        $nav_tree.height($nav.height() - $nav_header.height());
+				var height = ($nav.height() - $nav_header.height());
+
+				height = height > 50 ? height : 800; //keep min. height
+        $nav_tree.height(height);
         if ($nav_tree_content.length > 0) {
-            $nav_tree_content.height($nav_tree.height() - $nav_tree_content.position().top);
+            $nav_tree_content.height(height - $nav_tree_content.position().top);
         } else {
             // TODO: in fast filter search response there is no #pma_navigation_tree_content, needs to be added in php
             $nav_tree.css({


### PR DESCRIPTION
left database tree is not shown if size computes to 0 or less. This will ensure to have a min height.
Please describe your pull request.

Fixes #14591 

Signed-off-by: Marc Krämer <github@mokraemer.de>