### PR TITLE
Fixes #15136 Hex converter giving invalid result

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -2563,6 +2563,11 @@ class InsertEdit
                 return $multi_edit_funcs[$key] . '(' . $current_value . ",'"
                     . $this->dbi->escapeString($multi_edit_salt[$key]) . "')";
             }
+            elseif ($multi_edit_funcs[$key] == "HEX") {
+                $len = strlen($current_value);
+                $value = substr($current_value,1,$len-2);
+                return $multi_edit_funcs[$key] . '(' . (int)$value . ')';
+            }
 
             return $multi_edit_funcs[$key] . '(' . $current_value . ')';
         }


### PR DESCRIPTION
Signed-off-by: apoorv <apoorvkhare007@gmail.com>

### Description
The HEX() function in mysql behaves differently for string and int input. 
Changing the value to int which is string currently fixes the issue.

Fixes #15136

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
