### PR TITLE
Fix #15064 - Export SQL option hidden on sql query export results

### DIFF
--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -168,7 +168,8 @@ final class ExportController extends AbstractController
             $unlim_num_rows = 0;
         }
 
-        if (isset($_POST['raw_query'])) {
+        $isReturnBackFromRawExport = isset($_POST['export_type']) && $_POST['export_type'] === 'raw';
+        if (isset($_POST['raw_query']) || $isReturnBackFromRawExport) {
             $export_type = 'raw';
         } else {
             $export_type = 'table';

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -168,10 +168,16 @@ final class ExportController extends AbstractController
             $unlim_num_rows = 0;
         }
 
+        if (isset($_POST['raw_query'])) {
+            $export_type = 'raw';
+        } else {
+            $export_type = 'table';
+        }
+
         $displayExport = new DisplayExport();
         $this->response->addHTML(
             $displayExport->getDisplay(
-                'database',
+                $export_type,
                 $db,
                 $table,
                 $sql_query,

--- a/libraries/classes/Controllers/ExportController.php
+++ b/libraries/classes/Controllers/ExportController.php
@@ -334,6 +334,10 @@ final class ExportController extends AbstractController
                 'db' => $db,
                 'table' => $table,
             ]);
+        } elseif ($export_type === 'raw') {
+            $err_url = Url::getFromRoute('/server/export', [
+                'sql_query' => $sql_query,
+            ]);
         } else {
             Core::fatalError(__('Bad parameters!'));
         }
@@ -409,6 +413,11 @@ final class ExportController extends AbstractController
             $mime_type = '';
         }
 
