### PR TITLE
Fix PhpMyAdmin\Core::getRealSize('8000M') returns a float instead of an int

### DIFF
--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -426,7 +426,7 @@ class Core
         ];
 
         if (preg_match('/^([0-9]+)([KMGT])/i', $size, $matches)) {
-            return $matches[1] * $binaryprefixes[$matches[2]];
+            return (int) ($matches[1] * $binaryprefixes[$matches[2]]);
         }
 
         return (int) $size;


### PR DESCRIPTION
### Description

There were some serious issues after upgrading the PHP of server to PHP version 7.4.
I tried to fix some of them. But there are still problems.
I also downloaded the latest version of the script so it might be compatible with PHP 7.4.
But it seems that PHPMyAdmin is not yet compatible with PHP 7.4.

The old script has been working with php 7.4, but it always shows errors. But it worked anyway. But the errors were annoying.

My fork: https://github.com/MaxFork/phpmyadmin/commit/49d22968f12d8be5974de0a6300bbed64df615d5

https://github.com/phpmyadmin/phpmyadmin/issues/15926