### PR TITLE
Fixed url.php crashing because it's not loading the DatabaseInterface service

### DIFF
--- a/url.php
+++ b/url.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 use PhpMyAdmin\Core;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Sanitize;
+use PhpMyAdmin\DatabaseInterface;
 
 if (! defined('ROOT_PATH')) {
     define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR);
@@ -20,6 +21,9 @@ if (! defined('ROOT_PATH')) {
  */
 define('PMA_MINIMUM_COMMON', true);
 require_once ROOT_PATH . 'libraries/common.inc.php';
+
+// Load database service because services.yaml is not available here
+$containerBuilder->set(DatabaseInterface::class, DatabaseInterface::load());
 
 // Only output the http headers
 $response = Response::getInstance();


### PR DESCRIPTION
### Description

The url.php script was crashing because not finding the DatabaseInterface service in the container. This happend because the `PMA_MINIMUM_COMMON ` is defined and the
`$containerBuilder->set(DatabaseInterface::class, DatabaseInterface::load());` 
is not called.

The exception appear in the CheckUserPrivilages construct when the Response::getInstance() is called.

### Fixes

Added the DatabaseInterface service in the container in the url.php script.
