### PR TITLE
Made Username in User Account Overview Clickable

### DIFF
--- a/templates/server/privileges/users_overview.twig
+++ b/templates/server/privileges/users_overview.twig
@@ -32,7 +32,15 @@
                 {% if host.user is empty %}
                   <span class="text-danger">{% trans 'Any' %}</span>
                 {% else %}
-                  {{ host.user }}
+                 <a class="edit_user_anchor" href="{{ url('/server/privileges', {
+                  'username': host.user,
+                  'hostname': host.host,
+                  'dbname': '',
+                  'tablename': '',
+                  'routinename': '',
+                }) }}">
+                 {{ host.user }}
+                 </a>
                 {% endif %}
               </label>
             </td>


### PR DESCRIPTION
Signed-off-by: thesmallstar <42006277+thesmallstar@users.noreply.github.com>

### Description
I have made the required changes to make username in User Account Overview Clickable, It was mentioned in a comment to check if the user has the privileges to do so, I found that Edit Priviledegs
the button is always available, and only when the user visits the edit page his privileges are checked, so I have hardcoded the link.

If "Any"  text appears as the username, this username is applicable as any user, there is no point in going to edit privileges page and hence it has no link. 

![image](https://user-images.githubusercontent.com/42006277/72086619-35f4c500-332d-11ea-914e-3ba4cb5b8422.png)


Fixes #12726

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
