### PR TITLE
Fix - #14503 JavaScript events not activating when input comes from mouse or browser autocomplete

### DIFF
--- a/js/sql.js
+++ b/js/sql.js
@@ -164,7 +164,7 @@ function getFieldName ($table_results, $this_field) {
 AJAX.registerTeardown('sql.js', function () {
     $(document).off('click', 'a.delete_row.ajax');
     $(document).off('submit', '.bookmarkQueryForm');
-    $('input#bkm_label').off('keyup');
+    $('input#bkm_label').off('input');
     $(document).off('makegrid', '.sqlqueryresults');
     $(document).off('stickycolumns', '.sqlqueryresults');
     $('#togglequerybox').off('click');
@@ -280,11 +280,11 @@ AJAX.registerOnload('sql.js', function () {
     });
 
     /* Hides the bookmarkoptions checkboxes when the bookmark label is empty */
-    $('input#bkm_label').on('keyup', function () {
+    $('input#bkm_label').on('input', function () {
         $('input#id_bkm_all_users, input#id_bkm_replace')
             .parent()
             .toggle($(this).val().length > 0);
-    }).trigger('keyup');
+    }).trigger('input');
 
     /**
      * Attach Event Handler for 'Copy to clipbpard


### PR DESCRIPTION
Fix - #14503 JavaScript events not activating when input comes from mouse or browser autocomplete.

Signed-off-by: nmilo <nemanjamilosevic29@yahoo.com>

### Description

As suggested by @ibennetch switched to 'on input' listener, instead of 'on keyup', in sql.js . In the SQL tab, now you can see checkboxes next to the bookmark field, using right click copy.

Fixes #14503 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
