### PR TITLE
Fix Preview SQL not visible on Index dialog Box

### DIFF
--- a/js/indexes.js
+++ b/js/indexes.js
@@ -405,8 +405,6 @@ Indexes.showAddIndexDialog = function (sourceArray, arrayIndex, targetColumns, c
                                 containment: $('#index_columns').find('tbody'),
                                 tolerance: 'pointer'
                             });
-                            // We dont need the slider at this moment.
-                            $(this).find('fieldset.tblFooters').remove();
                         },
                         modal: true,
                         buttons: buttonOptions,

--- a/templates/table/index_form.twig
+++ b/templates/table/index_form.twig
@@ -218,6 +218,5 @@
     </fieldset>
     <fieldset class="tblFooters">
         <button class="btn btn-secondary" type="submit" id="preview_index_frm">{% trans 'Preview SQL' %}</button>
-        <input class="btn btn-primary" type="submit" id="save_index_frm" value="{% trans 'Go' %}">
     </fieldset>
 </form>


### PR DESCRIPTION
Signed-off-by: Manthan Surkar <manthan.surkar@gmail.com>

### Description

I have done the testing on the new Table page, but I am not sure of the behaviour on other pages, I could not find an add Index dropdown when I am editing the structure, I request you to test it :)  


![image](https://user-images.githubusercontent.com/42006277/73430427-11a46b00-4364-11ea-8607-7b427fa75cef.png)


Fixes #13519

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
