### PR TITLE
Fix #15570 - Page contents go underneath of floating menubar in some cases

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1138,6 +1138,8 @@ var ResizeHandler = function () {
                 'width': '100%',
                 'z-index': 99
             })
+            .append($('#serverinfo'))
+            .append($('#topmenucontainer'));
         // Allow the DOM to render, then adjust the padding on the body
         setTimeout(function () {
             $('body').css(


### PR DESCRIPTION
### Description

After reloading the designer page, https://github.com/phpmyadmin/phpmyadmin/blob/bfe1afb542c1c9b5c4f7773a2ffe245140db1a14/js/navigation.js#L1168-L1176

height of `$('#floating_menubar')` was 0. So i appended `$('#serverinfo')` and `$('#topmenucontainer')` to `$('#floating_menubar')`.

Fixes #15570 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