+        // For raw query export, filename will be export.extension
+        if ($export_type === 'raw') {
+            $filename = 'export.' . $export_plugin->getProperties()->getExtension();
+        }
+
         // Open file on server if needed
         if ($save_on_server) {
             list($save_filename, $message, $file_handle) = $this->export->openFile(
@@ -481,6 +490,10 @@ final class ExportController extends AbstractController
             $do_dates = isset($GLOBALS[$what . '_dates']);
 
             $whatStrucOrData = $GLOBALS[$what . '_structure_or_data'];
+
+            if ($export_type === 'raw') {
+                $whatStrucOrData = 'raw';
+            }
 
             /**
              * Builds the dump
@@ -556,6 +569,15 @@ final class ExportController extends AbstractController
                         $separate_files
                     );
                 }
+            } elseif ($export_type === 'raw') {
+                Export::exportRaw(
+                    $whatStrucOrData,
+                    $export_plugin,
+                    $crlf,
+                    $err_url,
+                    $sql_query,
+                    $export_type
+                );
             } else {
                 // We export just one table
                 // $allrows comes from the form when "Dump all rows" has been selected

--- a/libraries/classes/Controllers/ExportController.php
+++ b/libraries/classes/Controllers/ExportController.php
@@ -415,7 +415,7 @@ final class ExportController extends AbstractController
 
         // For raw query export, filename will be export.extension
         if ($export_type === 'raw') {
-            $filename = 'export.' . $export_plugin->getProperties()->getExtension();
+            [$filename ] = $this->export->getFinalFilenameAndMimetypeForFilename($export_plugin, $compression, 'export');
         }
 
         // Open file on server if needed

--- a/libraries/classes/Display/Export.php
+++ b/libraries/classes/Display/Export.php
@@ -552,7 +552,7 @@ class Export
         $html .= $this->getHtmlForOptionsSelection($exportType, $multiValues);
 
         $tableObject = new Table($table, $db);
-        if (strlen($table) > 0 && empty($numTables) && ! $tableObject->isMerge()) {
+        if (strlen($table) > 0 && empty($numTables) && ! $tableObject->isMerge() && $exportType != 'raw') {
             $html .= $this->getHtmlForOptionsRows($db, $table, $unlimNumRows);
         }
 

--- a/libraries/classes/Display/Export.php
+++ b/libraries/classes/Display/Export.php
@@ -552,7 +552,7 @@ class Export
         $html .= $this->getHtmlForOptionsSelection($exportType, $multiValues);
 
         $tableObject = new Table($table, $db);
-        if (strlen($table) > 0 && empty($numTables) && ! $tableObject->isMerge() && $exportType != 'raw') {
+        if (strlen($table) > 0 && empty($numTables) && ! $tableObject->isMerge() && $exportType !== 'raw') {
             $html .= $this->getHtmlForOptionsRows($db, $table, $unlimNumRows);
         }
 

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -4933,6 +4933,12 @@ class Results
                 $_url_params['single_table'] = 'true';
             }
 
+            // In case this query doesn't involve any tables,
+            // implies only raw query is to be exported
+            if (! $analyzed_sql_results['select_tables']) {
+                $_url_params['raw_query'] = 'true';
+            }
+
             if (! $header_shown) {
                 $results_operations_html .= $header;
                 $header_shown = true;

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -925,6 +925,9 @@ class Export
                 $sql_query,
                 $crlf
             )) {
+                $GLOBALS['message'] = Message::error(
+                    __('Exporting a raw query is not supported for this export method.')
+                );
                 return;
             }
         }

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -313,6 +313,14 @@ class Export
                     $filename_template
                 );
             }
+        } elseif ($export_type == 'raw') {
+            if (! empty($remember_template)) {
+                $GLOBALS['PMA_Config']->setUserValue(
+                    'pma_raw_filename_template',
+                    'Export/file_template_raw',
+                    $filename_template
+                );
+            }
         } else {
             if (! empty($remember_template)) {
                 $GLOBALS['PMA_Config']->setUserValue(
@@ -886,6 +894,38 @@ class Export
 
             if ($separate_files == 'database') {
                 $this->saveObjectInBuffer('events');
+            }
+        }
+    }
+
+    /**
+     * Export raw query
+     *
+     * @param string       $whatStrucOrData whether to export structure for each table or raw
+     * @param ExportPlugin $export_plugin   the selected export plugin
+     * @param string       $crlf            end of line character(s)
+     * @param string       $err_url         the URL in case of error
+     * @param string       $sql_query       the query to be executed
+     * @param string       $export_type     the export type
+     *
+     * @return void
+     */
+    public static function exportRaw(
+        string $whatStrucOrData,
+        ExportPlugin $export_plugin,
+        string $crlf,
+        string $err_url,
+        string $sql_query,
+        string $export_type
+    ): void {
+        // In case the we need to dump just the raw query
+        if ($whatStrucOrData == 'raw') {
+            if (! $export_plugin->exportRawQuery(
+                $err_url,
+                $sql_query,
+                $crlf
+            )) {
+                return;
             }
         }
     }

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -919,7 +919,7 @@ class Export
         string $export_type
     ): void {
         // In case the we need to dump just the raw query
-        if ($whatStrucOrData == 'raw') {
+        if ($whatStrucOrData === 'raw') {
             if (! $export_plugin->exportRawQuery(
                 $err_url,
                 $sql_query,

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -280,6 +280,52 @@ class Export
     }
 
     /**
+     * Returns the filename and MIME type for a compression and an export plugin
+     *
+     * @param ExportPlugin $exportPlugin the export plugin
+     * @param string       $compression  compression asked
+     * @param string       $filename     the filename
+     *
+     * @return string[]    the filename and mime type
+     */
+    public function getFinalFilenameAndMimetypeForFilename(
+        ExportPlugin $exportPlugin,
+        string $compression,
+        string $filename
+    ): array {
+        // Grab basic dump extension and mime type
+        // Check if the user already added extension;
+        // get the substring where the extension would be if it was included
+        $extensionStartPos = mb_strlen($filename) - mb_strlen(
+            $exportPlugin->getProperties()->getExtension()
+        ) - 1;
+        $userExtension = mb_substr(
+            $filename,
+            $extensionStartPos,
+            mb_strlen($filename)
+        );
+        $requiredExtension = '.' . $exportPlugin->getProperties()->getExtension();
+        if (mb_strtolower($userExtension) != $requiredExtension) {
+            $filename  .= $requiredExtension;
+        }
+        $mime_type  = $exportPlugin->getProperties()->getMimeType();
+
+        // If dump is going to be compressed, set correct mime_type and add
+        // compression to extension
+        if ($compression === 'gzip') {
+            $filename  .= '.gz';
+            $mime_type = 'application/x-gzip';
+        } elseif ($compression === 'zip') {
+            $filename  .= '.zip';
+            $mime_type = 'application/zip';
+        }
+        return [
+            $filename,
+            $mime_type,
+        ];
+    }
+
+    /**
      * Return the filename and MIME type for export file
      *
      * @param string       $export_type       type of export
@@ -333,38 +379,13 @@ class Export
         $filename = Util::expandUserString($filename_template);
         // remove dots in filename (coming from either the template or already
         // part of the filename) to avoid a remote code execution vulnerability
-        $filename = Sanitize::sanitizeFilename($filename, $replaceDots = true);
+        $filename = Sanitize::sanitizeFilename($filename, true);
 
-        // Grab basic dump extension and mime type
-        // Check if the user already added extension;
-        // get the substring where the extension would be if it was included
-        $extension_start_pos = mb_strlen($filename) - mb_strlen(
-            $export_plugin->getProperties()->getExtension()
-        ) - 1;
-        $user_extension = mb_substr(
-            $filename,
-            $extension_start_pos,
-            mb_strlen($filename)
+        return $this->getFinalFilenameAndMimetypeForFilename(
+            $export_plugin,
+            $compression,
+            $filename
         );
-        $required_extension = '.' . $export_plugin->getProperties()->getExtension();
-        if (mb_strtolower($user_extension) != $required_extension) {
-            $filename  .= $required_extension;
-        }
-        $mime_type  = $export_plugin->getProperties()->getMimeType();
-
-        // If dump is going to be compressed, set correct mime_type and add
-        // compression to extension
-        if ($compression == 'gzip') {
-            $filename  .= '.gz';
-            $mime_type = 'application/x-gzip';
-        } elseif ($compression == 'zip') {
-            $filename  .= '.zip';
-            $mime_type = 'application/zip';
-        }
-        return [
-            $filename,
-            $mime_type,
-        ];
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportCsv.php
+++ b/libraries/classes/Plugins/Export/ExportCsv.php
@@ -338,4 +338,18 @@ class ExportCsv extends ExportPlugin
 
         return true;
     }
+
+    /**
+     * Outputs result of raw query in CSV format
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the end of line sequence
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        return $this->exportData('', '', $crlf, $err_url, $sql_query);
+    }
 }

--- a/libraries/classes/Plugins/Export/ExportLatex.php
+++ b/libraries/classes/Plugins/Export/ExportLatex.php
@@ -440,6 +440,20 @@ class ExportLatex extends ExportPlugin
     } // end getTableLaTeX
 
     /**
+     * Outputs result raw query
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the seperator for a file
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        return $this->exportData('', '', $crlf, $err_url, $sql_query);
+    }
+
+    /**
      * Outputs table's structure
      *
      * @param string $db          database name

--- a/libraries/classes/Plugins/Export/ExportMediawiki.php
+++ b/libraries/classes/Plugins/Export/ExportMediawiki.php
@@ -289,7 +289,9 @@ class ExportMediawiki extends ExportPlugin
 
         // Print data comment
         $output = $this->_exportComment(
-            'Table data for ' . Util::backquote($table_alias)
+            $table_alias != ''
+                ? 'Table data for ' . Util::backquote($table_alias)
+                : 'Query results'
         );
 
         // Begin the table construction
@@ -346,6 +348,20 @@ class ExportMediawiki extends ExportPlugin
         $output .= '|}' . str_repeat($this->_exportCRLF(), 2);
 
         return $this->export->outputHandler($output);
+    }
+
+    /**
+     * Outputs result raw query in MediaWiki format
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the end of line sequence
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        return $this->exportData('', '', $crlf, $err_url, $sql_query);
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportOds.php
+++ b/libraries/classes/Plugins/Export/ExportOds.php
@@ -337,4 +337,18 @@ class ExportOds extends ExportPlugin
 
         return true;
     }
+
+    /**
+     * Outputs result raw query in ODS format
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the end of line sequence
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        return $this->exportData('', '', $crlf, $err_url, $sql_query);
+    }
 }

--- a/libraries/classes/Plugins/Export/ExportOdt.php
+++ b/libraries/classes/Plugins/Export/ExportOdt.php
@@ -260,9 +260,12 @@ class ExportOdt extends ExportPlugin
 
         $GLOBALS['odt_buffer']
             .= '<text:h text:outline-level="2" text:style-name="Heading_2"'
-            . ' text:is-list-header="true">'
-            . __('Dumping data for table') . ' ' . htmlspecialchars($table_alias)
-            . '</text:h>'
+            . ' text:is-list-header="true">';
+        $table_alias != ''
+            ? $GLOBALS['odt_buffer'] .= __('Dumping data for table') . ' ' . htmlspecialchars($table_alias)
+            : $GLOBALS['odt_buffer'] .= __('Dumping data for query result');
+        $GLOBALS['odt_buffer']
+            .= '</text:h>'
             . '<table:table'
             . ' table:name="' . htmlspecialchars($table_alias) . '_structure">'
             . '<table:table-column'
@@ -338,6 +341,20 @@ class ExportOdt extends ExportPlugin
         $GLOBALS['odt_buffer'] .= '</table:table>';
 
         return true;
+    }
+
+    /**
+     * Outputs result raw query in ODT format
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the end of line sequence
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        return $this->exportData('', '', $crlf, $err_url, $sql_query);
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportPdf.php
+++ b/libraries/classes/Plugins/Export/ExportPdf.php
@@ -233,6 +233,29 @@ class ExportPdf extends ExportPlugin
     } // end of the 'PMA_exportData()' function
 
     /**
+     * Outputs result of raw query in PDF format
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the end of line sequence
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        $pdf = $this->_getPdf();
+        $attr = [
+            'dbAlias'      => '----',
+            'tableAlias'   => '----',
+            'purpose'      => __('Query result data'),
+        ];
+        $pdf->setAttributes($attr);
+        $pdf->mysqlReport($sql_query);
+
+        return true;
+    }
+
+    /**
      * Outputs table structure
      *
      * @param string $db          database name

--- a/libraries/classes/Plugins/Export/ExportPhparray.php
+++ b/libraries/classes/Plugins/Export/ExportPhparray.php
@@ -249,4 +249,18 @@ class ExportPhparray extends ExportPlugin
 
         return true;
     }
+
+    /**
+     * Outputs result of raw query as PHP array
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the end of line sequence
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        return $this->exportData('', '', $crlf, $err_url, $sql_query);
+    }
 }

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -90,6 +90,13 @@ class ExportSql extends ExportPlugin
             $hide_sql = true;
         }
 
+        // In case we have `raw_query` parameter set,
+        // we initialize SQL option
+        if (isset($_REQUEST['raw_query'])) {
+            $hide_structure = false;
+            $hide_sql = false;
+        }
+
         if (! $hide_sql) {
             $exportPluginProperties = new ExportPluginProperties();
             $exportPluginProperties->setText('SQL');
@@ -2005,6 +2012,20 @@ class ExportSql extends ExportPlugin
 
         return $schema_create;
     } // end of the '_getTableComments()' function
+
+    /**
+     * Outputs raw query
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the seperator for a file
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        return $this->export->outputHandler($sql_query);
+    }
 
     /**
      * Outputs table's structure

--- a/libraries/classes/Plugins/Export/ExportTexytext.php
+++ b/libraries/classes/Plugins/Export/ExportTexytext.php
@@ -186,7 +186,9 @@ class ExportTexytext extends ExportPlugin
         $this->initAlias($aliases, $db_alias, $table_alias);
 
         if (! $this->export->outputHandler(
-            '== ' . __('Dumping data for table') . ' ' . $table_alias . "\n\n"
+            $table_alias != ''
+                ? '== ' . __('Dumping data for table') . ' ' . $table_alias . "\n\n"
+                : '==' . __('Dumping data for query result') . "\n\n"
         )
         ) {
             return false;
@@ -243,6 +245,20 @@ class ExportTexytext extends ExportPlugin
         $GLOBALS['dbi']->freeResult($result);
 
         return true;
+    }
+
+    /**
+     * Outputs result raw query in TexyText format
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the end of line sequence
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        return $this->exportData('', '', $crlf, $err_url, $sql_query);
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportYaml.php
+++ b/libraries/classes/Plugins/Export/ExportYaml.php
@@ -219,4 +219,18 @@ class ExportYaml extends ExportPlugin
 
         return true;
     } // end getTableYAML
+
+    /**
+     * Outputs result raw query in YAML format
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the end of line sequence
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
+    {
+        return $this->exportData('', '', $crlf, $err_url, $sql_query);
+    }
 }

--- a/libraries/classes/Plugins/ExportPlugin.php
+++ b/libraries/classes/Plugins/ExportPlugin.php
@@ -153,6 +153,7 @@ abstract class ExportPlugin
         string $sql_query,
         string $crlf
     ): bool {
+        return false;
     }
 
     /**

--- a/libraries/classes/Plugins/ExportPlugin.php
+++ b/libraries/classes/Plugins/ExportPlugin.php
@@ -140,6 +140,22 @@ abstract class ExportPlugin
     }
 
     /**
+     * Outputs for raw query
+     *
+     * @param string $err_url   the url to go back in case of error
+     * @param string $sql_query the rawquery to output
+     * @param string $crlf      the seperator for a file
+     *
+     * @return bool if succeeded
+     */
+    public function exportRawQuery(
+        string $err_url,
+        string $sql_query,
+        string $crlf
+    ): bool {
+    }
+
+    /**
      * Outputs table's structure
      *
      * @param string $db          database name

--- a/templates/display/export/option_header.twig
+++ b/templates/display/export/option_header.twig
@@ -6,7 +6,7 @@
         {% elseif export_type == 'database' %}
             {{ 'Exporting tables from "%s" database'|trans|format(db) }}
         {% elseif export_type == 'raw' %}
-            {{ 'Exporting raw query' }}
+            {% trans 'Exporting raw query' %}
         {% else %}
             {{ 'Exporting rows from "%s" table'|trans|format(table) }}
         {% endif %}

--- a/templates/display/export/option_header.twig
+++ b/templates/display/export/option_header.twig
@@ -5,6 +5,8 @@
             {% trans 'Exporting databases from the current server' %}
         {% elseif export_type == 'database' %}
             {{ 'Exporting tables from "%s" database'|trans|format(db) }}
+        {% elseif export_type == 'raw' %}
+            {{ 'Exporting raw query' }}
         {% else %}
             {{ 'Exporting rows from "%s" table'|trans|format(table) }}
         {% endif %}

--- a/test/classes/ExportTest.php
+++ b/test/classes/ExportTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Export;
+use PhpMyAdmin\Plugins\Export\ExportPhparray;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -102,5 +103,30 @@ class ExportTest extends TestCase
         ];
         $actual = $this->export->mergeAliases($aliases1, $aliases2);
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test for getFinalFilenameAndMimetypeForFilename
+     *
+     * @return void
+     */
+    public function testGetFinalFilenameAndMimetypeForFilename()
+    {
+        $exportPlugin = new ExportPhparray();
+        $finalFileName = $this->export->getFinalFilenameAndMimetypeForFilename($exportPlugin, 'zip', 'myfilename');
+        $this->assertSame([
+            'myfilename.php.zip',
+            'application/zip',
+        ], $finalFileName);
+        $finalFileName = $this->export->getFinalFilenameAndMimetypeForFilename($exportPlugin, 'gzip', 'myfilename');
+        $this->assertSame([
+            'myfilename.php.gz',
+            'application/x-gzip',
+        ], $finalFileName);
+        $finalFileName = $this->export->getFinalFilenameAndMimetypeForFilename($exportPlugin, 'gzip', 'export.db1.table1.file');
+        $this->assertSame([
+            'export.db1.table1.file.php.gz',
+            'application/x-gzip',
+        ], $finalFileName);
     }
 }


### PR DESCRIPTION
# Description 
Fixes #15064 - Export SQL option hidden on sql query export results.

* Shows export as SQL option for queries that do not involve use of table.
* In case of such queries the raw query (entered by user) will be exported as *.sql file.

# Approach
* To recognize this kind of query (which do not use any DB or table) we need a flag to be passed
In `libraries/classes/Display/Results.php` added `free_query` parameter.
* This adds `free_query` parameter to the export link.
* Now this parameter is passed in the check in `libraries/classes/Plugins/Export/ExportSql.php` this makes the SQL option visible for export for these type of queries.
* Now further we need to pass this parameter to `export.php`
* So made changes to `templates/display/export/hidden_inputs.twig` and added a hidden field as `free_query`
* At the moment none of the export plugins are designed to dump raw query (as entered by user), so made changes to that.
* made a function `exportRawQuery()` in `libraries/classes/Plugins/Export/ExportSql.php`
* Now for this part function to be executed, we define `$whatStrucOrData` to `free_query` in `export.php`
* This way we dump the raw queries in sql dump file.

# Result
* Video illustrating the progress https://drive.google.com/open?id=15zS1U24ids9TFOvCe9Shi6p7DIn25p2d

# Further works
* Now I have implemented the `exportRawQuery()` only in `ExportSql.php` plugin, we need to implement this function for all other export plugins.

# Contribution Checklist
- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
