### PR TITLE
Fix DB names starting with "b" being cut off in <option>, User account page

### DIFF
--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2858,7 +2858,7 @@ class Util
      */
     public static function convertBitDefaultValue($bit_default_value)
     {
-        return preg_replace("/^b'(.*?)'?$/s", '$1', htmlspecialchars_decode($bit_default_value, ENT_QUOTES), 1);
+        return preg_replace("/^b'(\d*)'?$/", '$1', htmlspecialchars_decode($bit_default_value, ENT_QUOTES), 1);
     }
 
     /**

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2858,7 +2858,7 @@ class Util
      */
     public static function convertBitDefaultValue($bit_default_value)
     {
-        return rtrim(ltrim(htmlspecialchars_decode($bit_default_value, ENT_QUOTES), "b'"), "'");
+        return preg_replace("/^b'(.*?)'?$/s", '$1', htmlspecialchars_decode($bit_default_value, ENT_QUOTES), 1);
     }
 
     /**

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -483,6 +483,22 @@ class UtilTest extends PmaTestCase
                 "b'010111010'",
                 "010111010",
             ],
+            "database name starting with b" => [
+                "big database",
+                "big database",
+            ],
+            "database name containing b'" => [
+                "a b'ig database",
+                "a b'ig database",
+            ],
+            "database name in single quotes" => [
+                "'a*database*name'",
+                "'a*database*name'",
+            ],
+            "database name with multiple b'" => [
+                "b'ens datab'ase'",
+                "b'ens datab'ase'",
+            ],
         ];
     }
 


### PR DESCRIPTION
### Description

Instead of rtrim and ltrim to turn ``b'010'`` into ``010``, regex replace is used to capture the text  between ``b'`` and the next occurrence of ``'`` and instead return that.

While there seems to be tests already in place for ``convertBitDefaultValue``, I don't believe there is a test case for input that is not a bit value, e.g. ``convertBitDefaultValue("big database")`` *expects* no change. I'm happy to add a test case for this with some instruction, if needed.

While working on this I noticed, based on a Travis test, ``convertBitDefaultValue`` is expected to return the empty string given the string ``b'``. I'm not sure if this behavior should be mentioned in the function's comment:

In Util.php, convertBitDefaultValue
```php
/*
Converts a BIT type default value
     * for example, b'010' becomes 010
*/
```
Would be like:
```php
/*
Converts a BIT type default value
     * for example, b'010' becomes 010
     * or, "b'01" becomes "01"
*/
```
I have verified that the <option> value in the referenced issue is correct.

Fixes #15831

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
