### PR TITLE
Fix #14918 - Use hex for the session token

### DIFF
--- a/libraries/classes/Session.php
+++ b/libraries/classes/Session.php
@@ -28,7 +28,7 @@ class Session
      */
     private static function generateToken()
     {
-        $_SESSION[' PMA_token '] = Util::generateRandom(16);
+        $_SESSION[' PMA_token '] = Util::generateRandom(16, true);
         $_SESSION[' HMAC_secret '] = Util::generateRandom(16);
 
         /**

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -4584,10 +4584,11 @@ class Util
      * Generates random string consisting of ASCII chars
      *
      * @param integer $length Length of string
+     * @param bool    $asHex  (optional) Send the result as hex
      *
      * @return string
      */
-    public static function generateRandom($length)
+    public static function generateRandom($length, $asHex = false)
     {
         $result = '';
         if (class_exists('phpseclib\\Crypt\\Random')) {
@@ -4604,7 +4605,7 @@ class Util
                 $result .= chr($byte);
             }
         }
-        return $result;
+        return $asHex ? bin2hex($result) : $result;
     }
 
     /**


### PR DESCRIPTION
Fixes: #14918

Use hex for the session token

QA or master ?