### PR TITLE
Fixed 500 error in MultiTableQuery page

### DIFF
--- a/js/db_multi_table_query.js
+++ b/js/db_multi_table_query.js
@@ -118,6 +118,11 @@ AJAX.registerOnload('db_multi_table_query.js', function () {
 
     $('#submit_query').on('click', function () {
         var query = editor.getDoc().getValue();
+        // Verifying that the query is not empty
+        if (query === '') {
+            PMA_ajaxShowMessage('Please enter the sql query first.', false, 'error');
+            return;
+        }
         var data = {
             'db': $('#db_name').val(),
             'sql_query': query,

--- a/js/db_multi_table_query.js
+++ b/js/db_multi_table_query.js
@@ -120,7 +120,7 @@ AJAX.registerOnload('db_multi_table_query.js', function () {
         var query = editor.getDoc().getValue();
         // Verifying that the query is not empty
         if (query === '') {
-            PMA_ajaxShowMessage('Please enter the sql query first.', false, 'error');
+            PMA_ajaxShowMessage(PMA_messages.strEmptyQuery, false, 'error');
             return;
         }
         var data = {

--- a/js/messages.php
+++ b/js/messages.php
@@ -139,8 +139,8 @@ $js_messages['strSQLQuery'] = __('SQL query:');
 /* l10n: Default label for the y-Axis of Charts */
 $js_messages['strYValues'] = __('Y values');
 
-/* DB MULTI TABLE QUERY */
-$js_messages['strEmptyQuery'] = __('Please enter the sql query first.');
+/* Database multi-table query */
+$js_messages['strEmptyQuery'] = __('Please enter the SQL query first.');
 
 /* For server_privileges.js */
 $js_messages['strHostEmpty'] = __('The host name is empty!');

--- a/js/messages.php
+++ b/js/messages.php
@@ -139,6 +139,9 @@ $js_messages['strSQLQuery'] = __('SQL query:');
 /* l10n: Default label for the y-Axis of Charts */
 $js_messages['strYValues'] = __('Y values');
 
+/* DB MULTI TABLE QUERY */
+$js_messages['strEmptyQuery'] = __('Please enter the sql query first.');
+
 /* For server_privileges.js */
 $js_messages['strHostEmpty'] = __('The host name is empty!');
 $js_messages['strUserEmpty'] = __('The user name is empty!');


### PR DESCRIPTION
Fixed the 500 error when a empty query is passed to MultiTableQuery.
This is in reference to solve issue #14298.

### Description
Fixed error 500 on MultiTableQuery page when a empty query is passed.

Please describe your pull request.

Fixes #14298 

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
