### PR TITLE
FIX: Unparenthesized `a ? b : c ? d : e` is deprecated.

### DIFF
--- a/libraries/tbl_columns_definition_form.inc.php
+++ b/libraries/tbl_columns_definition_form.inc.php
@@ -428,8 +428,8 @@ $html = Template::get('columns_definitions/column_definitions_form')->render([
     'max_rows' => intval($GLOBALS['cfg']['MaxRows']),
     'char_editing' => isset($GLOBALS['cfg']['CharEditing']) ? $GLOBALS['cfg']['CharEditing'] : null,
     'attribute_types' => $GLOBALS['dbi']->types->getAttributes(),
-    'privs_available' => (isset($GLOBALS['col_priv']) ? $GLOBALS['col_priv'] : false
-        && isset($GLOBALS['is_reload_priv']) ? $GLOBALS['is_reload_priv'] : false
+    'privs_available' => ((isset($GLOBALS['col_priv']) ? $GLOBALS['col_priv'] : false)
+        && (isset($GLOBALS['is_reload_priv']) ? $GLOBALS['is_reload_priv'] : false)
     ),
     'max_length' => $GLOBALS['dbi']->getVersion() >= 50503 ? 1024 : 255,
     'have_partitioning' => Partition::havePartitioning(),


### PR DESCRIPTION
### Description

A fix for the issue #15499 as described.

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [] Any new functionality is covered by tests.
