### PR TITLE
Fix phpmyadmin #15287 : Fix auto_increment field is too small

### DIFF
--- a/themes/original/css/common.css.php
+++ b/themes/original/css/common.css.php
@@ -2114,6 +2114,10 @@ fieldset .disabled-field td {
     -webkit-box-sizing: border-box;
 }
 
+input#auto_increment_opt {
+    width: min-content;
+}
+
 #placeholder {
     position: relative;
     border: 1px solid #aaa;

--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -224,6 +224,10 @@ input[type=number] {
     width: 50px;
 }
 
+input#auto_increment_opt {
+    width: min-content;
+}
+
 input[type=text],
 input[type=password],
 input[type=number],


### PR DESCRIPTION
Signed-off-by: Ankush Patil <aspraz2658@gmail.com>

### Description
As per issue #15287 : The auto_increment field only shows 5 most significant digits of numbers greater than 99999. Fixed using adding css style to id of the input field.

Fixes #15287 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
