### PR TITLE
 Phpmyadmin logo fixed

### DIFF
--- a/themes/metro/scss/_navigation.scss
+++ b/themes/metro/scss/_navigation.scss
@@ -83,11 +83,12 @@
       text-transform: uppercase;
       margin-#{$left}: 5px;
       content: "phpMyAdmin";
+      visibility: hidden;
     }
   }
 
   #imgpmalogo {
-    display: none;
+    margin-top: -6px;
   }
 
   #recentTableList {


### PR DESCRIPTION
 Signed-off-by: Abdullahi Abdulkabir <abdullahiabdulkabir1@gmail.com>

### Description
Fixed Phpmyadmin logo in metro theme and fix the css issue
Please describe your pull request.
The issue raised was to fix the metro navigation bar and phpmyadmin logo not showing. The navigation is fixed right before my pull request, I just ensure the phpmyadmin logo shows and the ::after css remains hidden because if the image is not found the alt of img takes care of that.

After fix:
![image](https://user-images.githubusercontent.com/33360580/75117973-680c7d00-5676-11ea-83b7-342a64d6f31f.png)

Fixes #15895

Before submitting pull request, please review the following checklist:

- [x ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x ] Every commit has a descriptive commit message.
- [x ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x ] Any new functionality is covered by tests.
