### PR TITLE
Fixed : Cannot copy user account - error#1133

### DIFF
--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -4423,7 +4423,7 @@ class Privileges
             isset($_POST['old_usergroup']) ? $_POST['old_usergroup'] : null;
         $this->setUserGroup($_POST['username'], $old_usergroup);
 
-        if ($create_user_real === null) {
+        if ($create_user_real !== null) {
             $queries[] = $create_user_real;
         }
         $queries[] = $real_sql_query;


### PR DESCRIPTION
Signed-off-by: Yash Bothra <yashrajbothra786@gmail.com>

### Description
 
As this issue was not in earlier version. I tried to track and got #14472 this PR has a commit which change `isset `to `is_null ` which i think should `! is_null`.

Refrence to commit: https://github.com/phpmyadmin/phpmyadmin/pull/14472/commits/d54c1106b9f2744c779dfb488d9db8eedb153f07

Fixes #15767 