### PR TITLE
Add missing 'IF EXISTS' to 'DROP EVENT' when exporting databases

### DIFF
--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -999,7 +999,7 @@ class ExportSql extends ExportPlugin
 
             foreach ($event_names as $event_name) {
                 if (! empty($GLOBALS['sql_drop_table'])) {
-                    $text .= 'DROP EVENT '
+                    $text .= 'DROP EVENT IF EXISTS '
                         . Util::backquote($event_name)
                         . $delimiter . $crlf;
                 }


### PR DESCRIPTION
Signed-off-by: Olivier Wahrenberger <O2Graphics@users.noreply.github.com>

### Description

This add the missing "IF EXISTS" to "DROP EVENT" when exporting databases. So, when we import it again with phpMyAdmin, it doesn't throw an error saying the event doesn't exists.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
