### PR TITLE
Implement absolute URL for links

### DIFF
--- a/libraries/classes/Twig/UrlExtension.php
+++ b/libraries/classes/Twig/UrlExtension.php
@@ -27,6 +27,10 @@ class UrlExtension extends AbstractExtension
     {
         return [
             new TwigFunction(
+                'base_url',
+                'PhpMyAdmin\Url::getBaseUrl'
+            ),
+            new TwigFunction(
                 'get_hidden_inputs',
                 'PhpMyAdmin\Url::getHiddenInputs',
                 ['is_safe' => ['html']]

--- a/libraries/classes/Url.php
+++ b/libraries/classes/Url.php
@@ -278,6 +278,32 @@ class Url
      */
     public static function getFromRoute(string $route, array $additionalParameters = []): string
     {
-        return 'index.php?route=' . $route . self::getCommon($additionalParameters, '&');
+        return self::getBaseUrl() . '/index.php?route=' . $route . self::getCommon($additionalParameters, '&');
+    }
+
+    /**
+     * @return string
+     */
+    public static function getBaseUrl(): string
+    {
+        $scheme = 'https';
+        if (empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === 'off') {
+            $scheme = 'http';
+        }
+        $host = $_SERVER['SERVER_NAME'];
+        if (! empty($_SERVER['HTTP_HOST'])) {
+            $host = $_SERVER['HTTP_HOST'];
+            if (strpos($host, ':') !== false) {
+                $pieces = explode(':', $host);
+                $host = $pieces[0];
+            }
+        }
+        $url = $scheme . '://' . $host;
+        $port = (int) ($_SERVER['SERVER_PORT'] ?? 80);
+        if (($scheme === 'https' && $port !== 443) || ($scheme === 'http' && $port !== 80)) {
+            $url .= ':' . $port;
+        }
+        $basePath = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/');
+        return $url . $basePath;
     }
 }

--- a/templates/scripts.twig
+++ b/templates/scripts.twig
@@ -1,5 +1,5 @@
 {% for file in files %}
-  <script data-cfasync="false" type="text/javascript" src="js/{{ file.filename }}
+  <script data-cfasync="false" type="text/javascript" src="{{ base_url() }}/js/{{ file.filename }}
     {{- '.php' in file.filename ? get_common(file.params|merge({'v': version})) : '?v=' ~ version|url_encode }}"></script>
 {% endfor %}
 

--- a/test/bootstrap-dist.php
+++ b/test/bootstrap-dist.php
@@ -70,6 +70,8 @@ if (PHP_SAPI == 'cli') {
 require_once ROOT_PATH . 'libraries/vendor_config.php';
 require_once AUTOLOAD_FILE;
 Loader::loadFunctions();
+$_SERVER['SERVER_NAME'] = 'localhost';
+$_SERVER['SCRIPT_NAME'] = '/index.php';
 $GLOBALS['PMA_Config'] = new Config();
 // Initialize PMA_VERSION variable
 define('PMA_VERSION', $GLOBALS['PMA_Config']->get('PMA_VERSION'));

--- a/test/classes/AdvisorTest.php
+++ b/test/classes/AdvisorTest.php
@@ -210,8 +210,8 @@ class AdvisorTest extends PmaTestCase
                     'id' => 'Variable',
                     'name' => 'Variable',
                     'issue' => 'issue',
-                    'recommendation' => 'Recommend <a href="index.php?route=/server/variables&amp;' .
-                    'filter=status_var&amp;lang=en">status_var</a>',
+                    'recommendation' => 'Recommend <a href="./url.php?url=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3D%2Fserver%2Fvariables%26amp%3Bfilter%3Dstatus_var%26amp%3Blang%3Den' .
+                    '" target="_blank" rel="noopener noreferrer">status_var</a>',
                 ],
                 null,
             ],

--- a/test/classes/BrowseForeignersTest.php
+++ b/test/classes/BrowseForeignersTest.php
@@ -219,7 +219,7 @@ class BrowseForeignersTest extends TestCase
         $this->assertStringContainsString(
             '<form class="ajax" '
             . 'id="browse_foreign_form" name="browse_foreign_from" '
-            . 'action="index.php?route=/browse-foreigners',
+            . 'action="http://localhost/index.php?route=/browse-foreigners',
             $result
         );
         $this->assertStringContainsString(

--- a/test/classes/CentralColumnsTest.php
+++ b/test/classes/CentralColumnsTest.php
@@ -661,7 +661,7 @@ class CentralColumnsTest extends TestCase
             $text_dir
         );
         $this->assertStringContainsString(
-            '<form action="index.php?route=/database/central_columns',
+            '<form action="http://localhost/index.php?route=/database/central_columns',
             $result
         );
         $this->assertStringContainsString(

--- a/test/classes/Config/PageSettingsTest.php
+++ b/test/classes/Config/PageSettingsTest.php
@@ -63,7 +63,7 @@ class PageSettingsTest extends PmaTestCase
             '<div id="page_settings_modal">'
             . '<div class="page_settings">'
             . '<form method="post" '
-            . 'action="phpunit?db=db&server=1&lang=en" '
+            . 'action="index.php?db=db&server=1&lang=en" '
             . 'class="config-form disableAjax">',
             $html
         );

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -142,7 +142,7 @@ class ResultsTest extends PmaTestCase
         );
 
         $this->assertStringContainsString(
-            '<form action="index.php?route=/sql',
+            '<form action="http://localhost/index.php?route=/sql',
             $actual
         );
         $this->assertStringContainsString(
@@ -1392,7 +1392,7 @@ class ResultsTest extends PmaTestCase
                 $meta,
                 $url_params,
                 null,
-                '<a href="index.php?route=/table/get_field&amp;db=foo&amp;table=bar&amp;server=0'
+                '<a href="http://localhost/index.php?route=/table/get_field&amp;db=foo&amp;table=bar&amp;server=0'
                 . '&amp;lang=en'
                 . '" class="disableAjax">1001</a>',
             ],
