### PR TITLE
Improve grammar in Validator

### DIFF
--- a/libraries/classes/Config/FormDisplay.php
+++ b/libraries/classes/Config/FormDisplay.php
@@ -100,7 +100,7 @@ class FormDisplay
             'error_nan_nneg' => __('Not a non-negative number!'),
             'error_incorrect_port' => __('Not a valid port number!'),
             'error_invalid_value' => __('Incorrect value!'),
-            'error_value_lte' => __('Value must be equal or lower than %s!'));
+            'error_value_lte' => __('Value must be lower than or equal to %s!'));
         $this->_configFile = $cf;
         // initialize validators
         Validator::getValidators($this->_configFile);

--- a/libraries/classes/Config/Validator.php
+++ b/libraries/classes/Config/Validator.php
@@ -580,6 +580,6 @@ class Validator
     {
         $result = $values[$path] <= $max_value;
         return array($path => ($result ? ''
-            : sprintf(__('Value must be equal or lower than %s!'), $max_value)));
+            : sprintf(__('Value must be lower than or equal to %s!'), $max_value)));
     }
 }


### PR DESCRIPTION
Signed-off-by: Si Jie <sijie123@gmail.com>

### Description

Currently, when an upper bound check fails, the message "Value must be equal or lower than %s" is given, which is grammatically incorrect.
Fixed to show "Value must be lower than or equal _to_ %s".

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
