### PR TITLE
Fix placement inconsistency of Export/Import tabs

### DIFF
--- a/libraries/classes/Config/Forms/User/UserFormList.php
+++ b/libraries/classes/Config/Forms/User/UserFormList.php
@@ -25,8 +25,8 @@ class UserFormList extends BaseFormList
         'Sql',
         'Navi',
         'Main',
-        'Import',
         'Export',
+        'Import'
     ];
     /**
      * @var string


### PR DESCRIPTION
Signed-off-by: Agha Saad Fraz <agha.saad04@gmail.com>

### Description

I have moved the array element Import and placed it after the Export element.

Fixes #15152 

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