@@ -1413,7 +1413,7 @@ class ResultsTest extends PmaTestCase
                 $meta,
                 $url_params,
                 null,
-                '<a href="index.php?route=/table/get_field&amp;db=foo&amp;table=bar&amp;server=0'
+                '<a href="http://localhost/index.php?route=/table/get_field&amp;db=foo&amp;table=bar&amp;server=0'
                 . '&amp;lang=en'
                 . '" class="disableAjax">0x123456</a>',
             ],
@@ -1434,7 +1434,7 @@ class ResultsTest extends PmaTestCase
                 $meta,
                 $url_params,
                 null,
-                '<a href="index.php?route=/table/get_field&amp;db=foo&amp;table=bar&amp;server=0'
+                '<a href="http://localhost/index.php?route=/table/get_field&amp;db=foo&amp;table=bar&amp;server=0'
                 . '&amp;lang=en'
                 . '" class="disableAjax">[BLOB - 4 B]</a>',
             ],
@@ -1585,7 +1585,7 @@ class ResultsTest extends PmaTestCase
                 0,
                 'binary',
                 '<td class="left   hex">' . "\n"
-                . '    <a href="index.php?route=/table/get_field&amp;'
+                . '    <a href="http://localhost/index.php?route=/table/get_field&amp;'
                 . 'db=foo&amp;table=tbl&amp;server=0&amp;lang=en'
                 . '" '
                 . 'class="disableAjax">[BLOB - 4 B]</a>' . "\n"

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -36,34 +36,15 @@ class InsertEditTest extends TestCase
      */
     protected function setUp(): void
     {
+        $GLOBALS['PMA_Config'] = new Config();
+        $GLOBALS['PMA_Config']->enableBc();
         $GLOBALS['server'] = 1;
         $GLOBALS['PMA_PHP_SELF'] = 'index.php';
         $GLOBALS['cfg']['ServerDefault'] = 1;
         $GLOBALS['text_dir'] = 'ltr';
         $GLOBALS['db'] = 'db';
         $GLOBALS['table'] = 'table';
-        $GLOBALS['cfg']['LimitChars'] = 50;
-        $GLOBALS['cfg']['LongtextDoubleTextarea'] = false;
-        $GLOBALS['cfg']['ShowFieldTypesInDataEditView'] = true;
-        $GLOBALS['cfg']['ShowFunctionFields'] = true;
-        $GLOBALS['cfg']['ProtectBinary'] = 'blob';
-        $GLOBALS['cfg']['MaxSizeForInputField'] = 10;
-        $GLOBALS['cfg']['MinSizeForInputField'] = 2;
-        $GLOBALS['cfg']['TextareaRows'] = 5;
-        $GLOBALS['cfg']['TextareaCols'] = 4;
-        $GLOBALS['cfg']['CharTextareaRows'] = 5;
-        $GLOBALS['cfg']['CharTextareaCols'] = 6;
-        $GLOBALS['cfg']['AllowThirdPartyFraming'] = false;
-        $GLOBALS['cfg']['SendErrorReports'] = 'ask';
-        $GLOBALS['cfg']['DefaultTabDatabase'] = 'structure';
-        $GLOBALS['cfg']['ShowDatabasesNavigationAsTree'] = true;
-        $GLOBALS['cfg']['DefaultTabTable'] = 'browse';
-        $GLOBALS['cfg']['NavigationTreeDefaultTabTable'] = 'structure';
-        $GLOBALS['cfg']['NavigationTreeDefaultTabTable2'] = '';
-        $GLOBALS['cfg']['Confirm'] = true;
-        $GLOBALS['cfg']['LoginCookieValidity'] = 1440;
-        $GLOBALS['cfg']['enable_drag_drop_import'] = true;
-        $GLOBALS['PMA_Config'] = new Config();
+        $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $this->insertEdit = new InsertEdit($GLOBALS['dbi']);
     }
