### PR TITLE
Fix wrong translation for `Th` in `fr.po`

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -2562,7 +2562,7 @@ msgstr "me"
 #. l10n: Minimal week day name
 #: js/messages.php:891
 msgid "Th"
-msgstr "me"
+msgstr "je"
 
 #. l10n: Minimal week day name
 #: js/messages.php:893


### PR DESCRIPTION
Signed-off-by: Benoit Portrat <benoit.portrat@gmail.com>

### Description

The french translation of the Thursday abbreviation `Th` is faulty in the `fr.po` file. It should be `je` for "jeudi". It seems to be a faulty copy-paste.

Fixes #

Set `je` instead of `me` for the `Th` translation in `fr.po`.                                                           