### PR TITLE
FIx #14763 Loading symbol not appearing when refreshing the navigation.

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -309,19 +309,20 @@ $(function () {
      */
     $(document).on('click', '#pma_navigation_reload', function (event) {
         event.preventDefault();
-        // reload icon object
-        var $icon = $(this).find('img');
-        // source of the hidden throbber icon
-        var icon_throbber_src = $('#pma_navigation').find('.throbber').attr('src');
-        // source of the reload icon
-        var icon_reload_src = $icon.attr('src');
-        // replace the source of the reload icon with the one for throbber
-        $icon.attr('src', icon_throbber_src);
-        PMA_reloadNavigation();
-        // after one second, put back the reload icon
-        setTimeout(function () {
-            $icon.attr('src', icon_reload_src);
-        }, 1000);
+
+        // Find the loading symbol and show it
+        var $icon_throbber_src = $('#pma_navigation').find('.throbber');
+        $icon_throbber_src.show();
+        // TODO Why is a loading symbol both hidden, and invisible?
+        $icon_throbber_src.css('visibility', '');
+
+        // Callback to be used to hide the loading symbol when done reloading
+        function hideNav() {
+            $icon_throbber_src.hide();
+        }
+
+        // Reload the navigation
+        PMA_reloadNavigation(hideNav);
     });
 
     $(document).on('change', '#navi_db_select',  function (event) {


### PR DESCRIPTION
Signed-off-by: Staz.IO <staz@staz.io>

### Description
This is a bug fix for issue #14763 
It fixes an issue where the refresh/loading symbol does not appear when the navigation reload button has been pressed.
Solution was by showing the throbber during a reload and hiding it after the loading completes.
A TODO was added for the future to understand why the ".icon .ic_ajax_clock_small .throbber" div has both the "display:none" and "visibility:hidden" tag. Recommend to remove the latter allowing jQuery.show and .hide to behave as expected.

Fixes #14763 

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
