### PR TITLE
Fix #16222 Secure parameters before giving them to DI

### DIFF
--- a/libraries/classes/Url.php
+++ b/libraries/classes/Url.php
@@ -273,4 +273,43 @@ class Url
                 return $separator;
         }
     }
+
+    /**
+     * Override standard parse_str function to return the query parsed
+     *
+     * @param string      $encoded_string String to decode
+     * @param string|null $separator      Separator to use to implode parameters
+     *
+     * @return string Query parsed
+     */
+    public static function parseStr(string $encoded_string, ?string $separator = null): string
+    {
+        parse_str($encoded_string, $urlParameters);
+        return self::buildQuery($urlParameters, $separator);
+    }
+
+    /**
+     * Implode an array in a query string style
+     *
+     * @param array       $pieces    Items to implode
+     * @param string|null $separator Glue to use between items
+     *
+     * @return string
+     */
+    public static function buildQuery(array $pieces, ?string $separator = null): string
+    {
+        if ($separator === null) {
+            $separator = static::getArgSeparator();
+        }
+        return implode(
+            $separator,
+            array_map(
+                static function ($key, $value) {
+                    return $key . '=' . $value;
+                },
+                array_keys($pieces),
+                $pieces
+            )
+        );
+    }
 }

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -23,7 +23,6 @@ use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\SqlParser\Utils\Error as ParserError;
 use PhpMyAdmin\Template;
-use PhpMyAdmin\Url;
 use phpseclib\Crypt\Random;
 use stdClass;
 use Williamdes\MariaDBMySQLKBS\KBException;

--- a/tbl_find_replace.php
+++ b/tbl_find_replace.php
@@ -10,6 +10,7 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Table\SearchController;
+use PhpMyAdmin\Url;
 use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
@@ -25,7 +26,7 @@ require_once ROOT_PATH . 'libraries/tbl_common.inc.php';
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
     'searchType' => 'replace',
-    'url_query' => &$url_query,
+    'url_query' => Url::parseStr($url_query),
 ];
 
 /** @var Definition $definition */

--- a/tbl_select.php
+++ b/tbl_select.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Table\SearchController;
+use PhpMyAdmin\Url;
 use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
@@ -25,7 +26,7 @@ require_once ROOT_PATH . 'libraries/tbl_common.inc.php';
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
     'searchType' => 'normal',
-    'url_query' => &$url_query,
+    'url_query' => Url::parseStr($url_query),
 ];
 
 /** @var Definition $definition */

--- a/tbl_zoom_select.php
+++ b/tbl_zoom_select.php
@@ -10,6 +10,7 @@
 declare(strict_types=1);
 
 use PhpMyAdmin\Controllers\Table\SearchController;
+use PhpMyAdmin\Url;
 use Symfony\Component\DependencyInjection\Definition;
 
 if (! defined('ROOT_PATH')) {
@@ -24,7 +25,7 @@ require_once ROOT_PATH . 'libraries/tbl_common.inc.php';
 /* Define dependencies for the concerned controller */
 $dependency_definitions = [
     'searchType' => 'zoom',
-    'url_query' => &$url_query,
+    'url_query' => Url::parseStr($url_query),
 ];
 
 /** @var Definition $definition */

--- a/test/classes/UrlTest.php
+++ b/test/classes/UrlTest.php
@@ -114,4 +114,116 @@ class UrlTest extends TestCase
         $expected = '?server=x' . htmlentities($separator) . 'lang=en' ;
         $this->assertEquals($expected, Url::getCommon());
     }
+
+    /**
+     * @dataProvider providerParseStr
+     *
+     * @param string      $expected  Expected result
+     * @param string      $input     Data to parse
+     * @param string|null $separator Separator to use to re-implode the parameters found
+     *
+     * @return void
+     */
+    public function testParseStr(string $expected, string $input, string $separator = null): void
+    {
+        $this->assertEquals($expected, Url::parseStr($input, $separator));
+    }
+
+    /**
+     * @return array[] Unit test sets
+     */
+    public function providerParseStr(): array
+    {
+        return [
+            [
+                'table=garcon',
+                'table=garcon',
+                null,
+            ],
+            [
+                'table=garcon',
+                'table=garcon',
+                '*',
+            ],
+            [
+                'table=garçon',
+                'table=gar%C3%A7on',
+                null,
+            ],
+            [
+                'table=garçon',
+                'table=gar%C3%A7on',
+                '*',
+            ],
+            [
+                '?db=gh16222&table=garcon',
+                '?db=gh16222&table=garcon',
+                null,
+            ],
+            [
+                '?db=gh16222*table=garcon',
+                '?db=gh16222&table=garcon',
+                '*',
+            ],
+            [
+                '?db=gh16222&table=garçon',
+                '?db=gh16222&table=gar%C3%A7on',
+                null,
+            ],
+            [
+                '?db=gh16222*table=garçon',
+                '?db=gh16222&table=gar%C3%A7on',
+                '*',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerBuildQuery
+     *
+     * @param string      $expected  Expected result
+     * @param array       $params    Params to use to build the query
+     * @param string|null $separator Separator to use to re-implode the parameters found
+     *
+     * @return void
+     */
+    public function testBuildQuery(string $expected, array $params, ?string $separator): void
+    {
+        $this->assertEquals($expected, Url::buildQuery($params, $separator));
+    }
+
+    /**
+     * @return array[] Unit test sets
+     */
+    public function providerBuildQuery()
+    {
+        return [
+            [
+                'db=my_db',
+                ['db' => 'my_db'],
+                null,
+            ],
+            [
+                'db=my_db',
+                ['db' => 'my_db'],
+                '*',
+            ],
+            [
+                'db=my_db&table=my_table',
+                [
+                    'db' => 'my_db',
+                    'table' => 'my_table',
+                ],
+                null,
+            ],
+            [
+                'db=my_db*table=my_table',
+                [
+                    'db' => 'my_db',
+                    'table' => 'my_table',
+                ],
+                '*',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
### Description

Parameters sent to DI may sometimes have content that look like DI parameters. The intent of this PR is to secure the `url_query` parameter used in many pages.

Fixes #16222

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
