### PR TITLE
Fix #15010 Sql preview show empty modal on

### DIFF
--- a/libraries/classes/Controllers/Table/TableRelationController.php
+++ b/libraries/classes/Controllers/Table/TableRelationController.php
@@ -128,9 +128,7 @@ class TableRelationController extends TableController
         }
 
         // updates for foreign keys
-        if (isset($_POST['destination_foreign_db'])) {
-            $this->updateForForeignKeysAction();
-        }
+        $this->updateForForeignKeysAction();
 
         // Updates for display field
         if ($this->cfgRelation['displaywork'] && isset($_POST['display_field'])) {
@@ -247,17 +245,21 @@ class TableRelationController extends TableController
 
         // (for now, one index name only; we keep the definitions if the
         // foreign db is not the same)
-        list($html, $preview_sql_data, $display_query, $seen_error)
-            = $this->upd_query->updateForeignKeys(
-                $_POST['destination_foreign_db'],
-                $multi_edit_columns_name, $_POST['destination_foreign_table'],
-                $_POST['destination_foreign_column'], $this->options_array,
-                $this->table,
-                isset($this->existrel_foreign)
-                ? $this->existrel_foreign['foreign_keys_data']
-                : null
-            );
-        $this->response->addHTML($html);
+        if (isset($_POST['destination_foreign_db'])
+            && isset($_POST['destination_foreign_table'])
+            && isset($_POST['destination_foreign_column'])) {
+            list($html, $preview_sql_data, $display_query, $seen_error)
+                = $this->upd_query->updateForeignKeys(
+                    $_POST['destination_foreign_db'],
+                    $multi_edit_columns_name, $_POST['destination_foreign_table'],
+                    $_POST['destination_foreign_column'], $this->options_array,
+                    $this->table,
+                    isset($this->existrel_foreign)
+                    ? $this->existrel_foreign['foreign_keys_data']
+                    : null
+                );
+            $this->response->addHTML($html);
+        }
 
         // If there is a request for SQL previewing.
         if (isset($_POST['preview_sql'])) {


### PR DESCRIPTION
Signed-off-by: Apoorv Khare <apoorvkhare007@gmail.com>

### Description

It was giving empty modal because the `previewSQL` function is being called from here:
`if (isset($_POST['destination_foreign_db'])) { $this->updateForForeignKeysAction(); }`
and in some cases `destination_foreign_db` param is not set in the request, so the modal is coming empty.
Removing the check from here and applying at other relevant places fixes the issue.
Fixes #15010 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
