### PR TITLE
Fix #15908: User accounts table left spacing

### DIFF
--- a/templates/server/privileges/users_overview.twig
+++ b/templates/server/privileges/users_overview.twig
@@ -1,6 +1,6 @@
 <form name="usersForm" id="usersForm" action="{{ url('/server/privileges') }}" method="post">
   {{ get_hidden_inputs() }}
-  <div class="responsivetable row">
+  <div class="responsivetable">
     <table id="tableuserrights" class="data">
       <thead>
         <tr>

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -2509,7 +2509,7 @@ input#auto_increment_opt {
 
 #table_name_col_no {
   position: fixed;
-  top: 55px;
+  top: 100px !important;
   width: 100%;
   background: #fff;
 }


### PR DESCRIPTION
Signed-off-by: Cliff Su <stu01509@yahoo.com.tw>

### Description

Fixes issue #15908

Remove CSS class to add left spacing.
![](https://i.imgur.com/YZ3eTgH.png)


Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