@@ -361,11 +342,11 @@ class InsertEditTest extends TestCase
         $result = $this->insertEdit->showTypeOrFunction('function', $url_params, false);
 
         $this->assertStringContainsString(
-            'index.php?route=/table/change',
+            'http://localhost/index.php?route=/table/change',
             $result
         );
         $this->assertStringContainsString(
-            'ShowFunctionFields=1&amp;ShowFieldTypesInDataEditView=1&amp;goto=index.php%3Froute%3D%2Fsql',
+            'ShowFunctionFields=1&amp;ShowFieldTypesInDataEditView=1&amp;goto=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3D%2Fsql',
             $result
         );
         $this->assertStringContainsString(
@@ -381,7 +362,7 @@ class InsertEditTest extends TestCase
             $result
         );
         $this->assertStringContainsString(
-            'ShowFunctionFields=0&amp;ShowFieldTypesInDataEditView=1&amp;goto=index.php%3Froute%3D%2Fsql',
+            'ShowFunctionFields=0&amp;ShowFieldTypesInDataEditView=1&amp;goto=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3D%2Fsql',
             $result
         );
         $this->assertStringContainsString(
@@ -397,7 +378,7 @@ class InsertEditTest extends TestCase
             $result
         );
         $this->assertStringContainsString(
-            'ShowFunctionFields=1&amp;ShowFieldTypesInDataEditView=1&amp;goto=index.php%3Froute%3D%2Fsql',
+            'ShowFunctionFields=1&amp;ShowFieldTypesInDataEditView=1&amp;goto=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3D%2Fsql',
             $result
         );
         $this->assertStringContainsString(
@@ -413,7 +394,7 @@ class InsertEditTest extends TestCase
             $result
         );
         $this->assertStringContainsString(
-            'ShowFunctionFields=1&amp;ShowFieldTypesInDataEditView=0&amp;goto=index.php%3Froute%3D%2Fsql',
+            'ShowFunctionFields=1&amp;ShowFieldTypesInDataEditView=0&amp;goto=http%3A%2F%2Flocalhost%2Findex.php%3Froute%3D%2Fsql',
             $result
         );
         $this->assertStringContainsString(
@@ -1028,7 +1009,7 @@ class InsertEditTest extends TestCase
             $result
         );
         $this->assertStringContainsString(
-            '<a class="ajax browse_foreign" href="index.php?route=/browse-foreigners',
+            '<a class="ajax browse_foreign" href="http://localhost/index.php?route=/browse-foreigners',
             $result
         );
 
