### PR TITLE
fixed bad UI: buttons showing instead of text (bootstrap theme) #15882 

### DIFF
--- a/libraries/classes/Config/Descriptions.php
+++ b/libraries/classes/Config/Descriptions.php
@@ -489,8 +489,8 @@ class Descriptions
             'NavigationLogoLink_desc' => __('URL where logo in the navigation panel will point to.'),
             'NavigationLogoLink_name' => __('Logo link URL'),
             'NavigationLogoLinkWindow_desc' => __(
-                'Open the linked page in the main window ([kbd]main[/kbd]) or in a new one '
-                . '([kbd]new[/kbd]).'
+                'Open the linked page in the main window ( main ) or in a new one '
+                . '( new ).'
             ),
             'NavigationLogoLinkWindow_name' => __('Logo link target'),
             'NavigationDisplayServers_desc' => __('Display server choice at the top of the navigation panel.'),

--- a/libraries/classes/Config/FormDisplayTemplate.php
+++ b/libraries/classes/Config/FormDisplayTemplate.php
@@ -107,7 +107,7 @@ class FormDisplayTemplate
             'class' => 'tabs responsivetable row',
             'items' => $items,
         ]);
-        $htmlOutput .= '<div class="tabs_contents row">';
+        $htmlOutput .= '<div class="tabs_contents col">';
         return $htmlOutput;
     }
 

--- a/libraries/classes/Config/FormDisplayTemplate.php
+++ b/libraries/classes/Config/FormDisplayTemplate.php
@@ -107,7 +107,7 @@ class FormDisplayTemplate
             'class' => 'tabs responsivetable row',
             'items' => $items,
         ]);
-        $htmlOutput .= '<div class="tabs_contents col">';
+        $htmlOutput .= '<div class="tabs_contents row">';
         return $htmlOutput;
     }
 


### PR DESCRIPTION
##signed-off-by: Anirudh Singh <anirudhsingh20.as@gmai.com>

### Description

Fixed Bad UI: buttons showing instead of text (bootstrap theme) #15882 
removed kbd text as it is responsible for padding and color around main and new text in navigation-settings -> navigation panel -> logo link target (description text) [ main and new ] 

updated Description.php file 


Fixes #15882 

![issuew](https://user-images.githubusercontent.com/49402380/73592639-67bf0d00-4522-11ea-9609-2bf1896626ac.png)
to 
![issue@1](https://user-images.githubusercontent.com/49402380/73592644-6db4ee00-4522-11ea-85ee-1ef29eb3bdbb.png)

