### PR TITLE
Fix/selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,18 @@ matrix:
     - php: "5.5"
       env: CI_MODE=test
       dist: trusty
+    - php: "7.3"
+      env: CI_MODE=test
+      name: "Run tests using phpunit 8"
+      install:
+       - composer require --no-interaction php>=7.1
+       - composer remove phpunit/phpunit-selenium --dev --no-interaction
+       - composer remove phpunit/phpunit --dev --no-interaction
+       - composer require --dev --no-interaction phpunit/phpunit ^8
+       - rm -rf test/selenium
+       - "find test/ -type f -print0 | xargs -0 sed -i 's/function setUpBeforeClass()/function setUpBeforeClass(): void/g'"
+       - "find test/ -type f -print0 | xargs -0 sed -i 's/function setUp()/function setUp(): void/g'"
+       - "find test/ -type f -print0 | xargs -0 sed -i 's/function tearDown()/function tearDown(): void/g'"
     - php: "7.1"
       env: CI_MODE=test DBASE=true
       install:

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1294,7 +1294,7 @@ class Util
             // if the unit is not bytes (as represented in current language)
             // reformat with max length of 5
             // 4th parameter=true means do not reformat if value < 1
-            $return_value = self::formatNumber($value, 5, $comma, true);
+            $return_value = self::formatNumber($value, 5, $comma, true, false);
         } else {
             // do not reformat, just handle the locale
             $return_value = self::formatNumber($value, 0);

--- a/test/Environment_test.php
+++ b/test/Environment_test.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Environment tests
  *
+ * @group environment
  * @package PhpMyAdmin-test
  */
 class Environment_Test extends TestCase

--- a/test/classes/AdvisorTest.php
+++ b/test/classes/AdvisorTest.php
@@ -26,7 +26,7 @@ class AdvisorTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['PMA_Config'] = new Config();
         $GLOBALS['server'] = 1;

--- a/test/classes/Config/FormDisplayTest.php
+++ b/test/classes/Config/FormDisplayTest.php
@@ -32,7 +32,7 @@ class FormDisplayTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
         $GLOBALS['PMA_Config'] = new Config();

--- a/test/classes/Config/FormTest.php
+++ b/test/classes/Config/FormTest.php
@@ -31,7 +31,7 @@ class FormTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['pmaThemePath'] = $GLOBALS['PMA_Theme']->getPath();
         $GLOBALS['PMA_Config'] = new Config();

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -12,7 +12,6 @@ use PhpMyAdmin\Config;
 use PhpMyAdmin\Tests\PmaTestCase;
 use PhpMyAdmin\Theme;
 use PHPUnit\Framework\Assert;
-use PHPUnit\Framework\Exception;
 
 /**
  * Tests behaviour of PhpMyAdmin\Config class
@@ -1338,18 +1337,25 @@ class ConfigTest extends PmaTestCase
      */
     public function testCheckServers($settings, $expected, $error = false)
     {
-        if ($error) {
-            $this->expectException(Exception::class);
+        try {
+            $this->object->settings['Servers'] = $settings;
+            $this->object->checkServers();
+            if (is_null($expected)) {
+                $expected = $this->object->default_server;
+            } else {
+                $expected = array_merge($this->object->default_server, $expected);
+            }
+            $this->assertEquals($expected, $this->object->settings['Servers'][1]);
+            if ($error) {
+                $this->assertTrue(false);
+            }
+        } catch (\Exception $e) {
+            if ($error) {
+                $this->assertTrue(true);
+            } else {
+                throw $e;
+            }
         }
-
-        $this->object->settings['Servers'] = $settings;
-        $this->object->checkServers();
-        if (is_null($expected)) {
-            $expected = $this->object->default_server;
-        } else {
-            $expected = array_merge($this->object->default_server, $expected);
-        }
-        $this->assertEquals($expected, $this->object->settings['Servers'][1]);
     }
 
     /**

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -11,7 +11,8 @@ namespace PhpMyAdmin\Tests;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Tests\PmaTestCase;
 use PhpMyAdmin\Theme;
-use PHPUnit_Framework_Assert as Assert;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Exception;
 
 /**
  * Tests behaviour of PhpMyAdmin\Config class
@@ -1333,7 +1334,7 @@ class ConfigTest extends PmaTestCase
     public function testCheckServers($settings, $expected, $error = false)
     {
         if ($error) {
-            $this->setExpectedException('PHPUnit_Framework_Error');
+            $this->expectException(Exception::class);
         }
 
         $this->object->settings['Servers'] = $settings;

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -937,6 +937,7 @@ class ConfigTest extends PmaTestCase
     /**
      * Test for isGitRevision
      *
+     * @group git-revision
      * @return void
      */
     public function testIsGitRevisionLocalGitDir()
@@ -997,6 +998,7 @@ class ConfigTest extends PmaTestCase
     /**
      * Test for isGitRevision
      *
+     * @group git-revision
      * @return void
      */
     public function testIsGitRevisionExternalGitDir()
@@ -1058,6 +1060,7 @@ class ConfigTest extends PmaTestCase
     /**
      * Test for checkGitRevision packs folder
      *
+     * @group git-revision
      * @return void
      */
     public function testCheckGitRevisionPacksFolder()
@@ -1122,6 +1125,7 @@ class ConfigTest extends PmaTestCase
     /**
      * Test for checkGitRevision packs folder
      *
+     * @group git-revision
      * @return void
      */
     public function testCheckGitRevisionRefFile()
@@ -1178,6 +1182,7 @@ class ConfigTest extends PmaTestCase
     /**
      * Test for checkGitRevision with packs as file
      *
+     * @group git-revision
      * @return void
      */
     public function testCheckGitRevisionPacksFile()

--- a/test/classes/Di/ContainerTest.php
+++ b/test/classes/Di/ContainerTest.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin\Tests\Di;
 
 use PhpMyAdmin\Di\Container;
 use PhpMyAdmin\Tests\PmaTestCase;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Tests for PhpMyAdmin\Di\Container class
@@ -64,7 +65,7 @@ class ContainerTest extends PmaTestCase
      */
     public function testGetThrowsNotFoundException()
     {
-        $this->setExpectedException('Psr\Container\NotFoundExceptionInterface');
+        $this->expectException(NotFoundExceptionInterface::class);
         $this->container->get('name');
     }
 

--- a/test/classes/Di/ContainerTest.php
+++ b/test/classes/Di/ContainerTest.php
@@ -65,8 +65,12 @@ class ContainerTest extends PmaTestCase
      */
     public function testGetThrowsNotFoundException()
     {
-        $this->expectException(NotFoundExceptionInterface::class);
-        $this->container->get('name');
+        try {
+            $this->container->get('name');
+            $this->assertTrue(false);
+        } catch (NotFoundExceptionInterface $e) {
+            $this->assertTrue(true);
+        }
     }
 
     /**

--- a/test/classes/ErrorTest.php
+++ b/test/classes/ErrorTest.php
@@ -119,7 +119,7 @@ class ErrorTest extends PmaTestCase
     public function testGetBacktraceDisplay()
     {
         $this->assertContains(
-            'PHPUnit_Framework_TestResult->run(<Class:PhpMyAdmin\Tests\ErrorTest>)<br />',
+            'TestResult->run(<Class:PhpMyAdmin\Tests\ErrorTest>)<br />',
             $this->object->getBacktraceDisplay()
         );
     }

--- a/test/classes/FileTest.php
+++ b/test/classes/FileTest.php
@@ -22,7 +22,7 @@ class FileTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['charset_conversion'] = false;
     }

--- a/test/classes/HeaderTest.php
+++ b/test/classes/HeaderTest.php
@@ -26,7 +26,7 @@ class HeaderTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         if (!defined('PMA_IS_WINDOWS')) {
             define('PMA_IS_WINDOWS', false);

--- a/test/classes/IndexTest.php
+++ b/test/classes/IndexTest.php
@@ -24,7 +24,7 @@ class IndexTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $this->_params['Schema'] = "PMA_Schema";
         $this->_params['Table'] = "PMA_Table";

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -32,7 +32,7 @@ class InsertEditTest extends TestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 1;
         $GLOBALS['PMA_PHP_SELF'] = 'index.php';

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -60,6 +60,7 @@ class InsertEditTest extends TestCase
         $GLOBALS['cfg']['NavigationTreeDefaultTabTable2'] = '';
         $GLOBALS['cfg']['Confirm'] = true;
         $GLOBALS['cfg']['LoginCookieValidity'] = 1440;
+        $GLOBALS['cfg']['enable_drag_drop_import'] = true;
         $GLOBALS['PMA_Config'] = new Config();
 
         $this->insertEdit = new InsertEdit($GLOBALS['dbi']);
@@ -2672,7 +2673,7 @@ class InsertEditTest extends TestCase
     public function testVerifyWhetherValueCanBeTruncatedAndAppendExtraData()
     {
         $extra_data = array('isNeedToRecheck' => true);
-        $meta = new stdClass();
+
         $_POST['where_clause'][0] = 1;
 
         $dbi = $this->getMockBuilder('PhpMyAdmin\DatabaseInterface')
@@ -2682,7 +2683,7 @@ class InsertEditTest extends TestCase
         $dbi->expects($this->at(0))
             ->method('tryQuery')
             ->with('SELECT `table`.`a` FROM `db`.`table` WHERE 1');
-
+        $meta = new stdClass();
         $meta->type = 'int';
         $dbi->expects($this->at(1))
             ->method('getFieldsMeta')
@@ -2699,7 +2700,9 @@ class InsertEditTest extends TestCase
             ->method('tryQuery')
             ->with('SELECT `table`.`a` FROM `db`.`table` WHERE 1');
 
+        $meta = new stdClass();
         $meta->type = 'int';
+        $meta->flags = '';
         $dbi->expects($this->at(5))
             ->method('getFieldsMeta')
             ->will($this->returnValue(array($meta)));
@@ -2715,7 +2718,9 @@ class InsertEditTest extends TestCase
             ->method('tryQuery')
             ->with('SELECT `table`.`a` FROM `db`.`table` WHERE 1');
 
+        $meta = new stdClass();
         $meta->type = 'timestamp';
+        $meta->flags = '';
         $dbi->expects($this->at(9))
             ->method('getFieldsMeta')
             ->will($this->returnValue(array($meta)));

--- a/test/classes/LanguageTest.php
+++ b/test/classes/LanguageTest.php
@@ -24,7 +24,7 @@ class LanguageTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $loc = LOCALE_PATH . '/cs/LC_MESSAGES/phpmyadmin.mo';
         if (! is_readable($loc)) {

--- a/test/classes/ListDatabaseTest.php
+++ b/test/classes/ListDatabaseTest.php
@@ -26,7 +26,7 @@ class ListDatabaseTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['cfg']['Server']['only_db'] = array('single\\_db');
         $this->object = new ListDatabase();

--- a/test/classes/MenuTest.php
+++ b/test/classes/MenuTest.php
@@ -23,7 +23,7 @@ class MenuTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         if (!defined('PMA_IS_WINDOWS')) {
             define('PMA_IS_WINDOWS', false);

--- a/test/classes/Navigation/NodeFactoryTest.php
+++ b/test/classes/Navigation/NodeFactoryTest.php
@@ -24,7 +24,7 @@ class NodeFactoryTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/NodeFactoryTest.php
+++ b/test/classes/Navigation/NodeFactoryTest.php
@@ -10,8 +10,6 @@ namespace PhpMyAdmin\Tests\Navigation;
 use PhpMyAdmin\Navigation\NodeFactory;
 use PhpMyAdmin\Navigation\Nodes\Node;
 use PhpMyAdmin\Tests\PmaTestCase;
-use PhpMyAdmin\Theme;
-use PHPUnit\Framework\Exception;
 
 /**
  * Tests for NodeFactory class
@@ -85,8 +83,12 @@ class NodeFactoryTest extends PmaTestCase
      */
     public function testFileError()
     {
-        $this->expectException(Exception::class);
-        NodeFactory::getInstance('NodeDoesNotExist');
+        try {
+            NodeFactory::getInstance('NodeDoesNotExist');
+            $this->assertTrue(false);
+        } catch (\Exception $e) {
+            $this->assertTrue(true);
+        }
     }
 
     /**
@@ -96,7 +98,11 @@ class NodeFactoryTest extends PmaTestCase
      */
     public function testClassNameError()
     {
-        $this->expectException(Exception::class);
-        NodeFactory::getInstance('Invalid');
+        try {
+            NodeFactory::getInstance('Invalid');
+            $this->assertTrue(false);
+        } catch (\Exception $e) {
+            $this->assertTrue(true);
+        }
     }
 }

--- a/test/classes/Navigation/NodeFactoryTest.php
+++ b/test/classes/Navigation/NodeFactoryTest.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\Navigation\NodeFactory;
 use PhpMyAdmin\Navigation\Nodes\Node;
 use PhpMyAdmin\Tests\PmaTestCase;
 use PhpMyAdmin\Theme;
+use PHPUnit\Framework\Exception;
 
 /**
  * Tests for NodeFactory class
@@ -84,7 +85,7 @@ class NodeFactoryTest extends PmaTestCase
      */
     public function testFileError()
     {
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        $this->expectException(Exception::class);
         NodeFactory::getInstance('NodeDoesNotExist');
     }
 
@@ -95,7 +96,7 @@ class NodeFactoryTest extends PmaTestCase
      */
     public function testClassNameError()
     {
-        $this->setExpectedException('PHPUnit_Framework_Error');
+        $this->expectException(Exception::class);
         NodeFactory::getInstance('Invalid');
     }
 }

