### PR TITLE
Fix missing variable on insert page

### DIFF
--- a/libraries/entry_points/table/change.php
+++ b/libraries/entry_points/table/change.php
@@ -19,7 +19,7 @@ if (! defined('PHPMYADMIN')) {
     exit;
 }
 
-global $cfg, $containerBuilder, $db, $table, $text_dir;
+global $cfg, $is_upload, $containerBuilder, $db, $table, $text_dir;
 
 /** @var Response $response */
 $response = $containerBuilder->get(Response::class);


### PR DESCRIPTION
Since the use of routes, the context changed because "entrypoints" are not called directly anymore, but are called in closures, so the context is not shared. So if you want to use a global variable that was in the parent context, you now need to explicitely ask for the global variable.
In our case, "$is_upload" wasn't shared anymore.