### PR TITLE
Fixed z-index

### DIFF
--- a/js/sql.js
+++ b/js/sql.js
@@ -959,7 +959,7 @@ function initStickyColumns ($table_results) {
     return $('<table class="sticky_columns"></table>')
         .insertBefore($table_results)
         .css('position', 'fixed')
-        .css('z-index', '99')
+        .css('z-index', '98')
         .css('width', $table_results.width())
         .css('margin-left', $('#page_content').css('margin-left'))
         .css('top', $('#floating_menubar').height())


### PR DESCRIPTION
### Description
close https://github.com/phpmyadmin/phpmyadmin/issues/12729
z-index of table class="sticky columns" changed to 98 from 99 .

Fixes #12729

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
