### PR TITLE
Fixes #15205 - Useless backquotes, sql preview, delete index

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -2424,14 +2424,14 @@ function PMA_confirmPreviewSQL (sql_data, url, callback) {
     var button_options = [
         {
             text: PMA_messages.strOK,
-            'class': 'submitOK',
+            class: 'submitOK',
             click: function () {
                 callback(url);
             }
         },
         {
             text: PMA_messages.strCancel,
-            'class': 'submitCancel',
+            class: 'submitCancel',
             click: function () {
                 $(this).dialog('close');
             }

--- a/js/functions.js
+++ b/js/functions.js
@@ -2420,7 +2420,6 @@ function PMA_confirmPreviewSQL (sql_data, url, callback) {
         + sql_data
         + '</pre></code></div>'
     );
-    var button_options = {};
     var button_options = [
         {
             text: PMA_messages.strOK,

--- a/js/functions.js
+++ b/js/functions.js
@@ -2408,10 +2408,17 @@ function PMA_previewSQL ($form) {
 }
 
 /**
+ * Callback called when submit/"OK" is clicked on sql preview/confirm modal
  *
- * @param sql_data  Sql query to preview
- * @param url       url to be sent to callback
- * @param callback  callback function
+ * @callback onSubmitCallback
+ * @param {string} url The url
+ */
+
+/**
+ *
+ * @param {string}           sql_data  Sql query to preview
+ * @param {string}           url       Url to be sent to callback
+ * @param {onSubmitCallback} callback  On submit callback function
  *
  * @return void
  */

--- a/js/functions.js
+++ b/js/functions.js
@@ -2408,6 +2408,52 @@ function PMA_previewSQL ($form) {
 }
 
 /**
+ *
+ * @param sql_data  Sql query to preview
+ * @param url       url to be sent to callback
+ * @param callback  callback function
+ *
+ * @return void
+ */
+function PMA_confirmPreviewSQL (sql_data, url, callback) {
+    var $dialog_content = $('<div class="preview_sql"><code class="sql"><pre>'
+        + sql_data
+        + '</pre></code></div>'
+    );
+    var button_options = {};
+    var button_options = [
+        {
+            text: PMA_messages.strOK,
+            'class': 'submitOK',
+            click: function () {
+                callback(url);
+            }
+        },
+        {
+            text: PMA_messages.strCancel,
+            'class': 'submitCancel',
+            click: function () {
+                $(this).dialog('close');
+            }
+        }
+    ];
+    var $response_dialog = $dialog_content.dialog({
+        minWidth: 550,
+        maxHeight: 400,
+        modal: true,
+        buttons: button_options,
+        title: PMA_messages.strPreviewSQL,
+        close: function () {
+            $(this).remove();
+        },
+        open: function () {
+            // Pretty SQL printing.
+            PMA_highlightSQL($(this));
+        }
+    });
+}
+
+/**
  * check for reserved keyword column name
  *
  * @param jQuery Object $form Form

--- a/js/indexes.js
+++ b/js/indexes.js
@@ -599,7 +599,7 @@ AJAX.registerOnload('indexes.js', function () {
                 .val()
         );
 
-        $anchor.PMA_confirm(question, $anchor.attr('href'), function (url) {
+        PMA_confirmPreviewSQL(question, $anchor.attr('href'), function (url) {
             var $msg = PMA_ajaxShowMessage(PMA_messages.strDroppingPrimaryKeyIndex, false);
             var params = getJSConfirmCommonParam(this, $anchor.getPostData());
             $.post(url, params, function (data) {

--- a/libraries/classes/Index.php
+++ b/libraries/classes/Index.php
@@ -759,7 +759,7 @@ class Index
                     $this_params['message_to_show'] = sprintf(
                         __('Index %s has been dropped.'), htmlspecialchars($index->getName())
                     );
-                    $js_msg = Sanitize::jsFormat($this_params['sql_query']);
+                    $js_msg = Sanitize::jsFormat($this_params['sql_query'], false);
                 }
 
                 $r .= '<td ' . $row_span . ' class="print_ignore">';

--- a/libraries/classes/Index.php
+++ b/libraries/classes/Index.php
@@ -751,7 +751,7 @@ class Index
                         . ' DROP PRIMARY KEY;';
                     $this_params['message_to_show']
                         = __('The primary key has been dropped.');
-                    $js_msg = Sanitize::jsFormat($this_params['sql_query']);
+                    $js_msg = Sanitize::jsFormat($this_params['sql_query'], false);
                 } else {
                     $this_params['sql_query'] = 'ALTER TABLE '
                         . Util::backquote($table) . ' DROP INDEX '


### PR DESCRIPTION
Signed-off-by: Saurabh Srivastava <saurabhsrivastava312@gmail.com>

### Description
Fixes #15205 

## Problem
* Pretty SQL not showing because we were using simple `PMA_confirm`
* The SQL query had backquotes because when sanitizing the query (line 754 `libraries/classes/Index.php`) we weren't passing `add_backquotes` to `false`.

## Solution
* Introduced a new function to `functions.js` --> `PMA_confirmPreviewSQL(....)`.
* Calling this function to show pretty SQL query in `indexes.js` line 602.
* Passing `add_backquotes` parameter as `false` (line 754 `libraries/classes/Index.php`) in function call - `Sanitize::jsFormat(....)`

This seems to fix our issue.

## Contribution Checklist
- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.