@@ -2634,7 +2615,7 @@ class InsertEditTest extends TestCase
     {
         $GLOBALS['cfg']['ServerDefault'] = 1;
         $this->assertEquals(
-            'index.php?route=/table/change&amp;lang=en',
+            'http://localhost/index.php?route=/table/change&amp;lang=en',
             $this->insertEdit->getErrorUrl([])
         );
 
@@ -2957,7 +2938,7 @@ class InsertEditTest extends TestCase
         $result = $this->insertEdit->getLinkForRelationalDisplayField($map, 'f', "=1", "a>", "b<");
 
         $this->assertEquals(
-            '<a href="index.php?route=/sql&amp;db=information_schema&amp;table=TABLES&amp;pos=0&amp;'
+            '<a href="http://localhost/index.php?route=/sql&amp;db=information_schema&amp;table=TABLES&amp;pos=0&amp;'
             . 'sql_query=SELECT+%2A+FROM+%60information_schema%60.%60TABLES%60+WHERE'
             . '+%60f%60%3D1&amp;lang=en" title="a&gt;">b&lt;</a>',
             $result
@@ -2967,7 +2948,7 @@ class InsertEditTest extends TestCase
         $result = $this->insertEdit->getLinkForRelationalDisplayField($map, 'f', "=1", "a>", "b<");
 
         $this->assertEquals(
-            '<a href="index.php?route=/sql&amp;db=information_schema&amp;table=TABLES&amp;pos=0&amp;'
+            '<a href="http://localhost/index.php?route=/sql&amp;db=information_schema&amp;table=TABLES&amp;pos=0&amp;'
             . 'sql_query=SELECT+%2A+FROM+%60information_schema%60.%60TABLES%60+WHERE'
             . '+%60f%60%3D1&amp;lang=en" title="b&lt;">a&gt;</a>',
             $result

--- a/test/classes/OperationsTest.php
+++ b/test/classes/OperationsTest.php
@@ -198,7 +198,7 @@ class OperationsTest extends TestCase
             'doclink',
         ]);
         $this->assertStringContainsString(
-            'href="index.php?route=/sql&amp;name=foo&amp;value=bar',
+            'href="http://localhost/index.php?route=/sql&amp;name=foo&amp;value=bar',
             $result
         );
         $this->assertStringContainsString(
@@ -265,7 +265,7 @@ class OperationsTest extends TestCase
             ]
         );
         $this->assertStringContainsString(
-            'action="index.php?route=/table/operations',
+            'action="http://localhost/index.php?route=/table/operations',
             $html
         );
         $this->assertRegExp('/.*ANALYZE.*/', $html);
@@ -300,7 +300,7 @@ class OperationsTest extends TestCase
             $actual
         );
         $this->assertStringContainsString(
-            'href="index.php?route=/sql',
+            'href="http://localhost/index.php?route=/sql',
             $actual
         );
     }

--- a/test/classes/Plugins/Auth/AuthenticationConfigTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationConfigTest.php
@@ -131,7 +131,7 @@ class AuthenticationConfigTest extends PmaTestCase
         );
 
         $this->assertStringContainsString(
-            '<a href="index.php?route=/&amp;server=0&amp;lang=en" '
+            '<a href="http://localhost/index.php?route=/&amp;server=0&amp;lang=en" '
             . 'class="button disableAjax">Retry to connect</a>',
             $html
         );

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -132,7 +132,7 @@ class TransformationPluginsTest extends PmaTestCase
                 '<input type="hidden" name="fields_prev2ndtest" '
                 . 'value="736f6d657468696e67"><input type="hidden" '
                 . 'name="fields2ndtest" value="736f6d657468696e67">'
-                . '<img src="index.php?route=/transformation/wrapper&amp;key=value&amp;lang=en" width="100" '
+                . '<img src="http://localhost/index.php?route=/transformation/wrapper&amp;key=value&amp;lang=en" width="100" '
                 . 'height="100" alt="Image preview here"><br><input type="file" '
                 . 'name="fields_upload2ndtest" accept="image/*" '
                 . 'class="image-upload">',
@@ -789,7 +789,7 @@ class TransformationPluginsTest extends PmaTestCase
                         'wrapper_params' => ['key' => 'value'],
                     ],
                 ],
-                '<a href="index.php?route=/transformation/wrapper&amp;key=value'
+                '<a href="http://localhost/index.php?route=/transformation/wrapper&amp;key=value'
                 . '&amp;ct=application%2Foctet-stream&amp;cn=filename&amp;lang=en" '
                 . 'title="filename" class="disableAjax">filename</a>',
             ],
@@ -804,7 +804,7 @@ class TransformationPluginsTest extends PmaTestCase
                         'wrapper_params' => ['key' => 'value'],
                     ],
                 ],
-                '<a href="index.php?route=/transformation/wrapper&amp;key=value'
+                '<a href="http://localhost/index.php?route=/transformation/wrapper&amp;key=value'
                 . '&amp;ct=application%2Foctet-stream&amp;cn=binary_file.dat&amp;lang=en" '
                 . 'title="binary_file.dat" class="disableAjax">binary_file.dat</a>',
             ],
