### PR TITLE
Enhancement#14735 Empty String Removed

### DIFF
--- a/libraries/classes/CreateAddField.php
+++ b/libraries/classes/CreateAddField.php
@@ -95,7 +95,7 @@ class CreateAddField
                         ? $_POST['field_null'][$i]
                         : 'NOT NULL',
                         $_POST['field_default_type'][$i],
-                        $_POST['field_default_value'][$i],
+                        $_POST['field_default_value'][$i] == '' || ctype_space($_POST['field_default_value'][$i]) ? 'NONE' : $_POST['field_default_value'],
                         isset($_POST['field_extra'][$i])
                         ? $_POST['field_extra'][$i]
                         : false,


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description
The Enhancement will remove the empty string default as suggested in #14735 And will now display A 'NONE' String instead of an Empty String
Enhancement #14735 
### Steps to See the Changes
Go to the Form of Creating a new table in some database.
Now in Default value if you select 'as defined' and do not enter any default value or put simply blank spaces and create that column, now you will see a 'NONE' string instead of some empty value in that field.
Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.