### PR TITLE
Fixes #14732 - Can't rename primary key with auto increment

### DIFF
--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -620,7 +620,7 @@ class Table
             $query .= ' AFTER ' . Util::backquote($move_to);
         }
         if (! $virtuality && ! empty($extra)) {
-            if ($columns_with_index !== null && ! in_array($name, $columns_with_index)) {
+            if (! $columns_with_index && ! in_array($name, $columns_with_index)) {
                 $query .= ', add PRIMARY KEY (' . Util::backquote($name) . ')';
             }
         }


### PR DESCRIPTION
Signed-off-by: Saurabh Srivastava <saurabhsrivastava312@gmail.com>

### Description
Fixes #14732 

## Background
* Currently the query formed is like -- `ALTER TABLE table_name CHANGE COLUMN 'old_name' 'new_name' int(10) UNSIGNED NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY ('new_name')`
* This query is wrong. `, ADD PRIMARY KEY ('new_name')` mustn't be at it's tale when updating name of column (column that already is a primary key).

## Problem
* When checking for `$columns_with_index` on line 623 `libraries/classes/Table.php`, here `$columns_with_index` will always be an array.
* As is clearly visible in line 2723 `libraries/classes/Table.php` function `getColumnsWithIndex()`.
* Use of `$columns_with_index !== null` causes the check to be true.
* And thus our query to tail with `, add PRIMARY KEY (....)`
* Thus making our query invalid.

## Solution
* Empty array is evaluated to false in PHP
* So simply use `! $columns_with_index`.
* This will take care that #14417 (Fix to #13235) doesn't break.

And wooohoooo this solves our problem : )

## Contribution Checklist
- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
