### PR TITLE
Move 'More settings' link from 'Appearance settings' to 'General settings'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@ phpMyAdmin - ChangeLog
 - issue #14829 Change table column comment field from input to textarea
 - issue #14725 Console: ctrl+l clear line and ctrl+u clear console
 - issue #14837 Use charset 'windows-1252' when format is MS Excel
+- issue #15030 Move 'More settings' link from 'Appearance settings' to 'General settings'
 
 4.8.6 (not yet released)
 - issue #14478 phpMyAdmin no longer streams the export data

--- a/templates/home/index.twig
+++ b/templates/home/index.twig
@@ -41,6 +41,7 @@
               </form>
             </li>
           {% endif %}
+          {{ user_preferences is not empty ? user_preferences|raw }}
         </ul>
       </div>
     {% endif %}
@@ -62,12 +63,6 @@
           </li>
         {% endif %}
       </ul>
-
-      {% if user_preferences is not empty %}
-        <ul>
-          {{ user_preferences|raw }}
-        </ul>
-      {% endif %}
     </div>
   </div>
 


### PR DESCRIPTION
### Description

Moves _More settings_ link from _Appearance settings_ group to _General settings_ group on _index.php_.

As _More settings_ is a link to the user preferences, I think it is more coherent to move this link to _General settings_.

### Before
![Screenshot from 2019-03-15 21-34-15](https://user-images.githubusercontent.com/120970/54468485-c3967100-476b-11e9-98f6-d781828d3341.png)

### After
![Screenshot from 2019-03-15 21-34-49](https://user-images.githubusercontent.com/120970/54468487-c85b2500-476b-11e9-9310-de8df5ce079f.png)

