### PR TITLE
Modified single sign on and storing credentials

### DIFF
--- a/libraries/classes/Plugins/AuthenticationPlugin.php
+++ b/libraries/classes/Plugins/AuthenticationPlugin.php
@@ -267,8 +267,7 @@ abstract class AuthenticationPlugin
      */
     public function isAuthenticated()
     {
-        if (isset($_SESSION['isAuthenticated']) && !empty($_SESSION['isAuthenticated']) && $_SESSION['isAuthenticated'] == true)
-        {
+        if (isset($_SESSION['isAuthenticated']) && ! empty($_SESSION['isAuthenticated']) && $_SESSION['isAuthenticated'] == true) {
             return true;
         } else {
             return false;

--- a/libraries/classes/Plugins/AuthenticationPlugin.php
+++ b/libraries/classes/Plugins/AuthenticationPlugin.php
@@ -106,8 +106,10 @@ abstract class AuthenticationPlugin
 
         $this->setSessionAccessTime();
 
-        $cfg['Server']['user']     = $_SESSION['authUser'];
-        $cfg['Server']['password'] = $_SESSION['authPass'];
+        if ($cfg['Server']['auth_type'] == 'signon') {
+            $cfg['Server']['user']     = $_SESSION['authUser'];
+            $cfg['Server']['password'] = $_SESSION['authPass'];
+        }
     }
 
     /**

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -344,7 +344,11 @@ if (! defined('PMA_MINIMUM_COMMON')) {
         }
         $auth_plugin = new $auth_class();
 
-        $auth_plugin->authenticate();
+        if ($auth_plugin->isAuthenticated() == false) {
+            $auth_plugin->authenticate();
+        } else {
+            $auth_plugin->rememberCredentials();
+        }
 
         // Try to connect MySQL with the control user profile (will be used to
         // get the privileges list for the current user but the true user link


### PR DESCRIPTION

Signed-off-by: Sven Rueß <github@sritd.de>

### Description

I had a problem with single sign on in my environment. The used credentials are not stored globally for later usage in phpMyAdmin. For every interaction, the credentials are loaded from the source. This does not make sense in single sign on environments. Those credentials are used for the first login and will be deleted after it. If needed, they have to be stored locally in the application.

Fixes open issue #13197

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
