### PR TITLE
Fix missed logging with AuthLogSuccess when logging to syslog

### DIFF
--- a/libraries/classes/Logging.php
+++ b/libraries/classes/Logging.php
@@ -80,7 +80,7 @@ class Logging
         }
         $message = self::getLogMessage($user, $status);
         if ($log_file == 'syslog') {
-            if (function_exists('syslog') && $status != 'ok') {
+            if (function_exists('syslog')) {
                 @openlog('phpMyAdmin', LOG_NDELAY | LOG_PID, LOG_AUTHPRIV);
                 @syslog(LOG_WARNING, $message);
                 closelog();


### PR DESCRIPTION
When logging with AuthLog to syslog, successful login messages were not logged even if $cfg['AuthLogSuccess'] was true.

Fixes #14672

Signed-off-by: Isaac Bennetch <bennetch@gmail.com>
