### PR TITLE
Removing inline styles from php files and adding class to css

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -282,7 +282,7 @@ class DatabaseInterface
         $error_message = $this->getError($link);
         if ($result == false && is_string($error_message)) {
             $dbgInfo['error']
-                = '<span style="color:red">'
+                = '<span class="color_red">'
                 . htmlspecialchars($error_message) . '</span>';
         }
         $dbgInfo['query'] = htmlspecialchars($query);

--- a/setup/frames/config.inc.php
+++ b/setup/frames/config.inc.php
@@ -32,7 +32,7 @@ echo '</textarea>';
 echo '</td>';
 echo '</tr>';
 echo '<tr>';
-echo '<td class="lastrow" style="text-align: left">';
+echo '<td class="lastrow left">';
 echo '<input type="submit" name="submit_download" value="'
     , __('Download') , '" class="green" />';
 echo '</td>';

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -990,6 +990,10 @@ form.login select {
     color: gray;
 }
 
+.color_red {
+    color: red;
+}
+
 .pma_sliding_message{
     display: inline-block;
 }


### PR DESCRIPTION
Signed-off-by: Rob <rlr@tcliffe.codes>

### Description

I removed inline styles from config.inc.php and DatabaseInterface.php. The .left class already existed, but the .color_red class was added to common.css.php for DatabaseInterface.

Related to #12262

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