--- a/test/classes/Navigation/Nodes/NodeColumnContainerTest.php
+++ b/test/classes/Navigation/Nodes/NodeColumnContainerTest.php
@@ -23,7 +23,7 @@ class NodeColumnContainerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeColumnTest.php
+++ b/test/classes/Navigation/Nodes/NodeColumnTest.php
@@ -23,7 +23,7 @@ class NodeColumnTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeDatabaseTest.php
+++ b/test/classes/Navigation/Nodes/NodeDatabaseTest.php
@@ -23,7 +23,7 @@ class NodeDatabaseTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';

--- a/test/classes/Navigation/Nodes/NodeEventContainerTest.php
+++ b/test/classes/Navigation/Nodes/NodeEventContainerTest.php
@@ -23,7 +23,7 @@ class NodeEventContainerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeEventTest.php
+++ b/test/classes/Navigation/Nodes/NodeEventTest.php
@@ -23,7 +23,7 @@ class NodeEventTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeFunctionContainerTest.php
+++ b/test/classes/Navigation/Nodes/NodeFunctionContainerTest.php
@@ -23,7 +23,7 @@ class NodeFunctionContainerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeFunctionTest.php
+++ b/test/classes/Navigation/Nodes/NodeFunctionTest.php
@@ -23,7 +23,7 @@ class NodeFunctionTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeIndexContainerTest.php
+++ b/test/classes/Navigation/Nodes/NodeIndexContainerTest.php
@@ -23,7 +23,7 @@ class NodeIndexContainerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeIndexTest.php
+++ b/test/classes/Navigation/Nodes/NodeIndexTest.php
@@ -23,7 +23,7 @@ class NodeIndexTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeProcedureContainerTest.php
+++ b/test/classes/Navigation/Nodes/NodeProcedureContainerTest.php
@@ -23,7 +23,7 @@ class NodeProcedureContainerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeProcedureTest.php
+++ b/test/classes/Navigation/Nodes/NodeProcedureTest.php
@@ -23,7 +23,7 @@ class NodeProcedureTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeTableContainerTest.php
+++ b/test/classes/Navigation/Nodes/NodeTableContainerTest.php
@@ -23,7 +23,7 @@ class NodeTableContainerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['NavigationTreeEnableGrouping'] = true;

