### PR TITLE
Fix #16049 - checking if select input exists before retrieving the value, but not checking hostname select input value

### DIFF
--- a/js/server/privileges.js
+++ b/js/server/privileges.js
@@ -14,13 +14,13 @@
  * @return boolean  whether the form is validated or not
  */
 function checkAddUser (theForm) {
-    if (theForm.elements.pred_hostname.value === 'userdefined' && theForm.elements.hostname.value === '') {
+    if (theForm.elements.hostname.value === '') {
         alert(Messages.strHostEmpty);
         theForm.elements.hostname.focus();
         return false;
     }
 
-    if (theForm.elements.pred_username.value === 'userdefined' && theForm.elements.username.value === '') {
+    if ((theForm.elements.pred_username && theForm.elements.pred_username.value === 'userdefined') && theForm.elements.username.value === '') {
         alert(Messages.strUserEmpty);
         theForm.elements.username.focus();
         return false;


### PR DESCRIPTION
### Description

I fixed a bug described in #16049, I added checking that select input element for username is provided and I removed checking that select input element **for hostname** is provided because value for any host is `%` so empty value for hostname is ever incorrect 

PS: I'm not sure that my commit message isn't too long

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
