### PR TITLE
Security confirm() before running UPDATE

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -711,11 +711,13 @@ function confirmQuery (theForm1, sqlQuery1) {
     var do_confirm_re_1 = new RegExp('^\\s*ALTER\\s+TABLE\\s+((`[^`]+`)|([A-Za-z0-9_$]+))\\s+DROP\\s', 'i');
     var do_confirm_re_2 = new RegExp('^\\s*DELETE\\s+FROM\\s', 'i');
     var do_confirm_re_3 = new RegExp('^\\s*TRUNCATE\\s', 'i');
+    var do_confirm_re_4 = new RegExp('^(?=.*UPDATE\\b)^((?!WHERE).)*$', 'i');
 
     if (do_confirm_re_0.test(sqlQuery1) ||
         do_confirm_re_1.test(sqlQuery1) ||
         do_confirm_re_2.test(sqlQuery1) ||
-        do_confirm_re_3.test(sqlQuery1)) {
+        do_confirm_re_3.test(sqlQuery1) ||
+        do_confirm_re_4.test(sqlQuery1)) {
         var message;
         if (sqlQuery1.length > 100) {
             message = sqlQuery1.substr(0, 100) + '\n    ...';


### PR DESCRIPTION
Signed-off-by: Wellington Braga <wellington.braga.inatel@gmail.com>

### Description

When the user tries to execute an UPDATE query without an appopriate WHERE statement, the system will prompt an confirm dialog box asking him if he is sure about that.

As far as I checked, the current state of the project already have a message which is displayed when the user tries to execute a DELETE statement, so this is not included on this pull-request.

Fixes #14677

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
