### PR TITLE
fix #15950: updated datetime picker UI

### DIFF
--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -3774,3 +3774,17 @@ body .ui-dialog {
 #filter_query_text {
   vertical-align: baseline;
 }
+
+.ui_tpicker_hour_slider,
+.ui_tpicker_minute_slider,
+.ui_tpicker_second_slider,
+.ui_tpicker_millisec_slider,
+.ui_tpicker_microsec_slider {
+  margin-left: 40px;
+  margin-top: 4px;
+  height: 0.75rem;
+}
+
+.ui-timepicker-div dl .ui_tpicker_timezone select {
+  margin-left: 50px;
+}

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -3459,3 +3459,13 @@ body {
 #filter_query_text {
   vertical-align: baseline;
 }
+
+.ui_tpicker_hour_slider,
+.ui_tpicker_minute_slider,
+.ui_tpicker_second_slider,
+.ui_tpicker_millisec_slider,
+.ui_tpicker_microsec_slider {
+  margin-left: 20px;
+  margin-top: 4px;
+  height: 0.75rem;
+}

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -3834,3 +3834,13 @@ body .ui-dialog {
 #filter_query_text {
   vertical-align: baseline;
 }
+
+.ui_tpicker_hour_slider,
+.ui_tpicker_minute_slider,
+.ui_tpicker_second_slider,
+.ui_tpicker_millisec_slider,
+.ui_tpicker_microsec_slider {
+  margin-left: 20px;
+  margin-top: 4px;
+  height: 0.75rem;
+}


### PR DESCRIPTION
### Description
signoff-by: Anirudh Singh <anirudhsingh20.as@gmail.com>

Updated DateTime picker UI in all the theme using CSS

Fixes #15950

Before fix:
no margin or space before sliders to select sec, min, millisec
![datetime](https://user-images.githubusercontent.com/49402380/74323352-65bf3e80-4dab-11ea-9e38-c1599a895c4d.PNG)

### After fix: 
In Bootstrap theme:


![datetimefixed1](https://user-images.githubusercontent.com/49402380/74329607-23e7c580-4db6-11ea-8965-56d291c7ebff.PNG)


In pmahomme theme:

![datetimefixedmetro](https://user-images.githubusercontent.com/49402380/74329124-39102480-4db5-11ea-9d98-c3b924360a4d.PNG)

In original theme:

![datetimefixedoriginal](https://user-images.githubusercontent.com/49402380/74329160-44635000-4db5-11ea-9ddd-565706f38ec6.PNG)

In metro theme: 

![datetimefixedmetro](https://user-images.githubusercontent.com/49402380/74329581-1599a980-4db6-11ea-9643-b4bf57a4813d.PNG)






