### PR TITLE
Issue#14965

### DIFF
--- a/libraries/classes/Controllers/Server/ServerDatabasesController.php
+++ b/libraries/classes/Controllers/Server/ServerDatabasesController.php
@@ -365,7 +365,7 @@ class ServerDatabasesController extends Controller
             'disp_name' => __('Collation'),
             'description_function' => [Charsets::class, 'getCollationDescr'],
             'format'    => 'string',
-            'footer'    => $this->dbi->getServerCollation(),
+            'footer'    => '',
         ];
         $column_order['SCHEMA_TABLES'] = [
             'disp_name' => __('Tables'),

--- a/libraries/classes/Controllers/Server/ServerDatabasesController.php
+++ b/libraries/classes/Controllers/Server/ServerDatabasesController.php
@@ -130,7 +130,6 @@ class ServerDatabasesController extends Controller
             'is_create_db_priv' => $GLOBALS['is_create_db_priv'],
             'dbstats' => $this->_dbstats,
             'db_to_create' => $GLOBALS['db_to_create'],
-            'server_collation' => $this->dbi->getServerCollation(),
             'databases' => isset($databases) ? $databases : null,
             'dbi' => $this->dbi,
             'disable_is' => $GLOBALS['cfg']['Server']['DisableIS'],

--- a/test/classes/Controllers/Server/ServerDatabasesControllerTest.php
+++ b/test/classes/Controllers/Server/ServerDatabasesControllerTest.php
@@ -267,7 +267,7 @@ class ServerDatabasesControllerTest extends PmaTestCase
                         'getCollationDescr'
                     ],
                     'format'    => 'string',
-                    'footer'    => 'utf8_general_ci'
+                    'footer'    => ''
                 ],
                 'SCHEMA_TABLES' => [
                     'disp_name' => __('Tables'),


### PR DESCRIPTION
Signed-off-by: Gaurav Punjabi gaurav.punjabi6@icloud.com

### Description
This is in reference to solve issue #14965. Removed the default server collation from the footer of databases table in the database page. Solved by simply removing the collation label in the footer.

##### Before
<img width="770" alt="screen shot 2018-11-01 at 12 41 07 am" src="https://user-images.githubusercontent.com/36587580/47868802-32150b00-de2b-11e8-97c9-4f25b919c03f.png">

##### After
<img width="721" alt="screen shot 2018-11-01 at 12 41 19 am" src="https://user-images.githubusercontent.com/36587580/47868814-3f31fa00-de2b-11e8-8498-91c36246ea97.png">

Fixes #14706 

Before submitting pull request, please review the following checklist:

  Make sure you have read our CONTRIBUTING.md document.
  Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the master branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
  Every commit has proper Signed-off-by line as described in our DCO. This ensures that the work you're submitting is your own creation.
  Every commit has a descriptive commit message.
  Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
  Any new functionality is covered by tests.
