### PR TITLE
Fix modal header in User accounts

### DIFF
--- a/libraries/classes/Response.php
+++ b/libraries/classes/Response.php
@@ -364,7 +364,9 @@ class Response
         }
 
         if ($this->_isSuccess) {
-            $this->addJSON('title', '<title>' . $this->getHeader()->getPageTitle() . '</title>');
+            if (!isset($this->_JSON['title'])) {
+                $this->addJSON('title', '<title>' . $this->getHeader()->getPageTitle() . '</title>');
+            }
 
             if (isset($GLOBALS['dbi'])) {
                 $menuHash = $this->getHeader()->getMenu()->getHash();


### PR DESCRIPTION
Signed-off-by: Ivan Kayzer <ivan.kayzer@outlook.com>

### Description

Fixes title in modal header in User Accounts -> Export mentioned in #16261 

Fixes #16261 

Before:
![image](https://user-images.githubusercontent.com/14001131/87579468-40c25500-c6d6-11ea-900b-5a181415de35.png)

After:
![image](https://user-images.githubusercontent.com/14001131/87579435-2ee0b200-c6d6-11ea-9aa7-8505e759beda.png)
