### PR TITLE
Fix #14252 - DisableIS and database tree list (refresh db list)

### DIFF
--- a/navigation.php
+++ b/navigation.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Navigation\Navigation;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\Response;
+use PhpMyAdmin\Util;
 
 require_once './libraries/common.inc.php';
 
@@ -29,6 +30,10 @@ if (! $response->isAjax()) {
 if (isset($_POST['getNaviSettings']) && $_POST['getNaviSettings']) {
     $response->addJSON('message', PageSettings::getNaviSettings());
     exit();
+}
+
+if (isset($_POST['reload'])) {
+    Util::cacheSet('dbs_to_test', false);// Empty database list cache, see #14252
 }
 
 $relation = new Relation();


### PR DESCRIPTION
Fixes: #14252

The database list has kept in cache, emptying the cache when the request is sent.