### PR TITLE
Fix #14673 - innodb & MySQL 8: DYNAMIC & COMPRESSED ROW_FORMAT missing

### DIFF
--- a/libraries/classes/Operations.php
+++ b/libraries/classes/Operations.php
@@ -1237,7 +1237,12 @@ class Operations
         } else {
             $innodb_file_format = '';
         }
-        if ('Barracuda' == $innodb_file_format
+        /**
+         * Newer MySQL/MariaDB always return empty a.k.a '' on $innodb_file_format otherwise
+         * old versions of MySQL/MariaDB must be returning something or not empty.
+         * This patch is to support newer MySQL/MariaDB while also for backward compatibilities.
+         */
+        if (( ('Barracuda' == $innodb_file_format) || ($innodb_file_format == '') )
             && $innodbEnginePlugin->supportsFilePerTable()
         ) {
             $possible_row_formats['INNODB']['DYNAMIC'] = 'DYNAMIC';


### PR DESCRIPTION
Signed-off-by: Nugroho Latifolia <nugroho.latifolia@gmail.com>

**Description**

Newer MySQL/MariaDB deprecated all InnoDB File Format parameters, so on PHPMyAdmin Table Operations only show ROW FORMAT to COMPACT & REDUNDANT excluding DYNAMIC & COMPRESSED. This proposed patch will support future generations of MySQL/MariaDB while preserving backward compatibilities with older generations.

Fixes #14673

```php
       /*
        Newer MySQL/MariaDB always return empty a.k.a '' on $innodb_file_format otherwise
        old versions of MySQL/MariaDB must be returning something or not empty.
        This patch is to support newer MySQL/MariaDB while also for backward compatibilities.
        */

        if ( (('Barracuda' == $innodb_file_format) || ('' == $innodb_file_format))
            && $innodbEnginePlugin->supportsFilePerTable()
        ) {
            $possible_row_formats['INNODB']['DYNAMIC'] = 'DYNAMIC';
            $possible_row_formats['INNODB']['COMPRESSED'] = 'COMPRESSED';
        }
```
Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
