### PR TITLE
Fix #15397 NULL values not shown in INT columns

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -2943,7 +2943,7 @@ class Results
 
                 $display_params['data'][$row_no][$i]
                     = $this->_getDataCellForNumericColumns(
-                        (string) $row[$i],
+                        null === $row[$i] ? null : (string) $row[$i],
                         $class,
                         $condition_field,
                         $meta,


### PR DESCRIPTION
### Description

Remove cast of values, because null can't be seen anymore.

Fixes #15397