### PR TITLE
FixedError#14425 Null Checkbox automatically unmarked

### DIFF
--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -823,7 +823,15 @@ function PMA_makegrid (t, enableResize, enableReorder, enableVisib, enableGridEd
                             $checkbox.prop('checked', false);
                         });
                     }
-
+                    //if some text is written in textbox automatically unmark the null checkbox and if it is emptied again mark the checkbox.
+                    $(g.cEdit).find('.edit_box').on('input',function(){
+                        if ($(g.cEdit).find('.edit_box').val()!=''){
+                            $checkbox.prop('checked', false);
+                        }
+                        else {
+                            $checkbox.prop('checked', true);
+                        }
+                    });
                     // if null checkbox is clicked empty the corresponding select/editor.
                     $checkbox.click(function () {
                         if ($td.is('.enum')) {


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description
The PR Ensures that Null Checkbox in Error #14425 will be automatically unmarked once you start writing in text-box. Also, if one empties the text-box again it will ensure that null checkbox is marked gain.
Fixes #14425 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.