### PR TITLE
FixError#14870 Now Zip files display correct date and time

### DIFF
--- a/libraries/classes/ZipExtension.php
+++ b/libraries/classes/ZipExtension.php
@@ -198,7 +198,7 @@ class ZipExtension
         foreach ($data as $table => $dump) {
             $temp_name = str_replace('\\', '/', $table);
 
-            /* Convert Unix timestamp to DOS timestamp */
+            /* Get Local Time */
             $timearray = getdate();
 
             if ($timearray['year'] < 1980) {

--- a/libraries/classes/ZipExtension.php
+++ b/libraries/classes/ZipExtension.php
@@ -199,7 +199,7 @@ class ZipExtension
             $temp_name = str_replace('\\', '/', $table);
 
             /* Convert Unix timestamp to DOS timestamp */
-            $timearray = ($time == 0) ? getdate() : getdate($time);
+            $timearray = getdate();
 
             if ($timearray['year'] < 1980) {
                 $timearray['year'] = 1980;


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description
The ODS zipped files used to display incorrect date and time when unzipped as mentioned in #14870. This will fix that bug and now will display correct date and time when unzipped as required.
Fixes #14870
Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.