### PR TITLE
Added alert message for extensions required

### DIFF
--- a/js/import.js
+++ b/js/import.js
@@ -168,4 +168,22 @@ AJAX.registerOnload('import.js', function () {
         }
         return true;
     });
+
+    /**
+     * Check compressions of file before displaying
+     *  warnings for required extension not present for importing.
+     */
+    $('#alert_message_for_zip').hide();
+    $('#alert_message_for_bz2').hide();
+    $('#input_import_file').on('change',function () {
+        var name = $('#input_import_file').get(0);
+        var file = name.files.item(0);
+        if (file && file.type) {
+            if (file.type === 'application/zip' || file.type === 'application/x-zip' || file.type === 'application/x-zip-compressed') {
+                $('#alert_message_for_zip').show();
+            } else if (file.type === 'application/bzip2' || file.type === 'application/x-bz2' || file.type === 'application/x-bzip') {
+                $('#alert_message_for_bz2').show();
+            }
+        }
+    });
 });

--- a/libraries/classes/Display/Import.php
+++ b/libraries/classes/Display/Import.php
@@ -101,6 +101,8 @@ class Import
         }
 
         return $template->render('display/import/import', [
+            'extension_zip' => extension_loaded('zip'),
+            'extension_bz2' => extension_loaded('bz2'),
             'upload_id' => $uploadId,
             'handler' => $_SESSION[$SESSION_KEY]["handler"],
             'id_key' => $_SESSION[$SESSION_KEY]['handler']::getIdKey(),

--- a/templates/display/import/import.twig
+++ b/templates/display/import/import.twig
@@ -60,6 +60,21 @@
                 </div>
             {% endif %}
 
+            {% if extension_zip == false %}
+            <div class="formelementrow error" id="alert_message_for_zip">
+                <p>
+                    <strong>{% trans 'Please enable the php-zip extension to import a .zip file or the import will be aborted.' %}</strong>
+                </p>
+            </div>
+            {% endif %}
+            {% if extension_bz2 == false %}
+            <div class="formelementrow error" id="alert_message_for_bz2">
+                <p>
+                    <strong>{% trans 'Please enable the php-bz2 extension to import a .bz2 file or the import will be aborted.' %}</strong>
+                </p>
+            </div>
+            {% endif %}
+
             <div class="formelementrow" id="upload_form">
                 {% if is_upload and upload_dir is not empty %}
                     <ul>


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description
.
This will add an alert message if the user is trying to import a file with zip extension or bzip2 extension that the required extensions must be present or enabled to import a zip or bzip2 file. 

Fixes #15328 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
