### PR TITLE
Fix #15898 - escape tbl_storage_engine argument

### DIFF
--- a/libraries/classes/CreateAddField.php
+++ b/libraries/classes/CreateAddField.php
@@ -467,7 +467,7 @@ class CreateAddField
         if (! empty($_POST['tbl_storage_engine'])
             && ($_POST['tbl_storage_engine'] != 'Default')
         ) {
-            $sqlQuery .= ' ENGINE = ' . $_POST['tbl_storage_engine'];
+            $sqlQuery .= ' ENGINE = ' . $this->dbi->escapeString($_POST['tbl_storage_engine']);
         }
         if (! empty($_POST['tbl_collation'])) {
             $sqlQuery .= Util::getCharsetQueryPart($_POST['tbl_collation']);

--- a/test/classes/CreateAddFieldTest.php
+++ b/test/classes/CreateAddFieldTest.php
@@ -114,6 +114,23 @@ class CreateAddFieldTest extends TestCase
                     'spatial_indexes' => '{}',
                 ],
             ],
+            [
+                'CREATE TABLE `db`.`table` () ENGINE = Inno\\\'DB CHARSET=armscii8 COMMENT = \'my \\\'table\';',
+                'db',
+                'table',
+                [
+                    'field_name' => [],
+                    'primary_indexes' => '{}',
+                    'indexes' => '{}',
+                    'unique_indexes' => '{}',
+                    'fulltext_indexes' => '{}',
+                    'spatial_indexes' => '{}',
+                    'tbl_storage_engine' => 'Inno\'DB',
+                    'tbl_collation' => 'armscii8',
+                    'connection' => 'aaaa',
+                    'comment' => 'my \'table',
+                ],
+            ],
         ];
     }
 

--- a/test/classes/Dbi/DbiDummyTest.php
+++ b/test/classes/Dbi/DbiDummyTest.php
@@ -147,5 +147,9 @@ class DbiDummyTest extends TestCase
             'a',
             $GLOBALS['dbi']->escapeString('a')
         );
+        $this->assertEquals(
+            'a\\\'',
+            $GLOBALS['dbi']->escapeString('a\'')
+        );
     }
 }

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -434,7 +434,7 @@ class DbiDummy implements DbiExtension
      */
     public function escapeString($link, $str)
     {
-        return $str;
+        return addslashes($str);
     }
 
     /**


### PR DESCRIPTION
Fixes #15898

The issue is public, so is the fix.

I am not sure this will prevent building bad queries because is is missing quotes at end and start

Do I make the change for 4.9 @ibennetch ?

Ref: CVE-2020-22452