### PR TITLE
Fixed Action Links UI

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -4795,7 +4795,7 @@ class Results
                         __('Create view'),
                         true
                     ),
-                    ['class' => 'create_view ajax']
+                    ['class' => 'create_view ajax btn']
                 )
                 . '</span>' . "\n";
         }
@@ -4841,7 +4841,10 @@ class Results
                 __('Copy to clipboard'),
                 true
             ),
-            ['id' => 'copyToClipBoard']
+            [
+                'id' => 'copyToClipBoard' ,
+                'class' => 'btn',
+            ]
         );
     }
 
@@ -4861,7 +4864,10 @@ class Results
                 __('Print'),
                 true
             ),
-            ['id' => 'printView'],
+            [
+                'id' => 'printView' ,
+                'class' => 'btn',
+            ],
             'print_view'
         );
     }
@@ -4968,9 +4974,9 @@ class Results
                     'b_tblexport',
                     __('Export'),
                     true
-                )
-            )
-            . "\n";
+                ),
+                ['class' => 'btn']
+            );
 
             // prepare chart
             $results_operations_html .= Util::linkOrButton(
@@ -4979,9 +4985,9 @@ class Results
                     'b_chart',
                     __('Display chart'),
                     true
-                )
-            )
-            . "\n";
+                ),
+                ['class' => 'btn']
+            );
 
             // prepare GIS chart
             $geometry_found = false;
@@ -5002,9 +5008,9 @@ class Results
                             'b_globe',
                             __('Visualize GIS data'),
                             true
-                        )
-                    )
-                    . "\n";
+                        ),
+                        ['class' => 'btn']
+                    );
             }
         }
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2187,11 +2187,6 @@ class Util
         if ($value == '') {
             $value = $text;
         }
-        if ($GLOBALS['cfg']['ActionLinksMode'] == 'text') {
-            return ' <input class="btn btn-link" type="submit" name="' . $button_name . '"'
-                . ' value="' . htmlspecialchars($value) . '"'
-                . ' title="' . htmlspecialchars($text) . '">' . "\n";
-        }
         return '<button class="btn btn-link ' . $button_class . '" type="submit"'
             . ' name="' . $button_name . '" value="' . htmlspecialchars($value)
             . '" title="' . htmlspecialchars($text) . '">' . "\n"


### PR DESCRIPTION
### Description

1. Removed `ActionLinkMode` check because it already there in `getIcon()`;

Before:  ![image](https://user-images.githubusercontent.com/47683556/72280150-a8cbac00-365d-11ea-8a13-db196ee44f5f.png)

After:  ![image](https://user-images.githubusercontent.com/47683556/72280290-0233db00-365e-11ea-96b1-c60b31b24061.png)

2. Added Space between links using `&emsp;` 

Before:  ![image](https://user-images.githubusercontent.com/47683556/72280451-6060be00-365e-11ea-89e5-725599bad6ff.png)

After: ![image](https://user-images.githubusercontent.com/47683556/72280493-78384200-365e-11ea-98dd-fb8c4fd6e8fb.png)


Fixes #15780 