### PR TITLE
Issue #12158: auto expand the single database

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -742,7 +742,7 @@ function PMA_showCurrentNavigation () {
     var table = PMA_commonParams.get('table');
 
     var autoexpand = $('#pma_navigation_tree').hasClass('autoexpand');
-    
+
     $('#pma_navigation_tree')
         .find('li.selected')
         .removeClass('selected');
@@ -769,17 +769,7 @@ function PMA_showCurrentNavigation () {
                 handleTableOrDb(table, $('#pma_navigation_tree_content'));
             }
         } else if ($dbItem) {
-            var $expander = $dbItem.children('div:first').children('a.expander');
-            // if not loaded or loaded but collapsed
-            if (! $expander.hasClass('loaded') ||
-                $expander.find('img').is('.ic_b_plus')
-            ) {
-                expandTreeNode($expander, function () {
-                    handleTableOrDb(table, $dbItem);
-                });
-            } else {
-                handleTableOrDb(table, $dbItem);
-            }
+            fullExpand(table, $dbItem);
         }
     } else if ($('#navi_db_select').length && $('#navi_db_select').val()) {
         $('#navi_db_select').val('').hide().trigger('change');
@@ -800,6 +790,11 @@ function PMA_showCurrentNavigation () {
             $('#pma_navigation_tree').find('> div'), dbItemName, 'database', !table
         );
 
+        fullExpand(table, $dbItem);
+    }
+    PMA_showFullName($('#pma_navigation_tree'));
+
+    function fullExpand(table, $dbItem) {
         var $expander = $dbItem.children('div:first').children('a.expander');
         // if not loaded or loaded but collapsed
         if (! $expander.hasClass('loaded') ||
@@ -812,7 +807,6 @@ function PMA_showCurrentNavigation () {
             handleTableOrDb(table, $dbItem);
         }
     }
-    PMA_showFullName($('#pma_navigation_tree'));
 
     function handleTableOrDb (table, $dbItem) {
         if (table) {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -740,6 +740,9 @@ function scrollToView ($element, $forceToTop) {
 function PMA_showCurrentNavigation () {
     var db = PMA_commonParams.get('db');
     var table = PMA_commonParams.get('table');
+
+    var autoexpand = $('#pma_navigation_tree').hasClass('autoexpand');
+    
     $('#pma_navigation_tree')
         .find('li.selected')
         .removeClass('selected');
@@ -780,7 +783,9 @@ function PMA_showCurrentNavigation () {
         }
     } else if ($('#navi_db_select').length && $('#navi_db_select').val()) {
         $('#navi_db_select').val('').hide().trigger('change');
-    } else if ($('#pma_navigation_tree_content > ul > li').length === 1) { // automatically expand the list if there is only 1 database
+    } else if (autoexpand && $('#pma_navigation_tree_content > ul > li').length === 1) {
+        // automatically expand the list if there is only single database
+
         // find the name of the database
         var dbItemName = "";
 
@@ -790,7 +795,7 @@ function PMA_showCurrentNavigation () {
                 dbItemName = name;
             }
         });
-        
+
         var $dbItem = findLoadedItem(
             $('#pma_navigation_tree').find('> div'), dbItemName, 'database', !table
         );

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -780,6 +780,32 @@ function PMA_showCurrentNavigation () {
         }
     } else if ($('#navi_db_select').length && $('#navi_db_select').val()) {
         $('#navi_db_select').val('').hide().trigger('change');
+    } else if ($('#pma_navigation_tree_content > ul > li').length === 1) { // automatically expand the list if there is only 1 database
+        // find the name of the database
+        var dbItemName = "";
+
+        $('#pma_navigation_tree_content > ul > li').children('a').each(function () {
+            var name = $(this).text();
+            if (!dbItemName && name.trim()) { // if the name is not empty, it is the desired element
+                dbItemName = name;
+            }
+        });
+        
+        var $dbItem = findLoadedItem(
+            $('#pma_navigation_tree').find('> div'), dbItemName, 'database', !table
+        );
+
+        var $expander = $dbItem.children('div:first').children('a.expander');
+        // if not loaded or loaded but collapsed
+        if (! $expander.hasClass('loaded') ||
+            $expander.find('img').is('.ic_b_plus')
+        ) {
+            expandTreeNode($expander, function () {
+                handleTableOrDb(table, $dbItem);
+            });
+        } else {
+            handleTableOrDb(table, $dbItem);
+        }
     }
     PMA_showFullName($('#pma_navigation_tree'));
 

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -777,7 +777,7 @@ function PMA_showCurrentNavigation () {
         // automatically expand the list if there is only single database
 
         // find the name of the database
-        var dbItemName = "";
+        var dbItemName = '';
 
         $('#pma_navigation_tree_content > ul > li').children('a').each(function () {
             var name = $(this).text();
@@ -794,7 +794,7 @@ function PMA_showCurrentNavigation () {
     }
     PMA_showFullName($('#pma_navigation_tree'));
 
-    function fullExpand(table, $dbItem) {
+    function fullExpand (table, $dbItem) {
         var $expander = $dbItem.children('div:first').children('a.expander');
         // if not loaded or loaded but collapsed
         if (! $expander.hasClass('loaded') ||

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -649,6 +649,7 @@ $(function () {
         } else {
             // If the user is different
             navTreeStateUpdate();
+            PMA_reloadNavigation();
         }
     }
 });

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -773,13 +773,13 @@ function PMA_showCurrentNavigation () {
         }
     } else if ($('#navi_db_select').length && $('#navi_db_select').val()) {
         $('#navi_db_select').val('').hide().trigger('change');
-    } else if (autoexpand && $('#pma_navigation_tree_content > ul > li').length === 1) {
+    } else if (autoexpand && $('#pma_navigation_tree_content > ul > li.database').length === 1) {
         // automatically expand the list if there is only single database
 
         // find the name of the database
         var dbItemName = '';
 
-        $('#pma_navigation_tree_content > ul > li').children('a').each(function () {
+        $('#pma_navigation_tree_content > ul > li.database').children('a').each(function () {
             var name = $(this).text();
             if (!dbItemName && name.trim()) { // if the name is not empty, it is the desired element
                 dbItemName = name;

--- a/libraries/classes/Config/Descriptions.php
+++ b/libraries/classes/Config/Descriptions.php
@@ -519,6 +519,8 @@ class Descriptions
             'NavigationTreeShowProcedures_desc' => __('Whether to show procedures under database in the navigation tree'),
             'NavigationTreeShowEvents_name' => __('Show events in tree'),
             'NavigationTreeShowEvents_desc' => __('Whether to show events under database in the navigation tree'),
+            'NavigationTreeAutoexpandSingleDb_name' => __('Expand single database'),
+            'NavigationTreeAutoexpandSingleDb_desc' => __('Whether to expand single database in the navigation tree automatically.'),
             'NumRecentTables_desc' => __('Maximum number of recently used tables; set 0 to disable.'),
             'NumFavoriteTables_desc' => __('Maximum number of favorite tables; set 0 to disable.'),
             'NumRecentTables_name' => __('Recently used tables'),

--- a/libraries/classes/Config/Forms/User/NaviForm.php
+++ b/libraries/classes/Config/Forms/User/NaviForm.php
@@ -44,7 +44,8 @@ class NaviForm extends BaseForm
                 'NavigationTreeShowViews',
                 'NavigationTreeShowFunctions',
                 'NavigationTreeShowProcedures',
-                'NavigationTreeShowEvents'
+                'NavigationTreeShowEvents',
+                'NavigationTreeAutoexpandSingleDb'
             ],
             'Navi_servers' => [
                 'NavigationDisplayServers',

--- a/libraries/classes/Navigation/NavigationHeader.php
+++ b/libraries/classes/Navigation/NavigationHeader.php
@@ -58,6 +58,9 @@ class NavigationHeader
         if ($GLOBALS['cfg']['NavigationTreePointerEnable']) {
             $class .= ' highlight';
         }
+        if ($GLOBALS['cfg']['NavigationTreeAutoexpandSingleDb']) {
+            $class .= ' autoexpand';
+        }
         $class .= '"';
         $buffer = '<div id="pma_navigation">';
         $buffer .= '<div id="pma_navigation_resizer"></div>';

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -1063,6 +1063,13 @@ $cfg['NavigationTreeShowEvents'] = true;
  */
 $cfg['NavigationWidth'] = 240;
 
+/**
+ * Automatically expands single database in navigation panel
+ *
+ * @global boolean $cfg['NavigationAutoexpandSingleDb']
+ */
+$cfg['NavigationTreeAutoexpandSingleDb'] = true;
+
 /*******************************************************************************
  * In the main panel, at startup...
  */


### PR DESCRIPTION
### Description

Implemented a new feature as discussed in #12158 with the following scenario:
If the logged user has only one database in the navigation tree, that database will be automatically expanded. I've also added this as a configurable option with default value **true**, so people can disable this change whenever they want.

Closes #12158