### PR TITLE
Fix PHP 7.4 deprecation: accessing offset on null/bool

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1183,6 +1183,8 @@ class Results
         $number_of_columns = $this->__get('fields_cnt');
 
         for ($j = 0; $j < $number_of_columns; $j++) {
+            // PHP 7.4 fix for accessing array offset on bool
+            $col_visib_current = is_array($col_visib) ? $col_visib[$j] : null;
 
             // assign $i with the appropriate column order
             $i = $col_order ? $col_order[$j] : $j;
@@ -1207,7 +1209,7 @@ class Results
                         $sort_expression_nodirection, $i, $unsorted_sql_query,
                         $session_max_rows, $comments,
                         $sort_direction, $col_visib,
-                        $col_visib[$j]
+                        $col_visib_current
                     );
 
                 $html .= $sorted_header_html;
@@ -1221,7 +1223,7 @@ class Results
                 // Results can't be sorted
                 $html
                     .= $this->_getDraggableClassForNonSortableColumns(
-                        $col_visib, $col_visib[$j], $condition_field,
+                        $col_visib, $col_visib_current, $condition_field,
                         $fields_meta[$i], $comments
                     );
 

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -1838,7 +1838,7 @@ class Privileges
             $row = $GLOBALS['dbi']->fetchSingleRow(
                 'SELECT @@default_authentication_plugin'
             );
-            $authentication_plugin = $row['@@default_authentication_plugin'];
+            $authentication_plugin = is_array($row) ? $row['@@default_authentication_plugin'] : null;
         }
 
         return $authentication_plugin;

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -549,6 +549,16 @@ class Tracker
 
         $mixed = $GLOBALS['dbi']->fetchAssoc($relation->queryAsControlUser($sql_query));
 
+        // PHP 7.4 fix for accessing array offset on null
+        if (!is_array($mixed)) {
+            $mixed = array(
+                'schema_sql' => null,
+                'data_sql' => null,
+                'tracking' => null,
+                'schema_snapshot' => null,
+            );
+        }
+
         // Parse log
         $log_schema_entries = explode('# log ',  $mixed['schema_sql']);
         $log_data_entries   = explode('# log ',  $mixed['data_sql']);

--- a/libraries/classes/Tracking.php
+++ b/libraries/classes/Tracking.php
@@ -259,7 +259,7 @@ class Tracking
     public static function getTableLastVersionNumber($sql_result)
     {
         $maxversion = $GLOBALS['dbi']->fetchArray($sql_result);
-        return intval($maxversion['version']);
+        return intval(is_array($maxversion) ? $maxversion['version'] : null);
     }
 
     /**


### PR DESCRIPTION
`null['xxx']` or `false['xxx']` emits a notice in PHP 7.4. Previously, they just return `null` directly.

I kinda clicked all possible links/buttons on my phpMyAdmin and found these.
This PR may be considered dirty but at least they indicate where problems are.

Problematic pages:

- phpMyAdmin/db_tracking.php?db=DB_NAME
- phpMyAdmin/server_privileges.php?adduser=1
- some other pages using POST method...
  ![image](https://user-images.githubusercontent.com/6594915/61987323-44ce1080-b048-11e9-9d69-1e9d4ce3d989.png)

https://github.com/php/php-src/blob/0e6e2297fcb27103cc5d550ee8434680ff1e879e/UPGRADING#L25-L28

---

There is still another deprecation, which is the most annoying actually, from upstream though.

```
Deprecation Notice in .\vendor\symfony\cache\Adapter\ArrayAdapter.php#48
 Unbinding $this of closure is deprecated
```

**Update:** The fix [PR](https://github.com/symfony/symfony/pull/32796/files) has been merged.