### PR TITLE
Don't fire keyboard shortcuts while SQL query area is focused

### DIFF
--- a/js/shortcuts_handler.js
+++ b/js/shortcuts_handler.js
@@ -25,7 +25,7 @@ $(function () {
     var keyC = 67;
     var keyBackSpace = 8;
     $(document).on('keyup', function (e) {
-        if (e.target.nodeName === 'INPUT' || e.target.nodeName === 'TEXTAREA' || e.target.nodeName === 'SELECT') {
+        if (e.target.nodeName === 'INPUT' || e.target.nodeName === 'TEXTAREA' || e.target.nodeName === 'SELECT' || $(':focus').prop('contenteditable') === true) {
             return;
         }
 
@@ -53,7 +53,7 @@ $(function () {
             Console.toggle();
         }
 
-        if (e.target.nodeName === 'INPUT' || e.target.nodeName === 'TEXTAREA' || e.target.nodeName === 'SELECT') {
+        if (e.target.nodeName === 'INPUT' || e.target.nodeName === 'TEXTAREA' || e.target.nodeName === 'SELECT' || $(':focus').prop('contenteditable') === true) {
             return;
         }
 


### PR DESCRIPTION
Fixes a bug where the keyboard shortcuts functions fire while typing in the SQL query area. The problem was that the SQL query area is not (always) a `<textarea>` but a `<div contenteditable="true">`

Fixes #15224 