### PR TITLE
Change Location of Profiling state documentation and Fix Sorting error

### DIFF
--- a/js/sql.js
+++ b/js/sql.js
@@ -1020,6 +1020,10 @@ Sql.initProfilingTables = function () {
     if (!$.tablesorter) {
         return;
     }
+    // Added to allow two direction sorting
+    $('#profiletable')
+        .find('thead th')
+        .off('click mousedown');
 
     $('#profiletable').tablesorter({
         widgets: ['zebra'],
@@ -1032,6 +1036,10 @@ Sql.initProfilingTables = function () {
             }
         }
     });
+    // Added to allow two direction sorting
+    $('#profilesummarytable')
+        .find('thead th')
+        .off('click mousedown');
 
     $('#profilesummarytable').tablesorter({
         widgets: ['zebra'],

--- a/templates/sql/profiling_chart.twig
+++ b/templates/sql/profiling_chart.twig
@@ -11,7 +11,6 @@
         </th>
         <th>
           {% trans 'State' %}
-          {{ show_mysql_docu('general-thread-states') }}
           <div class="sorticon"></div>
         </th>
         <th>
@@ -27,13 +26,12 @@
   </div>
 
   <div class="floatleft">
-    <h3>{% trans 'Summary by state' %}</h3>
+    <h3>{% trans 'Summary by state' %}{{ show_mysql_docu('general-thread-states') }}</h3>
     <table id="profilesummarytable">
       <thead>
       <tr>
         <th>
           {% trans 'State' %}
-          {{ show_mysql_docu('general-thread-states') }}
           <div class="sorticon"></div>
         </th>
         <th>


### PR DESCRIPTION
Signed-off-by: Manthan Surkar <manthan.surkar@gmail.com>

### Description

profiling table has tableSorter function(jquery), so we cannot add other link in the `<th>` tags, since `<th> `tags are  used as sorting links. 

I have moved the state documentation to a more suitable position.
![image](https://user-images.githubusercontent.com/42006277/72554442-b2088300-38c0-11ea-844d-e5d05528c024.png)


Fixes #15799

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
