### PR TITLE
fix Bookmark::get() id matching SQL

### DIFF
--- a/libraries/Bookmark.php
+++ b/libraries/Bookmark.php
@@ -344,7 +344,7 @@ class Bookmark
             $query .= ")";
         }
         $query .= " AND " . Util::backquote($id_field)
-            . " = " . $GLOBALS['dbi']->escapeString($id) . " LIMIT 1";
+            . " = '" . $GLOBALS['dbi']->escapeString($id) . "' LIMIT 1";
 
         $result = $GLOBALS['dbi']->fetchSingleRow($query, 'ASSOC', $controllink);
         if (! empty($result)) {


### PR DESCRIPTION
### Description

fix a mistake in SQL which causes default bookmark not working in 4.7 or above

Before submitting pull request, please review the following checklist:

- [*] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [*] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [*] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [*] Every commit has a descriptive commit message.
- [*] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [*] Any new functionality is covered by tests.
