### PR TITLE
Fix uncaught TypeError

### DIFF
--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -115,11 +115,6 @@ class Header
     private $template;
 
     /**
-     * @var Navigation
-     */
-    private $navigation;
-
-    /**
      * Creates a new class instance
      */
     public function __construct()
@@ -154,11 +149,6 @@ class Header
         }
 
         $this->userPreferences = new UserPreferences();
-        $this->navigation = new Navigation(
-            $this->template,
-            new Relation($GLOBALS['dbi']),
-            $GLOBALS['dbi']
-        );
     }
 
     /**
@@ -436,7 +426,12 @@ class Header
                 }
 
                 if ($this->_menuEnabled && $GLOBALS['server'] > 0) {
-                    $navigation = $this->navigation->getDisplay();
+                    $nav = new Navigation(
+                        $this->template,
+                        new Relation($GLOBALS['dbi']),
+                        $GLOBALS['dbi']
+                    );
+                    $navigation = $nav->getDisplay();
                 }
 
                 $customHeader = Config::renderHeader();

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -325,13 +325,10 @@ if (! defined('PMA_MINIMUM_COMMON')) {
 
     ThemeManager::getInstance()->setThemeCookie();
 
-    if (! empty($cfg['Server'])) {
-        /**
-         * Loads the proper database interface for this server
-         */
-        $containerBuilder->set(DatabaseInterface::class, DatabaseInterface::load());
-        $containerBuilder->setAlias('dbi', DatabaseInterface::class);
+    $containerBuilder->set(DatabaseInterface::class, DatabaseInterface::load());
+    $containerBuilder->setAlias('dbi', DatabaseInterface::class);
 
+    if (! empty($cfg['Server'])) {
         // get LoginCookieValidity from preferences cache
         // no generic solution for loading preferences from cache as some settings
         // need to be kept for processing in


### PR DESCRIPTION
> chdir() expects parameter 1 to be a valid path, null given

Partially reverts c642c29aa4304084c0064a15b4be63d6f53f6bd3.

Sets `$dbi` even if `$cfg['Server']` is empty.

Fixes #15761