### PR TITLE
Replaced `0` to `NULL`  in primary key

### DIFF
--- a/js/table/change.js
+++ b/js/table/change.js
@@ -473,7 +473,7 @@ AJAX.registerOnload('table/change.js', function () {
                     || thisElemSubmitTypeVal === 'insertignore'
                     || thisElemSubmitTypeVal === 'showinsert'
                 ) {
-                    $(valueField).val(0);
+                    $(valueField).val(null);
                 } else {
                     $(valueField).val(previousValue);
                 }


### PR DESCRIPTION
Signed-off-by: Yash Bothra <yashrajbothra786@gmail.com>

### Description

Replaced `0` to `null` for primary id when edited.

Fixes #15187 