### PR TITLE
Added margin-top to #fieldset_add_user_login label

### DIFF
--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -845,6 +845,7 @@ div#tablestatistics table {
     max-width: 100%;
     text-align: $right;
     padding-#{$right}: 0.5em;
+    margin-top: 0.5rem;
   }
 
   span.options {


### PR DESCRIPTION
Fixes #15939 

Improper alignment of add user account form labels 

### Screenshot showing fixed alignment
![fixed_alignment](https://user-images.githubusercontent.com/53087041/79124439-37061a00-7d94-11ea-964f-55b44a0b3fdc.png)