### PR TITLE
Fixes #15079 Responsive behaviour of instruction dialog box

### DIFF
--- a/js/server_status_advisor.js
+++ b/js/server_status_advisor.js
@@ -34,7 +34,7 @@ AJAX.registerOnload('server_status_advisor.js', function () {
         };
         $instructionsDialog.dialog({
             title: PMA_messages.strAdvisorSystem,
-            width: 700,
+            width: '60%',
             buttons: dlgBtns
         });
     });

--- a/js/server_status_monitor.js
+++ b/js/server_status_monitor.js
@@ -676,7 +676,7 @@ AJAX.registerOnload('server_status_monitor.js', function () {
         var $dialog = $('#monitorInstructionsDialog');
 
         $dialog.dialog({
-            width: 595,
+            width: '60%',
             height: 'auto'
         }).find('img.ajaxIcon').show();
 


### PR DESCRIPTION
Signed-off-by: apoorv <apoorvkhare007@gmail.com>

### Description
Initially the widths of dialog boxes were hardcoded in pixels making them unresponsive to change in screen widths.
Giving widths in percentage fixes this (60%). Done this for other dialog boxes as well.
Please describe your pull request.

Fixes #15079

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
