### PR TITLE
Add support for Twig 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "phpseclib/phpseclib": "^2.0",
         "google/recaptcha": "^1.1",
         "psr/container": "^1.0",
-        "twig/twig": "^1.34",
+        "twig/twig": "^1.34 || ^2.0",
         "twig/extensions": "~1.5.1",
         "symfony/expression-language": "^3.2 || ^2.8",
         "symfony/polyfill-mbstring": "^1.3"


### PR DESCRIPTION
### Description

Adds support for Twig 2 in `QA_4_9` branch to help package maintainers who wants to use PHP 7.

Twig 2 has a lot of backward compatibility with Twig 1, so this upgrade is probably safe.