### PR TITLE
ExportJson: prevent crash when encode returns boolean

### DIFF
--- a/libraries/classes/Plugins/Export/ExportJson.php
+++ b/libraries/classes/Plugins/Export/ExportJson.php
@@ -268,7 +268,11 @@ class ExportJson extends ExportPlugin
                 $data[$columns[$i]] = $record[$i];
             }
 
-            if (!Export::outputHandler($this->encode($data))) {
+            $encoded_data = $this->encode($data);
+            if (!$encoded_data) {
+                return false;
+            }
+            if (!Export::outputHandler($encoded_data)) {
                 return false;
             }
         }


### PR DESCRIPTION
Signed-off-by: Si Jie <sijie123@gmail.com>

Previously, ExportJson can crash as encode($data) calls json_encode, which will return false on failure. As outputHandler expects only either String or null, ExportJson will error out.

Fixes #14922 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests. [Not applicable]
