### PR TITLE
fixed html element typo in indexes.js

### DIFF
--- a/js/error_report.js
+++ b/js/error_report.js
@@ -123,8 +123,7 @@ var ErrorReport = {
         ErrorReport.removeErrorNotification();
 
         var $div = $(
-            '<div style="position:fixed;bottom:0;left:0;right:0;margin:0;' +
-            'z-index:1000" class="alert alert-danger" role="alert" id="error_notification"></div>'
+            '<div class="alert alert-danger userPermissionModal" role="alert" id="error_notification"></div>'
         ).append(
             Functions.getImage('s_error') + Messages.strErrorOccurred
         );

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -625,6 +625,15 @@ div#modalOverlay {
   z-index: 900;
 }
 
+div#userPermissionModal {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 0;
+  z-index: 1000;
+}
+
 form.login label {
   width: 10em;
   font-weight: bolder;

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -865,6 +865,15 @@ div#modalOverlay {
   z-index: 900;
 }
 
+div#userPermissionModal {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 0;
+  z-index: 1000;
+}
+
 form.login {
   input {
     &[type=text],


### PR DESCRIPTION
### Description

I was looking for issues with inline styles as described in this thread: https://github.com/phpmyadmin/phpmyadmin/issues/12262 when I found a misspelled element. I'm just getting to know this project, so let me know if there are any issues, or if this is too small to merge! 

I realize I forgot to signoff in my commit message, and will do so going forward.

Fixes #

Fixed misspelling of "label" on line 293 ('</lablel>')


