### PR TITLE
fix detectType: now considers cells with values like 0000123 (leading…

### DIFF
--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -814,6 +814,10 @@ class Import
             return self::BIGINT;
         }
 
+        if ($cell !== (string)(int)$cell) {
+            return self::VARCHAR;
+        }
+
         return self::INT;
     }
 


### PR DESCRIPTION
### Description

#### PROBLEM:
On xml imports, columns with leading zeros are converted to integers.

example:

xml_data.xml

```xml
<pma_xml_export version="1.0" xmlns:pma="https://www.phpmyadmin.net/some_doc_url/">
  <database name="test">
    <table name="my_table">
    <column name="ID">1</column>
    <column name="CODE">0001234</column>   
  </table>
  <table name="my_table">
    <column name="ID">2</column>
    <column name="CODE">0005678</column>
  </table>
</database>
</pma_xml_export>
```

After import
CODE column contains:  1234, 5678

#### SOLUTION:

detectType: now makes a final check before considering the cell an integer. 
Values like 0000123 (leading zeros) are now considered varchar types.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
