### PR TITLE
Fix #15717 - remove spinner when the message is not a loading message

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -2280,6 +2280,9 @@ Functions.ajaxShowMessage = function (message, timeout, type) {
             Messages.strDismiss
         );
     }
+    if (msg !== Messages.strLoading) {
+        $retval.css('background-image', 'none');
+    }
     Functions.highlightSql($retval);
 
     return $retval;

--- a/libraries/classes/Controllers/Table/StructureController.php
+++ b/libraries/classes/Controllers/Table/StructureController.php
@@ -291,8 +291,7 @@ class StructureController extends AbstractController
                 }
             } else {
                 $this->response->setRequestStatus(false);
-                $message = Message::error(__('No column selected.'));
-                $this->response->addJSON('message', $message);
+                $this->response->addJSON('message', __('No column selected.'));
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Jayati Shrivastava <gaurijove@gmail.com>
fixes #15717 .

After fixing:
![notify](https://user-images.githubusercontent.com/48182195/71763082-a5b61a80-2efd-11ea-8f70-296df70f888b.gif)


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
