### PR TITLE
Designer saves page successfully even if dB name has period.

### DIFF
--- a/libraries/classes/Database/Designer.php
+++ b/libraries/classes/Database/Designer.php
@@ -84,6 +84,7 @@ class Designer
         $cfgRelation = $this->relation->getRelationsParam();
         return $this->template->render('database/designer/page_save_as', [
             'db' => $db,
+            'number_of_dots' => substr_count($db, '.'),
             'pdfwork' => $cfgRelation['pdfwork'],
             'pages' => $this->getPageIdsAndNames($db),
         ]);

--- a/libraries/classes/Database/Designer/Common.php
+++ b/libraries/classes/Database/Designer/Common.php
@@ -508,7 +508,20 @@ class Common
         }
 
         foreach ($_REQUEST['t_h'] as $key => $value) {
-            list($DB, $TAB) = explode(".", $key);
+            $Dots = substr_count($key, '.');
+            $DB_Dots = $_POST['number_of_dots'];
+            $TAB_Dots = $DB - $DB_Dots - 1;
+            $Array = explode(".", $key);
+            $DB = '';
+            $TAB = '';
+            for($x = 0; $x < $DB_Dots; $x++){
+                $DB .= $Array[$x].".";
+            }
+            $DB .= $Array[$DB_Dots];
+            for($x = $DB_Dots+1; $x < $Dots; $x++){
+                $TAB .= $Array[$x].".";
+            }
+            $TAB .= $Array[$Dots];
             if (! $value) {
                 continue;
             }

--- a/templates/database/designer/page_save_as.twig
+++ b/templates/database/designer/page_save_as.twig
@@ -1,5 +1,6 @@
 <form action="db_designer.php" method="post" name="save_as_pages" id="save_as_pages" class="ajax">
     {{ get_hidden_inputs(db) }}
+    <input type="hidden" name="number_of_dots" value="{{number_of_dots}}">
     <fieldset id="page_save_as_options">
         <table>
             <tbody>


### PR DESCRIPTION
Signed-off-by: Mohit Kuri <mohit.kuri@research.iiit.ac.in>

### Description

Designer pages will now be successfully saved even if it has period.

Fixes #14945 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
