### PR TITLE
Unwanted button hide by see more Button in Pick Central Column removed

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -3658,7 +3658,7 @@ AJAX.registerOnload('functions.js', function () {
                     $('#col_list').append(fields);
                     resultPointer = i;
                     if (resultPointer === listSize) {
-                        $('.tblFooters').hide();
+                        $('#seeMore').hide();
                     }
                     return false;
                 });


### PR DESCRIPTION
Signed-off-by: Manthan Surkar <manthan.surkar@gmail.com>

### Description
Fixes  #14310 

*Before:**
![image](https://user-images.githubusercontent.com/42006277/72243794-d0495700-3612-11ea-93ce-83617bc7a629.png)

**After**

![image](https://user-images.githubusercontent.com/42006277/72243865-fb33ab00-3612-11ea-81da-268099627c95.png)

**What is done?**
When the number of (list items) == max we need to hide the see more button only, but they Go and preview button had a common class that created the problem. In the solution, I have instead used the see more button ID to hide it, which solves the problem.


Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
