### PR TITLE
Fix wrong locale code

### DIFF
--- a/libraries/classes/Charsets.php
+++ b/libraries/classes/Charsets.php
@@ -527,7 +527,7 @@ class Charsets
                         $name = _pgettext('Collation', 'Sinhalese');
                         break;
                     case 'slovak':
-                    case 'sl':
+                    case 'sk':
                         $name = _pgettext('Collation', 'Slovak');
                         break;
                     case 'slovenian':


### PR DESCRIPTION
### Description

`sl` code was duplicated for `Slovak` and `Slovenian`. It seems that it was wrong for `Slovak`.