### PR TITLE
Tooltip for truncated strings #14767

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -2821,6 +2821,13 @@ Design customization
     Maximum number of characters shown in any non-numeric field on browse
     view. Can be turned off by a toggle button on the browse page.
 
+.. config:option:: $cfg['CommentLimitChars']
+
+    :type: integer
+    :default: 200
+
+    Maximum number of characters shown in the tooltip of truncated string.
+
 .. config:option:: $cfg['RowActionLinks']
 
     :type: string

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -2826,7 +2826,7 @@ Design customization
     :type: integer
     :default: 200
 
-    Maximum number of characters shown in the tooltip of truncated string.
+    Maximum number of characters displayed in the tooltip of truncated string.
 
 .. config:option:: $cfg['RowActionLinks']
 

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1625,6 +1625,7 @@ class Results
             'comments_map' => $commentsMap,
             'fields_meta' => $fieldsMeta,
             'limit_chars' => $GLOBALS['cfg']['LimitChars'],
+            'comment_limit_chars' => $GLOBALS['cfg']['CommentLimitChars'],
         ]);
     }
 

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -2731,6 +2731,13 @@ $cfg['CharTextareaRows'] = 2;
 $cfg['LimitChars'] = 50;
 
 /**
+ * Max Comment field data length in browse mode for all non-numeric fields
+ *
+ * @global integer $cfg['CommentLimitChars']
+ */
+$cfg['CommentLimitChars'] = 200;
+
+/**
  * Where to show the edit/copy/delete links in browse mode
  * Possible values are 'left', 'right', 'both' and 'none'.
  *

--- a/libraries/config.values.php
+++ b/libraries/config.values.php
@@ -423,6 +423,7 @@ return [
         'NumRecentTables' => 'validateNonNegativeNumber',
         'NumFavoriteTables' => 'validateNonNegativeNumber',
         'LimitChars' => 'validatePositiveNumber',
+        'CommentLimitChars' => 'validatePositiveNumber',
         'LoginCookieValidity' => 'validatePositiveNumber',
         'LoginCookieStore' => 'validateNonNegativeNumber',
         'MaxDbList' => 'validatePositiveNumber',

--- a/templates/display/results/comment_for_row.twig
+++ b/templates/display/results/comment_for_row.twig
@@ -1,6 +1,12 @@
 {% if comments_map[fields_meta.table] is defined
     and comments_map[fields_meta.table][fields_meta.name] is defined %}
-    <br><span class="tblcomment" title="{{ comments_map[fields_meta.table][fields_meta.name] }}">
+    <br><span class="tblcomment" 
+        {% if comments_map[fields_meta.table][fields_meta.name]|length > comment_limit_chars %}     
+            title="{{ comments_map[fields_meta.table][fields_meta.name]|slice(0, comment_limit_chars) }}…
+        {%else %}
+            title="{{ comments_map[fields_meta.table][fields_meta.name] }}">
+        {% endif %}
+        
         {% if comments_map[fields_meta.table][fields_meta.name]|length > limit_chars %}
             {{ comments_map[fields_meta.table][fields_meta.name]|slice(0, limit_chars) }}…
         {% else %}

--- a/templates/display/results/comment_for_row.twig
+++ b/templates/display/results/comment_for_row.twig
@@ -1,12 +1,12 @@
 {% if comments_map[fields_meta.table] is defined
     and comments_map[fields_meta.table][fields_meta.name] is defined %}
-    <br><span class="tblcomment" 
+    <br><span class="tblcomment"
         {% if comments_map[fields_meta.table][fields_meta.name]|length > comment_limit_chars %}     
             title="{{ comments_map[fields_meta.table][fields_meta.name]|slice(0, comment_limit_chars) }}…
         {%else %}
             title="{{ comments_map[fields_meta.table][fields_meta.name] }}">
         {% endif %}
-        
+
         {% if comments_map[fields_meta.table][fields_meta.name]|length > limit_chars %}
             {{ comments_map[fields_meta.table][fields_meta.name]|slice(0, limit_chars) }}…
         {% else %}


### PR DESCRIPTION
Signed-off-by: amarjitaa <amarjitsingh52922@gmail.com>

### Description
Added enhancement as tooltip for truncated strings with limit set to 200 but it configurable in libraries/config.default.php as 
Line 2738
$cfg['CommentLimitChars'] = 200;

Fixes #14767

as described above in Description
Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
