### PR TITLE
Add check for empty input to change_collation

### DIFF
--- a/libraries/db_common.inc.php
+++ b/libraries/db_common.inc.php
@@ -139,6 +139,18 @@ if (isset($_POST['submitcollation'])
         $response->addJSON('message', $message);
         exit;
     }
+} elseif (isset($_POST['submitcollation'])
+    && isset($_POST['db_collation'])
+    && empty($_POST['db_collation'])
+) {
+    $response = Response::getInstance();
+    if ($response->isAjax()) {
+        $response->setRequestStatus(false);
+        $response->addJSON(
+            'message',
+            Message::error(__('No collation provided.'))
+        );
+    }
 }
 
 /**

--- a/tbl_operations.php
+++ b/tbl_operations.php
@@ -214,6 +214,18 @@ if (isset($_POST['submitoptions'])) {
             $GLOBALS['db'], $GLOBALS['table'], $_POST['tbl_collation']
         );
     }
+
+    if (isset($_POST['tbl_collation']) && empty($_POST['tbl_collation'])) {
+        $response = Response::getInstance();
+        if ($response->isAjax()) {
+            $response->setRequestStatus(false);
+            $response->addJSON(
+                'message',
+                Message::error(__('No collation provided.'))
+            );
+            exit;
+        }
+    }
 }
 /**
  * Reordering the table has been requested by the user


### PR DESCRIPTION
### Description

Currently, if an empty input is provided to change_collation, the behaviour is as if no user input were made.
This causes a bug in db_operations.php, where a blank form will be returned to the user instead of an error message.

By checking for empty($_REQUEST['db_collation']) separately, we can catch bad user input and return the appropriate error message.

Fixes #14987

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests. (Not applicable?)


For reviewer:
The github diff is misaligned. I essentially only added lines 86-88 and 136-144