### PR TITLE
consistent go button position

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1919,12 +1919,12 @@ class InsertEdit
         )
         . '</td>'
         . '<td colspan="3" class="right vmiddle">'
-        . '<input type="submit" class="control_at_footer" value="' . __('Go') . '"'
-        . ' tabindex="' . ($tabindex + $tabindex_for_value + 6) . '" id="buttonYes" />'
         . '<input type="button" class="preview_sql" value="' . __('Preview SQL') . '"'
-        . ' tabindex="' . ($tabindex + $tabindex_for_value + 7) . '" />'
+        . ' tabindex="' . ($tabindex + $tabindex_for_value + 6) . '" />'
         . '<input type="reset" class="control_at_footer" value="' . __('Reset') . '"'
-        . ' tabindex="' . ($tabindex + $tabindex_for_value + 8) . '" />'
+        . ' tabindex="' . ($tabindex + $tabindex_for_value + 7) . '" />'
+        . '<input type="submit" class="control_at_footer" value="' . __('Go') . '"'
+        . ' tabindex="' . ($tabindex + $tabindex_for_value + 8) . '" id="buttonYes" />'
         . '</td>';
     }
 

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -2151,6 +2151,7 @@ select.invalid_value,
 
     <?php echo $theme->getCssGradient('ffffff', 'cccccc'); ?>
     cursor: pointer;
+    float:right;
 }
 
 .format_specific_options h3 {


### PR DESCRIPTION
Signed-off-by: beekalam <beekalam@gmail.com>

### Description
- moves `Go` button to right on edit and insert tabs.
- moves `Go` button to right on import and export tabs.

Fixes #13067 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
