### PR TITLE
Fix table select range with Shift key

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -1046,7 +1046,7 @@ AJAX.registerOnload('functions.js', function () {
             last_click_checked = checked;
 
             // remember the last clicked row
-            last_clicked_row = last_click_checked ? $table.find('tr:not(.noclick)').index($tr) : -1;
+            last_clicked_row = last_click_checked ? $table.find('tbody tr:not(.noclick)').index($tr) : -1;
             last_shift_clicked_row = -1;
         } else {
             // handle the shift click
@@ -1072,7 +1072,7 @@ AJAX.registerOnload('functions.js', function () {
             }
 
             // handle new shift click
-            var curr_row = $table.find('tr:not(.noclick)').index($tr);
+            var curr_row = $table.find('tbody tr:not(.noclick)').index($tr);
             if (curr_row >= last_clicked_row) {
                 start = last_clicked_row;
                 end = curr_row;
@@ -1081,7 +1081,7 @@ AJAX.registerOnload('functions.js', function () {
                 end = last_clicked_row;
             }
             $tr.parent().find('tr:not(.noclick)')
-                .slice(start, end)
+                .slice(start, end + 1)
                 .addClass('marked')
                 .find(':checkbox')
                 .prop('checked', true)


### PR DESCRIPTION
Fixes issue when trying to select a range of items in a table by using the shift key.
The problem can be visualised in the custom mode while exporting tables, for example. Before the patch, clicking in the first line and then selecting the last one while pressing the shift key leads to one of the lines being unselected. There were also other unexpected situations while trying to select items in the inverse order.

Fixes https://github.com/phpmyadmin/phpmyadmin/issues/15578
Fixes https://github.com/phpmyadmin/phpmyadmin/issues/15327