### PR TITLE
default password 'cbb74bc' changed to 'change_password'

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -525,7 +525,7 @@ Or, if you prefer to not be prompted every time you log in:
     $i=0;
     $i++;
     $cfg['Servers'][$i]['user']          = 'root';
-    $cfg['Servers'][$i]['password']      = 'cbb74bc'; // use here your password
+    $cfg['Servers'][$i]['password']      = 'change_password'; // use here your password
     $cfg['Servers'][$i]['auth_type']     = 'config';
 
 .. warning::

--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -525,7 +525,7 @@ Or, if you prefer to not be prompted every time you log in:
     $i=0;
     $i++;
     $cfg['Servers'][$i]['user']          = 'root';
-    $cfg['Servers'][$i]['password']      = 'change_password'; // use here your password
+    $cfg['Servers'][$i]['password']      = 'changeme'; // use here your password
     $cfg['Servers'][$i]['auth_type']     = 'config';
 
 .. warning::


### PR DESCRIPTION
Signed-off-by: Olumide Olugbemiro <olugbemiro.olumide@gmail.com>

### Description
default password 'cbb74bc' changed to 'change_password' to infer that the password should be changed.

closes #16177
