### PR TITLE
Export view option added in Export

### DIFF
--- a/libraries/classes/Controllers/ExportController.php
+++ b/libraries/classes/Controllers/ExportController.php
@@ -169,6 +169,7 @@ final class ExportController extends AbstractController
             'sql_create_view',
             'sql_create_trigger',
             'sql_view_current_user',
+            'sql_simple_view_export',
             'sql_if_not_exists',
             'sql_or_replace_view',
             'sql_auto_increment',


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description
The PR adds export view option in export under data creation options and replaces `CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW...` with `CREATE VIEW...` as suggested. 
Fixes #14815 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
