### PR TITLE
Fix #14412 - AuthenticationSignon.php's showFailure function does not consider SignonCookieParams

### DIFF
--- a/libraries/classes/Plugins/Auth/AuthenticationSignon.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationSignon.php
@@ -41,6 +41,61 @@ class AuthenticationSignon extends AuthenticationPlugin
     }
 
     /**
+     * Set cookie params
+     *
+     * @param array $sessionCookieParams The cookie params
+     * @return void
+     */
+    public function setCookieParams(array $sessionCookieParams = null)
+    {
+        /* Session cookie params from config */
+        if ($sessionCookieParams === null) {
+            $sessionCookieParams = (array) $GLOBALS['cfg']['Server']['SignonCookieParams'];
+        }
+
+        /* Sanitize cookie params */
+        $defaultCookieParams = function ($key) {
+            switch ($key) {
+                case 'lifetime':
+                    return 0;
+                case 'path':
+                    return '/';
+                case 'domain':
+                    return '';
+                case 'secure':
+                    return false;
+                case 'httponly':
+                    return false;
+            }
+            return null;
+        };
+
+        foreach (array('lifetime', 'path', 'domain', 'secure', 'httponly') as $key) {
+            if (! isset($sessionCookieParams[$key])) {
+                $sessionCookieParams[$key] = $defaultCookieParams($key);
+            }
+        }
+
+        if (isset($sessionCookieParams['samesite'])
+            && ! in_array($sessionCookieParams['samesite'], array('Lax', 'Strict'))) {
+                // Not a valid value for samesite
+                unset($sessionCookieParams['samesite']);
+        }
+
+        if (version_compare(phpversion(), '7.3.0', '>=')) {
+            session_set_cookie_params($sessionCookieParams);
+        }
+
+        session_set_cookie_params(
+            $sessionCookieParams['lifetime'],
+            $sessionCookieParams['path'],
+            $sessionCookieParams['domain'],
+            $sessionCookieParams['secure'],
+            $sessionCookieParams['httponly']
+        );
+    }
+
+    /**
      * Gets authentication credentials
      *
      * @return boolean   whether we get authentication settings or not
@@ -60,9 +115,6 @@ class AuthenticationSignon extends AuthenticationPlugin
 
         /* Session name */
         $session_name = $GLOBALS['cfg']['Server']['SignonSession'];
-
-        /* Session cookie params */
-        $session_cookie_params = (array) $GLOBALS['cfg']['Server']['SignonCookieParams'];
 
         /* Login URL */
         $signon_url = $GLOBALS['cfg']['Server']['SignonURL'];
@@ -92,30 +144,13 @@ class AuthenticationSignon extends AuthenticationPlugin
             /* End current session */
             $old_session = session_name();
             $old_id = session_id();
-            $old_cookie_params = session_get_cookie_params();
+            $oldCookieParams = session_get_cookie_params();
             if (!defined('TESTSUITE')) {
                 session_write_close();
             }
