### PR TITLE
Fix #15446 Tables added from other databases are not collapsing in the designer section

### DIFF
--- a/db_designer.php
+++ b/db_designer.php
@@ -188,7 +188,7 @@ $response->addHTML(
 );
 
 $response->addHTML($databaseDesigner->getHtmlCanvas());
-$response->addHTML($databaseDesigner->getHtmlTableList($tab_pos, $display_page));
+$response->addHTML($databaseDesigner->getHtmlTableList());
 
 $response->addHTML(
     $databaseDesigner->getDatabaseTables(

--- a/db_designer.php
+++ b/db_designer.php
@@ -38,6 +38,7 @@ if (isset($_POST['dialog'])) {
         $req_key = array_search($required, $GLOBALS['designer']['TABLE_NAME']);
 
         $GLOBALS['designer']['TABLE_NAME'] = array($GLOBALS['designer']['TABLE_NAME'][$req_key]);
+        $GLOBALS['designer_url']['TABLE_NAME'] = array($GLOBALS['designer_url']['TABLE_NAME'][$req_key]);
         $GLOBALS['designer_url']['TABLE_NAME_SMALL'] = array($GLOBALS['designer_url']['TABLE_NAME_SMALL'][$req_key]);
         $GLOBALS['designer']['TABLE_NAME_SMALL'] = array($GLOBALS['designer']['TABLE_NAME_SMALL'][$req_key]);
         $GLOBALS['designer_out']['TABLE_NAME_SMALL'] = array($GLOBALS['designer_out']['TABLE_NAME_SMALL'][$req_key]);

--- a/js/designer/move.js
+++ b/js/designer/move.js
@@ -1341,20 +1341,20 @@ function Small_tab_all (id_this) {
     var value_sent = '';
 
     if (icon.alt === 'v') {
-        for (key in j_tabs) {
-            if (document.getElementById('id_hide_tbody_' + key).innerHTML === 'v') {
-                Small_tab(key, 0);
+        $('.designer_tab .small_tab,.small_tab2').each(function(index, element) {
+            if ($(element).text() === 'v') {
+                Small_tab($(element).attr('table_name'), 0);
             }
-        }
+        });
         icon.alt = '>';
         icon.src = icon.dataset.right;
         value_sent = 'v';
     } else {
-        for (key in j_tabs) {
-            if (document.getElementById('id_hide_tbody_' + key).innerHTML !== 'v') {
-                Small_tab(key, 0);
+        $('.designer_tab .small_tab,.small_tab2').each(function(index, element) {
+            if ($(element).text() !== 'v') {
+                Small_tab($(element).attr('table_name'), 0);
             }
-        }
+        });
         icon.alt = 'v';
         icon.src = icon.dataset.down;
         value_sent = '>';
@@ -1367,9 +1367,9 @@ function Small_tab_all (id_this) {
 
 // invert max/min all tables
 function Small_tab_invert () {
-    for (var key in j_tabs) {
-        Small_tab(key, 0);
-    }
+    $('.designer_tab .small_tab,.small_tab2').each(function(index, element) {
+        Small_tab($(element).attr('table_name'), 0);
+    });
     Re_load();
 }
 

--- a/js/designer/move.js
+++ b/js/designer/move.js
@@ -561,7 +561,7 @@ function Add_Other_db_tables () {
             'table' : table,
             'server': PMA_commonParams.get('server')
         }, function (data) {
-            $new_table_dom = $(data.message);
+            var $new_table_dom = $(data.message);
             $new_table_dom.find('a').first().remove();
             $('#container-form').append($new_table_dom);
             enableTableEvents(null, $new_table_dom);

--- a/js/designer/move.js
+++ b/js/designer/move.js
@@ -552,8 +552,8 @@ function Toggle_fullscreen () {
 function addTableToTablesList(index, table_dom) {
     var db = $(table_dom).find('.small_tab_pref').attr('db');
     var table = $(table_dom).find('.small_tab_pref').attr('table_name_small');
-    var db_encoded = encodeURI(db);
-    var table_encoded = encodeURI(table);
+    var db_encoded = encodeURIComponent(db);
+    var table_encoded = encodeURIComponent(table);
     var $new_table_line = $('<tr>' +
         '    <td title="' + PMA_messages.strStructure + '"' +
         '        width="1px"' +

--- a/js/designer/move.js
+++ b/js/designer/move.js
@@ -1337,7 +1337,6 @@ function Start_tab_upd (db, table) {
 // max/min all tables
 function Small_tab_all (id_this) {
     var icon = id_this.children[0];
-    var key;
     var value_sent = '';
 
     if (icon.alt === 'v') {

--- a/js/designer/move.js
+++ b/js/designer/move.js
@@ -564,18 +564,7 @@ function Add_Other_db_tables () {
             $new_table_dom = $(data.message);
             $new_table_dom.find('a').first().remove();
             $('#container-form').append($new_table_dom);
-            $('.designer_tab').on('click','.tab_field_2,.tab_field_3,.tab_field', function () {
-                var params = ($(this).attr('click_field_param')).split(',');
-                Click_field(params[3], params[0], params[1], params[2]);
-            });
-            $('.designer_tab').on('click', '.select_all_store_col', function () {
-                var params = ($(this).attr('store_column_param')).split(',');
-                store_column(params[0], params[1], params[2]);
-            });
-            $('.designer_tab').on('click', '.small_tab_pref_click_opt', function () {
-                var params = ($(this).attr('Click_option_param')).split(',');
-                Click_option(params[0], params[1], params[2]);
-            });
+            enableTableEvents(null, $new_table_dom);
         });
         $(this).dialog('close');
     };
@@ -1913,6 +1902,44 @@ function add_object () {
     $('#ab').accordion('refresh');
 }
 
+function enablePageContentEvents() {
+    $('#page_content').off('mousedown', MouseDown);
+    $('#page_content').off('mouseup', MouseUp);
+    $('#page_content').off('mousemove', MouseMove);
+    $('#page_content').on('mousedown', MouseDown);
+    $('#page_content').on('mouseup', MouseUp);
+    $('#page_content').on('mousemove', MouseMove);
+}
+
+/**
+ * This function enables the events on table items.
+ * It helps to enable them on page loading and when a table is added on the fly.
+ */
+function enableTableEvents(index, element) {
+    $(element).on('click', '.select_all_1', function () {
+        Select_all($(this).attr('designer_url_table_name'), $(this).attr('designer_out_owner'));
+    });
+    $(element).on('click', '.small_tab,.small_tab2', function () {
+        Small_tab($(this).attr('table_name'), 1);
+    });
+    $(element).on('click', '.small_tab_pref_1', function () {
+        Start_tab_upd($(this).attr('table_name_small'));
+    });
+    $(element).on('click', '.select_all_store_col', function () {
+        var params = ($(this).attr('store_column_param')).split(',');
+        store_column(params[0], params[1], params[2]);
+    });
+    $(element).on('click', '.small_tab_pref_click_opt', function () {
+        var params = ($(this).attr('Click_option_param')).split(',');
+        Click_option(params[0], params[1], params[2]);
+    });
+    $(element).on('click', '.tab_field_2,.tab_field_3,.tab_field', function () {
+        var params = ($(this).attr('click_field_param')).split(',');
+        Click_field(params[3], params[0], params[1], params[2]);
+    });
+    enablePageContentEvents();
+}
+
 AJAX.registerTeardown('designer/move.js', function () {
     $('#side_menu').off('mouseenter mouseleave');
     $('#key_Show_left_menu').off('click');
@@ -2073,15 +2100,9 @@ AJAX.registerOnload('designer/move.js', function () {
     $('#id_scroll_tab').find('tr').on('click', '.designer_Tabs2,.designer_Tabs', function () {
         Select_tab($(this).attr('designer_url_table_name'));
     });
-    $('.designer_tab').on('click', '.select_all_1', function () {
-        Select_all($(this).attr('designer_url_table_name'), $(this).attr('designer_out_owner'));
-    });
-    $('.designer_tab').on('click', '.small_tab,.small_tab2', function () {
-        Small_tab($(this).attr('table_name'), 1);
-    });
-    $('.designer_tab').on('click', '.small_tab_pref_1', function () {
-        Start_tab_upd($(this).attr('table_name_small'));
-    });
+
+    $('.designer_tab').each(enableTableEvents);
+
     $('.tab_zag_noquery').mouseover(function () {
         Table_onover($(this).attr('table_name'),0, $(this).attr('query_set'));
     });
@@ -2094,18 +2115,7 @@ AJAX.registerOnload('designer/move.js', function () {
     $('.tab_zag_query').mouseout(function () {
         Table_onover($(this).attr('table_name'),1, 1);
     });
-    $('.designer_tab').on('click','.tab_field_2,.tab_field_3,.tab_field', function () {
-        var params = ($(this).attr('click_field_param')).split(',');
-        Click_field(params[3], params[0], params[1], params[2]);
-    });
-    $('.designer_tab').on('click', '.select_all_store_col', function () {
-        var params = ($(this).attr('store_column_param')).split(',');
-        store_column(params[0], params[1], params[2]);
-    });
-    $('.designer_tab').on('click', '.small_tab_pref_click_opt', function () {
-        var params = ($(this).attr('Click_option_param')).split(',');
-        Click_option(params[0], params[1], params[2]);
-    });
+
     $('input#del_button').click(function () {
         Upd_relation();
     });
@@ -2125,13 +2135,5 @@ AJAX.registerOnload('designer/move.js', function () {
     $('input#cancel_new_rel_panel').click(function () {
         document.getElementById('layer_new_relation').style.display = 'none';
     });
-    $('#page_content').on('mousedown', function(e) {
-        MouseDown(e);
-    });
-    $('#page_content').on('mouseup', function(e) {
-        MouseUp(e);
-    });
-    $('#page_content').on('mousemove', function(e) {
-        MouseMove(e);
-    });
+    enablePageContentEvents();
 });

--- a/js/designer/move.js
+++ b/js/designer/move.js
@@ -1981,6 +1981,20 @@ function enableTableEvents(index, element) {
         var params = ($(this).attr('click_field_param')).split(',');
         Click_field(params[3], params[0], params[1], params[2]);
     });
+
+    $(element).find('.tab_zag_noquery').mouseover(function () {
+        Table_onover($(this).attr('table_name'),0, $(this).attr('query_set'));
+    });
+    $(element).find('.tab_zag_noquery').mouseout(function () {
+        Table_onover($(this).attr('table_name'),1, $(this).attr('query_set'));
+    });
+    $(element).find('.tab_zag_query').mouseover(function () {
+        Table_onover($(this).attr('table_name'),0, 1);
+    });
+    $(element).find('.tab_zag_query').mouseout(function () {
+        Table_onover($(this).attr('table_name'),1, 1);
+    });
+
     enablePageContentEvents();
 }
 
@@ -2138,19 +2152,6 @@ AJAX.registerOnload('designer/move.js', function () {
 
     $('.designer_tab').each(enableTableEvents);
     $('.designer_tab').each(addTableToTablesList);
-
-    $('.tab_zag_noquery').mouseover(function () {
-        Table_onover($(this).attr('table_name'),0, $(this).attr('query_set'));
-    });
-    $('.tab_zag_noquery').mouseout(function () {
-        Table_onover($(this).attr('table_name'),1, $(this).attr('query_set'));
-    });
-    $('.tab_zag_query').mouseover(function () {
-        Table_onover($(this).attr('table_name'),0, 1);
-    });
-    $('.tab_zag_query').mouseout(function () {
-        Table_onover($(this).attr('table_name'),1, 1);
-    });
 
     $('input#del_button').click(function () {
         Upd_relation();

--- a/js/designer/move.js
+++ b/js/designer/move.js
@@ -1284,7 +1284,8 @@ function Start_table_new () {
     PMA_commonActions.refreshMain('tbl_create.php');
 }
 
-function Start_tab_upd (table) {
+function Start_tab_upd (db, table) {
+    PMA_commonParams.set('db', db);
     PMA_commonParams.set('table', table);
     PMA_commonActions.refreshMain('tbl_structure.php');
 }
@@ -1923,7 +1924,7 @@ function enableTableEvents(index, element) {
         Small_tab($(this).attr('table_name'), 1);
     });
     $(element).on('click', '.small_tab_pref_1', function () {
-        Start_tab_upd($(this).attr('table_name_small'));
+        Start_tab_upd($(this).attr('db'), $(this).attr('table_name_small'));
     });
     $(element).on('click', '.select_all_store_col', function () {
         var params = ($(this).attr('store_column_param')).split(',');
@@ -2092,7 +2093,7 @@ AJAX.registerOnload('designer/move.js', function () {
         return false;
     });
     $('.scroll_tab_struct').click(function () {
-        Start_tab_upd($(this).attr('table_name'));
+        Start_tab_upd($(this).attr('db'), $(this).attr('table_name'));
     });
     $('.scroll_tab_checkbox').click(function () {
         VisibleTab(this,$(this).val());

--- a/js/designer/move.js
+++ b/js/designer/move.js
@@ -549,6 +549,48 @@ function Toggle_fullscreen () {
     saveValueInConfig('full_screen', value_sent);
 }
 
+function addTableToTablesList(index, table_dom) {
+    var db = $(table_dom).find('.small_tab_pref').attr('db');
+    var table = $(table_dom).find('.small_tab_pref').attr('table_name_small');
+    var db_encoded = encodeURI(db);
+    var table_encoded = encodeURI(table);
+    var $new_table_line = $('<tr>' +
+        '    <td title="' + PMA_messages.strStructure + '"' +
+        '        width="1px"' +
+        '        class="L_butt2_1">' +
+        '        <img alt=""' +
+        '            db="' + db + '"' +
+        '            table_name="' + table + '"' +
+        '            class="scroll_tab_struct"' +
+        '            src="' + pmaThemeImage + 'designer/exec.png"/>' +
+        '    </td>' +
+        '    <td width="1px">' +
+        '        <input class="scroll_tab_checkbox"' +
+        '            title="' + PMA_messages.strHide + '"' +
+        '            id="check_vis_' + encodeURI(db) + '.' + table_encoded + '"' +
+        '            style="margin:0;"' +
+        '            type="checkbox"' +
+        '            value="' + db_encoded + '.' + table_encoded + '"' +
+        '            checked="checked"' +
+        '            />' +
+        '    </td>' +
+        '    <td class="designer_Tabs"' +
+        '        designer_url_table_name="' + db_encoded + '.' + table_encoded + '">' + db + '.' + table + '</td>' +
+        '</tr>');
+    $('#id_scroll_tab table').first().append($new_table_line);
+    $($new_table_line).find('.scroll_tab_struct').click(function () {
+        Start_tab_upd(db, table);
+    });
+    $($new_table_line).on('click', '.designer_Tabs2,.designer_Tabs', function () {
+        Select_tab($(this).attr('designer_url_table_name'));
+    });
+    $($new_table_line).find('.scroll_tab_checkbox').click(function () {
+        VisibleTab(this,$(this).val());
+    });
+    var $tables_counter = $('#tables_counter');
+    $tables_counter.text(parseInt($tables_counter.text(), 10) + 1);
+}
+
 function Add_Other_db_tables () {
     var button_options = {};
     button_options[PMA_messages.strGo] = function () {
@@ -565,6 +607,7 @@ function Add_Other_db_tables () {
             $new_table_dom.find('a').first().remove();
             $('#container-form').append($new_table_dom);
             enableTableEvents(null, $new_table_dom);
+            addTableToTablesList(null, $new_table_dom);
         });
         $(this).dialog('close');
     };
@@ -2092,17 +2135,9 @@ AJAX.registerOnload('designer/move.js', function () {
         No_have_constr(this);
         return false;
     });
-    $('.scroll_tab_struct').click(function () {
-        Start_tab_upd($(this).attr('db'), $(this).attr('table_name'));
-    });
-    $('.scroll_tab_checkbox').click(function () {
-        VisibleTab(this,$(this).val());
-    });
-    $('#id_scroll_tab').find('tr').on('click', '.designer_Tabs2,.designer_Tabs', function () {
-        Select_tab($(this).attr('designer_url_table_name'));
-    });
 
     $('.designer_tab').each(enableTableEvents);
+    $('.designer_tab').each(addTableToTablesList);
 
     $('.tab_zag_noquery').mouseover(function () {
         Table_onover($(this).attr('table_name'),0, $(this).attr('query_set'));

--- a/js/messages.php
+++ b/js/messages.php
@@ -751,6 +751,10 @@ $js_messages['strStrong'] = __('Strong');
 $js_messages['strU2FTimeout'] = __('Timed out waiting for security key activation.');
 $js_messages['strU2FError'] = __('Failed security key activation (%s).');
 
+/* DB Designer */
+$js_messages['strHide'] = __('Hide');
+$js_messages['strStructure'] = __('Structure');
+
 echo "var PMA_messages = new Array();\n";
 foreach ($js_messages as $name => $js_message) {
     Sanitize::printJsValue("PMA_messages['" . $name . "']", $js_message);

--- a/libraries/classes/Database/Designer.php
+++ b/libraries/classes/Database/Designer.php
@@ -285,22 +285,13 @@ class Designer
     /**
      * Return HTML for the table list
      *
-     * @param array $tab_pos      table positions
-     * @param int   $display_page page number of the selected page
-     *
      * @return string html
      */
-    public function getHtmlTableList(array $tab_pos, $display_page)
+    public function getHtmlTableList()
     {
         return Template::get('database/designer/table_list')->render([
-            'db' => $GLOBALS['db'],
-            'tab_pos' => $tab_pos,
-            'display_page' => $display_page,
             'theme' => $GLOBALS['PMA_Theme'],
             'table_names' => $GLOBALS['designer']['TABLE_NAME'],
-            'table_names_url' => $GLOBALS['designer_url']['TABLE_NAME'],
-            'table_names_small_url' => $GLOBALS['designer_url']['TABLE_NAME_SMALL'],
-            'table_names_out' => $GLOBALS['designer_out']['TABLE_NAME'],
         ]);
     }
 

--- a/libraries/classes/Database/Designer.php
+++ b/libraries/classes/Database/Designer.php
@@ -293,6 +293,7 @@ class Designer
     public function getHtmlTableList(array $tab_pos, $display_page)
     {
         return Template::get('database/designer/table_list')->render([
+            'db' => $GLOBALS['db'],
             'tab_pos' => $tab_pos,
             'display_page' => $display_page,
             'theme' => $GLOBALS['PMA_Theme'],

--- a/templates/database/designer/database_tables.twig
+++ b/templates/database/designer/database_tables.twig
@@ -30,9 +30,7 @@
                 <td class="small_tab"
                     title="{% trans 'Show/hide columns' %}"
                     id="id_hide_tbody_{{ t_n_url|url_encode }}"
-                    table_name="{{ t_n_url|url_encode }}">
-                    {{ tab_pos[t_n] is not defined or tab_pos[t_n]['V'] is not empty ? 'v' : '&gt;' }}
-                </td>
+                    table_name="{{ t_n_url|url_encode }}">{{ tab_pos[t_n] is not defined or tab_pos[t_n]['V'] is not empty ? 'v' : '&gt;' }}</td>
                 <td class="small_tab_pref small_tab_pref_1"
                     table_name_small="{{ table_names_small_url[i] }}">
                     <img src="{{ theme.getImgPath('designer/exec_small.png') }}"

--- a/templates/database/designer/database_tables.twig
+++ b/templates/database/designer/database_tables.twig
@@ -32,6 +32,7 @@
                     id="id_hide_tbody_{{ t_n_url|url_encode }}"
                     table_name="{{ t_n_url|url_encode }}">{{ tab_pos[t_n] is not defined or tab_pos[t_n]['V'] is not empty ? 'v' : '&gt;' }}</td>
                 <td class="small_tab_pref small_tab_pref_1"
+                    db="{{ db }}"
                     table_name_small="{{ table_names_small_url[i] }}">
                     <img src="{{ theme.getImgPath('designer/exec_small.png') }}"
                         title="{% trans 'See table structure' %}" />

--- a/templates/database/designer/table_list.twig
+++ b/templates/database/designer/table_list.twig
@@ -25,6 +25,7 @@
                         width="1px"
                         class="L_butt2_1">
                         <img alt=""
+                            db="{{ db }}"
                             table_name="{{ table_names_small_url[i] }}"
                             class="scroll_tab_struct"
                             src="{{ theme.getImgPath('designer/exec.png') }}"/>

--- a/templates/database/designer/table_list.twig
+++ b/templates/database/designer/table_list.twig
@@ -18,42 +18,11 @@
         </a>
     </div>
     <div id="id_scroll_tab" class="scroll_tab">
-        <table width="100%" style="padding-left: 3px;">
-            {% for i in 0..table_names|length - 1 %}
-                <tr>
-                    <td title="{% trans 'Structure' %}"
-                        width="1px"
-                        class="L_butt2_1">
-                        <img alt=""
-                            db="{{ db }}"
-                            table_name="{{ table_names_small_url[i] }}"
-                            class="scroll_tab_struct"
-                            src="{{ theme.getImgPath('designer/exec.png') }}"/>
-                    </td>
-                    <td width="1px">
-                        <input class="scroll_tab_checkbox"
-                            title="{% trans 'Hide' %}"
-                            id="check_vis_{{ table_names_url[i]|url_encode }}"
-                            style="margin:0;"
-                            type="checkbox"
-                            value="{{ table_names_url[i]|url_encode }}"
-                            {% if (tab_pos[table_names[i]] is defined
-                                and tab_pos[table_names[i]]['H'])
-                                or display_page == -1 -%}
-                                checked="checked"
-                            {%- endif %} />
-                    </td>
-                    <td class="designer_Tabs"
-                        designer_url_table_name="{{ table_names_url[i]|url_encode }}">
-                        {{ table_names_out[i]|raw }}
-                    </td>
-                </tr>
-            {% endfor %}
-        </table>
+        <table width="100%" style="padding-left: 3px;"></table>
     </div>
     {# end id_scroll_tab #}
     <div class="center">
-        {% trans 'Number of tables:' %} {{ table_names|length }}
+        {% trans 'Number of tables:' %} <span id="tables_counter">0</span>
     </div>
     <div id="layer_menu_sizer">
         <div class="floatleft">


### PR DESCRIPTION
The events to link all buttons to collapse tables were initialized at page loading. But when a new table was added, the event wasn't declared for this one.
With this PR, the event is now also declared on table addition.

Fixes: #15446

----
## Roadmap of bugs
- [x] Add new table from other DB, (wrong structure link + on table list)
- [x] Add table and hover (yellow overlay is expected) 
![image](https://user-images.githubusercontent.com/7784660/63378576-cf2d3a00-c392-11e9-85c0-4ca58a92d226.png)

- [x] Add new table from DB and try to move around the table
- [x] Add 2 new tables and try to toggle the hide button (only the clicked table should be toggled)
- [x] Add new table should appear in table list and the number of tables should be updated (i++)
- [x] Hide/show all does not work for added tables
![image](https://user-images.githubusercontent.com/7784660/63379890-8f1b8680-c395-11e9-9314-1459379fe4f8.png)
- [x] Big/small does not work for added tables
![image](https://user-images.githubusercontent.com/7784660/63379939-ace8eb80-c395-11e9-9ea9-00bed4edfe01.png)