### PR TITLE
Fix error in NavigationTree where $key might be sent as an int instead of a str to urlencode

### DIFF
--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -799,7 +799,7 @@ class NavigationTree
                 if ($node instanceof NodeTableContainer
                     || $node instanceof NodeViewContainer
                 ) {
-                    $tblGroup = '&amp;tbl_group=' . urlencode($key);
+                    $tblGroup = '&amp;tbl_group=' . urlencode((string) $key);
                     $groups[$key]->links = [
                         'text' => $node->links['text'] . $tblGroup,
                         'icon' => $node->links['icon'] . $tblGroup,


### PR DESCRIPTION
### Description
PHP can end up giving an error if a user creates two tables prefixed with number + double underscore like:

```
2020__abc
2020__cde
```

Phpmyadmin will group these tables on the key `2020` and call `urlencode` with an integer and not astring.

Fixes #
The above bug.
