### PR TITLE
Remove exit from code

### DIFF
--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1361,7 +1361,7 @@ class Sql
      *
      * @return void
      */
-    private function sendResponseForGridEdit($result)
+    private function getResponseForGridEdit($result): void
     {
         $row = $GLOBALS['dbi']->fetchRow($result);
         $field_flags = $GLOBALS['dbi']->fieldFlags($result, 0);
@@ -1370,7 +1370,6 @@ class Sql
         }
         $response = Response::getInstance();
         $response->addJSON('value', $row[0]);
-        exit;
     }
 
     /**
@@ -1681,8 +1680,8 @@ class Sql
         // If we are retrieving the full value of a truncated field or the original
         // value of a transformed field, show it here
         if (isset($_POST['grid_edit']) && $_POST['grid_edit'] == true) {
-            $this->sendResponseForGridEdit($result);
-            // script has exited at this point
+            $this->getResponseForGridEdit($result);
+            exit;
         }
 
         // Gets the list of fields properties

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3001,7 +3001,7 @@ parameters:
 			path: libraries/classes/Sql.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\Sql\\:\\:sendResponseForGridEdit\\(\\) expects object, object\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\Sql\\:\\:getResponseForGridEdit\\(\\) expects object, object\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
 


### PR DESCRIPTION
### Description

I have no idea is this is a good enhancement but I wanted to remove as much 'exit;' to be able to mock the response function in order to test code and be able to remove some if TESTSUITE from codebase

Ref #15247