### PR TITLE
Fix #14916 Missing autofill of SQL query when creating a new view

### DIFF
--- a/templates/view_create.twig
+++ b/templates/view_create.twig
@@ -85,7 +85,11 @@
             <tr>
                 <td class="nowrap">AS</td>
                 <td>
-                    <textarea name="view[as]" rows="15" cols="40" dir="{{ text_dir }}" onclick="selectContent(this, sql_box_locked, true)">{{ view['as'] }}</textarea><br/>
+                    {% if view['as'] == '' %}
+                        <textarea name="view[as]" rows="15" cols="40" dir="{{ text_dir }}" onclick="selectContent(this, sql_box_locked, true)">{{ view['as'] }}</textarea><br/>
+                    {% else %}
+                        <input type="text" name="view[as]" maxlength="100" size="50" value="{{ view['as'] }}" /><br/>
+                    {% endif %}    
                     <input type="button" value="Format" id="format" class="button sqlbutton">
                     <span id="querymessage"></span>
                 </td>

--- a/templates/view_create.twig
+++ b/templates/view_create.twig
@@ -87,10 +87,10 @@
                 <td>
                     {% if view['as'] == '' %}
                         <textarea name="view[as]" rows="15" cols="40" dir="{{ text_dir }}" onclick="selectContent(this, sql_box_locked, true)">{{ view['as'] }}</textarea><br/>
+                        <input type="button" value="Format" id="format" class="button sqlbutton">
                     {% else %}
                         <input type="text" name="view[as]" maxlength="100" size="50" value="{{ view['as'] }}" /><br/>
                     {% endif %}    
-                    <input type="button" value="Format" id="format" class="button sqlbutton">
                     <span id="querymessage"></span>
                 </td>
             </tr>

--- a/view_create.php
+++ b/view_create.php
@@ -170,8 +170,6 @@ if (isset($_POST['createview']) || isset($_POST['alterview'])) {
     exit;
 }
 
-//$sql_query = ! empty($_GET['sql_query']) ? $_GET['sql_query'] : '';
-
 // prefill values if not already filled from former submission
 $view = array(
     'operation' => 'create',

--- a/view_create.php
+++ b/view_create.php
@@ -170,7 +170,7 @@ if (isset($_POST['createview']) || isset($_POST['alterview'])) {
     exit;
 }
 
-$sql_query = ! empty($_GET['sql_query']) ? $_GET['sql_query'] : '';
+//$sql_query = ! empty($_GET['sql_query']) ? $_GET['sql_query'] : '';
 
 // prefill values if not already filled from former submission
 $view = array(


### PR DESCRIPTION
### Description

Added provision for auto fill of SQL query, when create view is clicked. Fixed bug that makes the create view form unresponsive indefinitely when fields are empty.

Fixes #14916 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
