### PR TITLE
close dialog box after unhiding all tables

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -569,6 +569,8 @@ $(function () {
     $(document).on('click', 'a.unhideNavItem.ajax', function (event) {
         event.preventDefault();
         var $tr = $(this).parents('tr');
+        var $hidden_table_count = $tr.parents('tbody').children().length;
+        var $hide_dialog_box = $tr.closest('div.ui-dialog');
         var $msg = PMA_ajaxShowMessage();
         $.ajax({
             type: 'POST',
@@ -580,6 +582,9 @@ $(function () {
                 PMA_ajaxRemoveMessage($msg);
                 if (typeof data !== 'undefined' && data.success === true) {
                     $tr.remove();
+                    if ($hidden_table_count === 1) {
+                        $hide_dialog_box.remove();
+                    }
                     PMA_reloadNavigation();
                 } else {
                     PMA_ajaxShowMessage(data.error);

--- a/libraries/classes/Navigation/Navigation.php
+++ b/libraries/classes/Navigation/Navigation.php
@@ -243,7 +243,7 @@ class Navigation
                         $html .= '<td style="width:80px"><a href="navigation.php'
                             . Url::getCommon($params) . '"'
                             . ' class="unhideNavItem ajax">'
-                            . Util::getIcon('show', __('Show'))
+                            . Util::getIcon('show', __('Unhide'))
                             . '</a></td>';
                     }
                     $html .= '</tbody></table>';

--- a/libraries/mysql_relations.inc.php
+++ b/libraries/mysql_relations.inc.php
@@ -168,3 +168,4 @@ $GLOBALS['mysql_relations'] = [
         ],
     ],
 ];
+


### PR DESCRIPTION
Signed-off-by: Nakshatra Pradhan <nakshatrapradhan2013@gmail.com>

### Description

Dialog box will close as soon as the user unhides the table. Also the label "show" has been changed to "unhide"

Fixes #14683

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
