### PR TITLE
Fix #13788 - Exporting a view structure, no database selected error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ phpMyAdmin - ChangeLog
 - issue #14786 Table level Operations functions missing
 - issue #14791 PHP warning, db_export.php#L91 urldecode()
 - issue #14775 Export to SQL format not available for tables
+- issue #13788 Exporting a view structure based on another view with a sub-query throws no database selected error
 
 4.8.4 (2018-12-11)
 - issue #14452 Remove hash param in edit query URL

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -1482,6 +1482,7 @@ class ExportSql extends ExportPlugin
         // Note: SHOW CREATE TABLE, at least in MySQL 5.1.23, does not
         // produce a displayable result for the default value of a BIT
         // column, nor does the mysqldump command. See MySQL bug 35796
+        $GLOBALS['dbi']->tryQuery('USE ' . Util::backquote($db));
         $result = $GLOBALS['dbi']->tryQuery(
             'SHOW CREATE TABLE ' . Util::backquote($db) . '.'
             . Util::backquote($table)

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -965,13 +965,15 @@ class ExportSqlTest extends PmaTestCase
             ->with('res')
             ->will($this->returnValue($tmpres));
 
-        $dbi->expects($this->exactly(2))
+        $dbi->expects($this->exactly(3))
             ->method('tryQuery')
             ->withConsecutive(
                 array("SHOW TABLE STATUS FROM `db` WHERE Name = 'table'"),
+                array('USE `db`'),
                 array('SHOW CREATE TABLE `db`.`table`')
             )
             ->willReturnOnConsecutiveCalls(
+                'res',
                 'res',
                 'res'
             );
@@ -1139,13 +1141,15 @@ class ExportSqlTest extends PmaTestCase
             ->with('res')
             ->will($this->returnValue($tmpres));
 
-        $dbi->expects($this->exactly(2))
+        $dbi->expects($this->exactly(3))
             ->method('tryQuery')
             ->withConsecutive(
                 array("SHOW TABLE STATUS FROM `db` WHERE Name = 'table'"),
+                array('USE `db`'),
                 array('SHOW CREATE TABLE `db`.`table`')
             )
             ->willReturnOnConsecutiveCalls(
+                'res',
                 'res',
                 'res'
             );

--- a/test/classes/TrackerTest.php
+++ b/test/classes/TrackerTest.php
@@ -254,13 +254,15 @@ class TrackerTest extends PmaTestCase
                 'Update_time' => '2013-02-22 21:46:48'
             )
         );
-        $dbi->expects($this->exactly(2))
+        $dbi->expects($this->exactly(3))
             ->method('tryQuery')
             ->withConsecutive(
                 array("SHOW TABLE STATUS FROM `pma_test` WHERE Name = 'pma_tbl'"),
+                array('USE `pma_test`'),
                 array('SHOW CREATE TABLE `pma_test`.`pma_tbl`')
             )
             ->willReturnOnConsecutiveCalls(
+                'res',
                 'res',
                 'res'
             );


### PR DESCRIPTION
Fix #13788 - Exporting a view structure based on another view with a sub-query throws no database selected error

Fixes #13788 