### PR TITLE
Fix #15024: Change page settings buttons to Bootstrap

### DIFF
--- a/js/page_settings.js
+++ b/js/page_settings.js
@@ -18,6 +18,7 @@ function showSettings (selector) {
     };
 
     // Keeping a clone to restore in case the user cancels the operation
+
     var $clone = $(selector + ' .page_settings').clone(true);
     $(selector)
         .dialog({
@@ -33,6 +34,11 @@ function showSettings (selector) {
             },
             buttons: buttons
         });
+
+    var $buttonSet = $('.ui-dialog-buttonset');
+    $buttonSet.children().first().attr("class", "btn btn-primary");
+    $buttonSet.children().last().attr("class", "btn btn-secondary");
+
 }
 
 function showPageSettings () {


### PR DESCRIPTION
Signed-off-by: Mohammed Rabeeh <mohammadrabeeh@gmail.com>

### Description

Fixes #15024 

Fixes #

Changed buttons bootstrap classes. The buttons were generated using jquery-ui. Therefore a selector was initialised switching the classes to Bootstrap ones.

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
