### PR TITLE
Fixed deprecated jquery selectors (Serious changes)

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -3319,7 +3319,7 @@ AJAX.registerOnload('functions.js', function () {
 Functions.hideShowConnection = function ($engineSelector) {
     var $connection = $('.create_table_form input[name=connection]');
     var index = $connection.parent('td').index() + 1;
-    var $labelTh = $connection.parents('tr').prev('tr').children('th:nth-child(' + index + ')');
+    var $labelTh = $connection.parents('tr').prev('tr').children(document.querySelectorAll('th:nth-child(' + index + ')'));
     if ($engineSelector.val() !== 'FEDERATED') {
         $connection
             .prop('disabled', true)
@@ -4025,7 +4025,7 @@ Functions.toggleButton = function ($obj) {
     var w = parseInt(($('img', $obj).height() / 16) * 22, 10);
     // Resize the central part of the switch on the top
     // layer to match the background
-    $('table td:nth-child(2) > div', $obj).width(w);
+    $(document.querySelectorAll('table td:nth-child(2) > div'), $obj).width(w);
     /**
      *  var  imgw    Width of the background image
      *  var  tblw    Width of the foreground layer
@@ -4042,7 +4042,7 @@ Functions.toggleButton = function ($obj) {
      *  var  btnw    Outer width of the central part of the switch
      */
     var offw = $('td.toggleOff', $obj).outerWidth();
-    var btnw = $('table td:nth-child(2)', $obj).outerWidth();
+    var btnw = $(document.querySelectorAll('table td:nth-child(2)'), $obj).outerWidth();
     // Resize the main div so that exactly one side of
     // the switch plus the central part fit into it.
     $obj.width(offw + btnw + 2);

--- a/js/indexes.js
+++ b/js/indexes.js
@@ -57,7 +57,7 @@ Indexes.checkIndexType = function () {
     /**
      * @var Object Table header for the size column.
      */
-    var $sizeHeader = $('#index_columns').find('thead tr th:nth-child(2)');
+    var $sizeHeader = $('#index_columns').find(document.querySelectorAll('thead tr th:nth-child(2)'));
     /**
      * @var Object Inputs to specify the columns for the index.
      */

--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -288,15 +288,15 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
         shiftCol: function (oldn, newn) {
             $(g.t).find('tr').each(function () {
                 if (newn < oldn) {
-                    $(this).find('th.draggable:eq(' + newn + '),' +
-                                 'td:eq(' + (g.actionSpan + newn) + ')')
-                        .before($(this).find('th.draggable:eq(' + oldn + '),' +
-                                                'td:eq(' + (g.actionSpan + oldn) + ')'));
+                    $(this).find('th.draggable').eq(newn)
+                        .add($(this).find('td').eq(g.actionSpan + newn))
+                        .before($(this).find('th.draggable').eq(oldn)
+                            .add($(this).find('td').eq(g.actionSpan + oldn)));
                 } else {
-                    $(this).find('th.draggable:eq(' + newn + '),' +
-                                 'td:eq(' + (g.actionSpan + newn) + ')')
-                        .after($(this).find('th.draggable:eq(' + oldn + '),' +
-                                               'td:eq(' + (g.actionSpan + oldn) + ')'));
+                    $(this).find('th.draggable').eq(newn)
+                        .add($(this).find('td').eq(g.actionSpan + newn))
+                        .after($(this).find('th.draggable').eq(oldn)
+                            .add($(this).find('td').eq(g.actionSpan + oldn)));
                 }
             });
             // reposition the column resize bars
@@ -475,8 +475,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 // can hide if more than one column is visible
                 if (g.visibleHeadersCount > 1) {
                     $(g.t).find('tr').each(function () {
-                        $(this).find('th.draggable:eq(' + n + '),' +
-                                     'td:eq(' + (g.actionSpan + n) + ')')
+                        $(this).find('th.draggable').eq(n)
+                            .add($(this).find('td').eq(g.actionSpan + n))
                             .hide();
                     });
                     g.colVisib[n] = 0;
@@ -488,8 +488,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 }
             } else {    // column n is not visible
                 $(g.t).find('tr').each(function () {
-                    $(this).find('th.draggable:eq(' + n + '),' +
-                                 'td:eq(' + (g.actionSpan + n) + ')')
+                    $(this).find('th.draggable').eq(n)
+                        .add($(this).find('td').eq(g.actionSpan + n))
                         .show();
                 });
                 g.colVisib[n] = 1;

--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -1382,8 +1382,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                                     var $existingQuery = $(g.o).find('.result_query');
                                     // If two query box exists update query in second else add a second box
                                     if ($existingQuery.find('div.sqlOuter').length > 1) {
-                                        $existingQuery.children(':nth-child(4)').remove();
-                                        $existingQuery.children(':nth-child(4)').remove();
+                                        $existingQuery.children(document.querySelectorAll(':nth-child(4)')).remove();
+                                        $existingQuery.children(document.querySelectorAll(':nth-child(4)')).remove();
                                         $existingQuery.append(sqlOuter + tools);
                                     } else {
                                         $existingQuery.append(sqlOuter + tools);

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -486,8 +486,8 @@ $(function () {
         dialog.executeDialog($(this).parent());
     });
     /** Export Triggers and Events */
-    $(document).on('click', 'li.trigger div:eq(1) a.ajax img,' +
-        ' li.event div:eq(1) a.ajax img', function (event) {
+    $(document).on('click', 'li.trigger div.second a.ajax img,' +
+        ' li.event div.second a.ajax img', function (event) {
         event.preventDefault();
         var dialog = new RTE.Object();
         dialog.exportDialog($(this).parent());

--- a/js/server/privileges.js
+++ b/js/server/privileges.js
@@ -173,12 +173,13 @@ AJAX.registerOnload('server/privileges.js', function () {
 
                         // Re-check the classes of each row
                         $form
-                            .find('tbody').find('tr:odd')
-                            .removeClass('even').addClass('odd')
-                            .end()
-                            .find('tr:even')
-                            .removeClass('odd').addClass('even');
-
+                            .find('tbody').find('tr').each(function (index) {
+                                if (index >= 0 && index % 2 === 0) {
+                                    $(this).removeClass('odd').addClass('even');
+                                } else if (index >= 0 && index % 2 !== 0) {
+                                    $(this).removeClass('even').addClass('odd');
+                                }
+                            });
                         // update the checkall checkbox
                         $(Functions.checkboxesSel).trigger('change');
                     });

--- a/js/server/status/monitor.js
+++ b/js/server/status/monitor.js
@@ -1051,10 +1051,10 @@ AJAX.registerOnload('server/status/monitor.js', function () {
         /* Calculate how much spacing there is between each chart */
         $('#chartGrid').html('<tr><td></td><td></td></tr><tr><td></td><td></td></tr>');
         chartSpacing = {
-            width: $('#chartGrid').find('td:nth-child(2)').offset().left -
-                $('#chartGrid').find('td:nth-child(1)').offset().left,
-            height: $('#chartGrid').find('tr:nth-child(2) td:nth-child(2)').offset().top -
-                $('#chartGrid').find('tr:nth-child(1) td:nth-child(1)').offset().top
+            width: $('#chartGrid').find(document.querySelectorAll('td:nth-child(2)')).offset().left -
+                $('#chartGrid').find(document.querySelectorAll('td:nth-child(1)')).offset().left,
+            height: $('#chartGrid').find(document.querySelectorAll('td:nth-child(2) td:nth-child(2)')).offset().top -
+                $('#chartGrid').find(document.querySelectorAll('td:nth-child(1) td:nth-child(1)')).offset().top
         };
         $('#chartGrid').html('');
 
@@ -1807,7 +1807,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
             };
 
             // We just assume the sql text is always in the second last column, and that the total count is right of it
-            $('#logTable').find('table tbody tr td:nth-child(' + (runtime.logDataCols.length - 1) + ')').each(function () {
+            $('#logTable').find(document.querySelectorAll('table tbody tr td:nth-child(' + (runtime.logDataCols.length - 1) + ')')).each(function () {
                 var $t = $(this);
                 // If query is a SELECT and user enabled or disabled to group
                 // queries ignoring data in where statements, we
@@ -1843,10 +1843,10 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                         $t.next().text(rowData[sumColumnName]);
                         // Restore slow log columns
                         if (isSlowLog) {
-                            $t.parent().children('td:nth-child(3)').text(rowData.query_time);
-                            $t.parent().children('td:nth-child(4)').text(rowData.lock_time);
-                            $t.parent().children('td:nth-child(5)').text(rowData.rows_sent);
-                            $t.parent().children('td:nth-child(6)').text(rowData.rows_examined);
+                            $t.parent().children(document.querySelectorAll('td:nth-child(3)')).text(rowData.query_time);
+                            $t.parent().children(document.querySelectorAll('td:nth-child(4)')).text(rowData.lock_time);
+                            $t.parent().children(document.querySelectorAll('td:nth-child(5)')).text(rowData.rows_sent);
+                            $t.parent().children(document.querySelectorAll('td:nth-child(6)')).text(rowData.rows_examined);
                         }
                     }
                 }
@@ -1881,15 +1881,15 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                             return;
                         }
 
-                        row =  $table.children('tr:nth-child(' + (value + 1) + ')');
+                        row =  $table.children(document.querySelectorAll('td:nth-child(' + (value + 1) + ')'));
                         numCol = row.children(':nth-child(' + (runtime.logDataCols.length) + ')');
                         numCol.text(filteredQueries[key]);
 
                         if (isSlowLog) {
-                            row.children('td:nth-child(3)').text(secToTime(columnSums[key][0]));
-                            row.children('td:nth-child(4)').text(secToTime(columnSums[key][1]));
-                            row.children('td:nth-child(5)').text(columnSums[key][2]);
-                            row.children('td:nth-child(6)').text(columnSums[key][3]);
+                            row.children(document.querySelectorAll('td:nth-child(3)')).text(secToTime(columnSums[key][0]));
+                            row.children(document.querySelectorAll('td:nth-child(4)')).text(secToTime(columnSums[key][1]));
+                            row.children(document.querySelectorAll('td:nth-child(5)')).text(columnSums[key][2]);
+                            row.children(document.querySelectorAll('td:nth-child(6)')).text(columnSums[key][3]);
                         }
                     });
                 }

--- a/js/server/status/processes.js
+++ b/js/server/status/processes.js
@@ -58,8 +58,13 @@ var processList = {
                 // As we just removed a row, reapply odd-even classes
                 // to keep table stripes consistent
                 var $tableProcessListTr = $('#tableprocesslist').find('> tbody > tr');
-                $tableProcessListTr.filter(':even').removeClass('odd').addClass('even');
-                $tableProcessListTr.filter(':odd').removeClass('even').addClass('odd');
+                $tableProcessListTr.each(function (index) {
+                    if (index >= 0 && index % 2 === 0) {
+                        $(this).removeClass('odd').addClass('even');
+                    } else if (index >= 0 && index % 2 !== 0) {
+                        $(this).removeClass('even').addClass('odd');
+                    }
+                });
                 // Show process killed message
                 Functions.ajaxShowMessage(data.message, false);
             } else {

--- a/js/table/gis_visualization.js
+++ b/js/table/gis_visualization.js
@@ -99,7 +99,7 @@ function loadSVG () {
     });
 
     // Removes the second SVG element unnecessarily added due to the above command
-    $placeholder.find('svg:nth-child(2)').remove();
+    $placeholder.find(document.querySelectorAll('svg:nth-child(2)')).remove();
 }
 
 /**

--- a/js/table/select.js
+++ b/js/table/select.js
@@ -226,7 +226,7 @@ AJAX.registerOnload('table/select.js', function () {
         var outputGeomFunctions = binaryFunctions.concat(tempArray);
 
         // If the chosen function takes two geometry objects as parameters
-        var $operator = $geomFuncSelector.parents('tr').find('td:nth-child(5)').find('select');
+        var $operator = $geomFuncSelector.parents('tr').find(document.querySelectorAll('td:nth-child(5)')).find('select');
         if ($.inArray($geomFuncSelector.val(), binaryFunctions) >= 0) {
             $operator.prop('readonly', true);
         } else {

--- a/js/table/structure.js
+++ b/js/table/structure.js
@@ -202,8 +202,8 @@ AJAX.registerOnload('table/structure.js', function () {
                     }
                     // Adjust the row numbers
                     for (var $row = $currRow.next(); $row.length > 0; $row = $row.next()) {
-                        var newVal = parseInt($row.find('td:nth-child(2)').text(), 10) - 1;
-                        $row.find('td:nth-child(2)').text(newVal);
+                        var newVal = parseInt($row.find(document.querySelectorAll('td:nth-child(2)')).text(), 10) - 1;
+                        $row.find(document.querySelectorAll('td:nth-child(2)')).text(newVal);
                     }
                     $afterFieldItem.remove();
                     $currRow.hide('medium').remove();
@@ -337,7 +337,7 @@ AJAX.registerOnload('table/structure.js', function () {
                     // Adjust the row numbers and colors
                     for (var $row = $firstrow; $row.length > 0; $row = $row.next()) {
                         $row
-                            .find('td:nth-child(2)')
+                            .find(document.querySelectorAll('td:nth-child(2)'))
                             .text($row.index() + 1)
                             .end()
                             .removeClass('odd even')

--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -1166,7 +1166,7 @@ class NavigationTree
                 }
             }
 
-            $retval .= "<div class='block " . $divClass . "'>";
+            $retval .= "<div class='block second" . $divClass . "'>";
 
             if (isset($node->links['icon']) && ! empty($node->links['icon'])) {
                 $args = [];


### PR DESCRIPTION
### Description

(Commit : 98dc941)
1. `:eq` has been replaced with `.eq()`
Ref: https://api.jquery.com/eq-selector/

(Commit : e13b4aa)
1. `:odd` has been replaced with `foreach` loop which checks and filter odd.
Ref: https://api.jquery.com/odd-selector/

2. `:even` has been replaced with `foreach` loop which checks and filter even.
Ref: https://api.jquery.com/even-selector/

(Commit : 5366772)
1. `:nth:child` is replaced with this [sloution](https://jsfiddle.net/dhbqxpo0/)
Ref: https://api.jquery.com/nth-child-selector

Fixes: #15792