### PR TITLE
remove duplicate slash for tempdir path

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -1641,7 +1641,7 @@ class Config
         if (empty($path)) {
             $path = null;
         } else {
-            $path .= '/' . $name;
+            $path = rtrim($path, '/') . '/' . $name;
             if (! @is_dir($path)) {
                 @mkdir($path, 0770, true);
             }


### PR DESCRIPTION
### Description

When `TempDir` config([reference](https://docs.phpmyadmin.net/en/latest/config.html#cfg_TempDir)) is ending with `/`, calling `getTempDir` will get duplicate slash in path.  e.g. `/Users/codes/phpmyadmin/tmp//shp`.

This pull request removes ending slash from `TempDir` config to prevent duplicate slash.

---

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