@@ -844,7 +844,7 @@ class TransformationPluginsTest extends PmaTestCase
                     ],
                 ],
                 '<a class="disableAjax" target="_blank" rel="noopener noreferrer"'
-                . ' href="index.php?route=/transformation/wrapper&amp;key=value&amp;lang=en"'
+                . ' href="http://localhost/index.php?route=/transformation/wrapper&amp;key=value&amp;lang=en"'
                 . ' alt="[PMA_IMAGE_LINK]">[BLOB]</a>',
             ],
             [
@@ -1085,8 +1085,8 @@ class TransformationPluginsTest extends PmaTestCase
                         'wrapper_params' => ['key' => 'value'],
                     ],
                 ],
-                '<a href="index.php?route=/transformation/wrapper&amp;key=value&amp;lang=en" '
-                . 'rel="noopener noreferrer" target="_blank"><img src="index.php?route=/transformation/wrapper'
+                '<a href="http://localhost/index.php?route=/transformation/wrapper&amp;key=value&amp;lang=en" '
+                . 'rel="noopener noreferrer" target="_blank"><img src="http://localhost/index.php?route=/transformation/wrapper'
                 . '&amp;key=value&amp;resize=jpeg&amp;newWidth=0&amp;'
                 . 'newHeight=200&amp;lang=en" alt="[PMA_JPEG_Inline]" border="0"></a>',
             ];
@@ -1101,8 +1101,8 @@ class TransformationPluginsTest extends PmaTestCase
                         'wrapper_params' => ['key' => 'value'],
                     ],
                 ],
-                '<a href="index.php?route=/transformation/wrapper&amp;key=value&amp;lang=en"'
-                . ' rel="noopener noreferrer" target="_blank"><img src="index.php?route=/transformation/wrapper'
+                '<a href="http://localhost/index.php?route=/transformation/wrapper&amp;key=value&amp;lang=en"'
+                . ' rel="noopener noreferrer" target="_blank"><img src="http://localhost/index.php?route=/transformation/wrapper'
                 . '&amp;key=value&amp;resize=jpeg&amp;newWidth=0&amp;newHeight=200&amp;lang=en" '
                 . 'alt="[PMA_PNG_Inline]" border="0"></a>',
             ];

