### PR TITLE
Issue #14298 Error 500 when submitting a query

### DIFF
--- a/libraries/classes/Controllers/Server/ServerDatabasesController.php
+++ b/libraries/classes/Controllers/Server/ServerDatabasesController.php
@@ -365,7 +365,7 @@ class ServerDatabasesController extends Controller
             'disp_name' => __('Collation'),
             'description_function' => [Charsets::class, 'getCollationDescr'],
             'format'    => 'string',
-            'footer'    => $this->dbi->getServerCollation(),
+            'footer'    => '',
         ];
         $column_order['SCHEMA_TABLES'] = [
             'disp_name' => __('Tables'),

--- a/libraries/classes/Database/MultiTableQuery.php
+++ b/libraries/classes/Database/MultiTableQuery.php
@@ -111,6 +111,12 @@ class MultiTableQuery
      */
     public static function displayResults($sqlQuery, $db, $pmaThemeImage)
     {
+        if(empty($sqlQuery)) 
+        {
+            Message::error('Please enter the sql query first.');
+            exit;
+        }
+
         list(
             $analyzedSqlResults,
             $db,


### PR DESCRIPTION
### Description
This pull request solves the issue #14298 .i.e when no query is passed and ran in Multi Query Section it throws a 500 error.
The solution was to display a message regarding the empty query to the user.

Fixes #14298 

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
