### PR TITLE
Fixes #16223 JSON Editor Height and Width set to auto

### DIFF
--- a/themes/bootstrap/scss/_codemirror.scss
+++ b/themes/bootstrap/scss/_codemirror.scss
@@ -14,8 +14,8 @@ $textarea-rows: 15;
 }
 
 .insertRowTable .CodeMirror {
-  height: ceil($textarea-rows * 0.6em);
-  width: ceil($textarea-cols * 0.6em);
+  min-height: ceil($textarea-rows * 0.6em);
+  min-width: ceil($textarea-cols * 0.6em);
   border: 1px solid #a9a9a9;
 }
 

--- a/themes/metro/scss/_codemirror.scss
+++ b/themes/metro/scss/_codemirror.scss
@@ -24,8 +24,8 @@ $textarea-rows: 15 !default;
 }
 
 .insertRowTable .CodeMirror {
-  height: ceil($textarea-rows * 0.6em);
-  width: ceil($textarea-cols * 0.6em);
+  min-height: ceil($textarea-rows * 0.6em);
+  min-width: ceil($textarea-cols * 0.6em);
 }
 
 #pma_console .CodeMirror-gutters {

--- a/themes/pmahomme/scss/_codemirror.scss
+++ b/themes/pmahomme/scss/_codemirror.scss
@@ -11,8 +11,8 @@ $textarea-rows: 15;
 }
 
 .insertRowTable .CodeMirror {
-  height: ceil($textarea-rows * 0.6em);
-  width: ceil($textarea-cols * 0.6em);
+  min-height: ceil($textarea-rows * 0.6em);
+  min-width: ceil($textarea-cols * 0.6em);
   border: 1px solid #a9a9a9;
 }
 


### PR DESCRIPTION
### Description

This is a fix for  #16223  where OP had mentioned JSON input transformation editor being too narrow. This can be fixed by setting the height and width to `auto`. I did so because, JSON sometimes be very lengthy, and scrolling on a small box can be difficult. So setting it to `auto` makes scrolling much easier.

For example:

![Screenshot 2020-06-28 at 10 03 57 AM](https://user-images.githubusercontent.com/17223002/85938574-247b9580-b92c-11ea-8a4d-42717c88cdcd.png)
 
Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
