### PR TITLE
Removed Online Transaction for table-creation

### DIFF
--- a/templates/columns_definitions/column_definitions_form.twig
+++ b/templates/columns_definitions/column_definitions_form.twig
@@ -146,7 +146,9 @@
         </div>
     {% endif %}
     <fieldset class="tblFooters">
-        <input type="checkbox" name="online_transaction" value="ONLINE_TRANSACTION_ENABLED" />{% trans %}Online transaction{% context %}Online transaction part of the SQL DDL for InnoDB{% endtrans %}{{ show_mysql_docu('innodb-online-ddl') }}
+        {% if action == url('/table/add-field') %}
+            <input type="checkbox" name="online_transaction" value="ONLINE_TRANSACTION_ENABLED" />{% trans %}Online transaction{% context %}Online transaction part of the SQL DDL for InnoDB{% endtrans %}{{ show_mysql_docu('innodb-online-ddl') }}
+        {% endif %}
         <input class="btn btn-secondary preview_sql" type="button"
             value="{% trans 'Preview SQL' %}">
         <input class="btn btn-primary" type="submit"


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description

The PR removes button of online transaction for table-creation and so it is present only in in add-field.

Fixes #15312 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
