### PR TITLE
Fix Long2IP issue with PHP7.1

### DIFF
--- a/libraries/classes/Plugins/Transformations/Abs/LongToIPv4TransformationsPlugin.php
+++ b/libraries/classes/Plugins/Transformations/Abs/LongToIPv4TransformationsPlugin.php
@@ -9,6 +9,7 @@
 namespace PhpMyAdmin\Plugins\Transformations\Abs;
 
 use PhpMyAdmin\Plugins\TransformationsPlugin;
+use PhpMyAdmin\Util;
 
 /**
  * Provides common methods for all of the long to IPv4 transformations plugins.
@@ -41,13 +42,12 @@ abstract class LongToIPv4TransformationsPlugin extends TransformationsPlugin
      */
     public function applyTransformation($buffer, array $options = array(), $meta = '')
     {
-        if ($buffer < 0 || $buffer > 4294967295) {
+        if (! Util::isInteger($buffer) || $buffer < 0 || $buffer > 4294967295) {
             return htmlspecialchars($buffer);
         }
 
-        return long2ip($buffer);
+        return long2ip((int) $buffer);
     }
-
 
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */
 

--- a/libraries/classes/Plugins/Transformations/Output/Text_Plain_Binarytoip.php
+++ b/libraries/classes/Plugins/Transformations/Output/Text_Plain_Binarytoip.php
@@ -9,6 +9,7 @@
 namespace PhpMyAdmin\Plugins\Transformations\Output;
 
 use PhpMyAdmin\Plugins\TransformationsPlugin;
+use function hex2bin;
 
 /**
  * Handles the binary to IPv4/IPv6 transformation for text plain
@@ -45,15 +46,18 @@ class Text_Plain_Binarytoip extends TransformationsPlugin
      */
     public function applyTransformation($buffer, array $options = array(), $meta = '')
     {
-        $length = strlen($buffer);
-        if ($length == 4 || $length == 16) {
-            $val = @inet_ntop(pack('A' . $length, $buffer));
-            if ($val !== false) {
-                return $val;
-            }
+        if (0 !== strpos($buffer, '0x')) {
+            return $buffer;
         }
 
-        return $buffer;
+        $ipHex = substr($buffer, 2);
+        $ipBin = hex2bin($ipHex);
+
+        if (false === $ipBin) {
+            return $buffer;
+        }
+
+        return @inet_ntop($ipBin);
     }
 
 

--- a/libraries/classes/Plugins/Transformations/Output/Text_Plain_Binarytoip.php
+++ b/libraries/classes/Plugins/Transformations/Output/Text_Plain_Binarytoip.php
@@ -9,7 +9,6 @@
 namespace PhpMyAdmin\Plugins\Transformations\Output;
 
 use PhpMyAdmin\Plugins\TransformationsPlugin;
-use function hex2bin;
 
 /**
  * Handles the binary to IPv4/IPv6 transformation for text plain

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -4741,4 +4741,16 @@ class Util
 
         return self::linkOrButton($url, $title . $orderImg, $orderLinkParams);
     }
+
+    /**
+     * Check that input is an int or an int in a string
+     *
+     * @param mixed $input
+     *
+     * @return bool
+     */
+    public static function isInteger($input)
+    {
+        return (ctype_digit((string) $input));
+    }
 }

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -944,6 +944,26 @@ class TransformationPluginsTest extends PmaTestCase
                 ),
                 'suffixMA_suffix'
             ),
+            array(
+                new Text_Plain_Longtoipv4(),
+                array(168496141),
+                '10.11.12.13'
+            ),
+            array(
+                new Text_Plain_Longtoipv4(),
+                array('168496141'),
+                '10.11.12.13'
+            ),
+            array(
+                new Text_Plain_Longtoipv4(),
+                array('my ip'),
+                'my ip'
+            ),
+            array(
+                new Text_Plain_Longtoipv4(),
+                array('<my ip>'),
+                '&lt;my ip&gt;'
+            )
         );
 
         if (function_exists('imagecreatetruecolor')) {

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -2128,4 +2128,51 @@ class UtilTest extends PmaTestCase
             ],
         ];
     }
+
+    /**
+     * Test for Util::isInteger
+     *
+     * @param bool  $expected Expected result for a given input
+     * @param mixed $input    Input data to check
+     *
+     * @return void
+     *
+     * @dataProvider providerIsInteger
+     */
+    public function testIsInteger($expected, $input)
+    {
+        $isInteger = Util::isInteger($input);
+        $this->assertEquals($expected, $isInteger);
+    }
+
+    /**
+     * Data provider for Util::isInteger test
+     *
+     * @return array
+     */
+    public function providerIsInteger()
+    {
+        return [
+            [
+                true,
+                1000,
+            ],
+            [
+                true,
+                '1000',
+            ],
+            [
+                false,
+                1000.1,
+            ],
+            [
+                false,
+                '1000.1',
+            ],
+            [
+                false,
+                'input',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Since PHP7.1, as long2ip expects an int, due to the strict_mode, PHP throws an error.