### PR TITLE
Fix #15166 - Copy table keeps showing 'loading...' -- When no row is selected.

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -613,8 +613,8 @@ var AJAX = {
                 AJAX._callback = function () {};
             });
         } else {
+            PMA_ajaxShowMessage(data.error, false);
             PMA_ajaxRemoveMessage(AJAX.$msgbox);
-            $('div.error, div.success, div#ajaxError').remove();
             $ajaxError = $('<div></div>');
             $ajaxError.attr({ 'id': 'ajaxError' });
             $('#page_content').append($ajaxError);


### PR DESCRIPTION
Signed-off-by: Saurabh Srivastava <saurabhsrivastava312@gmail.com>

# Description
* Fixes #15166 

# Problem
* `responseHandler` in `ajax.js` has been called from different parts of codebase.
* Fixing #13023 (PR #14436) caused the case of error to handle in a different manner.
* It removed the box and instead displayed a message at the bottom (when creating insert error).
* But here in case when we click 'copy', the 'loading...' box doesn't disappear.

# Solution
* Why not show the error both in the overlay box and also at the footer.
* This will also take care of issue as discussed in #13023.

Video illustrating fix - https://drive.google.com/open?id=1KhhEvjlx4LsMuwBnwSXjZoz-6UfcSDdF

Hope this works well : )

# Contribution Checklist
- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.