### PR TITLE
Fix #13864 - Prevent resetting of enum fields when adding new rows to current insertion batch

### DIFF
--- a/js/table/change.js
+++ b/js/table/change.js
@@ -599,6 +599,16 @@ function addNewContinueInsertionFiels (event) {
             $anchor.attr('href', newHref);
         };
 
+        var restoreValue = function () {
+            if ($(this).closest('tr').find('span.column_type').html() === 'enum') {
+                if ($(this).val() === $checkedValue) {
+                    $(this).prop('checked', true);
+                } else {
+                    $(this).prop('checked', false);
+                }
+            }
+        };
+
         while (currRows < targetRows) {
             /**
              * @var $last_row    Object referring to the last row
@@ -609,6 +619,7 @@ function addNewContinueInsertionFiels (event) {
             // (also needs improvement because it should be calculated
             //  just once per cloned row, not once per column)
             var newRowIndex = 0;
+            var $checkedValue = $lastRow.find('input:checked').val();
 
             // Clone the insert tables
             $lastRow
@@ -619,6 +630,22 @@ function addNewContinueInsertionFiels (event) {
                 .end()
                 .find('.foreign_values_anchor')
                 .each(tempReplaceAnchor);
+
+            var $oldRow = $lastRow.find('.textfield');
+            $oldRow.each(restoreValue);
+
+            // set the value of enum field of new row to default
+            var $newRow = $('#insertForm').find('.insertRowTable:last');
+            $newRow.find('.textfield').each(function () {
+                if ($(this).closest('tr').find('span.column_type').html() === 'enum') {
+                    if ($(this).val() === $(this).closest('tr').find('span.default_value').html()) {
+                        $(this).prop('checked', true);
+                    } else {
+                        $(this).prop('checked', false);
+                    }
+                }
+            });
+
 
             // Insert/Clone the ignore checkboxes
             if (currRows === 1) {
@@ -667,15 +694,6 @@ function addNewContinueInsertionFiels (event) {
                 $(this).attr('tabindex', tabIndex);
                 // update the IDs of textfields to ensure that they are unique
                 $(this).attr('id', 'field_' + tabIndex + '_3');
-
-                // special handling for radio fields after updating ids to unique
-                if ($(this).closest('tr').find('span.column_type').html() === 'enum') {
-                    if ($(this).val() === $(this).closest('tr').find('span.default_value').html()) {
-                        $(this).prop('checked', true);
-                    } else {
-                        $(this).prop('checked', false);
-                    }
-                }
             });
         $('.control_at_footer')
             .each(function () {


### PR DESCRIPTION
 fixes #13864

Signed-off-by: Jayati Shrivastava <gaurijove@gmail.com>

### Description
Earlier, upon clicking on "continue insertion with" all the previously set enum fields would also get reset to default.
![bug](https://user-images.githubusercontent.com/48182195/70944862-ef87af80-2079-11ea-83fb-83d414e0e301.gif)

### Fixes 
Now, the previously set enum fields retain their value as expected and only the newly added enum fields are set to default value upon clicking "continue insertion with".
![fix](https://user-images.githubusercontent.com/48182195/70944885-fca49e80-2079-11ea-9ffc-c98aea6da34d.gif)


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