--- a/test/classes/Navigation/Nodes/NodeTableTest.php
+++ b/test/classes/Navigation/Nodes/NodeTableTest.php
@@ -23,7 +23,7 @@ class NodeTableTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['NavigationTreeDefaultTabTable'] = 'b_browse';

--- a/test/classes/Navigation/Nodes/NodeTest.php
+++ b/test/classes/Navigation/Nodes/NodeTest.php
@@ -25,7 +25,7 @@ class NodeTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['Server']['DisableIS'] = false;

--- a/test/classes/Navigation/Nodes/NodeTriggerContainerTest.php
+++ b/test/classes/Navigation/Nodes/NodeTriggerContainerTest.php
@@ -23,7 +23,7 @@ class NodeTriggerContainerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeTriggerTest.php
+++ b/test/classes/Navigation/Nodes/NodeTriggerTest.php
@@ -23,7 +23,7 @@ class NodeTriggerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/Navigation/Nodes/NodeViewContainerTest.php
+++ b/test/classes/Navigation/Nodes/NodeViewContainerTest.php
@@ -23,7 +23,7 @@ class NodeViewContainerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['NavigationTreeEnableGrouping'] = true;

--- a/test/classes/Navigation/Nodes/NodeViewTest.php
+++ b/test/classes/Navigation/Nodes/NodeViewTest.php
@@ -23,7 +23,7 @@ class NodeViewTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['server'] = 0;
     }

