### PR TITLE
Add padding in error box messages

### DIFF
--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -761,6 +761,15 @@ div.tools a:hover,
   font-weight: bold;
 }
 
+.error {
+  border: 1px solid maroon !important;
+  margin-left: 2px;
+  padding: 1px 2px;
+  color: #000;
+  background: pink;
+} 
+
+
 // disabled text
 .disabled {
   color: #666;

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -767,8 +767,7 @@ div.tools a:hover,
   padding: 1px 2px;
   color: #000;
   background: pink;
-} 
-
+}
 
 // disabled text
 .disabled {

--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -827,6 +827,13 @@ fieldset.confirmation legend {
   background-color: $browse-warning-color;
 }
 
+.error {
+  border: 1px solid $browse-warning-color !important;
+  padding: 5px;
+  color: $button-color;
+  background-color: $browse-warning-color;
+}
+
 /* end messageboxes */
 
 .column_name {

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -472,6 +472,16 @@ fieldset.confirmation {
   }
 }
 
+.error {
+  background-color: #ffc;
+  color: #f00;
+}
+
+label.error {
+  padding: 3px;
+  margin: 0px 4px;
+}
+
 /* end messageboxes */
 
 .new_central_col {

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -479,7 +479,7 @@ fieldset.confirmation {
 
 label.error {
   padding: 3px;
-  margin: 0px 4px;
+  margin-left: 4px;
 }
 
 /* end messageboxes */

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -740,6 +740,13 @@ td .icon {
   background-color: pink;
 }
 
+.error {
+  border: 1px solid maroon !important;
+  padding: 0.27em;
+  color: #000;
+  background: pink;
+}
+
 // end messageboxes
 
 .new_central_col {


### PR DESCRIPTION
### Description

Now, the error box message and the input box have equal sizes.

![Original Theme](https://user-images.githubusercontent.com/66565600/87483486-38044d00-c60a-11ea-8654-5a4b6b6ab4df.png)

![Pmahomme Theme](https://user-images.githubusercontent.com/66565600/87483676-b103a480-c60a-11ea-8c20-3b9ea2625670.png)

![Bootstrap Theme](https://user-images.githubusercontent.com/66565600/87483709-c11b8400-c60a-11ea-8bbc-0cd789e6343c.png)

![Metro Theme](https://user-images.githubusercontent.com/66565600/87483736-d09acd00-c60a-11ea-9970-7a933fc7e4fa.png)

Fixes #16217 

Signed-off-by: Felipe Barbosa <fekipedmb@gmail.com>