-
-            /* Sanitize cookie params */
-            $defaultCookieParams = function($key){
-                switch ($key) {
-                    case 'lifetime': return 0;
-                    case 'path': return '/';
-                    case 'domain': return '';
-                    case 'secure': return false;
-                    case 'httponly': return false;
-                }
-                return null;
-            };
-            foreach (array('lifetime', 'path', 'domain', 'secure', 'httponly') as $key) {
-                if (!isset($session_cookie_params[$key]))
-                    $session_cookie_params[$key] = $defaultCookieParams($key);
-            }
-
             /* Load single signon session */
             if (!defined('TESTSUITE')) {
-                session_set_cookie_params($session_cookie_params['lifetime'], $session_cookie_params['path'], $session_cookie_params['domain'], $session_cookie_params['secure'], $session_cookie_params['httponly']);
+                $this->setCookieParams();
                 session_name($session_name);
                 session_id($_COOKIE[$session_name]);
                 session_start();
@@ -156,7 +191,7 @@ class AuthenticationSignon extends AuthenticationPlugin
 
             /* Restart phpMyAdmin session */
             if (!defined('TESTSUITE')) {
-                session_set_cookie_params($old_cookie_params['lifetime'], $old_cookie_params['path'], $old_cookie_params['domain'], $old_cookie_params['secure'], $old_cookie_params['httponly']);
+                $this->setCookieParams($oldCookieParams);
                 session_name($old_session);
                 if (!empty($old_id)) {
                     session_id($old_id);
@@ -220,6 +255,7 @@ class AuthenticationSignon extends AuthenticationPlugin
                 session_write_close();
 
                 /* Load single signon session */
+                $this->setCookieParams();
                 session_name($session_name);
                 session_id($_COOKIE[$session_name]);
                 session_start();

--- a/test/classes/Plugins/Auth/AuthenticationSignonTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationSignonTest.php
@@ -278,7 +278,7 @@ class AuthenticationSignonTest extends PmaTestCase
         $GLOBALS['cfg']['Server']['SignonSession'] = 'newSession';
         $_COOKIE['newSession'] = '42';
 
-        $this->object = $this->getMockBuilder('PhpMyAdmin\Plugins\Auth\AuthenticationSignon')
+        $this->object = $this->getMockBuilder(AuthenticationSignon::class)
             ->disableOriginalConstructor()
             ->setMethods(array('showLoginForm'))
             ->getMock();
@@ -305,7 +305,7 @@ class AuthenticationSignonTest extends PmaTestCase
         $GLOBALS['cfg']['Server']['SignonSession'] = 'newSession';
         $_COOKIE['newSession'] = '42';
 
-        $this->object = $this->getMockBuilder('PhpMyAdmin\Plugins\Auth\AuthenticationSignon')
+        $this->object = $this->getMockBuilder(AuthenticationSignon::class)
             ->disableOriginalConstructor()
             ->setMethods(array('showLoginForm'))
             ->getMock();
@@ -331,7 +331,7 @@ class AuthenticationSignonTest extends PmaTestCase
         $GLOBALS['cfg']['Server']['SignonSession'] = 'newSession';
         $_COOKIE['newSession'] = '42';
 
-        $this->object = $this->getMockBuilder('PhpMyAdmin\Plugins\Auth\AuthenticationSignon')
+        $this->object = $this->getMockBuilder(AuthenticationSignon::class)
             ->disableOriginalConstructor()
             ->setMethods(array('showLoginForm'))
             ->getMock();
@@ -359,7 +359,7 @@ class AuthenticationSignonTest extends PmaTestCase
         $GLOBALS['cfg']['Server']['SignonSession'] = 'newSession';
         $_COOKIE['newSession'] = '42';
 
-        $this->object = $this->getMockBuilder('PhpMyAdmin\Plugins\Auth\AuthenticationSignon')
+        $this->object = $this->getMockBuilder(AuthenticationSignon::class)
             ->disableOriginalConstructor()
             ->setMethods(array('showLoginForm'))
             ->getMock();
@@ -395,7 +395,7 @@ class AuthenticationSignonTest extends PmaTestCase
         $GLOBALS['cfg']['Server']['SignonSession'] = 'newSession';
         $_COOKIE['newSession'] = '42';
 
-        $this->object = $this->getMockBuilder('PhpMyAdmin\Plugins\Auth\AuthenticationSignon')
+        $this->object = $this->getMockBuilder(AuthenticationSignon::class)
             ->disableOriginalConstructor()
             ->setMethods(array('showLoginForm'))
             ->getMock();
@@ -428,7 +428,7 @@ class AuthenticationSignonTest extends PmaTestCase
      */
     public function testSetCookieParamsDefaults()
     {
-        $this->object = $this->getMockBuilder('PhpMyAdmin\Plugins\Auth\AuthenticationSignon')
+        $this->object = $this->getMockBuilder(AuthenticationSignon::class)
         ->disableOriginalConstructor()
         ->setMethods(array('setCookieParams'))
         ->getMock();

--- a/test/classes/Plugins/Auth/AuthenticationSignonTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationSignonTest.php
@@ -420,4 +420,37 @@ class AuthenticationSignonTest extends PmaTestCase
             $_SESSION['PMA_single_signon_error_message']
         );
     }
+
+    /**
+     * Test for PhpMyAdmin\Plugins\Auth\AuthenticationSignon::setCookieParams
+     *
+     * @return void
+     */
+    public function testSetCookieParamsDefaults()
+    {
+        $this->object = $this->getMockBuilder('PhpMyAdmin\Plugins\Auth\AuthenticationSignon')
+        ->disableOriginalConstructor()
+        ->setMethods(array('setCookieParams'))
+        ->getMock();
+
+        $this->object->setCookieParams(array());
+
+        $defaultOptions = array(
+            'lifetime' => 0,
+            'path' => '/',
+            'domain' => '',
+            'secure' => false,
+            'httponly' => false,
+            'samesite' => ''
+        );
+        // php did not set 'samesite' attribute in session_get_cookie_params since not yet implemented
+        if (version_compare(phpversion(), '7.3.0', '<')) {
+            unset($defaultOptions['samesite']);
+        }
+
+        $this->assertSame(
+            $defaultOptions,
+            session_get_cookie_params()
+        );
+    }
 }


### PR DESCRIPTION
Fixes: #14412
Call `session_set_cookie_params` to set the cookie params