### PR TITLE
Add working environment configuration directive

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -3433,6 +3433,18 @@ Developer
 
     These settings might have huge effect on performance or security.
 
+.. config:option:: $cfg['environment']
+
+    :type: string
+    :default: ``'production'``
+
+    Sets the working environment.
+
+    This only needs to be changed when you are developing phpMyAdmin itself.
+    The ``development`` mode may display debug information in some places.
+
+    Possible values are ``'production'`` or ``'development'``.
+
 .. config:option:: $cfg['DBG']
 
     :type: array

--- a/libraries/classes/Template.php
+++ b/libraries/classes/Template.php
@@ -26,6 +26,7 @@ use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
+use Twig\Extension\DebugExtension;
 use Twig\Loader\FilesystemLoader;
 use Twig_Error_Loader;
 use Twig_Error_Runtime;
@@ -56,6 +57,8 @@ class Template
      */
     public function __construct()
     {
+        global $cfg;
+
         /** @var Config $config */
         $config = $GLOBALS['PMA_Config'];
         if (static::$twig === null) {
@@ -68,8 +71,11 @@ class Template
             $twig = new Environment($loader, [
                 'auto_reload' => true,
                 'cache' => $cache_dir,
-                'debug' => false,
             ]);
+            if ($cfg['environment'] === 'development') {
+                $twig->enableDebug();
+                $twig->addExtension(new DebugExtension());
+            }
             $twig->addExtension(new CoreExtension());
             $twig->addExtension(new I18nExtension());
             $twig->addExtension(new MessageExtension());

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -2858,6 +2858,15 @@ $cfg['DBG']['demo'] = false;
  */
 $cfg['DBG']['simple2fa'] = false;
 
+/**
+ * Sets the working environment
+ *
+ * This only needs to be changed when you are developing phpMyAdmin itself.
+ * The development mode may display debug information in some places.
+ *
+ * Possible values are 'production' or 'development'
+ */
+$cfg['environment'] = 'production';
 
 /*******************************************************************************
  * MySQL settings


### PR DESCRIPTION
### Description

Adds a configuration directive named `environment` that sets the working environment mode to `production` (default) or to `development`.

For now, it only enables the debug mode for Twig templates, however the idea is to use it in more places.

Related to the `environment` configuration introduced in #14464.