### PR TITLE
Remove underscore prefix from method names

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -171,7 +171,7 @@ class Config
      *
      * @param string $user_agent the user agent
      */
-    private function _setClientPlatform(string $user_agent): void
+    private function setClientPlatform(string $user_agent): void
     {
         if (mb_strstr($user_agent, 'Win')) {
             $this->set('PMA_USR_OS', 'Win');
@@ -203,7 +203,7 @@ class Config
         }
 
         // 1. Platform
-        $this->_setClientPlatform($HTTP_USER_AGENT);
+        $this->setClientPlatform($HTTP_USER_AGENT);
 
         // 2. browser and version
         // (must check everything else before Mozilla)
@@ -500,7 +500,7 @@ class Config
     /**
      * Sets the connection collation
      */
-    private function _setConnectionCollation(): void
+    private function setConnectionCollation(): void
     {
         $collation_connection = $this->get('DefaultConnectionCollation');
         if (empty($collation_connection)
@@ -617,7 +617,7 @@ class Config
         }
 
         // set connection collation
-        $this->_setConnectionCollation();
+        $this->setConnectionCollation();
     }
 
     /**
@@ -1205,7 +1205,7 @@ class Config
      * @param string $filename File to check and render
      * @param string $id       Div ID
      */
-    private static function _renderCustom(string $filename, string $id): string
+    private static function renderCustom(string $filename, string $id): string
     {
         $retval = '';
         if (@file_exists($filename)) {
@@ -1224,7 +1224,7 @@ class Config
      */
     public static function renderFooter(): string
     {
-        return self::_renderCustom(CUSTOM_FOOTER_FILE, 'pma_footer');
+        return self::renderCustom(CUSTOM_FOOTER_FILE, 'pma_footer');
     }
 
     /**
@@ -1232,7 +1232,7 @@ class Config
      */
     public static function renderHeader(): string
     {
-        return self::_renderCustom(CUSTOM_HEADER_FILE, 'pma_header');
+        return self::renderCustom(CUSTOM_HEADER_FILE, 'pma_header');
     }
 
     /**

--- a/libraries/classes/Config/FormDisplay.php
+++ b/libraries/classes/Config/FormDisplay.php
@@ -196,7 +196,7 @@ class FormDisplay
      *
      * @return void
      */
-    private function _validate()
+    private function validate()
     {
         if ($this->_isValidated) {
             return;
@@ -251,7 +251,7 @@ class FormDisplay
      *
      * @return string
      */
-    private function _displayForms(
+    private function displayForms(
         $showRestoreDefault,
         array &$jsDefault,
         array &$js,
@@ -279,7 +279,7 @@ class FormDisplay
                     ? ! isset($this->_userprefsDisallow[$path])
                     : null;
                 // display input
-                $htmlOutput .= $this->_displayFieldInput(
+                $htmlOutput .= $this->displayFieldInput(
                     $form,
                     $field,
                     $path,
@@ -349,14 +349,14 @@ class FormDisplay
             }
         }
         if (! $isNewServer) {
-            $this->_validate();
+            $this->validate();
         }
 
         // user preferences
-        $this->_loadUserprefsInfo();
+        $this->loadUserprefsInfo();
 
         // display forms
-        $htmlOutput .= $this->_displayForms(
+        $htmlOutput .= $this->displayForms(
             $showRestoreDefault,
             $jsDefault,
             $js,
@@ -404,7 +404,7 @@ class FormDisplay
      *
      * @return string|null HTML for input field
      */
-    private function _displayFieldInput(
+    private function displayFieldInput(
         Form $form,
         $field,
         $systemPath,
@@ -500,7 +500,7 @@ class FormDisplay
                 $v = $ip . ': ' . $v;
             }
         }
-        $this->_setComments($systemPath, $opts);
+        $this->setComments($systemPath, $opts);
 
         // send default value to form's JS
         $jsLine = '\'' . $translatedPath . '\': ';
@@ -549,7 +549,7 @@ class FormDisplay
      */
     public function displayErrors()
     {
-        $this->_validate();
+        $this->validate();
         if (count($this->_errors) === 0) {
             return null;
         }
@@ -575,7 +575,7 @@ class FormDisplay
      */
     public function fixErrors()
     {
-        $this->_validate();
+        $this->validate();
         if (count($this->_errors) === 0) {
             return;
         }
@@ -598,7 +598,7 @@ class FormDisplay
      *
      * @return bool
      */
-    private function _validateSelect(&$value, array $allowed): bool
+    private function validateSelect(&$value, array $allowed): bool
     {
         $valueCmp = is_bool($value)
             ? (int) $value
@@ -643,7 +643,7 @@ class FormDisplay
         $toSave = [];
         $isSetupScript = $GLOBALS['PMA_Config']->get('is_setup');
         if ($isSetupScript) {
-            $this->_loadUserprefsInfo();
+            $this->loadUserprefsInfo();
         }
 
         $this->_errors = [];
@@ -712,7 +712,7 @@ class FormDisplay
                         }
                         break;
                     case 'select':
-                        $successfullyValidated = $this->_validateSelect(
+                        $successfullyValidated = $this->validateSelect(
                             $_POST[$key],
                             $form->getOptionValueList($systemPath)
                         );
@@ -733,7 +733,7 @@ class FormDisplay
                         ? $_POST[$key]
                         : explode("\n", $_POST[$key]);
                         $_POST[$key] = [];
-                        $this->_fillPostArrayParameters($postValues, $key);
+                        $this->fillPostArrayParameters($postValues, $key);
                         break;
                 }
 
@@ -753,7 +753,7 @@ class FormDisplay
         // save forms
         if (! $allowPartialSave && ! empty($this->_errors)) {
             // don't look for non-critical errors
-            $this->_validate();
+            $this->validate();
 
             return $result;
         }
@@ -792,7 +792,7 @@ class FormDisplay
         }
 
         // don't look for non-critical errors
-        $this->_validate();
+        $this->validate();
 
         return $result;
     }
@@ -823,7 +823,7 @@ class FormDisplay
 
         return MySQLDocumentation::getDocumentationLink(
             'config',
-            'cfg_' . $this->_getOptName($path),
+            'cfg_' . $this->getOptName($path),
             Sanitize::isSetup() ? '../' : './'
         );
     }
@@ -835,7 +835,7 @@ class FormDisplay
      *
      * @return string
      */
-    private function _getOptName($path)
+    private function getOptName($path)
     {
         return str_replace(['Servers/1/', '/'], ['Servers/', '_'], $path);
     }
@@ -845,7 +845,7 @@ class FormDisplay
      *
      * @return void
      */
-    private function _loadUserprefsInfo()
+    private function loadUserprefsInfo()
     {
         if ($this->_userprefsKeys !== null) {
             return;
@@ -867,7 +867,7 @@ class FormDisplay
      *
      * @return void
      */
-    private function _setComments($systemPath, array &$opts)
+    private function setComments($systemPath, array &$opts)
     {
         // RecodingEngine - mark unavailable types
         if ($systemPath == 'RecodingEngine') {
@@ -955,7 +955,7 @@ class FormDisplay
      *
      * @return void
      */
-    private function _fillPostArrayParameters(array $postValues, $key)
+    private function fillPostArrayParameters(array $postValues, $key)
     {
         foreach ($postValues as $v) {
             $v = Util::requestString($v);

--- a/libraries/classes/Config/PageSettings.php
+++ b/libraries/classes/Config/PageSettings.php
@@ -81,11 +81,11 @@ class PageSettings
         if (isset($_POST['submit_save'])
             && $_POST['submit_save'] == $formGroupName
         ) {
-            $this->_processPageSettings($formDisplay, $cf, $error);
+            $this->processPageSettings($formDisplay, $cf, $error);
         }
 
         // Display forms
-        $this->_HTML = $this->_getPageSettingsDisplay($formDisplay, $error);
+        $this->_HTML = $this->getPageSettingsDisplay($formDisplay, $error);
     }
 
     /**
@@ -97,7 +97,7 @@ class PageSettings
      *
      * @return void
      */
-    private function _processPageSettings(&$formDisplay, &$cf, &$error)
+    private function processPageSettings(&$formDisplay, &$cf, &$error)
     {
         if (! $formDisplay->process(false) || $formDisplay->hasErrors()) {
             return;
@@ -125,7 +125,7 @@ class PageSettings
      *
      * @return void
      */
-    private function _storeError(&$formDisplay, &$error)
+    private function storeError(&$formDisplay, &$error)
     {
         $retval = '';
         if ($error) {
@@ -152,13 +152,13 @@ class PageSettings
      *
      * @return string
      */
-    private function _getPageSettingsDisplay(&$formDisplay, &$error)
+    private function getPageSettingsDisplay(&$formDisplay, &$error)
     {
         $response = Response::getInstance();
 
         $retval = '';
 
-        $this->_storeError($formDisplay, $error);
+        $this->storeError($formDisplay, $error);
 
         $retval .= '<div id="' . $this->_elemId . '">';
         $retval .= '<div class="page_settings">';

--- a/libraries/classes/Database/Qbe.php
+++ b/libraries/classes/Database/Qbe.php
@@ -264,10 +264,10 @@ class Qbe
         $this->relation = $relation;
         $this->template = $template;
 
-        $this->_loadCriterias();
+        $this->loadCriterias();
         // Sets criteria parameters
-        $this->_setSearchParams();
-        $this->_setCriteriaTablesAndColumns();
+        $this->setSearchParams();
+        $this->setCriteriaTablesAndColumns();
     }
 
     /**
@@ -275,7 +275,7 @@ class Qbe
      *
      * @return static
      */
-    private function _loadCriterias()
+    private function loadCriterias()
     {
         if ($this->_currentSearch === null
             || $this->_currentSearch->getCriterias() === null
@@ -294,7 +294,7 @@ class Qbe
      *
      * @return SavedSearches
      */
-    private function _getCurrentSearch()
+    private function getCurrentSearch()
     {
         return $this->_currentSearch;
     }
@@ -304,9 +304,9 @@ class Qbe
      *
      * @return void
      */
-    private function _setSearchParams()
+    private function setSearchParams()
     {
-        $criteriaColumnCount = $this->_initializeCriteriasCount();
+        $criteriaColumnCount = $this->initializeCriteriasCount();
 
         $this->_criteriaColumnInsert = Core::ifSetOr(
             $_POST['criteriaColumnInsert'],
@@ -341,7 +341,7 @@ class Qbe
      *
      * @return void
      */
-    private function _setCriteriaTablesAndColumns()
+    private function setCriteriaTablesAndColumns()
     {
         // The tables list sent by a previously submitted form
         if (Core::isValid($_POST['TableList'], 'array')) {
@@ -401,7 +401,7 @@ class Qbe
      *
      * @return string HTML for select options
      */
-    private function _showColumnSelectCell($column_number, $selected = '')
+    private function showColumnSelectCell($column_number, $selected = '')
     {
         return $this->template->render('database/qbe/column_select_cell', [
             'column_number' => $column_number,
@@ -418,7 +418,7 @@ class Qbe
      *
      * @return string HTML for select options
      */
-    private function _getSortSelectCell(
+    private function getSortSelectCell(
         $columnNumber,
         $selected = ''
     ) {
@@ -437,9 +437,9 @@ class Qbe
      *
      * @return string HTML for select options
      */
-    private function _getSortOrderSelectCell($columnNumber, $sortOrder)
+    private function getSortOrderSelectCell($columnNumber, $sortOrder)
     {
-        $totalColumnCount = $this->_getNewColumnCount();
+        $totalColumnCount = $this->getNewColumnCount();
 
         return $this->template->render('database/qbe/sort_order_select_cell', [
             'total_column_count' => $totalColumnCount,
@@ -453,7 +453,7 @@ class Qbe
      *
      * @return int new column count
      */
-    private function _getNewColumnCount()
+    private function getNewColumnCount()
     {
         $totalColumnCount = $this->_criteria_column_count;
         if (! empty($this->_criteriaColumnInsert)) {
@@ -471,7 +471,7 @@ class Qbe
      *
      * @return string HTML for search table's row
      */
-    private function _getColumnNamesRow()
+    private function getColumnNamesRow()
     {
         $html_output = '';
 
@@ -480,7 +480,7 @@ class Qbe
             if (isset($this->_criteriaColumnInsert[$column_index])
                 && $this->_criteriaColumnInsert[$column_index] == 'on'
             ) {
-                $html_output .= $this->_showColumnSelectCell(
+                $html_output .= $this->showColumnSelectCell(
                     $new_column_count
                 );
                 $new_column_count++;
@@ -497,7 +497,7 @@ class Qbe
                 $this->_formColumns[$new_column_count]
                     = $_POST['criteriaColumn'][$column_index];
             }
-            $html_output .= $this->_showColumnSelectCell(
+            $html_output .= $this->showColumnSelectCell(
                 $new_column_count,
                 $selected
             );
@@ -513,7 +513,7 @@ class Qbe
      *
      * @return string HTML for search table's row
      */
-    private function _getColumnAliasRow()
+    private function getColumnAliasRow()
     {
         $html_output = '';
 
@@ -561,7 +561,7 @@ class Qbe
      *
      * @return string HTML for search table's row
      */
-    private function _getSortRow()
+    private function getSortRow()
     {
         $html_output = '';
 
@@ -572,7 +572,7 @@ class Qbe
                 && isset($this->_criteriaColumnInsert[$colInd])
                 && $this->_criteriaColumnInsert[$colInd] == 'on'
             ) {
-                $html_output .= $this->_getSortSelectCell($new_column_count);
+                $html_output .= $this->getSortSelectCell($new_column_count);
                 $new_column_count++;
             } // end if
 
@@ -604,7 +604,7 @@ class Qbe
                 $this->_formSorts[$new_column_count] = '';
             }
 
-            $html_output .= $this->_getSortSelectCell(
+            $html_output .= $this->getSortSelectCell(
                 $new_column_count,
                 $selected
             );
@@ -619,7 +619,7 @@ class Qbe
      *
      * @return string HTML for search table's row
      */
-    private function _getSortOrder()
+    private function getSortOrder()
     {
         $html_output = '';
 
@@ -630,7 +630,7 @@ class Qbe
                 && isset($this->_criteriaColumnInsert[$colInd])
                 && $this->_criteriaColumnInsert[$colInd] == 'on'
             ) {
-                $html_output .= $this->_getSortOrderSelectCell(
+                $html_output .= $this->getSortOrderSelectCell(
                     $new_column_count,
                     null
                 );
@@ -651,7 +651,7 @@ class Qbe
                         = $_POST['criteriaSortOrder'][$colInd];
             }
 
-            $html_output .= $this->_getSortOrderSelectCell(
+            $html_output .= $this->getSortOrderSelectCell(
                 $new_column_count,
                 $sortOrder
             );
@@ -666,7 +666,7 @@ class Qbe
      *
      * @return string HTML for search table's row
      */
-    private function _getShowRow()
+    private function getShowRow()
     {
         $html_output = '';
 
@@ -711,7 +711,7 @@ class Qbe
      *
      * @return string HTML for search table's row
      */
-    private function _getCriteriaInputboxRow()
+    private function getCriteriaInputboxRow()
     {
         $html_output = '';
 
@@ -778,7 +778,7 @@ class Qbe
      *
      * @return string HTML for modification cell
      */
-    private function _getAndOrColCell(
+    private function getAndOrColCell(
         $column_number,
         $selected = null,
         $last_column = false
@@ -811,7 +811,7 @@ class Qbe
      *
      * @return string HTML for search table's row
      */
-    private function _getModifyColumnsRow()
+    private function getModifyColumnsRow()
     {
         $html_output = '';
 
@@ -821,7 +821,7 @@ class Qbe
                 && isset($this->_criteriaColumnInsert[$column_index])
                 && $this->_criteriaColumnInsert[$column_index] == 'on'
             ) {
-                $html_output .= $this->_getAndOrColCell($new_column_count);
+                $html_output .= $this->getAndOrColCell($new_column_count);
                 $new_column_count++;
             } // end if
 
@@ -846,7 +846,7 @@ class Qbe
                 $checked_options['and'] = ' checked="checked"';
                 $checked_options['or']  = '';
             }
-            $html_output .= $this->_getAndOrColCell(
+            $html_output .= $this->getAndOrColCell(
                 $new_column_count,
                 $checked_options,
                 $column_index + 1 == $this->_criteria_column_count
@@ -865,7 +865,7 @@ class Qbe
      *
      * @return string HTML table rows
      */
-    private function _getInputboxRow($new_row_index)
+    private function getInputboxRow($new_row_index)
     {
         $html_output = '';
         $new_column_count = 0;
@@ -916,7 +916,7 @@ class Qbe
      *
      * @return string HTML table rows
      */
-    private function _getInsDelAndOrCriteriaRows()
+    private function getInsDelAndOrCriteriaRows()
     {
         $html_output = '';
         $new_row_count = 0;
@@ -932,7 +932,7 @@ class Qbe
                     'row_index' => $new_row_count,
                     'checked_options' => $checked_options,
                 ]);
-                $html_output .= $this->_getInputboxRow(
+                $html_output .= $this->getInputboxRow(
                     $new_row_count
                 );
                 $new_row_count++;
@@ -961,7 +961,7 @@ class Qbe
                 'row_index' => $new_row_count,
                 'checked_options' => $checked_options,
             ]);
-            $html_output .= $this->_getInputboxRow(
+            $html_output .= $this->getInputboxRow(
                 $new_row_count
             );
             $new_row_count++;
@@ -977,7 +977,7 @@ class Qbe
      *
      * @return string Select clause
      */
-    private function _getSelectClause()
+    private function getSelectClause()
     {
         $select_clause = '';
         $select_clauses = [];
@@ -1009,7 +1009,7 @@ class Qbe
      *
      * @return string Where clause
      */
-    private function _getWhereClause()
+    private function getWhereClause()
     {
         $where_clause = '';
         $criteria_cnt = 0;
@@ -1095,7 +1095,7 @@ class Qbe
      *
      * @return string Order By clause
      */
-    private function _getOrderByClause()
+    private function getOrderByClause()
     {
         $orderby_clause = '';
         $orderby_clauses = [];
@@ -1150,7 +1150,7 @@ class Qbe
      *
      * @return array having UNIQUE and INDEX columns
      */
-    private function _getIndexes(
+    private function getIndexes(
         array $search_tables,
         array $search_columns,
         array $where_clause_columns
@@ -1197,7 +1197,7 @@ class Qbe
      *
      * @return array having UNIQUE and INDEX columns
      */
-    private function _getLeftJoinColumnCandidates(
+    private function getLeftJoinColumnCandidates(
         array $search_tables,
         array $search_columns,
         array $where_clause_columns
@@ -1205,7 +1205,7 @@ class Qbe
         $this->dbi->selectDb($this->_db);
 
         // Get unique columns and index columns
-        $indexes = $this->_getIndexes(
+        $indexes = $this->getIndexes(
             $search_tables,
             $search_columns,
             $where_clause_columns
@@ -1214,7 +1214,7 @@ class Qbe
         $index_columns = $indexes['index'];
 
         [$candidate_columns, $needsort]
-            = $this->_getLeftJoinColumnCandidatesBest(
+            = $this->getLeftJoinColumnCandidatesBest(
                 $search_tables,
                 $where_clause_columns,
                 $unique_columns,
@@ -1261,7 +1261,7 @@ class Qbe
      *
      * @return string table name
      */
-    private function _getMasterTable(
+    private function getMasterTable(
         array $search_tables,
         array $search_columns,
         array $where_clause_columns,
@@ -1277,7 +1277,7 @@ class Qbe
         // (When the control user is the same as the normal user
         // because they are using one of their databases as pmadb,
         // the last db selected is not always the one where we need to work)
-        $candidate_columns = $this->_getLeftJoinColumnCandidates(
+        $candidate_columns = $this->getLeftJoinColumnCandidates(
             $search_tables,
             $search_columns,
             $where_clause_columns
@@ -1349,7 +1349,7 @@ class Qbe
      *
      * @return array
      */
-    private function _getWhereClauseTablesAndColumns()
+    private function getWhereClauseTablesAndColumns()
     {
         $where_clause_columns = [];
         $where_clause_tables = [];
@@ -1388,7 +1388,7 @@ class Qbe
      *
      * @return string FROM clause
      */
-    private function _getFromClause(array $formColumns)
+    private function getFromClause(array $formColumns)
     {
         $from_clause = '';
         if (empty($formColumns)) {
@@ -1415,7 +1415,7 @@ class Qbe
         } // end while
 
         // Create LEFT JOINS out of Relations
-        $from_clause = $this->_getJoinForFromClause(
+        $from_clause = $this->getJoinForFromClause(
             $search_tables,
             $search_columns
         );
@@ -1441,23 +1441,23 @@ class Qbe
      *
      * @return string table name
      */
-    private function _getJoinForFromClause(array $searchTables, array $searchColumns)
+    private function getJoinForFromClause(array $searchTables, array $searchColumns)
     {
         // $relations[master_table][foreign_table] => clause
         $relations = [];
 
         // Fill $relations with inter table relationship data
         foreach ($searchTables as $oneTable) {
-            $this->_loadRelationsForTable($relations, $oneTable);
+            $this->loadRelationsForTable($relations, $oneTable);
         }
 
         // Get tables and columns with valid where clauses
-        $validWhereClauses = $this->_getWhereClauseTablesAndColumns();
+        $validWhereClauses = $this->getWhereClauseTablesAndColumns();
         $whereClauseTables = $validWhereClauses['where_clause_tables'];
         $whereClauseColumns = $validWhereClauses['where_clause_columns'];
 
         // Get master table
-        $master = $this->_getMasterTable(
+        $master = $this->getMasterTable(
             $searchTables,
             $searchColumns,
             $whereClauseColumns,
@@ -1472,7 +1472,7 @@ class Qbe
             $finalized[$master] = '';
         }
         // Fill the $finalized array with JOIN clauses for each table
-        $this->_fillJoinClauses($finalized, $relations, $searchTables);
+        $this->fillJoinClauses($finalized, $relations, $searchTables);
 
         // JOIN clause
         $join = '';
@@ -1495,7 +1495,7 @@ class Qbe
 
                         $table = $reference['table_name'];
 
-                        $this->_loadRelationsForTable($relations, $table);
+                        $this->loadRelationsForTable($relations, $table);
 
                         // Make copies
                         $tempFinalized = $finalized;
@@ -1503,7 +1503,7 @@ class Qbe
                         $tempSearchTables[] = $table;
 
                         // Try joining with the added table
-                        $this->_fillJoinClauses(
+                        $this->fillJoinClauses(
                             $tempFinalized,
                             $relations,
                             $tempSearchTables
@@ -1567,7 +1567,7 @@ class Qbe
      *
      * @return void
      */
-    private function _loadRelationsForTable(array &$relations, $oneTable)
+    private function loadRelationsForTable(array &$relations, $oneTable)
     {
         $relations[$oneTable] = [];
 
@@ -1608,7 +1608,7 @@ class Qbe
      *
      * @return void
      */
-    private function _fillJoinClauses(array &$finalized, array $relations, array $searchTables)
+    private function fillJoinClauses(array &$finalized, array $relations, array $searchTables)
     {
         while (true) {
             $added = false;
@@ -1651,20 +1651,20 @@ class Qbe
      *
      * @return string SQL query
      */
-    private function _getSQLQuery(array $formColumns)
+    private function getSQLQuery(array $formColumns)
     {
         $sql_query = '';
         // get SELECT clause
-        $sql_query .= $this->_getSelectClause();
+        $sql_query .= $this->getSelectClause();
         // get FROM clause
-        $from_clause = $this->_getFromClause($formColumns);
+        $from_clause = $this->getFromClause($formColumns);
         if (! empty($from_clause)) {
             $sql_query .= 'FROM ' . htmlspecialchars($from_clause) . "\n";
         }
         // get WHERE clause
-        $sql_query .= $this->_getWhereClause();
+        $sql_query .= $this->getWhereClause();
         // get ORDER BY clause
-        $sql_query .= $this->_getOrderByClause();
+        $sql_query .= $this->getOrderByClause();
 
         return $sql_query;
     }
@@ -1673,16 +1673,16 @@ class Qbe
     {
         global $cfgRelation;
 
-        $savedSearchesField = $cfgRelation['savedsearcheswork'] ? $this->_getSavedSearchesField() : '';
+        $savedSearchesField = $cfgRelation['savedsearcheswork'] ? $this->getSavedSearchesField() : '';
 
-        $columnNamesRow = $this->_getColumnNamesRow();
-        $columnAliasRow = $this->_getColumnAliasRow();
-        $showRow = $this->_getShowRow();
-        $sortRow = $this->_getSortRow();
-        $sortOrder = $this->_getSortOrder();
-        $criteriaInputBoxRow = $this->_getCriteriaInputboxRow();
-        $insDelAndOrCriteriaRows = $this->_getInsDelAndOrCriteriaRows();
-        $modifyColumnsRow = $this->_getModifyColumnsRow();
+        $columnNamesRow = $this->getColumnNamesRow();
+        $columnAliasRow = $this->getColumnAliasRow();
+        $showRow = $this->getShowRow();
+        $sortRow = $this->getSortRow();
+        $sortOrder = $this->getSortOrder();
+        $criteriaInputBoxRow = $this->getCriteriaInputboxRow();
+        $insDelAndOrCriteriaRows = $this->getInsDelAndOrCriteriaRows();
+        $modifyColumnsRow = $this->getModifyColumnsRow();
 
         $this->_new_row_count--;
         $url_params = [];
@@ -1693,7 +1693,7 @@ class Qbe
         if (empty($this->_formColumns)) {
             $this->_formColumns = [];
         }
-        $sqlQuery = $this->_getSQLQuery($this->_formColumns);
+        $sqlQuery = $this->getSQLQuery($this->_formColumns);
 
         return $this->template->render('database/qbe/selection_form', [
             'db' => $this->_db,
@@ -1718,13 +1718,13 @@ class Qbe
      *
      * @return string
      */
-    private function _getSavedSearchesField()
+    private function getSavedSearchesField()
     {
         $html_output = __('Saved bookmarked search:');
         $html_output .= ' <select name="searchId" id="searchId">';
         $html_output .= '<option value="">' . __('New bookmark') . '</option>';
 
-        $currentSearch = $this->_getCurrentSearch();
+        $currentSearch = $this->getCurrentSearch();
         $currentSearchId = null;
         $currentSearchName = null;
         if ($currentSearch != null) {
@@ -1764,7 +1764,7 @@ class Qbe
      *
      * @return int Previous number of columns
      */
-    private function _initializeCriteriasCount(): int
+    private function initializeCriteriasCount(): int
     {
         // sets column count
         $criteriaColumnCount = Core::ifSetOr(
@@ -1803,7 +1803,7 @@ class Qbe
      *
      * @return array
      */
-    private function _getLeftJoinColumnCandidatesBest(
+    private function getLeftJoinColumnCandidatesBest(
         array $search_tables,
         ?array $where_clause_columns,
         ?array $unique_columns,

--- a/libraries/classes/Footer.php
+++ b/libraries/classes/Footer.php
@@ -75,7 +75,7 @@ class Footer
     /**
      * Returns the message for demo server to error messages
      */
-    private function _getDemoMessage(): string
+    private function getDemoMessage(): string
     {
         $message = '<a href="/">' . __('phpMyAdmin Demo Server') . '</a>: ';
         if (@file_exists(ROOT_PATH . 'revision-info.php')) {
@@ -110,7 +110,7 @@ class Footer
      *
      * @return object Reference passed object
      */
-    private static function _removeRecursion(&$object, array $stack = [])
+    private static function removeRecursion(&$object, array $stack = [])
     {
         if ((is_object($object) || is_array($object)) && $object) {
             if ($object instanceof Traversable) {
@@ -118,7 +118,7 @@ class Footer
             } elseif (! in_array($object, $stack, true)) {
                 $stack[] = $object;
                 foreach ($object as &$subobject) {
-                    self::_removeRecursion($subobject, $stack);
+                    self::removeRecursion($subobject, $stack);
                 }
             } else {
                 $object = '***RECURSION***';
@@ -139,7 +139,7 @@ class Footer
             && ! empty($_SESSION['debug'])
         ) {
             // Remove recursions and iterators from $_SESSION['debug']
-            self::_removeRecursion($_SESSION['debug']);
+            self::removeRecursion($_SESSION['debug']);
 
             $retval = json_encode($_SESSION['debug']);
             $_SESSION['debug'] = [];
@@ -208,7 +208,7 @@ class Footer
      *
      * @param string $url The url of the page
      */
-    private function _getSelfLink(string $url): string
+    private function getSelfLink(string $url): string
     {
         $retval  = '';
         $retval .= '<div id="selflink" class="print_ignore">';
@@ -249,7 +249,7 @@ class Footer
     /**
      * Saves query in history
      */
-    private function _setHistory(): void
+    private function setHistory(): void
     {
         if (Core::isValid($_REQUEST['no_history'])
             || ! empty($GLOBALS['error_message'])
@@ -310,7 +310,7 @@ class Footer
      */
     public function getDisplay(): string
     {
-        $this->_setHistory();
+        $this->setHistory();
         if ($this->_isEnabled) {
             if (! $this->_isAjax && ! $this->_isMinimal) {
                 if (Core::getenv('SCRIPT_NAME')
@@ -340,7 +340,7 @@ class Footer
                     && ! $this->_isAjax
                 ) {
                     $url = $this->getSelfUrl();
-                    $selfLink = $this->_getSelfLink($url);
+                    $selfLink = $this->getSelfLink($url);
                 }
                 $this->_scripts->addCode(
                     'var debugSQLInfo = ' . $this->getDebugMessage() . ';'
@@ -350,7 +350,7 @@ class Footer
                 $scripts = $this->_scripts->getDisplay();
 
                 if ($GLOBALS['cfg']['DBG']['demo']) {
-                    $demoMessage = $this->_getDemoMessage();
+                    $demoMessage = $this->getDemoMessage();
                 }
 
                 $footer = Config::renderFooter();

--- a/libraries/classes/Gis/GisGeometryCollection.php
+++ b/libraries/classes/Gis/GisGeometryCollection.php
@@ -70,7 +70,7 @@ class GisGeometryCollection extends GisGeometry
             );
 
         // Split the geometry collection object to get its constituents.
-        $sub_parts = $this->_explodeGeomCol($goem_col);
+        $sub_parts = $this->explodeGeomCol($goem_col);
 
         foreach ($sub_parts as $sub_part) {
             $type_pos = mb_strpos($sub_part, '(');
@@ -135,7 +135,7 @@ class GisGeometryCollection extends GisGeometry
                 mb_strlen($spatial) - 20
             );
         // Split the geometry collection object to get its constituents.
-        $sub_parts = $this->_explodeGeomCol($goem_col);
+        $sub_parts = $this->explodeGeomCol($goem_col);
 
         foreach ($sub_parts as $sub_part) {
             $type_pos = mb_strpos($sub_part, '(');
@@ -183,7 +183,7 @@ class GisGeometryCollection extends GisGeometry
                 mb_strlen($spatial) - 20
             );
         // Split the geometry collection object to get its constituents.
-        $sub_parts = $this->_explodeGeomCol($goem_col);
+        $sub_parts = $this->explodeGeomCol($goem_col);
 
         foreach ($sub_parts as $sub_part) {
             $type_pos = mb_strpos($sub_part, '(');
@@ -232,7 +232,7 @@ class GisGeometryCollection extends GisGeometry
                 mb_strlen($spatial) - 20
             );
         // Split the geometry collection object to get its constituents.
-        $sub_parts = $this->_explodeGeomCol($goem_col);
+        $sub_parts = $this->explodeGeomCol($goem_col);
 
         foreach ($sub_parts as $sub_part) {
             $type_pos = mb_strpos($sub_part, '(');
@@ -282,7 +282,7 @@ class GisGeometryCollection extends GisGeometry
                 mb_strlen($spatial) - 20
             );
         // Split the geometry collection object to get its constituents.
-        $sub_parts = $this->_explodeGeomCol($goem_col);
+        $sub_parts = $this->explodeGeomCol($goem_col);
 
         foreach ($sub_parts as $sub_part) {
             $type_pos = mb_strpos($sub_part, '(');
@@ -316,7 +316,7 @@ class GisGeometryCollection extends GisGeometry
      *
      * @access private
      */
-    private function _explodeGeomCol($geom_col)
+    private function explodeGeomCol($geom_col)
     {
         $sub_parts = [];
         $br_count = 0;
@@ -406,7 +406,7 @@ class GisGeometryCollection extends GisGeometry
                 mb_strlen($wkt) - 20
             );
         // Split the geometry collection object to get its constituents.
-        $sub_parts = $this->_explodeGeomCol($goem_col);
+        $sub_parts = $this->explodeGeomCol($goem_col);
         $params['GEOMETRYCOLLECTION']['geom_count'] = count($sub_parts);
 
         $i = 0;

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -295,17 +295,17 @@ class GisMultiPolygon extends GisGeometry
 
             // If the polygon doesn't have an inner polygon
             if (mb_strpos($polygon, '),(') === false) {
-                $row .= $this->_drawPath($polygon, $scale_data);
+                $row .= $this->drawPath($polygon, $scale_data);
             } else {
                 // Separate outer and inner polygons
                 $parts = explode('),(', $polygon);
                 $outer = $parts[0];
                 $inner = array_slice($parts, 1);
 
-                $row .= $this->_drawPath($outer, $scale_data);
+                $row .= $this->drawPath($outer, $scale_data);
 
                 foreach ($inner as $inner_poly) {
-                    $row .= $this->_drawPath($inner_poly, $scale_data);
+                    $row .= $this->drawPath($inner_poly, $scale_data);
                 }
             }
             $polygon_options['id'] = $label . $this->getRandomId();
@@ -374,7 +374,7 @@ class GisMultiPolygon extends GisGeometry
      *
      * @access private
      */
-    private function _drawPath($polygon, array $scale_data)
+    private function drawPath($polygon, array $scale_data)
     {
         $points_arr = $this->extractPoints($polygon, $scale_data);
 

--- a/libraries/classes/Gis/GisPolygon.php
+++ b/libraries/classes/Gis/GisPolygon.php
@@ -259,17 +259,17 @@ class GisPolygon extends GisGeometry
 
         // If the polygon doesn't have an inner polygon
         if (mb_strpos($polygon, '),(') === false) {
-            $row .= $this->_drawPath($polygon, $scale_data);
+            $row .= $this->drawPath($polygon, $scale_data);
         } else {
             // Separate outer and inner polygons
             $parts = explode('),(', $polygon);
             $outer = $parts[0];
             $inner = array_slice($parts, 1);
 
-            $row .= $this->_drawPath($outer, $scale_data);
+            $row .= $this->drawPath($outer, $scale_data);
 
             foreach ($inner as $inner_poly) {
-                $row .= $this->_drawPath($inner_poly, $scale_data);
+                $row .= $this->drawPath($inner_poly, $scale_data);
             }
         }
 
@@ -338,7 +338,7 @@ class GisPolygon extends GisGeometry
      *
      * @access private
      */
-    private function _drawPath($polygon, array $scale_data)
+    private function drawPath($polygon, array $scale_data)
     {
         $points_arr = $this->extractPoints($polygon, $scale_data);
 

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -144,8 +144,8 @@ class GisVisualization
         if (isset($data)) {
             $this->_data = $data;
         } else {
-            $this->_modified_sql = $this->_modifySqlQuery($sql_query, $row, $pos);
-            $this->_data = $this->_fetchRawData();
+            $this->_modified_sql = $this->modifySqlQuery($sql_query, $row, $pos);
+            $this->_data = $this->fetchRawData();
         }
     }
 
@@ -158,7 +158,7 @@ class GisVisualization
      */
     protected function init()
     {
-        $this->_handleOptions();
+        $this->handleOptions();
     }
 
     /**
@@ -170,7 +170,7 @@ class GisVisualization
      *
      * @return string the modified sql query.
      */
-    private function _modifySqlQuery($sql_query, $rows, $pos)
+    private function modifySqlQuery($sql_query, $rows, $pos)
     {
         $modified_query = 'SELECT ';
         $spatialAsText = 'ASTEXT';
@@ -229,7 +229,7 @@ class GisVisualization
      *
      * @return array the raw data.
      */
-    private function _fetchRawData()
+    private function fetchRawData()
     {
         $modified_result = $GLOBALS['dbi']->tryQuery($this->_modified_sql);
 
@@ -253,7 +253,7 @@ class GisVisualization
      *
      * @access private
      */
-    private function _handleOptions()
+    private function handleOptions()
     {
         if ($this->_userSpecifiedSettings === null) {
             return;
@@ -275,7 +275,7 @@ class GisVisualization
      *
      * @access private
      */
-    private function _sanitizeName($file_name, $ext)
+    private function sanitizeName($file_name, $ext)
     {
         $file_name = Sanitize::sanitizeFilename($file_name);
 
@@ -307,9 +307,9 @@ class GisVisualization
      *
      * @access private
      */
-    private function _toFile($file_name, $type, $ext)
+    private function writeToFile($file_name, $type, $ext)
     {
-        $file_name = $this->_sanitizeName($file_name, $ext);
+        $file_name = $this->sanitizeName($file_name, $ext);
         Core::downloadHeader($file_name, $type);
     }
 
@@ -320,7 +320,7 @@ class GisVisualization
      *
      * @access private
      */
-    private function _svg()
+    private function svg()
     {
         $this->init();
 
@@ -332,8 +332,8 @@ class GisVisualization
             . ' height="' . intval($this->_settings['height']) . '">'
             . '<g id="groupPanel">';
 
-        $scale_data = $this->_scaleDataSet($this->_data);
-        $output .= $this->_prepareDataSet($this->_data, $scale_data, 'svg', '');
+        $scale_data = $this->scaleDataSet($this->_data);
+        $output .= $this->prepareDataSet($this->_data, $scale_data, 'svg', '');
 
         $output .= '</g></svg>';
 
@@ -349,7 +349,7 @@ class GisVisualization
      */
     public function asSVG()
     {
-        return $this->_svg();
+        return $this->svg();
     }
 
     /**
@@ -363,8 +363,8 @@ class GisVisualization
      */
     public function toFileAsSvg($file_name)
     {
-        $img = $this->_svg();
-        $this->_toFile($file_name, 'image/svg+xml', 'svg');
+        $img = $this->svg();
+        $this->writeToFile($file_name, 'image/svg+xml', 'svg');
         echo $img;
     }
 
@@ -375,7 +375,7 @@ class GisVisualization
      *
      * @access private
      */
-    private function _png()
+    private function png()
     {
         $this->init();
 
@@ -396,8 +396,8 @@ class GisVisualization
             $bg
         );
 
-        $scale_data = $this->_scaleDataSet($this->_data);
-        $image = $this->_prepareDataSet($this->_data, $scale_data, 'png', $image);
+        $scale_data = $this->scaleDataSet($this->_data);
+        $image = $this->prepareDataSet($this->_data, $scale_data, 'png', $image);
 
         return $image;
     }
@@ -411,7 +411,7 @@ class GisVisualization
      */
     public function asPng()
     {
-        $img = $this->_png();
+        $img = $this->png();
 
         // render and save it to variable
         ob_start();
@@ -436,8 +436,8 @@ class GisVisualization
      */
     public function toFileAsPng($file_name)
     {
-        $img = $this->_png();
-        $this->_toFile($file_name, 'image/png', 'png');
+        $img = $this->png();
+        $this->writeToFile($file_name, 'image/png', 'png');
         imagepng($img, null, 9, PNG_ALL_FILTERS);
         imagedestroy($img);
     }
@@ -453,7 +453,7 @@ class GisVisualization
     public function asOl()
     {
         $this->init();
-        $scale_data = $this->_scaleDataSet($this->_data);
+        $scale_data = $this->scaleDataSet($this->_data);
         $output
             = 'if (typeof OpenLayers !== "undefined") {'
             . 'var options = {'
@@ -479,7 +479,7 @@ class GisVisualization
             . 'map.addLayers([layerOSM,layerNone]);'
             . 'var vectorLayer = new OpenLayers.Layer.Vector("Data");'
             . 'var bound;';
-        $output .= $this->_prepareDataSet($this->_data, $scale_data, 'ol', '');
+        $output .= $this->prepareDataSet($this->_data, $scale_data, 'ol', '');
         $output .= 'map.addLayer(vectorLayer);'
             . 'map.zoomToExtent(bound);'
             . 'if (map.getZoom() < 2) {'
@@ -525,11 +525,11 @@ class GisVisualization
         // add a page
         $pdf->AddPage();
 
-        $scale_data = $this->_scaleDataSet($this->_data);
-        $pdf = $this->_prepareDataSet($this->_data, $scale_data, 'pdf', $pdf);
+        $scale_data = $this->scaleDataSet($this->_data);
+        $pdf = $this->prepareDataSet($this->_data, $scale_data, 'pdf', $pdf);
 
         // sanitize file name
-        $file_name = $this->_sanitizeName($file_name, 'pdf');
+        $file_name = $this->sanitizeName($file_name, 'pdf');
         $pdf->Output($file_name, 'D');
     }
 
@@ -585,7 +585,7 @@ class GisVisualization
      *
      * @access private
      */
-    private function _scaleDataSet(array $data)
+    private function scaleDataSet(array $data)
     {
         $min_max = [
             'maxX' => 0.0,
@@ -683,7 +683,7 @@ class GisVisualization
      *
      * @access private
      */
-    private function _prepareDataSet(array $data, array $scale_data, $format, $results)
+    private function prepareDataSet(array $data, array $scale_data, $format, $results)
     {
         $color_number = 0;
 

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -139,7 +139,7 @@ class Header
         $this->_warningsEnabled = true;
         $this->_isPrintView = false;
         $this->_scripts = new Scripts();
-        $this->_addDefaultScripts();
+        $this->addDefaultScripts();
         $this->_headerIsSent = false;
         // if database storage for user preferences is transient,
         // offer to load exported settings from localStorage
@@ -157,7 +157,7 @@ class Header
     /**
      * Loads common scripts
      */
-    private function _addDefaultScripts(): void
+    private function addDefaultScripts(): void
     {
         // Localised strings
         $this->_scripts->addFile('vendor/jquery/jquery.min.js');
@@ -384,7 +384,7 @@ class Header
 
         $recentTable = '';
         if (empty($_REQUEST['recent_table'])) {
-            $recentTable = $this->_addRecentTable($db, $table);
+            $recentTable = $this->addRecentTable($db, $table);
         }
 
         if ($this->_isAjax) {
@@ -649,7 +649,7 @@ class Header
      * @param string $db    Database name where the table is located.
      * @param string $table The table name
      */
-    private function _addRecentTable(string $db, string $table): string
+    private function addRecentTable(string $db, string $table): string
     {
         $retval = '';
         if ($this->_menuEnabled

--- a/libraries/classes/Html/Generator.php
+++ b/libraries/classes/Html/Generator.php
@@ -571,7 +571,7 @@ class Generator
      *
      * @return string query resuls
      */
-    private static function _generateRowQueryOutput($sqlQuery): string
+    private static function generateRowQueryOutput($sqlQuery): string
     {
         $ret = '';
         $result = $GLOBALS['dbi']->query($sqlQuery);
@@ -758,7 +758,7 @@ class Generator
                         ) . ']';
                     $url = 'https://mariadb.org/explain_analyzer/analyze/'
                         . '?client=phpMyAdmin&raw_explain='
-                        . urlencode(self::_generateRowQueryOutput($sql_query));
+                        . urlencode(self::generateRowQueryOutput($sql_query));
                     $explain_link .= ' ['
                         . self::linkOrButton(
                             htmlspecialchars('url.php?url=' . urlencode($url)),

--- a/libraries/classes/Index.php
+++ b/libraries/classes/Index.php
@@ -118,7 +118,7 @@ class Index
      */
     public static function singleton($schema, $table, $index_name = '')
     {
-        self::_loadIndexes($table, $schema);
+        self::loadIndexes($table, $schema);
         if (! isset(self::$_registry[$schema][$table][$index_name])) {
             $index = new Index();
             if (strlen($index_name) > 0) {
@@ -142,7 +142,7 @@ class Index
      */
     public static function getFromTable($table, $schema)
     {
-        self::_loadIndexes($table, $schema);
+        self::loadIndexes($table, $schema);
 
         if (isset(self::$_registry[$schema][$table])) {
             return self::$_registry[$schema][$table];
@@ -206,7 +206,7 @@ class Index
      */
     public static function getPrimary($table, $schema)
     {
-        self::_loadIndexes($table, $schema);
+        self::loadIndexes($table, $schema);
 
         if (isset(self::$_registry[$schema][$table]['PRIMARY'])) {
             return self::$_registry[$schema][$table]['PRIMARY'];
@@ -223,7 +223,7 @@ class Index
      *
      * @return bool whether loading was successful
      */
-    private static function _loadIndexes($table, $schema)
+    private static function loadIndexes($table, $schema)
     {
         if (isset(self::$_registry[$schema][$table])) {
             return true;

--- a/libraries/classes/Menu.php
+++ b/libraries/classes/Menu.php
@@ -76,8 +76,8 @@ class Menu
      */
     public function getDisplay()
     {
-        $retval  = $this->_getBreadcrumbs();
-        $retval .= $this->_getMenu();
+        $retval  = $this->getBreadcrumbs();
+        $retval .= $this->getMenu();
 
         return $retval;
     }
@@ -90,7 +90,7 @@ class Menu
     public function getHash()
     {
         return substr(
-            md5($this->_getMenu() . $this->_getBreadcrumbs()),
+            md5($this->getMenu() . $this->getBreadcrumbs()),
             0,
             8
         );
@@ -101,25 +101,25 @@ class Menu
      *
      * @return string HTML formatted menubar
      */
-    private function _getMenu(): string
+    private function getMenu(): string
     {
         $url_params = [];
 
         if (strlen((string) $this->_table) > 0) {
-            $tabs = $this->_getTableTabs();
+            $tabs = $this->getTableTabs();
             $url_params['db'] = $this->_db;
             $url_params['table'] = $this->_table;
             $level = 'table';
         } elseif (strlen($this->_db) > 0) {
-            $tabs = $this->_getDbTabs();
+            $tabs = $this->getDbTabs();
             $url_params['db'] = $this->_db;
             $level = 'db';
         } else {
-            $tabs = $this->_getServerTabs();
+            $tabs = $this->getServerTabs();
             $level = 'server';
         }
 
-        $allowedTabs = $this->_getAllowedTabs($level);
+        $allowedTabs = $this->getAllowedTabs($level);
         foreach ($tabs as $key => $value) {
             if (array_key_exists($key, $allowedTabs)) {
                 continue;
@@ -141,7 +141,7 @@ class Menu
      *
      * @return array list of allowed tabs
      */
-    private function _getAllowedTabs($level)
+    private function getAllowedTabs($level)
     {
         /** @var DatabaseInterface $dbi */
         global $dbi;
@@ -187,7 +187,7 @@ class Menu
      *
      * @return string HTML formatted breadcrumbs
      */
-    private function _getBreadcrumbs(): string
+    private function getBreadcrumbs(): string
     {
         global $cfg, $dbi;
 
@@ -257,7 +257,7 @@ class Menu
      *
      * @return array Data for generating table tabs
      */
-    private function _getTableTabs()
+    private function getTableTabs()
     {
         /** @var DatabaseInterface $dbi */
         global $route, $dbi;
@@ -385,7 +385,7 @@ class Menu
      *
      * @return array Data for generating db tabs
      */
-    private function _getDbTabs()
+    private function getDbTabs()
     {
         /** @var DatabaseInterface $dbi */
         global $route, $dbi;
@@ -509,7 +509,7 @@ class Menu
      *
      * @return array Data for generating server tabs
      */
-    private function _getServerTabs()
+    private function getServerTabs()
     {
         /** @var DatabaseInterface $dbi */
         global $route, $dbi;

--- a/libraries/classes/OutputBuffering.php
+++ b/libraries/classes/OutputBuffering.php
@@ -38,7 +38,7 @@ class OutputBuffering
      */
     private function __construct()
     {
-        $this->_mode = $this->_getMode();
+        $this->_mode = $this->getMode();
         $this->_on = false;
     }
 
@@ -47,7 +47,7 @@ class OutputBuffering
      *
      * @return int the output buffer mode
      */
-    private function _getMode()
+    private function getMode()
     {
         $mode = 0;
         if ($GLOBALS['cfg']['OBGzip'] && function_exists('ob_start')) {

--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -370,7 +370,7 @@ class AuthenticationCookie extends AuthenticationPlugin
 
         $value = $this->cookieDecrypt(
             $serverCookie,
-            $this->_getEncryptionSecret()
+            $this->getEncryptionSecret()
         );
 
         if ($value === false) {
@@ -420,7 +420,7 @@ class AuthenticationCookie extends AuthenticationPlugin
         }
         $value = $this->cookieDecrypt(
             $serverCookie,
-            $this->_getSessionEncryptionSecret()
+            $this->getSessionEncryptionSecret()
         );
         if ($value === false) {
             return false;
@@ -569,7 +569,7 @@ class AuthenticationCookie extends AuthenticationPlugin
             'pmaUser-' . $GLOBALS['server'],
             $this->cookieEncrypt(
                 $username,
-                $this->_getEncryptionSecret()
+                $this->getEncryptionSecret()
             )
         );
     }
@@ -592,7 +592,7 @@ class AuthenticationCookie extends AuthenticationPlugin
             'pmaAuth-' . $GLOBALS['server'],
             $this->cookieEncrypt(
                 json_encode($payload),
-                $this->_getSessionEncryptionSecret()
+                $this->getSessionEncryptionSecret()
             ),
             null,
             (int) $GLOBALS['cfg']['LoginCookieStore']
@@ -637,10 +637,10 @@ class AuthenticationCookie extends AuthenticationPlugin
      *
      * @return string
      */
-    private function _getEncryptionSecret()
+    private function getEncryptionSecret()
     {
         if (empty($GLOBALS['cfg']['blowfish_secret'])) {
-            return $this->_getSessionEncryptionSecret();
+            return $this->getSessionEncryptionSecret();
         }
 
         return $GLOBALS['cfg']['blowfish_secret'];
@@ -651,7 +651,7 @@ class AuthenticationCookie extends AuthenticationPlugin
      *
      * @return string
      */
-    private function _getSessionEncryptionSecret()
+    private function getSessionEncryptionSecret()
     {
         if (empty($_SESSION['encryption_key'])) {
             if ($this->_use_openssl) {

--- a/libraries/classes/Plugins/Export/ExportCodegen.php
+++ b/libraries/classes/Plugins/Export/ExportCodegen.php
@@ -51,7 +51,7 @@ class ExportCodegen extends ExportPlugin
      */
     protected function initSpecificVariables()
     {
-        $this->_setCgFormats([
+        $this->setCgFormats([
             self::HANDLER_NHIBERNATE_CS => 'NHibernate C# DO',
             self::HANDLER_NHIBERNATE_XML => 'NHibernate XML',
         ]);
@@ -86,7 +86,7 @@ class ExportCodegen extends ExportPlugin
             'format',
             __('Format:')
         );
-        $leaf->setValues($this->_getCgFormats());
+        $leaf->setValues($this->getCgFormats());
         $generalOptions->addProperty($leaf);
         // add the main group to the root group
         $exportSpecificOptions->addProperty($generalOptions);
@@ -388,7 +388,7 @@ class ExportCodegen extends ExportPlugin
      *
      * @return array
      */
-    private function _getCgFormats()
+    private function getCgFormats()
     {
         return $this->_cgFormats;
     }
@@ -400,7 +400,7 @@ class ExportCodegen extends ExportPlugin
      *
      * @return void
      */
-    private function _setCgFormats(array $CG_FORMATS)
+    private function setCgFormats(array $CG_FORMATS)
     {
         $this->_cgFormats = $CG_FORMATS;
     }

--- a/libraries/classes/Plugins/Export/ExportMediawiki.php
+++ b/libraries/classes/Plugins/Export/ExportMediawiki.php
@@ -202,25 +202,25 @@ class ExportMediawiki extends ExportPlugin
                 $row_cnt = count($columns);
 
                 // Print structure comment
-                $output = $this->_exportComment(
+                $output = $this->exportComment(
                     'Table structure for '
                     . Util::backquote($table_alias)
                 );
 
                 // Begin the table construction
                 $output .= '{| class="wikitable" style="text-align:center;"'
-                    . $this->_exportCRLF();
+                    . $this->exportCRLF();
 
                 // Add the table name
                 if (isset($GLOBALS['mediawiki_caption'])) {
-                    $output .= "|+'''" . $table_alias . "'''" . $this->_exportCRLF();
+                    $output .= "|+'''" . $table_alias . "'''" . $this->exportCRLF();
                 }
 
                 // Add the table headers
                 if (isset($GLOBALS['mediawiki_headers'])) {
-                    $output .= '|- style="background:#ffdead;"' . $this->_exportCRLF();
+                    $output .= '|- style="background:#ffdead;"' . $this->exportCRLF();
                     $output .= '! style="background:#ffffff" | '
-                    . $this->_exportCRLF();
+                    . $this->exportCRLF();
                     for ($i = 0; $i < $row_cnt; ++$i) {
                         $col_as = $columns[$i]['Field'];
                         if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])
@@ -228,36 +228,36 @@ class ExportMediawiki extends ExportPlugin
                             $col_as
                                 = $aliases[$db]['tables'][$table]['columns'][$col_as];
                         }
-                        $output .= ' | ' . $col_as . $this->_exportCRLF();
+                        $output .= ' | ' . $col_as . $this->exportCRLF();
                     }
                 }
 
                 // Add the table structure
-                $output .= '|-' . $this->_exportCRLF();
-                $output .= '! Type' . $this->_exportCRLF();
+                $output .= '|-' . $this->exportCRLF();
+                $output .= '! Type' . $this->exportCRLF();
                 for ($i = 0; $i < $row_cnt; ++$i) {
-                    $output .= ' | ' . $columns[$i]['Type'] . $this->_exportCRLF();
+                    $output .= ' | ' . $columns[$i]['Type'] . $this->exportCRLF();
                 }
 
-                $output .= '|-' . $this->_exportCRLF();
-                $output .= '! Null' . $this->_exportCRLF();
+                $output .= '|-' . $this->exportCRLF();
+                $output .= '! Null' . $this->exportCRLF();
                 for ($i = 0; $i < $row_cnt; ++$i) {
-                    $output .= ' | ' . $columns[$i]['Null'] . $this->_exportCRLF();
+                    $output .= ' | ' . $columns[$i]['Null'] . $this->exportCRLF();
                 }
 
-                $output .= '|-' . $this->_exportCRLF();
-                $output .= '! Default' . $this->_exportCRLF();
+                $output .= '|-' . $this->exportCRLF();
+                $output .= '! Default' . $this->exportCRLF();
                 for ($i = 0; $i < $row_cnt; ++$i) {
-                    $output .= ' | ' . $columns[$i]['Default'] . $this->_exportCRLF();
+                    $output .= ' | ' . $columns[$i]['Default'] . $this->exportCRLF();
                 }
 
-                $output .= '|-' . $this->_exportCRLF();
-                $output .= '! Extra' . $this->_exportCRLF();
+                $output .= '|-' . $this->exportCRLF();
+                $output .= '! Extra' . $this->exportCRLF();
                 for ($i = 0; $i < $row_cnt; ++$i) {
-                    $output .= ' | ' . $columns[$i]['Extra'] . $this->_exportCRLF();
+                    $output .= ' | ' . $columns[$i]['Extra'] . $this->exportCRLF();
                 }
 
-                $output .= '|}' . str_repeat($this->_exportCRLF(), 2);
+                $output .= '|}' . str_repeat($this->exportCRLF(), 2);
                 break;
         } // end switch
 
@@ -289,7 +289,7 @@ class ExportMediawiki extends ExportPlugin
         $this->initAlias($aliases, $db_alias, $table_alias);
 
         // Print data comment
-        $output = $this->_exportComment(
+        $output = $this->exportComment(
             $table_alias != ''
                 ? 'Table data for ' . Util::backquote($table_alias)
                 : 'Query results'
@@ -299,11 +299,11 @@ class ExportMediawiki extends ExportPlugin
         // Use the "wikitable" class for style
         // Use the "sortable"  class for allowing tables to be sorted by column
         $output .= '{| class="wikitable sortable" style="text-align:center;"'
-            . $this->_exportCRLF();
+            . $this->exportCRLF();
 
         // Add the table name
         if (isset($GLOBALS['mediawiki_caption'])) {
-            $output .= "|+'''" . $table_alias . "'''" . $this->_exportCRLF();
+            $output .= "|+'''" . $table_alias . "'''" . $this->exportCRLF();
         }
 
         // Add the table headers
@@ -314,7 +314,7 @@ class ExportMediawiki extends ExportPlugin
             // Add column names as table headers
             if ($column_names !== null) {
                 // Use '|-' for separating rows
-                $output .= '|-' . $this->_exportCRLF();
+                $output .= '|-' . $this->exportCRLF();
 
                 // Use '!' for separating table headers
                 foreach ($column_names as $column) {
@@ -323,7 +323,7 @@ class ExportMediawiki extends ExportPlugin
                         $column
                             = $aliases[$db]['tables'][$table]['columns'][$column];
                     }
-                    $output .= ' ! ' . $column . '' . $this->_exportCRLF();
+                    $output .= ' ! ' . $column . '' . $this->exportCRLF();
                 }
             }
         }
@@ -337,16 +337,16 @@ class ExportMediawiki extends ExportPlugin
         $fields_cnt = $GLOBALS['dbi']->numFields($result);
 
         while ($row = $GLOBALS['dbi']->fetchRow($result)) {
-            $output .= '|-' . $this->_exportCRLF();
+            $output .= '|-' . $this->exportCRLF();
 
             // Use '|' for separating table columns
             for ($i = 0; $i < $fields_cnt; ++$i) {
-                $output .= ' | ' . $row[$i] . '' . $this->_exportCRLF();
+                $output .= ' | ' . $row[$i] . '' . $this->exportCRLF();
             }
         }
 
         // End table construction
-        $output .= '|}' . str_repeat($this->_exportCRLF(), 2);
+        $output .= '|}' . str_repeat($this->exportCRLF(), 2);
 
         return $this->export->outputHandler($output);
     }
@@ -372,13 +372,13 @@ class ExportMediawiki extends ExportPlugin
      *
      * @return string The formatted comment
      */
-    private function _exportComment($text = '')
+    private function exportComment($text = '')
     {
         // see https://www.mediawiki.org/wiki/Help:Formatting
-        $comment = $this->_exportCRLF();
-        $comment .= '<!--' . $this->_exportCRLF();
-        $comment .= htmlspecialchars($text) . $this->_exportCRLF();
-        $comment .= '-->' . str_repeat($this->_exportCRLF(), 2);
+        $comment = $this->exportCRLF();
+        $comment .= '<!--' . $this->exportCRLF();
+        $comment .= htmlspecialchars($text) . $this->exportCRLF();
+        $comment .= '-->' . str_repeat($this->exportCRLF(), 2);
 
         return $comment;
     }
@@ -388,7 +388,7 @@ class ExportMediawiki extends ExportPlugin
      *
      * @return string CRLF
      */
-    private function _exportCRLF()
+    private function exportCRLF()
     {
         // The CRLF expected by the mediawiki format is "\n"
         return "\n";

--- a/libraries/classes/Plugins/Export/ExportPdf.php
+++ b/libraries/classes/Plugins/Export/ExportPdf.php
@@ -64,9 +64,9 @@ class ExportPdf extends ExportPlugin
     protected function initSpecificVariables()
     {
         if (! empty($_POST['pdf_report_title'])) {
-            $this->_setPdfReportTitle($_POST['pdf_report_title']);
+            $this->setPdfReportTitle($_POST['pdf_report_title']);
         }
-        $this->_setPdf(new Pdf('L', 'pt', 'A3'));
+        $this->setPdf(new Pdf('L', 'pt', 'A3'));
     }
 
     /**
@@ -130,8 +130,8 @@ class ExportPdf extends ExportPlugin
      */
     public function exportHeader()
     {
-        $pdf_report_title = $this->_getPdfReportTitle();
-        $pdf = $this->_getPdf();
+        $pdf_report_title = $this->getPdfReportTitle();
+        $pdf = $this->getPdf();
         $pdf->Open();
 
         $attr = [
@@ -151,7 +151,7 @@ class ExportPdf extends ExportPlugin
      */
     public function exportFooter()
     {
-        $pdf = $this->_getPdf();
+        $pdf = $this->getPdf();
 
         // instead of $pdf->Output():
         return $this->export->outputHandler($pdf->getPDFData());
@@ -219,7 +219,7 @@ class ExportPdf extends ExportPlugin
         $db_alias = $db;
         $table_alias = $table;
         $this->initAlias($aliases, $db_alias, $table_alias);
-        $pdf = $this->_getPdf();
+        $pdf = $this->getPdf();
         $attr = [
             'currentDb'    => $db,
             'currentTable' => $table,
@@ -245,7 +245,7 @@ class ExportPdf extends ExportPlugin
      */
     public function exportRawQuery(string $err_url, string $sql_query, string $crlf): bool
     {
-        $pdf = $this->_getPdf();
+        $pdf = $this->getPdf();
         $attr = [
             'dbAlias'      => '----',
             'tableAlias'   => '----',
@@ -297,7 +297,7 @@ class ExportPdf extends ExportPlugin
         $table_alias = $table;
         $purpose = null;
         $this->initAlias($aliases, $db_alias, $table_alias);
-        $pdf = $this->_getPdf();
+        $pdf = $this->getPdf();
         // getting purpose to show at top
         switch ($export_mode) {
             case 'create_table':
@@ -370,7 +370,7 @@ class ExportPdf extends ExportPlugin
      *
      * @return Pdf
      */
-    private function _getPdf()
+    private function getPdf()
     {
         return $this->_pdf;
     }
@@ -382,7 +382,7 @@ class ExportPdf extends ExportPlugin
      *
      * @return void
      */
-    private function _setPdf($pdf)
+    private function setPdf($pdf)
     {
         $this->_pdf = $pdf;
     }
@@ -392,7 +392,7 @@ class ExportPdf extends ExportPlugin
      *
      * @return string
      */
-    private function _getPdfReportTitle()
+    private function getPdfReportTitle()
     {
         return $this->_pdfReportTitle;
     }
@@ -404,7 +404,7 @@ class ExportPdf extends ExportPlugin
      *
      * @return void
      */
-    private function _setPdfReportTitle($pdfReportTitle)
+    private function setPdfReportTitle($pdfReportTitle)
     {
         $this->_pdfReportTitle = $pdfReportTitle;
     }

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -533,7 +533,7 @@ class ExportSql extends ExportPlugin
      *
      * @return string SQL query
      */
-    protected function _exportRoutineSQL(
+    protected function exportRoutineSQL(
         $db,
         array $aliases,
         $type,
@@ -543,9 +543,9 @@ class ExportSql extends ExportPlugin
     ) {
         global $crlf;
 
-        $text = $this->_exportComment()
-            . $this->_exportComment($name)
-            . $this->_exportComment();
+        $text = $this->exportComment()
+            . $this->exportComment($name)
+            . $this->exportComment();
 
         $used_alias = false;
         $proc_query = '';
@@ -570,13 +570,13 @@ class ExportSql extends ExportPlugin
             $proc_query .= $create_query . $delimiter . $crlf . $crlf;
         }
         if ($used_alias) {
-            $text .= $this->_exportComment(
+            $text .= $this->exportComment(
                 __('It appears your database uses routines;')
             )
-            . $this->_exportComment(
+            . $this->exportComment(
                 __('alias export may not work reliably in all cases.')
             )
-            . $this->_exportComment();
+            . $this->exportComment();
         }
         $text .= $proc_query;
 
@@ -610,7 +610,7 @@ class ExportSql extends ExportPlugin
                 . 'DELIMITER ' . $delimiter . $crlf;
 
             if ($procedure_names) {
-                $text .= $this->_exportRoutineSQL(
+                $text .= $this->exportRoutineSQL(
                     $db,
                     $aliases,
                     'PROCEDURE',
@@ -621,7 +621,7 @@ class ExportSql extends ExportPlugin
             }
 
             if ($function_names) {
-                $text .= $this->_exportRoutineSQL(
+                $text .= $this->exportRoutineSQL(
                     $db,
                     $aliases,
                     'FUNCTION',
@@ -648,7 +648,7 @@ class ExportSql extends ExportPlugin
      *
      * @return string The formatted comment
      */
-    private function _exportComment($text = '')
+    private function exportComment($text = '')
     {
         if (isset($GLOBALS['sql_include_comments'])
             && $GLOBALS['sql_include_comments']
@@ -675,7 +675,7 @@ class ExportSql extends ExportPlugin
      *
      * @return string crlf or nothing
      */
-    private function _possibleCRLF()
+    private function possibleCRLF()
     {
         if (isset($GLOBALS['sql_include_comments'])
             && $GLOBALS['sql_include_comments']
@@ -743,24 +743,24 @@ class ExportSql extends ExportPlugin
             $GLOBALS['dbi']->tryQuery('SET SQL_MODE="' . $tmp_compat . '"');
             unset($tmp_compat);
         }
-        $head = $this->_exportComment('phpMyAdmin SQL Dump')
-            . $this->_exportComment('version ' . PMA_VERSION)
-            . $this->_exportComment('https://www.phpmyadmin.net/')
-            . $this->_exportComment();
+        $head = $this->exportComment('phpMyAdmin SQL Dump')
+            . $this->exportComment('version ' . PMA_VERSION)
+            . $this->exportComment('https://www.phpmyadmin.net/')
+            . $this->exportComment();
         $host_string = __('Host:') . ' ' . $cfg['Server']['host'];
         if (! empty($cfg['Server']['port'])) {
             $host_string .= ':' . $cfg['Server']['port'];
         }
-        $head .= $this->_exportComment($host_string);
-        $head .= $this->_exportComment(
+        $head .= $this->exportComment($host_string);
+        $head .= $this->exportComment(
             __('Generation Time:') . ' '
             . Util::localisedDate()
         )
-        . $this->_exportComment(
+        . $this->exportComment(
             __('Server version:') . ' ' . $GLOBALS['dbi']->getVersionString()
         )
-        . $this->_exportComment(__('PHP Version:') . ' ' . PHP_VERSION)
-        . $this->_possibleCRLF();
+        . $this->exportComment(__('PHP Version:') . ' ' . PHP_VERSION)
+        . $this->possibleCRLF();
 
         if (isset($GLOBALS['sql_header_comment'])
             && ! empty($GLOBALS['sql_header_comment'])
@@ -768,11 +768,11 @@ class ExportSql extends ExportPlugin
             // '\n' is not a newline (like "\n" would be), it's the characters
             // backslash and n, as explained on the export interface
             $lines = explode('\n', $GLOBALS['sql_header_comment']);
-            $head .= $this->_exportComment();
+            $head .= $this->exportComment();
             foreach ($lines as $one_line) {
-                $head .= $this->_exportComment($one_line);
+                $head .= $this->exportComment($one_line);
             }
-            $head .= $this->_exportComment();
+            $head .= $this->exportComment();
         }
 
         if (isset($GLOBALS['sql_disable_fk'])) {
@@ -799,7 +799,7 @@ class ExportSql extends ExportPlugin
             $GLOBALS['dbi']->query('SET time_zone = "+00:00"');
         }
 
-        $head .= $this->_possibleCRLF();
+        $head .= $this->possibleCRLF();
 
         if (! empty($GLOBALS['asfile'])) {
             // we are saving as file, therefore we provide charset information
@@ -891,7 +891,7 @@ class ExportSql extends ExportPlugin
             return false;
         }
 
-        return $this->_exportUseStatement($db_alias, $compat);
+        return $this->exportUseStatement($db_alias, $compat);
     }
 
     /**
@@ -902,7 +902,7 @@ class ExportSql extends ExportPlugin
      *
      * @return bool Whether it succeeded
      */
-    private function _exportUseStatement($db, $compat)
+    private function exportUseStatement($db, $compat)
     {
         global $crlf;
 
@@ -943,8 +943,8 @@ class ExportSql extends ExportPlugin
         } else {
             $compat = 'NONE';
         }
-        $head = $this->_exportComment()
-            . $this->_exportComment(
+        $head = $this->exportComment()
+            . $this->exportComment(
                 __('Database:') . ' '
                 . Util::backquoteCompat(
                     $db_alias,
@@ -952,7 +952,7 @@ class ExportSql extends ExportPlugin
                     isset($GLOBALS['sql_backquotes'])
                 )
             )
-            . $this->_exportComment();
+            . $this->exportComment();
 
         return $this->export->outputHandler($head);
     }
@@ -1013,9 +1013,9 @@ class ExportSql extends ExportPlugin
             $text .= $crlf
                 . 'DELIMITER ' . $delimiter . $crlf;
 
-            $text .= $this->_exportComment()
-                . $this->_exportComment(__('Events'))
-                . $this->_exportComment();
+            $text .= $this->exportComment()
+                . $this->exportComment(__('Events'))
+                . $this->exportComment();
 
             foreach ($event_names as $event_name) {
                 if (! empty($GLOBALS['sql_drop_table'])) {
@@ -1056,16 +1056,16 @@ class ExportSql extends ExportPlugin
             return true;
         }
 
-        $comment = $this->_possibleCRLF()
-            . $this->_possibleCRLF()
-            . $this->_exportComment()
-            . $this->_exportComment(__('Metadata'))
-            . $this->_exportComment();
+        $comment = $this->possibleCRLF()
+            . $this->possibleCRLF()
+            . $this->exportComment()
+            . $this->exportComment(__('Metadata'))
+            . $this->exportComment();
         if (! $this->export->outputHandler($comment)) {
             return false;
         }
 
-        if (! $this->_exportUseStatement(
+        if (! $this->exportUseStatement(
             $cfgRelation['db'],
             $GLOBALS['sql_compatibility']
         )
@@ -1123,18 +1123,18 @@ class ExportSql extends ExportPlugin
 
         $aliases = [];
 
-        $comment = $this->_possibleCRLF()
-            . $this->_exportComment();
+        $comment = $this->possibleCRLF()
+            . $this->exportComment();
 
         if (isset($table)) {
-            $comment .= $this->_exportComment(
+            $comment .= $this->exportComment(
                 sprintf(
                     __('Metadata for table %s'),
                     $table
                 )
             );
         } else {
-            $comment .= $this->_exportComment(
+            $comment .= $this->exportComment(
                 sprintf(
                     __('Metadata for database %s'),
                     $db
@@ -1142,7 +1142,7 @@ class ExportSql extends ExportPlugin
             );
         }
 
-        $comment .= $this->_exportComment();
+        $comment .= $this->exportComment();
 
         if (! $this->export->outputHandler($comment)) {
             return false;
@@ -1321,7 +1321,7 @@ class ExportSql extends ExportPlugin
      *
      * @return string resulting schema
      */
-    private function _getTableDefForView(
+    private function getTableDefForView(
         $db,
         $view,
         $crlf,
@@ -1384,7 +1384,7 @@ class ExportSql extends ExportPlugin
             $compat = 'NONE';
         }
         if ($compat == 'MSSQL') {
-            $create_query = $this->_makeCreateTableMSSQLCompatible(
+            $create_query = $this->makeCreateTableMSSQLCompatible(
                 $create_query
             );
         }
@@ -1466,39 +1466,39 @@ class ExportSql extends ExportPlugin
                     && isset($tmpres['Create_time'])
                     && ! empty($tmpres['Create_time'])
                 ) {
-                    $schema_create .= $this->_exportComment(
+                    $schema_create .= $this->exportComment(
                         __('Creation:') . ' '
                         . Util::localisedDate(
                             strtotime($tmpres['Create_time'])
                         )
                     );
-                    $new_crlf = $this->_exportComment() . $crlf;
+                    $new_crlf = $this->exportComment() . $crlf;
                 }
 
                 if ($show_dates
                     && isset($tmpres['Update_time'])
                     && ! empty($tmpres['Update_time'])
                 ) {
-                    $schema_create .= $this->_exportComment(
+                    $schema_create .= $this->exportComment(
                         __('Last update:') . ' '
                         . Util::localisedDate(
                             strtotime($tmpres['Update_time'])
                         )
                     );
-                    $new_crlf = $this->_exportComment() . $crlf;
+                    $new_crlf = $this->exportComment() . $crlf;
                 }
 
                 if ($show_dates
                     && isset($tmpres['Check_time'])
                     && ! empty($tmpres['Check_time'])
                 ) {
-                    $schema_create .= $this->_exportComment(
+                    $schema_create .= $this->exportComment(
                         __('Last check:') . ' '
                         . Util::localisedDate(
                             strtotime($tmpres['Check_time'])
                         )
                     );
-                    $new_crlf = $this->_exportComment() . $crlf;
+                    $new_crlf = $this->exportComment() . $crlf;
                 }
             }
             $GLOBALS['dbi']->freeResult($result);
@@ -1555,7 +1555,7 @@ class ExportSql extends ExportPlugin
                 trigger_error($message, E_USER_ERROR);
             }
 
-            return $this->_exportComment($message);
+            return $this->exportComment($message);
         }
 
         // Old mode is stored so it can be restored once exporting is done.
@@ -1638,14 +1638,14 @@ class ExportSql extends ExportPlugin
 
             // One warning per view.
             if ($flag && $view) {
-                $warning = $this->_exportComment()
-                    . $this->_exportComment(
+                $warning = $this->exportComment()
+                    . $this->exportComment(
                         __('It appears your database uses views;')
                     )
-                    . $this->_exportComment(
+                    . $this->exportComment(
                         __('alias export may not work reliably in all cases.')
                     )
-                    . $this->_exportComment();
+                    . $this->exportComment();
             }
 
             // Adding IF NOT EXISTS, if required.
@@ -1659,7 +1659,7 @@ class ExportSql extends ExportPlugin
 
             // Making the query MSSQL compatible.
             if ($compat == 'MSSQL') {
-                $create_query = $this->_makeCreateTableMSSQLCompatible(
+                $create_query = $this->makeCreateTableMSSQLCompatible(
                     $create_query
                 );
             }
@@ -1928,7 +1928,7 @@ class ExportSql extends ExportPlugin
      *
      * @return string resulting comments
      */
-    private function _getTableComments(
+    private function getTableComments(
         $db,
         $table,
         $crlf,
@@ -1959,18 +1959,18 @@ class ExportSql extends ExportPlugin
         }
 
         if (isset($mime_map) && count($mime_map) > 0) {
-            $schema_create .= $this->_possibleCRLF()
-                . $this->_exportComment()
-                . $this->_exportComment(
+            $schema_create .= $this->possibleCRLF()
+                . $this->exportComment()
+                . $this->exportComment(
                     __('MEDIA TYPES FOR TABLE') . ' '
                     . Util::backquote($table, $sql_backquotes) . ':'
                 );
             foreach ($mime_map as $mime_field => $mime) {
-                $schema_create .= $this->_exportComment(
+                $schema_create .= $this->exportComment(
                     '  '
                     . Util::backquote($mime_field, $sql_backquotes)
                 )
-                . $this->_exportComment(
+                . $this->exportComment(
                     '      '
                     . Util::backquote(
                         $mime['mimetype'],
@@ -1978,13 +1978,13 @@ class ExportSql extends ExportPlugin
                     )
                 );
             }
-            $schema_create .= $this->_exportComment();
+            $schema_create .= $this->exportComment();
         }
 
         if ($have_rel) {
-            $schema_create .= $this->_possibleCRLF()
-                . $this->_exportComment()
-                . $this->_exportComment(
+            $schema_create .= $this->possibleCRLF()
+                . $this->exportComment()
+                . $this->exportComment(
                     __('RELATIONSHIPS FOR TABLE') . ' '
                     . Util::backquote($table_alias, $sql_backquotes)
                     . ':'
@@ -1996,14 +1996,14 @@ class ExportSql extends ExportPlugin
                         $aliases[$db]['tables'][$table]['columns'][$rel_field]
                     ) ? $aliases[$db]['tables'][$table]['columns'][$rel_field]
                         : $rel_field;
-                    $schema_create .= $this->_exportComment(
+                    $schema_create .= $this->exportComment(
                         '  '
                         . Util::backquote(
                             $rel_field_alias,
                             $sql_backquotes
                         )
                     )
-                    . $this->_exportComment(
+                    . $this->exportComment(
                         '      '
                         . Util::backquote(
                             $rel['foreign_table'],
@@ -2022,14 +2022,14 @@ class ExportSql extends ExportPlugin
                                 $aliases[$db]['tables'][$table]['columns'][$field]
                             ) ? $aliases[$db]['tables'][$table]['columns'][$field]
                                 : $field;
-                            $schema_create .= $this->_exportComment(
+                            $schema_create .= $this->exportComment(
                                 '  '
                                 . Util::backquote(
                                     $rel_field_alias,
                                     $sql_backquotes
                                 )
                             )
-                            . $this->_exportComment(
+                            . $this->exportComment(
                                 '      '
                                 . Util::backquote(
                                     $one_key['ref_table_name'],
@@ -2045,7 +2045,7 @@ class ExportSql extends ExportPlugin
                     }
                 }
             }
-            $schema_create .= $this->_exportComment();
+            $schema_create .= $this->exportComment();
         }
 
         return $schema_create;
@@ -2115,17 +2115,17 @@ class ExportSql extends ExportPlugin
             $compat,
             isset($GLOBALS['sql_backquotes'])
         );
-        $dump = $this->_possibleCRLF()
-            . $this->_exportComment(str_repeat('-', 56))
-            . $this->_possibleCRLF()
-            . $this->_exportComment();
+        $dump = $this->possibleCRLF()
+            . $this->exportComment(str_repeat('-', 56))
+            . $this->possibleCRLF()
+            . $this->exportComment();
 
         switch ($export_mode) {
             case 'create_table':
-                $dump .= $this->_exportComment(
+                $dump .= $this->exportComment(
                     __('Table structure for table') . ' ' . $formatted_table_name
                 );
-                $dump .= $this->_exportComment();
+                $dump .= $this->exportComment();
                 $dump .= $this->getTableDef(
                     $db,
                     $table,
@@ -2137,7 +2137,7 @@ class ExportSql extends ExportPlugin
                     true,
                     $aliases
                 );
-                $dump .= $this->_getTableComments(
+                $dump .= $this->getTableComments(
                     $db,
                     $table,
                     $crlf,
@@ -2151,12 +2151,12 @@ class ExportSql extends ExportPlugin
                 $delimiter = '$$';
                 $triggers = $GLOBALS['dbi']->getTriggers($db, $table, $delimiter);
                 if ($triggers) {
-                    $dump .= $this->_possibleCRLF()
-                    . $this->_exportComment()
-                    . $this->_exportComment(
+                    $dump .= $this->possibleCRLF()
+                    . $this->exportComment()
+                    . $this->exportComment(
                         __('Triggers') . ' ' . $formatted_table_name
                     )
-                        . $this->_exportComment();
+                        . $this->exportComment();
                     $used_alias = false;
                     $trigger_query = '';
                     foreach ($triggers as $trigger) {
@@ -2179,25 +2179,25 @@ class ExportSql extends ExportPlugin
                     }
                     // One warning per table.
                     if ($used_alias) {
-                        $dump .= $this->_exportComment(
+                        $dump .= $this->exportComment(
                             __('It appears your table uses triggers;')
                         )
-                        . $this->_exportComment(
+                        . $this->exportComment(
                             __('alias export may not work reliably in all cases.')
                         )
-                        . $this->_exportComment();
+                        . $this->exportComment();
                     }
                     $dump .= $trigger_query;
                 }
                 break;
             case 'create_view':
                 if (empty($GLOBALS['sql_views_as_tables'])) {
-                    $dump .= $this->_exportComment(
+                    $dump .= $this->exportComment(
                         __('Structure for view')
                         . ' '
                         . $formatted_table_name
                     )
-                    . $this->_exportComment();
+                    . $this->exportComment();
                     // delete the stand-in table previously created (if any)
                     if ($export_type != 'table') {
                         $dump .= 'DROP TABLE IF EXISTS '
@@ -2215,19 +2215,19 @@ class ExportSql extends ExportPlugin
                         $aliases
                     );
                 } else {
-                    $dump .= $this->_exportComment(
+                    $dump .= $this->exportComment(
                         sprintf(
                             __('Structure for view %s exported as a table'),
                             $formatted_table_name
                         )
                     )
-                    . $this->_exportComment();
+                    . $this->exportComment();
                     // delete the stand-in table previously created (if any)
                     if ($export_type != 'table') {
                         $dump .= 'DROP TABLE IF EXISTS '
                         . Util::backquote($table_alias) . ';' . $crlf;
                     }
-                    $dump .= $this->_getTableDefForView(
+                    $dump .= $this->getTableDefForView(
                         $db,
                         $table,
                         $crlf,
@@ -2237,13 +2237,13 @@ class ExportSql extends ExportPlugin
                 }
                 break;
             case 'stand_in':
-                $dump .= $this->_exportComment(
+                $dump .= $this->exportComment(
                     __('Stand-in structure for view') . ' ' . $formatted_table_name
                 )
-                    . $this->_exportComment(
+                    . $this->exportComment(
                         __('(See below for the actual view)')
                     )
-                    . $this->_exportComment();
+                    . $this->exportComment();
                 // export a stand-in definition to resolve view dependencies
                 $dump .= $this->getTableDefStandIn($db, $table, $crlf, $aliases);
         } // end switch
@@ -2303,12 +2303,12 @@ class ExportSql extends ExportPlugin
         if ($GLOBALS['dbi']->getTable($db, $table)->isView()
             && empty($GLOBALS['sql_views_as_tables'])
         ) {
-            $head = $this->_possibleCRLF()
-                . $this->_exportComment()
-                . $this->_exportComment('VIEW ' . $formatted_table_name)
-                . $this->_exportComment(__('Data:') . ' ' . __('None'))
-                . $this->_exportComment()
-                . $this->_possibleCRLF();
+            $head = $this->possibleCRLF()
+                . $this->exportComment()
+                . $this->exportComment('VIEW ' . $formatted_table_name)
+                . $this->exportComment(__('Data:') . ' ' . __('None'))
+                . $this->exportComment()
+                . $this->possibleCRLF();
 
             return $this->export->outputHandler($head);
         }
@@ -2328,7 +2328,7 @@ class ExportSql extends ExportPlugin
             }
 
             return $this->export->outputHandler(
-                $this->_exportComment($message)
+                $this->exportComment($message)
             );
         }
 
@@ -2406,13 +2406,13 @@ class ExportSql extends ExportPlugin
                         $compat,
                         $sql_backquotes
                     ) . ';';
-                $truncatehead = $this->_possibleCRLF()
-                    . $this->_exportComment()
-                    . $this->_exportComment(
+                $truncatehead = $this->possibleCRLF()
+                    . $this->exportComment()
+                    . $this->exportComment(
                         __('Truncate table before insert') . ' '
                         . $formatted_table_name
                     )
-                    . $this->_exportComment()
+                    . $this->exportComment()
                     . $crlf;
                 $this->export->outputHandler($truncatehead);
                 $this->export->outputHandler($truncate);
@@ -2458,13 +2458,13 @@ class ExportSql extends ExportPlugin
 
         while ($row = $GLOBALS['dbi']->fetchRow($result)) {
             if ($current_row == 0) {
-                $head = $this->_possibleCRLF()
-                    . $this->_exportComment()
-                    . $this->_exportComment(
+                $head = $this->possibleCRLF()
+                    . $this->exportComment()
+                    . $this->exportComment(
                         __('Dumping data for table') . ' '
                         . $formatted_table_name
                     )
-                    . $this->_exportComment()
+                    . $this->exportComment()
                     . $crlf;
                 if (! $this->export->outputHandler($head)) {
                     return false;
@@ -2650,7 +2650,7 @@ class ExportSql extends ExportPlugin
      *
      * @return string MSSQL compatible create table statement
      */
-    private function _makeCreateTableMSSQLCompatible($create_query)
+    private function makeCreateTableMSSQLCompatible($create_query)
     {
         // In MSSQL
         // 1. No 'IF NOT EXISTS' in CREATE TABLE
@@ -2972,24 +2972,24 @@ class ExportSql extends ExportPlugin
                 $sql_statement = '';
             } else {
                 $sql_statement = $crlf
-                    . $this->_exportComment()
-                    . $this->_exportComment($comment1)
-                    . $this->_exportComment();
+                    . $this->exportComment()
+                    . $this->exportComment($comment1)
+                    . $this->exportComment();
             }
         }
 
         // comments for current table
         if (! isset($GLOBALS['no_constraints_comments'])) {
             $sql_statement .= $crlf
-                . $this->_exportComment()
-                . $this->_exportComment(
+                . $this->exportComment()
+                . $this->exportComment(
                     $comment2 . ' ' . Util::backquoteCompat(
                         $table_alias,
                         $compat,
                         isset($GLOBALS['sql_backquotes'])
                     )
                 )
-                . $this->_exportComment();
+                . $this->exportComment();
         }
 
         return $sql_statement;

--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -66,12 +66,12 @@ class ExportXml extends ExportPlugin
     protected function initSpecificVariables()
     {
         global $table, $tables;
-        $this->_setTable($table);
+        $this->setTable($table);
         if (! is_array($tables)) {
             return;
         }
 
-        $this->_setTables($tables);
+        $this->setTables($tables);
     }
 
     /**
@@ -177,7 +177,7 @@ class ExportXml extends ExportPlugin
             $dbitype
         );
 
-        return $this->_exportDefinitions($db, $type, $dbitype, $routines);
+        return $this->exportDefinitions($db, $type, $dbitype, $routines);
     }
 
     /**
@@ -190,7 +190,7 @@ class ExportXml extends ExportPlugin
      *
      * @return string XML with definitions
      */
-    private function _exportDefinitions($db, $type, $dbitype, array $names)
+    private function exportDefinitions($db, $type, $dbitype, array $names)
     {
         global $crlf;
 
@@ -224,8 +224,8 @@ class ExportXml extends ExportPlugin
     {
         $this->initSpecificVariables();
         global $crlf, $cfg, $db;
-        $table = $this->_getTable();
-        $tables = $this->_getTables();
+        $table = $this->getTable();
+        $tables = $this->getTables();
 
         $export_struct = isset($GLOBALS['xml_export_functions'])
             || isset($GLOBALS['xml_export_procedures'])
@@ -373,7 +373,7 @@ class ExportXml extends ExportPlugin
                     . "WHERE EVENT_SCHEMA='" . $GLOBALS['dbi']->escapeString($db)
                     . "'"
                 );
-                $head .= $this->_exportDefinitions(
+                $head .= $this->exportDefinitions(
                     $db,
                     'event',
                     'EVENT',
@@ -559,7 +559,7 @@ class ExportXml extends ExportPlugin
      *
      * @return string
      */
-    private function _getTable()
+    private function getTable()
     {
         return $this->_table;
     }
@@ -571,7 +571,7 @@ class ExportXml extends ExportPlugin
      *
      * @return void
      */
-    private function _setTable($table)
+    private function setTable($table)
     {
         $this->_table = $table;
     }
@@ -581,7 +581,7 @@ class ExportXml extends ExportPlugin
      *
      * @return array
      */
-    private function _getTables()
+    private function getTables()
     {
         return $this->_tables;
     }
@@ -593,7 +593,7 @@ class ExportXml extends ExportPlugin
      *
      * @return void
      */
-    private function _setTables(array $tables)
+    private function setTables(array $tables)
     {
         $this->_tables = $tables;
     }

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -57,10 +57,10 @@ class ImportCsv extends AbstractImportCsv
      */
     protected function setProperties()
     {
-        $this->_setAnalyze(false);
+        $this->setAnalyze(false);
 
         if ($GLOBALS['plugin_param'] !== 'table') {
-            $this->_setAnalyze(true);
+            $this->setAnalyze(true);
         }
 
         $generalOptions = parent::setProperties();
@@ -521,7 +521,7 @@ class ImportCsv extends AbstractImportCsv
                     $values[] = '';
                 }
 
-                if ($this->_getAnalyze()) {
+                if ($this->getAnalyze()) {
                     foreach ($values as $val) {
                         $tempRow[] = $val;
                         ++$col_count;
@@ -608,7 +608,7 @@ class ImportCsv extends AbstractImportCsv
             }
         } // End of import loop
 
-        if ($this->_getAnalyze()) {
+        if ($this->getAnalyze()) {
             /* Fill out all rows */
             $num_rows = count($rows);
             for ($i = 0; $i < $num_rows; ++$i) {
@@ -752,7 +752,7 @@ class ImportCsv extends AbstractImportCsv
         $requiredFields = 0;
         $sqlTemplate = '';
         $fields = [];
-        if (! $this->_getAnalyze() && $db !== null && $table !== null) {
+        if (! $this->getAnalyze() && $db !== null && $table !== null) {
             $sqlTemplate = 'INSERT';
             if (isset($_POST['csv_ignore'])) {
                 $sqlTemplate .= ' IGNORE';
@@ -841,7 +841,7 @@ class ImportCsv extends AbstractImportCsv
      *
      * @return bool
      */
-    private function _getAnalyze()
+    private function getAnalyze()
     {
         return $this->_analyze;
     }
@@ -853,7 +853,7 @@ class ImportCsv extends AbstractImportCsv
      *
      * @return void
      */
-    private function _setAnalyze($analyze)
+    private function setAnalyze($analyze)
     {
         $this->_analyze = $analyze;
     }

--- a/libraries/classes/Plugins/Import/ImportMediawiki.php
+++ b/libraries/classes/Plugins/Import/ImportMediawiki.php
@@ -47,9 +47,9 @@ class ImportMediawiki extends ImportPlugin
      */
     protected function setProperties()
     {
-        $this->_setAnalyze(false);
+        $this->setAnalyze(false);
         if ($GLOBALS['plugin_param'] !== 'table') {
-            $this->_setAnalyze(true);
+            $this->setAnalyze(true);
         }
 
         $importPluginProperties = new ImportPluginProperties();
@@ -181,7 +181,7 @@ class ImportMediawiki extends ImportPlugin
                             $inside_data_comment = true;
 
                             $inside_structure_comment
-                                = $this->_mngInsideStructComm(
+                                = $this->mngInsideStructComm(
                                     $inside_structure_comment
                                 );
                         } elseif (preg_match(
@@ -246,7 +246,7 @@ class ImportMediawiki extends ImportPlugin
                         ];
 
                         // Import the current table data into the database
-                        $this->_importDataOneTable($current_table, $sql_data);
+                        $this->importDataOneTable($current_table, $sql_data);
 
                         // Reset table name
                         $cur_table_name = '';
@@ -266,9 +266,9 @@ class ImportMediawiki extends ImportPlugin
                     }
 
                     // Loop through each table cell
-                    $cells = $this->_explodeMarkup($cur_buffer_line);
+                    $cells = $this->explodeMarkup($cur_buffer_line);
                     foreach ($cells as $cell) {
-                        $cell = $this->_getCellData($cell);
+                        $cell = $this->getCellData($cell);
 
                         // Delete the beginning of the column, if there is one
                         $cell = trim($cell);
@@ -277,7 +277,7 @@ class ImportMediawiki extends ImportPlugin
                             '!',
                         ];
                         foreach ($col_start_chars as $col_start_char) {
-                            $cell = $this->_getCellContent($cell, $col_start_char);
+                            $cell = $this->getCellContent($cell, $col_start_char);
                         }
 
                         // Add the cell to the row
@@ -312,15 +312,15 @@ class ImportMediawiki extends ImportPlugin
      *
      * @global bool $analyze whether to scan for column types
      */
-    private function _importDataOneTable(array $table, array &$sql_data)
+    private function importDataOneTable(array $table, array &$sql_data)
     {
-        $analyze = $this->_getAnalyze();
+        $analyze = $this->getAnalyze();
         if ($analyze) {
             // Set the table name
-            $this->_setTableName($table[0]);
+            $this->setTableName($table[0]);
 
             // Set generic names for table headers if they don't exist
-            $this->_setTableHeaders($table[1], $table[2][0]);
+            $this->setTableHeaders($table[1], $table[2][0]);
 
             // Create the tables array to be used in Import::buildSql()
             $tables = [];
@@ -334,7 +334,7 @@ class ImportMediawiki extends ImportPlugin
             $analyses = [];
             $analyses[] = $this->import->analyzeTable($tables[0]);
 
-            $this->_executeImportTables($tables, $analyses, $sql_data);
+            $this->executeImportTables($tables, $analyses, $sql_data);
         }
 
         // Commit any possible data in buffers
@@ -348,7 +348,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @return void
      */
-    private function _setTableName(&$table_name)
+    private function setTableName(&$table_name)
     {
         if (! empty($table_name)) {
             return;
@@ -368,7 +368,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @return void
      */
-    private function _setTableHeaders(array &$table_headers, array $table_row)
+    private function setTableHeaders(array &$table_headers, array $table_row)
     {
         if (! empty($table_headers)) {
             return;
@@ -401,7 +401,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @global string $db      name of the database to import in
      */
-    private function _executeImportTables(array &$tables, array &$analyses, array &$sql_data)
+    private function executeImportTables(array &$tables, array &$analyses, array &$sql_data)
     {
         global $db;
 
@@ -427,7 +427,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @return string with replacements
      */
-    private function _delimiterReplace($replace, $subject)
+    private function delimiterReplace($replace, $subject)
     {
         // String that will be returned
         $cleaned = '';
@@ -512,7 +512,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @return array
      */
-    private function _explodeMarkup($text)
+    private function explodeMarkup($text)
     {
         $separator = '||';
         $placeholder = "\x00";
@@ -522,7 +522,7 @@ class ImportMediawiki extends ImportPlugin
 
         // Replace instances of the separator inside HTML-like
         // tags with the placeholder
-        $cleaned = $this->_delimiterReplace($placeholder, $text);
+        $cleaned = $this->delimiterReplace($placeholder, $text);
         // Explode, then put the replaced separators back in
         $items = explode($separator, $cleaned);
         foreach ($items as $i => $str) {
@@ -539,7 +539,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @return bool
      */
-    private function _getAnalyze()
+    private function getAnalyze()
     {
         return $this->_analyze;
     }
@@ -551,7 +551,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @return void
      */
-    private function _setAnalyze($analyze)
+    private function setAnalyze($analyze)
     {
         $this->_analyze = $analyze;
     }
@@ -563,7 +563,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @return mixed
      */
-    private function _getCellData($cell)
+    private function getCellData($cell)
     {
         // A cell could contain both parameters and data
         $cell_data = explode('|', $cell, 2);
@@ -588,7 +588,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @return bool
      */
-    private function _mngInsideStructComm($inside_structure_comment)
+    private function mngInsideStructComm($inside_structure_comment)
     {
         // End ignoring structure rows
         if ($inside_structure_comment) {
@@ -606,7 +606,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @return string
      */
-    private function _getCellContent($cell, $col_start_char)
+    private function getCellContent($cell, $col_start_char)
     {
         if (mb_strpos($cell, $col_start_char) === 0) {
             $cell = trim(mb_substr($cell, 1));

--- a/libraries/classes/Plugins/Import/ImportSql.php
+++ b/libraries/classes/Plugins/Import/ImportSql.php
@@ -107,7 +107,7 @@ class ImportSql extends ImportPlugin
         global $error, $timeout_passed;
 
         // Handle compatibility options.
-        $this->_setSQLMode($GLOBALS['dbi'], $_REQUEST);
+        $this->setSQLMode($GLOBALS['dbi'], $_REQUEST);
 
         $bq = new BufferedQuery();
         if (isset($_POST['sql_delimiter'])) {
@@ -176,7 +176,7 @@ class ImportSql extends ImportPlugin
      *
      * @return void
      */
-    private function _setSQLMode($dbi, array $request)
+    private function setSQLMode($dbi, array $request)
     {
         $sql_modes = [];
         if (isset($request['sql_compatibility'])

--- a/libraries/classes/Plugins/Schema/Dia/DiaRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/Dia/DiaRelationSchema.php
@@ -98,7 +98,7 @@ class DiaRelationSchema extends ExportRelationSchema
                  */
                 if ($master_field != 'foreign_keys_data') {
                     if (in_array($rel['foreign_table'], $alltables)) {
-                        $this->_addRelation(
+                        $this->addRelation(
                             $one_table,
                             $master_field,
                             $rel['foreign_table'],
@@ -115,7 +115,7 @@ class DiaRelationSchema extends ExportRelationSchema
                     }
 
                     foreach ($one_key['index_list'] as $index => $one_field) {
-                        $this->_addRelation(
+                        $this->addRelation(
                             $one_table,
                             $one_field,
                             $one_key['ref_table_name'],
@@ -126,10 +126,10 @@ class DiaRelationSchema extends ExportRelationSchema
                 }
             }
         }
-        $this->_drawTables();
+        $this->drawTables();
 
         if ($seen_a_relation) {
-            $this->_drawRelations();
+            $this->drawRelations();
         }
         $this->diagram->endDiaDoc();
     }
@@ -161,7 +161,7 @@ class DiaRelationSchema extends ExportRelationSchema
      *
      * @access private
      */
-    private function _addRelation(
+    private function addRelation(
         $masterTable,
         $masterField,
         $foreignTable,
@@ -208,7 +208,7 @@ class DiaRelationSchema extends ExportRelationSchema
      *
      * @access private
      */
-    private function _drawRelations()
+    private function drawRelations()
     {
         foreach ($this->_relations as $relation) {
             $relation->relationDraw($this->showColor);
@@ -227,7 +227,7 @@ class DiaRelationSchema extends ExportRelationSchema
      *
      * @access private
      */
-    private function _drawTables()
+    private function drawTables()
     {
         foreach ($this->_tables as $table) {
             $table->tableDraw($this->showColor);

--- a/libraries/classes/Plugins/Schema/Dia/RelationStatsDia.php
+++ b/libraries/classes/Plugins/Schema/Dia/RelationStatsDia.php
@@ -39,7 +39,7 @@ class RelationStatsDia
     public $referenceColor;
 
     /**
-     * @see Relation_Stats_Dia::_getXy
+     * @see Relation_Stats_Dia::getXy
      *
      * @param Dia           $diagram       The DIA diagram
      * @param TableStatsDia $master_table  The master table name

--- a/libraries/classes/Plugins/Schema/Dia/RelationStatsDia.php
+++ b/libraries/classes/Plugins/Schema/Dia/RelationStatsDia.php
@@ -55,8 +55,8 @@ class RelationStatsDia
         $foreign_field
     ) {
         $this->diagram = $diagram;
-        $src_pos  = $this->_getXy($master_table, $master_field);
-        $dest_pos = $this->_getXy($foreign_table, $foreign_field);
+        $src_pos  = $this->getXy($master_table, $master_field);
+        $dest_pos = $this->getXy($foreign_table, $foreign_field);
         $this->srcConnPointsLeft = $src_pos[0];
         $this->srcConnPointsRight = $src_pos[1];
         $this->destConnPointsLeft = $dest_pos[0];
@@ -81,7 +81,7 @@ class RelationStatsDia
      *
      * @access private
      */
-    private function _getXy($table, $column)
+    private function getXy($table, $column)
     {
         $pos = array_search($column, $table->fields);
         // left, right, position

--- a/libraries/classes/Plugins/Schema/Eps/EpsRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/Eps/EpsRelationSchema.php
@@ -109,7 +109,7 @@ class EpsRelationSchema extends ExportRelationSchema
                 */
                 if ($master_field != 'foreign_keys_data') {
                     if (in_array($rel['foreign_table'], $alltables)) {
-                        $this->_addRelation(
+                        $this->addRelation(
                             $one_table,
                             $this->diagram->getFont(),
                             $this->diagram->getFontSize(),
@@ -128,7 +128,7 @@ class EpsRelationSchema extends ExportRelationSchema
                     }
 
                     foreach ($one_key['index_list'] as $index => $one_field) {
-                        $this->_addRelation(
+                        $this->addRelation(
                             $one_table,
                             $this->diagram->getFont(),
                             $this->diagram->getFontSize(),
@@ -142,10 +142,10 @@ class EpsRelationSchema extends ExportRelationSchema
             }
         }
         if ($seen_a_relation) {
-            $this->_drawRelations();
+            $this->drawRelations();
         }
 
-        $this->_drawTables();
+        $this->drawTables();
         $this->diagram->endEpsDoc();
     }
 
@@ -175,7 +175,7 @@ class EpsRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _addRelation(
+    private function addRelation(
         $masterTable,
         $font,
         $fontSize,
@@ -227,7 +227,7 @@ class EpsRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _drawRelations()
+    private function drawRelations()
     {
         foreach ($this->_relations as $relation) {
             $relation->relationDraw();
@@ -241,7 +241,7 @@ class EpsRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _drawTables()
+    private function drawTables()
     {
         foreach ($this->_tables as $table) {
             $table->tableDraw($this->showColor);

--- a/libraries/classes/Plugins/Schema/Eps/TableStatsEps.php
+++ b/libraries/classes/Plugins/Schema/Eps/TableStatsEps.php
@@ -70,10 +70,10 @@ class TableStatsEps extends TableStats
         );
 
         // height and width
-        $this->_setHeightTable($fontSize);
+        $this->setHeightTable($fontSize);
         // setWidth must me after setHeight, because title
         // can include table height which changes table width
-        $this->_setWidthTable($font, $fontSize);
+        $this->setWidthTable($font, $fontSize);
         if ($same_wide_width >= $this->width) {
             return;
         }
@@ -105,7 +105,7 @@ class TableStatsEps extends TableStats
      *
      * @return void
      */
-    private function _setWidthTable($font, $fontSize)
+    private function setWidthTable($font, $fontSize)
     {
         foreach ($this->fields as $field) {
             $this->width = max(
@@ -139,7 +139,7 @@ class TableStatsEps extends TableStats
      *
      * @return void
      */
-    private function _setHeightTable($fontSize)
+    private function setHeightTable($fontSize)
     {
         $this->heightCell = $fontSize + 4;
         $this->height = (count($this->fields) + 1) * $this->heightCell;

--- a/libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -167,7 +167,7 @@ class PdfRelationSchema extends ExportRelationSchema
             if ($this->sameWide) {
                 $this->_tables[$table]->width = $this->_tablewidth;
             }
-            $this->_setMinMax($this->_tables[$table]);
+            $this->setMinMax($this->_tables[$table]);
         }
 
         // Defines the scale factor
@@ -194,7 +194,7 @@ class PdfRelationSchema extends ExportRelationSchema
 
         if ($this->_showGrid) {
             $this->diagram->SetFontSize(10);
-            $this->_strokeGrid();
+            $this->strokeGrid();
         }
         $this->diagram->setFontSizeScale(14);
         // previous logic was checking master tables and foreign tables
@@ -215,7 +215,7 @@ class PdfRelationSchema extends ExportRelationSchema
                 // to do a === false and this is not PHP3 compatible)
                 if ($master_field != 'foreign_keys_data') {
                     if (in_array($rel['foreign_table'], $alltables)) {
-                        $this->_addRelation(
+                        $this->addRelation(
                             $one_table,
                             $master_field,
                             $rel['foreign_table'],
@@ -231,7 +231,7 @@ class PdfRelationSchema extends ExportRelationSchema
                     }
 
                     foreach ($one_key['index_list'] as $index => $one_field) {
-                        $this->_addRelation(
+                        $this->addRelation(
                             $one_table,
                             $one_field,
                             $one_key['ref_table_name'],
@@ -243,9 +243,9 @@ class PdfRelationSchema extends ExportRelationSchema
         } // end while
 
         if ($seen_a_relation) {
-            $this->_drawRelations();
+            $this->drawRelations();
         }
-        $this->_drawTables();
+        $this->drawTables();
     }
 
     /**
@@ -331,7 +331,7 @@ class PdfRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _setMinMax($table)
+    private function setMinMax($table)
     {
         $this->_xMax = max($this->_xMax, $table->x + $table->width);
         $this->_yMax = max($this->_yMax, $table->y + $table->height);
@@ -342,7 +342,7 @@ class PdfRelationSchema extends ExportRelationSchema
     /**
      * Defines relation objects
      *
-     * @see _setMinMax
+     * @see setMinMax
      *
      * @param string $masterTable  The master table name
      * @param string $masterField  The relation field in the master table
@@ -351,7 +351,7 @@ class PdfRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _addRelation(
+    private function addRelation(
         $masterTable,
         $masterField,
         $foreignTable,
@@ -368,7 +368,7 @@ class PdfRelationSchema extends ExportRelationSchema
                 $this->showKeys,
                 $this->tableDimension
             );
-            $this->_setMinMax($this->_tables[$masterTable]);
+            $this->setMinMax($this->_tables[$masterTable]);
         }
         if (! isset($this->_tables[$foreignTable])) {
             $this->_tables[$foreignTable] = new TableStatsPdf(
@@ -381,7 +381,7 @@ class PdfRelationSchema extends ExportRelationSchema
                 $this->showKeys,
                 $this->tableDimension
             );
-            $this->_setMinMax($this->_tables[$foreignTable]);
+            $this->setMinMax($this->_tables[$foreignTable]);
         }
         $this->relations[] = new RelationStatsPdf(
             $this->diagram,
@@ -399,7 +399,7 @@ class PdfRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _strokeGrid()
+    private function strokeGrid()
     {
         $gridSize = 10;
         $labelHeight = 4;
@@ -460,7 +460,7 @@ class PdfRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _drawRelations()
+    private function drawRelations()
     {
         $i = 0;
         foreach ($this->relations as $relation) {
@@ -476,7 +476,7 @@ class PdfRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _drawTables()
+    private function drawTables()
     {
         foreach ($this->_tables as $table) {
             $table->tableDraw(null, $this->_withDoc, $this->showColor);

--- a/libraries/classes/Plugins/Schema/Pdf/TableStatsPdf.php
+++ b/libraries/classes/Plugins/Schema/Pdf/TableStatsPdf.php
@@ -72,12 +72,12 @@ class TableStatsPdf extends TableStats
         );
 
         $this->heightCell = 6;
-        $this->_setHeight();
+        $this->setHeight();
         /*
          * setWidth must me after setHeight, because title
         * can include table height which changes table width
         */
-        $this->_setWidth($fontSize);
+        $this->setWidth($fontSize);
         if ($sameWideWidth >= $this->width) {
             return;
         }
@@ -126,7 +126,7 @@ class TableStatsPdf extends TableStats
      *
      * @access private
      */
-    private function _setWidth($fontSize)
+    private function setWidth($fontSize)
     {
         foreach ($this->fields as $field) {
             $this->width = max($this->width, $this->diagram->GetStringWidth($field));
@@ -150,7 +150,7 @@ class TableStatsPdf extends TableStats
      *
      * @access private
      */
-    private function _setHeight()
+    private function setHeight()
     {
         $this->height = (count($this->fields) + 1) * $this->heightCell;
     }

--- a/libraries/classes/Plugins/Schema/RelationStats.php
+++ b/libraries/classes/Plugins/Schema/RelationStats.php
@@ -50,8 +50,8 @@ abstract class RelationStats
     ) {
         $this->diagram = $diagram;
 
-        $src_pos = $this->_getXy($master_table, $master_field);
-        $dest_pos = $this->_getXy($foreign_table, $foreign_field);
+        $src_pos = $this->getXy($master_table, $master_field);
+        $dest_pos = $this->getXy($foreign_table, $foreign_field);
         /*
          * [0] is x-left
         * [1] is x-right
@@ -103,7 +103,7 @@ abstract class RelationStats
      *
      * @access private
      */
-    private function _getXy($table, $column)
+    private function getXy($table, $column)
     {
         $pos = array_search($column, $table->fields);
 

--- a/libraries/classes/Plugins/Schema/Svg/SvgRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/Svg/SvgRelationSchema.php
@@ -91,7 +91,7 @@ class SvgRelationSchema extends ExportRelationSchema
             if ($this->sameWide) {
                 $this->_tables[$table]->width = &$this->_tablewidth;
             }
-            $this->_setMinMax($this->_tables[$table]);
+            $this->setMinMax($this->_tables[$table]);
         }
 
         $border = 15;
@@ -118,7 +118,7 @@ class SvgRelationSchema extends ExportRelationSchema
                 */
                 if ($master_field != 'foreign_keys_data') {
                     if (in_array($rel['foreign_table'], $alltables)) {
-                        $this->_addRelation(
+                        $this->addRelation(
                             $one_table,
                             $this->diagram->getFont(),
                             $this->diagram->getFontSize(),
@@ -137,7 +137,7 @@ class SvgRelationSchema extends ExportRelationSchema
                     }
 
                     foreach ($one_key['index_list'] as $index => $one_field) {
-                        $this->_addRelation(
+                        $this->addRelation(
                             $one_table,
                             $this->diagram->getFont(),
                             $this->diagram->getFontSize(),
@@ -151,10 +151,10 @@ class SvgRelationSchema extends ExportRelationSchema
             }
         }
         if ($seen_a_relation) {
-            $this->_drawRelations();
+            $this->drawRelations();
         }
 
-        $this->_drawTables();
+        $this->drawTables();
         $this->diagram->endSvgDoc();
     }
 
@@ -175,7 +175,7 @@ class SvgRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _setMinMax($table)
+    private function setMinMax($table)
     {
         $this->_xMax = max($this->_xMax, $table->x + $table->width);
         $this->_yMax = max($this->_yMax, $table->y + $table->height);
@@ -186,7 +186,7 @@ class SvgRelationSchema extends ExportRelationSchema
     /**
      * Defines relation objects
      *
-     * @see _setMinMax,Table_Stats_Svg::__construct(),
+     * @see setMinMax,Table_Stats_Svg::__construct(),
      *       PhpMyAdmin\Plugins\Schema\Svg\RelationStatsSvg::__construct()
      *
      * @param string $masterTable    The master table name
@@ -199,7 +199,7 @@ class SvgRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _addRelation(
+    private function addRelation(
         $masterTable,
         $font,
         $fontSize,
@@ -220,7 +220,7 @@ class SvgRelationSchema extends ExportRelationSchema
                 false,
                 $tableDimension
             );
-            $this->_setMinMax($this->_tables[$masterTable]);
+            $this->setMinMax($this->_tables[$masterTable]);
         }
         if (! isset($this->_tables[$foreignTable])) {
             $this->_tables[$foreignTable] = new TableStatsSvg(
@@ -234,7 +234,7 @@ class SvgRelationSchema extends ExportRelationSchema
                 false,
                 $tableDimension
             );
-            $this->_setMinMax($this->_tables[$foreignTable]);
+            $this->setMinMax($this->_tables[$foreignTable]);
         }
         $this->_relations[] = new RelationStatsSvg(
             $this->diagram,
@@ -254,7 +254,7 @@ class SvgRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _drawRelations()
+    private function drawRelations()
     {
         foreach ($this->_relations as $relation) {
             $relation->relationDraw($this->showColor);
@@ -268,7 +268,7 @@ class SvgRelationSchema extends ExportRelationSchema
      *
      * @return void
      */
-    private function _drawTables()
+    private function drawTables()
     {
         foreach ($this->_tables as $table) {
             $table->tableDraw($this->showColor);

--- a/libraries/classes/Plugins/Schema/Svg/TableStatsSvg.php
+++ b/libraries/classes/Plugins/Schema/Svg/TableStatsSvg.php
@@ -70,10 +70,10 @@ class TableStatsSvg extends TableStats
         );
 
         // height and width
-        $this->_setHeightTable($fontSize);
+        $this->setHeightTable($fontSize);
         // setWidth must me after setHeight, because title
         // can include table height which changes table width
-        $this->_setWidthTable($font, $fontSize);
+        $this->setWidthTable($font, $fontSize);
         if ($same_wide_width >= $this->width) {
             return;
         }
@@ -107,7 +107,7 @@ class TableStatsSvg extends TableStats
      *
      * @access private
      */
-    private function _setWidthTable($font, $fontSize): void
+    private function setWidthTable($font, $fontSize): void
     {
         foreach ($this->fields as $field) {
             $this->width = max(
@@ -135,7 +135,7 @@ class TableStatsSvg extends TableStats
      *
      * @return void
      */
-    private function _setHeightTable($fontSize): void
+    private function setHeightTable($fontSize): void
     {
         $this->heightCell = $fontSize + 4;
         $this->height = (count($this->fields) + 1) * $this->heightCell;

--- a/libraries/classes/RecentFavoriteTable.php
+++ b/libraries/classes/RecentFavoriteTable.php
@@ -72,7 +72,7 @@ class RecentFavoriteTable
         if (! isset($_SESSION['tmpval'][$this->_tableType . 'Tables'][$server_id])
         ) {
             $_SESSION['tmpval'][$this->_tableType . 'Tables'][$server_id]
-                = $this->_getPmaTable() ? $this->getFromDb() : [];
+                = $this->getPmaTable() ? $this->getFromDb() : [];
         }
         $this->_tables
             =& $_SESSION['tmpval'][$this->_tableType . 'Tables'][$server_id];
@@ -113,7 +113,7 @@ class RecentFavoriteTable
     {
         // Read from phpMyAdmin database, if recent tables is not in session
         $sql_query
-            = ' SELECT `tables` FROM ' . $this->_getPmaTable() .
+            = ' SELECT `tables` FROM ' . $this->getPmaTable() .
             " WHERE `username` = '" . $GLOBALS['dbi']->escapeString($GLOBALS['cfg']['Server']['user']) . "'";
 
         $return = [];
@@ -137,7 +137,7 @@ class RecentFavoriteTable
     {
         $username = $GLOBALS['cfg']['Server']['user'];
         $sql_query
-            = ' REPLACE INTO ' . $this->_getPmaTable() . ' (`username`, `tables`)' .
+            = ' REPLACE INTO ' . $this->getPmaTable() . ' (`username`, `tables`)' .
                 " VALUES ('" . $GLOBALS['dbi']->escapeString($username) . "', '"
                 . $GLOBALS['dbi']->escapeString(
                     json_encode($this->_tables)
@@ -298,7 +298,7 @@ class RecentFavoriteTable
             array_unshift($this->_tables, $table_arr);
             $this->_tables = array_merge(array_unique($this->_tables, SORT_REGULAR));
             $this->trim();
-            if ($this->_getPmaTable()) {
+            if ($this->getPmaTable()) {
                 return $this->saveToDb();
             }
         }
@@ -348,7 +348,7 @@ class RecentFavoriteTable
 
             unset($this->_tables[$key]);
         }
-        if ($this->_getPmaTable()) {
+        if ($this->getPmaTable()) {
             return $this->saveToDb();
         }
 
@@ -404,7 +404,7 @@ class RecentFavoriteTable
      *
      * @return string|null pma table name
      */
-    private function _getPmaTable(): ?string
+    private function getPmaTable(): ?string
     {
         $cfgRelation = $this->relation->getRelationsParam();
         if (! $cfgRelation['recentwork']) {

--- a/libraries/classes/Response.php
+++ b/libraries/classes/Response.php
@@ -364,7 +364,7 @@ class Response
      */
     private function _htmlResponse()
     {
-        echo $this->_getDisplay();
+        echo $this->getDisplay();
     }
 
     /**
@@ -376,13 +376,13 @@ class Response
     {
         /* Avoid wrapping in case we're disabled */
         if ($this->_isDisabled) {
-            echo $this->_getDisplay();
+            echo $this->getDisplay();
 
             return;
         }
 
         if (! isset($this->_JSON['message'])) {
-            $this->_JSON['message'] = $this->_getDisplay();
+            $this->_JSON['message'] = $this->getDisplay();
         } elseif ($this->_JSON['message'] instanceof Message) {
             $this->_JSON['message'] = $this->_JSON['message']->getDisplay();
         }
@@ -521,9 +521,9 @@ class Response
             $this->_HTML = $buffer->getContents();
         }
         if ($this->isAjax()) {
-            $this->_ajaxResponse();
+            $this->ajaxResponse();
         } else {
-            $this->_htmlResponse();
+            $this->htmlResponse();
         }
         $buffer->flush();
         exit;

--- a/libraries/classes/Response.php
+++ b/libraries/classes/Response.php
@@ -344,7 +344,7 @@ class Response
      *
      * @return string
      */
-    private function _getDisplay()
+    private function getDisplay()
     {
         // The header may contain nothing at all,
         // if its content was already rendered
@@ -362,7 +362,7 @@ class Response
      *
      * @return void
      */
-    private function _htmlResponse()
+    private function htmlResponse()
     {
         echo $this->getDisplay();
     }
@@ -372,7 +372,7 @@ class Response
      *
      * @return void
      */
-    private function _ajaxResponse()
+    private function ajaxResponse()
     {
         /* Avoid wrapping in case we're disabled */
         if ($this->_isDisabled) {

--- a/libraries/classes/Scripts.php
+++ b/libraries/classes/Scripts.php
@@ -63,7 +63,7 @@ class Scripts
             return;
         }
 
-        $has_onload = $this->_eventBlacklist($filename);
+        $has_onload = $this->eventBlacklist($filename);
         $this->_files[$hash] = [
             'has_onload' => $has_onload,
             'filename' => $filename,
@@ -93,7 +93,7 @@ class Scripts
      *
      * @return int 1 to fire up the event, 0 not to
      */
-    private function _eventBlacklist($filename)
+    private function eventBlacklist($filename)
     {
         if (strpos($filename, 'jquery') !== false
             || strpos($filename, 'codemirror') !== false

--- a/libraries/classes/Server/Status/Data.php
+++ b/libraries/classes/Server/Status/Data.php
@@ -55,7 +55,7 @@ class Data
      *
      * @return array
      */
-    private function _getAllocations()
+    private function getAllocations()
     {
         return [
             // variable name => section
@@ -109,7 +109,7 @@ class Data
      *
      * @return array
      */
-    private function _getSections()
+    private function getSections()
     {
         return [
             // section => section name (description)
@@ -140,7 +140,7 @@ class Data
      *
      * @return array
      */
-    private function _getLinks()
+    private function getLinks()
     {
         $links = [];
         // variable or section name => (name => url)
@@ -214,7 +214,7 @@ class Data
      *
      * @return array
      */
-    private function _calculateValues(array $server_status, array $server_variables)
+    private function calculateValues(array $server_status, array $server_variables)
     {
         // Key_buffer_fraction
         if (isset($server_status['Key_blocks_unused'], $server_variables['key_cache_block_size'])
@@ -278,7 +278,7 @@ class Data
      *
      * @return array ($allocationMap, $sectionUsed, $used_queries)
      */
-    private function _sortVariables(
+    private function sortVariables(
         array $server_status,
         array $allocations,
         array $allocationMap,
@@ -349,18 +349,18 @@ class Data
         $server_status = self::cleanDeprecated($server_status);
 
         // calculate some values
-        $server_status = $this->_calculateValues(
+        $server_status = $this->calculateValues(
             $server_status,
             $server_variables
         );
 
         // split variables in sections
-        $allocations = $this->_getAllocations();
+        $allocations = $this->getAllocations();
 
-        $sections = $this->_getSections();
+        $sections = $this->getSections();
 
         // define some needful links/commands
-        $links = $this->_getLinks();
+        $links = $this->getLinks();
 
         // Variable to contain all com_ variables (query statistics)
         $used_queries = [];
@@ -377,7 +377,7 @@ class Data
             $allocationMap,
             $sectionUsed,
             $used_queries,
-        ] = $this->_sortVariables(
+        ] = $this->sortVariables(
             $server_status,
             $allocations,
             $allocationMap,

--- a/libraries/classes/Server/SysInfo/SunOs.php
+++ b/libraries/classes/Server/SysInfo/SunOs.php
@@ -28,7 +28,7 @@ class SunOs extends Base
      *
      * @return string with value
      */
-    private function _kstat($key)
+    private function kstat($key)
     {
         $m = shell_exec('kstat -p d ' . $key);
 
@@ -48,7 +48,7 @@ class SunOs extends Base
      */
     public function loadavg()
     {
-        $load1 = $this->_kstat('unix:0:system_misc:avenrun_1min');
+        $load1 = $this->kstat('unix:0:system_misc:avenrun_1min');
 
         return ['loadavg' => $load1];
     }
@@ -70,14 +70,14 @@ class SunOs extends Base
      */
     public function memory()
     {
-        $pagesize = (int) $this->_kstat('unix:0:seg_cache:slab_size');
+        $pagesize = (int) $this->kstat('unix:0:seg_cache:slab_size');
         $mem = [];
-        $mem['MemTotal'] = (int) $this->_kstat('unix:0:system_pages:pagestotal') * $pagesize;
-        $mem['MemUsed'] = (int) $this->_kstat('unix:0:system_pages:pageslocked') * $pagesize;
-        $mem['MemFree'] = (int) $this->_kstat('unix:0:system_pages:pagesfree') * $pagesize;
-        $mem['SwapTotal'] = (int) $this->_kstat('unix:0:vminfo:swap_avail') / 1024;
-        $mem['SwapUsed'] = (int) $this->_kstat('unix:0:vminfo:swap_alloc') / 1024;
-        $mem['SwapFree'] = (int) $this->_kstat('unix:0:vminfo:swap_free') / 1024;
+        $mem['MemTotal'] = (int) $this->kstat('unix:0:system_pages:pagestotal') * $pagesize;
+        $mem['MemUsed'] = (int) $this->kstat('unix:0:system_pages:pageslocked') * $pagesize;
+        $mem['MemFree'] = (int) $this->kstat('unix:0:system_pages:pagesfree') * $pagesize;
+        $mem['SwapTotal'] = (int) $this->kstat('unix:0:vminfo:swap_avail') / 1024;
+        $mem['SwapUsed'] = (int) $this->kstat('unix:0:vminfo:swap_alloc') / 1024;
+        $mem['SwapFree'] = (int) $this->kstat('unix:0:vminfo:swap_free') / 1024;
 
         return $mem;
     }

--- a/libraries/classes/Server/SysInfo/WindowsNt.php
+++ b/libraries/classes/Server/SysInfo/WindowsNt.php
@@ -48,7 +48,7 @@ class WindowsNt extends Base
     public function loadavg()
     {
         $sum = 0;
-        $buffer = $this->_getWMI('Win32_Processor', ['LoadPercentage']);
+        $buffer = $this->getWMI('Win32_Processor', ['LoadPercentage']);
 
         foreach ($buffer as $load) {
             $value = $load['LoadPercentage'];
@@ -76,7 +76,7 @@ class WindowsNt extends Base
      *
      * @return array with results
      */
-    private function _getWMI($strClass, array $strValue = [])
+    private function getWMI($strClass, array $strValue = [])
     {
         $arrData = [];
 
@@ -111,7 +111,7 @@ class WindowsNt extends Base
      */
     public function memory()
     {
-        $buffer = $this->_getWMI(
+        $buffer = $this->getWMI(
             'Win32_OperatingSystem',
             [
                 'TotalVisibleMemorySize',
@@ -123,7 +123,7 @@ class WindowsNt extends Base
         $mem['MemFree'] = $buffer[0]['FreePhysicalMemory'];
         $mem['MemUsed'] = $mem['MemTotal'] - $mem['MemFree'];
 
-        $buffer = $this->_getWMI('Win32_PageFileUsage');
+        $buffer = $this->getWMI('Win32_PageFileUsage');
 
         $mem['SwapTotal'] = 0;
         $mem['SwapUsed'] = 0;

--- a/libraries/classes/Setup/ConfigGenerator.php
+++ b/libraries/classes/Setup/ConfigGenerator.php
@@ -59,7 +59,7 @@ class ConfigGenerator
 
         foreach ($conf as $k => $v) {
             $k = preg_replace('/[^A-Za-z0-9_]/', '_', $k);
-            $ret .= self::_getVarExport($k, $v, $crlf);
+            $ret .= self::getVarExport($k, $v, $crlf);
             if (! isset($persistKeys[$k])) {
                 continue;
             }
@@ -73,7 +73,7 @@ class ConfigGenerator
             }
 
             $k = preg_replace('/[^A-Za-z0-9_]/', '_', $k);
-            $ret .= self::_getVarExport($k, $cf->getDefault($k), $crlf);
+            $ret .= self::getVarExport($k, $cf->getDefault($k), $crlf);
         }
 
         return $ret . '?>';
@@ -88,16 +88,16 @@ class ConfigGenerator
      *
      * @return string
      */
-    private static function _getVarExport($var_name, $var_value, $crlf)
+    private static function getVarExport($var_name, $var_value, $crlf)
     {
         if (! is_array($var_value) || empty($var_value)) {
             return "\$cfg['" . $var_name . "'] = "
                 . var_export($var_value, true) . ';' . $crlf;
         }
         $ret = '';
-        if (self::_isZeroBasedArray($var_value)) {
+        if (self::isZeroBasedArray($var_value)) {
             $ret = "\$cfg['" . $var_name . "'] = "
-                . self::_exportZeroBasedArray($var_value, $crlf)
+                . self::exportZeroBasedArray($var_value, $crlf)
                 . ';' . $crlf;
         } else {
             // string keys: $cfg[key][subkey] = value
@@ -118,7 +118,7 @@ class ConfigGenerator
      *
      * @return bool
      */
-    private static function _isZeroBasedArray(array $array)
+    private static function isZeroBasedArray(array $array)
     {
         for ($i = 0, $nb = count($array); $i < $nb; $i++) {
             if (! isset($array[$i])) {
@@ -137,7 +137,7 @@ class ConfigGenerator
      *
      * @return string
      */
-    private static function _exportZeroBasedArray(array $array, $crlf)
+    private static function exportZeroBasedArray(array $array, $crlf)
     {
         $retv = [];
         foreach ($array as $v) {
@@ -182,8 +182,8 @@ class ConfigGenerator
             foreach ($server as $k => $v) {
                 $k = preg_replace('/[^A-Za-z0-9_]/', '_', $k);
                 $ret .= "\$cfg['Servers'][\$i]['" . $k . "'] = "
-                    . (is_array($v) && self::_isZeroBasedArray($v)
-                        ? self::_exportZeroBasedArray($v, $crlf)
+                    . (is_array($v) && self::isZeroBasedArray($v)
+                        ? self::exportZeroBasedArray($v, $crlf)
                         : var_export($v, true))
                     . ';' . $crlf;
             }

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -1745,7 +1745,7 @@ class Table
      *
      * @return array
      */
-    private function _formatColumns(array $indexed, $backquoted, $fullName)
+    private function formatColumns(array $indexed, $backquoted, $fullName)
     {
         $return = [];
         foreach ($indexed as $column) {
@@ -1777,7 +1777,7 @@ class Table
         );
         $indexed = $this->_dbi->fetchResult($sql, 'Column_name', 'Column_name');
 
-        return $this->_formatColumns($indexed, $backquoted, $fullName);
+        return $this->formatColumns($indexed, $backquoted, $fullName);
     }
 
     /**
@@ -1795,7 +1795,7 @@ class Table
         $sql = 'SHOW COLUMNS FROM ' . $this->getFullName(true);
         $indexed = $this->_dbi->fetchResult($sql, 'Field', 'Field');
 
-        return $this->_formatColumns($indexed, $backquoted, $fullName);
+        return $this->formatColumns($indexed, $backquoted, $fullName);
     }
 
     /**
@@ -2581,7 +2581,7 @@ class Table
                 continue;
             }
 
-            $create_query = $this->_getSQLToCreateForeignKey(
+            $create_query = $this->getSQLToCreateForeignKey(
                 $table,
                 $master_field,
                 $foreign_db,
@@ -2635,7 +2635,7 @@ class Table
 
             // a rollback may be better here
             $sql_query_recreate = '# Restoring the dropped constraint...' . "\n";
-            $sql_query_recreate .= $this->_getSQLToCreateForeignKey(
+            $sql_query_recreate .= $this->getSQLToCreateForeignKey(
                 $table,
                 $master_field,
                 $existrel_foreign[$master_field_md5]['ref_db_name'],
@@ -2675,7 +2675,7 @@ class Table
      *
      * @return string SQL query for foreign key constraint creation
      */
-    private function _getSQLToCreateForeignKey(
+    private function getSQLToCreateForeignKey(
         $table,
         array $field,
         $foreignDb,

--- a/libraries/classes/ThemeManager.php
+++ b/libraries/classes/ThemeManager.php
@@ -134,7 +134,7 @@ class ThemeManager
      */
     public function setThemesPath($path)
     {
-        if (! $this->_checkThemeFolder($path)) {
+        if (! $this->checkThemeFolder($path)) {
             return false;
         }
 
@@ -255,7 +255,7 @@ class ThemeManager
      *
      * @access private
      */
-    private function _checkThemeFolder($folder)
+    private function checkThemeFolder($folder)
     {
         if (! is_dir($folder)) {
             trigger_error(

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -91,7 +91,7 @@ class Tracker
             return false;
         }
 
-        $pma_table = self::_getTrackingTable();
+        $pma_table = self::getTrackingTable();
 
         return $pma_table !== null;
     }
@@ -154,7 +154,7 @@ class Tracker
             return false;
         }
 
-        $sql_query = ' SELECT tracking_active FROM ' . self::_getTrackingTable() .
+        $sql_query = ' SELECT tracking_active FROM ' . self::getTrackingTable() .
         " WHERE db_name = '" . $GLOBALS['dbi']->escapeString($dbname) . "' " .
         " AND table_name = '" . $GLOBALS['dbi']->escapeString($tablename) . "' " .
         ' ORDER BY version DESC LIMIT 1';
@@ -271,7 +271,7 @@ class Tracker
         // Save version
 
         $sql_query = "/*NOTRACK*/\n" .
-        'INSERT INTO ' . self::_getTrackingTable() . ' (' .
+        'INSERT INTO ' . self::getTrackingTable() . ' (' .
         'db_name, ' .
         'table_name, ' .
         'version, ' .
@@ -320,7 +320,7 @@ class Tracker
         $relation = new Relation($GLOBALS['dbi']);
 
         $sql_query = "/*NOTRACK*/\n"
-            . 'DELETE FROM ' . self::_getTrackingTable()
+            . 'DELETE FROM ' . self::getTrackingTable()
             . " WHERE `db_name` = '"
             . $GLOBALS['dbi']->escapeString($dbname) . "'"
             . " AND `table_name` = '"
@@ -372,7 +372,7 @@ class Tracker
 
         // Save version
         $sql_query = "/*NOTRACK*/\n" .
-        'INSERT INTO ' . self::_getTrackingTable() . ' (' .
+        'INSERT INTO ' . self::getTrackingTable() . ' (' .
         'db_name, ' .
         'table_name, ' .
         'version, ' .
@@ -410,7 +410,7 @@ class Tracker
      *
      * @static
      */
-    private static function _changeTracking(
+    private static function changeTracking(
         $dbname,
         $tablename,
         $version,
@@ -418,7 +418,7 @@ class Tracker
     ) {
         $relation = new Relation($GLOBALS['dbi']);
 
-        $sql_query = ' UPDATE ' . self::_getTrackingTable() .
+        $sql_query = ' UPDATE ' . self::getTrackingTable() .
         " SET `tracking_active` = '" . $new_state . "' " .
         " WHERE `db_name` = '" . $GLOBALS['dbi']->escapeString($dbname) . "' " .
         " AND `table_name` = '" . $GLOBALS['dbi']->escapeString($tablename) . "' " .
@@ -468,7 +468,7 @@ class Tracker
             $new_data_processed = $new_data;
         }
 
-        $sql_query = ' UPDATE ' . self::_getTrackingTable() .
+        $sql_query = ' UPDATE ' . self::getTrackingTable() .
         ' SET `' . $save_to . "` = '" . $new_data_processed . "' " .
         " WHERE `db_name` = '" . $GLOBALS['dbi']->escapeString($dbname) . "' " .
         " AND `table_name` = '" . $GLOBALS['dbi']->escapeString($tablename) . "' " .
@@ -492,7 +492,7 @@ class Tracker
      */
     public static function activateTracking($dbname, $tablename, $version)
     {
-        return self::_changeTracking($dbname, $tablename, $version, 1);
+        return self::changeTracking($dbname, $tablename, $version, 1);
     }
 
     /**
@@ -508,7 +508,7 @@ class Tracker
      */
     public static function deactivateTracking($dbname, $tablename, $version)
     {
-        return self::_changeTracking($dbname, $tablename, $version, 0);
+        return self::changeTracking($dbname, $tablename, $version, 0);
     }
 
     /**
@@ -527,7 +527,7 @@ class Tracker
     {
         $relation = new Relation($GLOBALS['dbi']);
 
-        $sql_query = ' SELECT MAX(version) FROM ' . self::_getTrackingTable() .
+        $sql_query = ' SELECT MAX(version) FROM ' . self::getTrackingTable() .
         " WHERE `db_name` = '" . $GLOBALS['dbi']->escapeString($dbname) . "' " .
         " AND `table_name` = '" . $GLOBALS['dbi']->escapeString($tablename) . "' ";
 
@@ -556,7 +556,7 @@ class Tracker
     {
         $relation = new Relation($GLOBALS['dbi']);
 
-        $sql_query = ' SELECT * FROM ' . self::_getTrackingTable() .
+        $sql_query = ' SELECT * FROM ' . self::getTrackingTable() .
             " WHERE `db_name` = '" . $GLOBALS['dbi']->escapeString($dbname) . "' ";
         if (! empty($tablename)) {
             $sql_query .= " AND `table_name` = '"
@@ -908,7 +908,7 @@ class Tracker
 
         // Mark it as untouchable
         $sql_query = " /*NOTRACK*/\n"
-            . ' UPDATE ' . self::_getTrackingTable()
+            . ' UPDATE ' . self::getTrackingTable()
             . ' SET ' . Util::backquote($save_to)
             . ' = CONCAT( ' . Util::backquote($save_to) . ",'\n"
             . $GLOBALS['dbi']->escapeString($query) . "') ,"
@@ -942,7 +942,7 @@ class Tracker
      *
      * @return string tracking table
      */
-    private static function _getTrackingTable()
+    private static function getTrackingTable()
     {
         $relation = new Relation($GLOBALS['dbi']);
         $cfgRelation = $relation->getRelationsParam();

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -278,7 +278,7 @@ class Util
      *
      * @return int the possibly modified row count
      */
-    private static function _checkRowCount($db, array $table)
+    private static function checkRowCount($db, array $table)
     {
         $rowCount = 0;
 
@@ -349,7 +349,7 @@ class Util
         $table_groups = [];
 
         foreach ($tables as $table_name => $table) {
-            $table['Rows'] = self::_checkRowCount($db, $table);
+            $table['Rows'] = self::checkRowCount($db, $table);
 
             // in $group we save the reference to the place in $table_groups
             // where to store the table info

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -196,7 +196,7 @@ parameters:
 			path: libraries/classes/Config/FormDisplay.php
 
 		-
-			message: "#^Parameter \\#4 \\$workPath of method PhpMyAdmin\\\\Config\\\\FormDisplay\\:\\:_displayFieldInput\\(\\) expects string, int\\|string\\|false given\\.$#"
+			message: "#^Parameter \\#4 \\$workPath of method PhpMyAdmin\\\\Config\\\\FormDisplay\\:\\:displayFieldInput\\(\\) expects string, int\\|string\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Config/FormDisplay.php
 
@@ -861,12 +861,12 @@ parameters:
 			path: libraries/classes/Database/Qbe.php
 
 		-
-			message: "#^Parameter \\#2 \\$sortOrder of method PhpMyAdmin\\\\Database\\\\Qbe\\:\\:_getSortOrderSelectCell\\(\\) expects int, null given\\.$#"
+			message: "#^Parameter \\#2 \\$sortOrder of method PhpMyAdmin\\\\Database\\\\Qbe\\:\\:getSortOrderSelectCell\\(\\) expects int, null given\\.$#"
 			count: 1
 			path: libraries/classes/Database/Qbe.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Database\\\\Qbe\\:\\:_getMasterTable\\(\\) should return string but returns int\\|string\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Database\\\\Qbe\\:\\:getMasterTable\\(\\) should return string but returns int\\|string\\.$#"
 			count: 1
 			path: libraries/classes/Database/Qbe.php
 
@@ -1481,7 +1481,7 @@ parameters:
 			path: libraries/classes/Footer.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Footer\\:\\:_removeRecursion\\(\\) should return object but returns array\\|object\\|string\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Footer\\:\\:removeRecursion\\(\\) should return object but returns array\\|object\\|string\\.$#"
 			count: 1
 			path: libraries/classes/Footer.php
 
@@ -1916,7 +1916,7 @@ parameters:
 			path: libraries/classes/Linter.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Menu\\:\\:_getAllowedTabs\\(\\) should return array but returns array\\|null\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Menu\\:\\:getAllowedTabs\\(\\) should return array but returns array\\|null\\.$#"
 			count: 1
 			path: libraries/classes/Menu.php
 
@@ -2216,7 +2216,7 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
-			message: "#^Parameter \\#1 \\$create_query of method PhpMyAdmin\\\\Plugins\\\\Export\\\\ExportSql\\:\\:_makeCreateTableMSSQLCompatible\\(\\) expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$create_query of method PhpMyAdmin\\\\Plugins\\\\Export\\\\ExportSql\\:\\:makeCreateTableMSSQLCompatible\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
@@ -2256,7 +2256,7 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Export\\\\ExportSql\\:\\:_makeCreateTableMSSQLCompatible\\(\\) should return string but returns string\\|null\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Export\\\\ExportSql\\:\\:makeCreateTableMSSQLCompatible\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
@@ -2591,7 +2591,7 @@ parameters:
 			path: libraries/classes/Plugins/Schema/Dia/DiaRelationSchema.php
 
 		-
-			message: "#^Parameter \\#2 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Dia\\\\DiaRelationSchema\\:\\:_addRelation\\(\\) expects string, int\\|string given\\.$#"
+			message: "#^Parameter \\#2 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Dia\\\\DiaRelationSchema\\:\\:addRelation\\(\\) expects string, int\\|string given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Schema/Dia/DiaRelationSchema.php
 
@@ -2691,7 +2691,7 @@ parameters:
 			path: libraries/classes/Plugins/Schema/Eps/EpsRelationSchema.php
 
 		-
-			message: "#^Parameter \\#4 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Eps\\\\EpsRelationSchema\\:\\:_addRelation\\(\\) expects string, int\\|string given\\.$#"
+			message: "#^Parameter \\#4 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Eps\\\\EpsRelationSchema\\:\\:addRelation\\(\\) expects string, int\\|string given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Schema/Eps/EpsRelationSchema.php
 
@@ -2901,7 +2901,7 @@ parameters:
 			path: libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
 
 		-
-			message: "#^Parameter \\#2 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Pdf\\\\PdfRelationSchema\\:\\:_addRelation\\(\\) expects string, int\\|string given\\.$#"
+			message: "#^Parameter \\#2 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Pdf\\\\PdfRelationSchema\\:\\:addRelation\\(\\) expects string, int\\|string given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
 
@@ -3006,7 +3006,7 @@ parameters:
 			path: libraries/classes/Plugins/Schema/RelationStats.php
 
 		-
-			message: "#^Parameter \\#1 \\$table of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\RelationStats\\:\\:_getXy\\(\\) expects PhpMyAdmin\\\\Plugins\\\\Schema\\\\TableStats, string given\\.$#"
+			message: "#^Parameter \\#1 \\$table of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\RelationStats\\:\\:getXy\\(\\) expects PhpMyAdmin\\\\Plugins\\\\Schema\\\\TableStats, string given\\.$#"
 			count: 2
 			path: libraries/classes/Plugins/Schema/RelationStats.php
 
@@ -3061,12 +3061,12 @@ parameters:
 			path: libraries/classes/Plugins/Schema/Svg/SvgRelationSchema.php
 
 		-
-			message: "#^Parameter \\#1 \\$table of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Svg\\\\SvgRelationSchema\\:\\:_setMinMax\\(\\) expects PhpMyAdmin\\\\Plugins\\\\Schema\\\\Svg\\\\TableStatsSvg, PhpMyAdmin\\\\Plugins\\\\Schema\\\\Dia\\\\TableStatsDia\\|PhpMyAdmin\\\\Plugins\\\\Schema\\\\Eps\\\\TableStatsEps\\|PhpMyAdmin\\\\Plugins\\\\Schema\\\\Pdf\\\\TableStatsPdf\\|PhpMyAdmin\\\\Plugins\\\\Schema\\\\Svg\\\\TableStatsSvg given\\.$#"
+			message: "#^Parameter \\#1 \\$table of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Svg\\\\SvgRelationSchema\\:\\:setMinMax\\(\\) expects PhpMyAdmin\\\\Plugins\\\\Schema\\\\Svg\\\\TableStatsSvg, PhpMyAdmin\\\\Plugins\\\\Schema\\\\Dia\\\\TableStatsDia\\|PhpMyAdmin\\\\Plugins\\\\Schema\\\\Eps\\\\TableStatsEps\\|PhpMyAdmin\\\\Plugins\\\\Schema\\\\Pdf\\\\TableStatsPdf\\|PhpMyAdmin\\\\Plugins\\\\Schema\\\\Svg\\\\TableStatsSvg given\\.$#"
 			count: 3
 			path: libraries/classes/Plugins/Schema/Svg/SvgRelationSchema.php
 
 		-
-			message: "#^Parameter \\#4 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Svg\\\\SvgRelationSchema\\:\\:_addRelation\\(\\) expects string, int\\|string given\\.$#"
+			message: "#^Parameter \\#4 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Svg\\\\SvgRelationSchema\\:\\:addRelation\\(\\) expects string, int\\|string given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Schema/Svg/SvgRelationSchema.php
 
@@ -3756,7 +3756,7 @@ parameters:
 			path: libraries/classes/Server/UserGroups.php
 
 		-
-			message: "#^Parameter \\#1 \\$var_name of static method PhpMyAdmin\\\\Setup\\\\ConfigGenerator\\:\\:_getVarExport\\(\\) expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$var_name of static method PhpMyAdmin\\\\Setup\\\\ConfigGenerator\\:\\:getVarExport\\(\\) expects string, string\\|null given\\.$#"
 			count: 2
 			path: libraries/classes/Setup/ConfigGenerator.php
 
@@ -4091,7 +4091,7 @@ parameters:
 			path: libraries/classes/Tracker.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Tracker\\:\\:_changeTracking\\(\\) should return int but returns bool\\|resource\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Tracker\\:\\:changeTracking\\(\\) should return int but returns bool\\|resource\\.$#"
 			count: 1
 			path: libraries/classes/Tracker.php
 

--- a/test/classes/Config/FormDisplayTest.php
+++ b/test/classes/Config/FormDisplayTest.php
@@ -254,7 +254,7 @@ class FormDisplayTest extends AbstractTestCase
     }
 
     /**
-     * Test for FormDisplay::_validateSelect
+     * Test for FormDisplay::validateSelect
      *
      * @return void
      */
@@ -371,7 +371,7 @@ class FormDisplayTest extends AbstractTestCase
     }
 
     /**
-     * Test for FormDisplay::_getOptName
+     * Test for FormDisplay::getOptName
      *
      * @return void
      */
@@ -392,7 +392,7 @@ class FormDisplayTest extends AbstractTestCase
     }
 
     /**
-     * Test for FormDisplay::_loadUserprefsInfo
+     * Test for FormDisplay::loadUserprefsInfo
      *
      * @return void
      */
@@ -415,7 +415,7 @@ class FormDisplayTest extends AbstractTestCase
     }
 
     /**
-     * Test for FormDisplay::_setComments
+     * Test for FormDisplay::setComments
      *
      * @return void
      */

--- a/test/classes/Config/FormDisplayTest.php
+++ b/test/classes/Config/FormDisplayTest.php
@@ -262,7 +262,7 @@ class FormDisplayTest extends AbstractTestCase
     {
         $attrValidateSelect = new ReflectionMethod(
             FormDisplay::class,
-            '_validateSelect'
+            'validateSelect'
         );
         $attrValidateSelect->setAccessible(true);
 
@@ -377,7 +377,7 @@ class FormDisplayTest extends AbstractTestCase
      */
     public function testGetOptName()
     {
-        $method = new ReflectionMethod(FormDisplay::class, '_getOptName');
+        $method = new ReflectionMethod(FormDisplay::class, 'getOptName');
         $method->setAccessible(true);
 
         $this->assertEquals(
@@ -398,7 +398,7 @@ class FormDisplayTest extends AbstractTestCase
      */
     public function testLoadUserprefsInfo()
     {
-        $method = new ReflectionMethod(FormDisplay::class, '_loadUserprefsInfo');
+        $method = new ReflectionMethod(FormDisplay::class, 'loadUserprefsInfo');
         $method->setAccessible(true);
 
         $attrUserprefs = new ReflectionProperty(
@@ -421,7 +421,7 @@ class FormDisplayTest extends AbstractTestCase
      */
     public function testSetComments()
     {
-        $method = new ReflectionMethod(FormDisplay::class, '_setComments');
+        $method = new ReflectionMethod(FormDisplay::class, 'setComments');
         $method->setAccessible(true);
 
         // recoding

--- a/test/classes/Database/DesignerTest.php
+++ b/test/classes/Database/DesignerTest.php
@@ -60,7 +60,7 @@ class DesignerTest extends AbstractTestCase
      *
      * @return void
      */
-    private function _mockDatabaseInteraction($db)
+    private function mockDatabaseInteraction($db)
     {
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
@@ -106,7 +106,7 @@ class DesignerTest extends AbstractTestCase
     public function testGetPageIdsAndNames()
     {
         $db = 'db';
-        $this->_mockDatabaseInteraction($db);
+        $this->mockDatabaseInteraction($db);
 
         $template = new Template();
         $this->designer = new Designer($GLOBALS['dbi'], new Relation($GLOBALS['dbi'], $template), $template);
@@ -133,7 +133,7 @@ class DesignerTest extends AbstractTestCase
     {
         $db = 'db';
         $operation = 'edit';
-        $this->_mockDatabaseInteraction($db);
+        $this->mockDatabaseInteraction($db);
 
         $template = new Template();
         $this->designer = new Designer($GLOBALS['dbi'], new Relation($GLOBALS['dbi'], $template), $template);
@@ -162,7 +162,7 @@ class DesignerTest extends AbstractTestCase
     public function testGetHtmlForPageSaveAs()
     {
         $db = 'db';
-        $this->_mockDatabaseInteraction($db);
+        $this->mockDatabaseInteraction($db);
 
         $template = new Template();
         $this->designer = new Designer($GLOBALS['dbi'], new Relation($GLOBALS['dbi'], $template), $template);

--- a/test/classes/Database/QbeTest.php
+++ b/test/classes/Database/QbeTest.php
@@ -72,7 +72,7 @@ class QbeTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getSortSelectCell
+     * Test for getSortSelectCell
      *
      * @return void
      */
@@ -83,7 +83,7 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getSortSelectCell',
+                'getSortSelectCell',
                 [1]
             )
         );
@@ -92,7 +92,7 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getSortSelectCell',
+                'getSortSelectCell',
                 [1]
             )
         );
@@ -101,7 +101,7 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getSortSelectCell',
+                'getSortSelectCell',
                 [
                     1,
                     'ASC',
@@ -111,7 +111,7 @@ class QbeTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getSortRow
+     * Test for getSortRow
      *
      * @return void
      */
@@ -122,7 +122,7 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getSortRow',
+                'getSortRow',
                 []
             )
         );
@@ -131,7 +131,7 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getSortRow',
+                'getSortRow',
                 []
             )
         );
@@ -140,14 +140,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getSortRow',
+                'getSortRow',
                 []
             )
         );
     }
 
     /**
-     * Test for _getShowRow
+     * Test for getShowRow
      *
      * @return void
      */
@@ -162,14 +162,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getShowRow',
+                'getShowRow',
                 []
             )
         );
     }
 
     /**
-     * Test for _getCriteriaInputboxRow
+     * Test for getCriteriaInputboxRow
      *
      * @return void
      */
@@ -189,14 +189,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getCriteriaInputboxRow',
+                'getCriteriaInputboxRow',
                 []
             )
         );
     }
 
     /**
-     * Test for _getAndOrColCell
+     * Test for getAndOrColCell
      *
      * @return void
      */
@@ -212,14 +212,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getAndOrColCell',
+                'getAndOrColCell',
                 [1]
             )
         );
     }
 
     /**
-     * Test for _getModifyColumnsRow
+     * Test for getModifyColumnsRow
      *
      * @return void
      */
@@ -243,14 +243,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getModifyColumnsRow',
+                'getModifyColumnsRow',
                 []
             )
         );
     }
 
     /**
-     * Test for _getInputboxRow
+     * Test for getInputboxRow
      *
      * @return void
      */
@@ -266,14 +266,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getInputboxRow',
+                'getInputboxRow',
                 [2]
             )
         );
     }
 
     /**
-     * Test for _getInsDelAndOrCriteriaRows
+     * Test for getInsDelAndOrCriteriaRows
      *
      * @return void
      */
@@ -282,7 +282,7 @@ class QbeTest extends AbstractTestCase
         $actual = $this->callFunction(
             $this->object,
             Qbe::class,
-            '_getInsDelAndOrCriteriaRows',
+            'getInsDelAndOrCriteriaRows',
             [
                 2,
                 3,
@@ -302,7 +302,7 @@ class QbeTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getSelectClause
+     * Test for getSelectClause
      *
      * @return void
      */
@@ -313,14 +313,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getSelectClause',
+                'getSelectClause',
                 []
             )
         );
     }
 
     /**
-     * Test for _getWhereClause
+     * Test for getWhereClause
      *
      * @return void
      */
@@ -331,14 +331,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getWhereClause',
+                'getWhereClause',
                 []
             )
         );
     }
 
     /**
-     * Test for _getOrderByClause
+     * Test for getOrderByClause
      *
      * @return void
      */
@@ -349,14 +349,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getOrderByClause',
+                'getOrderByClause',
                 []
             )
         );
     }
 
     /**
-     * Test for _getIndexes
+     * Test for getIndexes
      *
      * @return void
      */
@@ -370,7 +370,7 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getIndexes',
+                'getIndexes',
                 [
                     [
                         '`table1`',
@@ -388,7 +388,7 @@ class QbeTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getLeftJoinColumnCandidates
+     * Test for getLeftJoinColumnCandidates
      *
      * @return void
      */
@@ -399,7 +399,7 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getLeftJoinColumnCandidates',
+                'getLeftJoinColumnCandidates',
                 [
                     [
                         '`table1`',
@@ -417,7 +417,7 @@ class QbeTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getMasterTable
+     * Test for getMasterTable
      *
      * @return void
      */
@@ -428,7 +428,7 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getMasterTable',
+                'getMasterTable',
                 [
                     [
                         'table1',
@@ -447,7 +447,7 @@ class QbeTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getWhereClauseTablesAndColumns
+     * Test for getWhereClauseTablesAndColumns
      *
      * @return void
      */
@@ -467,14 +467,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getWhereClauseTablesAndColumns',
+                'getWhereClauseTablesAndColumns',
                 []
             )
         );
     }
 
     /**
-     * Test for _getFromClause
+     * Test for getFromClause
      *
      * @return void
      */
@@ -491,14 +491,14 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getFromClause',
+                'getFromClause',
                 [['`table1`.`id`']]
             )
         );
     }
 
     /**
-     * Test for _getSQLQuery
+     * Test for getSQLQuery
      *
      * @return void
      */
@@ -515,7 +515,7 @@ class QbeTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Qbe::class,
-                '_getSQLQuery',
+                'getSQLQuery',
                 [['`table1`.`id`']]
             )
         );

--- a/test/classes/Database/SearchTest.php
+++ b/test/classes/Database/SearchTest.php
@@ -134,7 +134,7 @@ class SearchTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getSearchSqls
+     * Test for getSearchSqls
      *
      * @return void
      */

--- a/test/classes/FooterTest.php
+++ b/test/classes/FooterTest.php
@@ -120,7 +120,7 @@ class FooterTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getSelfLink
+     * Test for getSelfLink
      *
      * @return void
      */

--- a/test/classes/FooterTest.php
+++ b/test/classes/FooterTest.php
@@ -94,7 +94,7 @@ class FooterTest extends AbstractTestCase
     }
 
     /**
-     * Test for _removeRecursion
+     * Test for removeRecursion
      *
      * @return void
      */
@@ -107,7 +107,7 @@ class FooterTest extends AbstractTestCase
         $this->callFunction(
             $this->object,
             Footer::class,
-            '_removeRecursion',
+            'removeRecursion',
             [
                 &$object,
             ]
@@ -139,7 +139,7 @@ class FooterTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Footer::class,
-                '_getSelfLink',
+                'getSelfLink',
                 [
                     $this->object->getSelfUrl(),
                 ]
@@ -148,7 +148,7 @@ class FooterTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getSelfLink
+     * Test for getSelfLink
      *
      * @return void
      */
@@ -166,7 +166,7 @@ class FooterTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Footer::class,
-                '_getSelfLink',
+                'getSelfLink',
                 [
                     $this->object->getSelfUrl(),
                 ]
@@ -175,7 +175,7 @@ class FooterTest extends AbstractTestCase
     }
 
     /**
-     * Test for _getSelfLink
+     * Test for getSelfLink
      *
      * @return void
      */
@@ -193,7 +193,7 @@ class FooterTest extends AbstractTestCase
             $this->callFunction(
                 $this->object,
                 Footer::class,
-                '_getSelfLink',
+                'getSelfLink',
                 [
                     $this->object->getSelfUrl(),
                 ]

--- a/test/classes/Gis/GisMultiPolygonTest.php
+++ b/test/classes/Gis/GisMultiPolygonTest.php
@@ -53,7 +53,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
      *
      * @return array common data for data providers
      */
-    private function _getData()
+    private function getData()
     {
         return [
             'MULTIPOLYGON' => [
@@ -137,7 +137,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
     public function providerForTestGenerateWkt()
     {
         $temp = [
-            0 => $this->_getData(),
+            0 => $this->getData(),
         ];
 
         $temp1 = $temp;
@@ -191,9 +191,9 @@ class GisMultiPolygonTest extends GisGeomTestCase
      */
     public function providerForTestGenerateParams()
     {
-        $temp = $this->_getData();
+        $temp = $this->getData();
 
-        $temp1 = $this->_getData();
+        $temp1 = $this->getData();
         $temp1['gis_type'] = 'MULTIPOLYGON';
 
         return [

--- a/test/classes/Gis/GisPolygonTest.php
+++ b/test/classes/Gis/GisPolygonTest.php
@@ -53,7 +53,7 @@ class GisPolygonTest extends GisGeomTestCase
      *
      * @return array common data for data providers
      */
-    private function _getData()
+    private function getData()
     {
         return [
             'POLYGON' => [
@@ -112,7 +112,7 @@ class GisPolygonTest extends GisGeomTestCase
     public function providerForTestGenerateWkt()
     {
         $temp = [
-            0 => $this->_getData(),
+            0 => $this->getData(),
         ];
 
         $temp1 = $temp;
@@ -176,7 +176,7 @@ class GisPolygonTest extends GisGeomTestCase
      */
     public function providerForTestGenerateParams()
     {
-        $temp = $this->_getData();
+        $temp = $this->getData();
 
         $temp1 = $temp;
         $temp1['gis_type'] = 'POLYGON';
@@ -388,7 +388,7 @@ class GisPolygonTest extends GisGeomTestCase
      */
     public function providerForTestGetPointOnSurface()
     {
-        $temp = $this->_getData();
+        $temp = $this->getData();
         unset($temp['POLYGON'][0]['no_of_points']);
         unset($temp['POLYGON'][1]['no_of_points']);
 

--- a/test/classes/Gis/GisVisualizationTest.php
+++ b/test/classes/Gis/GisVisualizationTest.php
@@ -20,7 +20,7 @@ class GisVisualizationTest extends AbstractTestCase
                 'spatialColumn' => 'abc',
             ]),
             GisVisualization::class,
-            '_modifySqlQuery',
+            'modifySqlQuery',
             [
                 '',
                 0,
@@ -45,7 +45,7 @@ class GisVisualizationTest extends AbstractTestCase
                 'spatialColumn' => 'abc',
             ]),
             GisVisualization::class,
-            '_modifySqlQuery',
+            'modifySqlQuery',
             [
                 '',
                 0,
@@ -70,7 +70,7 @@ class GisVisualizationTest extends AbstractTestCase
                 'spatialColumn' => 'abc',
             ]),
             GisVisualization::class,
-            '_modifySqlQuery',
+            'modifySqlQuery',
             [
                 '',
                 0,

--- a/test/classes/Plugins/Auth/AuthenticationCookieTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -906,7 +906,7 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
     }
 
     /**
-     * Test for PhpMyAdmin\Plugins\Auth\AuthenticationConfig::_getEncryptionSecret
+     * Test for PhpMyAdmin\Plugins\Auth\AuthenticationConfig::getEncryptionSecret
      *
      * @return void
      */
@@ -935,7 +935,7 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
     }
 
     /**
-     * Test for PhpMyAdmin\Plugins\Auth\AuthenticationConfig::_getEncryptionSecret
+     * Test for PhpMyAdmin\Plugins\Auth\AuthenticationConfig::getEncryptionSecret
      *
      * @return void
      */

--- a/test/classes/Plugins/Auth/AuthenticationCookieTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -914,7 +914,7 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
     {
         $method = new ReflectionMethod(
             AuthenticationCookie::class,
-            '_getEncryptionSecret'
+            'getEncryptionSecret'
         );
         $method->setAccessible(true);
 
@@ -943,7 +943,7 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
     {
         $method = new ReflectionMethod(
             AuthenticationCookie::class,
-            '_getEncryptionSecret'
+            'getEncryptionSecret'
         );
         $method->setAccessible(true);
 
@@ -1128,7 +1128,7 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
         ];
         $method = new ReflectionMethod(
             AuthenticationCookie::class,
-            '_getSessionEncryptionSecret'
+            'getSessionEncryptionSecret'
         );
         $method->setAccessible(true);
 

--- a/test/classes/Plugins/Export/ExportCodegenTest.php
+++ b/test/classes/Plugins/Export/ExportCodegenTest.php
@@ -435,8 +435,8 @@ class ExportCodegenTest extends AbstractTestCase
 
     /**
      * Test for
-     *     - PhpMyAdmin\Plugins\Export\ExportCodegen::_getCgFormats
-     *     - PhpMyAdmin\Plugins\Export\ExportCodegen::_setCgFormats
+     *     - PhpMyAdmin\Plugins\Export\ExportCodegen::getCgFormats
+     *     - PhpMyAdmin\Plugins\Export\ExportCodegen::setCgFormats
      *
      * @return void
      */
@@ -444,8 +444,8 @@ class ExportCodegenTest extends AbstractTestCase
     {
         $reflection = new ReflectionClass(ExportCodegen::class);
 
-        $getter = $reflection->getMethod('_getCgFormats');
-        $setter = $reflection->getMethod('_setCgFormats');
+        $getter = $reflection->getMethod('getCgFormats');
+        $setter = $reflection->getMethod('setCgFormats');
 
         $getter->setAccessible(true);
         $setter->setAccessible(true);

--- a/test/classes/Plugins/Export/ExportPdfTest.php
+++ b/test/classes/Plugins/Export/ExportPdfTest.php
@@ -311,18 +311,18 @@ class ExportPdfTest extends AbstractTestCase
 
     /**
      * Test for
-     *     - PhpMyAdmin\Plugins\Export\ExportPdf::_setPdf
-     *     - PhpMyAdmin\Plugins\Export\ExportPdf::_getPdf
+     *     - PhpMyAdmin\Plugins\Export\ExportPdf::setPdf
+     *     - PhpMyAdmin\Plugins\Export\ExportPdf::getPdf
      *
      * @return void
      */
     public function testSetGetPdf()
     {
-        $setter = new ReflectionMethod(ExportPdf::class, '_setPdf');
+        $setter = new ReflectionMethod(ExportPdf::class, 'setPdf');
         $setter->setAccessible(true);
         $setter->invoke($this->object, new Pdf());
 
-        $getter = new ReflectionMethod(ExportPdf::class, '_getPdf');
+        $getter = new ReflectionMethod(ExportPdf::class, 'getPdf');
         $getter->setAccessible(true);
         $this->assertInstanceOf(
             Pdf::class,
@@ -332,18 +332,18 @@ class ExportPdfTest extends AbstractTestCase
 
     /**
      * Test for
-     *     - PhpMyAdmin\Plugins\Export\ExportPdf::_setPdfReportTitle
-     *     - PhpMyAdmin\Plugins\Export\ExportPdf::_getPdfReportTitle
+     *     - PhpMyAdmin\Plugins\Export\ExportPdf::setPdfReportTitle
+     *     - PhpMyAdmin\Plugins\Export\ExportPdf::getPdfReportTitle
      *
      * @return void
      */
     public function testSetGetPdfTitle()
     {
-        $setter = new ReflectionMethod(ExportPdf::class, '_setPdfReportTitle');
+        $setter = new ReflectionMethod(ExportPdf::class, 'setPdfReportTitle');
         $setter->setAccessible(true);
         $setter->invoke($this->object, 'title');
 
-        $getter = new ReflectionMethod(ExportPdf::class, '_getPdfReportTitle');
+        $getter = new ReflectionMethod(ExportPdf::class, 'getPdfReportTitle');
         $getter->setAccessible(true);
         $this->assertEquals(
             'title',

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -390,13 +390,13 @@ class ExportSqlTest extends AbstractTestCase
     }
 
     /**
-     * Test for PhpMyAdmin\Plugins\Export\ExportSql::_exportComment
+     * Test for PhpMyAdmin\Plugins\Export\ExportSql::exportComment
      *
      * @return void
      */
     public function testExportComment()
     {
-        $method = new ReflectionMethod(ExportSql::class, '_exportComment');
+        $method = new ReflectionMethod(ExportSql::class, 'exportComment');
         $method->setAccessible(true);
 
         $GLOBALS['crlf'] = '##';
@@ -428,13 +428,13 @@ class ExportSqlTest extends AbstractTestCase
     }
 
     /**
-     * Test for PhpMyAdmin\Plugins\Export\ExportSql::_possibleCRLF
+     * Test for PhpMyAdmin\Plugins\Export\ExportSql::possibleCRLF
      *
      * @return void
      */
     public function testPossibleCRLF()
     {
-        $method = new ReflectionMethod(ExportSql::class, '_possibleCRLF');
+        $method = new ReflectionMethod(ExportSql::class, 'possibleCRLF');
         $method->setAccessible(true);
 
         $GLOBALS['crlf'] = '##';
@@ -855,7 +855,7 @@ class ExportSqlTest extends AbstractTestCase
     }
 
     /**
-     * Test for PhpMyAdmin\Plugins\Export\ExportSql::_getTableDefForView
+     * Test for PhpMyAdmin\Plugins\Export\ExportSql::getTableDefForView
      *
      * @return void
      */
@@ -891,7 +891,7 @@ class ExportSqlTest extends AbstractTestCase
         $GLOBALS['dbi'] = $dbi;
         $GLOBALS['sql_compatibility'] = 'MSSQL';
 
-        $method = new ReflectionMethod(ExportSql::class, '_getTableDefForView');
+        $method = new ReflectionMethod(ExportSql::class, 'getTableDefForView');
         $method->setAccessible(true);
         $result = $method->invoke(
             $this->object,
@@ -1238,7 +1238,7 @@ class ExportSqlTest extends AbstractTestCase
     }
 
     /**
-     * Test for PhpMyAdmin\Plugins\Export\ExportSql::_getTableComments
+     * Test for PhpMyAdmin\Plugins\Export\ExportSql::getTableComments
      *
      * @return void
      */
@@ -1284,7 +1284,7 @@ class ExportSqlTest extends AbstractTestCase
         $GLOBALS['dbi'] = $dbi;
         $this->object->relation = new Relation($dbi);
 
-        $method = new ReflectionMethod(ExportSql::class, '_getTableComments');
+        $method = new ReflectionMethod(ExportSql::class, 'getTableComments');
         $method->setAccessible(true);
         $result = $method->invoke(
             $this->object,
@@ -1894,7 +1894,7 @@ class ExportSqlTest extends AbstractTestCase
     }
 
     /**
-     * Test for PhpMyAdmin\Plugins\Export\ExportSql::_makeCreateTableMSSQLCompatible
+     * Test for PhpMyAdmin\Plugins\Export\ExportSql::makeCreateTableMSSQLCompatible
      *
      * @return void
      */
@@ -1919,7 +1919,7 @@ class ExportSqlTest extends AbstractTestCase
 
         $method = new ReflectionMethod(
             ExportSql::class,
-            '_makeCreateTableMSSQLCompatible'
+            'makeCreateTableMSSQLCompatible'
         );
         $method->setAccessible(true);
         $result = $method->invoke(

--- a/test/classes/Setup/ConfigGeneratorTest.php
+++ b/test/classes/Setup/ConfigGeneratorTest.php
@@ -87,14 +87,14 @@ class ConfigGeneratorTest extends AbstractTestCase
     }
 
     /**
-     * Test for ConfigGenerator::_getVarExport
+     * Test for ConfigGenerator::getVarExport
      *
      * @return void
      */
     public function testGetVarExport()
     {
         $reflection = new ReflectionClass(ConfigGenerator::class);
-        $method = $reflection->getMethod('_getVarExport');
+        $method = $reflection->getMethod('getVarExport');
         $method->setAccessible(true);
 
         $this->assertEquals(
@@ -138,14 +138,14 @@ class ConfigGeneratorTest extends AbstractTestCase
     }
 
     /**
-     * Test for ConfigGenerator::_isZeroBasedArray
+     * Test for ConfigGenerator::isZeroBasedArray
      *
      * @return void
      */
     public function testIsZeroBasedArray()
     {
         $reflection = new ReflectionClass(ConfigGenerator::class);
-        $method = $reflection->getMethod('_isZeroBasedArray');
+        $method = $reflection->getMethod('isZeroBasedArray');
         $method->setAccessible(true);
 
         $this->assertFalse(
@@ -189,14 +189,14 @@ class ConfigGeneratorTest extends AbstractTestCase
     }
 
     /**
-     * Test for ConfigGenerator::_exportZeroBasedArray
+     * Test for ConfigGenerator::exportZeroBasedArray
      *
      * @return void
      */
     public function testExportZeroBasedArray()
     {
         $reflection = new ReflectionClass(ConfigGenerator::class);
-        $method = $reflection->getMethod('_exportZeroBasedArray');
+        $method = $reflection->getMethod('exportZeroBasedArray');
         $method->setAccessible(true);
 
         $arr = [

--- a/test/classes/TableTest.php
+++ b/test/classes/TableTest.php
@@ -1173,7 +1173,7 @@ class TableTest extends AbstractTestCase
     }
 
     /**
-     * Tests for _getSQLToCreateForeignKey() method.
+     * Tests for getSQLToCreateForeignKey() method.
      *
      * @return void
      *
@@ -1198,7 +1198,7 @@ class TableTest extends AbstractTestCase
         $sql = $this->callFunction(
             $tableObj,
             Table::class,
-            '_getSQLToCreateForeignKey',
+            'getSQLToCreateForeignKey',
             [
                 $table,
                 $field,
@@ -1219,7 +1219,7 @@ class TableTest extends AbstractTestCase
         $sql = $this->callFunction(
             $tableObj,
             Table::class,
-            '_getSQLToCreateForeignKey',
+            'getSQLToCreateForeignKey',
             [
                 $table,
                 $field,

--- a/test/classes/TrackerTest.php
+++ b/test/classes/TrackerTest.php
@@ -444,7 +444,7 @@ class TrackerTest extends AbstractTestCase
         $result = null;
 
         if ($type === null) {
-            $method = new ReflectionMethod(Tracker::class, '_changeTracking');
+            $method = new ReflectionMethod(Tracker::class, 'changeTracking');
             $method->setAccessible(true);
             $result = $method->invoke(
                 null,

--- a/test/selenium/CreateDropDatabaseTest.php
+++ b/test/selenium/CreateDropDatabaseTest.php
@@ -54,7 +54,7 @@ class CreateDropDatabaseTest extends TestBase
         );
         $this->assertEquals(1, $result->num_rows);
 
-        $this->_dropDatabase();
+        $this->dropDatabase();
     }
 
     /**
@@ -62,7 +62,7 @@ class CreateDropDatabaseTest extends TestBase
      *
      * @return void
      */
-    private function _dropDatabase()
+    private function dropDatabase()
     {
         $this->gotoHomepage();
 

--- a/test/selenium/Database/EventsTest.php
+++ b/test/selenium/Database/EventsTest.php
@@ -63,7 +63,7 @@ class EventsTest extends TestBase
      *
      * @return void
      */
-    private function _eventSQL()
+    private function eventSQL()
     {
         $start = date('Y-m-d H:i:s', strtotime('-1 day'));
         $end = date('Y-m-d H:i:s', strtotime('+1 day'));
@@ -164,7 +164,7 @@ class EventsTest extends TestBase
      */
     public function testEditEvents()
     {
-        $this->_eventSQL();
+        $this->eventSQL();
         $this->waitForElement('partialLinkText', 'Events')->click();
         $this->waitAjax();
 
@@ -205,7 +205,7 @@ class EventsTest extends TestBase
      */
     public function testDropEvent()
     {
-        $this->_eventSQL();
+        $this->eventSQL();
         $this->waitForElement('partialLinkText', 'Events')->click();
         $this->waitAjax();
 

--- a/test/selenium/Database/OperationsTest.php
+++ b/test/selenium/Database/OperationsTest.php
@@ -28,7 +28,7 @@ class OperationsTest extends TestBase
     /**
      * @return void
      */
-    private function _getToDBOperations()
+    private function getToDBOperations()
     {
         $this->gotoHomepage();
 
@@ -52,7 +52,7 @@ class OperationsTest extends TestBase
     {
         $this->skipIfNotPMADB();
 
-        $this->_getToDBOperations();
+        $this->getToDBOperations();
         $this->byName('comment')->sendKeys('comment_foobar');
         $this->byCssSelector(
             "form#formDatabaseComment input[type='submit']"
@@ -75,7 +75,7 @@ class OperationsTest extends TestBase
      */
     public function testRenameDB()
     {
-        $this->_getToDBOperations();
+        $this->getToDBOperations();
 
         $new_db_name = $this->database_name . 'rename';
 
@@ -117,7 +117,7 @@ class OperationsTest extends TestBase
      */
     public function testCopyDb()
     {
-        $this->_getToDBOperations();
+        $this->getToDBOperations();
 
         $this->reloadPage();// Reload or scrolling will not work ..
         $new_db_name = $this->database_name . 'copy';

--- a/test/selenium/Database/ProceduresTest.php
+++ b/test/selenium/Database/ProceduresTest.php
@@ -80,7 +80,7 @@ class ProceduresTest extends TestBase
      *
      * @return void
      */
-    private function _procedureSQL()
+    private function procedureSQL()
     {
         $this->dbQuery(
             'CREATE PROCEDURE `test_procedure`(IN `inp` VARCHAR(20), OUT `outp` INT)'
@@ -144,7 +144,7 @@ class ProceduresTest extends TestBase
         );
 
         $this->assertEquals(1, $result->num_rows);
-        $this->_executeProcedure('test_procedure', 14);
+        $this->executeProcedure('test_procedure', 14);
     }
 
     /**
@@ -156,7 +156,7 @@ class ProceduresTest extends TestBase
      */
     public function testEditProcedure()
     {
-        $this->_procedureSQL();
+        $this->procedureSQL();
         $this->waitForElement('partialLinkText', 'Routines')->click();
         $this->waitAjax();
 
@@ -178,7 +178,7 @@ class ProceduresTest extends TestBase
             . "'Routine `test_procedure` has been modified')]"
         );
 
-        $this->_executeProcedure('test_procedure', 14);
+        $this->executeProcedure('test_procedure', 14);
     }
 
     /**
@@ -190,7 +190,7 @@ class ProceduresTest extends TestBase
      */
     public function testDropProcedure()
     {
-        $this->_procedureSQL();
+        $this->procedureSQL();
         $this->waitForElement('partialLinkText', 'Routines')->click();
         $this->waitAjax();
 
@@ -221,7 +221,7 @@ class ProceduresTest extends TestBase
      *
      * @return void
      */
-    private function _executeProcedure($text, $length)
+    private function executeProcedure($text, $length)
     {
         $this->waitAjax();
         $this->waitUntilElementIsVisible('partialLinkText', 'Execute', 30)->click();

--- a/test/selenium/Database/TriggersTest.php
+++ b/test/selenium/Database/TriggersTest.php
@@ -51,7 +51,7 @@ class TriggersTest extends TestBase
      *
      * @return void
      */
-    private function _triggerSQL()
+    private function triggerSQL()
     {
         $this->dbQuery(
             'CREATE TRIGGER `test_trigger` '
@@ -137,7 +137,7 @@ class TriggersTest extends TestBase
     {
         $this->expandMore();
 
-        $this->_triggerSQL();
+        $this->triggerSQL();
         $this->waitForElement('partialLinkText', 'Triggers')->click();
         $this->waitAjax();
 
@@ -178,7 +178,7 @@ class TriggersTest extends TestBase
     {
         $this->expandMore();
 
-        $this->_triggerSQL();
+        $this->triggerSQL();
         $ele = $this->waitForElement('partialLinkText', 'Triggers');
         $ele->click();
 

--- a/test/selenium/ExportTest.php
+++ b/test/selenium/ExportTest.php
@@ -45,7 +45,7 @@ class ExportTest extends TestBase
      */
     public function testServerExport($plugin, $expected): void
     {
-        $text = $this->_doExport('server', $plugin);
+        $text = $this->doExport('server', $plugin);
 
         foreach ($expected as $str) {
             $this->assertStringContainsString($str, $text);
@@ -65,7 +65,7 @@ class ExportTest extends TestBase
     {
         $this->navigateDatabase($this->database_name);
 
-        $text = $this->_doExport('db', $plugin);
+        $text = $this->doExport('db', $plugin);
 
         foreach ($expected as $str) {
             $this->assertStringContainsString($str, $text);
@@ -87,7 +87,7 @@ class ExportTest extends TestBase
 
         $this->navigateTable('test_table');
 
-        $text = $this->_doExport('table', $plugin);
+        $text = $this->doExport('table', $plugin);
 
         foreach ($expected as $str) {
             $this->assertStringContainsString($str, $text);
@@ -129,7 +129,7 @@ class ExportTest extends TestBase
      *
      * @return string export string
      */
-    private function _doExport($type, $plugin)
+    private function doExport($type, $plugin)
     {
         $this->expandMore();
         $this->waitForElement('partialLinkText', 'Export')->click();

--- a/test/selenium/ImportTest.php
+++ b/test/selenium/ImportTest.php
@@ -32,7 +32,7 @@ class ImportTest extends TestBase
      */
     public function testServerImport()
     {
-        $this->_doImport('server');
+        $this->doImport('server');
         $result = $this->dbQuery("SHOW DATABASES LIKE 'test_import%'");
         $this->assertGreaterThanOrEqual(2, $result->num_rows);
 
@@ -53,7 +53,7 @@ class ImportTest extends TestBase
         $this->dbQuery('CREATE DATABASE ' . $this->database_name);
         $this->navigateDatabase($this->database_name);
 
-        $this->_doImport('db');
+        $this->doImport('db');
 
         $this->dbQuery('USE ' . $this->database_name);
         $result = $this->dbQuery('SHOW TABLES');
@@ -78,7 +78,7 @@ class ImportTest extends TestBase
 
         $this->navigateTable('test_table');
 
-        $this->_doImport('table');
+        $this->doImport('table');
 
         $result = $this->dbQuery('SELECT * FROM test_table');
         $this->assertEquals(2, $result->num_rows);
@@ -91,7 +91,7 @@ class ImportTest extends TestBase
      *
      * @return void
      */
-    private function _doImport($type)
+    private function doImport($type)
     {
         $this->waitForElement('partialLinkText', 'Import')->click();
         $this->waitAjax();

--- a/test/selenium/NormalizationTest.php
+++ b/test/selenium/NormalizationTest.php
@@ -67,7 +67,7 @@ class NormalizationTest extends TestBase
         );
         $this->byCssSelector('input[name=submit_normalize]')->click();
         $this->waitForElement('id', 'mainContent');
-        $this->_test1NFSteps();
+        $this->test1NFSteps();
     }
 
     /**
@@ -75,7 +75,7 @@ class NormalizationTest extends TestBase
      *
      * @return void
      */
-    private function _test1NFSteps()
+    private function test1NFSteps()
     {
         $this->assertEquals(
             'First step of normalization (1NF)',

--- a/test/selenium/NormalizationTest.php
+++ b/test/selenium/NormalizationTest.php
@@ -67,15 +67,13 @@ class NormalizationTest extends TestBase
         );
         $this->byCssSelector('input[name=submit_normalize]')->click();
         $this->waitForElement('id', 'mainContent');
-        $this->test1NFSteps();
+        $this->assert1NFSteps();
     }
 
     /**
      * assertions in 1NF steps 1.1, 1.2, 1.3
-     *
-     * @return void
      */
-    private function test1NFSteps()
+    private function assert1NFSteps(): void
     {
         $this->assertEquals(
             'First step of normalization (1NF)',

--- a/test/selenium/ServerSettingsTest.php
+++ b/test/selenium/ServerSettingsTest.php
@@ -36,7 +36,7 @@ class ServerSettingsTest extends TestBase
      *
      * @return void
      */
-    private function _saveConfig()
+    private function saveConfig()
     {
         // Submit the form
         $ele = $this->waitForElement(
@@ -73,13 +73,13 @@ class ServerSettingsTest extends TestBase
         $ele->clear();
         $ele->sendKeys($this->database_name);
 
-        $this->_saveConfig();
+        $this->saveConfig();
         $this->assertFalse(
             $this->isElementPresent('partialLinkText', $this->database_name)
         );
 
         $this->waitForElement('name', 'Servers-1-hide_db')->clear();
-        $this->_saveConfig();
+        $this->saveConfig();
         $this->assertTrue(
             $this->isElementPresent('partialLinkText', $this->database_name)
         );
@@ -130,13 +130,13 @@ class ServerSettingsTest extends TestBase
 
         $this->waitForElement('name', 'NavigationDisplayLogo')
             ->click();
-        $this->_saveConfig();
+        $this->saveConfig();
         $this->assertFalse(
             $this->isElementPresent('id', 'imgpmalogo')
         );
 
         $this->byCssSelector("a[href='#NavigationDisplayLogo']")->click();
-        $this->_saveConfig();
+        $this->saveConfig();
         $this->assertTrue(
             $this->isElementPresent('id', 'imgpmalogo')
         );

--- a/test/selenium/SqlQueryTest.php
+++ b/test/selenium/SqlQueryTest.php
@@ -147,13 +147,10 @@ class SqlQueryTest extends TestBase
         );
 
         // test inline edit button
-        $this->testInlineEdit();
+        $this->assertInlineEdit();
     }
 
-    /**
-     * @return void
-     */
-    private function testInlineEdit()
+    private function assertInlineEdit(): void
     {
         $this->waitForElement('cssSelector', 'a.inline_edit_sql')->click();
         // empty current query

--- a/test/selenium/SqlQueryTest.php
+++ b/test/selenium/SqlQueryTest.php
@@ -74,7 +74,7 @@ class SqlQueryTest extends TestBase
         );
 
         // test inline edit button
-        $this->_testInlineEdit();
+        $this->testInlineEdit();
     }
 
     /**
@@ -108,7 +108,7 @@ class SqlQueryTest extends TestBase
         );
 
         // test inline edit button
-        $this->_testInlineEdit();
+        $this->testInlineEdit();
     }
 
     /**
@@ -147,13 +147,13 @@ class SqlQueryTest extends TestBase
         );
 
         // test inline edit button
-        $this->_testInlineEdit();
+        $this->testInlineEdit();
     }
 
     /**
      * @return void
      */
-    private function _testInlineEdit()
+    private function testInlineEdit()
     {
         $this->waitForElement('cssSelector', 'a.inline_edit_sql')->click();
         // empty current query

--- a/test/selenium/Table/CreateTest.php
+++ b/test/selenium/Table/CreateTest.php
@@ -98,7 +98,7 @@ class CreateTest extends TestBase
 
         $this->waitForElement('partialLinkText', 'test_table');
 
-        $this->_tableStructureAssertions();
+        $this->tableStructureAssertions();
     }
 
     /**
@@ -106,7 +106,7 @@ class CreateTest extends TestBase
      *
      * @return void
      */
-    private function _tableStructureAssertions()
+    private function tableStructureAssertions()
     {
         $this->gotoHomepage();
         $this->waitAjax();

--- a/test/selenium/Table/InsertTest.php
+++ b/test/selenium/Table/InsertTest.php
@@ -101,7 +101,7 @@ class InsertTest extends TestBase
         );
         $this->assertStringContainsString('1 row inserted', $ele->getText());
 
-        $this->_assertDataPresent();
+        $this->assertDataPresent();
     }
 
     /**
@@ -109,7 +109,7 @@ class InsertTest extends TestBase
      *
      * @return void
      */
-    private function _assertDataPresent()
+    private function assertDataPresent()
     {
         $this->byPartialLinkText('Browse')->click();
 

--- a/test/selenium/TrackingTest.php
+++ b/test/selenium/TrackingTest.php
@@ -65,7 +65,7 @@ class TrackingTest extends TestBase
      */
     public function testTrackingData()
     {
-        $this->_executeSqlAndReturnToTableTracking();
+        $this->executeSqlAndReturnToTableTracking();
 
         $this->byPartialLinkText('Tracking report')->click();
         $this->waitForElement(
@@ -156,7 +156,7 @@ class TrackingTest extends TestBase
             'cssSelector',
             "input[value='Activate now']"
         );
-        $this->_executeSqlAndReturnToTableTracking();
+        $this->executeSqlAndReturnToTableTracking();
         $this->assertFalse(
             $this->isElementPresent('id', 'dml_versions')
         );
@@ -254,7 +254,7 @@ class TrackingTest extends TestBase
      *
      * @return void
      */
-    private function _executeSqlAndReturnToTableTracking()
+    private function executeSqlAndReturnToTableTracking()
     {
         $this->byPartialLinkText('SQL')->click();
         $this->waitAjax();


### PR DESCRIPTION
### Description

Removed underscore prefix from method names for PSR-12 compliance.

### Fixes 
Methods and method calls had underscore prefix removed.

Fixes: #16149 

The following methods were left unchanged because removing underscore created error “Cannot make public method private”:

classes/DatabaseInterface _FetchValue()
classes/Plugins/Export/ExportXml _exportRoutines()
libraries/classes/Plugins/Export/ExportSql _exportMetadata()

Additionally, method _putpages() of class "libraries/classes/Pdf" overrides method _putpages() in parent class TCPDF, so _putpages() remains with underscore.