### PR TITLE
Double tap to edit on Mobile

### DIFF
--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -2022,7 +2022,7 @@ function PMA_makegrid (t, enableResize, enableReorder, enableVisib, enableGridEd
                         }
                     }
                 })
-                .dblclick(function (e) {
+                .doubletap(function (e) {
                     if ($(e.target).is('.grid_edit a')) {
                         e.preventDefault();
                     } else {

--- a/js/vendor/jquery/jquery.double-tap.js
+++ b/js/vendor/jquery/jquery.double-tap.js
@@ -1,0 +1,17 @@
+(function($){
+    $.fn.doubletap = function(callback, delay) {
+        delay = delay == null ? 500 : delay;
+        $(this).bind('click', function(event) {
+            var now = new Date().getTime();
+            var lastTouch = $(this).data('lastTouch') || now + 1;
+            var delta = now - lastTouch;
+            if (delta < 500 && delta > 0) {
+                if ($.isFunction(callback)) {
+                    callback.call(this, event);
+                }
+            }
+            $(this).data('lastTouch', now);
+        });
+        return this;
+    };
+})(jQuery);

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -179,6 +179,7 @@ class Header
         $this->_scripts->addFile('keyhandler.js');
         $this->_scripts->addFile('vendor/jquery/jquery-ui.min.js');
         $this->_scripts->addFile('vendor/js.cookie.js');
+        $this->_scripts->addFile('vendor/jquery/jquery.double-tap.js');
         $this->_scripts->addFile('vendor/jquery/jquery.mousewheel.js');
         $this->_scripts->addFile('vendor/jquery/jquery.event.drag-2.2.js');
         $this->_scripts->addFile('vendor/jquery/jquery.validate.js');


### PR DESCRIPTION
Signed-off-by: Magnus Hauge Bakke magnus@idrift.no

### Description

Created a small jQuery plugin to detect double click on both mobile and desktop. `.doubletap()` can be used instead of `dblclick`.

### Tested on

**Browsers**
* `Google Chrome`
* `Safari `

**Operating system**
* `iOs 12.0` on `iPhone 7`

Fixes #14411 : Double tap to edit on Mobile

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
