### PR TITLE
Remove mysql extension checks as it was removed in php 7.0

### DIFF
--- a/libraries/classes/Config/Validator.php
+++ b/libraries/classes/Config/Validator.php
@@ -225,31 +225,15 @@ class Validator
 
         error_clear_last();
 
-        if (DatabaseInterface::checkDbExtension('mysqli')) {
-            $socket = empty($socket) ? null : $socket;
-            $port = empty($port) ? null : $port;
-            $extension = 'mysqli';
-        } else {
-            $socket = empty($socket) ? null : ':' . ($socket[0] == '/' ? '' : '/') . $socket;
-            $port = empty($port) ? null : ':' . $port;
-            $extension = 'mysql';
-        }
+        $socket = empty($socket) ? null : $socket;
+        $port = empty($port) ? null : $port;
 
-        if ($extension == 'mysql') {
-            $conn = @mysql_connect($host . $port . $socket, $user, $pass);
-            if (! $conn) {
-                $error = __('Could not connect to the database server!');
-            } else {
-                mysql_close($conn);
-            }
-        } else {
-            $conn = @mysqli_connect($host, $user, $pass, null, $port, $socket);
+        $conn = @mysqli_connect($host, $user, $pass, null, $port, $socket);
             if (! $conn) {
                 $error = __('Could not connect to the database server!');
             } else {
                 mysqli_close($conn);
             }
-        }
         if ($error !== null) {
             $lastError = error_get_last();
             if ($lastError !== null) {

--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -126,21 +126,6 @@ class Routines
             'has_privilege' => Util::currentUserHasPrivilege('CREATE ROUTINE', $db, $table),
         ]);
 
-        /**
-         * Display a warning for users with PHP's old "mysql" extension.
-         */
-        if (! DatabaseInterface::checkDbExtension('mysqli')) {
-            trigger_error(
-                __(
-                    'You are using PHP\'s deprecated \'mysql\' extension, '
-                    . 'which is not capable of handling multi queries. '
-                    . '[strong]The execution of some stored routines may fail![/strong] '
-                    . 'Please use the improved \'mysqli\' extension to '
-                    . 'avoid any problems.'
-                ),
-                E_USER_WARNING
-            );
-        }
     }
 
     /**

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -153,16 +153,6 @@ class DatabaseInterface implements DbalInterface
     }
 
     /**
-     * Checks whether database extension is loaded
-     *
-     * @param string $extension mysql extension to check
-     */
-    public static function checkDbExtension(string $extension = 'mysqli'): bool
-    {
-        return function_exists($extension . '_connect');
-    }
-
-    /**
      * runs a query
      *
      * @param string $query               SQL query to execute
@@ -3161,7 +3151,7 @@ class DatabaseInterface implements DbalInterface
             return new self($extension);
         }
 
-        if (! self::checkDbExtension('mysqli')) {
+        if (! Util::checkDbExtension('mysqli')) {
             $docUrl = MySQLDocumentation::getDocumentationLink('faq', 'faqmysql');
             $docLink = sprintf(
                 __('See %sour documentation%s for more information.'),

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2938,6 +2938,16 @@ class Util
     }
 
     /**
+     * Checks whether database extension is loaded
+     *
+     * @param string $extension mysql extension to check
+     */
+    public static function checkDbExtension(string $extension = 'mysqli'): bool
+    {
+        return function_exists($extension . '_connect');
+    }
+
+    /**
      * Returs list of used PHP extensions.
      *
      * @return array of strings
@@ -2945,10 +2955,8 @@ class Util
     public static function listPHPExtensions()
     {
         $result = [];
-        if (DatabaseInterface::checkDbExtension('mysqli')) {
+        if (Util::checkDbExtension('mysqli')) {
             $result[] = 'mysqli';
-        } else {
-            $result[] = 'mysql';
         }
 
         if (extension_loaded('curl')) {

--- a/templates/display/results/table_navigation_button.twig
+++ b/templates/display/results/table_navigation_button.twig
@@ -1,5 +1,5 @@
 <td>
-    <form action="{{ url('/sql') }}" method="post"{{ onsubmit|raw }}>
+    <form action="{{ url('/sql') }}" method="post" {{ onsubmit|raw }}>
         {{ get_hidden_inputs(db, table) }}
         <input type="hidden" name="sql_query" value="{{ sql_query|raw }}">
         <input type="hidden" name="pos" value="{{ pos }}">


### PR DESCRIPTION
Ref: https://www.php.net/manual/en/function.mysql-connect.php

Why do we still check, removing this legacy code will make everybody and Scrutinizer happy!
