### PR TITLE
Added missing padding in error box

### DIFF
--- a/setup/styles.css
+++ b/setup/styles.css
@@ -175,6 +175,7 @@ div.notice {
   border: 1px solid maroon !important;
   color: #000;
   background: pink;
+  padding: 0.27em;
 }
 
 h1.error,


### PR DESCRIPTION
### Description

The size of error box was smaller than the input box.

Fixes #

![active](https://user-images.githubusercontent.com/47316899/87258039-dcc34500-c4b9-11ea-97db-b08e5ef4fec8.JPG)


Padding is added in the error box so now both boxes look the same. 

Signed-off-by: Rosheen Naeem <rosheennaeem4@gmail.com>
