### PR TITLE
Input field ajaxified and will automatically switch to Use Text Area

### DIFF
--- a/js/server_privileges.js
+++ b/js/server_privileges.js
@@ -130,7 +130,16 @@ AJAX.registerOnload('server_privileges.js', function () {
         username = username.val();
         checkPasswordStrength($(this).val(), meter_obj, meter_obj_label, username);
     });
-
+    
+    /**
+     * Automatically swithcing to 'Use Text field' from 'No password' once start writing in text area
+     */
+    $('#text_pma_pw').on('input', function() {
+        if($('#text_pma_pw').val() != '') {
+            $('#select_pred_password').val('userdefined');
+        }
+    });
+    
     $('#text_pma_change_pw').on('keyup', function () {
         meter_obj = $('#change_password_strength_meter');
         meter_obj_label = $('#change_password_strength');

--- a/js/server_privileges.js
+++ b/js/server_privileges.js
@@ -130,7 +130,7 @@ AJAX.registerOnload('server_privileges.js', function () {
         username = username.val();
         checkPasswordStrength($(this).val(), meter_obj, meter_obj_label, username);
     });
-    
+
     /**
      * Automatically swithcing to 'Use Text field' from 'No password' once start writing in text area
      */


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description

The input field will automatically switch to 'Use Text Area:' from 'No Password' once the user starts writing in the input field and will thus do the required task.

Fixes #15219 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
