### PR TITLE
Support CaptchaSiteVerifyURL config for ReCaptcha to allow for custom siteVerifyUrl value

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1892,6 +1892,17 @@ Cookie authentication options
 
     reCaptcha will be then used in :ref:`cookie`.
 
+.. config:option:: $cfg['CaptchaSiteVerifyURL']
+
+    :type: string
+    :default: ``''``
+
+    The URL for the reCaptcha service to do siteverify action.
+
+    reCaptcha will be then used in :ref:`cookie`.
+
+    .. versionadded:: 5.1.0
+
 Navigation panel setup
 ----------------------
 

--- a/libraries/classes/Config/Descriptions.php
+++ b/libraries/classes/Config/Descriptions.php
@@ -898,6 +898,8 @@ class Descriptions
             'CaptchaLoginPublicKey_name' => __('Public key for reCaptcha'),
             'CaptchaLoginPrivateKey_desc' => __('Enter your private key for your domain reCaptcha service.'),
             'CaptchaLoginPrivateKey_name' => __('Private key for reCaptcha'),
+            'CaptchaSiteVerifyURL_desc' => __('Enter your siteverify URL for your reCaptcha service.'),
+            'CaptchaSiteVerifyURL_name' => __('URL for reCaptcha siteverify'),
 
             'SendErrorReports_desc' => __('Choose the default action when sending error reports.'),
             'SendErrorReports_name' => __('Send error reports'),

--- a/libraries/classes/Config/Forms/Setup/FeaturesForm.php
+++ b/libraries/classes/Config/Forms/Setup/FeaturesForm.php
@@ -49,6 +49,7 @@ class FeaturesForm extends \PhpMyAdmin\Config\Forms\User\FeaturesForm
             'LoginCookieDeleteAll',
             'CaptchaLoginPublicKey',
             'CaptchaLoginPrivateKey',
+            'CaptchaSiteVerifyURL',
         ];
         $result['Developer'] = [
             'UserprefsDeveloperTab',

--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -268,20 +268,22 @@ class AuthenticationCookie extends AuthenticationPlugin
                 && ! empty($GLOBALS['cfg']['CaptchaLoginPublicKey'])
             ) {
                 if (! empty($_POST['g-recaptcha-response'])) {
+                    $captchaSiteVerifyURL = $GLOBALS['cfg']['CaptchaSiteVerifyURL'] ?? '';
+                    $captchaSiteVerifyURL = empty($captchaSiteVerifyURL) ? null : $captchaSiteVerifyURL;
                     if (function_exists('curl_init')) {
                         $reCaptcha = new ReCaptcha\ReCaptcha(
                             $GLOBALS['cfg']['CaptchaLoginPrivateKey'],
-                            new ReCaptcha\RequestMethod\CurlPost()
+                            new ReCaptcha\RequestMethod\CurlPost(null, $captchaSiteVerifyURL)
                         );
                     } elseif (ini_get('allow_url_fopen')) {
                         $reCaptcha = new ReCaptcha\ReCaptcha(
                             $GLOBALS['cfg']['CaptchaLoginPrivateKey'],
-                            new ReCaptcha\RequestMethod\Post()
+                            new ReCaptcha\RequestMethod\Post($captchaSiteVerifyURL)
                         );
                     } else {
                         $reCaptcha = new ReCaptcha\ReCaptcha(
                             $GLOBALS['cfg']['CaptchaLoginPrivateKey'],
-                            new ReCaptcha\RequestMethod\SocketPost()
+                            new ReCaptcha\RequestMethod\SocketPost(null, $captchaSiteVerifyURL)
                         );
                     }
 

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -849,6 +849,13 @@ $cfg['CaptchaLoginPublicKey'] = '';
 $cfg['CaptchaLoginPrivateKey'] = '';
 
 /**
+ * if reCaptcha is enabled may need an URL for site verify
+ *
+ * @global string $cfg['CaptchaSiteVerifyURL']
+ */
+$cfg['CaptchaSiteVerifyURL'] = '';
+
+/**
  * Enable drag and drop import
  *
  * @see feature request : https://github.com/phpmyadmin/phpmyadmin/issues/13155


### PR DESCRIPTION
Added the ability to customize ReCaptcha's siteVerifyUrl parameter in the RequestMethod constructors. This is useful when web application servers reside behind firewalls, and are unable to whitelist google.com for recaptcha validation.

Signed-off-by: Dubz <REDACTED>

#15496 