### PR TITLE
Fixing #14763 -- Show refresh indicator while refreshing all database tree

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -309,19 +309,12 @@ $(function () {
      */
     $(document).on('click', '#pma_navigation_reload', function (event) {
         event.preventDefault();
-        // reload icon object
-        var $icon = $(this).find('img');
-        // source of the hidden throbber icon
-        var icon_throbber_src = $('#pma_navigation').find('.throbber').attr('src');
-        // source of the reload icon
-        var icon_reload_src = $icon.attr('src');
-        // replace the source of the reload icon with the one for throbber
-        $icon.attr('src', icon_throbber_src);
-        PMA_reloadNavigation();
-        // after one second, put back the reload icon
-        setTimeout(function () {
-            $icon.attr('src', icon_reload_src);
-        }, 1000);
+        var icon_throbber_src = $('#pma_navigation').find('.throbber');
+        icon_throbber_src.show();
+        icon_throbber_src.css('visibility', 'visible');
+        PMA_reloadNavigation(() => {
+            icon_throbber_src.hide();
+        });
     });
 
     $(document).on('change', '#navi_db_select',  function (event) {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -312,7 +312,7 @@ $(function () {
         var icon_throbber_src = $('#pma_navigation').find('.throbber');
         icon_throbber_src.show();
         icon_throbber_src.css('visibility', 'visible');
-        PMA_reloadNavigation(() => {
+        PMA_reloadNavigation(function () {
             icon_throbber_src.hide();
         });
     });


### PR DESCRIPTION
#14763 -- Show refresh indicator while refreshing all database tree

Signed-off-by: saurass <saurabhsrivastava312@gmail.com>

Fixes #
- the icon is hidden using jQuery hide()
- show only when fetching database tree

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.