### PR TITLE
AllowThirdPartyFraming adjustement

### DIFF
--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -572,7 +572,7 @@ class Header
             header(
                 'X-Frame-Options: DENY'
             );
-        } 
+        }
         header('Referrer-Policy: no-referrer');
         header(
             "Content-Security-Policy: default-src 'self' "

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -564,14 +564,10 @@ class Header
         }
         /* Prevent against ClickJacking by disabling framing */
         if ( strtolower($GLOBALS['cfg']['AllowThirdPartyFraming']) === 'sameorigin') {
-            header(
-                'X-Frame-Options: SAMEORIGIN'
-            );
+            header('X-Frame-Options: SAMEORIGIN');
         }
         else if ( $GLOBALS['cfg']['AllowThirdPartyFraming'] !== true ) {
-            header(
-                'X-Frame-Options: DENY'
-            );
+            header('X-Frame-Options: DENY');
         }
         header('Referrer-Policy: no-referrer');
         header(

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -563,15 +563,16 @@ class Header
             $captcha_url = '';
         }
         /* Prevent against ClickJacking by disabling framing */
-        if (! $GLOBALS['cfg']['AllowThirdPartyFraming']) {
-            header(
-                'X-Frame-Options: DENY'
-            );
-        } elseif ($GLOBALS['cfg']['AllowThirdPartyFraming'] === 'sameorigin') {
+        if ( strtolower($GLOBALS['cfg']['AllowThirdPartyFraming']) === 'sameorigin') {
             header(
                 'X-Frame-Options: SAMEORIGIN'
             );
         }
+        else if ( $GLOBALS['cfg']['AllowThirdPartyFraming'] !== true ) {
+            header(
+                'X-Frame-Options: DENY'
+            );
+        } 
         header('Referrer-Policy: no-referrer');
         header(
             "Content-Security-Policy: default-src 'self' "

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -563,7 +563,7 @@ class Header
             $captcha_url = '';
         }
         /* Prevent against ClickJacking by disabling framing */
-        if ( strtolower( $GLOBALS['cfg']['AllowThirdPartyFraming'] ) === 'sameorigin') {
+        if ( strtolower($GLOBALS['cfg']['AllowThirdPartyFraming']) === 'sameorigin') {
             header('X-Frame-Options: SAMEORIGIN');
         }
         else if ( $GLOBALS['cfg']['AllowThirdPartyFraming'] !== true ) {

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -563,7 +563,7 @@ class Header
             $captcha_url = '';
         }
         /* Prevent against ClickJacking by disabling framing */
-        if ( strtolower($GLOBALS['cfg']['AllowThirdPartyFraming']) === 'sameorigin') {
+        if ( strtolower( $GLOBALS['cfg']['AllowThirdPartyFraming'] ) === 'sameorigin') {
             header('X-Frame-Options: SAMEORIGIN');
         }
         else if ( $GLOBALS['cfg']['AllowThirdPartyFraming'] !== true ) {


### PR DESCRIPTION
1) some people  might use uppercase when setting headers i.e. `SAMEORIGIN` instead of `sameorigin`
2) the existing version of checking  with exclamation mark !  fails if accidentaly the value is set to anything (string, numeric, whatever, but not explicitly `false`.  So, as a security precaution, unless user explicitly sets the value `true`, all other posibilities should be percepted as `false`, so it should lead to the blocking of external-framing).

### Description

Please describe your pull request.

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.


Signed-off-by: Tazo Todua tazotodua+int@gmail.com