### PR TITLE
Fix - #15588 Layout issue @ Table structure

### DIFF
--- a/templates/table/structure/display_table_stats.twig
+++ b/templates/table/structure/display_table_stats.twig
@@ -10,7 +10,7 @@
         <a id="showusage"></a>
 
         {% if not tbl_is_view and not db_is_system_schema %}
-            <table id="tablespaceusage" class="w-100 data">
+            <table id="tablespaceusage" class="data">
                 <caption class="tblHeaders">{% trans 'Space usage' %}</caption>
                 <tbody>
                     <tr>
@@ -70,7 +70,7 @@
 
         {% set avg_size = avg_size is defined ? avg_size : null %}
         {% set avg_unit = avg_unit is defined ? avg_unit : null %}
-        <table id="tablerowstats" class="w-100 data">
+        <table id="tablerowstats" class="data">
             <caption class="tblHeaders">{% trans 'Row statistics' %}</caption>
             <tbody>
                 {% if showtable['Row_format'] is defined %}


### PR DESCRIPTION
Signed-off-by: Shailesh Jain <jainshailesh91@gmail.com>

### Description
Removed `w-100` class from template file to prevent tables taking width 100%. The styling for the tables is already defined in `div#tablestatistics table`.

Fixes #15588

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
