### PR TITLE
Fix #14756: Browser display transformation selection

### DIFF
--- a/libraries/tbl_columns_definition_form.inc.php
+++ b/libraries/tbl_columns_definition_form.inc.php
@@ -111,13 +111,15 @@ if ($cfgRelation['mimework'] && $GLOBALS['cfg']['BrowseMIME']) {
 }
 
 // this will be used on templates/columns_definitions/transformation.twig
-$mime_type = 'input_transformation';
-if (isset($available_mime[$mime_type]) and is_iterable($available_mime[$mime_type])) {
-    foreach ($available_mime[$mime_type] as $mimekey => $transform) {
-        $available_mime[$mime_type . '_file_quoted'][$mimekey] = preg_quote(
-            $available_mime[$mime_type . '_file'][$mimekey],
-            '@'
-        );
+$mime_types = ['input_transformation', 'transformation'];
+foreach($mime_types as $mime_type) {
+    if (isset($available_mime[$mime_type]) and is_iterable($available_mime[$mime_type])) {
+        foreach ($available_mime[$mime_type] as $mimekey => $transform) {
+            $available_mime[$mime_type . '_file_quoted'][$mimekey] = preg_quote(
+                $available_mime[$mime_type . '_file'][$mimekey],
+                '@'
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Dhyey Thakore <dhyey35@gmail.com>

### Description

All options for `Browser Display Transformation` when editing a column of a table are set to `selected` which doesn't show the option previously saved by the user. This issue was probably caused by https://github.com/phpmyadmin/phpmyadmin/pull/14317. 

The field `_file_quoted` was set only for `input_transformation` and not for `transformation` (`transformation` is used for `Browser display transformation` )

Fixes #14756 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
