### PR TITLE
Fix #15150 - Generate password hidden on second open of change password modal

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -3196,6 +3196,7 @@ AJAX.registerOnload('functions.js', function () {
                 .find('input#text_pma_pw').focus();
             $('#fieldset_change_password_footer').hide();
             PMA_ajaxRemoveMessage($msgbox);
+            displayPasswordGenerateButton();
             $('#change_password_form').on('submit', function (e) {
                 e.preventDefault();
                 $(this)

--- a/js/server_privileges.js
+++ b/js/server_privileges.js
@@ -468,7 +468,6 @@ AJAX.registerOnload('server_privileges.js', function () {
 
     $('input.autofocus').focus();
     $(checkboxes_sel).trigger('change');
-    displayPasswordGenerateButton();
     if ($('#edit_user_dialog').length > 0) {
         addOrUpdateSubmenu();
     }


### PR DESCRIPTION
Signed-off-by: Saurabh Srivastava <saurabhsrivastava312@gmail.com>

# Description
* Fixes #15150 

# Problem
* The JS function `displayPasswordGenerateButton()` was called only when `js/server_privileges.js` was loaded.
* So the function ran only once, not when the modal was loaded again, it wasn't called and failed.

# Solution
* A very simple way, call the `displayPasswordGenerateButton()` function just after the AJAX is loaded.
* And thus calling the function after AJAX load in `js/function.js` line 3199.
* Remove the function call from `js/server_privileges.js`.

And hurray it works : )

# Contribution Checklist
- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
