### PR TITLE
fix #14875 - fix shp filename sanitization and update test

### DIFF
--- a/libraries/classes/Plugins/Import/ImportShp.php
+++ b/libraries/classes/Plugins/Import/ImportShp.php
@@ -114,21 +114,24 @@ class ImportShp extends ImportPlugin
                         $dbf_file_name
                     );
                     if ($extracted !== false) {
-                        $dbf_file_path = $temp . (PMA_IS_WINDOWS ? '\\' : '/')
-                            . Sanitize::sanitizeFilename($dbf_file_name, true);
-                        $handle = fopen($dbf_file_path, 'wb');
-                        if ($handle !== false) {
-                            fwrite($handle, $extracted);
-                            fclose($handle);
+                        // remove filename extension, e.g.
+                        // dresden_osm.shp/gis.osm_transport_a_v06.dbf
+                        // to
+                        // dresden_osm.shp/gis.osm_transport_a_v06
+                        $path_parts = pathinfo($dbf_file_name);
+                        $dbf_file_name = $path_parts['dirname'] . '/' . $path_parts['filename'];
+
+                        // sanitize filename
+                        $dbf_file_name = Sanitize::sanitizeFilename($dbf_file_name, true);
+
+                        // concat correct filename and extension
+                        $dbf_file_path = $temp . '/' . $dbf_file_name . '.dbf';
+
+                        if (file_put_contents($dbf_file_path, $extracted, LOCK_EX) !== false) {
                             $temp_dbf_file = true;
-                            // Replace the .dbf with .*, as required
-                            // by the bsShapeFiles library.
-                            $file_name = substr(
-                                $dbf_file_path,
-                                0,
-                                strlen($dbf_file_path) - 4
-                            ) . '.*';
-                            $shp->FileName = $file_name;
+
+                            // Replace the .dbf with .*, as required by the bsShapeFiles library.
+                            $shp->FileName = substr($dbf_file_path, 0, -4) . '.*';
                         }
                     }
                 }
@@ -149,6 +152,9 @@ class ImportShp extends ImportPlugin
             }
         }
 
+        // It should load data before file being deleted
+        $shp->loadFromFile('');
+
         // Delete the .dbf file extracted to 'TempDir'
         if ($temp_dbf_file
             && isset($dbf_file_path)
@@ -157,8 +163,6 @@ class ImportShp extends ImportPlugin
             unlink($dbf_file_path);
         }
 
-        // Load data
-        $shp->loadFromFile('');
         if ($shp->lastError != '') {
             $error = true;
             $message = Message::error(
@@ -223,7 +227,7 @@ class ImportShp extends ImportPlugin
 
                 if ($shp->getDBFHeader() !== null) {
                     foreach ($shp->getDBFHeader() as $c) {
-                        $cell = trim($record->DBFData[$c[0]]);
+                        $cell = trim((string) $record->DBFData[$c[0]]);
 
                         if (! strcmp($cell, '')) {
                             $cell = 'NULL';

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1983,16 +1983,6 @@ parameters:
 			path: libraries/classes/Plugins/Import/ImportShp.php
 
 		-
-			message: "#^Ternary operator condition is always false\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportShp.php
-
-		-
-			message: "#^Parameter \\#2 \\$str of function fwrite expects string, string\\|true given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportShp.php
-
-		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportShp.php

--- a/test/classes/Plugins/Import/ImportShpTest.php
+++ b/test/classes/Plugins/Import/ImportShpTest.php
@@ -140,13 +140,20 @@ class ImportShpTest extends PmaTestCase
         $this->runImport('test/test_data/dresden_osm.shp.zip');
 
         $this->assertMessages($import_notice);
+
+        $endsWith = "13.737122 51.0542065)))'))";
+
+        if (extension_loaded('dbase')) {
+            $endsWith = "13.737122 51.0542065)))'),";
+        }
+
         $this->assertStringContainsString(
             "(GeomFromText('MULTIPOLYGON((("
             . '13.737122 51.0542065,'
             . '13.7373039 51.0541298,'
             . '13.7372661 51.0540944,'
             . '13.7370842 51.0541711,'
-            . "13.737122 51.0542065)))'))",
+            . $endsWith,
             $sql_query
         );
     }
@@ -168,22 +175,41 @@ class ImportShpTest extends PmaTestCase
         //Test function called
         $this->runImport('test/test_data/timezone.shp.zip');
 
-        //asset that all sql are executed
+        // asset that all sql are executed
         $this->assertStringContainsString(
             'CREATE DATABASE IF NOT EXISTS `SHP_DB` DEFAULT CHARACTER '
             . 'SET utf8 COLLATE utf8_general_ci',
             $sql_query
         );
-        $this->assertStringContainsString(
-            'CREATE TABLE IF NOT EXISTS `SHP_DB`.`TBL_NAME` '
-            . '(`SPATIAL` geometry) DEFAULT CHARACTER '
-            . 'SET utf8 COLLATE utf8_general_ci;',
-            $sql_query
-        );
-        $this->assertStringContainsString(
-            'INSERT INTO `SHP_DB`.`TBL_NAME` (`SPATIAL`) VALUES',
-            $sql_query
-        );
+
+        // dbase extension will generate different sql statement
+        if (extension_loaded('dbase')) {
+            $this->assertStringContainsString(
+                'CREATE TABLE IF NOT EXISTS `SHP_DB`.`TBL_NAME` '
+                . '(`SPATIAL` geometry, `ID` int(2), `AUTHORITY` varchar(25), `NAME` varchar(42)) '
+                . 'DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;',
+                $sql_query
+            );
+
+            $this->assertStringContainsString(
+                'INSERT INTO `SHP_DB`.`TBL_NAME` (`SPATIAL`, `ID`, `AUTHORITY`, `NAME`) VALUES',
+                $sql_query
+            );
+        } else {
+            $this->assertStringContainsString(
+                'CREATE TABLE IF NOT EXISTS `SHP_DB`.`TBL_NAME` '
+                . '(`SPATIAL` geometry) DEFAULT CHARACTER '
+                . 'SET utf8 COLLATE utf8_general_ci;',
+                $sql_query
+            );
+
+            $this->assertStringContainsString(
+                'INSERT INTO `SHP_DB`.`TBL_NAME` (`SPATIAL`) VALUES',
+                $sql_query
+            );
+        }
+
+
         $this->assertStringContainsString(
             "GeomFromText('POINT(1294523.1759236",
             $sql_query


### PR DESCRIPTION
### Description

Origin sanitization will remove the filename extension and it will result in file not found when loading the content([referece](https://travis-ci.org/phpmyadmin/phpmyadmin/jobs/633026890#L569-L581)).

This pull request fixes shp filename sanitization bug. 

Fixes #14875

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
