### PR TITLE
Prevent line wrap in DB structure size column

### DIFF
--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -129,8 +129,7 @@
         {% if is_show_stats %}
             <td class="value tbl_size">
                 <a href="tbl_structure.php{{ tbl_url_query|raw }}#showusage">
-                    <span>{{ formatted_size }}</span>
-                    <span class="unit">{{ unit }}</span>
+                    <span>{{ formatted_size }}</span>&nbsp;<span class="unit">{{ unit }}</span>
                 </a>
             </td>
             <td class="value tbl_overhead">


### PR DESCRIPTION
### Description

Template adjustment for DB structure (tables list) view; Inserts &amp;nbsp; between value and unit field in "size" column, as already done in the "overhead" column.

Before:
![before](https://user-images.githubusercontent.com/1614754/70560436-dc13aa80-1b88-11ea-9337-13705fdc6aa9.png)

After:
![after](https://user-images.githubusercontent.com/1614754/70560448-e33ab880-1b88-11ea-9328-152af610cdda.png)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.

Signed-off-by: Peter Mandrella <following@online.de>