### PR TITLE
Remove old DI container from various files

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 use PhpMyAdmin\Controllers\AjaxController;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Util;
 

--- a/ajax.php
+++ b/ajax.php
@@ -22,16 +22,12 @@ $_GET['ajax_request'] = 'true';
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
+$response->setAjax(true);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
-
-$response->setAjax(true);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var AjaxController $controller */
 $controller = $containerBuilder->get(AjaxController::class);

--- a/browse_foreigners.php
+++ b/browse_foreigners.php
@@ -23,14 +23,11 @@ require_once ROOT_PATH . 'libraries/common.inc.php';
 
 Util::checkParameters(['db', 'table', 'field'], true);
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Template $template */
 $template = $containerBuilder->get('template');

--- a/browse_foreigners.php
+++ b/browse_foreigners.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 use PhpMyAdmin\BrowseForeigners;
 use PhpMyAdmin\Controllers\BrowseForeignersController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Util;

--- a/chk_rel.php
+++ b/chk_rel.php
@@ -18,14 +18,11 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Relation $relation */
 $relation = $containerBuilder->get('relation');

--- a/chk_rel.php
+++ b/chk_rel.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\Response;
 

--- a/db_central_columns.php
+++ b/db_central_columns.php
@@ -14,41 +14,16 @@ if (! defined('ROOT_PATH')) {
 use PhpMyAdmin\CentralColumns;
 use PhpMyAdmin\Controllers\Database\CentralColumnsController;
 use PhpMyAdmin\Core;
-use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Response;
-use Symfony\Component\DependencyInjection\Definition;
-
-global $db;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
-
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
 $response = $containerBuilder->get(Response::class);
 
-/** @var DatabaseInterface $dbi */
-$dbi = $containerBuilder->get(DatabaseInterface::class);
-
-$centralColumns = new CentralColumns($dbi);
-/* Define dependencies for the concerned controller */
-$dependency_definitions = [
-    'db' => $container->get('db'),
-    'centralColumns' => $centralColumns,
-];
-
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(CentralColumnsController::class);
-array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
-    },
-    array_keys($dependency_definitions),
-    $dependency_definitions
-);
+/** @var CentralColumns $centralColumns */
+$centralColumns = $containerBuilder->get('central_columns');
 
 /** @var CentralColumnsController $controller */
 $controller = $containerBuilder->get(CentralColumnsController::class);

