### PR TITLE
fixed browse foreign values modal with grid edit

### DIFF
--- a/templates/sql/relational_column_dropdown.twig
+++ b/templates/sql/relational_column_dropdown.twig
@@ -1,4 +1,4 @@
 <span class="curr_value">{{ current_value }}</span>
-<a href="browse_foreigners.php" data-post="{{ get_common(params, '') }}">
+<a href="browse_foreigners.php" data-post="{{ get_common(params, '') }}" class="ajax browse_foreign">
   {% trans 'Browse foreign values' %}
 </a>


### PR DESCRIPTION
Closes #15811 
The class name for modal was dropped when converting into twig templates which is fixed in this commit.