### PR TITLE
Add missing base_dir when adding javascript files

### DIFF
--- a/libraries/classes/Scripts.php
+++ b/libraries/classes/Scripts.php
@@ -146,7 +146,10 @@ class Scripts
      */
     public function getDisplay()
     {
+        $baseDir = defined('PMA_PATH_TO_BASEDIR') ? PMA_PATH_TO_BASEDIR : '';
+
         return $this->template->render('scripts', [
+            'base_dir' => $baseDir,
             'files' => $this->_files,
             'version' => PMA_VERSION,
             'code' => $this->_code,

--- a/templates/scripts.twig
+++ b/templates/scripts.twig
@@ -1,5 +1,5 @@
 {% for file in files %}
-  <script data-cfasync="false" type="text/javascript" src="js/{{ file.filename }}
+  <script data-cfasync="false" type="text/javascript" src="{{ base_dir }}js/{{ file.filename }}
     {{- '.php' in file.filename ? get_common(file.params|merge({'v': version})) : '?v=' ~ version|url_encode }}"></script>
 {% endfor %}
 


### PR DESCRIPTION
### Description

Fix missing "base_dir" when adding Javascript files to HTML page.

(This is already used in ``header.twig``).

