### PR TITLE
Fix #14732 -  Renaming of the primary key

### DIFF
--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -641,7 +641,7 @@ class Table
             $query .= ' AFTER ' . Util::backquote($move_to);
         }
         if (! $virtuality && ! empty($extra)) {
-            if (is_array($columns_with_index) && ! in_array($name, $columns_with_index)) {
+            if (empty($columns_with_index) && ! in_array($name, $columns_with_index)) {
                 $query .= ', add PRIMARY KEY (' . Util::backquote($name) . ')';
             }
         }


### PR DESCRIPTION
Signed-off-by: Nikhil Nagdev <nnagdev58@gmail.com>

### Description

Checked if the table contains any primary key because if the table had primary key then there was no need to append `, add PRIMARY KEY (' . Util::backquote($name) . ')` to the `ALTER` query

Fixes #14732

Broken-by: 836cc74413e789d3961e255ca9e939c0402bbbb4

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
