### PR TITLE
fixes #16248: identifying searchType in validation function

### DIFF
--- a/js/table/change.js
+++ b/js/table/change.js
@@ -151,7 +151,7 @@ function checkForCheckbox (multiEdit) {
 
 // used in Search page mostly for INT fields
 // eslint-disable-next-line no-unused-vars
-function verifyAfterSearchFieldChange (index) {
+function verifyAfterSearchFieldChange (index, searchFormId) {
     var $thisInput = $('input[name=\'criteriaValues[' + index + ']\']');
     // validation for integer type
     if ($thisInput.data('type') === 'INT') {
@@ -159,8 +159,9 @@ function verifyAfterSearchFieldChange (index) {
         $thisInput.val($thisInput.val().trim());
 
         var hasMultiple = $thisInput.prop('multiple');
+
         if (hasMultiple) {
-            $('#tbl_search_form').validate();
+            $(searchFormId).validate();
             // validator method for IN(...), NOT IN(...)
             // BETWEEN and NOT BETWEEN
             jQuery.validator.addMethod('validationFunctionForMultipleInt', function (value) {
@@ -170,7 +171,7 @@ function verifyAfterSearchFieldChange (index) {
             );
             validateMultipleIntField($thisInput, true);
         } else {
-            $('#tbl_search_form').validate();
+            $(searchFormId).validate();
             validateIntField($thisInput, true);
         }
     }

--- a/js/table/zoom_plot_jqplot.js
+++ b/js/table/zoom_plot_jqplot.js
@@ -129,6 +129,17 @@ AJAX.registerOnload('table/zoom_plot_jqplot.js', function () {
         searchedData = null;
     }
 
+    // adding event listener on select after AJAX request
+    var comparisonOperatorOnChange = function () {
+        var tableRows = $('#inputSection select.column-operator');
+        $.each(tableRows, function (index, item) {
+            $(item).on('change', function () {
+                // eslint-disable-next-line no-undef
+                changeValueFieldType(this, index);
+            });
+        });
+    };
+
     /**
      ** Input form submit on field change
      **/
@@ -153,6 +164,7 @@ AJAX.registerOnload('table/zoom_plot_jqplot.js', function () {
             $('#types_0').val(data.field_type);
             xType = data.field_type;
             $('#collations_0').val(data.field_collations);
+            comparisonOperatorOnChange();
             Functions.addDateTimePicker();
         });
     });
@@ -177,6 +189,7 @@ AJAX.registerOnload('table/zoom_plot_jqplot.js', function () {
             $('#types_1').val(data.field_type);
             yType = data.field_type;
             $('#collations_1').val(data.field_collations);
+            comparisonOperatorOnChange();
             Functions.addDateTimePicker();
         });
     });
@@ -198,6 +211,7 @@ AJAX.registerOnload('table/zoom_plot_jqplot.js', function () {
             $('#tableFieldsId').find('tr:eq(4) td:eq(3)').html(data.field_value);
             $('#types_2').val(data.field_type);
             $('#collations_2').val(data.field_collations);
+            comparisonOperatorOnChange();
             Functions.addDateTimePicker();
         });
     });
@@ -219,6 +233,7 @@ AJAX.registerOnload('table/zoom_plot_jqplot.js', function () {
             $('#tableFieldsId').find('tr:eq(5) td:eq(3)').html(data.field_value);
             $('#types_3').val(data.field_type);
             $('#collations_3').val(data.field_collations);
+            comparisonOperatorOnChange();
             Functions.addDateTimePicker();
         });
     });

--- a/libraries/classes/Controllers/Table/SearchController.php
+++ b/libraries/classes/Controllers/Table/SearchController.php
@@ -979,7 +979,9 @@ class SearchController extends AbstractController
             $type = 'INT';
         }
 
-        $html_attributes .= " onchange= 'return verifyAfterSearchFieldChange(" . $column_index . ")'";
+        $searchFormId = $this->_searchType === 'zoom' ? '#zoom_search_form' : '#tbl_search_form';
+
+        $html_attributes .= ' onchange="return verifyAfterSearchFieldChange(' . $column_index . ', \'' . $searchFormId . '\')"';
 
         $value = $this->template->render('table/search/input_box', [
             'str' => '',


### PR DESCRIPTION
Signed-off-by: Ankush Patil <aspraz2658@gmail.com>

### Description
Passing a searchType parameter in the validation function. Also needed to add event listener on comparison operators which are loaded after AJAX requests.

Still, There is little disturbance in UI when it shows the validation message.

Fixes #16248 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
