### PR TITLE
Fix #16222 Secure parameters before giving them to DI

### DIFF
--- a/libraries/classes/Di/Migration.php
+++ b/libraries/classes/Di/Migration.php
@@ -66,6 +66,6 @@ class Migration
     public function setGlobal(string $key, $value)
     {
         $GLOBALS[$key] = $value;
-        $this->containerBuilder->setParameter($key, $value);
+        $this->containerBuilder->setParameter($key, $this->containerBuilder->getParameterBag()->escapeValue($value));
     }
 }

--- a/tbl_chart.php
+++ b/tbl_chart.php
@@ -25,9 +25,10 @@ $dependency_definitions = [
 
 /** @var Definition $definition */
 $definition = $containerBuilder->getDefinition(ChartController::class);
+$parameterBag = $containerBuilder->getParameterBag();
 array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
+    static function (string $parameterName, $value) use ($definition, $parameterBag) {
+        $definition->replaceArgument($parameterName, $parameterBag->escapeValue($value));
     },
     array_keys($dependency_definitions),
     $dependency_definitions

--- a/tbl_find_replace.php
+++ b/tbl_find_replace.php
@@ -30,9 +30,10 @@ $dependency_definitions = [
 
 /** @var Definition $definition */
 $definition = $containerBuilder->getDefinition(SearchController::class);
+$parameterBag = $containerBuilder->getParameterBag();
 array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
+    static function (string $parameterName, $value) use ($definition, $parameterBag) {
+        $definition->replaceArgument($parameterName, $parameterBag->escapeValue($value));
     },
     array_keys($dependency_definitions),
     $dependency_definitions

--- a/tbl_gis_visualization.php
+++ b/tbl_gis_visualization.php
@@ -42,9 +42,10 @@ $dependency_definitions = [
 
 /** @var Definition $definition */
 $definition = $containerBuilder->getDefinition(GisVisualizationController::class);
+$parameterBag = $containerBuilder->getParameterBag();
 array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
+    static function (string $parameterName, $value) use ($definition, $parameterBag) {
+        $definition->replaceArgument($parameterName, $parameterBag->escapeValue($value));
     },
     array_keys($dependency_definitions),
     $dependency_definitions

--- a/tbl_relation.php
+++ b/tbl_relation.php
@@ -77,9 +77,10 @@ if (Util::isForeignKeySupported($tbl_storage_engine)) {
 
 /** @var Definition $definition */
 $definition = $containerBuilder->getDefinition(RelationController::class);
+$parameterBag = $containerBuilder->getParameterBag();
 array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
+    static function (string $parameterName, $value) use ($definition, $parameterBag) {
+        $definition->replaceArgument($parameterName, $parameterBag->escapeValue($value));
     },
     array_keys($dependency_definitions),
     $dependency_definitions

--- a/tbl_select.php
+++ b/tbl_select.php
@@ -30,9 +30,10 @@ $dependency_definitions = [
 
 /** @var Definition $definition */
 $definition = $containerBuilder->getDefinition(SearchController::class);
+$parameterBag = $containerBuilder->getParameterBag();
 array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
+    static function (string $parameterName, $value) use ($definition, $parameterBag) {
+        $definition->replaceArgument($parameterName, $parameterBag->escapeValue($value));
     },
     array_keys($dependency_definitions),
     $dependency_definitions

--- a/tbl_structure.php
+++ b/tbl_structure.php
@@ -55,9 +55,10 @@ $dependency_definitions = [
 
 /** @var Definition $definition */
 $definition = $containerBuilder->getDefinition(StructureController::class);
+$parameterBag = $containerBuilder->getParameterBag();
 array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
+    static function (string $parameterName, $value) use ($definition, $parameterBag) {
+        $definition->replaceArgument($parameterName, $parameterBag->escapeValue($value));
     },
     array_keys($dependency_definitions),
     $dependency_definitions

--- a/tbl_zoom_select.php
+++ b/tbl_zoom_select.php
@@ -29,9 +29,10 @@ $dependency_definitions = [
 
 /** @var Definition $definition */
 $definition = $containerBuilder->getDefinition(SearchController::class);
+$parameterBag = $containerBuilder->getParameterBag();
 array_map(
-    static function (string $parameterName, $value) use ($definition) {
-        $definition->replaceArgument($parameterName, $value);
+    static function (string $parameterName, $value) use ($definition, $parameterBag) {
+        $definition->replaceArgument($parameterName, $parameterBag->escapeValue($value));
     },
     array_keys($dependency_definitions),
     $dependency_definitions


### PR DESCRIPTION
### Description

Parameters sent to DI may sometimes have content that look like DI parameters. The intent of this PR is to secure the url_query parameter used in many pages.

Fixes #16222 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
