### PR TITLE
Use "strpos" instead of "strstr" to improve performances

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -324,8 +324,8 @@ class Config
         // some versions return Microsoft-IIS, some Microsoft/IIS
         // we could use a preg_match() but it's slower
         if (Core::getenv('SERVER_SOFTWARE')
-            && stristr(Core::getenv('SERVER_SOFTWARE'), 'Microsoft')
-            && stristr(Core::getenv('SERVER_SOFTWARE'), 'IIS')
+            && false !== stripos(Core::getenv('SERVER_SOFTWARE'), 'Microsoft')
+            && false !== stripos(Core::getenv('SERVER_SOFTWARE'), 'IIS')
         ) {
             $this->set('PMA_IS_IIS', 1);
         } else {
@@ -344,10 +344,10 @@ class Config
         $this->set('PMA_IS_WINDOWS', 0);
         // If PHP_OS is defined then continue
         if (defined('PHP_OS')) {
-            if (stristr(PHP_OS, 'win') && ! stristr(PHP_OS, 'darwin')) {
+            if (false !== stripos(PHP_OS, 'win') && false === stripos(PHP_OS, 'darwin')) {
                 // Is it some version of Windows
                 $this->set('PMA_IS_WINDOWS', 1);
-            } elseif (stristr(PHP_OS, 'OS/2')) {
+            } elseif (false !== stripos(PHP_OS, 'OS/2')) {
                 // Is it OS/2 (No file permissions like Windows)
                 $this->set('PMA_IS_WINDOWS', 1);
             }
@@ -442,7 +442,7 @@ class Config
 
         $branch = false;
         // are we on any branch?
-        if (strstr($ref_head, '/')) {
+        if (false !== strpos($ref_head, '/')) {
             // remove ref: prefix
             $ref_head = substr(trim($ref_head), 5);
             if (substr($ref_head, 0, 11) === 'refs/heads/') {

--- a/libraries/classes/Database/Designer.php
+++ b/libraries/classes/Database/Designer.php
@@ -263,17 +263,17 @@ class Designer
                     $columns_type[$table_column_name] = 'designer/FieldKey_small';
                 } else {
                     $columns_type[$table_column_name] = 'designer/Field_small';
-                    if (strstr($tab_column[$table_name]['TYPE'][$j], 'char')
-                        || strstr($tab_column[$table_name]['TYPE'][$j], 'text')) {
+                    if (false !== strpos($tab_column[$table_name]['TYPE'][$j], 'char')
+                        || false !== strpos($tab_column[$table_name]['TYPE'][$j], 'text')) {
                         $columns_type[$table_column_name] .= '_char';
-                    } elseif (strstr($tab_column[$table_name]['TYPE'][$j], 'int')
-                        || strstr($tab_column[$table_name]['TYPE'][$j], 'float')
-                        || strstr($tab_column[$table_name]['TYPE'][$j], 'double')
-                        || strstr($tab_column[$table_name]['TYPE'][$j], 'decimal')) {
+                    } elseif (false !== strpos($tab_column[$table_name]['TYPE'][$j], 'int')
+                        || false !== strpos($tab_column[$table_name]['TYPE'][$j], 'float')
+                        || false !== strpos($tab_column[$table_name]['TYPE'][$j], 'double')
+                        || false !== strpos($tab_column[$table_name]['TYPE'][$j], 'decimal')) {
                         $columns_type[$table_column_name] .= '_int';
-                    } elseif (strstr($tab_column[$table_name]['TYPE'][$j], 'date')
-                        || strstr($tab_column[$table_name]['TYPE'][$j], 'time')
-                        || strstr($tab_column[$table_name]['TYPE'][$j], 'year')) {
+                    } elseif (false !== strpos($tab_column[$table_name]['TYPE'][$j], 'date')
+                        || false !== strpos($tab_column[$table_name]['TYPE'][$j], 'time')
+                        || false !== strpos($tab_column[$table_name]['TYPE'][$j], 'year')) {
                         $columns_type[$table_column_name] .= '_date';
                     }
                 }
@@ -346,17 +346,17 @@ class Designer
                     $columnsType[$tableColumnName] = 'designer/FieldKey_small';
                 } else {
                     $columnsType[$tableColumnName] = 'designer/Field_small';
-                    if (strstr($tabColumn[$tableName]['TYPE'][$j], 'char')
-                        || strstr($tabColumn[$tableName]['TYPE'][$j], 'text')) {
+                    if (false !== strpos($tabColumn[$tableName]['TYPE'][$j], 'char')
+                        || false !== strpos($tabColumn[$tableName]['TYPE'][$j], 'text')) {
                         $columnsType[$tableColumnName] .= '_char';
-                    } elseif (strstr($tabColumn[$tableName]['TYPE'][$j], 'int')
-                        || strstr($tabColumn[$tableName]['TYPE'][$j], 'float')
-                        || strstr($tabColumn[$tableName]['TYPE'][$j], 'double')
-                        || strstr($tabColumn[$tableName]['TYPE'][$j], 'decimal')) {
+                    } elseif (false !== strpos($tabColumn[$tableName]['TYPE'][$j], 'int')
+                        || false !== strpos($tabColumn[$tableName]['TYPE'][$j], 'float')
+                        || false !== strpos($tabColumn[$tableName]['TYPE'][$j], 'double')
+                        || false !== strpos($tabColumn[$tableName]['TYPE'][$j], 'decimal')) {
                         $columnsType[$tableColumnName] .= '_int';
-                    } elseif (strstr($tabColumn[$tableName]['TYPE'][$j], 'date')
-                        || strstr($tabColumn[$tableName]['TYPE'][$j], 'time')
-                        || strstr($tabColumn[$tableName]['TYPE'][$j], 'year')) {
+                    } elseif (false !== strpos($tabColumn[$tableName]['TYPE'][$j], 'date')
+                        || false !== strpos($tabColumn[$tableName]['TYPE'][$j], 'time')
+                        || false !== strpos($tabColumn[$tableName]['TYPE'][$j], 'year')) {
                         $columnsType[$tableColumnName] .= '_date';
                     }
                 }

--- a/libraries/classes/Database/Qbe.php
+++ b/libraries/classes/Database/Qbe.php
@@ -1457,7 +1457,7 @@ class Qbe
             // we can check which of our columns has a where clause
             if (! empty($this->_criteria[$column_index])) {
                 if (mb_substr($this->_criteria[$column_index], 0, 1) == '='
-                    || stristr($this->_criteria[$column_index], 'is')
+                    || false !== stripos($this->_criteria[$column_index], 'is')
                 ) {
                     $where_clause_columns[$column] = $column;
                     $where_clause_tables[$table]  = $table;

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3799,12 +3799,12 @@ class Results
         // if binary fields are protected
         // or transformation plugin is of non text type
         // such as image
-        if ((stristr($field_flags, self::BINARY_FIELD)
+        if ((false !== stripos($field_flags, self::BINARY_FIELD)
             && ($GLOBALS['cfg']['ProtectBinary'] === 'all'
             || ($GLOBALS['cfg']['ProtectBinary'] === 'noblob'
-            && ! stristr($meta->type, self::BLOB_FIELD))
+            && false === stripos($meta->type, self::BLOB_FIELD))
             || ($GLOBALS['cfg']['ProtectBinary'] === 'blob'
-            && stristr($meta->type, self::BLOB_FIELD))))
+            && false !== stripos($meta->type, self::BLOB_FIELD))))
             || $bIsText
         ) {
             $class = str_replace('grid_edit', '', $class);
@@ -3824,7 +3824,7 @@ class Results
         // (unless it's a link-type transformation or binary)
         if (! (gettype($transformation_plugin) === "object"
             && strpos($transformation_plugin->getName(), 'Link') !== false)
-            && ! stristr($field_flags, self::BINARY_FIELD)
+            && false === stripos($field_flags, self::BINARY_FIELD)
         ) {
             list(
                 $is_field_truncated,
@@ -3843,7 +3843,7 @@ class Results
             // some results of PROCEDURE ANALYSE() are reported as
             // being BINARY but they are quite readable,
             // so don't treat them as BINARY
-        } elseif (stristr($field_flags, self::BINARY_FIELD)
+        } elseif (false !== stripos($field_flags, self::BINARY_FIELD)
             && ! (isset($is_analyse) && $is_analyse)
         ) {
             // we show the BINARY or BLOB message and field's size
@@ -3874,7 +3874,7 @@ class Results
             $result = strip_tags($column);
             // disable inline grid editing
             // if binary or blob data is not shown
-            if (stristr($result, $binary_or_blob)) {
+            if (false !== stripos($result, $binary_or_blob)) {
                 $class = str_replace('grid_edit', '', $class);
             }
             $formatted = true;
@@ -4429,7 +4429,7 @@ class Results
         // check for non printable sorted row data
         $meta = $fields_meta[$sorted_column_index];
 
-        if (stristr($meta->type, self::BLOB_FIELD)
+        if (false !== stripos($meta->type, self::BLOB_FIELD)
             || ($meta->type == self::GEOMETRY_FIELD)
         ) {
             $column_for_first_row = $this->_handleNonPrintableContents(
@@ -4458,7 +4458,7 @@ class Results
 
         // check for non printable sorted row data
         $meta = $fields_meta[$sorted_column_index];
-        if (stristr($meta->type, self::BLOB_FIELD)
+        if (false !== stripos($meta->type, self::BLOB_FIELD)
             || ($meta->type == self::GEOMETRY_FIELD)
         ) {
             $column_for_last_row = $this->_handleNonPrintableContents(
@@ -5114,7 +5114,7 @@ class Results
         if (($_SESSION['tmpval']['display_binary']
             && $meta->type === self::STRING_FIELD)
             || ($_SESSION['tmpval']['display_blob']
-            && stristr($meta->type, self::BLOB_FIELD))
+            && false !== stripos($meta->type, self::BLOB_FIELD))
         ) {
             // in this case, restart from the original $content
             if (mb_check_encoding($content, 'utf-8')

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -3531,7 +3531,7 @@ class InsertEdit
     private function userHasColumnPrivileges(array $table_column, $insert_mode)
     {
         $privileges = $table_column['Privileges'];
-        return ($insert_mode && strstr($privileges, 'insert') !== false)
-            || (! $insert_mode && strstr($privileges, 'update') !== false);
+        return ($insert_mode && false !== strpos($privileges, 'insert'))
+            || (! $insert_mode && false !== strpos($privileges, 'update'));
     }
 }

--- a/libraries/classes/Plugins/Export/ExportOds.php
+++ b/libraries/classes/Plugins/Export/ExportOds.php
@@ -275,7 +275,7 @@ class ExportOds extends ExportPlugin
                         . htmlspecialchars($GLOBALS[$what . '_null'])
                         . '</text:p>'
                         . '</table:table-cell>';
-                } elseif (stristr($field_flags[$j], 'BINARY')
+                } elseif (false !== stripos($field_flags[$j], 'BINARY')
                     && $fields_meta[$j]->blob
                 ) {
                     // ignore BLOB

--- a/libraries/classes/Plugins/Export/ExportOdt.php
+++ b/libraries/classes/Plugins/Export/ExportOdt.php
@@ -316,7 +316,7 @@ class ExportOdt extends ExportPlugin
                         . htmlspecialchars($GLOBALS[$what . '_null'])
                         . '</text:p>'
                         . '</table:table-cell>';
-                } elseif (stristr($field_flags[$j], 'BINARY')
+                } elseif (false !== stripos($field_flags[$j], 'BINARY')
                     && $fields_meta[$j]->blob
                 ) {
                     // ignore BLOB

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -2436,7 +2436,7 @@ class ExportSql extends ExportPlugin
                     // timestamp is numeric on some MySQL 4.1, BLOBs are
                     // sometimes numeric
                     $values[] = $row[$j];
-                } elseif (stristr($field_flags[$j], 'BINARY') !== false
+                } elseif (false !== stripos($field_flags[$j], 'BINARY')
                     && isset($GLOBALS['sql_hex_for_binary'])
                 ) {
                     // a true BLOB

--- a/libraries/classes/Plugins/Export/Helpers/Pdf.php
+++ b/libraries/classes/Plugins/Export/Helpers/Pdf.php
@@ -786,7 +786,7 @@ class Pdf extends PdfLib
                  * @todo do not deactivate completely the display
                  * but show the field's name and [BLOB]
                  */
-                    if (stristr($this->fields[$i]->flags, 'BINARY')) {
+                    if (false !== stripos($this->fields[$i]->flags, 'BINARY')) {
                         $this->display_column[$i] = false;
                         unset($this->colTitles[$i]);
                     }

--- a/libraries/classes/Plugins/ExportPlugin.php
+++ b/libraries/classes/Plugins/ExportPlugin.php
@@ -306,7 +306,7 @@ abstract class ExportPlugin
         // search each database
         foreach ($aliases as $db_key => $db) {
             // check if id is database and has alias
-            if (stristr($type, 'db') !== false
+            if (false !== stripos($type, 'db')
                 && $db_key === $id
                 && ! empty($db['alias'])
             ) {
@@ -323,7 +323,7 @@ abstract class ExportPlugin
             // search each of its tables
             foreach ($db['tables'] as $table_key => $table) {
                 // check if id is table and has alias
-                if (stristr($type, 'tbl') !== false
+                if (false !== stripos($type, 'tbl')
                     && $table_key === $id
                     && ! empty($table['alias'])
                 ) {
@@ -335,7 +335,7 @@ abstract class ExportPlugin
                 // search each of its columns
                 foreach ($table['columns'] as $col_key => $col) {
                     // check if id is column
-                    if (stristr($type, 'col') !== false
+                    if (false !== stripos($type, 'col')
                         && $col_key === $id
                         && ! empty($col)
                     ) {

--- a/libraries/classes/Rte/Routines.php
+++ b/libraries/classes/Rte/Routines.php
@@ -1696,8 +1696,8 @@ class Routines
             $retval .= "<td>{$routine['item_param_type'][$i]}</td>\n";
             if ($cfg['ShowFunctionFields']) {
                 $retval .= "<td>\n";
-                if (stristr($routine['item_param_type'][$i], 'enum')
-                    || stristr($routine['item_param_type'][$i], 'set')
+                if (false !== stripos($routine['item_param_type'][$i], 'enum')
+                    || false !== stripos($routine['item_param_type'][$i], 'set')
                     || in_array(
                         mb_strtolower($routine['item_param_type'][$i]),
                         $no_support_types

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1504,7 +1504,7 @@ class Sql
     {
         $row = $GLOBALS['dbi']->fetchRow($result);
         $field_flags = $GLOBALS['dbi']->fieldFlags($result, 0);
-        if (stristr($field_flags, DisplayResults::BINARY_FIELD)) {
+        if (false !== stripos($field_flags, DisplayResults::BINARY_FIELD)) {
             $row[0] = bin2hex($row[0]);
         }
         $response = Response::getInstance();

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2069,7 +2069,7 @@ class Util
                 ) {
                     $con_val = '= ' . $row[$i];
                 } elseif ((($meta->type == 'blob') || ($meta->type == 'string'))
-                    && stristr($field_flags, 'BINARY')
+                    && false !== stripos($field_flags, 'BINARY')
                     && ! empty($row[$i])
                 ) {
                     // hexify only if this is a true not empty BLOB or a BINARY


### PR DESCRIPTION
### Description

Regarding documentation: `If you only want to determine if a particular needle occurs within haystack, use the faster and less memory intensive function strpos() instead.`