### PR TITLE
Fix #14614 - Commands out of sync; you can't run this command now

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -327,12 +327,17 @@ class DatabaseInterface
             $this->_dbgQuery($query, $link, $result, $time);
             if ($GLOBALS['cfg']['DBG']['sqllog']) {
                 if ($options & DatabaseInterface::QUERY_STORE == DatabaseInterface::QUERY_STORE) {
-                    $tmp = $this->_extension->realQuery('
-                        SHOW COUNT(*) WARNINGS', $this->_links[$link], DatabaseInterface::QUERY_STORE
+                    $tmp = $this->_extension->realQuery(
+                        'SHOW COUNT(*) WARNINGS', $this->_links[$link], DatabaseInterface::QUERY_STORE
                     );
                     $warnings = $this->fetchRow($tmp);
+
+                    if ($this->_extension->moreResults($this->_links[$link])) {
+                        $this->_extension->nextResult($this->_links[$link]);
+                    }
+
                 } else {
-                    $warnings = 0;
+                    $warnings = [ '' ];
                 }
 
                 openlog('phpMyAdmin', LOG_NDELAY | LOG_PID, LOG_USER);

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -2229,6 +2229,10 @@ EOT;
                 isset($extra_data) ? $extra_data : null
             );
 
+        if ($GLOBALS['dbi']->moreResults()) {
+            $GLOBALS['dbi']->nextResult();
+        }
+
         $operations = new Operations();
         $warning_messages = $operations->getWarningMessagesArray();
 


### PR DESCRIPTION
### Description

Fixes `#2014 - Commands out of sync; you can't run this command now" returned when stored procedure does not return any result set`

Fixes #14614

