### PR TITLE
Renders absolutely nothing when header is not enabled.

### DIFF
--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -402,8 +402,8 @@ class Header
      */
     public function getDisplay(): string
     {
-        if (! $this->_headerIsSent) {
-            if (! $this->_isAjax && $this->_isEnabled) {
+        if (! $this->_headerIsSent && $this->_isEnabled) {
+            if (! $this->_isAjax) {
                 $this->sendHttpHeaders();
 
                 $baseDir = defined('PMA_PATH_TO_BASEDIR') ? PMA_PATH_TO_BASEDIR : '';
@@ -452,7 +452,7 @@ class Header
                 $console = $this->_console->getDisplay();
                 $messages = $this->getMessage();
             }
-            if ($this->_isEnabled && empty($_REQUEST['recent_table'])) {
+            if (empty($_REQUEST['recent_table'])) {
                 $recentTable = $this->_addRecentTable(
                     $GLOBALS['db'],
                     $GLOBALS['table']

--- a/test/classes/HeaderTest.php
+++ b/test/classes/HeaderTest.php
@@ -65,6 +65,20 @@ class HeaderTest extends PmaTestCase
     }
 
     /**
+     * Test for enable
+     *
+     * @return void
+     */
+    public function testEnable()
+    {
+        $header = new Header();
+        $this->assertStringContainsString(
+            '<title>phpMyAdmin</title>',
+            $header->getDisplay()
+        );
+    }
+
+    /**
      * Test for Set BodyId
      *
      * @return void

--- a/test/classes/HeaderTest.php
+++ b/test/classes/HeaderTest.php
@@ -59,7 +59,7 @@ class HeaderTest extends PmaTestCase
         $header = new Header();
         $header->disable();
         $this->assertEquals(
-            "\n",
+            '',
             $header->getDisplay()
         );
     }


### PR DESCRIPTION
# Description
When downloading blob data from database, the header template will be rendered as `\n` which adds an extra 0x0A at the beginning of the blob data. This fixes the problem.