### PR TITLE
Fixed deprecated jquery selectors (Obvious changes)

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -615,10 +615,10 @@ function setupConfigTabs () {
                 e.preventDefault();
                 setTab($(this).attr('href').substr(1));
             })
-            .filter(':first')
+            .first()
             .parent()
             .addClass('active');
-        $this.find('div.tabs_contents fieldset').hide().filter(':first').show();
+        $this.find('div.tabs_contents fieldset').hide().first().show();
     });
 }
 

--- a/js/database/central_columns.js
+++ b/js/database/central_columns.js
@@ -80,7 +80,7 @@ AJAX.registerOnload('database/central_columns.js', function () {
     });
     $('#add_new').find('td').each(function () {
         if ($(this).attr('name') !== 'undefined') {
-            $(this).find('input,select:first').attr('name', $(this).attr('name'));
+            $(this).find('input,select').first().attr('name', $(this).attr('name'));
         }
     });
     $('#field_0_0').attr('required','required');
@@ -138,7 +138,7 @@ AJAX.registerOnload('database/central_columns.js', function () {
         var rownum = $(this).data('rownum');
         $('#f_' + rownum + ' td').each(function () {
             if ($(this).attr('name') !== 'undefined') {
-                $(this).find(':input[type!="hidden"],select:first')
+                $(this).find(':input[type!="hidden"],select').first()
                     .attr('name', $(this).attr('name'));
             }
         });
@@ -192,7 +192,7 @@ AJAX.registerOnload('database/central_columns.js', function () {
     });
     $('#table-select').on('change', function () {
         var selectValue = $(this).val();
-        var defaultColumnSelect = $('#column-select').find('option:first');
+        var defaultColumnSelect = $('#column-select').find('option').first();
         var href = 'index.php?route=/database/central-columns';
         var params = {
             'ajax_request' : true,

--- a/js/database/structure.js
+++ b/js/database/structure.js
@@ -50,7 +50,7 @@ DatabaseStructure.adjustTotals = function () {
     /**
      * @var $allTr jQuery object that references all the rows in the list of tables
      */
-    var $allTr = $('#tablesForm').find('table.data tbody:first tr');
+    var $allTr = $('#tablesForm').find('table.data tbody').first().find('tr');
     // New summary values for the table
     var tableSum = $allTr.length;
     var rowsSum = 0;

--- a/js/database/tracking.js
+++ b/js/database/tracking.js
@@ -12,7 +12,7 @@ AJAX.registerTeardown('database/tracking.js', function () {
  */
 AJAX.registerOnload('database/tracking.js', function () {
     var $versions = $('#versions');
-    $versions.find('tr:first th').append($('<div class="sorticon"></div>'));
+    $versions.find('tr').first().find('th').append($('<div class="sorticon"></div>'));
     $versions.tablesorter({
         sortList: [[1, 0]],
         headers: {
@@ -25,7 +25,7 @@ AJAX.registerOnload('database/tracking.js', function () {
     });
 
     var $noVersions = $('#noversions');
-    $noVersions.find('tr:first th').append($('<div class="sorticon"></div>'));
+    $noVersions.find('tr').first().find('th').append($('<div class="sorticon"></div>'));
     $noVersions.tablesorter({
         sortList: [[1, 0]],
         headers: {

--- a/js/export.js
+++ b/js/export.js
@@ -863,7 +863,7 @@ Export.addAlias = function (type, name, field, value) {
 
     var row = $('#alias_data tfoot tr').clone();
     row.find('th').text(type);
-    row.find('td:first').text(name);
+    row.find('td').first().text(name);
     row.find('input').attr('name', field);
     row.find('input').val(value);
     row.find('.alias_remove').on('click', function () {

--- a/js/functions.js
+++ b/js/functions.js
@@ -2942,7 +2942,7 @@ AJAX.registerOnload('functions.js', function () {
                             /**
                              * @var curr_last_row   Object referring to the last <tr> element in {@link tablesTable}
                              */
-                            var currLastRow = $(tablesTable).find('tr:last');
+                            var currLastRow = $(tablesTable).find('tr').last();
                             /**
                              * @var curr_last_row_index_string   String containing the index of {@link currLastRow}
                              */
@@ -3416,7 +3416,7 @@ var $enumEditorDialog = null;
 AJAX.registerOnload('functions.js', function () {
     $(document).on('click', 'a.open_enum_editor', function () {
         // Get the name of the column that is being edited
-        var colname = $(this).closest('tr').find('input:first').val();
+        var colname = $(this).closest('tr').find('input').first().val();
         var title;
         var i;
         // And use it to make up a title for the page
@@ -3541,7 +3541,7 @@ AJAX.registerOnload('functions.js', function () {
             buttons: buttonOptions,
             open: function () {
                 // Focus the "Go" button after opening the dialog
-                $(this).closest('.ui-dialog').find('.ui-dialog-buttonpane button:first').trigger('focus');
+                $(this).closest('.ui-dialog').find('.ui-dialog-buttonpane button').first().trigger('focus');
             },
             close: function () {
                 $(this).remove();
@@ -3687,7 +3687,7 @@ AJAX.registerOnload('functions.js', function () {
                     }
                     return false;
                 });
-                $(this).closest('.ui-dialog').find('.ui-dialog-buttonpane button:first').trigger('focus');
+                $(this).closest('.ui-dialog').find('.ui-dialog-buttonpane button').first().trigger('focus');
             },
             close: function () {
                 $('#col_list').off('click', '.pick');
@@ -3714,7 +3714,7 @@ AJAX.registerOnload('functions.js', function () {
                     Functions.getImage('b_drop') +
                     '</td></tr>'
                 )
-                .find('tr:last')
+                .find('tr').last()
                 .show('fast');
         }
     });
@@ -3785,7 +3785,7 @@ AJAX.registerOnload('functions.js', function () {
         while (rowsToAdd--) {
             var $indexColumns = $('#index_columns');
             var $newrow = $indexColumns
-                .find('tbody > tr:first')
+                .find('tbody > tr').first()
                 .clone()
                 .appendTo(
                     $indexColumns.find('tbody')
@@ -4585,7 +4585,7 @@ AJAX.registerOnload('functions.js', function () {
                 // was also prevented in IE
                 $(this).trigger('blur');
 
-                $(this).closest('.ui-dialog').find('.ui-button:first').trigger('click');
+                $(this).closest('.ui-dialog').find('.ui-button').first().trigger('click');
             }
         }); // end $(document).on()
     }
@@ -4954,8 +4954,8 @@ AJAX.registerOnload('functions.js', function () {
 
             // There could be multiple submit buttons on the same form,
             // we assume all of them behave identical and just click one.
-            if (! $form.find('input[type="submit"]:first') ||
-                ! $form.find('input[type="submit"]:first').trigger('click')
+            if (! $form.find('input[type="submit"]').first() ||
+                ! $form.find('input[type="submit"]').first().trigger('click')
             ) {
                 $form.trigger('submit');
             }

--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -92,7 +92,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 n: n,
                 obj: obj,
                 objLeft: $(obj).position().left,
-                objWidth: $(g.t).find('th.draggable:visible:eq(' + n + ') span').outerWidth()
+                objWidth: $(g.t).find('th.draggable:visible').eq(n).find('span').outerWidth()
             };
             $(document.body).css('cursor', 'col-resize').noSelect();
             if (g.isCellEditActive) {
@@ -242,8 +242,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
          */
         resize: function (n, nw) {
             $(g.t).find('tr').each(function () {
-                $(this).find('th.draggable:visible:eq(' + n + ') span,' +
-                             'td:visible:eq(' + (g.actionSpan + n) + ') span')
+                $(this).find('th.draggable:visible').eq(n).find('span')
+                    .add($(this).find('td:visible').eq(g.actionSpan + n).find('span'))
                     .css('width', nw);
             });
         },
@@ -304,11 +304,11 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
             // adjust the column visibility list
             if (newn < oldn) {
-                $(g.cList).find('.lDiv div:eq(' + newn + ')')
-                    .before($(g.cList).find('.lDiv div:eq(' + oldn + ')'));
+                $(g.cList).find('.lDiv div').eq(newn)
+                    .before($(g.cList).find('.lDiv div').eq(oldn));
             } else {
-                $(g.cList).find('.lDiv div:eq(' + newn + ')')
-                    .after($(g.cList).find('.lDiv div:eq(' + oldn + ')'));
+                $(g.cList).find('.lDiv div').eq(newn)
+                    .after($(g.cList).find('.lDiv div').eq(oldn));
             }
             // adjust the colOrder
             var tmp = g.colOrder[oldn];
@@ -481,10 +481,10 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             .hide();
                     });
                     g.colVisib[n] = 0;
-                    $(g.cList).find('.lDiv div:eq(' + n + ') input').prop('checked', false);
+                    $(g.cList).find('.lDiv div').eq(n).find('input').prop('checked', false);
                 } else {
                     // cannot hide, force the checkbox to stay checked
-                    $(g.cList).find('.lDiv div:eq(' + n + ') input').prop('checked', true);
+                    $(g.cList).find('.lDiv div').eq(n).find('input').prop('checked', true);
                     return false;
                 }
             } else {    // column n is not visible
@@ -494,7 +494,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         .show();
                 });
                 g.colVisib[n] = 1;
-                $(g.cList).find('.lDiv div:eq(' + n + ') input').prop('checked', true);
+                $(g.cList).find('.lDiv div').eq(n).find('input').prop('checked', true);
             }
             return true;
         },
@@ -552,7 +552,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
         reposDrop: function () {
             var $th = $(t).find('th:not(.draggable)');
             for (var i = 0; i < $th.length; i++) {
-                var $cd = $(g.cDrop).find('div:eq(' + i + ')');   // column drop-down arrow
+                var $cd = $(g.cDrop).find('div').eq(i);   // column drop-down arrow
                 var pos = $($th[i]).position();
                 $cd.css({
                     left: pos.left + $($th[i]).width() - $cd.width(),
@@ -713,13 +713,13 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 }
                 if (data.transformations !== undefined) {
                     $.each(data.transformations, function (cellIndex, value) {
-                        var $thisField = $(g.t).find('.to_be_saved:eq(' + cellIndex + ')');
+                        var $thisField = $(g.t).find('.to_be_saved').eq(cellIndex);
                         $thisField.find('span').html(value);
                     });
                 }
                 if (data.relations !== undefined) {
                     $.each(data.relations, function (cellIndex, value) {
-                        var $thisField = $(g.t).find('.to_be_saved:eq(' + cellIndex + ')');
+                        var $thisField = $(g.t).find('.to_be_saved').eq(cellIndex);
                         $thisField.find('span').html(value);
                     });
                 }

--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -253,9 +253,9 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
          */
         reposRsz: function () {
             $(g.cRsz).find('div').hide();
-            var $firstRowCols = $(g.t).find('tr:first th.draggable:visible');
+            var $firstRowCols = $(g.t).find('tr').first().find('th.draggable:visible');
             var $resizeHandles = $(g.cRsz).find('div').removeClass('condition');
-            $(g.t).find('table.pma_table').find('thead th:first').removeClass('before-condition');
+            $(g.t).find('table.pma_table').find('thead th').first().removeClass('before-condition');
             for (var n = 0, l = $firstRowCols.length; n < l; n++) {
                 var $col = $($firstRowCols[n]);
                 var colWidth;
@@ -274,7 +274,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 }
             }
             if ($($resizeHandles[0]).hasClass('condition')) {
-                $(g.t).find('thead th:first').addClass('before-condition');
+                $(g.t).find('thead th').first().addClass('before-condition');
             }
             $(g.cRsz).css('height', $(g.t).height());
         },
@@ -512,7 +512,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
             g.sendColPrefs();
 
             // check visible first row headers count
-            g.visibleHeadersCount = $(g.t).find('tr:first th.draggable:visible').length;
+            g.visibleHeadersCount = $(g.t).find('tr').first().find('th.draggable:visible').length;
             g.refreshRestoreButton();
         },
 
@@ -1383,7 +1383,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                                 var tools = $resultQuery.find('.tools').wrap('<p>').parent().html();
                                 // sqlOuter and tools will not be present if 'Show SQL queries' configuration is off
                                 if (typeof sqlOuter !== 'undefined' && typeof tools !== 'undefined') {
-                                    $(g.o).find('.result_query:not(:last)').remove();
+                                    $(g.o).find('.result_query').not().last().remove();
                                     var $existingQuery = $(g.o).find('.result_query');
                                     // If two query box exists update query in second else add a second box
                                     if ($existingQuery.find('div.sqlOuter').length > 1) {
@@ -1563,7 +1563,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
             g.cRsz.className = 'cRsz';
 
             // get data columns in the first row of the table
-            var $firstRowCols = $(g.t).find('tr:first th.draggable');
+            var $firstRowCols = $(g.t).find('tr').first().find('th.draggable');
 
             // create column borders
             $firstRowCols.each(function () {
@@ -1599,7 +1599,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
             g.reorderHint = Messages.strColOrderHint;
 
             // get data columns in the first row of the table
-            var $firstRowCols = $(g.t).find('tr:first th.draggable');
+            var $firstRowCols = $(g.t).find('tr').first().find('th.draggable');
 
             // initialize column order
             var $colOrder = $(g.o).find('.col_order');   // check if column order is passed from PHP
@@ -1694,7 +1694,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
             g.showAllColText = Messages.strShowAllCol;
 
             // get data columns in the first row of the table
-            var $firstRowCols = $(g.t).find('tr:first th.draggable');
+            var $firstRowCols = $(g.t).find('tr').first().find('th.draggable');
 
             var i;
             // initialize column visibility
@@ -2161,14 +2161,14 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
     g.o = $(t).parents('.sqlqueryresults');
 
     // get data columns in the first row of the table
-    var $firstRowCols = $(t).find('tr:first th.draggable');
+    var $firstRowCols = $(t).find('tr').first().find('th.draggable');
 
     // initialize visible headers count
     g.visibleHeadersCount = $firstRowCols.filter(':visible').length;
 
     // assign first column (actions) span
-    if (! $(t).find('tr:first th:first').hasClass('draggable')) {  // action header exist
-        g.actionSpan = $(t).find('tr:first th:first').prop('colspan');
+    if (! $(t).find('tr').first().find('th').first().hasClass('draggable')) {  // action header exist
+        g.actionSpan = $(t).find('tr').first().find('th').first().prop('colspan');
     } else {
         g.actionSpan = 0;
     }

--- a/js/menu_resizer.js
+++ b/js/menu_resizer.js
@@ -79,7 +79,7 @@
     MenuResizer.prototype.resize = function () {
         var wmax = this.widthCalculator.call(this.$container);
         var windowWidth = $(window).width();
-        var $submenu = this.$container.find('.submenu:last');
+        var $submenu = this.$container.find('.submenu').last();
         var submenuW = $submenu.outerWidth(true);
         var $submenuUl = $submenu.find('ul');
         var $li = this.$container.find('> li');

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -250,7 +250,7 @@ Navigation.traverseForPaths = function () {
                 pos2Name = $(this)
                     .parent()
                     .parent()
-                    .find('span.pos2_name:last')
+                    .find('span.pos2_name').last()
                     .text();
             }
             var pos2Value = $(this).find('span.pos2_value').text();
@@ -258,7 +258,7 @@ Navigation.traverseForPaths = function () {
                 pos2Value = $(this)
                     .parent()
                     .parent()
-                    .find('span.pos2_value:last')
+                    .find('span.pos2_value').last()
                     .text();
             }
 
@@ -773,7 +773,7 @@ Navigation.showCurrent = function () {
                 return;
             }
             // If loaded database in navigation is not same as current one
-            if ($('#pma_navigation_tree_content').find('span.loaded_db:first').text()
+            if ($('#pma_navigation_tree_content').find('span.loaded_db').first().text()
                 !== $('#navi_db_select').val()
             ) {
                 Navigation.loadChildNodes(false, $('option:selected', $('#navi_db_select')), function () {
@@ -811,7 +811,7 @@ Navigation.showCurrent = function () {
     Navigation.showFullName($('#pma_navigation_tree'));
 
     function fullExpand (table, $dbItem) {
-        var $expander = $dbItem.children('div:first').children('a.expander');
+        var $expander = $dbItem.children('div').first().children('a.expander');
         // if not loaded or loaded but collapsed
         if (! $expander.hasClass('loaded') ||
             $expander.find('img').is('.ic_b_plus')
@@ -831,7 +831,7 @@ Navigation.showCurrent = function () {
             var $container = $dbItem.children('div.list_container');
             var $tableContainer = $container.children('ul').children('li.tableContainer');
             if ($tableContainer.length > 0) {
-                var $expander = $tableContainer.children('div:first').children('a.expander');
+                var $expander = $tableContainer.children('div').first().children('a.expander');
                 $tableContainer.addClass('selected');
                 Navigation.expandTreeNode($expander, function () {
                     Navigation.scrollToView($dbItem, true);
@@ -868,7 +868,7 @@ Navigation.showCurrent = function () {
                         var $cont = $(this).children('div.list_container');
                         if (! $cont.is(':visible')) {
                             $(this)
-                                .children('div:first')
+                                .children('div').first()
                                 .children('a.expander')
                                 .trigger('click');
                         }
@@ -896,7 +896,7 @@ Navigation.showCurrent = function () {
                 itemName, null, true
             );
             // Show directly
-            showTableOrView($whichItem, $relatedContainer.children('div:first').children('a.expander'));
+            showTableOrView($whichItem, $relatedContainer.children('div').first().children('a.expander'));
         // else if item not there, try loading once
         } else {
             var $subContainers = $dbItem.find('.subContainer');
@@ -906,7 +906,7 @@ Navigation.showCurrent = function () {
                 $subContainers.each(function (index) {
                     $containers[index] = $(this);
                     $expander = $containers[index]
-                        .children('div:first')
+                        .children('div').first()
                         .children('a.expander');
                     if (! $expander.hasClass('loaded')) {
                         loadAndShowTableOrView($expander, $containers[index], itemName);
@@ -915,7 +915,7 @@ Navigation.showCurrent = function () {
             // else if no subContainers
             } else {
                 $expander = $dbItem
-                    .children('div:first')
+                    .children('div').first()
                     .children('a.expander');
                 if (! $expander.hasClass('loaded')) {
                     loadAndShowTableOrView($expander, $dbItem, itemName);
@@ -1115,11 +1115,11 @@ Navigation.treePagination = function ($this) {
                 if (val) {
                     $parent.find('li.fast_filter input.searchClause').val(val);
                 }
-                $parent.find('span.pos2_value:first').text(
-                    $parent.find('span.pos2_value:last').text()
+                $parent.find('span.pos2_value').first().text(
+                    $parent.find('span.pos2_value').last().text()
                 );
-                $parent.find('span.pos3_value:first').text(
-                    $parent.find('span.pos3_value:last').text()
+                $parent.find('span.pos3_value').first().text(
+                    $parent.find('span.pos3_value').last().text()
                 );
             }
         } else {
@@ -1616,7 +1616,7 @@ Navigation.FastFilter.Filter.prototype.request = function () {
     var url = $('#pma_navigation').find('a.navigation_url').attr('href');
     var params = self.$this.find('> ul > li > form.fast_filter').first().serialize();
 
-    if (self.$this.find('> ul > li > form.fast_filter:first input[name=searchClause]').length === 0) {
+    if (self.$this.find('> ul > li > form.fast_filter').first().find('input[name=searchClause]').length === 0) {
         var $input = $('#pma_navigation_tree').find('li.fast_filter.db_fast_filter input.searchClause');
         if ($input.length && $input.val() !== $input[0].defaultValue) {
             params += CommonParams.get('arg_separator') + 'searchClause=' + encodeURIComponent($input.val());

--- a/js/normalization.js
+++ b/js/normalization.js
@@ -664,7 +664,7 @@ AJAX.registerOnload('normalization.js', function () {
         });
 
         if (repeatingCols !== '') {
-            var newColName = $('#extra input[type=checkbox]:checked:first').val();
+            var newColName = $('#extra input[type=checkbox]:checked').first().val();
             repeatingCols = repeatingCols.slice(0, -2);
             var confirmStr = Functions.sprintf(Messages.strMoveRepeatingGroup, Functions.escapeHtml(repeatingCols), Functions.escapeHtml(CommonParams.get('table')));
             confirmStr += '<input type="text" name="repeatGroupTable" placeholder="' + Messages.strNewTablePlaceholder + '">' +

--- a/js/rte.js
+++ b/js/rte.js
@@ -801,15 +801,15 @@ RTE.ROUTINE = {
         case 'MEDIUMTEXT':
         case 'LONGBLOB':
         case 'LONGTEXT':
-            $text.closest('tr').find('a:first').hide();
+            $text.closest('tr').find('a').first().hide();
             $len.parent().hide();
             $noLen.show();
             break;
         default:
             if ($type.val() === 'ENUM' || $type.val() === 'SET') {
-                $text.closest('tr').find('a:first').show();
+                $text.closest('tr').find('a').first().show();
             } else {
-                $text.closest('tr').find('a:first').hide();
+                $text.closest('tr').find('a').first().hide();
             }
             $len.parent().show();
             $noLen.hide();

--- a/js/server/privileges.js
+++ b/js/server/privileges.js
@@ -359,7 +359,7 @@ AJAX.registerOnload('server/privileges.js', function () {
                 $('#initials_table')
                     .prop('id', 'initials_table_old')
                     .after(data.message).show('medium')
-                    .siblings('h2').not(':first').remove();
+                    .siblings('h2').not().first().remove();
                 // prevent double initials table
                 $('#initials_table_old').remove();
             } else {

--- a/js/server/status/monitor.js
+++ b/js/server/status/monitor.js
@@ -466,7 +466,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
 
         /* Reorder all charts that it fills all column cells */
         var numColumns;
-        var $tr = $('#chartGrid').find('tr:first');
+        var $tr = $('#chartGrid').find('tr').first();
 
         var tempManageCols = function () {
             if (numColumns > monitorSettings.columns) {
@@ -480,7 +480,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
 
         var tempAddCol = function () {
             if ($(this).next().length !== 0) {
-                $(this).append($(this).next().find('td:first'));
+                $(this).append($(this).next().find('td').first());
             }
         };
 
@@ -494,7 +494,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
             if ($tr.next().length > 0) {
                 var cnt = monitorSettings.columns - $tr.find('td').length;
                 for (var i = 0; i < cnt; i++) {
-                    $tr.append($tr.next().find('td:first'));
+                    $tr.append($tr.next().find('td').first());
                     $tr.nextAll().each(tempAddCol);
                 }
             }
@@ -1072,7 +1072,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
         var numCharts = $('#chartGrid').find('.monitorChart').length;
         var numMissingCells = (monitorSettings.columns - numCharts % monitorSettings.columns) % monitorSettings.columns;
         for (i = 0; i < numMissingCells; i++) {
-            $('#chartGrid').find('tr:last').append('<td></td>');
+            $('#chartGrid').find('tr').last().append('<td></td>');
         }
 
         // Empty cells should keep their size so you can drop onto them
@@ -1211,7 +1211,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
             if (!chartSize) {
                 calculateChartSize();
             }
-            $('#chartGrid').find('tr:last').append(
+            $('#chartGrid').find('tr').last().append(
                 '<td><div id="gridChartContainer' + runtime.chartAI + '" class="">' +
                 '<div class="ui-state-default monitorChart"' +
                 ' id="gridchart' + runtime.chartAI + '"' +
@@ -1988,8 +1988,8 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                     '</span></th><th class="right">' + data.sum.TOTAL + '</th></tr></tfoot>');
 
         // Append a tooltip to the count column, if there exist one
-        if ($('#logTable').find('tr:first th:last').text().indexOf('#') > -1) {
-            $('#logTable').find('tr:first th:last').append('&nbsp;' + Functions.getImage('b_help', '', { 'class': 'qroupedQueryInfoIcon' }));
+        if ($('#logTable').find('tr').first().find('th').last().text().indexOf('#') > -1) {
+            $('#logTable').find('tr').first().find('th').last().append('&nbsp;' + Functions.getImage('b_help', '', { 'class': 'qroupedQueryInfoIcon' }));
 
             var tooltipContent = Messages.strCountColumnExplanation;
             if (groupInserts) {

--- a/js/server/status/sorter.js
+++ b/js/server/status/sorter.js
@@ -16,7 +16,7 @@ function initTableSorter (tabid) {
         break;
     }
     $table.tablesorter(opts);
-    $table.find('tr:first th')
+    $table.find('tr').first().find('th')
         .append('<div class="sorticon"></div>');
 }
 

--- a/js/server/user_groups.js
+++ b/js/server/user_groups.js
@@ -23,7 +23,7 @@ AJAX.registerOnload('server/user_groups.js', function () {
     $(document).on('click', 'a.deleteUserGroup.ajax', function (event) {
         event.preventDefault();
         var $link = $(this);
-        var groupName = $link.parents('tr').find('td:first').text();
+        var groupName = $link.parents('tr').find('td').first().text();
         var buttonOptions = {};
         buttonOptions[Messages.strGo] = function () {
             $(this).dialog('close');

--- a/js/sql.js
+++ b/js/sql.js
@@ -145,9 +145,9 @@ Sql.getFieldName = function ($tableResults, $thisField) {
     var thisFieldIndex = $thisField.index();
     // ltr or rtl direction does not impact how the DOM was generated
     // check if the action column in the left exist
-    var leftActionExist = !$tableResults.find('th:first').hasClass('draggable');
+    var leftActionExist = !$tableResults.find('th').first().hasClass('draggable');
     // number of column span for checkbox and Actions
-    var leftActionSkip = leftActionExist ? $tableResults.find('th:first').attr('colspan') - 1 : 0;
+    var leftActionSkip = leftActionExist ? $tableResults.find('th').first().attr('colspan') - 1 : 0;
 
     // If this column was sorted, the text of the a element contains something
     // like <small>1</small> that is useful to indicate the order in case
@@ -163,7 +163,7 @@ Sql.getFieldName = function ($tableResults, $thisField) {
         .text();    // grab the text
     // happens when just one row (headings contain no a)
     if (fieldName === '') {
-        var $heading = $tableResults.find('thead').find('th:eq(' + (thisFieldIndex - leftActionSkip) + ')').children('span');
+        var $heading = $tableResults.find('thead').find('th').eq(thisFieldIndex - leftActionSkip).children('span');
         // may contain column comment enclosed in a span - detach it temporarily to read the column name
         var $tempColComment = $heading.children().detach();
         fieldName = $heading.text();
@@ -856,7 +856,7 @@ AJAX.registerOnload('sql.js', function () {
 Sql.changeClassForColumn = function ($thisTh, newClass, isAddClass) {
     // index 0 is the th containing the big T
     var thIndex = $thisTh.index();
-    var hasBigT = $thisTh.closest('tr').children(':first').hasClass('column_action');
+    var hasBigT = $thisTh.closest('tr').children().first().hasClass('column_action');
     // .eq() is zero-based
     if (hasBigT) {
         thIndex--;
@@ -1076,12 +1076,12 @@ Sql.initStickyColumns = function ($tableResults) {
  */
 Sql.rearrangeStickyColumns = function ($stickyColumns, $tableResults) {
     var $originalHeader = $tableResults.find('thead');
-    var $originalColumns = $originalHeader.find('tr:first').children();
+    var $originalColumns = $originalHeader.find('tr').first().children();
     var $clonedHeader = $originalHeader.clone();
     var isFirefox = navigator.userAgent.indexOf('Firefox') > -1;
     var isSafari = navigator.userAgent.indexOf('Safari') > -1;
     // clone width per cell
-    $clonedHeader.find('tr:first').children().each(function (i) {
+    $clonedHeader.find('tr').first().children().each(function (i) {
         var width = $originalColumns.eq(i).width();
         if (! isFirefox && ! isSafari) {
             width += 1;

--- a/js/sql.js
+++ b/js/sql.js
@@ -155,7 +155,9 @@ Sql.getFieldName = function ($tableResults, $thisField) {
     // of the column name so we strip it ( .clone() to .end() )
     var fieldName = $tableResults
         .find('thead')
-        .find('th:eq(' + (thisFieldIndex - leftActionSkip) + ') a')
+        .find('th')
+        .eq(thisFieldIndex - leftActionSkip)
+        .find('a')
         .clone()    // clone the element
         .children() // select all the children
         .remove()   // remove all of them
@@ -865,7 +867,7 @@ Sql.changeClassForColumn = function ($thisTh, newClass, isAddClass) {
     if (! $table.length) {
         $table = $thisTh.parents('table').siblings('.table_results');
     }
-    var $tds = $table.find('tbody tr').find('td.data:eq(' + thIndex + ')');
+    var $tds = $table.find('tbody tr').find('td.data').eq(thIndex);
     if (isAddClass === undefined) {
         $tds.toggleClass(newClass);
     } else {

--- a/js/table/change.js
+++ b/js/table/change.js
@@ -383,7 +383,7 @@ AJAX.registerOnload('table/change.js', function () {
         // Current value
         var value = $span.parent('td').children('input[type=\'text\']').val();
         // Field name
-        var field = $span.parents('tr').children('td:first').find('input[type=\'hidden\']').val();
+        var field = $span.parents('tr').children('td').first().find('input[type=\'hidden\']').val();
         // Column type
         var type = $span.parents('tr').find('span.column_type').text();
         // Names of input field and null checkbox
@@ -480,7 +480,7 @@ function addNewContinueInsertionFiels (event) {
     /**
      * @var columnCount   Number of number of columns table has.
      */
-    var columnCount = $('table.insertRowTable:first').find('tr').has('input[name*=\'fields_name\']').length;
+    var columnCount = $('table.insertRowTable').first().find('tr').has('input[name*=\'fields_name\']').length;
     /**
      * @var curr_rows   Number of current insert rows already on page
      */
@@ -602,7 +602,7 @@ function addNewContinueInsertionFiels (event) {
             /**
              * @var $last_row    Object referring to the last row
              */
-            var $lastRow = $('#insertForm').find('.insertRowTable:last');
+            var $lastRow = $('#insertForm').find('.insertRowTable').last();
 
             // need to access this at more than one level
             // (also needs improvement because it should be calculated
@@ -622,13 +622,13 @@ function addNewContinueInsertionFiels (event) {
             // Insert/Clone the ignore checkboxes
             if (currRows === 1) {
                 $('<input id="insert_ignore_1" type="checkbox" name="insert_ignore_1" checked="checked">')
-                    .insertBefore('table.insertRowTable:last')
+                    .insertBefore('table.insertRowTable').last()
                     .after('<label for="insert_ignore_1">' + Messages.strIgnore + '</label>');
             } else {
                 /**
                  * @var $last_checkbox   Object reference to the last checkbox in #insertForm
                  */
-                var $lastCheckbox = $('#insertForm').children('input:checkbox:last');
+                var $lastCheckbox = $('#insertForm').children('input:checkbox').last();
 
                 /** name of {@link $lastCheckbox} */
                 var lastCheckboxName = $lastCheckbox.attr('name');
@@ -638,21 +638,21 @@ function addNewContinueInsertionFiels (event) {
                 var newName = lastCheckboxName.replace(/\d+/, lastCheckboxIndex + 1);
 
                 $('<br><div class="clearfloat"></div>')
-                    .insertBefore('table.insertRowTable:last');
+                    .insertBefore('table.insertRowTable').last();
 
                 $lastCheckbox
                     .clone()
                     .attr({ 'id': newName, 'name': newName })
                     .prop('checked', true)
-                    .insertBefore('table.insertRowTable:last');
+                    .insertBefore('table.insertRowTable').last();
 
-                $('label[for^=insert_ignore]:last')
+                $('label[for^=insert_ignore]').last()
                     .clone()
                     .attr('for', newName)
-                    .insertBefore('table.insertRowTable:last');
+                    .insertBefore('table.insertRowTable').last();
 
                 $('<br>')
-                    .insertBefore('table.insertRowTable:last');
+                    .insertBefore('table.insertRowTable').last();
             }
             currRows++;
         }
@@ -689,7 +689,7 @@ function addNewContinueInsertionFiels (event) {
         var checkLock = jQuery.isEmptyObject(AJAX.lockedTargets);
         if (checkLock || confirm(Messages.strConfirmRowChange) === true) {
             while (currRows > targetRows) {
-                $('input[id^=insert_ignore]:last')
+                $('input[id^=insert_ignore]').last()
                     .nextUntil('fieldset')
                     .addBack()
                     .remove();

--- a/js/table/relation.js
+++ b/js/table/relation.js
@@ -164,7 +164,7 @@ AJAX.registerOnload('table/relation.js', function () {
 
         // Add foreign field.
         var $sourceElem = $('select[name^="destination_foreign_column[' +
-            $(this).attr('data-index') + ']"]:last').parent();
+            $(this).attr('data-index') + ']"]').last().parent();
         $sourceElem
             .clone(true, true)
             .insertAfter($sourceElem)
@@ -190,11 +190,11 @@ AJAX.registerOnload('table/relation.js', function () {
         $newRow.find('a.add_foreign_key_field').attr('data-index', newIndex);
 
         // Update form parameter names.
-        $newRow.find('select[name^="foreign_key_fields_name"]:not(:first), ' +
-            'select[name^="destination_foreign_column"]:not(:first)'
-        ).each(function () {
-            $(this).parent().remove();
-        });
+        $newRow.find('select[name^="foreign_key_fields_name"]').not().first().find(
+            'select[name^="destination_foreign_column"]').not().first()
+            .each(function () {
+                $(this).parent().remove();
+            });
         $newRow.find('input, select').each(function () {
             $(this).attr('name',
                 $(this).attr('name').replace(/\d/, newIndex)

--- a/js/table/select.js
+++ b/js/table/select.js
@@ -280,7 +280,8 @@ AJAX.registerOnload('table/select.js', function () {
         // Get the column name.
         var columnName = $(this)
             .closest('tr')
-            .find('th:first')
+            .find('th')
+            .first()
             .text();
 
         // Get the data-type of column excluding size.

--- a/js/table/structure.js
+++ b/js/table/structure.js
@@ -215,7 +215,7 @@ AJAX.registerOnload('table/structure.js', function () {
 
                     // by default select the (new) last option to add new column
                     // (in case last column is dropped)
-                    $('select[name=after_field] option:last').attr('selected','selected');
+                    $('select[name=after_field] option').last().attr('selected','selected');
 
                     // refresh table stats
                     if (data.tableStat) {

--- a/js/table/tracking.js
+++ b/js/table/tracking.js
@@ -11,7 +11,7 @@ AJAX.registerTeardown('table/tracking.js', function () {
  * Bind event handlers
  */
 AJAX.registerOnload('table/tracking.js', function () {
-    $('#versions tr:first th').append($('<div class="sorticon"></div>'));
+    $('#versions tr').first().find('th').append($('<div class="sorticon"></div>'));
     $('#versions').tablesorter({
         sortList: [[1, 0]],
         headers: {
@@ -23,7 +23,7 @@ AJAX.registerOnload('table/tracking.js', function () {
     });
 
     if ($('#ddl_versions tbody tr').length > 0) {
-        $('#ddl_versions tr:first th').append($('<div class="sorticon"></div>'));
+        $('#ddl_versions tr').first().find('th').append($('<div class="sorticon"></div>'));
         $('#ddl_versions').tablesorter({
             sortList: [[0, 0]],
             headers: {
@@ -35,7 +35,7 @@ AJAX.registerOnload('table/tracking.js', function () {
     }
 
     if ($('#dml_versions tbody tr').length > 0) {
-        $('#dml_versions tr:first th').append($('<div class="sorticon"></div>'));
+        $('#dml_versions tr').first().find('th').append($('<div class="sorticon"></div>'));
         $('#dml_versions').tablesorter({
             sortList: [[0, 0]],
             headers: {

--- a/js/table/zoom_plot_jqplot.js
+++ b/js/table/zoom_plot_jqplot.js
@@ -144,10 +144,10 @@ AJAX.registerOnload('table/zoom_plot_jqplot.js', function () {
             'field' : $('#tableid_0').val(),
             'it' : 0
         }, function (data) {
-            $('#tableFieldsId').find('tr:eq(1) td:eq(0)').html(data.field_type);
-            $('#tableFieldsId').find('tr:eq(1) td:eq(1)').html(data.field_collation);
-            $('#tableFieldsId').find('tr:eq(1) td:eq(2)').html(data.field_operators);
-            $('#tableFieldsId').find('tr:eq(1) td:eq(3)').html(data.field_value);
+            $('#tableFieldsId').find('tr').eq(1).find('td').eq(0).html(data.field_type);
+            $('#tableFieldsId').find('tr').eq(1).find('td').eq(1).html(data.field_collation);
+            $('#tableFieldsId').find('tr').eq(1).find('td').eq(2).html(data.field_operators);
+            $('#tableFieldsId').find('tr').eq(1).find('td').eq(3).html(data.field_value);
             xLabel = $('#tableid_0').val();
             $('#types_0').val(data.field_type);
             xType = data.field_type;
@@ -168,10 +168,10 @@ AJAX.registerOnload('table/zoom_plot_jqplot.js', function () {
             'field' : $('#tableid_1').val(),
             'it' : 1
         }, function (data) {
-            $('#tableFieldsId').find('tr:eq(2) td:eq(0)').html(data.field_type);
-            $('#tableFieldsId').find('tr:eq(2) td:eq(1)').html(data.field_collation);
-            $('#tableFieldsId').find('tr:eq(2) td:eq(2)').html(data.field_operators);
-            $('#tableFieldsId').find('tr:eq(2) td:eq(3)').html(data.field_value);
+            $('#tableFieldsId').find('tr').eq(2).find('td').eq(0).html(data.field_type);
+            $('#tableFieldsId').find('tr').eq(2).find('td').eq(1).html(data.field_collation);
+            $('#tableFieldsId').find('tr').eq(2).find('td').eq(2).html(data.field_operators);
+            $('#tableFieldsId').find('tr').eq(2).find('td').eq(3).html(data.field_value);
             yLabel = $('#tableid_1').val();
             $('#types_1').val(data.field_type);
             yType = data.field_type;
@@ -191,10 +191,10 @@ AJAX.registerOnload('table/zoom_plot_jqplot.js', function () {
             'field' : $('#tableid_2').val(),
             'it' : 2
         }, function (data) {
-            $('#tableFieldsId').find('tr:eq(4) td:eq(0)').html(data.field_type);
-            $('#tableFieldsId').find('tr:eq(4) td:eq(1)').html(data.field_collation);
-            $('#tableFieldsId').find('tr:eq(4) td:eq(2)').html(data.field_operators);
-            $('#tableFieldsId').find('tr:eq(4) td:eq(3)').html(data.field_value);
+            $('#tableFieldsId').find('tr').eq(4).find('td').eq(0).html(data.field_type);
+            $('#tableFieldsId').find('tr').eq(4).find('td').eq(1).html(data.field_collation);
+            $('#tableFieldsId').find('tr').eq(4).find('td').eq(2).html(data.field_operators);
+            $('#tableFieldsId').find('tr').eq(4).find('td').eq(3).html(data.field_value);
             $('#types_2').val(data.field_type);
             $('#collations_2').val(data.field_collations);
             Functions.addDateTimePicker();
@@ -212,10 +212,10 @@ AJAX.registerOnload('table/zoom_plot_jqplot.js', function () {
             'field' : $('#tableid_3').val(),
             'it' : 3
         }, function (data) {
-            $('#tableFieldsId').find('tr:eq(5) td:eq(0)').html(data.field_type);
-            $('#tableFieldsId').find('tr:eq(5) td:eq(1)').html(data.field_collation);
-            $('#tableFieldsId').find('tr:eq(5) td:eq(2)').html(data.field_operators);
-            $('#tableFieldsId').find('tr:eq(5) td:eq(3)').html(data.field_value);
+            $('#tableFieldsId').find('tr').eq(5).find('td').eq(0).html(data.field_type);
+            $('#tableFieldsId').find('tr').eq(5).find('td').eq(1).html(data.field_collation);
+            $('#tableFieldsId').find('tr').eq(5).find('td').eq(2).html(data.field_operators);
+            $('#tableFieldsId').find('tr').eq(5).find('td').eq(3).html(data.field_value);
             $('#types_3').val(data.field_type);
             $('#collations_3').val(data.field_collations);
             Functions.addDateTimePicker();


### PR DESCRIPTION
### Description

(Commit: b93ae50)
1. `:first` has been replaced to `.first()`
Ref: https://api.jquery.com/first-selector/

2. `:last` has been replaced to `.last()`
Ref: https://api.jquery.com/last-selector/

(Commit : 9888c50)
1. `:eq` has been replaced with `.eq()`
Ref: https://api.jquery.com/eq-selector/

Fixes: #15792

