### PR TITLE
require twig ^2.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "symfony/polyfill-ctype": "^1.8",
         "symfony/polyfill-mbstring": "^1.3",
         "symfony/yaml": "^4.2.8",
-        "twig/twig": "^2.4",
+        "twig/twig": "^2.9",
         "williamdes/mariadb-mysql-kbs": "^1.2"
     },
     "conflict": {


### PR DESCRIPTION
this is necessary for the 'apply' tag which came in 2.9 and 1.40

See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=954766
See: https://salsa.debian.org/phpmyadmin-team/phpmyadmin/issues/43
Signed-Off-By: Matthias Blümel <blaimi@blaimi.de>

Fixes: #15983