### PR TITLE
charset as windows-1252 when format is MS Excel

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -309,7 +309,7 @@ AJAX.registerOnload('export.js', function () {
     });
     
     // When MS Excel is selected as the Format automatically Switch to Character Set as windows-1252
-    $('#plugins').change(function () { 
+    $('#plugins').change(function () {
         var selected_plugin_name = $('#plugins').find('option:selected').val();
         if(selected_plugin_name == "excel"){
             $('#select_charset').val('windows-1252');
@@ -318,7 +318,7 @@ AJAX.registerOnload('export.js', function () {
             $('#select_charset').val('utf-8');
         }
     });
-
+    
     // For separate-file exports only ZIP compression is allowed
     $('input[type="checkbox"][name="as_separate_files"]').on('change', function () {
         if ($(this).is(':checked')) {

--- a/js/export.js
+++ b/js/export.js
@@ -311,7 +311,7 @@ AJAX.registerOnload('export.js', function () {
     // When MS Excel is selected as the Format automatically Switch to Character Set as windows-1252
     $('#plugins').change(function () {
         var selected_plugin_name = $('#plugins').find('option:selected').val();
-        if (selected_plugin_name == "excel") {
+        if (selected_plugin_name === 'excel') {
             $('#select_charset').val('windows-1252');
         } else {
             $('#select_charset').val('utf-8');

--- a/js/export.js
+++ b/js/export.js
@@ -307,18 +307,17 @@ AJAX.registerOnload('export.js', function () {
             $('#checkbox_sql_auto_increment').prop('disabled', false).parent().fadeTo('fast', 1);
         }
     });
-    
+
     // When MS Excel is selected as the Format automatically Switch to Character Set as windows-1252
     $('#plugins').change(function () {
         var selected_plugin_name = $('#plugins').find('option:selected').val();
-        if(selected_plugin_name == "excel"){
+        if (selected_plugin_name == "excel") {
             $('#select_charset').val('windows-1252');
-        }
-        else{
+        } else {
             $('#select_charset').val('utf-8');
         }
     });
-    
+
     // For separate-file exports only ZIP compression is allowed
     $('input[type="checkbox"][name="as_separate_files"]').on('change', function () {
         if ($(this).is(':checked')) {

--- a/js/export.js
+++ b/js/export.js
@@ -307,6 +307,17 @@ AJAX.registerOnload('export.js', function () {
             $('#checkbox_sql_auto_increment').prop('disabled', false).parent().fadeTo('fast', 1);
         }
     });
+    
+    // When MS Excel is selected as the Format automatically Switch to Character Set as windows-1252
+    $('#plugins').change(function () { 
+        var selected_plugin_name = $('#plugins').find('option:selected').val();
+        if(selected_plugin_name == "excel"){
+            $('#select_charset').val('windows-1252');
+        }
+        else{
+            $('#select_charset').val('utf-8');
+        }
+    });
 
     // For separate-file exports only ZIP compression is allowed
     $('input[type="checkbox"][name="as_separate_files"]').on('change', function () {


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description
The PR ensures that the text imported in MS Excel is not imported with wrong or incorrect characters by automatically changing the character set of file to windows-1252 when 'CSV for MS Excel' is selected as format as suggested in #14837 . It also changes the character set back to Default 'utf-8' in case some other format is selected.
Enhancement #14837 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
