### PR TITLE
Close dialog when last table is unhidden

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -569,23 +569,21 @@ $(function () {
     $(document).on('click', 'a.unhideNavItem.ajax', function (event) {
         event.preventDefault();
         var $tr = $(this).parents('tr');
-        var $tbody = $tr.parents('tbody');
-        var $hidden_table_count = $tbody.children().length;
+        var $dialog_box = $tr.closest('div.ui-dialog');
+        var $hidden_table_count = $tr.parents('tbody').children().length;
         var $msg = PMA_ajaxShowMessage();
         $.ajax({
             type: 'POST',
             data: {
                 server: PMA_commonParams.get('server'),
             },
-            url: $(this).attr('href') + PMA_commonParams.get('arg_separator') + 'ajax_request=true' + PMA_commonParams.get('arg_separator') + 'hidden_table_count=' + $hidden_table_count,
+            url: $(this).attr('href') + PMA_commonParams.get('arg_separator') + 'ajax_request=true',
             success: function (data) {
                 PMA_ajaxRemoveMessage($msg);
                 if (typeof data !== 'undefined' && data.success === true) {
                     $tr.remove();
-                    //If there are no more tables to show, display message
                     if($hidden_table_count == 1){
-                    	var $show_msg = document.createTextNode(data.message);
-                    	$tbody.append($show_msg);
+                    	$dialog_box.remove();
                     }
                     PMA_reloadNavigation();
                 } else {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -569,17 +569,24 @@ $(function () {
     $(document).on('click', 'a.unhideNavItem.ajax', function (event) {
         event.preventDefault();
         var $tr = $(this).parents('tr');
+        var $tbody = $tr.parents('tbody');
+        var $hidden_table_count = $tbody.children().length;
         var $msg = PMA_ajaxShowMessage();
         $.ajax({
             type: 'POST',
             data: {
                 server: PMA_commonParams.get('server'),
             },
-            url: $(this).attr('href') + PMA_commonParams.get('arg_separator') + 'ajax_request=true',
+            url: $(this).attr('href') + PMA_commonParams.get('arg_separator') + 'ajax_request=true' + PMA_commonParams.get('arg_separator') + 'hidden_table_count=' + $hidden_table_count,
             success: function (data) {
                 PMA_ajaxRemoveMessage($msg);
                 if (typeof data !== 'undefined' && data.success === true) {
                     $tr.remove();
+                    //If there are no more tables to show, display message
+                    if($hidden_table_count == 1){
+                    	var $show_msg = document.createTextNode(data.message);
+                    	$tbody.append($show_msg);
+                    }
                     PMA_reloadNavigation();
                 } else {
                     PMA_ajaxShowMessage(data.error);

--- a/navigation.php
+++ b/navigation.php
@@ -60,11 +60,7 @@ if ($cfgRelation['navwork']) {
                 $_REQUEST['dbName'],
                 (! empty($_REQUEST['tableName']) ? $_REQUEST['tableName'] : null)
             );
-            if ($_REQUEST['hidden_table_count'] == '1'){
-                echo __('No Hidden Tables Exists');
-            }
         }
-        
         exit;
     }
 

--- a/navigation.php
+++ b/navigation.php
@@ -60,7 +60,11 @@ if ($cfgRelation['navwork']) {
                 $_REQUEST['dbName'],
                 (! empty($_REQUEST['tableName']) ? $_REQUEST['tableName'] : null)
             );
+            if ($_REQUEST['hidden_table_count'] == '1'){
+                echo __('No Hidden Tables Exists');
+            }
         }
+        
         exit;
     }
 


### PR DESCRIPTION
Signed-off-by: computerManiac <fkarim6@gmail.com>

### Description

If there are no more hidden tables, close the Show hidden navigation tree items dialog box.

Fixes #14683 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
