### PR TITLE
Fix #14950 Prevent empty after field when adding new table column.

### DIFF
--- a/libraries/classes/CreateAddField.php
+++ b/libraries/classes/CreateAddField.php
@@ -147,7 +147,7 @@ class CreateAddField
         if ($previousField == -1) {
             if ((string) $_POST['field_where'] === 'first') {
                 $sqlSuffix .= ' FIRST';
-            } else {
+            } else if (!empty($_POST['after_field'])){
                 $sqlSuffix .= ' AFTER '
                         . Util::backquote($_POST['after_field']);
             }


### PR DESCRIPTION
Signed-off-by: Shen Chen schen89@live.com

### Description

Please describe your pull request.

Fixes #15430, #14950

Currently, there is alwasys an empty `after` at the end of column adding sql which results in syntax error when trying to add new columns.

This PR adds an if condition to make sure the key `after` is only added when the field is not empty.

##### Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
