### PR TITLE
Fix crash when tablename or dbname is not set

### DIFF
--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -917,10 +917,10 @@ class Tracker
                 // we want to track
                 $sql_query .=
                 " WHERE FIND_IN_SET('" . $result['identifier'] . "',tracking) > 0" .
-                " AND `db_name` = '" . $GLOBALS['dbi']->escapeString($dbname) . "' " .
+                " AND `db_name` = '" . $GLOBALS['dbi']->escapeString($dbname ?? '') . "' " .
                 " AND `table_name` = '"
                 . $GLOBALS['dbi']->escapeString($result['tablename']) . "' " .
-                " AND `version` = '" . $GLOBALS['dbi']->escapeString($version) . "' ";
+                " AND `version` = '" . $GLOBALS['dbi']->escapeString($version ?? '') . "' ";
 
                 $relation->queryAsControlUser($sql_query);
             }


### PR DESCRIPTION
### Description

Drop statements don't give proper tablenames, resulting in a crash. Obviously, that issue needs fixed as well, but handling it cleanly seems preferable.

Signed-off-by: Sean Mollet <sean@malmoset.com>

Fixes #

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
