### PR TITLE
Improve AllowThirdPartyFraming configuration

### DIFF
--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -563,16 +563,18 @@ class Header
             $captcha_url = '';
         }
         /* Prevent against ClickJacking by disabling framing */
-        if (! $GLOBALS['cfg']['AllowThirdPartyFraming']) {
-            header(
-                'X-Frame-Options: DENY'
-            );
-        } elseif ($GLOBALS['cfg']['AllowThirdPartyFraming'] === 'sameorigin') {
+        if (strtolower($GLOBALS['cfg']['AllowThirdPartyFraming']) === 'sameorigin') {
             header(
                 'X-Frame-Options: SAMEORIGIN'
             );
+        } elseif ($GLOBALS['cfg']['AllowThirdPartyFraming'] !== true) {
+            header(
+                'X-Frame-Options: DENY'
+            );
         }
-        header('Referrer-Policy: no-referrer');
+        header(
+            'Referrer-Policy: no-referrer'
+        );
         header(
             "Content-Security-Policy: default-src 'self' "
             . $captcha_url


### PR DESCRIPTION
### Description

The only correct way to check the frame-options. The existing version was incorrect. Even setting to value to "blabla", it bypassed the `!` check in php. So, at first, it should be checked if the "sameorigin" is value, and after that, everything other than `true` should DENY the frame.

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.


Signed-off-by: T.Todua <samplemail@gmail.com>