--- a/test/classes/PdfTest.php
+++ b/test/classes/PdfTest.php
@@ -23,7 +23,7 @@ class PdfTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['PMA_Config'] = new Config();
         $GLOBALS['PMA_Config']->enableBc();

--- a/test/classes/Plugins/Auth/AuthenticationCookieTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -34,7 +34,7 @@ class AuthenticationCookieTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['PMA_Config'] = new Config();
         $GLOBALS['PMA_Config']->enableBc();

--- a/test/classes/Plugins/Export/ExportCodegenTest.php
+++ b/test/classes/Plugins/Export/ExportCodegenTest.php
@@ -28,7 +28,7 @@ class ExportCodegenTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $this->object = new ExportCodegen(null);

--- a/test/classes/Plugins/Export/ExportCsvTest.php
+++ b/test/classes/Plugins/Export/ExportCsvTest.php
@@ -28,7 +28,7 @@ class ExportCsvTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $this->object = new ExportCsv();

--- a/test/classes/Plugins/Export/ExportExcelTest.php
+++ b/test/classes/Plugins/Export/ExportExcelTest.php
@@ -27,7 +27,7 @@ class ExportExcelTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $this->object = new ExportExcel();

--- a/test/classes/Plugins/Export/ExportHtmlwordTest.php
+++ b/test/classes/Plugins/Export/ExportHtmlwordTest.php
@@ -28,7 +28,7 @@ class ExportHtmlwordTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $this->object = new ExportHtmlword();

