### PR TITLE
Update and revert "Remove a test that can not be predictible"

### DIFF
--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -1025,6 +1025,23 @@ class ConfigTest extends PmaTestCase
     }
 
     /**
+     * Test for getUploadTempDir
+     *
+     * @return void
+     *
+     * @group file-system
+     */
+    public function testGetUploadTempDir(): void
+    {
+        $this->object->set('TempDir', realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR);
+
+        $this->assertEquals(
+            $this->object->getTempDir('upload'),
+            $this->object->getUploadTempDir()
+        );
+    }
+
+    /**
      * Test for isGitRevision
      *
      * @return void


### PR DESCRIPTION
### Description

This commit reverts a6155da6a92716c1836c2e6da434c43a260f93e8 and fix unpredict problem. 

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
