### PR TITLE
Fixed condition on the emptiness of enum type criteriaValues array

### DIFF
--- a/libraries/classes/Controllers/Table/TableSearchController.php
+++ b/libraries/classes/Controllers/Table/TableSearchController.php
@@ -1152,7 +1152,7 @@ class TableSearchController extends TableController
         $where = '';
         if ($unaryFlag) {
             $where = $backquoted_name . ' ' . $func_type;
-        } elseif (strncasecmp($types, 'enum', 4) == 0 && ! empty($criteriaValues)) {
+        } elseif (strncasecmp($types, 'enum', 4) == 0 && (! empty($criteriaValues) || $criteriaValues[0] === '0')) {
             $where = $backquoted_name;
             $where .= $this->_getEnumWhereClause($criteriaValues, $func_type);
         } elseif ($criteriaValues != '') {


### PR DESCRIPTION
Signed-off-by: Alessandro Dolci <alessandro.dolci@pm.me>

### Description

The if condition has a call to the empty function on the criteriaValues array, but in the considered case that array only contains a '0', so this makes it look empty to the function. I added a control on the first element of the array, to avoid this specific situation.
It's my first contribution, so I hope I did well with the branches. Let me know if there's something missing or to do, I'm happy to help.

Fixes #14630

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
