### PR TITLE
Prevents return to Browse page.

### DIFF
--- a/js/indexes.js
+++ b/js/indexes.js
@@ -667,10 +667,9 @@ AJAX.registerOnload('indexes.js', function () {
                             .prependTo('#structure_content');
                         Functions.highlightSql($('#page_content'));
                     }
-                    CommonActions.refreshMain(false, function () {
-                        $('a.ajax[href^=#indexes]').trigger('click');
-                    });
                     Navigation.reload();
+                    var tableStructureUrl = 'index.php?route=/table/structure' + CommonParams.getUrlQuery('&');
+                    CommonActions.refreshMain(tableStructureUrl);
                 } else {
                     Functions.ajaxShowMessage(Messages.strErrorProcessingRequest + ' : ' + data.error, false);
                 }
@@ -704,10 +703,8 @@ AJAX.registerOnload('indexes.js', function () {
         }
         url += CommonParams.get('arg_separator') + 'ajax_request=true';
         Functions.indexEditorDialog(url, title, function () {
-            // refresh the page using ajax
-            CommonActions.refreshMain(false, function () {
-                $('a.ajax[href^=#indexes]').trigger('click');
-            });
+            var tableStructureUrl = 'index.php?route=/table/structure' + CommonParams.getUrlQuery('&');
+            CommonActions.refreshMain(tableStructureUrl);
         });
     });
 


### PR DESCRIPTION
Fixes #15662

Signed-off-by: Jayati Shrivastava <gaurijove@gmail.com>

The Bug - After dropping an index/key the user gets redirected to the Browse page rather than staying on the table structure page.

This has been fixed.


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
