### PR TITLE
fix typo in language name

### DIFF
--- a/libraries/classes/LanguageManager.php
+++ b/libraries/classes/LanguageManager.php
@@ -525,7 +525,7 @@ class LanguageManager
         ],
         'sq' => [
             'sq',
-            'Slbanian',
+            'Albanian',
             'Shqip',
             'sq|albanian',
             'sq_AL',


### PR DESCRIPTION
Signed-off-by: Jan Demter <jan@demter.de>

### Description

Fixes a typo in the english name of the Albanian language in the language chooser ("Slbanian").