### PR TITLE
Removed 3rd Parameter to fix #15571

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -230,7 +230,6 @@ class InsertEdit
      *
      * @param array  $url_params         containing $db and $table as url parameters
      * @param array  $where_clause_array where clauses array
-     * @param string $where_clause       where clause
      *
      * @return array Add some url parameters to $url_params array and return it
      */

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -236,10 +236,9 @@ class InsertEdit
      */
     public function urlParamsInEditMode(
         array $url_params,
-        array $where_clause_array,
-        $where_clause
+        array $where_clause_array
     ) {
-        if (isset($where_clause)) {
+        if (isset($where_clause_array)) {
             foreach ($where_clause_array as $where_clause) {
                 $url_params['where_clause'] = trim($where_clause);
             }

--- a/tbl_change.php
+++ b/tbl_change.php
@@ -119,7 +119,7 @@ $biggest_max_file_size = 0;
 $url_params['db'] = $db;
 $url_params['table'] = $table;
 $url_params = $insertEdit->urlParamsInEditMode(
-    $url_params, $where_clause_array, $where_clause
+    $url_params, $where_clause_array
 );
 
 $has_blob_field = false;

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -297,7 +297,7 @@ class InsertEditTest extends TestCase
         $where_clause_array = array('foo=1', 'bar=2');
         $_POST['sql_query'] = 'SELECT 1';
 
-        $result = $this->insertEdit->urlParamsInEditMode(array(1), $where_clause_array, '');
+        $result = $this->insertEdit->urlParamsInEditMode(array(1), $where_clause_array);
 
         $this->assertEquals(
             array(


### PR DESCRIPTION
Signed-off-by: Ashwin Ginoria <ashwinginoria@gmail.com>

Date:      Wed Dec 4 14:26:34 2019 +0530

### Description

Removed the 3rd Parameter ```$where_clause``` from ```urlParamsInEditMode``` and made necessary changes. 

Fixes #15571 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
