### PR TITLE
Fix#14986 Removed Quotes from SQL statement and unecessary zeroes after decimal

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -2682,7 +2682,10 @@ class InsertEdit
         $where_clause,
         $table,
         $multi_edit_funcs
-    ) {
+    ) { 
+        // Timestamp Conditions to remove quotes in SQL Query
+        $curr_timestamp = array("CURRENT_TIMESTAMP()", "CURRENT_TIMESTAMP", "current_timestamp()", "CURRENT_TIMESTAMP(1)", "CURRENT_TIMESTAMP(2)", "CURRENT_TIMESTAMP(3)", "CURRENT_TIMESTAMP(4)", "CURRENT_TIMESTAMP(5)", "CURRENT_TIMESTAMP(6)");
+        
         // Fetch the current values of a row to use in case we have a protected field
         if ($is_insert
             && $using_key && isset($multi_edit_columns_type)
@@ -2752,9 +2755,8 @@ class InsertEdit
                 $current_value = "b'" . $this->dbi->escapeString($current_value)
                     . "'";
             } elseif (! ($type == 'datetime' || $type == 'timestamp')
-                || ($current_value != 'CURRENT_TIMESTAMP' && $current_value != 'CURRENT_TIMESTAMP()' && $current_value != 'CURRENT_TIMESTAMP(1)' && $current_value != 'CURRENT_TIMESTAMP(2)' && $current_value != 'CURRENT_TIMESTAMP(3)' && $current_value != 'CURRENT_TIMESTAMP(4)' && $current_value != 'CURRENT_TIMESTAMP(5)' && $current_value != 'CURRENT_TIMESTAMP(6)'
-                && $current_value != 'current_timestamp()')
-            ) {
+                || (! in_array($current_value, $curr_timestamp)
+            )) {
                 $current_value = "'" . $this->dbi->escapeString($current_value)
                     . "'";
             }

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -2752,8 +2752,8 @@ class InsertEdit
                 $current_value = "b'" . $this->dbi->escapeString($current_value)
                     . "'";
             } elseif (! ($type == 'datetime' || $type == 'timestamp')
-                || ($current_value != 'CURRENT_TIMESTAMP'
-                    && $current_value != 'current_timestamp()')
+                || ($current_value != 'CURRENT_TIMESTAMP' && $current_value != 'CURRENT_TIMESTAMP()' && $current_value != 'CURRENT_TIMESTAMP(1)' && $current_value != 'CURRENT_TIMESTAMP(2)' && $current_value != 'CURRENT_TIMESTAMP(3)' && $current_value != 'CURRENT_TIMESTAMP(4)' && $current_value != 'CURRENT_TIMESTAMP(5)' && $current_value != 'CURRENT_TIMESTAMP(6)'
+                && $current_value != 'current_timestamp()')
             ) {
                 $current_value = "'" . $this->dbi->escapeString($current_value)
                     . "'";

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -2682,8 +2682,7 @@ class InsertEdit
         $where_clause,
         $table,
         $multi_edit_funcs
-    ) { 
-        // Timestamp Conditions to remove quotes in SQL Query
+    ) { // Timestamp Conditions to remove quotes in SQL Query
         $curr_timestamp = array("CURRENT_TIMESTAMP()", "CURRENT_TIMESTAMP", "current_timestamp()", "CURRENT_TIMESTAMP(1)", "CURRENT_TIMESTAMP(2)", "CURRENT_TIMESTAMP(3)", "CURRENT_TIMESTAMP(4)", "CURRENT_TIMESTAMP(5)", "CURRENT_TIMESTAMP(6)");
         
         // Fetch the current values of a row to use in case we have a protected field

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -4048,10 +4048,9 @@ class Util
         }
 
         if (mb_strpos($value, '.') === false) {
-            return $value . '.000000';
+            return $value;
         }
 
-        $value .= '000000';
         return mb_substr(
             $value,
             0,


### PR DESCRIPTION

Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description

This PR will ensure that the `Current_Timestamp()` based SQL Query executes correctly. It has also removed the invalid `.00000` zeroes which were unnecessary based on current execution of query and provided invalid value to SQL Query. The changes have been implemented based on the discussion in #14986 and on the fact that the maximum argument of Current_Timestamp is 6 as it is its maximum precision. 

Fixes #14986 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
