### PR TITLE
Fixed configuration for FilterLanguages

### DIFF
--- a/libraries/classes/LanguageManager.php
+++ b/libraries/classes/LanguageManager.php
@@ -726,11 +726,11 @@ class LanguageManager
     {
         if (! $this->_available_locales) {
 
-            if (empty($GLOBALS['cfg']['FilterLanguages'])) {
+            if (!isset($GLOBALS['PMA_Config']) || empty($GLOBALS['PMA_Config']->get('FilterLanguages'))) {
                 $this->_available_locales = $this->listLocaleDir();
             } else {
                 $this->_available_locales = preg_grep(
-                    '@' . $GLOBALS['cfg']['FilterLanguages'] . '@',
+                    '@' . $GLOBALS['PMA_Config']->get('FilterLanguages') . '@',
                     $this->listLocaleDir()
                 );
             }

--- a/test/classes/LanguageTest.php
+++ b/test/classes/LanguageTest.php
@@ -46,13 +46,13 @@ class LanguageTest extends PmaTestCase
      */
     public function testAvailable()
     {
-        $GLOBALS['cfg']['FilterLanguages'] = 'cs|en$';
+        $GLOBALS['PMA_Config']->set('FilterLanguages', 'cs|en$');
 
         $langs = $this->manager->availableLocales();
 
         $this->assertCount(2, $langs);
         $this->assertContains('cs', $langs);
-        $GLOBALS['cfg']['FilterLanguages'] = '';
+        $GLOBALS['PMA_Config']->set('FilterLanguages', '');
     }
 
     /**
@@ -62,7 +62,7 @@ class LanguageTest extends PmaTestCase
      */
     public function testAllAvailable()
     {
-        $GLOBALS['cfg']['FilterLanguages'] = '';
+        $GLOBALS['PMA_Config']->set('FilterLanguages', '');
 
         $langs = $this->manager->availableLocales();
 


### PR DESCRIPTION
### Description

The "FilterLanguages" option is set to "^(us|ru)$", but in the "Language" form all languages are available for selection.

`$GLOBALS['cfg']`  is not set before :

https://github.com/phpmyadmin/phpmyadmin/blob/c8478f5eadd8f514326b82e2cb4f9a2bbf3914b0/libraries/common.inc.php#L295

The variable `$GLOBALS['cfg']['FilterLanguages']` is accessed according to the following chain:

https://github.com/phpmyadmin/phpmyadmin/blob/c8478f5eadd8f514326b82e2cb4f9a2bbf3914b0/libraries/common.inc.php#L263

In function `selectLanguage()`:
https://github.com/phpmyadmin/phpmyadmin/blob/c8478f5eadd8f514326b82e2cb4f9a2bbf3914b0/libraries/classes/LanguageManager.php#L875

In function `availableLanguages()`:
https://github.com/phpmyadmin/phpmyadmin/blob/c8478f5eadd8f514326b82e2cb4f9a2bbf3914b0/libraries/classes/LanguageManager.php#L761

https://github.com/phpmyadmin/phpmyadmin/blob/c8478f5eadd8f514326b82e2cb4f9a2bbf3914b0/libraries/classes/LanguageManager.php#L725-L739

### Fixes

Use `$GLOBALS['PMA_Config']->get('FilterLanguages')` insted of `$GLOBALS['cfg']['FilterLanguages']`. 

Tested on 4.9.0.1.