### PR TITLE
fixed the font size

### DIFF
--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -1790,6 +1790,7 @@ kbd {
 }
 
 code {
+  font-size: 1em;
   color: $main-color;
 
   &.php {


### PR DESCRIPTION
fixes #15618 

earlier font-size:1em was used which was
being overrided by a default BS styling
reverted back to old styling by overriding
it.