### PR TITLE
Fixes #10846 TypeError: Cannot read property 'substring' of undefined

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -147,7 +147,7 @@ var PMA_commonActions = {
      */
     refreshMain: function (url, callback) {
         if (! url) {
-            url = $('#selflink').find('a').attr('href');
+            url = $('#selflink').find('a').attr('href') || window.location.pathname;
             url = url.substring(0, url.indexOf('?'));
         }
         url += PMA_commonParams.getUrlQuery();

--- a/libraries/classes/Controllers/Database/DatabaseStructureController.php
+++ b/libraries/classes/Controllers/Database/DatabaseStructureController.php
@@ -384,23 +384,7 @@ class DatabaseStructureController extends DatabaseController
     {
         // filtering
         $this->response->addHTML(
-            Template::get('filter')->render(array('filter_value' => ''))
-        );
-        // table form
-        $this->response->addHTML(
-            Template::get('database/structure/table_header')->render([
-                'db' => $this->db,
-                'db_is_system_schema' => $this->_db_is_system_schema,
-                'replication' => $GLOBALS['replication_info']['slave']['status'],
-                'properties_num_columns' => $GLOBALS['cfg']['PropertiesNumColumns'],
-                'is_show_stats' => $GLOBALS['is_show_stats'],
-                'show_charset' => $GLOBALS['cfg']['ShowDbStructureCharset'],
-                'show_comment' => $GLOBALS['cfg']['ShowDbStructureComment'],
-                'show_creation' => $GLOBALS['cfg']['ShowDbStructureCreation'],
-                'show_last_update' => $GLOBALS['cfg']['ShowDbStructureLastUpdate'],
-                'show_last_check' => $GLOBALS['cfg']['ShowDbStructureLastCheck'],
-                'num_favorite_tables' => $GLOBALS['cfg']['NumFavoriteTables'],
-            ])
+            Template::get('filter')->render(['filter_value' => ''])
         );
 
         $i = $sum_entries = 0;
@@ -417,6 +401,7 @@ class DatabaseStructureController extends DatabaseController
 
         $hidden_fields = array();
         $overall_approx_rows = false;
+        $structure_table_rows = [];
         foreach ($this->_tables as $keyname => $current_table) {
             // Get valid statistics whatever is the table type
 
@@ -616,10 +601,6 @@ class DatabaseStructureController extends DatabaseController
                 $row_count = 1;
 
                 $this->response->addHTML(
-                    '</tr></tbody></table></div></form>'
-                );
-
-                $this->response->addHTML(
                     Template::get('database/structure/table_header')->render([
                         'db' => $this->db,
                         'db_is_system_schema' => $this->_db_is_system_schema,
@@ -632,8 +613,10 @@ class DatabaseStructureController extends DatabaseController
                         'show_last_update' => $GLOBALS['cfg']['ShowDbStructureLastUpdate'],
                         'show_last_check' => $GLOBALS['cfg']['ShowDbStructureLastCheck'],
                         'num_favorite_tables' => $GLOBALS['cfg']['NumFavoriteTables'],
+                        'structure_table_rows' => $structure_table_rows,
                     ])
                 );
+                $structure_table_rows = [];
             }
 
             list($approx_rows, $show_superscript) = $this->isRowCountApproximated(
@@ -642,70 +625,75 @@ class DatabaseStructureController extends DatabaseController
 
             list($do, $ignored) = $this->getReplicationStatus($truename);
 
-            $this->response->addHTML(
-                Template::get('database/structure/structure_table_row')
-                    ->render(
-                        array(
-                            'db'                    => $this->db,
-                            'curr'                  => $i,
-                            'input_class'           => implode(' ', $input_class),
-                            'table_is_view'         => $table_is_view,
-                            'current_table'         => $current_table,
-                            'browse_table_label'    => $browse_table_label,
-                            'tracking_icon'         => $this->getTrackingIcon($truename),
-                            'server_slave_status'   => $GLOBALS['replication_info']['slave']['status'],
-                            'browse_table'          => $browse_table,
-                            'tbl_url_query'         => $tbl_url_query,
-                            'search_table'          => $search_table,
-                            'db_is_system_schema'   => $this->_db_is_system_schema,
-                            'titles'                => $titles,
-                            'empty_table'           => $empty_table,
-                            'drop_query'            => $drop_query,
-                            'drop_message'          => $drop_message,
-                            'collation'             => $collation,
-                            'formatted_size'        => $formatted_size,
-                            'unit'                  => $unit,
-                            'overhead'              => $overhead,
-                            'create_time'           => isset($create_time)
-                                ? $create_time : '',
-                            'update_time'           => isset($update_time)
-                                ? $update_time : '',
-                            'check_time'            => isset($check_time)
-                                ? $check_time : '',
-                            'charset'               => isset($charset)
-                                ? $charset : '',
-                            'is_show_stats'         => $this->_is_show_stats,
-                            'ignored'               => $ignored,
-                            'do'                    => $do,
-                            'approx_rows'           => $approx_rows,
-                            'show_superscript'      => $show_superscript,
-                            'already_favorite'      => $this->checkFavoriteTable(
-                                $current_table['TABLE_NAME']
-                            ),
-                            'num_favorite_tables'   => $GLOBALS['cfg']['NumFavoriteTables'],
-                            'properties_num_columns' => $GLOBALS['cfg']['PropertiesNumColumns'],
-                            'limit_chars'            => $GLOBALS['cfg']['LimitChars'],
-                            'show_charset'           => $GLOBALS['cfg']['ShowDbStructureCharset'],
-                            'show_comment'           => $GLOBALS['cfg']['ShowDbStructureComment'],
-                            'show_creation'          => $GLOBALS['cfg']['ShowDbStructureCreation'],
-                            'show_last_update'       => $GLOBALS['cfg']['ShowDbStructureLastUpdate'],
-                            'show_last_check'        => $GLOBALS['cfg']['ShowDbStructureLastCheck'],
-                        )
-                    )
-            );
+            $structure_table_rows[] = [
+                'db'                    => $this->db,
+                'curr'                  => $i,
+                'input_class'           => implode(' ', $input_class),
+                'table_is_view'         => $table_is_view,
+                'current_table'         => $current_table,
+                'browse_table_label'    => $browse_table_label,
+                'tracking_icon'         => $this->getTrackingIcon($truename),
+                'server_slave_status'   => $GLOBALS['replication_info']['slave']['status'],
+                'browse_table'          => $browse_table,
+                'tbl_url_query'         => $tbl_url_query,
+                'search_table'          => $search_table,
+                'db_is_system_schema'   => $this->_db_is_system_schema,
+                'titles'                => $titles,
+                'empty_table'           => $empty_table,
+                'drop_query'            => $drop_query,
+                'drop_message'          => $drop_message,
+                'collation'             => $collation,
+                'formatted_size'        => $formatted_size,
+                'unit'                  => $unit,
+                'overhead'              => $overhead,
+                'create_time'           => isset($create_time)
+                    ? $create_time : '',
+                'update_time'           => isset($update_time)
+                    ? $update_time : '',
+                'check_time'            => isset($check_time)
+                    ? $check_time : '',
+                'charset'               => isset($charset)
+                    ? $charset : '',
+                'is_show_stats'         => $this->_is_show_stats,
+                'ignored'               => $ignored,
+                'do'                    => $do,
+                'approx_rows'           => $approx_rows,
+                'show_superscript'      => $show_superscript,
+                'already_favorite'      => $this->checkFavoriteTable(
+                    $current_table['TABLE_NAME']
+                ),
+                'num_favorite_tables'   => $GLOBALS['cfg']['NumFavoriteTables'],
+                'properties_num_columns' => $GLOBALS['cfg']['PropertiesNumColumns'],
+                'limit_chars'            => $GLOBALS['cfg']['LimitChars'],
+                'show_charset'           => $GLOBALS['cfg']['ShowDbStructureCharset'],
+                'show_comment'           => $GLOBALS['cfg']['ShowDbStructureComment'],
+                'show_creation'          => $GLOBALS['cfg']['ShowDbStructureCreation'],
+                'show_last_update'       => $GLOBALS['cfg']['ShowDbStructureLastUpdate'],
+                'show_last_check'        => $GLOBALS['cfg']['ShowDbStructureLastCheck'],
+            ];
 
             $overall_approx_rows = $overall_approx_rows || $approx_rows;
         } // end foreach
 
-        $this->response->addHTML('</tbody>');
-
         $db_collation = $this->dbi->getDbCollation($this->db);
         $db_charset = mb_substr($db_collation, 0, mb_strpos($db_collation, "_"));
 
-        // Show Summary
+        // table form
         $this->response->addHTML(
-            Template::get('database/structure/body_for_table_summary')->render(
-                array(
+            Template::get('database/structure/table_header')->render([
+                'db' => $this->db,
+                'db_is_system_schema' => $this->_db_is_system_schema,
+                'replication' => $GLOBALS['replication_info']['slave']['status'],
+                'properties_num_columns' => $GLOBALS['cfg']['PropertiesNumColumns'],
+                'is_show_stats' => $GLOBALS['is_show_stats'],
+                'show_charset' => $GLOBALS['cfg']['ShowDbStructureCharset'],
+                'show_comment' => $GLOBALS['cfg']['ShowDbStructureComment'],
+                'show_creation' => $GLOBALS['cfg']['ShowDbStructureCreation'],
+                'show_last_update' => $GLOBALS['cfg']['ShowDbStructureLastUpdate'],
+                'show_last_check' => $GLOBALS['cfg']['ShowDbStructureLastCheck'],
+                'num_favorite_tables' => $GLOBALS['cfg']['NumFavoriteTables'],
+                'structure_table_rows' => $structure_table_rows,
+                'body_for_table_summary' => [
                     'num_tables' => $this->_num_tables,
                     'server_slave_status' => $GLOBALS['replication_info']['slave']['status'],
                     'db_is_system_schema' => $this->_db_is_system_schema,
@@ -728,24 +716,18 @@ class DatabaseStructureController extends DatabaseController
                     'show_creation' => $GLOBALS['cfg']['ShowDbStructureCreation'],
                     'show_last_update' => $GLOBALS['cfg']['ShowDbStructureLastUpdate'],
                     'show_last_check' => $GLOBALS['cfg']['ShowDbStructureLastCheck'],
-                )
-            )
-        );
-        $this->response->addHTML('</table>');
-
-        //check all
-        $this->response->addHTML(
-            Template::get('database/structure/check_all_tables')->render([
-                'pma_theme_image' => $GLOBALS['pmaThemeImage'],
-                'text_dir' => $GLOBALS['text_dir'],
-                'overhead_check' => $overhead_check,
-                'db_is_system_schema' => $this->_db_is_system_schema,
-                'hidden_fields' => $hidden_fields,
-                'disable_multi_table' => $GLOBALS['cfg']['DisableMultiTableMaintenance'],
-                'central_columns_work' => $GLOBALS['cfgRelation']['centralcolumnswork'],
+                ],
+                'check_all_tables' => [
+                    'pma_theme_image' => $GLOBALS['pmaThemeImage'],
+                    'text_dir' => $GLOBALS['text_dir'],
+                    'overhead_check' => $overhead_check,
+                    'db_is_system_schema' => $this->_db_is_system_schema,
+                    'hidden_fields' => $hidden_fields,
+                    'disable_multi_table' => $GLOBALS['cfg']['DisableMultiTableMaintenance'],
+                    'central_columns_work' => $GLOBALS['cfgRelation']['centralcolumnswork'],
+                ],
             ])
         );
-        $this->response->addHTML('</form>'); //end of form
     }
 
     /**

--- a/templates/database/structure/table_header.twig
+++ b/templates/database/structure/table_header.twig
@@ -65,3 +65,16 @@
         </tr>
     </thead>
     <tbody>
+    {% for structure_table_row in structure_table_rows %}
+        {% include 'database/structure/structure_table_row.twig' with structure_table_row only %}
+    {% endfor %}
+    </tbody>
+    {% if body_for_table_summary %}
+        {% include 'database/structure/body_for_table_summary.twig' with body_for_table_summary only %}
+    {% endif %}
+</table>
+</div>
+{% if check_all_tables %}
+    {% include 'database/structure/check_all_tables.twig' with check_all_tables only %}
+{% endif %}
+</form>


### PR DESCRIPTION
Signed-off-by: Eugene Kazakov <ekazakov@plesk.com>

### Description

Fixes #10846
The issue could be reproduced with phpMyAdmin versions 4.8.5 and 5.0.0-dev with the following steps:

1. Create a database and a table (empty is okay)
2. Click on the database name
3. Refresh the browser (notice the icon "Open new phpMyAdmin window" in the right bottom corner is present)
4. Click on the table name (notice the icon "Open new phpMyAdmin window" disappeared)
5. Click "Operations"
6. "Rename table to" enter a new name and click "Go"

**Javascript TypeError: Cannot read property 'substring' of undefined**
```json
{
    "pma_version": "4.8.5",
    "browser_name": "CHROME",
    "browser_version": "74.0.3729.131",
    "user_os": "Mac",
    "server_software": "nginx/1.14.1",
    "user_agent_string": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36",
    "locale": "en",
    "configuration_storage": "enabled",
    "php_version": "7.3.5",
    "exception_type": "js",
    "exception": {
        "mode": "stack",
        "name": "TypeError",
        "message": "Cannot read property 'substring' of undefined",
        "stack": [
            {
                "func": "Object.refreshMain",
                "line": "151",
                "column": "23",
                "uri": "index.php?v=4.8.5",
                "scriptname": "index.php"
            },
            {
                "func": "Object.success",
                "line": "114",
                "column": "39",
                "uri": "index.php?v=4.8.5",
                "scriptname": "index.php"
            },
            {
                "func": "u",
                "line": "2",
                "column": "27457",
                "uri": "index.php?v=4.8.5",
                "scriptname": "index.php"
            },
            {
                "func": "Object.fireWith [as resolveWith]",
                "line": "2",
                "column": "28202",
                "uri": "index.php?v=4.8.5",
                "scriptname": "index.php"
            },
            {
                "func": "k",
                "line": "2",
                "column": "77651",
                "uri": "index.php?v=4.8.5",
                "scriptname": "index.php"
            },
            {
                "func": "XMLHttpRequest.",
                "line": "2",
                "column": "79907",
                "uri": "index.php?v=4.8.5",
                "scriptname": "index.php"
            }
        ],
        "uri": "index.php?"
    },
    "script_name": "index.php",
    "microhistory": null
}
```

The root cause of the issue is a corrupted layout: missing closing `div` - because of it, `selflink` appears inside `page_content` and then is replaced with the content of the next page.
I would like to also make the redirect function more reliable and use a fallback with the current location in case the link is lost again.

Let me know if it makes sense to submit the PR to a released version branch.
