### PR TITLE
Fix #14635 #14762 - git dir removed first after login

### DIFF
--- a/index.php
+++ b/index.php
@@ -134,10 +134,12 @@ if ($response->isAjax() && ! empty($_REQUEST['recent_table'])) {
 }
 
 if ($GLOBALS['PMA_Config']->isGitRevision()) {
+    // If ajax request to get revision
     if (isset($_REQUEST['git_revision']) && $response->isAjax()) {
         GitRevision::display();
         exit;
     }
+    // Else show empty html
     echo '<div id="is_git_revision"></div>';
 }
 

--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -358,12 +358,12 @@ class Config
 
     /**
      * detects if Git revision
-     *
+     * @param string &$git_location (optional) verified git directory
      * @return boolean
      */
-    public function isGitRevision()
+    public function isGitRevision(&$git_location = NULL)
     {
-        if (!$this->get('ShowGitRevision')) {
+        if (! $this->get('ShowGitRevision')) {
             return false;
         }
 
@@ -372,16 +372,41 @@ class Config
             if ($_SESSION['is_git_revision']) {
                 $this->set('PMA_VERSION_GIT', 1);
             }
+            $git_location = $_SESSION['git_location'];
             return $_SESSION['is_git_revision'];
         }
         // find out if there is a .git folder
-        $git_folder = '.git';
-        if (! @file_exists($git_folder)
-            || ! @file_exists($git_folder . '/config')
-        ) {
+        // or a .git file (--separate-git-dir)
+        $git = '.git';
+        if (is_dir($git)) {
+            if (@is_file($git . '/config')) {
+                $git_location = $git;
+            } else {
+                $_SESSION['is_git_revision'] = false;
+                return false;
+            }
+        } elseif (is_file($git)) {
+            $contents = file_get_contents($git);
+            $gitmatch = array();
+            // Matches expected format
+            if (! preg_match('/^gitdir: (.*)$/',
+                $contents, $gitmatch)) {
+                $_SESSION['is_git_revision'] = false;
+                return false;
+            } else {
+                if (@is_dir($gitmatch[1])) {
+                    //Detected git external folder location
+                    $git_location = $gitmatch[1];
+                } else {
+                    $_SESSION['is_git_revision'] = false;
+                    return false;
+                }
+            }
+        } else {
             $_SESSION['is_git_revision'] = false;
             return false;
         }
+        $_SESSION['git_location'] = $git_location;
         $_SESSION['is_git_revision'] = true;
         return true;
     }
@@ -394,8 +419,8 @@ class Config
     public function checkGitRevision()
     {
         // find out if there is a .git folder
-        $git_folder = '.git';
-        if (! $this->isGitRevision()) {
+        $git_folder = '';
+        if (! $this->isGitRevision($git_folder)) {
             return;
         }
 

--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -403,6 +403,10 @@ class Config
             return;
         }
 
+        if ($common_dir_contents = @file_get_contents($git_folder . '/commondir')) {
+            $git_folder = $git_folder . DIRECTORY_SEPARATOR . trim($common_dir_contents);
+        }
+
         $branch = false;
         // are we on any branch?
         if (strstr($ref_head, '/')) {

--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -717,7 +717,7 @@ class Config
             } while ($dataline != '');
             $message = trim(implode(' ', $commit));
 
-        } elseif (isset($commit_json) && isset($commit_json->author) && isset($commit_json->committer)) {
+        } elseif (isset($commit_json) && isset($commit_json->author) && isset($commit_json->committer) && isset($commit_json->message)) {
             $author = array(
                 'name' => $commit_json->author->name,
                 'email' => $commit_json->author->email,

--- a/libraries/classes/Display/GitRevision.php
+++ b/libraries/classes/Display/GitRevision.php
@@ -25,14 +25,15 @@ class GitRevision
     */
     public static function display()
     {
+
+        // load revision data from repo
+        $GLOBALS['PMA_Config']->checkGitRevision();
+
         if (! $GLOBALS['PMA_Config']->get('PMA_VERSION_GIT')) {
             $response = Response::getInstance();
             $response->setRequestStatus(false);
             return;
         }
-
-        // load revision data from repo
-        $GLOBALS['PMA_Config']->checkGitRevision();
 
         // if using a remote commit fast-forwarded, link to GitHub
         $commit_hash = substr(


### PR DESCRIPTION
### Description

- Cherry picked commits to `QA_4_8` 
- Added tests
- Added some comments to code because some cases are tricky
- Fixed caching for git folder detection

I tested merge on master and #14635 #14762 are fixed.
We need to have this fix on `QA_4_8` first ;)

Fixes #14635
Fixes #14762