### PR TITLE
Shown error in a dialog box

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -650,6 +650,23 @@ AJAX.registerOnload('config.js', function () {
     });
 });
 
+var Input_flag = 0;
+AJAX.registerOnload('config.js', function () {
+    Input_flag = 0;
+    $('.optbox input[type=submit][name=submit_save]').on('click', function () {
+        var fields = $(this).closest('fieldset').find('textarea');
+        for (var i = 0, imax = fields.length; i < imax; i++) {
+            if (fields[i].value==="" && !(fields[i].name ==="DefaultTransformations-PreApPend")){
+                Input_flag = 1;
+            }
+        }
+        if(Input_flag){
+            alert("Some of the input fields are empty");
+            // $('.optbox input[type=button][name=submit_save]').off('click');
+        }
+    });
+});
+
 //
 // END: Form reset buttons
 // ------------------------------------------------------------------


### PR DESCRIPTION

Signed-off-by: Bournvita1998 <mohit.kuri@research.iiit.ac.in>

Haven't solved this issue completely.

Right now it shows the error if some of the required fields are empty.
![Selection_039](https://user-images.githubusercontent.com/26218090/56482231-92cef780-64e0-11e9-88a5-5f9db00e2f79.png)

To-dos:
- Stop the post request when error is shown
- improve UI for error message as per discussion

Fixes #15044 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
