### PR TITLE
Fixes virtuality dropdown menu

### DIFF
--- a/libraries/classes/Normalization.php
+++ b/libraries/classes/Normalization.php
@@ -189,6 +189,7 @@ class Normalization
             'is_virtual_columns_supported' => Util::isVirtualColumnsSupported(),
             'browse_mime' => $GLOBALS['cfg']['BrowseMIME'],
             'server_type' => Util::getServerType(),
+            'server_version' => $this->dbi->getVersion(),
             'max_rows' => intval($GLOBALS['cfg']['MaxRows']),
             'char_editing' => $GLOBALS['cfg']['CharEditing'],
             'attribute_types' => $this->dbi->types->getAttributes(),

--- a/libraries/tbl_columns_definition_form.inc.php
+++ b/libraries/tbl_columns_definition_form.inc.php
@@ -531,6 +531,7 @@ $html = $template->render('columns_definitions/column_definitions_form', [
     'is_virtual_columns_supported' => Util::isVirtualColumnsSupported(),
     'browse_mime' => $GLOBALS['cfg']['BrowseMIME'] ?? null,
     'server_type' => Util::getServerType(),
+    'server_version' => $GLOBALS['dbi']->getVersion(),
     'max_rows' => intval($GLOBALS['cfg']['MaxRows']),
     'char_editing' => $GLOBALS['cfg']['CharEditing'] ?? null,
     'attribute_types' => $GLOBALS['dbi']->types->getAttributes(),

--- a/templates/columns_definitions/column_definitions_form.twig
+++ b/templates/columns_definitions/column_definitions_form.twig
@@ -54,6 +54,7 @@
             'content_cells': content_cells,
             'change_column': change_column,
             'is_virtual_columns_supported': is_virtual_columns_supported,
+            'server_version' : server_version,
             'browse_mime': browse_mime,
             'server_type': server_type,
             'max_rows': max_rows,

--- a/templates/columns_definitions/table_fields_definitions.twig
+++ b/templates/columns_definitions/table_fields_definitions.twig
@@ -95,9 +95,8 @@
         {% endif %}
     </tr>
     {% set options = {'': '', 'VIRTUAL': 'VIRTUAL'} %}
-    {% if server_type == 'MariaDB' %}
+    {% if server_type == 'MariaDB' and server_version <= 100200 %}
         {% set options = options|merge({'PERSISTENT': 'PERSISTENT'}) %}
-        {% set options = options|merge({'STORED': 'STORED'}) %}
     {% else %}
         {% set options = options|merge({'STORED': 'STORED'}) %}
     {% endif %}


### PR DESCRIPTION
Fixes #15729

Signed-off-by: Jayati Shrivastava <gaurijove@gmail.com>

### Description
MariaDb added 'stored' as an alias for 'persistent' to versions 10.2.1 and later.
'stored' keyword is not recognized by earlier versions.The options for the dropdown menu are set accordingly.



