### PR TITLE
Fixed the extra zeroes being added while editing date

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -2859,10 +2859,7 @@ class InsertEdit
         $meta = $fields_meta[0];
         if ($row = $this->dbi->fetchRow($result)) {
             $new_value = $row[0];
-            if ((substr($meta->type, 0, 9) == 'timestamp')
-                || ($meta->type == 'datetime')
-                || ($meta->type == 'time')
-            ) {
+            if (($meta->type == 'time')) {
                 $new_value = Util::addMicroseconds($new_value);
             } elseif (mb_strpos($meta->flags, 'binary') !== false) {
                 $new_value = '0x' . bin2hex($new_value);


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description

The changes should fix the extra zeroes being added while editing date or datetime. This was caused due to microseconds being added which should not be added in date or datetime type column.

Fixes #15629 

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
