### PR TITLE
Fix #15806 Layout: Bad alignment of sticky column headers after scroll

### DIFF
--- a/js/sql.js
+++ b/js/sql.js
@@ -427,6 +427,9 @@ AJAX.registerOnload('sql.js', function () {
             $(document).on('scroll', window, function () {
                 Sql.handleStickyColumns($stickColumns, $tableResults);
             });
+            $(window).on('resize', function () {
+                Sql.resizeStickyColumns($stickColumns, $tableResults);
+            });
         });
     });
 
@@ -1101,6 +1104,14 @@ Sql.rearrangeStickyColumns = function ($stickyColumns, $tableResults) {
         }
     });
     $stickyColumns.empty().append($clonedHeader);
+};
+
+/**
+ * Adjust sticky columns on window resize
+ */
+Sql.resizeStickyColumns = function ($stickyColumns, $tableResults) {
+    $stickyColumns.css('width', $tableResults.width());
+    Sql.rearrangeStickyColumns($stickyColumns, $tableResults);
 };
 
 /**


### PR DESCRIPTION
Signed-off-by: Richard Beard <lordregent@aol.com>

### Description

Fixes #15806

Fix "jumpiness" of sticky headers in "Browse" when scrolling; the issue occurs after resizing the window/view or changing the zoom level.


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
