### PR TITLE
fixes #14896 - [QA_4_8] Expanded DB, refresh, plus/minus icon

### DIFF
--- a/libraries/classes/Navigation/Nodes/Node.php
+++ b/libraries/classes/Navigation/Nodes/Node.php
@@ -797,6 +797,10 @@ class Node
             $this->visible = true;
 
             return Util::getImage('b_minus');
+        } elseif ($match && $this->is_group) {
+            $this->visible = true;
+
+            return Util::getImage('b_minus');
         }
 
         return Util::getImage('b_plus', __('Expand/Collapse'));

--- a/libraries/classes/Navigation/Nodes/Node.php
+++ b/libraries/classes/Navigation/Nodes/Node.php
@@ -793,11 +793,7 @@ class Node
         if (!$GLOBALS['cfg']['NavigationTreeEnableExpansion']
         ) {
             return '';
-        } elseif ($match && !$this->is_group) {
-            $this->visible = true;
-
-            return Util::getImage('b_minus');
-        } elseif ($match && $this->is_group) {
+        } elseif ($match) {
             $this->visible = true;
 
             return Util::getImage('b_minus');


### PR DESCRIPTION
Signed-off-by: saurass <saurabhsrivastava312@gmail.com>

### Description

Fixes #14896 - [QA_4_8] Expanded DB, refresh, plus/minus icon

- In libraries/classes/Navigation/Nodes/Node.php
    -> function getIcon(....)  -- is responsible to get b_plus or b_minus icon
    -> in case the node is a group, there was no check and it returned b_plus

- Solution
    -> add a check for group nodes and return b_minus 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
