### PR TITLE
Fix #15895: make navigation icons in a correct position

### DIFF
--- a/themes/metro/scss/_navigation.scss
+++ b/themes/metro/scss/_navigation.scss
@@ -149,7 +149,7 @@ img {
   height: 16px;
   width: 16px;
   color: $main-color;
-  margin-#{$right}: 10px;
+  margin-#{$right}: 5px;
   padding: 5px;
   font-size: 15px;
 


### PR DESCRIPTION
Signed-off-by: Mouad Boulahdoud <mouad123b@gmail.com>

### Description

fix #15895

### Fixes
Before Fix:
![image](https://user-images.githubusercontent.com/28781942/73655134-99a0b280-468d-11ea-8741-b3ef06ea5df4.png)
After Fix:
<!-- ![image](https://user-images.githubusercontent.com/28781942/73655240-cc4aab00-468d-11ea-904a-8b752d9db0bb.png) -->
![image](https://user-images.githubusercontent.com/7784660/80275829-3cdcf300-86e4-11ea-93e3-d3cf080f1066.png)
