### PR TITLE
Fix PHP 7.4 deprecation: array/string curly braces access

### DIFF
--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -3872,7 +3872,7 @@ class Privileges
             }
             $drop_user_error = '';
             foreach ($queries as $sql_query) {
-                if ($sql_query{0} != '#') {
+                if ($sql_query[0] != '#') {
                     if (! $GLOBALS['dbi']->tryQuery($sql_query)) {
                         $drop_user_error .= $GLOBALS['dbi']->getError() . "\n";
                     }
@@ -4119,7 +4119,7 @@ class Privileges
     {
         $tmp_count = 0;
         foreach ($queries as $sql_query) {
-            if ($sql_query{0} != '#') {
+            if ($sql_query[0] != '#') {
                 $GLOBALS['dbi']->query($sql_query);
             }
             // when there is a query containing a hidden password, take it

--- a/libraries/classes/Url.php
+++ b/libraries/classes/Url.php
@@ -248,7 +248,7 @@ class Url
             if (mb_strpos($arg_separator, ';') !== false) {
                 $separator = ';';
             } elseif (strlen($arg_separator) > 0) {
-                $separator = $arg_separator{0};
+                $separator = $arg_separator[0];
             } else {
                 $separator = '&';
             }


### PR DESCRIPTION
Deprecated: Array and string offset access syntax with curly braces is deprecated

Hopefully these are all (or most) of them:
```
[Clover@Clover-NB phpmyadmin](master)$ rg "(\\$|->|::)[A-Za-z0-9_]+\{"
libraries\replication.inc.php:125:// set $server_{master/slave}_status and assign values
libraries\classes\Url.php:253:                $separator = $arg_separator{0};
libraries\classes\Server\Privileges.php:4014:                if ($sql_query{0} != '#') {
libraries\classes\Server\Privileges.php:4269:            if ($sql_query{0} != '#') {
```

https://github.com/php/php-src/blob/0e6e2297fcb27103cc5d550ee8434680ff1e879e/UPGRADING#L356-L357

---

Also apply to the QA_4_9 branch?