### PR TITLE
fix #15491 Generate password complexity setting

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -483,7 +483,7 @@ Functions.suggestPassword = function (passwordForm) {
     // restrict the password to just letters and numbers to avoid problems:
     // "editors and viewers regard the password as multiple words and
     // things like double click no longer work"
-    var pwchars = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWYXZ';
+    var pwchars = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWYXZ@!_.*/()[]-';
     var passwordlength = 16;    // do we want that to be dynamic?  no, keep it simple :)
     var passwd = passwordForm.generated_pw;
     var randomWords = new Int32Array(passwordlength);


### PR DESCRIPTION
Add symbols to possible characters for suggested passwords to have a chance to match the default value of validate_password_special_char_count when 	validate_password_policy is set to MEDIUM or higher.

Fixes: #15491 