### PR TITLE
fixed font sizing

### DIFF
--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -350,7 +350,7 @@ fieldset {
     -webkit-box-shadow: 3px 3px 15px #bbb;
     box-shadow: 3px 3px 15px #bbb;
     width: initial;
-    font-size: 1rem;
+    font-size: 1em;
   }
 }
 


### PR DESCRIPTION
Closes #15598 

Used a global styling 1em unit and set font-size to 82% for HTML (it was so in earlier versions)

Signed-off-by: Rahul Gurung <gurungrahul2@gmail.com>

