### PR TITLE
fix get unix timestamp for monitor

### DIFF
--- a/libraries/classes/Controllers/Server/Status/MonitorController.php
+++ b/libraries/classes/Controllers/Server/Status/MonitorController.php
@@ -48,7 +48,7 @@ class MonitorController extends AbstractController
     public function index(): string
     {
         $form = [
-            'server_time' => microtime(true) * 1000,
+            'server_time' => (int) (microtime(true) * 1000),
             'server_os' => SysInfo::getOs(),
             'is_superuser' => $this->dbi->isSuperuser(),
             'server_db_isLocal' => $this->data->db_isLocal,

--- a/libraries/classes/Server/Status/Monitor.php
+++ b/libraries/classes/Server/Status/Monitor.php
@@ -85,7 +85,7 @@ class Monitor
         // ...and now assign them
         $ret = $this->getJsonForChartingDataSet($ret, $statusVarValues, $serverVarValues);
 
-        $ret['x'] = microtime(true) * 1000;
+        $ret['x'] = (int) (microtime(true) * 1000);
         return $ret;
     }
 


### PR DESCRIPTION
Signed-off-by: Gleb Borkov <long76.git@mail.ru>

### Description

Used `intval` for return unixtime in ms. In some locales uses comma-separated in float values and `monitor.js` return NaN by implicit conversion.

Fixes #16070

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
