### PR TITLE
Lock inactive closed issues with GitHub actions

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,19 @@
+name: 'Lock threads'
+
+on:
+  schedule:
+    - cron: '0 0,12 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-exclude-created-before: '2018-01-01T00:00:00Z'
+          issue-lock-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          process-only: 'issues'


### PR DESCRIPTION
Uses https://github.com/marketplace/actions/lock-threads.
