### PR TITLE
Issue #14909 - Define the 1st day of week of the calendar in config.php

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -2874,6 +2874,16 @@ Design customization
     name of the column. The comment is shown as a tool-tip for that
     column.
 
+.. config:option:: $cfg['FirstDayOfCalendar']
+
+    :type: integer
+    :default: 0
+
+    This will define the first day of week in the calendar. The number
+    can be set from 0 to 6, which represents the seven days of the week,
+    Sunday to Saturday respectively. This value can also be configured by the user
+    in server settings -> features -> general -> First Day calendar field.
+
 Text fields
 -----------
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -215,7 +215,8 @@ Functions.addDateTimePicker = function () {
                 showMillisec: showMillisec,
                 showMicrosec: showMicrosec,
                 timeFormat: timeFormat,
-                hourMax: hourMax
+                hourMax: hourMax,
+                firstDay: firstDayOfCalendar
             });
             // Add a tip regarding entering MySQL allowed-values
             // for TIME and DATE data-type

--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -1077,7 +1077,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     Functions.addDatepicker($inputField, $td.attr('data-type'), {
                         showMillisec: showMillisec,
                         showMicrosec: showMicrosec,
-                        timeFormat: timeFormat
+                        timeFormat: timeFormat,
+                        firstDay: firstDayOfCalendar
                     });
 
                     $inputField.on('keyup', function (e) {

--- a/js/messages.php
+++ b/js/messages.php
@@ -767,6 +767,13 @@ foreach ($js_messages as $name => $js_message) {
     Sanitize::printJsValue("Messages." . $name . "", $js_message);
 }
 
+/* Calendar */
+echo "var themeCalendarImage = '" , $GLOBALS['pmaThemeImage']
+    , 'b_calendar.png' , "';\n";
+
+/* Calendar First Day */
+echo "var firstDayOfCalendar = '" , $GLOBALS['cfg']['FirstDayOfCalendar'] , "';\n";
+
 /* Image path */
 echo "var pmaThemeImage = '" , $GLOBALS['pmaThemeImage'] , "';\n";
 

--- a/js/server/status/monitor.js
+++ b/js/server/status/monitor.js
@@ -1358,12 +1358,14 @@ AJAX.registerOnload('server/status/monitor.js', function () {
         Functions.addDatepicker($dateStart, 'datetime', {
             showMillisec: false,
             showMicrosec: false,
-            timeFormat: 'HH:mm:ss'
+            timeFormat: 'HH:mm:ss',
+            firstDay: firstDayOfCalendar
         });
         Functions.addDatepicker($dateEnd, 'datetime', {
             showMillisec: false,
             showMicrosec: false,
-            timeFormat: 'HH:mm:ss'
+            timeFormat: 'HH:mm:ss',
+            firstDay: firstDayOfCalendar
         });
         $dateStart.datepicker('setDate', min);
         $dateEnd.datepicker('setDate', max);

--- a/libraries/classes/Config/Descriptions.php
+++ b/libraries/classes/Config/Descriptions.php
@@ -283,6 +283,7 @@ class Descriptions
             'ForeignKeyMaxLimit_name' => __('Foreign key limit'),
             'DefaultForeignKeyChecks_desc' => __('Default value for foreign key checks checkbox for some queries.'),
             'DefaultForeignKeyChecks_name' => __('Foreign key checks'),
+            'FirstDayOfCalendar_name' => __('First day of calendar'),
             'Form_Browse_name' => __('Browse mode'),
             'Form_Browse_desc' => __('Customize browse mode.'),
             'Form_CodeGen_name' => 'CodeGen',

--- a/libraries/classes/Config/Forms/User/FeaturesForm.php
+++ b/libraries/classes/Config/Forms/User/FeaturesForm.php
@@ -33,6 +33,7 @@ class FeaturesForm extends BaseForm
                 'SendErrorReports',
                 'ConsoleEnterExecutes',
                 'DisableShortcutKeys',
+                'FirstDayOfCalendar',
             ],
             'Databases' => [
                 'Servers/1/only_db', // saves to Server/only_db

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -3250,6 +3250,13 @@ $cfg['DefaultTransformations']['DateFormat'] = [
 ];
 
 /**
+ * Set default for FirstDayOfCalendar
+ *
+ * @global integer $cfg['FirstDayOfCalendar']
+ */
+$cfg['FirstDayOfCalendar'] = 0;
+
+/**
  * Default transformations for Inline
  *
  * @global array $cfg['DefaultTransformations']['Inline']

--- a/libraries/config.values.php
+++ b/libraries/config.values.php
@@ -189,6 +189,15 @@ return [
         'closed' => __('Closed'),
         'disabled' => __('Disabled'),
     ],
+    'FirstDayOfCalendar' => [
+        '1' => __('Monday'),
+        '2' => __('Tuesday'),
+        '3' => __('Wednesday'),
+        '4' => __('Thursday'),
+        '5' => __('Friday'),
+        '6' => __('Saturday'),
+        '7' => __('Sunday'),
+    ],
     'SendErrorReports' => [
         'ask' => __('Ask before sending error reports'),
         'always' => __('Always send error reports'),


### PR DESCRIPTION
# Description
Fixes #14909
- Add config option to server_settings -> settings -> config.
- A form (Time_form) enables you to configure first day of the week.
- This will cause datePicker to pick selected day as first day of week.

## Approach
- In libraries/classes/Config/Forms/User/UserFormList.php added 'Config' in user form list array .
- In libraries/user_preferences.inc.php added 'Config' Tab icon.
- Made Config Form in libraries/classes/Config/Forms/User/ConfigForm.php, adding required fields.
- In libraries/classes/Config/Descriptions.php we describe input fields, form name and description.
- In libraries/config.values.php added the list of possible values for input field 'FirstDay'.
- In js/messages.php declare JS variable 'firstDayCalendar' and set its value same as that selected by user in config.
- In js/functions.js we declare 'firstDay: firstDayCalendar'.

## Result
- The datepicker shows first day of week as per selection by user in config -> time form.
- Video illustrating the fix https://drive.google.com/open?id=189VmqBHofYQNYdrY1BklT9ow0vip5pze

## WIP tasks
- Writing tests for these new features.
- Fixing lint errors.

# Contribution Checklist
Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
