### PR TITLE
Do not submit forms multiple times on CTRL + ENTER

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -4890,8 +4890,11 @@ AJAX.registerOnload('functions.js', function () {
     $('form input, form textarea, form select').on('keydown', function (e) {
         if ((e.ctrlKey && e.which === 13) || (e.altKey && e.which === 13)) {
             $form = $(this).closest('form');
-            if (! $form.find('input[type="submit"]') ||
-                ! $form.find('input[type="submit"]').click()
+
+            // There could be multiple submit buttons on the same form,
+            // we assume all of them behave identical and just click one.
+            if (! $form.find('input[type="submit"]:first') ||
+                ! $form.find('input[type="submit"]:first').trigger('click')
             ) {
                 $form.submit();
             }


### PR DESCRIPTION
When there are multiple submit buttons, using the CTRL+ENTER shortcut will submit the same form multiple times. This fixes known issue https://github.com/phpmyadmin/phpmyadmin/issues/14460. 

The PMA module adds a lot of duplicate submit buttons. So in that situation it will occur a lot. One example can be seen here, both submit buttons belong to the same form.
![screenshot from 2019-02-22 10-14-22](https://user-images.githubusercontent.com/91910/53232657-d4335a00-368b-11e9-9f1b-93337cdbe468.png)