### PR TITLE
Fix #16194 - View definition missing for non definer user

### DIFF
--- a/view_create.php
+++ b/view_create.php
@@ -225,6 +225,22 @@ if (isset($_GET['db']) && isset($_GET['table'])) {
     $view['as'] = $item['VIEW_DEFINITION'];
     $view['with'] = $item['CHECK_OPTION'];
     $view['algorithm'] = $item['ALGORITHM'];
+
+    // [user]@[host]
+    $definerParts = explode("@", $view['definer'], 2);
+
+    if (count($definerParts) == 2) {
+        // Get AS part from CREATE VIEW query
+        $asSelectPosition = strpos(strtolower($view['as']), "as select");
+
+        // +3 to skip AS<space> and start from select
+        $view['as'] = substr($view['as'], $asSelectPosition + 3);
+
+        // Remove CHECK OPTIONS at the end
+        $checkOptionsRegex = "/WITH (CASCADED|LOCAL) CHECK OPTION/";
+
+        $view['as'] = preg_replace($checkOptionsRegex, "", $view['as']);
+    }
 }
 
 if (Core::isValid($_POST['view'], 'array')) {


### PR DESCRIPTION
Signed-off-by: Shahlin <shahlin44@gmail.com>

### Description

The following commit allows users who are not definers of the view to be able to see the view query (instead of it being blank). The fix uses a string manipulation approach as the result could not be achieved with an existing MySQL query.

Fixes #16194

- Get the select statement from the CREATE VIEW query stored in the `information_schema` table and display that

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
