### PR TITLE
Fix #16130 - Local documentation links

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -3162,11 +3162,10 @@ class DatabaseInterface
         }
 
         if (! self::checkDbExtension('mysqli')) {
-            $docUrl = Util::getDocuLink('faq', 'faqmysql');
             $docLink = sprintf(
                 __('See %sour documentation%s for more information.'),
-                '[a@' . $docUrl . '@documentation]',
-                '[/a]'
+                '[doc@faqmysql]',
+                '[/doc]'
             );
             Core::warnMissingExtension(
                 'mysqli',

--- a/libraries/classes/Sanitize.php
+++ b/libraries/classes/Sanitize.php
@@ -141,9 +141,11 @@ class Sanitize
     public static function replaceDocLink(array $found)
     {
         if (count($found) >= 4) {
+            /* doc@page@anchor pattern */
             $page = $found[1];
             $anchor = $found[3];
         } else {
+            /* doc@anchor pattern */
             $anchor = $found[1];
             if (strncmp('faq', $anchor, 3) == 0) {
                 $page = 'faq';

--- a/test/classes/MessageTest.php
+++ b/test/classes/MessageTest.php
@@ -428,6 +428,18 @@ class MessageTest extends PmaTestCase
                 . 'latest%2Fsetup.html%23foo" '
                 . 'target="documentation">link</a>',
             ],
+            [
+                '[doc@page@anchor]link[/doc]',
+                '<a href="./url.php?url=https%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2F'
+                . 'latest%2Fpage.html%23anchor" '
+                . 'target="documentation">link</a>',
+            ],
+            [
+                '[doc@faqmysql]link[/doc]',
+                '<a href="./url.php?url=https%3A%2F%2Fdocs.phpmyadmin.net%2Fen%2F'
+                . 'latest%2Ffaq.html%23faqmysql" '
+                . 'target="documentation">link</a>',
+            ],
         ];
     }
 


### PR DESCRIPTION
Signed-off-by: Petr Duda <petrduda@seznam.cz>

### Description

Corrected the bb code tags for local documentation (i.e. [doc]) in the mysqli missing extension warning; added the respective test cases.

Fixes #16130

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