--- a/test/classes/Plugins/Export/ExportJsonTest.php
+++ b/test/classes/Plugins/Export/ExportJsonTest.php
@@ -27,7 +27,7 @@ class ExportJsonTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/ExportLatexTest.php
+++ b/test/classes/Plugins/Export/ExportLatexTest.php
@@ -27,7 +27,7 @@ class ExportLatexTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/ExportMediawikiTest.php
+++ b/test/classes/Plugins/Export/ExportMediawikiTest.php
@@ -28,7 +28,7 @@ class ExportMediawikiTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/ExportOdsTest.php
+++ b/test/classes/Plugins/Export/ExportOdsTest.php
@@ -29,7 +29,7 @@ class ExportOdsTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -29,7 +29,7 @@ class ExportOdtTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/ExportPdfTest.php
+++ b/test/classes/Plugins/Export/ExportPdfTest.php
@@ -28,7 +28,7 @@ class ExportPdfTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/ExportPhparrayTest.php
+++ b/test/classes/Plugins/Export/ExportPhparrayTest.php
@@ -28,7 +28,7 @@ class ExportPhparrayTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -30,7 +30,7 @@ class ExportSqlTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['db'] = 'db';

--- a/test/classes/Plugins/Export/ExportTexytextTest.php
+++ b/test/classes/Plugins/Export/ExportTexytextTest.php
@@ -28,7 +28,7 @@ class ExportTexytextTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/ExportXmlTest.php
+++ b/test/classes/Plugins/Export/ExportXmlTest.php
@@ -29,7 +29,7 @@ class ExportXmlTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/ExportYamlTest.php
+++ b/test/classes/Plugins/Export/ExportYamlTest.php
@@ -28,7 +28,7 @@ class ExportYamlTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $GLOBALS['output_kanji_conversion'] = false;

