### PR TITLE
Fixed most of deprecated Jquery calls

### DIFF
--- a/js/ajax.js
+++ b/js/ajax.js
@@ -404,7 +404,7 @@ var AJAX = {
             if (data.sendErrorAlways === '1' &&
                 data.stopErrorReportLoop !== '1'
             ) {
-                $('#pma_report_errors_form').submit();
+                $('#pma_report_errors_form').trigger('submit');
                 Functions.ajaxShowMessage(Messages.phpErrorsBeingSubmitted, false);
                 $('html, body').animate({ scrollTop:$(document).height() }, 'slow');
             } else if (data.promptPhpErrors) {
@@ -599,7 +599,7 @@ var AJAX = {
                     if (data.sendErrorAlways === '1' &&
                         data.stopErrorReportLoop !== '1'
                     ) {
-                        $('#pma_report_errors_form').submit();
+                        $('#pma_report_errors_form').trigger('submit');
                         Functions.ajaxShowMessage(Messages.phpErrorsBeingSubmitted, false);
                         $('html, body').animate({ scrollTop:$(document).height() }, 'slow');
                     } else if (data.promptPhpErrors) {

--- a/js/config.js
+++ b/js/config.js
@@ -879,7 +879,7 @@ function offerPrefsAutoimport () {
             return;
         }
         $cnt.find('input[name=json]').val(window.localStorage.config);
-        $cnt.find('form').submit();
+        $cnt.find('form').trigger('submit');
     });
     $cnt.show();
 }

--- a/js/console.js
+++ b/js/console.js
@@ -428,8 +428,8 @@ var ConsoleResizer = {
         }
         ConsoleResizer.posY = event.pageY;
         ConsoleResizer.height = Console.$consoleContent.height();
-        $(document).mousemove(ConsoleResizer.mouseMove);
-        $(document).mouseup(ConsoleResizer.mouseUp);
+        $(document).on('mousemove', ConsoleResizer.mouseMove);
+        $(document).on('mouseup', ConsoleResizer.mouseUp);
         // Disable text selection while resizing
         $(document).on('selectstart', function () {
             return false;

--- a/js/database/central_columns.js
+++ b/js/database/central_columns.js
@@ -55,7 +55,7 @@ AJAX.registerOnload('database/central_columns.js', function () {
         }
         Functions.ajaxShowMessage();
         $('#del_col_name').val(multiDeleteColumns);
-        $('#del_form').submit();
+        $('#del_form').trigger('submit');
     });
     $('#tableslistcontainer').find('button[name="edit_central_columns"]').on('click', function (event) {
         event.preventDefault();
@@ -120,7 +120,7 @@ AJAX.registerOnload('database/central_columns.js', function () {
         $td.confirm(question, null, function () {
             var rownum = $td.data('rownum');
             $('#del_col_name').val('selected_fld%5B%5D=' + $('#checkbox_row_' + rownum).val());
-            $('#del_form').submit();
+            $('#del_form').trigger('submit');
         });
     });
     $('.edit_cancel_form').on('click', function (event) {

--- a/js/database/qbe.js
+++ b/js/database/qbe.js
@@ -45,7 +45,7 @@ AJAX.registerOnload('database/qbe.js', function () {
      */
     $(document).on('change', '#searchId', function () {
         $('#action').val('load');
-        $('#formQBE').submit();
+        $('#formQBE').trigger('submit');
     });
 
     /**

--- a/js/database/structure.js
+++ b/js/database/structure.js
@@ -222,7 +222,7 @@ AJAX.registerOnload('database/structure.js', function () {
             event.stopPropagation();
             jqConfirm(
                 Messages.makeConsistentMessage, function () {
-                    $('#tablesForm').submit();
+                    $('#tablesForm').trigger('submit');
                 }
             );
             return false;
@@ -254,7 +254,7 @@ AJAX.registerOnload('database/structure.js', function () {
                 $('body').append(dialogObj);
                 var buttonOptions = {};
                 buttonOptions[Messages.strContinue] = function () {
-                    $('#ajax_form').submit();
+                    $('#ajax_form').trigger('submit');
                     $(this).dialog('close');
                 };
                 buttonOptions[Messages.strCancel] = function () {
@@ -270,7 +270,7 @@ AJAX.registerOnload('database/structure.js', function () {
                 });
             });
         } else {
-            $('#tablesForm').submit();
+            $('#tablesForm').trigger('submit');
         }
     });
 

--- a/js/designer/history.js
+++ b/js/designer/history.js
@@ -802,7 +802,7 @@ DesignerHistory.buildQuery = function () {
             vqbEditor.save();
             $elm.val(vqbEditor.getValue());
         }
-        $('#vqb_form').submit();
+        $('#vqb_form').trigger('submit');
     };
 
     var $ajaxDialog = $('#box').dialog({
@@ -826,7 +826,7 @@ DesignerHistory.buildQuery = function () {
         vqbEditor.focus();
     } else {
         $elm.val(qSelect);
-        $elm.focus();
+        $elm.trigger('focus');
     }
 };
 

--- a/js/designer/move.js
+++ b/js/designer/move.js
@@ -627,7 +627,7 @@ DesignerMove.save = function (url) {
         document.getElementById('t_h_' + key + '_').value = document.getElementById('check_vis_' + key).checked ? 1 : 0;
     }
     document.form1.action = url;
-    $(document.form1).submit();
+    $(document.form1).trigger('submit');
 };
 
 DesignerMove.getUrlPos = function (forceString) {
@@ -735,7 +735,7 @@ DesignerMove.save3 = function (callback) {
         var buttonOptions = {};
         buttonOptions[Messages.strGo] = function () {
             var $form = $('#save_page');
-            $form.submit();
+            $form.trigger('submit');
         };
         buttonOptions[Messages.strCancel] = function () {
             $(this).dialog('close');
@@ -1043,7 +1043,7 @@ DesignerMove.promptToSaveCurrentPage = function (callback) {
 DesignerMove.exportPages = function () {
     var buttonOptions = {};
     buttonOptions[Messages.strGo] = function () {
-        $('#id_export_pages').submit();
+        $('#id_export_pages').trigger('submit');
         $(this).dialog('close');
     };
     buttonOptions[Messages.strCancel] = function () {

--- a/js/export_output.js
+++ b/js/export_output.js
@@ -3,7 +3,7 @@ AJAX.registerOnload('export_output.js', function () {
     $(document).on('keydown', function (e) {
         if ((e.which || e.keyCode) === 116) {
             e.preventDefault();
-            $('#export_refresh_form').submit();
+            $('#export_refresh_form').trigger('submit');
         }
     });
 });

--- a/js/functions.js
+++ b/js/functions.js
@@ -1021,7 +1021,7 @@ AJAX.registerOnload('functions.js', function () {
                         $('.ui-dialog').each(function () {
                             $('#' + $(this).attr('aria-describedby')).dialog('close');
                         });
-                        $('#input_username').focus();
+                        $('#input_username').trigger('focus');
                     } else {
                         CommonParams.set('token', data.new_token);
                         $('input[name=token]').val(data.new_token);
@@ -1846,7 +1846,7 @@ AJAX.registerOnload('functions.js', function () {
             return false;
         }
         $('.success').hide();
-        $fakeForm.appendTo($('body')).submit();
+        $fakeForm.appendTo($('body')).trigger('submit');
     });
 
     $(document).on('click', 'input#sql_query_edit_discard', function () {
@@ -1990,7 +1990,7 @@ Functions.bindCodeMirrorToInlineEditor = function () {
                 .on('keydown', Functions.catchKeypressesFromSqlInlineEdit);
         } else {
             $inlineEditor
-                .focus()
+                .trigger('focus')
                 .on('keydown', Functions.catchKeypressesFromSqlInlineEdit);
         }
     }
@@ -2455,7 +2455,7 @@ $(function () {
         var $temp = $('<input>');
         $temp.css({ 'position': 'fixed', 'width': '2em', 'border': 0, 'top': 0, 'left': 0, 'padding': 0, 'background': 'transparent' });
         $('body').append($temp);
-        $temp.val(text).select();
+        $temp.val(text).trigger('select');
         try {
             var res = document.execCommand('copy');
             $temp.remove();
@@ -3066,7 +3066,7 @@ Functions.checkPassword = function ($theForm) {
         alert(alertMessage);
         $password.val('');
         $passwordRepeat.val('');
-        $password.focus();
+        $password.trigger('focus');
         return false;
     }
     return true;
@@ -3088,7 +3088,7 @@ AJAX.registerOnload('functions.js', function () {
         } else if (this.value === 'hosttable') {
             hostname.val('').prop('required', false);
         } else if (this.value === 'userdefined') {
-            hostname.focus().select().prop('required', true);
+            hostname.trigger('focus').select().prop('required', true);
         }
     });
 
@@ -3104,7 +3104,7 @@ AJAX.registerOnload('functions.js', function () {
             $('#pma_username').val('').prop('required', false);
             $('#user_exists_warning').css('display', 'none');
         } else if (this.value === 'userdefined') {
-            $('#pma_username').focus().select().prop('required', true);
+            $('#pma_username').trigger('focus').select().prop('required', true);
         }
     });
 
@@ -3121,7 +3121,7 @@ AJAX.registerOnload('functions.js', function () {
             $('#text_pma_pw').prop('required', false).val('');
         } else if (this.value === 'userdefined') {
             $('#text_pma_pw2').prop('required', true);
-            $('#text_pma_pw').prop('required', true).focus().select();
+            $('#text_pma_pw').prop('required', true).trigger('focus').select();
         } else {
             $('#text_pma_pw2').prop('required', false);
             $('#text_pma_pw').prop('required', false);
@@ -3218,7 +3218,7 @@ AJAX.registerOnload('functions.js', function () {
             $('fieldset#fieldset_change_password')
                 .find('legend').remove().end()
                 .find('table.noclick').unwrap().addClass('some-margin')
-                .find('input#text_pma_pw').focus();
+                .find('input#text_pma_pw').trigger('focus');
             $('#fieldset_change_password_footer').hide();
             Functions.ajaxRemoveMessage($msgbox);
             Functions.displayPasswordGenerateButton();
@@ -3500,7 +3500,7 @@ AJAX.registerOnload('functions.js', function () {
             buttons: buttonOptions,
             open: function () {
                 // Focus the "Go" button after opening the dialog
-                $(this).closest('.ui-dialog').find('.ui-dialog-buttonpane button:first').focus();
+                $(this).closest('.ui-dialog').find('.ui-dialog-buttonpane button:first').trigger('focus');
             },
             close: function () {
                 $(this).remove();
@@ -3646,7 +3646,7 @@ AJAX.registerOnload('functions.js', function () {
                     }
                     return false;
                 });
-                $(this).closest('.ui-dialog').find('.ui-dialog-buttonpane button:first').focus();
+                $(this).closest('.ui-dialog').find('.ui-dialog-buttonpane button:first').trigger('focus');
             },
             close: function () {
                 $('#col_list').off('click', '.pick');
@@ -3738,7 +3738,7 @@ AJAX.registerOnload('functions.js', function () {
             if ($(this).find('option:selected').val() === '') {
                 return true;
             }
-            $(this).closest('tr').find('input').focus();
+            $(this).closest('tr').find('input').trigger('focus');
         };
 
         while (rowsToAdd--) {
@@ -3882,14 +3882,14 @@ Functions.showIndexEditDialog = function ($outer) {
         if ($(this).find('option:selected').val() === '') {
             return true;
         }
-        $(this).closest('tr').find('input').focus();
+        $(this).closest('tr').find('input').trigger('focus');
     });
     // Focus the slider, otherwise it looks nearly transparent
     $('a.ui-slider-handle').addClass('ui-state-focus');
     // set focus on index name input, if empty
     var input = $outer.find('input#input_index_name');
     if (! input.val()) {
-        input.focus();
+        input.trigger('focus');
     }
 };
 
@@ -4342,7 +4342,7 @@ AJAX.registerOnload('functions.js', function () {
             codeMirrorEditor.on('blur', Functions.updateQueryParameters);
         } else {
             // without codemirror
-            $elm.focus().on('blur', Functions.updateQueryParameters);
+            $elm.trigger('focus').on('blur', Functions.updateQueryParameters);
         }
     }
     Functions.highlightSql($('body'));
@@ -4437,7 +4437,7 @@ AJAX.registerOnload('functions.js', function () {
      * Automatic form submission on change.
      */
     $(document).on('change', '.autosubmit', function () {
-        $(this).closest('form').submit();
+        $(this).closest('form').trigger('submit');
     });
 
     /**
@@ -4542,7 +4542,7 @@ AJAX.registerOnload('functions.js', function () {
 
                 // with preventing default, selection by <select> tag
                 // was also prevented in IE
-                $(this).blur();
+                $(this).trigger('blur');
 
                 $(this).closest('.ui-dialog').find('.ui-button:first').trigger('click');
             }
@@ -4594,7 +4594,7 @@ Functions.createViewDialog = function ($this) {
             });
             // Attach syntax highlighted editor
             codeMirrorEditor = Functions.getSqlEditor($dialog.find('textarea'));
-            $('input:visible[type=text]', $dialog).first().focus();
+            $('input:visible[type=text]', $dialog).first().trigger('focus');
         } else {
             Functions.ajaxShowMessage(data.error);
         }
@@ -4890,7 +4890,7 @@ Functions.toggleDatepickerIfInvalid = function ($td, $inputField) {
  * Function to submit the login form after validation is done.
  */
 Functions.recaptchaCallback = function () {
-    $('#login_form').submit();
+    $('#login_form').trigger('submit');
 };
 
 /**
@@ -4913,7 +4913,7 @@ AJAX.registerOnload('functions.js', function () {
             if (! $form.find('input[type="submit"]:first') ||
                 ! $form.find('input[type="submit"]:first').trigger('click')
             ) {
-                $form.submit();
+                $form.trigger('submit');
             }
         }
     });

--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -617,7 +617,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     $(g.cEdit).find('.edit_box').val(value);
 
                     g.currentEditCell = cell;
-                    $(g.cEdit).find('.edit_box').focus();
+                    $(g.cEdit).find('.edit_box').trigger('focus');
                     moveCursorToEnd($(g.cEdit).find('.edit_box'));
                     $(g.cEdit).find('*').prop('disabled', false);
                 }
@@ -627,7 +627,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 var originalValue = input.val();
                 var originallength = originalValue.length;
                 input.val('');
-                input.blur().focus().val(originalValue);
+                input.trigger('blur').trigger('focus').val(originalValue);
                 input[0].setSelectionRange(originallength, originallength);
             }
         },
@@ -730,7 +730,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
             // hide the cell editing area
             $(g.cEdit).hide();
-            $(g.cEdit).find('.edit_box').blur();
+            $(g.cEdit).find('.edit_box').trigger('blur');
             g.isCellEditActive = false;
             g.currentEditCell = null;
             // destroy datepicker in edit area, if exist
@@ -1629,13 +1629,13 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         $(this).css('cursor', 'inherit');
                     }
                 })
-                .mouseleave(function () {
+                .on('mouseleave', function () {
                     g.showReorderHint = false;
                     $(this).tooltip('option', {
                         content: g.updateHint()
                     });
                 })
-                .dblclick(function (e) {
+                .on('dblclick', function (e) {
                     e.preventDefault();
                     $('<div></div>')
                         .prop('title', Messages.strColNameCopyTitle)
@@ -1650,10 +1650,10 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             resizable: false,
                             modal: true
                         })
-                        .find('input').focus().select();
+                        .find('input').trigger('focus').trigger('select');
                 });
             $(g.t).find('th.draggable a')
-                .dblclick(function (e) {
+                .on('dblclick', function (e) {
                     e.stopPropagation();
                 });
             // restore column order when the restore button is clicked
@@ -2048,7 +2048,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         }
                     }
                 })
-                .dblclick(function (e) {
+                .on('dblclick', function (e) {
                     if ($(e.target).is('.grid_edit a')) {
                         e.preventDefault();
                     } else {
@@ -2058,7 +2058,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
             $(g.cEditStd).on('keydown', 'input.edit_box, select', handleCtrlNavigation);
 
-            $(g.cEditStd).find('.edit_box').focus(function () {
+            $(g.cEditStd).find('.edit_box').on('focus', function () {
                 g.showEditArea();
             });
             $(g.cEditStd).on('keydown', '.edit_box, select', function (e) {
@@ -2077,7 +2077,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
             $(g.cEditTextarea).on('keydown', 'textarea.edit_box, select', handleCtrlNavigation);
 
-            $(g.cEditTextarea).find('.edit_box').focus(function () {
+            $(g.cEditTextarea).find('.edit_box').on('focus', function () {
                 g.showEditArea();
             });
             $(g.cEditTextarea).on('keydown', '.edit_box, select', function (e) {
@@ -2231,7 +2231,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 content: g.updateHint()
             });
         })
-        .mouseleave(function () {
+        .on('mouseleave', function () {
             g.showSortHint = false;
             g.showMultiSortHint = false;
             $(t).find('th.draggable').tooltip('option', {
@@ -2241,10 +2241,10 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
     // register events for dragging-related feature
     if (isResizeEnabled || isReorderEnabled) {
-        $(document).mousemove(function (e) {
+        $(document).on('mousemove', function (e) {
             g.dragMove(e);
         });
-        $(document).mouseup(function (e) {
+        $(document).on('mouseup', function (e) {
             $(g.o).removeClass('turnOffSelect');
             g.dragEnd(e);
         });

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -220,7 +220,7 @@ Navigation.collapseTreeNode = function ($expandElem) {
             $children.slideUp('fast');
         }
     }
-    $expandElem.blur();
+    $expandElem.trigger('blur');
     $children.promise().done(Navigation.treeStateUpdate);
 };
 
@@ -720,7 +720,7 @@ Navigation.expandTreeNode = function ($expandElem, callback) {
             $children.promise().done(Navigation.treeStateUpdate);
         });
     }
-    $expandElem.blur();
+    $expandElem.trigger('blur');
 };
 
 /**
@@ -1448,7 +1448,7 @@ Navigation.FastFilter = {
             if ($(this).val() === this.defaultValue) {
                 $(this).val('');
             } else {
-                $(this).select();
+                $(this).trigger('select');
             }
         },
         blur: function () {
@@ -1647,7 +1647,7 @@ Navigation.FastFilter.Filter.prototype.restore = function (focus) {
         this.$this.html(this.$clone.html()).children().show();
         this.$this.data('fastFilter', this);
         if (focus) {
-            this.$this.find('li.fast_filter input.searchClause').focus();
+            this.$this.find('li.fast_filter input.searchClause').trigger('focus');
         }
     }
     this.searchClause = '';

--- a/js/normalization.js
+++ b/js/normalization.js
@@ -445,11 +445,11 @@ function moveRepeatingGroup (repeatingCols) {
     var newTable = $('input[name=repeatGroupTable]').val();
     var newColumn = $('input[name=repeatGroupColumn]').val();
     if (!newTable) {
-        $('input[name=repeatGroupTable]').focus();
+        $('input[name=repeatGroupTable]').trigger('focus');
         return false;
     }
     if (!newColumn) {
-        $('input[name=repeatGroupColumn]').focus();
+        $('input[name=repeatGroupColumn]').trigger('focus');
         return false;
     }
     var datastring = {
@@ -544,7 +544,7 @@ AJAX.registerOnload('normalization.js', function () {
     $('.tblFooters').on('click','#saveSplit', function () {
         centralColumnList = [];
         if ($('#newCols #field_0_1').val() === '') {
-            $('#newCols #field_0_1').focus();
+            $('#newCols #field_0_1').trigger('focus');
             return false;
         }
         var argsep = CommonParams.get('arg_separator');

--- a/js/page_settings.js
+++ b/js/page_settings.js
@@ -11,7 +11,7 @@
 function showSettings (selector) {
     var buttons = {};
     buttons[Messages.strApply] = function () {
-        $('.config-form').submit();
+        $('.config-form').trigger('submit');
     };
 
     buttons[Messages.strCancel] = function () {

--- a/js/rte.js
+++ b/js/rte.js
@@ -78,7 +78,7 @@ RTE.COMMON = {
         // and the definition must be provided for an item
         $elm = $('table.rte_table').last().find('input[name=item_name]');
         if ($elm.val() === '') {
-            $elm.focus();
+            $elm.trigger('focus');
             alert(Messages.strFormEmpty);
             return false;
         }
@@ -87,7 +87,7 @@ RTE.COMMON = {
             if (this.syntaxHiglighter !== null) {
                 this.syntaxHiglighter.focus();
             } else {
-                $('textarea[name=item_definition]').last().focus();
+                $('textarea[name=item_definition]').last().trigger('focus');
             }
             alert(Messages.strFormEmpty);
             return false;
@@ -345,7 +345,7 @@ RTE.COMMON = {
                         if ($('#rteDialog').parents('.ui-dialog').height() > $(window).height()) {
                             $('#rteDialog').dialog('option', 'height', $(window).height());
                         }
-                        $(this).find('input[name=item_name]').focus();
+                        $(this).find('input[name=item_name]').trigger('focus');
                         $(this).find('input.datefield').each(function () {
                             Functions.addDatepicker($(this).css('width', '95%'), 'date');
                         });
@@ -555,7 +555,7 @@ RTE.EVENT = {
             // The interval field must not be empty for recurring events
             $elm = this.$ajaxDialog.find('input[name=item_interval_value]');
             if ($elm.val() === '') {
-                $elm.focus();
+                $elm.trigger('focus');
                 alert(Messages.strFormEmpty);
                 return false;
             }
@@ -563,7 +563,7 @@ RTE.EVENT = {
             // The execute_at field must not be empty for "once off" events
             $elm = this.$ajaxDialog.find('input[name=item_execute_at]');
             if ($elm.val() === '') {
-                $elm.focus();
+                $elm.trigger('focus');
                 alert(Messages.strFormEmpty);
                 return false;
             }
@@ -673,7 +673,7 @@ RTE.ROUTINE = {
                         inputname.substr(0, 15) === 'item_param_name' ||
                         inputname.substr(0, 15) === 'item_param_type') {
                         if ($(this).val() === '') {
-                            $(this).focus();
+                            $(this).trigger('focus');
                             isSuccess = false;
                             return false;
                         }
@@ -695,7 +695,7 @@ RTE.ROUTINE = {
                 if (($inputtyp.val() === 'ENUM' || $inputtyp.val() === 'SET' || $inputtyp.val().substr(0, 3) === 'VAR') &&
                     $inputlen.val() === ''
                 ) {
-                    $inputlen.focus();
+                    $inputlen.trigger('focus');
                     isSuccess = false;
                     return false;
                 }
@@ -713,7 +713,7 @@ RTE.ROUTINE = {
             if (($returntyp.val() === 'ENUM' || $returntyp.val() === 'SET' || $returntyp.val().substr(0, 3) === 'VAR') &&
                 $returnlen.val() === ''
             ) {
-                $returnlen.focus();
+                $returnlen.trigger('focus');
                 alert(Messages.strFormEmpty);
                 return false;
             }
@@ -868,7 +868,7 @@ RTE.ROUTINE = {
                             $(this).remove();
                         }
                     });
-                    $ajaxDialog.find('input[name^=params]').first().focus();
+                    $ajaxDialog.find('input[name^=params]').first().trigger('focus');
                     /**
                      * Attach the datepickers to the relevant form fields
                      */

--- a/js/server/databases.js
+++ b/js/server/databases.js
@@ -105,7 +105,7 @@ AJAX.registerOnload('server/databases.js', function () {
         // TODO Remove this section when all browsers support HTML5 "required" property
         var newDbNameInput = $form.find('input[name=new_db]');
         if (newDbNameInput.val() === '') {
-            newDbNameInput.focus();
+            newDbNameInput.trigger('focus');
             alert(Messages.strFormEmpty);
             return;
         }

--- a/js/server/privileges.js
+++ b/js/server/privileges.js
@@ -479,7 +479,7 @@ AJAX.registerOnload('server/privileges.js', function () {
         $('html, body').animate({ scrollTop: 0 }, 'fast');
     };
 
-    $('input.autofocus').focus();
+    $('input.autofocus').trigger('focus');
     $(checkboxesSel).trigger('change');
     Functions.displayPasswordGenerateButton();
     if ($('#edit_user_dialog').length > 0) {

--- a/js/server/status/monitor.js
+++ b/js/server/status/monitor.js
@@ -1318,7 +1318,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
             drawTimeSpan = false;
         });
 
-        $(document.body).mouseup(function () {
+        $(document.body).on('mouseup', function () {
             if ($('#selection_box').length) {
                 $('#selection_box').remove();
             }

--- a/js/server/variables.js
+++ b/js/server/variables.js
@@ -100,7 +100,7 @@ AJAX.registerOnload('server/variables.js', function () {
                     .data('content', $valueCell.html())
                     .html($editor)
                     .find('input')
-                    .focus()
+                    .trigger('focus')
                     .on('keydown', function (event) { // Keyboard shortcuts
                         if (event.keyCode === 13) { // Enter key
                             $mySaveLink.trigger('click');

--- a/js/sql.js
+++ b/js/sql.js
@@ -758,7 +758,7 @@ AJAX.registerOnload('sql.js', function () {
 
         if (query.length === 0) {
             alert(Messages.strFormEmpty);
-            $('#sqlquery').focus();
+            $('#sqlquery').trigger('focus');
             return false;
         }
 

--- a/js/table/change.js
+++ b/js/table/change.js
@@ -463,7 +463,7 @@ AJAX.registerOnload('table/change.js', function () {
     /**
      * Handle ENTER key when press on Continue insert with field
      */
-    $('#insert_rows').keypress(function (e) {
+    $('#insert_rows').on('keypress', function (e) {
         var key = e.which;
         if (key === 13) {
             addNewContinueInsertionFiels(e);

--- a/js/table/chart.js
+++ b/js/table/chart.js
@@ -311,14 +311,14 @@ AJAX.registerOnload('table/chart.js', function () {
 
     // handle changes in chart title
     $('input[name="chartTitle"]')
-        .focus(function () {
+        .on('focus', function () {
             tempChartTitle = $(this).val();
         })
         .on('keyup', function () {
             currentSettings.title = $('input[name="chartTitle"]').val();
             drawChart();
         })
-        .blur(function () {
+        .on('blur', function () {
             if ($(this).val() !== tempChartTitle) {
                 drawChart();
             }
@@ -421,5 +421,5 @@ AJAX.registerOnload('table/chart.js', function () {
     onXAxisChange();
     onDataSeriesChange();
 
-    $('#tblchartform').submit();
+    $('#tblchartform').trigger('submit');
 });

--- a/js/table/operations.js
+++ b/js/table/operations.js
@@ -100,10 +100,10 @@ AJAX.registerOnload('table/operations.js', function () {
         } else {
             if ($tblCollationField.val() !== collationOrigValue && $changeAllColumnCollationsCheckBox.is(':checked')) {
                 $form.confirm(question, $form.attr('action'), function () {
-                    $form.removeClass('ajax').submit().addClass('ajax');
+                    $form.removeClass('ajax').trigger('submit').addClass('ajax');
                 });
             } else {
-                $form.removeClass('ajax').submit().addClass('ajax');
+                $form.removeClass('ajax').trigger('submit').addClass('ajax');
             }
         }
 

--- a/js/u2f.js
+++ b/js/u2f.js
@@ -23,7 +23,7 @@ AJAX.registerOnload('u2f.js', function () {
 
                 // Fill and submit form.
                 $inputReg.val(JSON.stringify(data));
-                $formReg.submit();
+                $formReg.trigger('submit');
             });
         }, 1000);
     }
@@ -50,7 +50,7 @@ AJAX.registerOnload('u2f.js', function () {
 
                 // Fill and submit form.
                 $inputAuth.val(JSON.stringify(data));
-                $formAuth.submit();
+                $formAuth.trigger('submit');
             });
         }, 1000);
     }


### PR DESCRIPTION
```regex
\.(blur|focus|focusin|focusout|resize|scroll|click|dblclick|mousedown|mouseup|mousemove|mouseover|mouseout|mouseenter|mouseleave|change|select|submit|keydown|keypress|keyup|contextmenu)\(\)
```

Ref:  #13173

