### PR TITLE
Fix #15388 Allow rollback if empty statement

### DIFF
--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -1617,7 +1617,7 @@ class Import
         $parser = new Parser($sql_query);
 
         if (empty($parser->statements[0])) {
-            return false;
+            return true;
         }
 
         $statement = $parser->statements[0];


### PR DESCRIPTION
When statement finishes with spaces, there is an "empty" statement. An empty statement is rollbackable.

Fixes: #15388