### PR TITLE
Added Rename Button to use RENAME INDEX syntax of MySQL

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -3812,8 +3812,7 @@ AJAX.registerOnload('functions.js', function () {
         }
     });
 });
-
-Functions.indexEditorDialog = function (url, title, callbackSuccess, callbackFailure) {
+Functions.indexDialogModal = function (routeUrl, url, title, callbackSuccess, callbackFailure) {
     /* Remove the hidden dialogs if there are*/
     var $editIndexDialog = $('#edit_index_dialog');
     if ($editIndexDialog.length !== 0) {
@@ -3882,7 +3881,7 @@ Functions.indexEditorDialog = function (url, title, callbackSuccess, callbackFai
         $(this).dialog('close');
     };
     var $msgbox = Functions.ajaxShowMessage();
-    $.post('index.php?route=/table/indexes', url, function (data) {
+    $.post(routeUrl, url, function (data) {
         if (typeof data !== 'undefined' && data.success === false) {
             // in the case of an error, show the error message returned.
             Functions.ajaxShowMessage(data.error, false);
@@ -3905,6 +3904,14 @@ Functions.indexEditorDialog = function (url, title, callbackSuccess, callbackFai
             Functions.showIndexEditDialog($div);
         }
     }); // end $.get()
+};
+
+Functions.indexEditorDialog = function (url, title, callbackSuccess, callbackFailure) {
+    Functions.indexDialogModal('index.php?route=/table/indexes', url, title, callbackSuccess, callbackFailure);
+};
+
+Functions.indexRenameDialog = function (url, title, callbackSuccess, callbackFailure) {
+    Functions.indexDialogModal('index.php?route=/table/indexes/rename', url, title, callbackSuccess, callbackFailure);
 };
 
 Functions.showIndexEditDialog = function ($outer) {

--- a/js/src/indexes.js
+++ b/js/src/indexes.js
@@ -567,6 +567,7 @@ AJAX.registerTeardown('indexes.js', function () {
     $(document).off('change', '#select_index_choice');
     $(document).off('click', 'a.drop_primary_key_index_anchor.ajax');
     $(document).off('click', '#table_index tbody tr td.edit_index.ajax, #index_div .add_index.ajax');
+    $(document).off('click', '#table_index tbody tr td.rename_index.ajax');
     $(document).off('click', '#index_frm input[type=submit]');
     $('body').off('change', 'select[name*="field_key"]');
     $(document).off('click', '.show_index_dialog');
@@ -684,8 +685,8 @@ AJAX.registerOnload('indexes.js', function () {
     }); // end Drop Primary Key/Index
 
     /**
-     *Ajax event handler for index edit
-    **/
+     * Ajax event handler for index edit
+     **/
     $(document).on('click', '#table_index tbody tr td.edit_index.ajax, #index_div .add_index.ajax', function (event) {
         event.preventDefault();
         var url;
@@ -709,6 +710,21 @@ AJAX.registerOnload('indexes.js', function () {
         }
         url += CommonParams.get('arg_separator') + 'ajax_request=true';
         Functions.indexEditorDialog(url, title, function (data) {
+            CommonParams.set('db', data.params.db);
+            CommonParams.set('table', data.params.table);
+            CommonActions.refreshMain('index.php?route=/table/structure');
+        });
+    });
+
+    /**
+     * Ajax event handler for index rename
+     **/
+    $(document).on('click', '#table_index tbody tr td.rename_index.ajax', function (event) {
+        event.preventDefault();
+        var url = $(this).find('a').getPostData();
+        var title = Messages.strRenameIndex;
+        url += CommonParams.get('arg_separator') + 'ajax_request=true';
+        Functions.indexRenameDialog(url, title, function (data) {
             CommonParams.set('db', data.params.db);
             CommonParams.set('table', data.params.table);
             CommonActions.refreshMain('index.php?route=/table/structure');

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -100,6 +100,8 @@ final class JavaScriptMessagesController
             'strEnterValidLength' => __('Please enter a valid length!'),
             'strAddIndex' => __('Add index'),
             'strEditIndex' => __('Edit index'),
+            /* l10n: Rename a table Index */
+            'strRenameIndex' => __('Rename index'),
             'strAddToIndex' => __('Add %s column(s) to index'),
             'strCreateSingleColumnIndex' => __('Create single-column index'),
             'strCreateCompositeIndex' => __('Create composite index'),

--- a/libraries/classes/Query/Compatibility.php
+++ b/libraries/classes/Query/Compatibility.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Query;
 
+use PhpMyAdmin\Util;
 use function is_string;
 use function strlen;
 use function strpos;
@@ -155,5 +156,33 @@ class Compatibility
         }
 
         return $columns;
+    }
+
+    public static function isMySqlOrPerconaDb(): bool
+    {
+        $serverType = Util::getServerType();
+
+        return $serverType === 'MySQL' || $serverType === 'Percona Server';
+    }
+
+    public static function isMariaDb(): bool
+    {
+        $serverType = Util::getServerType();
+
+        return $serverType === 'MariaDB';
+    }
+
+    public static function isCompatibleRenameIndex(int $serverVersion): bool
+    {
+        if (self::isMySqlOrPerconaDb()) {
+            return $serverVersion >= 50700;
+        }
+
+        // @see https://mariadb.com/kb/en/alter-table/#rename-indexkey
+        if (self::isMariaDb()) {
+            return $serverVersion >= 100502;
+        }
+
+        return false;
     }
 }

--- a/libraries/classes/Query/Generator.php
+++ b/libraries/classes/Query/Generator.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Util;
 use function count;
 use function implode;
 use function is_array;
+use function sprintf;
 
 /**
  * Handles generating SQL queries
@@ -355,5 +356,23 @@ class Generator
         }
 
         return [$sql, $arrayKeys];
+    }
+
+    /**
+     * Function to get sql query for renaming the index using SQL RENAME INDEX Syntax
+     */
+    public static function getSqlQueryForIndexRename(
+        string $dbName,
+        string $tableName,
+        string $oldIndexName,
+        string $newIndexName
+    ): string {
+        return sprintf(
+            'ALTER TABLE %s.%s RENAME INDEX %s TO %s;',
+            Util::backquote($dbName),
+            Util::backquote($tableName),
+            Util::backquote($oldIndexName),
+            Util::backquote($newIndexName)
+        );
     }
 }

--- a/libraries/routes.php
+++ b/libraries/routes.php
@@ -282,6 +282,7 @@ return static function (RouteCollector $routes): void {
         $routes->addRoute(['GET', 'POST'], '/gis-visualization', [GisVisualizationController::class, 'index']);
         $routes->addRoute(['GET', 'POST'], '/import', [TableImportController::class, 'index']);
         $routes->addRoute(['GET', 'POST'], '/indexes', [IndexesController::class, 'index']);
+        $routes->addRoute(['GET', 'POST'], '/indexes/rename', [IndexesController::class, 'indexRename']);
         $routes->addGroup('/maintenance', static function (RouteCollector $routes): void {
             $routes->post('/analyze', [MaintenanceController::class, 'analyze']);
             $routes->post('/check', [MaintenanceController::class, 'check']);

--- a/templates/table/index_rename_form.twig
+++ b/templates/table/index_rename_form.twig
@@ -1,0 +1,30 @@
+<form action="{{ url('/table/indexes/rename') }}" method="post" name="index_frm" id="index_frm" class="ajax">
+
+  {{ get_hidden_inputs(form_params) }}
+
+  <fieldset id="index_edit_fields">
+    <div class="index_info">
+      <div>
+          <div class="label">
+              <strong>
+                  <label for="input_index_name">
+                      {% trans 'Index name:' %}
+                      {{ show_hint('"PRIMARY" <b>must</b> be the name of and <b>only of</b> a primary key!'|trans) }}
+                  </label>
+              </strong>
+          </div>
+
+          <input type="text"
+              name="index[Key_name]"
+              id="input_index_name"
+              size="25"
+              maxlength="64"
+              value="{{ index.getName() }}"
+              onfocus="this.select()">
+      </div>
+    </div>
+  </fieldset>
+  <fieldset class="tblFooters">
+    <button class="btn btn-secondary" type="submit" id="preview_index_frm">{% trans 'Preview SQL' %}</button>
+  </fieldset>
+</form>

--- a/templates/table/structure/display_structure.twig
+++ b/templates/table/structure/display_structure.twig
@@ -410,7 +410,7 @@
           <table id="table_index">
             <thead>
               <tr>
-                <th colspan="2" class="print_ignore">{% trans 'Action' %}</th>
+                <th colspan="3" class="print_ignore">{% trans 'Action' %}</th>
                 <th>{% trans 'Keyname' %}</th>
                 <th>{% trans 'Type' %}</th>
                 <th>{% trans 'Unique' %}</th>
@@ -434,6 +434,15 @@
                     'index': index.getName()
                   }, '') }}">
                     {{ get_icon('b_edit', 'Edit'|trans) }}
+                  </a>
+                </td>
+                <td rowspan="{{ columns_count }}" class="rename_index print_ignore ajax" >
+                  <a class="ajax" href="{{ url('/table/indexes/rename') }}" data-post="{{ get_common({
+                    'db': db,
+                    'table': table,
+                    'index': index.getName()
+                  }, '') }}">
+                    {{ get_icon('b_rename', 'Rename'|trans) }}
                   </a>
                 </td>
                 <td rowspan="{{ columns_count }}" class="print_ignore">

--- a/test/classes/Controllers/Table/IndexesControllerTest.php
+++ b/test/classes/Controllers/Table/IndexesControllerTest.php
@@ -108,7 +108,7 @@ class IndexesControllerTest extends AbstractTestCase
 
         // Preview SQL
         $_POST['preview_sql'] = true;
-        $ctrl->doSaveData($index);
+        $ctrl->doSaveData($index, false);
         $jsonArray = $response->getJSONResult();
         $this->assertArrayHasKey('sql_data', $jsonArray);
         $this->assertStringContainsString(
@@ -120,7 +120,7 @@ class IndexesControllerTest extends AbstractTestCase
         $response->clear();
         Response::getInstance()->setAjax(true);
         unset($_POST['preview_sql']);
-        $ctrl->doSaveData($index);
+        $ctrl->doSaveData($index, false);
         $jsonArray = $response->getJSONResult();
         $this->assertArrayHasKey('index_table', $jsonArray);
         $this->assertArrayHasKey('message', $jsonArray);

--- a/themes/bootstrap/img/b_rename.svg
+++ b/themes/bootstrap/img/b_rename.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="m14 4v2h4v20h-4v2h10v-2h-4v-20h4v-2zm-12 4v16h14v-2h-12v-12h12v-2zm20 0v2h6v12h-6v2h8v-16z"/><path d="m6 12v8h10v-8z"/></svg>

--- a/themes/bootstrap/scss/_icons.scss
+++ b/themes/bootstrap/scss/_icons.scss
@@ -216,6 +216,10 @@
   background-image: url('../img/report.svg');
 }
 
+.ic_b_rename {
+  background-image: url('../img/b_rename.svg');
+}
+
 .ic_b_routine_add {
   background-image: url('../img/routine-plus.svg');
 }

--- a/themes/metro/img/b_rename.svg
+++ b/themes/metro/img/b_rename.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="m14 4v2h4v20h-4v2h10v-2h-4v-20h4v-2zm-12 4v16h14v-2h-12v-12h12v-2zm20 0v2h6v12h-6v2h8v-16z"/><path d="m6 12v8h10v-8z"/></svg>

--- a/themes/metro/scss/_icons.scss
+++ b/themes/metro/scss/_icons.scss
@@ -207,6 +207,10 @@
   background-image: url('../img/b_report.png');
 }
 
+.ic_b_rename {
+  background-image: url('../img/b_rename.svg');
+}
+
 .ic_b_routine_add {
   background-image: url('../img/b_routine_add.png');
 }

--- a/themes/original/img/b_rename.svg
+++ b/themes/original/img/b_rename.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="m14 4v2h4v20h-4v2h10v-2h-4v-20h4v-2zm-12 4v16h14v-2h-12v-12h12v-2zm20 0v2h6v12h-6v2h8v-16z"/><path d="m6 12v8h10v-8z"/></svg>

--- a/themes/original/scss/_icons.scss
+++ b/themes/original/scss/_icons.scss
@@ -207,6 +207,10 @@
   background-image: url('../img/b_report.png');
 }
 
+.ic_b_rename {
+  background-image: url('../img/b_rename.svg');
+}
+
 .ic_b_routine_add {
   background-image: url('../img/b_routine_add.png');
 }

--- a/themes/pmahomme/img/b_rename.svg
+++ b/themes/pmahomme/img/b_rename.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="m14 4v2h4v20h-4v2h10v-2h-4v-20h4v-2zm-12 4v16h14v-2h-12v-12h12v-2zm20 0v2h6v12h-6v2h8v-16z"/><path d="m6 12v8h10v-8z"/></svg>

--- a/themes/pmahomme/scss/_icons.scss
+++ b/themes/pmahomme/scss/_icons.scss
@@ -207,6 +207,10 @@
   background-image: url('../img/b_report.png');
 }
 
+.ic_b_rename {
+  background-image: url('../img/b_rename.svg');
+}
+
 .ic_b_routine_add {
   background-image: url('../img/b_routine_add.png');
 }


### PR DESCRIPTION
Signed-off-by: Kartik Kathuria <kathuriakartik0@gmail.com>

### Description

The PR adds Rename button in options of index in case the user only wants to Rename Index and not change any other properties of Index. Through this button we can use the RENAME INDEX syntax of MySQL but for MariaDB since this syntax is not applicable it will use the OLD ADD/DROP Method. For MySQL it will save a lot of time for large tables.

Fixes #14953 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