--- a/test/classes/Plugins/Export/Helpers/TablePropertyTest.php
+++ b/test/classes/Plugins/Export/Helpers/TablePropertyTest.php
@@ -24,7 +24,7 @@ class TablePropertyTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['server'] = 0;
         $row = array(' name ', 'int ', true, ' PRI', '0', 'mysql');

--- a/test/classes/Properties/Options/Groups/OptionsPropertyMainGroupTest.php
+++ b/test/classes/Properties/Options/Groups/OptionsPropertyMainGroupTest.php
@@ -24,7 +24,7 @@ class OptionsPropertyMainGroupTest extends TestCase
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->object = new OptionsPropertyMainGroup();
     }

--- a/test/classes/Properties/Options/Groups/OptionsPropertyRootGroupTest.php
+++ b/test/classes/Properties/Options/Groups/OptionsPropertyRootGroupTest.php
@@ -24,7 +24,7 @@ class OptionsPropertyRootGroupTest extends TestCase
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->object = new OptionsPropertyRootGroup();
     }

--- a/test/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
+++ b/test/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
@@ -24,7 +24,7 @@ class OptionsPropertySubgroupTest extends TestCase
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->object = new OptionsPropertySubgroup();
     }

--- a/test/classes/Properties/Options/OptionsPropertyGroupTest.php
+++ b/test/classes/Properties/Options/OptionsPropertyGroupTest.php
@@ -24,7 +24,7 @@ class OptionsPropertyGroupTest extends TestCase
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->stub = $this->getMockForAbstractClass('PhpMyAdmin\Properties\Options\OptionsPropertyGroup');
     }

--- a/test/classes/Properties/Options/OptionsPropertyItemTest.php
+++ b/test/classes/Properties/Options/OptionsPropertyItemTest.php
@@ -23,7 +23,7 @@ class OptionsPropertyItemTest extends TestCase
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->stub = $this->getMockForAbstractClass('PhpMyAdmin\Properties\Options\OptionsPropertyItem');
     }

--- a/test/classes/Properties/Options/OptionsPropertyOneItemTest.php
+++ b/test/classes/Properties/Options/OptionsPropertyOneItemTest.php
@@ -23,7 +23,7 @@ class OptionsPropertyOneItemTest extends TestCase
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->stub = $this->getMockForAbstractClass('PhpMyAdmin\Properties\Options\OptionsPropertyOneItem');
     }

--- a/test/classes/Properties/Plugins/ExportPluginPropertiesTest.php
+++ b/test/classes/Properties/Plugins/ExportPluginPropertiesTest.php
@@ -25,7 +25,7 @@ class ExportPluginPropertiesTest extends ImportPluginPropertiesTest
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->object = new ExportPluginProperties();
     }

--- a/test/classes/Properties/Plugins/ImportPluginPropertiesTest.php
+++ b/test/classes/Properties/Plugins/ImportPluginPropertiesTest.php
@@ -24,7 +24,7 @@ class ImportPluginPropertiesTest extends TestCase
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->object = new ImportPluginProperties();
     }

--- a/test/classes/Properties/Plugins/PluginPropertyItemTest.php
+++ b/test/classes/Properties/Plugins/PluginPropertyItemTest.php
@@ -23,7 +23,7 @@ class PluginPropertyItemTest extends TestCase
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->stub = $this->getMockForAbstractClass('PhpMyAdmin\Properties\Plugins\PluginPropertyItem');
     }

--- a/test/classes/Properties/PropertyItemTest.php
+++ b/test/classes/Properties/PropertyItemTest.php
@@ -23,7 +23,7 @@ class PropertyItemTest extends TestCase
      *
      * @return void
      */
-    protected function setup()
+    protected function setUp()
     {
         $this->stub = $this->getMockForAbstractClass('PhpMyAdmin\Properties\PropertyItem');
     }

--- a/test/classes/Server/Status/DataTest.php
+++ b/test/classes/Server/Status/DataTest.php
@@ -29,7 +29,7 @@ class DataTest extends PmaTestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['PMA_PHP_SELF'] = Core::getenv('PHP_SELF');
         $GLOBALS['cfg']['Server']['host'] = "::1";

