### PR TITLE
Fix #14763 - Show refresh indicator while refreshing all databases tree listing

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -309,19 +309,16 @@ $(function () {
      */
     $(document).on('click', '#pma_navigation_reload', function (event) {
         event.preventDefault();
-        // reload icon object
         var $icon = $(this).find('img');
-        // source of the hidden throbber icon
-        var icon_throbber_src = $('#pma_navigation').find('.throbber').attr('src');
-        // source of the reload icon
-        var icon_reload_src = $icon.attr('src');
-        // replace the source of the reload icon with the one for throbber
-        $icon.attr('src', icon_throbber_src);
-        PMA_reloadNavigation();
-        // after one second, put back the reload icon
-        setTimeout(function () {
-            $icon.attr('src', icon_reload_src);
-        }, 1000);
+        var icon_throbber_src = $('#pma_navigation').find('.throbber');
+        // By default hidden by jQuery
+        icon_throbber_src.show();
+        // set visibility from none
+        icon_throbber_src.css('visibility', 'visible');
+        // hide reload icon upon reload complete (using callback)
+        PMA_reloadNavigation(() => {
+            icon_throbber_src.hide();
+        })
     });
 
     $(document).on('change', '#navi_db_select',  function (event) {

--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -127,23 +127,21 @@ class Processes
             ],
         ];
         $sortableColCount = count($sortable_columns);
-
         $sql_query = $show_full_sql
             ? 'SHOW FULL PROCESSLIST'
             : 'SHOW PROCESSLIST';
-        if ((! empty($_POST['order_by_field'])
-            && ! empty($_POST['sort_order']))
-            || (! empty($_POST['showExecuting']))
+        if ( (!empty($_REQUEST['order_by_field']) && !empty($_REQUEST['sort_order']))
+                || (!empty($_REQUEST['showExecuting'])) 
         ) {
             $sql_query = 'SELECT * FROM `INFORMATION_SCHEMA`.`PROCESSLIST` ';
         }
-        if (! empty($_POST['showExecuting'])) {
+        if (! empty($_REQUEST['showExecuting'])) {
             $sql_query .= ' WHERE state != "" ';
         }
-        if (! empty($_POST['order_by_field']) && ! empty($_POST['sort_order'])) {
+        if (! empty($_REQUEST['order_by_field']) && ! empty($_REQUEST['sort_order'])) {
             $sql_query .= ' ORDER BY '
-                . Util::backquote($_POST['order_by_field'])
-                . ' ' . $_POST['sort_order'];
+                . Util::backquote($_REQUEST['order_by_field'])
+                . ' ' . $_REQUEST['sort_order'];
         }
 
         $result = $GLOBALS['dbi']->query($sql_query);
@@ -155,15 +153,15 @@ class Processes
         $retval .= '<tr>';
         $retval .= '<th>' . __('Processes') . '</th>';
         foreach ($sortable_columns as $column) {
-            $is_sorted = ! empty($_POST['order_by_field'])
-                && ! empty($_POST['sort_order'])
-                && ($_POST['order_by_field'] == $column['order_by_field']);
+            $is_sorted = ! empty($_REQUEST['order_by_field'])
+                && ! empty($_REQUEST['sort_order'])
+                && ($_REQUEST['order_by_field'] == $column['order_by_field']);
 
             $column['sort_order'] = 'ASC';
-            if ($is_sorted && $_POST['sort_order'] === 'ASC') {
+            if ($is_sorted && $_REQUEST['sort_order'] === 'ASC') {
                 $column['sort_order'] = 'DESC';
             }
-            if (isset($_POST['showExecuting'])) {
+            if (isset($_REQUEST['showExecuting'])) {
                 $column['showExecuting'] = 'on';
             }
 
@@ -176,7 +174,7 @@ class Processes
             if ($is_sorted) {
                 $asc_display_style = 'inline';
                 $desc_display_style = 'none';
-                if ($_POST['sort_order'] === 'DESC') {
+                if ($_REQUEST['sort_order'] === 'DESC') {
                     $desc_display_style = 'inline';
                     $asc_display_style = 'none';
                 }
@@ -235,7 +233,7 @@ class Processes
     public static function getHtmlForProcessListFilter()
     {
         $showExecuting = '';
-        if (! empty($_POST['showExecuting'])) {
+        if (! empty($_REQUEST['showExecuting'])) {
             $showExecuting = ' checked="checked"';
         }
 
@@ -279,8 +277,8 @@ class Processes
     {
         // Array keys need to modify due to the way it has used
         // to display column values
-        if ((! empty($_POST['order_by_field']) && ! empty($_POST['sort_order']))
-            || (! empty($_POST['showExecuting']))
+        if ((! empty($_REQUEST['order_by_field']) && ! empty($_REQUEST['sort_order']))
+            || (! empty($_REQUEST['showExecuting']))
         ) {
             foreach (array_keys($process) as $key) {
                 $new_key = ucfirst(mb_strtolower($key));

--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -36,7 +36,7 @@ class Processes
                 . 'heavy traffic between the web server and the MySQL server.'
             )
         )->getDisplay();
-        $retval  = $notice . '<div class="tabLinks">';
+        $retval = $notice . '<div class="tabLinks">';
         $retval .= '<label>' . __('Refresh rate') . ': ';
         $retval .= Data::getHtmlForRefreshList(
             'refreshRate',
@@ -73,17 +73,17 @@ class Processes
     {
         $url_params = [];
 
-        $show_full_sql = ! empty($_POST['full']);
+        $show_full_sql = !empty($_POST['full']);
         if ($show_full_sql) {
             $url_params['full'] = 1;
             $full_text_link = 'server_status_processes.php' . Url::getCommon(
-                [],
-                '?'
-            );
+                    [],
+                    '?'
+                );
         } else {
             $full_text_link = 'server_status_processes.php' . Url::getCommon(
-                ['full' => 1]
-            );
+                    ['full' => 1]
+                );
         }
 
         // This array contains display name and real column name of each
@@ -130,15 +130,15 @@ class Processes
         $sql_query = $show_full_sql
             ? 'SHOW FULL PROCESSLIST'
             : 'SHOW PROCESSLIST';
-        if ( (!empty($_REQUEST['order_by_field']) && !empty($_REQUEST['sort_order']))
-                || (!empty($_REQUEST['showExecuting'])) 
+        if ((!empty($_REQUEST['order_by_field']) && !empty($_REQUEST['sort_order']))
+            || (!empty($_REQUEST['showExecuting']))
         ) {
             $sql_query = 'SELECT * FROM `INFORMATION_SCHEMA`.`PROCESSLIST` ';
         }
-        if (! empty($_REQUEST['showExecuting'])) {
+        if (!empty($_REQUEST['showExecuting'])) {
             $sql_query .= ' WHERE state != "" ';
         }
-        if (! empty($_REQUEST['order_by_field']) && ! empty($_REQUEST['sort_order'])) {
+        if (!empty($_REQUEST['order_by_field']) && !empty($_REQUEST['sort_order'])) {
             $sql_query .= ' ORDER BY '
                 . Util::backquote($_REQUEST['order_by_field'])
                 . ' ' . $_REQUEST['sort_order'];
@@ -153,8 +153,8 @@ class Processes
         $retval .= '<tr>';
         $retval .= '<th>' . __('Processes') . '</th>';
         foreach ($sortable_columns as $column) {
-            $is_sorted = ! empty($_REQUEST['order_by_field'])
-                && ! empty($_REQUEST['sort_order'])
+            $is_sorted = !empty($_REQUEST['order_by_field'])
+                && !empty($_REQUEST['sort_order'])
                 && ($_REQUEST['order_by_field'] == $column['order_by_field']);
 
             $column['sort_order'] = 'ASC';
@@ -233,7 +233,7 @@ class Processes
     public static function getHtmlForProcessListFilter()
     {
         $showExecuting = '';
-        if (! empty($_REQUEST['showExecuting'])) {
+        if (!empty($_REQUEST['showExecuting'])) {
             $showExecuting = ' checked="checked"';
         }
 
@@ -242,11 +242,11 @@ class Processes
             'full' => (isset($_POST['full']) ? $_POST['full'] : ''),
             'column_name' => (isset($_POST['column_name']) ? $_POST['column_name'] : ''),
             'order_by_field'
-                => (isset($_POST['order_by_field']) ? $_POST['order_by_field'] : ''),
+            => (isset($_POST['order_by_field']) ? $_POST['order_by_field'] : ''),
             'sort_order' => (isset($_POST['sort_order']) ? $_POST['sort_order'] : ''),
         ];
 
-        $retval  = '';
+        $retval = '';
         $retval .= '<fieldset id="tableFilter">';
         $retval .= '<legend>' . __('Filters') . '</legend>';
         $retval .= '<form action="server_status_processes.php" method="post">';
@@ -268,8 +268,8 @@ class Processes
     /**
      * Prints Every Item of Server Process
      *
-     * @param array $process       data of Every Item of Server Process
-     * @param bool  $show_full_sql show full sql or not
+     * @param array $process data of Every Item of Server Process
+     * @param bool $show_full_sql show full sql or not
      *
      * @return string
      */
@@ -277,8 +277,8 @@ class Processes
     {
         // Array keys need to modify due to the way it has used
         // to display column values
-        if ((! empty($_REQUEST['order_by_field']) && ! empty($_REQUEST['sort_order']))
-            || (! empty($_REQUEST['showExecuting']))
+        if ((!empty($_REQUEST['order_by_field']) && !empty($_REQUEST['sort_order']))
+            || (!empty($_REQUEST['showExecuting']))
         ) {
             foreach (array_keys($process) as $key) {
                 $new_key = ucfirst(mb_strtolower($key));
@@ -289,14 +289,14 @@ class Processes
             }
         }
 
-        $retval  = '<tr>';
+        $retval = '<tr>';
         $retval .= '<td><a class="ajax kill_process" href="server_status_processes.php"'
             . ' data-post="' . Url::getCommon(['kill' => $process['Id']], '') . '">'
             . __('Kill') . '</a></td>';
         $retval .= '<td class="value">' . $process['Id'] . '</td>';
         $retval .= '<td>' . htmlspecialchars($process['User']) . '</td>';
         $retval .= '<td>' . htmlspecialchars($process['Host']) . '</td>';
-        $retval .= '<td>' . ((! isset($process['db'])
+        $retval .= '<td>' . ((!isset($process['db'])
                 || strlen($process['db']) === 0)
                 ? '<i>' . __('None') . '</i>'
                 : htmlspecialchars($process['db'])) . '</td>';
@@ -311,7 +311,7 @@ class Processes
         if (empty($process['Info'])) {
             $retval .= '---';
         } else {
-            $retval .= Util::formatSql($process['Info'], ! $show_full_sql);
+            $retval .= Util::formatSql($process['Info'], !$show_full_sql);
         }
         $retval .= '</td>';
         $retval .= '</tr>';

--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -36,7 +36,7 @@ class Processes
                 . 'heavy traffic between the web server and the MySQL server.'
             )
         )->getDisplay();
-        $retval = $notice . '<div class="tabLinks">';
+        $retval  = $notice . '<div class="tabLinks">';
         $retval .= '<label>' . __('Refresh rate') . ': ';
         $retval .= Data::getHtmlForRefreshList(
             'refreshRate',
@@ -73,17 +73,17 @@ class Processes
     {
         $url_params = [];
 
-        $show_full_sql = !empty($_POST['full']);
+        $show_full_sql = ! empty($_POST['full']);
         if ($show_full_sql) {
             $url_params['full'] = 1;
             $full_text_link = 'server_status_processes.php' . Url::getCommon(
-                    [],
-                    '?'
-                );
+                [],
+                '?'
+            );
         } else {
             $full_text_link = 'server_status_processes.php' . Url::getCommon(
-                    ['full' => 1]
-                );
+                ['full' => 1]
+            );
         }
 
         // This array contains display name and real column name of each
@@ -127,18 +127,20 @@ class Processes
             ],
         ];
         $sortableColCount = count($sortable_columns);
+
         $sql_query = $show_full_sql
             ? 'SHOW FULL PROCESSLIST'
             : 'SHOW PROCESSLIST';
-        if ((!empty($_REQUEST['order_by_field']) && !empty($_REQUEST['sort_order']))
-            || (!empty($_REQUEST['showExecuting']))
+        if ((! empty($_REQUEST['order_by_field'])
+            && ! empty($_REQUEST['sort_order']))
+                || (! empty($_REQUEST['showExecuting']))
         ) {
             $sql_query = 'SELECT * FROM `INFORMATION_SCHEMA`.`PROCESSLIST` ';
         }
-        if (!empty($_REQUEST['showExecuting'])) {
+        if (! empty($_REQUEST['showExecuting'])) {
             $sql_query .= ' WHERE state != "" ';
         }
-        if (!empty($_REQUEST['order_by_field']) && !empty($_REQUEST['sort_order'])) {
+        if (! empty($_REQUEST['order_by_field']) && ! empty($_REQUEST['sort_order'])) {
             $sql_query .= ' ORDER BY '
                 . Util::backquote($_REQUEST['order_by_field'])
                 . ' ' . $_REQUEST['sort_order'];
@@ -153,8 +155,8 @@ class Processes
         $retval .= '<tr>';
         $retval .= '<th>' . __('Processes') . '</th>';
         foreach ($sortable_columns as $column) {
-            $is_sorted = !empty($_REQUEST['order_by_field'])
-                && !empty($_REQUEST['sort_order'])
+            $is_sorted = ! empty($_REQUEST['order_by_field'])
+                && ! empty($_REQUEST['sort_order'])
                 && ($_REQUEST['order_by_field'] == $column['order_by_field']);
 
             $column['sort_order'] = 'ASC';
@@ -233,7 +235,7 @@ class Processes
     public static function getHtmlForProcessListFilter()
     {
         $showExecuting = '';
-        if (!empty($_REQUEST['showExecuting'])) {
+        if (! empty($_REQUEST['showExecuting'])) {
             $showExecuting = ' checked="checked"';
         }
 
@@ -242,11 +244,11 @@ class Processes
             'full' => (isset($_POST['full']) ? $_POST['full'] : ''),
             'column_name' => (isset($_POST['column_name']) ? $_POST['column_name'] : ''),
             'order_by_field'
-            => (isset($_POST['order_by_field']) ? $_POST['order_by_field'] : ''),
+                => (isset($_POST['order_by_field']) ? $_POST['order_by_field'] : ''),
             'sort_order' => (isset($_POST['sort_order']) ? $_POST['sort_order'] : ''),
         ];
 
-        $retval = '';
+        $retval  = '';
         $retval .= '<fieldset id="tableFilter">';
         $retval .= '<legend>' . __('Filters') . '</legend>';
         $retval .= '<form action="server_status_processes.php" method="post">';
@@ -268,8 +270,8 @@ class Processes
     /**
      * Prints Every Item of Server Process
      *
-     * @param array $process data of Every Item of Server Process
-     * @param bool $show_full_sql show full sql or not
+     * @param array $process       data of Every Item of Server Process
+     * @param bool  $show_full_sql show full sql or not
      *
      * @return string
      */
@@ -277,8 +279,8 @@ class Processes
     {
         // Array keys need to modify due to the way it has used
         // to display column values
-        if ((!empty($_REQUEST['order_by_field']) && !empty($_REQUEST['sort_order']))
-            || (!empty($_REQUEST['showExecuting']))
+        if ((! empty($_REQUEST['order_by_field']) && ! empty($_REQUEST['sort_order']))
+            || (! empty($_REQUEST['showExecuting']))
         ) {
             foreach (array_keys($process) as $key) {
                 $new_key = ucfirst(mb_strtolower($key));
@@ -289,14 +291,14 @@ class Processes
             }
         }
 
-        $retval = '<tr>';
+        $retval  = '<tr>';
         $retval .= '<td><a class="ajax kill_process" href="server_status_processes.php"'
             . ' data-post="' . Url::getCommon(['kill' => $process['Id']], '') . '">'
             . __('Kill') . '</a></td>';
         $retval .= '<td class="value">' . $process['Id'] . '</td>';
         $retval .= '<td>' . htmlspecialchars($process['User']) . '</td>';
         $retval .= '<td>' . htmlspecialchars($process['Host']) . '</td>';
-        $retval .= '<td>' . ((!isset($process['db'])
+        $retval .= '<td>' . ((! isset($process['db'])
                 || strlen($process['db']) === 0)
                 ? '<i>' . __('None') . '</i>'
                 : htmlspecialchars($process['db'])) . '</td>';
@@ -311,7 +313,7 @@ class Processes
         if (empty($process['Info'])) {
             $retval .= '---';
         } else {
-            $retval .= Util::formatSql($process['Info'], !$show_full_sql);
+            $retval .= Util::formatSql($process['Info'], ! $show_full_sql);
         }
         $retval .= '</td>';
         $retval .= '</tr>';


### PR DESCRIPTION
### Fix #14763 - Show refresh indicator while refreshing all databases tree listing

Fixes #
- Using jQuery the icon was hidden
- Using jQuery show when clicked
- Hiding again the when reload complete - using callback on PMA_reloadNavigation()

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
