### PR TITLE
Fixes #15037 Unexpected behaviour of reset button

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -421,6 +421,22 @@ function displayErrors (error_list) {
 }
 
 /**
+ * Validates fields and fieldsets and call displayError function as required
+ */
+function setDisplayError(){
+    var $elements = $('.optbox input[id], .optbox select[id], .optbox textarea[id]');
+    // run all field validators
+    var errors = {};
+    for (var i = 0; i < $elements.length; i++) {
+        validate_field($elements[i], false, errors);
+    }
+    // run all fieldset validators
+    $('fieldset.optbox').each(function () {
+        validate_fieldset(this, false, errors);
+    });
+    displayErrors(errors);
+}
+/**
  * Validates fieldset and puts errors in 'errors' object
  *
  * @param {Element} fieldset
@@ -648,6 +664,7 @@ AJAX.registerOnload('config.js', function () {
         for (var i = 0, imax = fields.length; i < imax; i++) {
             setFieldValue(fields[i], getFieldType(fields[i]), defaultValues[fields[i].id]);
         }
+        setDisplayError();
     });
 });
 


### PR DESCRIPTION
### Description
The Function responsible for showing and hiding error messages `displayError()` was not being called in case when reset button is clicked. 
I added a new function `setDisplayError()` which calls `displayError()` function accordingly and fix this issue.
Fixes #15037

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
