### PR TITLE
Fix #15119 - Uninterpreted HTML on Settings->Export page

### DIFF
--- a/libraries/classes/Config/Descriptions.php
+++ b/libraries/classes/Config/Descriptions.php
@@ -248,7 +248,7 @@ class Descriptions
                 return __('Maximum execution time');
             case 'Export_lock_tables_name':
                 return sprintf(
-                    __('Use %s statement'), '<code>LOCK TABLES</code>'
+                    __('Use %s statement'), htmlspecialchars('<code>LOCK TABLES</code>')
                 );
             case 'Export_asfile_name':
                 return __('Save as file');

--- a/libraries/classes/Config/FormDisplayTemplate.php
+++ b/libraries/classes/Config/FormDisplayTemplate.php
@@ -216,7 +216,7 @@ class FormDisplayTemplate
 
         $htmlOutput = '<tr' . $tr_class . '>';
         $htmlOutput .= '<th>';
-        $htmlOutput .= '<label for="' . htmlspecialchars($path) . '">' . $name
+        $htmlOutput .= '<label for="' . htmlspecialchars($path) . '">' . htmlspecialchars_decode($name)
             . '</label>';
 
         if (! empty($opts['doc'])) {


### PR DESCRIPTION
Signed-off-by: Saurabh Srivastava <saurabhsrivastava312@gmail.com>

Fixes: #15119

### Description

Just some simple tweaks to the form description. Convert html to special chars while sprintf in `Descriptions.php` and decode it on `FormDisplayTemplata.php`.
This fixes the issue : )

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
