### PR TITLE
Fix #14812: Table chart not opening

### DIFF
--- a/libraries/classes/Controllers/Table/TableChartController.php
+++ b/libraries/classes/Controllers/Table/TableChartController.php
@@ -244,9 +244,8 @@ class TableChartController extends TableController
         foreach ($data as $data_row_number => $data_row) {
             $tmp_row = [];
             foreach ($data_row as $data_column => $data_value) {
-                $tmp_row[htmlspecialchars($data_column)] = htmlspecialchars(
-                    $data_value
-                );
+                $escaped_value = is_null($data_value) ? null : htmlspecialchars($data_value);
+                $tmp_row[htmlspecialchars($data_column)] = $escaped_value;
             }
             $sanitized_data[] = $tmp_row;
         }


### PR DESCRIPTION
Signed-off-by: Feliks Toomsoo <feliks.toomsoo@gmail.com>

### Description
Fixes issue https://github.com/phpmyadmin/phpmyadmin/issues/14812 
The problem was that the Table chart view didn't open when clicking on the 'Display chart' button. The loader icon kept spinning and in the ajax response we could see the following error `htmlspecialchars() expects parameter 1 to be string, null given`. This is error is being triggered in the new version due to `declare(strict_types=1);` being set on `tbl_chart.php`.

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