--- a/test/classes/ReplicationGuiTest.php
+++ b/test/classes/ReplicationGuiTest.php
@@ -197,7 +197,7 @@ class ReplicationGuiTest extends TestCase
 
         //validate 4: navigation URL
         $this->assertStringContainsString(
-            '<a href="index.php?route=/server/replication',
+            '<a href="http://localhost/index.php?route=/server/replication',
             $html
         );
         $this->assertStringContainsString(
@@ -278,7 +278,7 @@ class ReplicationGuiTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            '<form method="post" action="index.php?route=/server/replication',
+            '<form method="post" action="http://localhost/index.php?route=/server/replication',
             $html
         );
         $this->assertStringContainsString(

--- a/test/classes/ScriptsTest.php
+++ b/test/classes/ScriptsTest.php
@@ -64,7 +64,7 @@ class ScriptsTest extends PmaTestCase
         $actual = $this->object->getDisplay();
 
         $this->assertStringContainsString(
-            'src="js/common.js?v=' . PMA_VERSION . '"',
+            'src="http://localhost/js/common.js?v=' . PMA_VERSION . '"',
             $actual
         );
         $this->assertStringContainsString(

--- a/test/classes/Server/PrivilegesTest.php
+++ b/test/classes/Server/PrivilegesTest.php
@@ -1942,12 +1942,12 @@ class PrivilegesTest extends TestCase
         $this->assertStringContainsString('<td>A</td>', $actual);
         $this->assertStringContainsString('<td>Z</td>', $actual);
         $this->assertStringContainsString(
-            '<a class="ajax" href="index.php?route=/server/privileges&amp;initial=-'
+            '<a class="ajax" href="http://localhost/index.php?route=/server/privileges&amp;initial=-'
             . '&amp;lang=en">-</a>',
             $actual
         );
         $this->assertStringContainsString(
-            '<a class="ajax" href="index.php?route=/server/privileges&amp;initial=%22'
+            '<a class="ajax" href="http://localhost/index.php?route=/server/privileges&amp;initial=%22'
             . '&amp;lang=en">"</a>',
             $actual
         );

--- a/test/classes/Server/UsersTest.php
+++ b/test/classes/Server/UsersTest.php
@@ -51,7 +51,7 @@ class UsersTest extends TestCase
 
         //validate 3: not-active for /server/user_groups
         $this->assertStringContainsString(
-            '<a href="index.php?route=/server/user_groups',
+            '<a href="http://localhost/index.php?route=/server/user_groups',
             $html
         );
         $this->assertStringContainsString(

--- a/test/classes/ThemeTest.php
+++ b/test/classes/ThemeTest.php
@@ -250,7 +250,7 @@ class ThemeTest extends PmaTestCase
             $this->object->getPrintPreview()
         );
         $this->assertStringContainsString(
-            'name="" href="index.php?route=/set-theme&amp;set_theme=&amp;server=99&amp;lang=en">',
+            'name="" href="http://localhost/index.php?route=/set-theme&amp;set_theme=&amp;server=99&amp;lang=en">',
             $this->object->getPrintPreview()
         );
         $this->assertStringContainsString(

--- a/test/classes/UrlTest.php
+++ b/test/classes/UrlTest.php
@@ -113,4 +113,54 @@ class UrlTest extends TestCase
         $expected = '?server=x' . htmlentities($separator) . 'lang=en' ;
         $this->assertEquals($expected, Url::getCommon());
     }
+
+    /**
+     * @param string      $expected   Expected result.
+     * @param string|null $https      HTTPS value of $_SERVER array.
+     * @param string|null $host       HTTP_HOST value of $_SERVER array.
+     * @param string|null $port       SERVER_PORT value of $_SERVER array.
+     * @param string|null $serverName SERVER_NAME value of $_SERVER array.
+     * @param string|null $scriptName SCRIPT_NAME value of $_SERVER array.
+     *
+     * @return void
+     *
+     * @dataProvider getBaseUrlProvider
+     */
+    public function testGetBaseUrl(
+        string $expected,
+        ?string $https,
+        ?string $host,
+        ?string $port,
+        ?string $serverName,
+        ?string $scriptName
+    ): void {
+        $_SERVER['HTTPS'] = $https;
+        $_SERVER['HTTP_HOST'] = $host;
+        $_SERVER['SERVER_PORT'] = $port;
+        $_SERVER['SERVER_NAME'] = $serverName;
+        $_SERVER['SCRIPT_NAME'] = $scriptName;
+        $url = Url::getBaseUrl();
+        $this->assertEquals($expected, $url);
+    }
+
+    /**
+     * @return array
+     */
+    public function getBaseUrlProvider(): array
+    {
+        return [
+            ['http://localhost', null, 'localhost', null, null, null],
+            ['http://localhost', 'off', 'localhost', '80', null, null],
+            ['http://localhost:123', '', 'localhost', '123', null, null],
+            ['https://localhost', 'on', 'localhost', '443', null, null],
+            ['https://localhost:123', 'on', 'localhost', '123', null, null],
+            ['http://localhost:321', null, 'localhost:123', '321', '0.0.0.0', null],
+            ['http://0.0.0.0', null, null, '80', '0.0.0.0', null],
+            ['http://0.0.0.0:123', null, null, '123', '0.0.0.0', null],
+            ['http://localhost', null, 'localhost', '80', null, '/index.php'],
+            ['http://localhost/phpmyadmin', null, 'localhost', '80', null, '/phpmyadmin/index.php'],
+            ['http://localhost:123', null, 'localhost', '123', null, '/index.php'],
+            ['http://localhost:123/phpmyadmin', null, 'localhost', '123', null, '/phpmyadmin/index.php'],
+        ];
+    }
 }


### PR DESCRIPTION
Currently phpMyAdmin uses relative URLs for links. This pull request changes the relative URLs with absolute URLs.

For example:
```diff
- <a href="index.php?route=/server/databases">
+ <a href="http://localhost/index.php?route=/server/databases">

- <script src="js/server/databases.js"></script>
+ <script src="http://localhost:8000/js/server/databases.js"></script>
```

The way phpMyAdmin works, using relative URLs is not an issue, but it doesn't work when using URL rewriting, because the base of the URL is always changing.

So using absolute URLs is a necessary step to add support for URL rewriting.