### PR TITLE
Fix #15885 - Removed back labels from Metro login form

### DIFF
--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -19,6 +19,10 @@ body#loginform {
   margin: 0;
   background-color: #666;
 
+  form#login_form label {
+    display: none !important;
+  }
+
   #page_content {
     background-color: $navi-background;
     margin: 0 !important;
@@ -138,10 +142,6 @@ body#loginform {
       clear: none;
     }
   }
-}
-
-form.login label {
-  display: none;
 }
 
 .turnOffSelect {


### PR DESCRIPTION
**Signed-off-by:** Anirudh Singh <anirudhsingh20.as@gmail.com>

### Description

Added a margin-right around username and password label in the login form to make UI better for the metro theme and it is working fine for all themes.

Issue #15885

There is no margin after username: and **"     :     "**  is not visible.

![margin0](https://user-images.githubusercontent.com/49402380/73608476-69073d00-45e9-11ea-99b9-b8dc063c4e38.PNG)
![margin1](https://user-images.githubusercontent.com/49402380/73608479-6d335a80-45e9-11ea-8351-f4e6b555d13a.PNG)


Fixes #

![margin2](https://user-images.githubusercontent.com/49402380/73608481-70c6e180-45e9-11ea-994f-a1f8b16b7d05.PNG)

