### PR TITLE
Fix #14986 problems with inserting data of DEFAULT values using PMA-GUI insert Tab

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -2604,8 +2604,10 @@ class InsertEdit
         $key,
         $multi_edit_columns_null_prev
     ) {
+        $field = $multi_edit_columns_name[$key];
+        $isEqualToDefault = $this->checkIfFieldValueEqualToDefault($field, $current_value);
         //  i n s e r t
-        if ($is_insert) {
+        if ($is_insert && ! $isEqualToDefault) {
             // no need to add column into the valuelist
             if (strlen($current_value_as_an_array) > 0) {
                 $query_values[] = $current_value_as_an_array;
@@ -2632,7 +2634,7 @@ class InsertEdit
             || ('0x' . $multi_edit_columns_prev[$key] === $current_value))
         ) {
             // No change for this column and no MySQL function is used -> next column
-        } elseif (! empty($current_value)) {
+        } elseif (! empty($current_value) && ! $isEqualToDefault) {
             // avoid setting a field to NULL when it's already NULL
             // (field had the null checkbox before the update
             //  field still has the null checkbox)
@@ -2645,6 +2647,25 @@ class InsertEdit
             }
         }
         return array($query_values, $query_fields);
+    }
+
+    /**
+     * The function will check for default value is equal to input by user
+     *
+     * @param   $field          string  field name
+     * @param   $current_value  string  current value of field
+     *
+     * @return  bool
+     */
+    public function checkIfFieldValueEqualToDefault($field, $current_value)
+    {
+        $data = $this->getTableColumns($GLOBALS['db'], $GLOBALS['table']);
+        foreach ($data as $datum) {
+            if($datum['Field'] == $field && $datum['Default'] == trim($current_value, "'")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -4048,7 +4048,7 @@ class Util
         }
 
         if (mb_strpos($value, '.') === false) {
-            return $value . '.000000';
+            return $value;
         }
 
         $value .= '000000';


### PR DESCRIPTION
## Description

Please describe your pull request.

Fixes #14986 problems with inserting data of DEFAULT values using PMA-GUI insert Tab

## Problem
* When inserting data using PMA GUI insert tab, the generated query also contains the default value to insert.
* If we want to insert default value in field, then that field can be ignored from the query.

## Solution
* So let's remove such fields from the query. And let MySQL/MariaDB server take care if we are trying to insert default value.

## Contribution Checklist
- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
