### PR TITLE
Keep PMA_handleRedirectAndReload compatility with old versions

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -1027,6 +1027,7 @@ AJAX.registerOnload('functions.js', function () {
                         $('input[name=token]').val(data.new_token);
                     }
                     idleSecondsCounter = 0;
+                    Functions.handleRedirectAndReload(data);
                 }
             }
         });


### PR DESCRIPTION
In versions prior 5.0.0 `reload_flag` or `redirect_flag` (ajax) forced browser to reload when user session expired.

In v5.0.0 `functions.js` `UpdateIdleTime` method this ability is missing. This could break custom authentication plugins which make use of this possibility to force reload user to login form.

In previous versions - there was a call to: `PMA_handleRedirectAndReload` but in 5.0.0 it's no longer there (function was moved to `Functions.handleRedirectAndReload(data);` but wasn't triggered here)