### PR TITLE
Fix property visibility

### DIFF
--- a/libraries/classes/Controllers/AbstractController.php
+++ b/libraries/classes/Controllers/AbstractController.php
@@ -33,7 +33,7 @@ abstract class AbstractController
     /**
      * @var Template
      */
-    public $template;
+    protected $template;
 
     /**
      * AbstractController constructor.


### PR DESCRIPTION
### Description

`$template` was `public`. But it doesn't seem to be used externally and I don't see any reason to keep it `public`.