### PR TITLE
Fix error#14943

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -4550,7 +4550,6 @@ AJAX.registerOnload('functions.js', function () {
 
 function PMA_createViewDialog ($this) {
     var $msg = PMA_ajaxShowMessage();
-    var syntaxHighlighter = null;
     var sep = PMA_commonParams.get('arg_separator');
     var params = getJSConfirmCommonParam(this, $this.getPostData());
     params += sep + 'ajax_dialog=1';
@@ -4570,7 +4569,7 @@ function PMA_createViewDialog ($this) {
                         $('.result_query').html(data.message);
                         PMA_reloadNavigation();
                     } else {
-                        PMA_ajaxShowMessage(data.error, false);
+                        PMA_ajaxShowMessage(data.error);
                     }
                 });
             };

--- a/templates/view_create.twig
+++ b/templates/view_create.twig
@@ -108,15 +108,11 @@
         </table>
     </fieldset>
 
-    {% if ajax_dialog %}
-        <fieldset class="tblFooters">
-            <input type="hidden" name="{{ (view['operation'] == 'create') ? 'createview' : 'alterview' }}" value="1" />
-            <input type="submit" name="" value="{% trans 'Go' %}" />
-        </fieldset>
-    {% else %}
-        <input type="hidden" name="{{ (view['operation'] == 'create') ? 'createview' : 'alterview' }}" value="1" />
+    <input type="hidden" name="ajax_request" value="1" />
+    <input type="hidden" name="{{ (view['operation'] == 'create') ? 'createview' : 'alterview' }}" value="1" />
+
+    {% if ajax_dialog == false %}
         <input type="hidden" name="ajax_dialog" value="1" />
-        <input type="hidden" name="ajax_request" value="1" />
         <input type="submit" name="" value="{% trans 'Go' %}" />
     {% endif %}
 


### PR DESCRIPTION
### Description

In the issue # 14943, when the user tries to create a view without fill any field in the dialog / modal, the system show one "Loading" message forever.

Fixes #14943

I  removed the "Go" button in the dialog, because it's  duplicated.
I  removed the "false" second parameter in the "PMA_ajaxShowMessage" function, because I believe that the error message needs to have a timeout to be hidden (currently, the user needs to click in the error to it be hidden).
I removed the variable "syntaxHighlighter" because it's declared but never used.
I have fixed the input hiddens to the modal view. The issue has occurred because the modal does not get the error in JSON format. So, i had added the input hidden "ajax_request" for both situations (in modal or no)

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
