### PR TITLE
Bugfix 14631: Enum with comma produces incorrect search dropdown

### DIFF
--- a/libraries/classes/Twig/UtilExtension.php
+++ b/libraries/classes/Twig/UtilExtension.php
@@ -184,6 +184,11 @@ class UtilExtension extends AbstractExtension
                 'PhpMyAdmin\Util::sortableTableHeader',
                 array('is_safe' => array('html'))
             ),
+            new TwigFunction(
+                'Util_parseEnumSetValues',
+                'PhpMyAdmin\Util::parseEnumSetValues',
+                array('is_safe' => array('html'))
+            ),
         );
     }
 }

--- a/templates/table/search/input_box.twig
+++ b/templates/table/search/input_box.twig
@@ -44,7 +44,7 @@
 {% elseif column_type starts with 'enum'
     or (column_type starts with 'set' and in_zoom_search_edit) %}
     {% set in_zoom_search_edit = false %}
-    {% set value = column_type|e|slice(5, -1)|replace({'&#039;': ''})|split(', ') %}
+    {% set value = Util_parseEnumSetValues(column_type) %}
     {% set cnt_value = value|length %}
     {#
     Enum in edit mode   --> dropdown
@@ -68,12 +68,12 @@
         {% if criteria_values[column_index] is defined
             and criteria_values[column_index] is iterable
             and value[i] in criteria_values[column_index] %}
-            <option value="{{ value[i]|raw }}" selected>
-                {{ value[i]|raw }}
+            <option value="{{ value[i]|e }}" selected>
+                {{ value[i]|e }}
             </option>
         {% else %}
-            <option value="{{ value[i]|raw }}">
-                {{ value[i]|raw }}
+            <option value="{{ value[i]|e }}">
+                {{ value[i]|e }}
             </option>
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
### Description

Signed-off-by: Wellington Braga <wellington.braga.inatel@gmail.com>

When a comma is used withing the value of an ENUM field the search dropdown incorrectly splits it.

The bug occurs due a wrong split logic. The split function was assuming just a single quote as delimiter. This commit alters the delimiter to a single quote followed by a comma.

Fixes #14631 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
