### PR TITLE
correct properties for display in metro

### DIFF
--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -2314,7 +2314,6 @@ input {
 .ajax_notification {
   top: 0;
   position: fixed;
-  width: 100%;
   z-index: 1100;
   text-align: center;
   display: inline;
@@ -2328,7 +2327,6 @@ input {
   color: $main-color;
   padding: 10px !important;
   border: none;
-  height: 19px;
 }
 
 .dismissable {


### PR DESCRIPTION
Signed-off-by: Nitish Bahl <nitishbahl24@gmail.com>

### Description

Property is ignored due to the display. With 'display: inline', the width, height, margin-top, margin-bottom, and float properties have no effect. Ref - http://csslint.net/about.html

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
