### PR TITLE
Fix #15561 - Added a clear button for blob/binary data in insert page of the table

### DIFF
--- a/js/table/change.js
+++ b/js/table/change.js
@@ -475,14 +475,14 @@ AJAX.registerOnload('table/change.js', function () {
     $(document).on('change', '#insert_rows', addNewContinueInsertionFiels);
 
     /**
-     *  Clear blob/binary field.    
+     *  Clear blob/binary field.
      */
      $(document).on('click', '.clear_blob', function() {
         // Retrieving id of the input file
         var id = this.dataset.info;
         var fileInputField = document.getElementById(id);
         fileInputField.value = "";
-     });
+    });
 });
 
 function addNewContinueInsertionFiels (event) {

--- a/js/table/change.js
+++ b/js/table/change.js
@@ -473,6 +473,16 @@ AJAX.registerOnload('table/change.js', function () {
      * Continue Insertion form
      */
     $(document).on('change', '#insert_rows', addNewContinueInsertionFiels);
+
+    /**
+     *  Clear blob/binary field.    
+     */
+     $(document).on('click', '.clear_blob', function() {
+        // Retrieving id of the input file
+        var id = this.dataset.info;
+        var fileInputField = document.getElementById(id);
+        fileInputField.value = "";
+     });
 });
 
 function addNewContinueInsertionFiels (event) {

--- a/js/table/change.js
+++ b/js/table/change.js
@@ -477,11 +477,11 @@ AJAX.registerOnload('table/change.js', function () {
     /**
      *  Clear blob/binary field.
      */
-     $(document).on('click', '.clear_blob', function() {
+    $(document).on('click', '.clear_blob', function () {
         // Retrieving id of the input file
         var id = this.dataset.info;
         var fileInputField = document.getElementById(id);
-        fileInputField.value = "";
+        fileInputField.value = '';
     });
 });
 

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1381,6 +1381,9 @@ class InsertEdit
             || ($GLOBALS['cfg']['ProtectBinary'] === 'noblob' && ! $column['is_blob'])
         ) {
             $html_output .= __('Binary - do not edit');
+
+
+
             if (isset($data)) {
                 $data_size = Util::formatByteDown(
                     mb_strlen(stripslashes($data)),
@@ -1390,6 +1393,12 @@ class InsertEdit
                 $html_output .= ' (' . $data_size[0] . ' ' . $data_size[1] . ')';
                 unset($data_size);
             }
+            
+            // Adding clear blob button
+            $html_output .= '<button type="button" class="btn btn-sm clear_blob" data-info="field_' . $idindex . '_3">'
+                    . Util::getIcon('b_drop')
+                    . '</button>';
+
             $fields_type_val = 'protected';
             $html_output .= '<input type="hidden" name="fields'
                 . $column_name_appendix . '" value="">';


### PR DESCRIPTION
### Description
Added a clear button for blob/binary data in insert page of the table.
This is in reference to solve issue #15561.

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
