### PR TITLE
Fix #14334 : Export table structure shows rows fields

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -382,16 +382,20 @@ function toggle_structure_data_opts () {
     var radioFormName = pluginName + '_structure_or_data';
     var dataDiv = '#' + pluginName + '_data';
     var structureDiv = '#' + pluginName + '_structure';
+    var rowDiv = '#rows';
     var show = $('input[type=\'radio\'][name=\'' + radioFormName + '\']:checked').val();
     if (show === 'data') {
         $(dataDiv).slideDown('slow');
         $(structureDiv).slideUp('slow');
+        $(rowDiv).slideDown('slow');
     } else {
         $(structureDiv).slideDown('slow');
         if (show === 'structure') {
             $(dataDiv).slideUp('slow');
+            $(rowDiv).slideUp('slow');
         } else {
             $(dataDiv).slideDown('slow');
+            $(rowDiv).slideDown('slow');
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Agus Perwira Purnomo <furunomail@gmail.com>

### Description

Fixes #14334 : Export table structure shows rows fields.

The rows options are now hidden when structure only is choosen.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
