### PR TITLE
Fixed borders in Operations/Index template

### DIFF
--- a/templates/home/index.twig
+++ b/templates/home/index.twig
@@ -31,7 +31,7 @@
               <div class="card-header">
                 {% trans 'General settings' %}
               </div>
-              <ul class="list-group list-group-flush">
+              <ul class="list-group-noborder list-group-flush">
                 {% if has_server_selection %}
                   <li id="li_select_server" class="list-group-item">
                     {{ get_image('s_host') }}
@@ -77,7 +77,7 @@
               <div class="card-header">
                 {% trans 'Appearance settings' %}
               </div>
-              <ul class="list-group list-group-flush">
+              <ul class="list-group-noborder list-group-flush">
                 {% if language_selector is not empty %}
                   <li id="li_select_lang" class="list-group-item">
                     {{ get_image('s_lang') }}
@@ -101,7 +101,7 @@
             <div class="card-header">
               {% trans 'Database server' %}
             </div>
-            <ul class="list-group list-group-flush">
+            <ul class="list-group-noborder list-group-flush">
               <li class="list-group-item">
                 {% trans 'Server:' %}
                 {{ database_server.host }}
@@ -141,7 +141,7 @@
             <div class="card-header">
               {% trans 'Web server' %}
             </div>
-            <ul class="list-group list-group-flush">
+            <ul class="list-group-noborder list-group-flush">
               {% if web_server is not empty %}
                 <li class="list-group-item">
                   {{ web_server.software }}
@@ -173,7 +173,7 @@
             <div class="card-header">
               phpMyAdmin
             </div>
-            <ul class="list-group list-group-flush">
+            <ul class="list-group-noborder list-group-flush">
               <li id="li_pma_version" class="list-group-item{{ is_version_checked ? ' jsversioncheck' }}">
                 {% trans 'Version information:' %}
                 <span class="version">{{ phpmyadmin_version }}</span>

--- a/templates/table/operations/index.twig
+++ b/templates/table/operations/index.twig
@@ -310,7 +310,7 @@
 
 <div class="card mb-2">
   <div class="card-header">{% trans 'Table maintenance' %}</div>
-  <ul class="list-group list-group-flush" id="tbl_maintenance">
+  <ul class="list-group-noborder list-group-flush" id="tbl_maintenance">
     {% for action in maintenance_actions %}
       <li class="list-group-item">
         {{ link_or_button(
@@ -327,7 +327,7 @@
 {% if not is_system_schema %}
   <div class="card mb-2">
     <div class="card-header">{% trans 'Delete data or table' %}</div>
-    <ul class="list-group list-group-flush">
+    <ul class="list-group-noborder list-group-flush">
       {% if not is_view %}
         <li class="list-group-item">
           {{ link_or_button(
@@ -415,7 +415,7 @@
 {% if foreigners is not empty %}
   <div class="card mb-2">
     <div class="card-header">{% trans 'Check referential integrity' %}</div>
-    <ul class="list-group list-group-flush">
+    <ul class="list-group-noborder list-group-flush">
       {% for foreign in foreigners %}
         <li class="list-group-item">
           <a class="text-nowrap" href="{{ url('/sql', foreign.params) }}">

--- a/themes/pmahomme/scss/_list-group-noborder.scss
+++ b/themes/pmahomme/scss/_list-group-noborder.scss
@@ -1,0 +1,22 @@
+.list-group-noborder {
+  padding-#{$left}: 40px;
+  margin: 1rem 0;
+  border: none;
+}
+
+.list-group-item {
+  display: list-item;
+  border: none;
+}
+
+#li_select_server,
+#li_change_password,
+#li_select_mysql_collation,
+#li_user_preferences,
+#li_select_lang,
+#li_select_theme {
+  &.list-group-item {
+    display: block;
+    margin-#{$left}: -20px;
+  }
+}

--- a/themes/pmahomme/scss/theme.scss
+++ b/themes/pmahomme/scss/theme.scss
@@ -19,5 +19,5 @@
 @import "card";
 @import "breadcrumb";
 @import "alert";
-@import "list-group";
+@import "list-group-noborder";
 @import "modal";


### PR DESCRIPTION
### Description

Please describe your pull request.
The problem was due to .card > .list-group border.
It was fixed by changing the class in template to .list-group-noborder & attaching a separate scss for it.

Fixes #16295 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
