### PR TITLE
Fixed Action buttons on join query

### DIFF
--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1514,9 +1514,9 @@ class Sql
                 }
             }
 
-            if ($analyzed_sql_results['join']
-                || $analyzed_sql_results['is_subquery']
-                || count($analyzed_sql_results['select_tables']) !== 1
+            if (($analyzed_sql_results['join']
+                || $analyzed_sql_results['is_subquery'])
+                && count($analyzed_sql_results['select_tables']) !== 1
             ) {
                 $just_one_table = false;
             }


### PR DESCRIPTION
Signed-off-by: Yash Bothra <yashrajbothra786@gmail.com>

### Description

Replaced `||` with `&&` so `just_one_table` is only false when there is more than one table

Fixes #13488 