### PR TITLE
fixed bottom-most table name blockage

### DIFF
--- a/themes/pmahomme/css/common.css.php
+++ b/themes/pmahomme/css/common.css.php
@@ -962,7 +962,7 @@ form.login select {
 }
 
 li.last.database{
-    margin-bottom: 15px
+    margin-bottom: 15px !important;
 }
 /******************************************************************************/
 /* specific elements */


### PR DESCRIPTION
Closes #14898 

I think making this CSS property `!important` is necessary as it conflicts with other CSS property which do `margin: 0;`. Moreover, I think there are no side effects as this is selecting only the last database in the list. :)