### PR TITLE
Fixed some translations  cause error "has no type"

### DIFF
--- a/libraries/classes/Config/Form.php
+++ b/libraries/classes/Config/Form.php
@@ -199,7 +199,11 @@ class Form
         $paths = $this->fields;
         $this->fields = [];
         foreach ($paths as $path) {
-            $key = ltrim(
+            $key = '';
+            if (mb_strpos((string) $path, ':group:') === 0) {
+                $key = ':group:';
+            }
+            $key .= ltrim(
                 mb_substr($path, (int) mb_strrpos($path, '/')),
                 '/'
             );


### PR DESCRIPTION
Fix : for field type "group", some translations containing slashes cause errors "has no type".
eg: "OpenDocument Spreadsheet" => "OpenDocument/OpenOffice 試算表"

### Description

Please describe your pull request.

Fixes #15836

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
