### PR TITLE
fix incorrect change password form action route

### DIFF
--- a/templates/display/change_password/file_a.twig
+++ b/templates/display/change_password/file_a.twig
@@ -1,5 +1,5 @@
 <form method="post" id="change_password_form"
-action="{{ is_privileges ? url('/server/privileges') : url('/user_password') }}" name="chgPassword" class="{{ is_privileges ? 'submenu-item' }}">
+action="{{ is_privileges ? url('/server/privileges') : url('/user-password') }}" name="chgPassword" class="{{ is_privileges ? 'submenu-item' }}">
 {{ get_hidden_inputs() }}
 {% if is_privileges %}
     <input type="hidden" name="username" value="{{ username }}">


### PR DESCRIPTION
### Description

Fixes incorrect form action route for home page `Change password` link.

![image](https://user-images.githubusercontent.com/8221099/71987012-6292d900-3268-11ea-89a9-6a4390bb5b80.png)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