--- a/test/classes/Setup/IndexTest.php
+++ b/test/classes/Setup/IndexTest.php
@@ -22,7 +22,7 @@ class IndexTest extends TestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['cfg']['ProxyUrl'] = '';
     }

--- a/test/classes/TemplateTest.php
+++ b/test/classes/TemplateTest.php
@@ -90,8 +90,12 @@ class TemplateTest extends PmaTestCase
      */
     public function testRenderTemplateNotFound()
     {
-        $this->expectException(LoaderError::class);
-        Template::get('template not found')->render();
+        try {
+            Template::get('template not found')->render();
+            $this->assertTrue(false);
+        } catch (LoaderError $e) {
+            $this->assertTrue(true);
+        }
     }
 
     /**

--- a/test/classes/TemplateTest.php
+++ b/test/classes/TemplateTest.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\PmaTestCase;
+use Twig\Error\LoaderError;
 
 /**
  * Test for PhpMyAdmin\Template class
@@ -89,7 +90,7 @@ class TemplateTest extends PmaTestCase
      */
     public function testRenderTemplateNotFound()
     {
-        $this->setExpectedException('Twig\Error\LoaderError');
+        $this->expectException(LoaderError::class);
         Template::get('template not found')->render();
     }
 

--- a/test/classes/ThemeManagerTest.php
+++ b/test/classes/ThemeManagerTest.php
@@ -23,7 +23,7 @@ class ThemeManagerTest extends PmaTestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['cfg']['ThemePerServer'] = false;
         $GLOBALS['cfg']['ThemeDefault'] = 'pmahomme';

--- a/test/classes/TrackerTest.php
+++ b/test/classes/TrackerTest.php
@@ -11,7 +11,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Tests\PmaTestCase;
 use PhpMyAdmin\Tracker;
 use PhpMyAdmin\Util;
-use PHPUnit_Framework_Assert as Assert;
+use PHPUnit\Framework\Assert;
 use ReflectionClass;
 
 /**

--- a/test/classes/TransformationsTest.php
+++ b/test/classes/TransformationsTest.php
@@ -23,7 +23,7 @@ class TransformationsTest extends TestCase
      *
      * @return void
      */
-    public function setup()
+    public function setUp()
     {
         $GLOBALS['table'] = 'table';
         $GLOBALS['db'] = 'db';

--- a/test/libraries/database_interface_test.php
+++ b/test/libraries/database_interface_test.php
@@ -24,7 +24,7 @@ class PMA_DBI_Test extends TestCase
      *
      * @return void
      */
-    function setup()
+    function setUp()
     {
         $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['cfg']['IconvExtraParams'] = '';

--- a/test/selenium/ChangePasswordTest.php
+++ b/test/selenium/ChangePasswordTest.php
@@ -9,6 +9,8 @@
 
 namespace PhpMyAdmin\Tests\Selenium;
 
+use PHPUnit\Framework\AssertionFailedError;
+
 /**
  * PrivilegesTest class
  *
@@ -38,19 +40,19 @@ class ChangePasswordTest extends TestBase
         try {
             $ele = $this->waitForElement("byName", "pma_pw");
             $this->assertEquals("", $ele->value());
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             array_push($this->verificationErrors, $e->toString());
         }
         try {
             $ele = $this->waitForElement("byName", "pma_pw2");
             $this->assertEquals("", $ele->value());
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             array_push($this->verificationErrors, $e->toString());
         }
         try {
             $ele = $this->waitForElement("byName", "generated_pw");
             $this->assertEquals("", $ele->value());
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             array_push($this->verificationErrors, $e->toString());
         }
         $this->byId("button_generate_password")->click();


### PR DESCRIPTION
public static function formatByteDown($value, $limes = 6, $comma = 0)
            // if the unit is not bytes (as represented in current language)	            
            // reformat with max length of 5	          
            // 4th parameter=true means do not reformat if value < 1	          
            $return_value = self::formatNumber($value, 5, $comma, true);	          
        } else {	        } else {
            // do not reformat, just handle the locale	       
            $return_value = self::formatNumber($value, 0);	          
