### PR TITLE
Fix#15205 - Fixed useless backquotes on preview sql screen, deleting index

### DIFF
--- a/js/indexes.js
+++ b/js/indexes.js
@@ -598,6 +598,15 @@ AJAX.registerOnload('indexes.js', function () {
                 .children('.drop_primary_key_index_msg')
                 .val()
         );
+        
+        /** SQL Preview Statement **/
+        var preview = question.split("`");
+        if(preview[5] == " DROP PRIMARY KEY;") {
+            question = "ALTER TABLE " + "`" + preview[3] + "` " + preview[5] ;
+        }
+        else{
+            question = "ALTER TABLE " + "`" + preview[3] + "` " + "DROP INDEX " + "`" + preview[7] + "` " + " ;" ;
+        }
 
         $anchor.PMA_confirm(question, $anchor.attr('href'), function (url) {
             var $msg = PMA_ajaxShowMessage(PMA_messages.strDroppingPrimaryKeyIndex, false);

--- a/js/indexes.js
+++ b/js/indexes.js
@@ -602,10 +602,10 @@ AJAX.registerOnload('indexes.js', function () {
         /** SQL Preview Statement **/
         var preview = question.split("`");
         if(preview[5] == " DROP PRIMARY KEY;") {
-            question = "ALTER TABLE " + "`" + preview[3] + "` " + preview[5] ;
+            question = "ALTER TABLE " + "`" + preview[3] + "` " + preview[5];
         }
-        else{
-            question = "ALTER TABLE " + "`" + preview[3] + "` " + "DROP INDEX " + "`" + preview[7] + "` " + " ;" ;
+        else {
+            question = "ALTER TABLE " + "`" + preview[3] + "` " + "DROP INDEX " + "`" + preview[7] + "` " + " ;";
         }
 
         $anchor.PMA_confirm(question, $anchor.attr('href'), function (url) {


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description

This PR will fix the useless backquotes on the preview SQL screen while dropping an index. Since, the backend in php was working fine for it, it needed only corresponding front-end changes in javascript

Fixes #15205

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
