### PR TITLE
Implemented password_hash function

### DIFF
--- a/js/table/change.js
+++ b/js/table/change.js
@@ -184,6 +184,15 @@ function verificationsAfterFieldChange (urlField, multiEdit, theType) {
         $('#salt_' + target.id).remove();
     }
 
+    // Alert Message for PASSWORD_HASH to alert it as a PHP function and not SQL function
+    var new_alert_box = '<br><p name=salt[multi_edit][' + multi_edit + '][' + urlField + ']' +
+        ' id=salt_' + target.id + ' placeholder=\'' + PMA_messages.strEncryptionKey + '\'+ style="background-color:#FEF3CD;color:#8E6F29;padding:20px;">' + 'ALERT: PASSWORD_HASH is a PHP function and not a SQL function' + '<p>';
+    if (target.value === 'PASSWORD_HASH'){
+        if (!($('#salt_' + target.id).length)) {
+            $this_input.after(new_alert_box);
+        }
+    }
+
     if (target.value === 'AES_DECRYPT'
             || target.value === 'AES_ENCRYPT'
             || target.value === 'MD5') {

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -2613,6 +2613,12 @@ class InsertEdit
                     . $this->dbi->escapeString($multi_edit_salt[$key]) . "')";
             }
 
+            // php Implementation of password_hash() function
+            elseif ($multi_edit_funcs[$key] == "PASSWORD_HASH") {
+                $current_value = password_hash($current_value,PASSWORD_DEFAULT);
+                return '\'' . $current_value . '\'';
+            }
+
             return $multi_edit_funcs[$key] . '(' . $current_value . ')';
         }
 

--- a/libraries/classes/Types.php
+++ b/libraries/classes/Types.php
@@ -501,6 +501,7 @@ class Types
                     'MONTHNAME',
                     'OLD_PASSWORD',
                     'PASSWORD',
+                    'PASSWORD_HASH',
                     'QUOTE',
                     'REVERSE',
                     'RTRIM',


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description

Password_hash function has been implemented through this PR by php. To use it you must go to Insert field of any column and then select 'PASSWORD_HASH' as a function in some column which supports text like when we use 'PASSWORD' function. Then Enter the desired password and click on 'Go' and you will see that the row has been inserted with password in the form of hash from password_hash function.
 
Fixes #14772 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
