### PR TITLE
Button on Export Page to show SQL Query

### DIFF
--- a/js/export.js
+++ b/js/export.js
@@ -232,6 +232,27 @@ AJAX.registerTeardown('export.js', function () {
 });
 
 AJAX.registerOnload('export.js', function () {
+    $('#showsqlquery').on('click', function () {
+        // Creating a dialog box similar to preview sql container to show sql query
+        var modalOptions = {};
+        modalOptions[Messages.strClose] = function () {
+            $(this).dialog('close');
+        };
+        $('#export_sql_modal_content').clone().dialog({
+            minWidth: 550,
+            maxHeight: 400,
+            modal: true,
+            buttons: modalOptions,
+            title: Messages.strQuery,
+            close: function () {
+                $(this).remove();
+            }, open: function () {
+                // Pretty SQL printing.
+                Functions.highlightSql($(this));
+            }
+        });
+    });
+
     /**
      * Export template handling code
      */

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -195,6 +195,8 @@ final class JavaScriptMessagesController
             'strAddChart' => __('Add chart to grid'),
             'strAddOneSeriesWarning' => __('Please add at least one variable to the series!'),
             'strNone' => __('None'),
+            /* l10n: SQL Query on modal to show exported query */
+            'strQuery' => __('SQL Query'),
             'strResumeMonitor' => __('Resume monitor'),
             'strPauseMonitor' => __('Pause monitor'),
             'strStartRefresh' => __('Start auto refresh'),

--- a/libraries/classes/Display/Export.php
+++ b/libraries/classes/Display/Export.php
@@ -711,6 +711,10 @@ class Export
             ]);
         }
 
+        $html .= $this->template->render('display/export/query', [
+            'sql_query' => $sqlQuery,
+        ]);
+
         $html .= '<form method="post" action="' . Url::getFromRoute('/export')
             . '" name="dump" class="disableAjax">';
 

--- a/templates/display/export/query.twig
+++ b/templates/display/export/query.twig
@@ -1,0 +1,18 @@
+<div class="exportoptions">
+  {# l10n: Title of the option on the Export page #}
+	<h3>{% trans 'SQL query:' %}</h3>
+	<div class="floatleft">
+		<div id="sqlqueryform">
+      {# l10n: Button to show the SQL query on the export page #}
+			<input class="btn btn-secondary" type="submit" id="showsqlquery" value="{% trans 'Show SQL query' %}">
+		</div>
+		<div class="d-none">
+      <div id="export_sql_modal_content">
+        <code class="sql">
+          <pre id="sql_preview_query">{{ sql_query }}</pre>
+        </code>
+      </div>
+    </div>
+	</div>
+	<div class="clearfloat"></div>
+</div>


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description
Please describe your pull request.
The following PR adds Show SQL Query button on Export page, to show the SQL Query used for exporting. In case, one does not go to the export page after executing some SQL Query the button is not shown. 
Fixes #14340 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