--- a/db_central_columns.php
+++ b/db_central_columns.php
@@ -28,6 +28,9 @@ $centralColumns = $containerBuilder->get('central_columns');
 /** @var CentralColumnsController $controller */
 $controller = $containerBuilder->get(CentralColumnsController::class);
 
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
 if (isset($_POST['edit_save'])) {
     echo $controller->editSave([
         'col_name' => $_POST['col_name'] ?? null,

--- a/db_central_columns.php
+++ b/db_central_columns.php
@@ -28,10 +28,10 @@ $container = Container::getDefaultContainer();
 $container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $centralColumns = new CentralColumns($dbi);
 /* Define dependencies for the concerned controller */

--- a/db_datadict.php
+++ b/db_datadict.php
@@ -8,11 +8,8 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Database\DataDictionaryController;
-use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Di\Container;
-use PhpMyAdmin\Relation;
 use PhpMyAdmin\Response;
-use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Util;
 use Symfony\Component\DependencyInjection\Definition;
 

--- a/db_datadict.php
+++ b/db_datadict.php
@@ -8,41 +8,19 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Database\DataDictionaryController;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Util;
-use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $db;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
 Util::checkParameters(['db']);
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
 $response = $containerBuilder->get(Response::class);
-
-/* Define dependencies for the concerned controller */
-$dependency_definitions = [
-    'db' => $container->get('db'),
-];
-
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(DataDictionaryController::class);
-array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
-    },
-    array_keys($dependency_definitions),
-    $dependency_definitions
-);
 
 /** @var DataDictionaryController $controller */
 $controller = $containerBuilder->get(DataDictionaryController::class);

--- a/db_datadict.php
+++ b/db_datadict.php
@@ -30,7 +30,7 @@ $container = Container::getDefaultContainer();
 $container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [

--- a/db_designer.php
+++ b/db_designer.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 use PhpMyAdmin\Database\Designer;
 use PhpMyAdmin\Database\Designer\Common;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 
 if (! defined('ROOT_PATH')) {

--- a/db_designer.php
+++ b/db_designer.php
@@ -21,14 +21,11 @@ global $db;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Designer $databaseDesigner */
 $databaseDesigner = $containerBuilder->get('designer');

--- a/db_events.php
+++ b/db_events.php
@@ -27,10 +27,10 @@ $container = Container::getDefaultContainer();
 $container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $_PMA_RTE = 'EVN';
 

--- a/db_events.php
+++ b/db_events.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Database\EventsController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
@@ -18,12 +17,7 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $db, $table;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
-
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
 $response = $containerBuilder->get(Response::class);

--- a/db_events.php
+++ b/db_events.php
@@ -30,6 +30,12 @@ $_PMA_RTE = 'EVN';
 /** @var EventsController $controller */
 $controller = $containerBuilder->get(EventsController::class);
 
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
+/** @var string $table */
+$table = $containerBuilder->getParameter('table');
+
 if (! $response->isAjax()) {
     /**
      * Displays the header and tabs

--- a/db_events.php
+++ b/db_events.php
@@ -34,10 +34,6 @@ $dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $_PMA_RTE = 'EVN';
 
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(EventsController::class);
-$definition->replaceArgument('db', $container->get('db'));
-
 /** @var EventsController $controller */
 $controller = $containerBuilder->get(EventsController::class);
 

--- a/db_events.php
+++ b/db_events.php
@@ -13,7 +13,6 @@ use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
-use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);

--- a/db_export.php
+++ b/db_export.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Display\Export as DisplayExport;
 use PhpMyAdmin\Export;
 use PhpMyAdmin\Message;

--- a/db_export.php
+++ b/db_export.php
@@ -24,14 +24,11 @@ global $db, $table, $url_query;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 PageSettings::showGroup('Export');
 

--- a/db_multi_table_query.php
+++ b/db_multi_table_query.php
@@ -26,10 +26,10 @@ $container = Container::getDefaultContainer();
 $container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Definition $definition */
 $definition = $containerBuilder->getDefinition(MultiTableQueryController::class);

--- a/db_multi_table_query.php
+++ b/db_multi_table_query.php
@@ -9,31 +9,20 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Database\MultiTableQueryController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Template;
-use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $db;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
-
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
 $response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
 $dbi = $containerBuilder->get(DatabaseInterface::class);
-
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(MultiTableQueryController::class);
-$definition->replaceArgument('db', $container->get('db'));
 
 /** @var MultiTableQueryController $controller */
 $controller = $containerBuilder->get(MultiTableQueryController::class);

--- a/db_operations.php
+++ b/db_operations.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Display\CreateTable;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Operations;

--- a/db_operations.php
+++ b/db_operations.php
@@ -34,14 +34,11 @@ global $cfg, $db, $server, $url_query;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $checkUserPrivileges = new CheckUserPrivileges($dbi);
 $checkUserPrivileges->getPrivileges();

--- a/db_qbe.php
+++ b/db_qbe.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Database\Qbe;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\Response;

--- a/db_qbe.php
+++ b/db_qbe.php
@@ -27,14 +27,11 @@ global $db, $pmaThemeImage, $url_query;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Relation $relation */
 $relation = $containerBuilder->get('relation');

--- a/db_routines.php
+++ b/db_routines.php
@@ -28,10 +28,10 @@ $container = Container::getDefaultContainer();
 $container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $checkUserPrivileges = new CheckUserPrivileges($dbi);
 $checkUserPrivileges->getPrivileges();

--- a/db_routines.php
+++ b/db_routines.php
@@ -10,22 +10,15 @@ declare(strict_types=1);
 use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\Database\RoutinesController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
-use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $db, $table;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
-
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
 $response = $containerBuilder->get(Response::class);
@@ -37,10 +30,6 @@ $checkUserPrivileges = new CheckUserPrivileges($dbi);
 $checkUserPrivileges->getPrivileges();
 
 $_PMA_RTE = 'RTN';
-
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(RoutinesController::class);
-$definition->replaceArgument('db', $container->get('db'));
 
 /** @var RoutinesController $controller */
 $controller = $containerBuilder->get(RoutinesController::class);

--- a/db_routines.php
+++ b/db_routines.php
@@ -32,7 +32,8 @@ $db = $containerBuilder->getParameter('db');
 /** @var string $table */
 $table = $containerBuilder->getParameter('table');
 
-$checkUserPrivileges = new CheckUserPrivileges($dbi);
+/** @var CheckUserPrivileges $checkUserPrivileges */
+$checkUserPrivileges = $containerBuilder->get('check_user_privileges');
 $checkUserPrivileges->getPrivileges();
 
 $_PMA_RTE = 'RTN';

--- a/db_routines.php
+++ b/db_routines.php
@@ -26,6 +26,12 @@ $response = $containerBuilder->get(Response::class);
 /** @var DatabaseInterface $dbi */
 $dbi = $containerBuilder->get(DatabaseInterface::class);
 
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
+/** @var string $table */
+$table = $containerBuilder->getParameter('table');
+
 $checkUserPrivileges = new CheckUserPrivileges($dbi);
 $checkUserPrivileges->getPrivileges();
 

--- a/db_search.php
+++ b/db_search.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Database\Search;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Util;

--- a/db_search.php
+++ b/db_search.php
@@ -24,14 +24,11 @@ global $db, $url_query;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Template $template */
 $template = $containerBuilder->get('template');

--- a/db_sql.php
+++ b/db_sql.php
@@ -12,13 +12,10 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\SqlQueryForm;
-use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
-
-global $db;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
@@ -30,10 +27,6 @@ $response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
 $dbi = $containerBuilder->get(DatabaseInterface::class);
-
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(SqlController::class);
-$definition->replaceArgument('db', $container->get('db'));
 
 /** @var SqlController $controller */
 $controller = $containerBuilder->get(SqlController::class);

--- a/db_sql.php
+++ b/db_sql.php
@@ -26,10 +26,10 @@ $container = Container::getDefaultContainer();
 $container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Definition $definition */
 $definition = $containerBuilder->getDefinition(SqlController::class);

--- a/db_sql_autocomplete.php
+++ b/db_sql_autocomplete.php
@@ -17,14 +17,11 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 if ($GLOBALS['cfg']['EnableAutocompleteForTablesAndColumns']) {
     $db = isset($_POST['db']) ? $_POST['db'] : $GLOBALS['db'];

--- a/db_sql_autocomplete.php
+++ b/db_sql_autocomplete.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 
 if (! defined('ROOT_PATH')) {

--- a/db_structure.php
+++ b/db_structure.php
@@ -24,12 +24,11 @@ global $db;
 require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/db_common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
+/** @var Response $response */
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
@@ -48,9 +47,6 @@ array_map(
 
 /** @var StructureController $controller */
 $controller = $containerBuilder->get(StructureController::class);
-
-/** @var Response $response */
-$response = $container->get(Response::class);
 
 if ($response->isAjax() && ! empty($_REQUEST['favorite_table'])) {
     $json = $controller->addRemoveFavoriteTablesAction([

--- a/db_structure.php
+++ b/db_structure.php
@@ -9,9 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Database\StructureController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
-use PhpMyAdmin\Relation;
-use PhpMyAdmin\Replication;
 use PhpMyAdmin\Response;
 use Symfony\Component\DependencyInjection\Definition;
 

--- a/db_structure.php
+++ b/db_structure.php
@@ -10,13 +10,10 @@ declare(strict_types=1);
 use PhpMyAdmin\Controllers\Database\StructureController;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Response;
-use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
-
-global $db;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/db_common.inc.php';
@@ -26,21 +23,6 @@ $response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
 $dbi = $containerBuilder->get(DatabaseInterface::class);
-
-/* Define dependencies for the concerned controller */
-$dependency_definitions = [
-    'db' => $db,
-];
-
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(StructureController::class);
-array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
-    },
-    array_keys($dependency_definitions),
-    $dependency_definitions
-);
 
 /** @var StructureController $controller */
 $controller = $containerBuilder->get(StructureController::class);

--- a/db_triggers.php
+++ b/db_triggers.php
@@ -27,10 +27,10 @@ $container = Container::getDefaultContainer();
 $container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $_PMA_RTE = 'TRI';
 

--- a/db_triggers.php
+++ b/db_triggers.php
@@ -9,22 +9,15 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Database\TriggersController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
-use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $db, $table;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
-
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
 $response = $containerBuilder->get(Response::class);
@@ -33,10 +26,6 @@ $response = $containerBuilder->get(Response::class);
 $dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $_PMA_RTE = 'TRI';
-
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(TriggersController::class);
-$definition->replaceArgument('db', $container->get('db'));
 
 /** @var TriggersController $controller */
 $controller = $containerBuilder->get(TriggersController::class);

--- a/db_triggers.php
+++ b/db_triggers.php
@@ -30,6 +30,12 @@ $_PMA_RTE = 'TRI';
 /** @var TriggersController $controller */
 $controller = $containerBuilder->get(TriggersController::class);
 
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
+/** @var string $table */
+$table = $containerBuilder->getParameter('table');
+
 if (! $response->isAjax()) {
     /**
      * Displays the header and tabs

--- a/export.php
+++ b/export.php
@@ -31,14 +31,11 @@ global $db, $sql_query;
 
 include_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $header = $response->getHeader();
 $scripts = $header->getScripts();

--- a/export.php
+++ b/export.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Encoding;
 use PhpMyAdmin\Export;
 use PhpMyAdmin\Plugins;

--- a/import.php
+++ b/import.php
@@ -35,14 +35,11 @@ global $db, $pmaThemeImage, $table;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var import $import */
 $import = $containerBuilder->get('import');

--- a/index.php
+++ b/index.php
@@ -60,14 +60,11 @@ if (! empty($_REQUEST['target'])
     exit;
 }
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var HomeController $controller */
 $controller = $containerBuilder->get(HomeController::class);

--- a/index.php
+++ b/index.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 use PhpMyAdmin\Controllers\HomeController;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use PhpMyAdmin\Di\Migration;
 use PhpMyAdmin\Display\Error as DisplayError;
 
 /**
@@ -905,7 +906,7 @@ class Core
         foreach (array_keys($_POST) as $post_key) {
             foreach ($post_patterns as $one_post_pattern) {
                 if (preg_match($one_post_pattern, $post_key)) {
-                    $GLOBALS[$post_key] = $_POST[$post_key];
+                    Migration::getInstance()->setGlobal($post_key, $_POST[$post_key]);
                 }
             }
         }
@@ -920,13 +921,12 @@ class Core
      */
     public static function setGlobalDbOrTable(string $param): void
     {
-        $GLOBALS[$param] = '';
+        $value = '';
         if (self::isValid($_REQUEST[$param])) {
-            // can we strip tags from this?
-            // only \ and / is not allowed in db names for MySQL
-            $GLOBALS[$param] = $_REQUEST[$param];
-            $GLOBALS['url_params'][$param] = $GLOBALS[$param];
+            $value = $_REQUEST[$param];
         }
+        Migration::getInstance()->setGlobal($param, $value);
+        Migration::getInstance()->setGlobal('url_params', [$param => $value] + $GLOBALS['url_params']);
     }
 
     /**

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -3166,10 +3166,6 @@ class DatabaseInterface
         }
         $dbi = new DatabaseInterface($extension);
 
-        $container = Container::getDefaultContainer();
-        $container->set(DatabaseInterface::class, $dbi);
-        $container->alias('dbi', DatabaseInterface::class);
-
         return $dbi;
     }
 }

--- a/libraries/classes/Di/Migration.php
+++ b/libraries/classes/Di/Migration.php
@@ -1,0 +1,59 @@
+<?php
+/* vim: set expandtab sw=4 ts=4 sts=4: */
+/**
+ * Migration from home-made DI to Symfony DI
+ *
+ * @package PhpMyAdmin\Di
+ */
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Di;
+
+use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Migration from home-made DI to Symfony DI
+ *
+ * @package PhpMyAdmin\Di
+ */
+class Migration
+{
+    /** @var self */
+    protected static $instance;
+
+    /** @var ContainerBuilder */
+    protected $containerBuilder;
+
+    public static function getInstance(?ContainerBuilder $containerBuilder = null): self
+    {
+        if (null !== self::$instance) {
+            return self::$instance;
+        }
+
+        if (null === $containerBuilder) {
+            throw new InvalidArgumentException('Container builder should be sent for ' . self::class . ' creation');
+        }
+
+        return self::$instance = new self($containerBuilder);
+    }
+
+    public function __construct(ContainerBuilder $containerBuilder)
+    {
+        $this->containerBuilder = $containerBuilder;
+    }
+
+    /**
+     * Get the instance of the service
+     *
+     * @param string $key
+     * @param        $value
+     *
+     * @return void
+     */
+    public function setGlobal(string $key, $value)
+    {
+        $GLOBALS[$key] = $value;
+        $this->containerBuilder->setParameter($key, $value);
+    }
+}

--- a/libraries/classes/Di/Migration.php
+++ b/libraries/classes/Di/Migration.php
@@ -25,6 +25,13 @@ class Migration
     /** @var ContainerBuilder */
     protected $containerBuilder;
 
+    /**
+     * Get instance of this class
+     *
+     * @param ContainerBuilder|null $containerBuilder ContainerBuilder object that should be used to store the data
+     *
+     * @return Migration
+     */
     public static function getInstance(?ContainerBuilder $containerBuilder = null): self
     {
         if (null !== self::$instance) {
@@ -38,7 +45,12 @@ class Migration
         return self::$instance = new self($containerBuilder);
     }
 
-    public function __construct(ContainerBuilder $containerBuilder)
+    /**
+     * Migration constructor.
+     *
+     * @param ContainerBuilder $containerBuilder ContainerBuilder object that should be used to store the data
+     */
+    protected function __construct(ContainerBuilder $containerBuilder)
     {
         $this->containerBuilder = $containerBuilder;
     }
@@ -46,8 +58,8 @@ class Migration
     /**
      * Get the instance of the service
      *
-     * @param string $key
-     * @param        $value
+     * @param string $key   Key of data to store
+     * @param mixed  $value Data to store
      *
      * @return void
      */

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Di\Migration;
 use PhpMyAdmin\ErrorHandler;
 use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\Logging;
@@ -92,6 +93,8 @@ $containerBuilder = new ContainerBuilder();
 $loader = new YamlFileLoader($containerBuilder, new FileLocator(__DIR__));
 $loader->load('../services.yml');
 $loader->load('../services_controllers.yml');
+/** @var Migration $diMigration */
+$diMigration = $containerBuilder->get('di_migration');
 
 /**
  * Load gettext functions.
@@ -142,17 +145,17 @@ if (! defined('PMA_NO_SESSION')) {
  * holds parameters to be passed to next page
  * @global array $GLOBALS['url_params']
  */
-$GLOBALS['url_params'] = [];
+$diMigration->setGlobal('url_params', []);
 
 /**
  * holds page that should be displayed
  * @global string $GLOBALS['goto']
  */
-$GLOBALS['goto'] = '';
+$diMigration->setGlobal('goto', '');
 // Security fix: disallow accessing serious server files via "?goto="
 if (isset($_REQUEST['goto']) && Core::checkPageValidity($_REQUEST['goto'])) {
-    $GLOBALS['goto'] = $_REQUEST['goto'];
-    $GLOBALS['url_params']['goto'] = $_REQUEST['goto'];
+    $diMigration->setGlobal('goto', $_REQUEST['goto']);
+    $diMigration->setGlobal('url_params', ['goto' => $_REQUEST['goto']]);
 } else {
     unset($_REQUEST['goto'], $_GET['goto'], $_POST['goto'], $_COOKIE['goto']);
 }
@@ -162,7 +165,7 @@ if (isset($_REQUEST['goto']) && Core::checkPageValidity($_REQUEST['goto'])) {
  * @global string $GLOBALS['back']
  */
 if (isset($_REQUEST['back']) && Core::checkPageValidity($_REQUEST['back'])) {
-    $GLOBALS['back'] = $_REQUEST['back'];
+    $diMigration->setGlobal('back', $_REQUEST['back']);
 } else {
     unset($_REQUEST['back'], $_GET['back'], $_POST['back'], $_COOKIE['back']);
 }
@@ -232,24 +235,32 @@ Core::setGlobalDbOrTable('table');
 if (isset($_REQUEST['selected_recent_table']) && Core::isValid($_REQUEST['selected_recent_table'])) {
     $recent_table = json_decode($_REQUEST['selected_recent_table'], true);
 
-    $GLOBALS['db']
-        = (array_key_exists('db', $recent_table) && is_string($recent_table['db'])) ?
-            $recent_table['db'] : '';
-    $GLOBALS['url_params']['db'] = $GLOBALS['db'];
+    $diMigration->setGlobal(
+        'db',
+        (array_key_exists('db', $recent_table) && is_string($recent_table['db'])) ? $recent_table['db'] : ''
+    );
+    $diMigration->setGlobal(
+        'url_params',
+        ['db' => $containerBuilder->getParameter('db')] + $containerBuilder->getParameter('url_params')
+    );
 
-    $GLOBALS['table']
-        = (array_key_exists('table', $recent_table) && is_string($recent_table['table'])) ?
-            $recent_table['table'] : '';
-    $GLOBALS['url_params']['table'] = $GLOBALS['table'];
+    $diMigration->setGlobal(
+        'table',
+        (array_key_exists('table', $recent_table) && is_string($recent_table['table'])) ? $recent_table['table'] : ''
+    );
+    $diMigration->setGlobal(
+        'url_params',
+        ['table' => $containerBuilder->getParameter('table')] + $containerBuilder->getParameter('url_params')
+    );
 }
 
 /**
  * SQL query to be executed
  * @global string $GLOBALS['sql_query']
  */
-$GLOBALS['sql_query'] = '';
+$diMigration->setGlobal('sql_query', '');
 if (Core::isValid($_POST['sql_query'])) {
-    $GLOBALS['sql_query'] = $_POST['sql_query'];
+    $diMigration->setGlobal('sql_query', $_POST['sql_query']);
 }
 
 //$_REQUEST['set_theme'] // checked later in this file LABEL_theme_setup
@@ -287,8 +298,8 @@ $GLOBALS['PMA_Config']->checkServers();
  * current server
  * @global integer $GLOBALS['server']
  */
-$GLOBALS['server'] = $GLOBALS['PMA_Config']->selectServer();
-$GLOBALS['url_params']['server'] = $GLOBALS['server'];
+$diMigration->setGlobal('server', $GLOBALS['PMA_Config']->selectServer());
+$diMigration->setGlobal('url_params', ['server' => $containerBuilder->getParameter('server')] + $containerBuilder->getParameter('url_params'));
 
 /**
  * BC - enable backward compatibility

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Di\Migration;
 use PhpMyAdmin\ErrorHandler;
 use PhpMyAdmin\LanguageManager;
@@ -95,6 +96,9 @@ $loader->load('../services.yml');
 $loader->load('../services_controllers.yml');
 /** @var Migration $diMigration */
 $diMigration = $containerBuilder->get('di_migration');
+
+/** @var Container $oldContainer */
+$oldContainer = Container::getDefaultContainer();
 
 /**
  * Load gettext functions.
@@ -329,6 +333,8 @@ if (! defined('PMA_MINIMUM_COMMON')) {
          */
         $containerBuilder->set(DatabaseInterface::class, DatabaseInterface::load());
         $containerBuilder->setAlias('dbi', DatabaseInterface::class);
+        $oldContainer->set(DatabaseInterface::class, $containerBuilder->get(DatabaseInterface::class));
+        $oldContainer->alias('dbi', DatabaseInterface::class);
 
         // get LoginCookieValidity from preferences cache
         // no generic solution for loading preferences from cache as some settings

--- a/libraries/tbl_columns_definition_form.inc.php
+++ b/libraries/tbl_columns_definition_form.inc.php
@@ -8,6 +8,7 @@
  */
 declare(strict_types=1);
 
+use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Partition;
 use PhpMyAdmin\Relation;
@@ -106,8 +107,8 @@ $comments_map = $relation->getComments($db, $table);
 
 $move_columns = [];
 if (isset($fields_meta)) {
-    /** @var PhpMyAdmin\DatabaseInterface $dbi */
-    $dbi = Container::getDefaultContainer()->get('dbi');
+    /** @var DatabaseInterface $dbi */
+    $dbi = $containerBuilder->get('dbi');
     $move_columns = $dbi->getTable($db, $table)->getColumnsMeta();
 }
 

--- a/libraries/tbl_columns_definition_form.inc.php
+++ b/libraries/tbl_columns_definition_form.inc.php
@@ -9,7 +9,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Partition;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\Response;

--- a/navigation.php
+++ b/navigation.php
@@ -23,14 +23,11 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Navigation $navigation */
 $navigation = $containerBuilder->get('navigation');

--- a/navigation.php
+++ b/navigation.php
@@ -9,12 +9,10 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Navigation\Navigation;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\Response;
-use PhpMyAdmin\Template;
 use PhpMyAdmin\Util;
 
 if (! defined('ROOT_PATH')) {

--- a/normalization.php
+++ b/normalization.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Normalization;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Url;

--- a/normalization.php
+++ b/normalization.php
@@ -22,14 +22,11 @@ global $db, $table;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Normalization $normalization */
 $normalization = $containerBuilder->get('normalization');

--- a/schema_export.php
+++ b/schema_export.php
@@ -19,11 +19,6 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-
-/** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
-
 /**
  * get all variables needed for exporting relational schema
  * in $cfgRelation

--- a/schema_export.php
+++ b/schema_export.php
@@ -7,8 +7,6 @@
  */
 declare(strict_types=1);
 
-use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Export;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\Util;

--- a/server_binlog.php
+++ b/server_binlog.php
@@ -17,15 +17,11 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /** @var BinlogController $controller */
 $controller = $containerBuilder->get(BinlogController::class);
 
 /** @var Response $response */
-$response = $container->get('response');
+$response = $containerBuilder->get(Response::class);
 
 $response->addHTML($controller->indexAction([
     'log' => $_POST['log'] ?? null,

--- a/server_binlog.php
+++ b/server_binlog.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\BinlogController;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 
 if (! defined('ROOT_PATH')) {

--- a/server_collations.php
+++ b/server_collations.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\CollationsController;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 
 if (! defined('ROOT_PATH')) {

--- a/server_collations.php
+++ b/server_collations.php
@@ -17,12 +17,9 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /** @var CollationsController $controller */
 $controller = $containerBuilder->get(CollationsController::class);
-$response = $container->get('response');
 
+/** @var Response $response */
+$response = $containerBuilder->get(Response::class);
 $response->addHTML($controller->indexAction());

--- a/server_databases.php
+++ b/server_databases.php
@@ -20,14 +20,11 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$response = $containerBuilder->get('response', ContainerInterface::NULL_ON_INVALID_REFERENCE) ?? Response::getInstance();
-
-$container = Container::getDefaultContainer();
-$container->set(Response::class, $response);
-$container->alias('response', Response::class);
-
 /** @var DatabasesController $controller */
 $controller = $containerBuilder->get(DatabasesController::class);
+
+/** @var Response $response */
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
 $dbi = $containerBuilder->get(DatabaseInterface::class);

--- a/server_databases.php
+++ b/server_databases.php
@@ -10,9 +10,7 @@ declare(strict_types=1);
 use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\Server\DatabasesController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);

--- a/server_engines.php
+++ b/server_engines.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\EnginesController;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 
 if (! defined('ROOT_PATH')) {

--- a/server_engines.php
+++ b/server_engines.php
@@ -17,15 +17,11 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /** @var EnginesController $controller */
 $controller = $containerBuilder->get(EnginesController::class);
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 if (isset($_GET['engine']) && $_GET['engine'] !== '') {
     $response->addHTML($controller->show([

--- a/server_plugins.php
+++ b/server_plugins.php
@@ -17,14 +17,9 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /** @var PluginsController $controller */
 $controller = $containerBuilder->get(PluginsController::class);
 
 /** @var Response $response */
-$response = $container->get(Response::class);
-
+$response = $containerBuilder->get(Response::class);
 $response->addHTML($controller->index());

--- a/server_plugins.php
+++ b/server_plugins.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\PluginsController;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 
 if (! defined('ROOT_PATH')) {

--- a/server_privileges.php
+++ b/server_privileges.php
@@ -27,10 +27,11 @@ global $db, $pmaThemeImage, $text_dir, $url_query;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
+/** @var Response $response */
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $checkUserPrivileges = new CheckUserPrivileges($dbi);
 $checkUserPrivileges->getPrivileges();
@@ -42,7 +43,6 @@ $cfgRelation = $relation->getRelationsParam();
 /**
  * Does the common work
  */
-$response = Response::getInstance();
 $header   = $response->getHeader();
 $scripts  = $header->getScripts();
 $scripts->addFile('server/privileges.js');

--- a/server_privileges.php
+++ b/server_privileges.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\RelationCleanup;

--- a/server_replication.php
+++ b/server_replication.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\ReplicationController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\ReplicationGui;
 use PhpMyAdmin\Response;
 

--- a/server_replication.php
+++ b/server_replication.php
@@ -21,14 +21,11 @@ require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/server_common.inc.php';
 require_once ROOT_PATH . 'libraries/replication.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var ReplicationController $controller */
 $controller = $containerBuilder->get(ReplicationController::class);

--- a/server_sql.php
+++ b/server_sql.php
@@ -19,14 +19,11 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var SqlController $controller */
 $controller = $containerBuilder->get(SqlController::class);

--- a/server_sql.php
+++ b/server_sql.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\SqlController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\SqlQueryForm;
 

--- a/server_status.php
+++ b/server_status.php
@@ -21,14 +21,11 @@ require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/server_common.inc.php';
 require_once ROOT_PATH . 'libraries/replication.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var StatusController $controller */
 $controller = $containerBuilder->get(StatusController::class);

--- a/server_status.php
+++ b/server_status.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\Status\StatusController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\ReplicationGui;
 use PhpMyAdmin\Response;
 

--- a/server_status_advisor.php
+++ b/server_status_advisor.php
@@ -20,14 +20,11 @@ if (! defined('ROOT_PATH')) {
 require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/replication.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $scripts = $response->getHeader()->getScripts();
 $scripts->addFile('server/status/advisor.js');

--- a/server_status_advisor.php
+++ b/server_status_advisor.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\Status\AdvisorController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
-use PhpMyAdmin\Server\Status\Data;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);

--- a/server_status_monitor.php
+++ b/server_status_monitor.php
@@ -22,14 +22,11 @@ require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/server_common.inc.php';
 require_once ROOT_PATH . 'libraries/replication.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var MonitorController $controller */
 $controller = $containerBuilder->get(MonitorController::class);

--- a/server_status_monitor.php
+++ b/server_status_monitor.php
@@ -9,10 +9,7 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\Status\MonitorController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
-use PhpMyAdmin\Server\Status\Data;
-use PhpMyAdmin\Server\Status\Monitor;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);

--- a/server_status_processes.php
+++ b/server_status_processes.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\Status\ProcessesController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
-use PhpMyAdmin\Server\Status\Data;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);

--- a/server_status_processes.php
+++ b/server_status_processes.php
@@ -21,14 +21,11 @@ require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/server_common.inc.php';
 require_once ROOT_PATH . 'libraries/replication.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var ProcessesController $controller */
 $controller = $containerBuilder->get(ProcessesController::class);

--- a/server_status_queries.php
+++ b/server_status_queries.php
@@ -21,14 +21,11 @@ require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/server_common.inc.php';
 require_once ROOT_PATH . 'libraries/replication.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var QueriesController $controller */
 $controller = $containerBuilder->get(QueriesController::class);

--- a/server_status_queries.php
+++ b/server_status_queries.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\Status\QueriesController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
-use PhpMyAdmin\Server\Status\Data;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);

--- a/server_status_variables.php
+++ b/server_status_variables.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\Status\VariablesController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
-use PhpMyAdmin\Server\Status\Data;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);

--- a/server_status_variables.php
+++ b/server_status_variables.php
@@ -21,14 +21,11 @@ require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/server_common.inc.php';
 require_once ROOT_PATH . 'libraries/replication.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var VariablesController $controller */
 $controller = $containerBuilder->get(VariablesController::class);

--- a/server_user_groups.php
+++ b/server_user_groups.php
@@ -20,14 +20,11 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Relation $relation */
 $relation = $containerBuilder->get('relation');

--- a/server_user_groups.php
+++ b/server_user_groups.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Server\UserGroups;

--- a/server_variables.php
+++ b/server_variables.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Server\VariablesController;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 
 if (! defined('ROOT_PATH')) {

--- a/server_variables.php
+++ b/server_variables.php
@@ -17,15 +17,11 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /** @var VariablesController $controller */
 $controller = $containerBuilder->get(VariablesController::class);
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 if ($response->isAjax()
     && isset($_GET['type']) && $_GET['type'] === 'getval') {

--- a/services.yml
+++ b/services.yml
@@ -71,6 +71,9 @@ services:
       replication: '@replication'
       template: '@template'
 
+  response:
+    factory: 'PhpMyAdmin\Response::getInstance'
+
   sql_query_form:
     class: 'PhpMyAdmin\SqlQueryForm'
 
@@ -93,3 +96,9 @@ services:
 
   transformations:
     class: 'PhpMyAdmin\Transformations'
+
+  #Aliases
+
+  PhpMyAdmin\Response: '@response'
+
+  PhpMyAdmin\DatabaseInterface: '@dbi'

--- a/services.yml
+++ b/services.yml
@@ -70,6 +70,12 @@ services:
       transformations: '@transformations'
       template: '@template'
 
+  operations:
+    class: 'PhpMyAdmin\Operations'
+    arguments:
+      dbi: '@dbi'
+      relation: '@relation'
+
   relation:
     class: 'PhpMyAdmin\Relation'
     arguments: ['@dbi', '@template']

--- a/services.yml
+++ b/services.yml
@@ -9,6 +9,10 @@ services:
     class: 'PhpMyAdmin\Config'
     arguments: [!php/const CONFIG_FILE]
 
+  central_columns:
+    class: '\PhpMyAdmin\CentralColumns'
+    arguments: ['@dbi']
+
   create_add_field:
     class: 'PhpMyAdmin\CreateAddField'
     arguments: ['@dbi']

--- a/services.yml
+++ b/services.yml
@@ -46,6 +46,10 @@ services:
   import:
     class: 'PhpMyAdmin\Import'
 
+  di_migration:
+    factory: 'PhpMyAdmin\Di\Migration::getInstance'
+    arguments: ['@service_container']
+
   navigation:
     class: 'PhpMyAdmin\Navigation\Navigation'
     arguments: ['@template', '@relation', '@dbi']

--- a/services.yml
+++ b/services.yml
@@ -13,6 +13,10 @@ services:
     class: '\PhpMyAdmin\CentralColumns'
     arguments: ['@dbi']
 
+  check_user_privileges:
+    class: '\PhpMyAdmin\CheckUserPrivileges'
+    arguments: ['@dbi']
+
   create_add_field:
     class: 'PhpMyAdmin\CreateAddField'
     arguments: ['@dbi']

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -65,7 +65,7 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
+      db: '%db%'
 
   PhpMyAdmin\Controllers\Database\StructureController:
     class: 'PhpMyAdmin\Controllers\Database\StructureController'

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -279,8 +279,8 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
-      table: null
+      db: '%db%'
+      table: '%table%'
       db_is_system_schema: null
       tbl_is_view: null
       tbl_storage_engine: null

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -206,8 +206,8 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
-      table: null
+      db: '%db%'
+      table: '%table%'
       sql_query: null
       url_query: null
       cfg: null

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -73,7 +73,7 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
+      db: '%db%'
       relation: '@relation'
       replication: '@replication'
 

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -242,8 +242,8 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
-      table: null
+      db: '%db%'
+      table: '%table%'
       options_array: null
       cfgRelation: null
       tbl_storage_engine: null

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -41,7 +41,7 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
+      db: '%db%'
 
   PhpMyAdmin\Controllers\Database\MultiTableQueryController:
     class: 'PhpMyAdmin\Controllers\Database\MultiTableQueryController'

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -232,8 +232,8 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
-      table: null
+      db: '%db%'
+      table: '%table%'
       index: null
 
   PhpMyAdmin\Controllers\Table\RelationController:

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -270,8 +270,8 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
-      table: null
+      db: '%db%'
+      table: '%table%'
 
   PhpMyAdmin\Controllers\Table\StructureController:
     class: 'PhpMyAdmin\Controllers\Table\StructureController'

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -22,8 +22,8 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
-      centralColumns: null
+      db: '%db%'
+      centralColumns: '@central_columns'
 
   PhpMyAdmin\Controllers\Database\DataDictionaryController:
     class: 'PhpMyAdmin\Controllers\Database\DataDictionaryController'

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -49,7 +49,7 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
+      db: '%db%'
 
   PhpMyAdmin\Controllers\Database\RoutinesController:
     class: 'PhpMyAdmin\Controllers\Database\RoutinesController'
@@ -57,7 +57,7 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
+      db: '%db%'
 
   PhpMyAdmin\Controllers\Database\SqlController:
     class: 'PhpMyAdmin\Controllers\Database\SqlController'
@@ -83,7 +83,7 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
+      db: '%db%'
 
   PhpMyAdmin\Controllers\HomeController:
     class: 'PhpMyAdmin\Controllers\HomeController'

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -258,8 +258,8 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
-      table: null
+      db: '%db%'
+      table: '%table%'
       searchType: null
       url_query: null
       relation: '@relation'

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -234,7 +234,7 @@ services:
       template: '@template'
       db: '%db%'
       table: '%table%'
-      index: null
+      index: '%index%'
 
   PhpMyAdmin\Controllers\Table\RelationController:
     class: 'PhpMyAdmin\Controllers\Table\RelationController'

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -218,8 +218,8 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
-      table: null
+      db: '%db%'
+      table: '%table%'
       sql_query: null
       url_params: null
       goto: null

--- a/services_controllers.yml
+++ b/services_controllers.yml
@@ -31,7 +31,7 @@ services:
       response: '@response'
       dbi: '@dbi'
       template: '@template'
-      db: null
+      db: '%db%'
       relation: '@relation'
       transformations: '@transformations'
 

--- a/tbl_addfield.php
+++ b/tbl_addfield.php
@@ -7,6 +7,7 @@
  */
 declare(strict_types=1);
 
+use PhpMyAdmin\Config;
 use PhpMyAdmin\CreateAddField;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Message;
@@ -36,6 +37,16 @@ Util::checkParameters(['db', 'table']);
 
 /** @var Transformations $transformations */
 $transformations = $containerBuilder->get('transformations');
+
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
+/** @var string $table */
+$table = $containerBuilder->getParameter('table');
+
+/** @var Config $config */
+$config = $containerBuilder->get('config');
+$cfg = $config->settings;
 
 /**
  * Defines the url to return to in case of error in a sql statement

--- a/tbl_addfield.php
+++ b/tbl_addfield.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\CreateAddField;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Transformations;
@@ -20,18 +19,13 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $cfg, $db, $table;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $header = $response->getHeader();
 $scripts = $header->getScripts();

--- a/tbl_chart.php
+++ b/tbl_chart.php
@@ -8,8 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Table\ChartController;
-use PhpMyAdmin\Di\Container;
-use PhpMyAdmin\Response;
 use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
@@ -18,14 +16,8 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
-    'db' => $container->get('db'),
-    'table' => $container->get('table'),
     'sql_query' => &$GLOBALS['sql_query'],
     'url_query' => &$GLOBALS['url_query'],
     'cfg' => &$GLOBALS['cfg'],

--- a/tbl_create.php
+++ b/tbl_create.php
@@ -7,6 +7,7 @@
  */
 declare(strict_types=1);
 
+use PhpMyAdmin\Config;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\CreateAddField;
 use PhpMyAdmin\DatabaseInterface;
@@ -32,6 +33,16 @@ Util::checkParameters(['db']);
 
 /** @var Transformations $transformations */
 $transformations = $containerBuilder->get('transformations');
+
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
+/** @var string $table */
+$table = $containerBuilder->getParameter('table');
+
+/** @var Config $config */
+$config = $containerBuilder->get('config');
+$cfg = $config->settings;
 
 /* Check if database name is empty */
 if (strlen($db) === 0) {

--- a/tbl_create.php
+++ b/tbl_create.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 use PhpMyAdmin\Core;
 use PhpMyAdmin\CreateAddField;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Url;
@@ -20,23 +19,19 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $cfg, $db, $table;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 // Check parameters
 Util::checkParameters(['db']);
 
-$transformations = new Transformations();
+/** @var Transformations $transformations */
+$transformations = $containerBuilder->get('transformations');
 
 /* Check if database name is empty */
 if (strlen($db) === 0) {

--- a/tbl_find_replace.php
+++ b/tbl_find_replace.php
@@ -10,27 +10,17 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Table\SearchController;
-use PhpMyAdmin\Di\Container;
-use PhpMyAdmin\Response;
 use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $url_query;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/tbl_common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
-    'db' => $container->get('db'),
-    'table' => $container->get('table'),
     'searchType' => 'replace',
     'url_query' => &$url_query,
 ];

--- a/tbl_find_replace.php
+++ b/tbl_find_replace.php
@@ -16,6 +16,9 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
+/** @var string $url_query Overwritten in tbl_common.inc.php */
+$url_query = null;
+
 require_once ROOT_PATH . 'libraries/common.inc.php';
 require_once ROOT_PATH . 'libraries/tbl_common.inc.php';
 

--- a/tbl_get_field.php
+++ b/tbl_get_field.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Mime;
 use PhpMyAdmin\Response;
 
@@ -17,18 +16,19 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $db, $table;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
+
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
+/** @var string $table */
+$table = $containerBuilder->getParameter('table');
 
 $response->disable();
 

--- a/tbl_gis_visualization.php
+++ b/tbl_gis_visualization.php
@@ -25,8 +25,6 @@ $container->alias('response', Response::class);
 
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
-    'db' => $container->get('db'),
-    'table' => $container->get('table'),
     'sql_query' => &$GLOBALS['sql_query'],
     'url_params' => &$GLOBALS['url_params'],
     'goto' => Util::getScriptNameForOption(

--- a/tbl_gis_visualization.php
+++ b/tbl_gis_visualization.php
@@ -19,10 +19,6 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
     'sql_query' => &$GLOBALS['sql_query'],

--- a/tbl_indexes.php
+++ b/tbl_indexes.php
@@ -47,8 +47,6 @@ if (isset($_POST['index'])) {
 
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
-    'db' => $container->get('db'),
-    'table' => $container->get('table'),
     'index' => $index,
 ];
 

--- a/tbl_indexes.php
+++ b/tbl_indexes.php
@@ -9,10 +9,7 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Table\IndexesController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Index;
-use PhpMyAdmin\Response;
-use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
@@ -20,16 +17,14 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
-/* Define dependencies for the concerned controller */
-$db = $container->get('db');
-$table = $container->get('table');
-
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get('dbi');
+
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
+/** @var string $table */
+$table = $containerBuilder->getParameter('table');
 
 if (! isset($_POST['create_edit_table'])) {
     include_once ROOT_PATH . 'libraries/tbl_common.inc.php';
@@ -46,19 +41,7 @@ if (isset($_POST['index'])) {
 }
 
 /* Define dependencies for the concerned controller */
-$dependency_definitions = [
-    'index' => $index,
-];
-
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(IndexesController::class);
-array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
-    },
-    array_keys($dependency_definitions),
-    $dependency_definitions
-);
+$containerBuilder->setParameter('index', $index);
 
 /** @var IndexesController $controller */
 $controller = $containerBuilder->get(IndexesController::class);

--- a/tbl_operations.php
+++ b/tbl_operations.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Index;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Operations;
@@ -23,20 +22,24 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $db, $table, $url_query;
+global $url_query;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
-$checkUserPrivileges = new CheckUserPrivileges($dbi);
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
+/** @var string $table */
+$table = $containerBuilder->getParameter('table');
+
+/** @var CheckUserPrivileges $checkUserPrivileges */
+$checkUserPrivileges = $containerBuilder->get('check_user_privileges');
 $checkUserPrivileges->getPrivileges();
 
 // lower_case_table_names=1 `DB` becomes `db`
@@ -64,9 +67,10 @@ $url_params['goto'] = $url_params['back'] = 'tbl_operations.php';
  */
 /** @var Relation $relation */
 $relation = $containerBuilder->get('relation');
-$operations = new Operations($dbi, $relation);
-
 $cfgRelation = $relation->getRelationsParam();
+
+/** @var Operations $operations */
+$operations = $containerBuilder->get('operations');
 
 // reselect current db (needed in some cases probably due to
 // the calling of PhpMyAdmin\Relation)

--- a/tbl_relation.php
+++ b/tbl_relation.php
@@ -57,8 +57,6 @@ $upd_query = new Table($table, $db, $dbi);
 
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
-    'db' => $container->get('db'),
-    'table' => $container->get('table'),
     'options_array' => $options_array,
     'cfgRelation' => $cfgRelation,
     'tbl_storage_engine' => $tbl_storage_engine,

--- a/tbl_relation.php
+++ b/tbl_relation.php
@@ -17,9 +17,7 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Table\RelationController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Relation;
-use PhpMyAdmin\Response;
 use PhpMyAdmin\Table;
 use PhpMyAdmin\Util;
 use Symfony\Component\DependencyInjection\Definition;
@@ -30,16 +28,12 @@ if (! defined('ROOT_PATH')) {
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /* Define dependencies for the concerned controller */
-$db = $container->get('db');
-$table = $container->get('table');
+$db = $containerBuilder->getParameter('db');
+$table = $containerBuilder->getParameter('table');
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $options_array = [
     'CASCADE' => 'CASCADE',

--- a/tbl_sql.php
+++ b/tbl_sql.php
@@ -26,10 +26,10 @@ $container = Container::getDefaultContainer();
 $container->set(Response::class, Response::getInstance());
 
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [

--- a/tbl_sql.php
+++ b/tbl_sql.php
@@ -18,8 +18,6 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $db, $table;
-
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
 $container = Container::getDefaultContainer();
@@ -30,22 +28,6 @@ $response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
 $dbi = $containerBuilder->get(DatabaseInterface::class);
-
-/* Define dependencies for the concerned controller */
-$dependency_definitions = [
-    'db' => $container->get('db'),
-    'table' => $container->get('table'),
-];
-
-/** @var Definition $definition */
-$definition = $containerBuilder->getDefinition(SqlController::class);
-array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
-    },
-    array_keys($dependency_definitions),
-    $dependency_definitions
-);
 
 /** @var SqlController $controller */
 $controller = $containerBuilder->get(SqlController::class);

--- a/tbl_structure.php
+++ b/tbl_structure.php
@@ -18,7 +18,7 @@ if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 }
 
-global $db, $table, $db_is_system_schema, $tbl_is_view, $tbl_storage_engine;
+global $db_is_system_schema, $tbl_is_view, $tbl_storage_engine;
 global $table_info_num_rows, $tbl_collation, $showtable;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
@@ -30,11 +30,14 @@ $container->alias('response', Response::class);
 /** @var DatabaseInterface $dbi */
 $dbi = $container->get(DatabaseInterface::class);
 
-$dbi->selectDb($GLOBALS['db']);
-$table_class_object = $dbi->getTable(
-    $GLOBALS['db'],
-    $GLOBALS['table']
-);
+/** @var string $db */
+$db = $containerBuilder->getParameter('db');
+
+/** @var string $table */
+$table = $containerBuilder->getParameter('table');
+
+$dbi->selectDb($db);
+$table_class_object = $dbi->getTable($db, $table);
 $reread_info = $table_class_object->getStatusInfo(null, true);
 $GLOBALS['showtable'] = $table_class_object->getStatusInfo(null, (isset($reread_info) && $reread_info ? true : false));
 if ($table_class_object->isView()) {
@@ -48,8 +51,6 @@ $tbl_collation = $table_class_object->getCollation();
 $table_info_num_rows = $table_class_object->getNumRows();
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
-    'db' => $db,
-    'table' => $table,
     'db_is_system_schema' => $db_is_system_schema,
     'tbl_is_view' => $tbl_is_view,
     'tbl_storage_engine' => $tbl_storage_engine,

--- a/tbl_structure.php
+++ b/tbl_structure.php
@@ -10,8 +10,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Table\StructureController;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
-use PhpMyAdmin\Response;
 use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
@@ -23,12 +21,8 @@ global $table_info_num_rows, $tbl_collation, $showtable;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-$container->alias('response', Response::class);
-
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get('dbi');
 
 /** @var string $db */
 $db = $containerBuilder->getParameter('db');

--- a/test/bootstrap-dist.php
+++ b/test/bootstrap-dist.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\LanguageManager;
 use PhpMyAdmin\MoTranslator\Loader;
 use PhpMyAdmin\Theme;
@@ -79,7 +80,9 @@ define('PMA_MAJOR_VERSION', $GLOBALS['PMA_Config']->get('PMA_MAJOR_VERSION'));
 LanguageManager::getInstance()->getLanguage('en')->activate();
 
 /* Load Database interface */
-DatabaseInterface::load();
+$oldContainer = Container::getDefaultContainer();
+$oldContainer->set(DatabaseInterface::class, DatabaseInterface::load());
+$oldContainer->alias('dbi', DatabaseInterface::class);
 
 // Set proxy information from env, if available
 $http_proxy = getenv('http_proxy');

--- a/test/bootstrap-phpstan.php
+++ b/test/bootstrap-phpstan.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\MoTranslator\Loader;
 
 if (! defined('ROOT_PATH')) {
@@ -38,4 +39,6 @@ $GLOBALS['PMA_Config']->enableBc();// Defines constants, phpstan:level=1
 
 Loader::loadFunctions();
 
-DatabaseInterface::load();
+$oldContainer = Container::getDefaultContainer();
+$oldContainer->set(DatabaseInterface::class, DatabaseInterface::load());
+$oldContainer->alias('dbi', DatabaseInterface::class);

--- a/transformation_overview.php
+++ b/transformation_overview.php
@@ -11,7 +11,6 @@ use PhpMyAdmin\Controllers\TransformationOverviewController;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Response;
-use PhpMyAdmin\Transformations;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);

--- a/transformation_wrapper.php
+++ b/transformation_wrapper.php
@@ -24,14 +24,11 @@ global $db, $table;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 /** @var Transformations $transformations */
 $transformations = $containerBuilder->get('transformations');

--- a/transformation_wrapper.php
+++ b/transformation_wrapper.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Transformations;

--- a/view_operations.php
+++ b/view_operations.php
@@ -8,7 +8,6 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Operations;
 use PhpMyAdmin\Relation;

--- a/view_operations.php
+++ b/view_operations.php
@@ -25,14 +25,11 @@ global $sql_query, $url_query;
 
 require_once ROOT_PATH . 'libraries/common.inc.php';
 
-$container = Container::getDefaultContainer();
-$container->set(Response::class, Response::getInstance());
-
 /** @var Response $response */
-$response = $container->get(Response::class);
+$response = $containerBuilder->get(Response::class);
 
 /** @var DatabaseInterface $dbi */
-$dbi = $container->get(DatabaseInterface::class);
+$dbi = $containerBuilder->get(DatabaseInterface::class);
 
 $pma_table = new Table($GLOBALS['table'], $GLOBALS['db']);
 


### PR DESCRIPTION
### Description

Try to get rid of PhpMyAdmin\DI and replace it by Symfony DI.
Some tasks are needed, like giving all needed objects to every scripts / classes (instead of getting instance of container) and use `db`, `table`, … as DI parameters instead of updating the definition.

Related to #15266 and #15271

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
