### PR TITLE
Fixed 500 error in MultTableQuery

### DIFF
--- a/js/db_multi_table_query.js
+++ b/js/db_multi_table_query.js
@@ -118,6 +118,11 @@ AJAX.registerOnload('db_multi_table_query.js', function () {
 
     $('#submit_query').on('click', function () {
         var query = editor.getDoc().getValue();
+        // Verifying that the query is not empty
+        if (query === '') {
+            PMA_ajaxShowMessage('Please enter the sql query first.', false, 'error');
+            return;
+        }
         var data = {
             'db': $('#db_name').val(),
             'sql_query': query,


### PR DESCRIPTION
Fixed the 500 error occured when a empty query is passed to the the MutliTableQuery.

Signed-off-by: Gaurav Punjabi <gaurav.bpunjabi@gmail.com>

### Description
This pull request is in reference to solving issue #14298 
Please describe your pull request.

Fixes #14298 

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
