### PR TITLE
Fix broken logic after switching away from jQuery selectors

### DIFF
--- a/js/makegrid.js
+++ b/js/makegrid.js
@@ -1378,7 +1378,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                                 var tools = $resultQuery.find('.tools').wrap('<p>').parent().html();
                                 // sqlOuter and tools will not be present if 'Show SQL queries' configuration is off
                                 if (typeof sqlOuter !== 'undefined' && typeof tools !== 'undefined') {
-                                    $(g.o).find('.result_query').not().last().remove();
+                                    $(g.o).find('.result_query').not($(g.o).find('.result_query').last()).remove();
                                     var $existingQuery = $(g.o).find('.result_query');
                                     // If two query box exists update query in second else add a second box
                                     if ($existingQuery.find('div.sqlOuter').length > 1) {

--- a/js/server/privileges.js
+++ b/js/server/privileges.js
@@ -360,7 +360,11 @@ AJAX.registerOnload('server/privileges.js', function () {
                 $('#initials_table')
                     .prop('id', 'initials_table_old')
                     .after(data.message).show('medium')
-                    .siblings('h2').not().first().remove();
+                    .siblings('h2').not($('#initials_table')
+                        .prop('id', 'initials_table_old')
+                        .after(data.message).show('medium')
+                        .siblings('h2').first())
+                    .remove();
                 // prevent double initials table
                 $('#initials_table_old').remove();
             } else {

--- a/js/table/relation.js
+++ b/js/table/relation.js
@@ -190,8 +190,12 @@ AJAX.registerOnload('table/relation.js', function () {
         $newRow.find('a.add_foreign_key_field').attr('data-index', newIndex);
 
         // Update form parameter names.
-        $newRow.find('select[name^="foreign_key_fields_name"]').not().first().find(
-            'select[name^="destination_foreign_column"]').not().first()
+        $newRow.find('select[name^="foreign_key_fields_name"]')
+           .not($newRow.find('select[name^="foreign_key_fields_name"]').first())
+              .find('select[name^="destination_foreign_column"]')
+              .not($newRow.find('select[name^="foreign_key_fields_name"]')
+                  .not($newRow.find('select[name^="foreign_key_fields_name"]').first())
+                  .find('select[name^="destination_foreign_column"]').first())
             .each(function () {
                 $(this).parent().remove();
             });


### PR DESCRIPTION
### Description

#15801 had a logical error while using `.not().first()` and `.not().last()`. This PR restores the proper intended behaviour.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
