### PR TITLE
Fix failure if relational display field value is NULL

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -5164,7 +5164,7 @@ class Results
      * @param stdClass $meta             the meta-information about the field
      * @param string   $where_comparison data for the where clause
      *
-     * @return string  formatted data
+     * @return string|null  formatted data
      *
      * @access  private
      *
@@ -5344,7 +5344,7 @@ class Results
                     ) {
                         // user chose "relational display field" in the
                         // display options, so show display field in the cell
-                        $displayedData = $default_function($dispval);
+                        $displayedData = $dispval === null ? '<em>NULL</em>' : $default_function($dispval);
                     } else {
                         // otherwise display data in the cell
                         $displayedData = $default_function($displayedData);


### PR DESCRIPTION
If table has FK relation to another table, but relational display field value is NULL, table fails to be rendered.

AJAX response for _Browse_ tab is empty.

_Search_ tab fails with `Fatal error: Uncaught TypeError: Argument 1 passed to PhpMyAdmin\Core::mimeDefaultFunction() must be of the type string, null given, called in phpMyAdmin\libraries\classes\Display\Results.php on line 5337`.

---

To reproduce error, create these tables:

#### `users` table

id | name (nullable)
-- | -------------
1 | John
2 | _NULL_

Set `name` as _display field_

#### `articles` table

id | user_id | title
-- | ------- | ------
1 | 1    | Alpha
2 | 2    | Beta

Then try to open `articles` table with _Display column for relationships_ option selected.
