### PR TITLE
Fixes #15157 - 'Settings' not marked as active when browsing 2FA settings

### DIFF
--- a/libraries/classes/Menu.php
+++ b/libraries/classes/Menu.php
@@ -639,6 +639,7 @@ class Menu
             [
                 'prefs_forms.php',
                 'prefs_manage.php',
+                'prefs_twofactor.php',
             ]
         );
 


### PR DESCRIPTION
Signed-off-by: Agha Saad Fraz <agha.saad04@gmail.com>

### Description
I have added the file name 'prefs_twofactor.php' and that worked like a charm :)

### Fixes #15157 

### Screenshot

![image](https://user-images.githubusercontent.com/36513474/55658543-6e53f980-5817-11e9-95a8-085f25238a15.png)


Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
