### PR TITLE
Fix #16325 Editing geometry data throws error on using the GUI

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -2597,6 +2597,9 @@ class InsertEdit
             $current_value = mb_substr($current_value, 1, -1);
             // Remove escaping apostrophes
             $current_value = str_replace("''", "'", $current_value);
+            // Remove backslash-escaped apostrophes
+            $current_value = str_replace("\'", "'", $current_value);
+
             return $multi_edit_funcs[$key] . '(' . $current_value . ')';
         } elseif (! in_array($multi_edit_funcs[$key], $func_no_param)
             || ($current_value != "''"


### PR DESCRIPTION
Signed-off-by: Petr Duda <petrduda@seznam.cz>

### Description

Remove backslash-escaped apostrophes from values for "gis_from_text_functions" 

Fixes #16325, Fixes #15109

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
