### PR TITLE
Fixes #15059 Server charset hardcoded in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -369,12 +369,17 @@ if ($server > 0 && $GLOBALS['cfg']['ShowServerInfo']) {
     echo '    <li id="li_select_mysql_charset">';
     echo '        ' , __('Server charset:') , ' '
        . '        <span lang="en" dir="ltr">';
-    $unicode = Charsets::$mysql_charset_map['utf-8'];
+
+       $charset = Charsets::getCharset(
+        $GLOBALS['dbi'],
+        $GLOBALS['cfg']['Server']['DisableIS']
+    );
     $charsets = Charsets::getMySQLCharsetsDescriptions(
         $GLOBALS['dbi'],
         $GLOBALS['cfg']['Server']['DisableIS']
     );
-    echo '           ' , $charsets[$unicode], ' (' . $unicode, ')';
+
+    echo '           ' , $charsets[$charset], ' (' . $charset, ')';
     echo '        </span>'
        . '    </li>'
        . '  </ul>'

--- a/libraries/classes/Charsets.php
+++ b/libraries/classes/Charsets.php
@@ -49,6 +49,7 @@ class Charsets
     );
 
     private static $_charsets = array();
+    private static $_charset;
     private static $_charsets_descriptions = array();
     private static $_collations = array();
     private static $_default_collations = array();
@@ -125,6 +126,26 @@ class Charsets
         foreach (self::$_collations as $key => $value) {
             sort(self::$_collations[$key], SORT_STRING);
         }
+    }
+
+     /**
+     * Get current MySQL server charset.
+     *
+     * @param DatabaseInterface $dbi       DatabaseInterface instance
+     * @param boolean           $disableIs Disable use of INFORMATION_SCHEMA
+     *
+     * @return string
+     */
+    public static function getCharset(DatabaseInterface $dbi, $disableIs)
+    {
+        $sql = 'SHOW VARIABLES LIKE  \'character_set_server\';';
+        $res = $dbi->query($sql);
+        while ($row = $dbi->fetchAssoc($res)) {
+            $charset = $row['Value'];
+            self::$_charset = $charset;
+        }
+        $dbi->freeResult($res);
+        return self::$_charset ;
     }
 
     /**


### PR DESCRIPTION
### Description

Please describe your pull request.
Initially server charset was hardcoded to `utf-8` in index.php, so even after changing the server charset for mysql it always showed `utf-8` in phpMyAdmin. 
Adding a function `getCharset()` which takes current server-charset through mysql client fixes this issue.

Fixes #15059 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
