### PR TITLE
Fix #13975 - Missing query time in German (fix decimal number format issue)

### DIFF
--- a/libraries/classes/Message.php
+++ b/libraries/classes/Message.php
@@ -454,7 +454,7 @@ class Message
      */
     public function addParam($param)
     {
-        if ($param instanceof Message) {
+        if ($param instanceof Message || is_float($param) || is_int($param)) {
             $this->params[] = $param;
         } else {
             $this->params[] = htmlspecialchars($param);


### PR DESCRIPTION
Signed-off-by: Patrik Pasterčík <plaki@seznam.cz>

### Description

Problem is conversion of number from int/float to string (when adding parameter to `Message` class) and then using `sprintf` funciton to format string. Some locales use comma as decimal separator and it is problem, when we want use this number (as string) in `sprintf` function. PHP can't convert number from string to float when decimal separator is comma (with dot working fine), so it converts it to integer number, because comma is invalid character to convert to number. I think that if we want format number by `sprintf` function, number parameter must have right number format (numeric variable or string with dot decimal separator), if it's string, it's convert string to number and then format it. I hope that I describe it understandably.

Fix is about updating `addParam` method in `Message` class. Now if added parameter is numeric variable (integer or float), method add this value to parameter array without converting it to string by using `htmlspecialchars` function (numeric variable not contains any unwanted characters/scripts). This allow to format numeric parameter in `Message` class by `sprintf` function correctly. 

Fixes #13975 
