### PR TITLE
fixes #14734 Invalid default value for bit field

### DIFF
--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2757,7 +2757,7 @@ class Util
      */
     public static function convertBitDefaultValue($bit_default_value)
     {
-        return rtrim(ltrim($bit_default_value, "b'"), "'");
+        return rtrim(ltrim(htmlspecialchars_decode($bit_default_value, ENT_QUOTES), "b'"), "'");
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Nitish Bahl <nitishbahl24@gmail.com>

### Description

I worked on the issue and found that `$bit_default_value` passed to the Util.php is `b&#039;1&#039; `instead of b'1' . Hence, I modified `Util.php` to satisfy our needs without affecting previous functionality. 

Fixes #14734 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
