### PR TITLE
Upgrade pragmarx/google2fa to v4

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -15,7 +15,7 @@ build:
             dependencies:
                 before:
                     - composer install
-                    - composer require tecnickcom/tcpdf pragmarx/google2fa bacon/bacon-qr-code samyoul/u2f-php-server
+                    - composer require tecnickcom/tcpdf pragmarx/google2fa-qrcode samyoul/u2f-php-server
                     - ./vendor/bin/phpcs --config-set installed_paths `pwd`/vendor/phpmyadmin/coding-standard
             tests:
                 override:

--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,8 @@
     "conflict": {
         "phpseclib/phpseclib": "2.0.8",
         "tecnickcom/tcpdf": "<6.2",
-        "pragmarx/google2fa": "<3.0.1",
-        "bacon/bacon-qr-code": "<1.0",
+        "pragmarx/google2fa-qrcode": "<1.0",
+        "bacon/bacon-qr-code": "<1.0 || >=2.0",
         "samyoul/u2f-php-server": "<1.1"
     },
     "suggest": {
@@ -75,8 +75,7 @@
         "ext-gd2": "For image transformations",
         "ext-mbstring": "For best performance",
         "tecnickcom/tcpdf": "For PDF support",
-        "pragmarx/google2fa": "For 2FA authentication",
-        "bacon/bacon-qr-code": "For 2FA authentication",
+        "pragmarx/google2fa-qrcode": "For 2FA authentication",
         "samyoul/u2f-php-server": "For FIDO U2F authentication"
     },
     "require-dev": {
@@ -85,8 +84,7 @@
         "phpunit/phpunit-selenium": "^4.1",
         "squizlabs/php_codesniffer": "^3.0",
         "tecnickcom/tcpdf": "^6.2",
-        "pragmarx/google2fa": "^3.0",
-        "bacon/bacon-qr-code": "^1.0",
+        "pragmarx/google2fa-qrcode": "^1.0",
         "samyoul/u2f-php-server": "^1.1",
         "phpmyadmin/coding-standard": "^0.3",
         "phpstan/phpstan": "^0.10.3"

--- a/doc/two_factor.rst
+++ b/doc/two_factor.rst
@@ -15,7 +15,7 @@ manually; the typical way of doing so is with the command:
 
 .. code-block:: sh
 
-    composer require pragmarx/google2fa bacon/bacon-qr-code
+    composer require pragmarx/google2fa-qrcode
 
 Or when using a hardware security key with FIDO U2F:
 

--- a/libraries/classes/Plugins/TwoFactor/Application.php
+++ b/libraries/classes/Plugins/TwoFactor/Application.php
@@ -12,7 +12,7 @@ namespace PhpMyAdmin\Plugins\TwoFactor;
 use PhpMyAdmin\TwoFactor;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Plugins\TwoFactorPlugin;
-use PragmaRX\Google2FA\Google2FA;
+use PragmaRX\Google2FAQRCode\Google2FA;
 
 /**
  * HOTP and TOTP based two-factor authentication

--- a/libraries/classes/TwoFactor.php
+++ b/libraries/classes/TwoFactor.php
@@ -118,7 +118,7 @@ class TwoFactor
         if ($GLOBALS['cfg']['DBG']['simple2fa']) {
             $result[] = 'simple';
         }
-        if (class_exists('PragmaRX\Google2FA\Google2FA') && class_exists('BaconQrCode\Renderer\Image\Png')) {
+        if (class_exists('PragmaRX\Google2FAQRCode\Google2FA')) {
             $result[] = 'application';
         }
         if (class_exists('Samyoul\U2F\U2FServer\U2FServer')) {
@@ -135,10 +135,10 @@ class TwoFactor
     public function getMissingDeps()
     {
         $result = [];
-        if (!class_exists('PragmaRX\Google2FA\Google2FA')) {
+        if (!class_exists('PragmaRX\Google2FAQRCode\Google2FA')) {
             $result[] = [
                 'class' => \PhpMyAdmin\Plugins\TwoFactor\Application::getName(),
-                'dep' => 'pragmarx/google2fa',
+                'dep' => 'pragmarx/google2fa-qrcode',
             ];
         }
         if (!class_exists('BaconQrCode\Renderer\Image\Png')) {

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -235,7 +235,7 @@ if [ ! -d libraries/tcpdf ] ; then
     echo "* Running composer"
     composer config platform.php "$PHP_REQ"
     composer update --no-dev
-    composer require --update-no-dev tecnickcom/tcpdf pragmarx/google2fa bacon/bacon-qr-code samyoul/u2f-php-server
+    composer require --update-no-dev tecnickcom/tcpdf pragmarx/google2fa-qrcode samyoul/u2f-php-server
     mv composer.json.backup composer.json
     echo "* Cleanup of composer packages"
     rm -rf \


### PR DESCRIPTION
The QRCode generation was moved to [pragmarx/google2fa-qrcode](https://packagist.org/packages/pragmarx/google2fa-qrcode) in [pragmarx/google2fa](https://packagist.org/packages/pragmarx/google2fa#v4.0.0) v4.0.

