### PR TITLE
Parenthesis problem

### DIFF
--- a/libraries/sql.lib.php
+++ b/libraries/sql.lib.php
@@ -610,7 +610,7 @@ function PMA_isRememberSortingOrder($analyzed_sql_results)
             || $analyzed_sql_results['is_analyse'])
         && $analyzed_sql_results['select_from']
         && ((empty($analyzed_sql_results['select_expr']))
-            || (count($analyzed_sql_results['select_expr'] == 1)
+            || ((count($analyzed_sql_results['select_expr']) == 1)
                 && ($analyzed_sql_results['select_expr'][0] == '*')))
         && count($analyzed_sql_results['select_tables']) == 1;
 }


### PR DESCRIPTION
### Description
On my PHP 7.2 / Ubuntu, leads to an error displaying tables. There is obviously an error because count() is counting a boolean.

Fixes #
Displaying tables without error.

Signed-off-by: Florent Lartet <florent.lartet@drozdi.fr>