### PR TITLE
Fixes #14698. Navigation tree no longer breaks on encountering a database named 'New'

### DIFF
--- a/libraries/classes/Navigation/Nodes/Node.php
+++ b/libraries/classes/Navigation/Nodes/Node.php
@@ -168,7 +168,7 @@ class Node
             }
         } else {
             foreach ($this->children as $child) {
-                if ($child->name == $name) {
+                if ($child->name == $name  && $child->isNew === false) {
                     return $child;
                 }
             }


### PR DESCRIPTION
Signed-off-by: Nina Pypchenko <22447785+nina-py@users.noreply.github.com>

### Description

Fixes #14698 . If a database is named "New", a fatal error will no longer appear, breaking the navigation tree. `Node::getChild()` now makes sure the child node returned doesn't have the `isNew` property set to true (this is only set for links to create new objects, i.e. databases or tables).  