### PR TITLE
Fix #14795 - async Routine export list

### DIFF
--- a/js/src/rte.js
+++ b/js/src/rte.js
@@ -131,23 +131,26 @@ RTE.COMMON = {
             if (count === 0) {
                 Functions.ajaxShowMessage(Messages.NoExportable);
             }
-
+            var p = $.when();
             exportAnchors.each(function () {
-                $.get($(this).attr('href'), { 'ajax_request': true }, function (data) {
-                    returnCount++;
-                    if (data.success === true) {
-                        combined.message += '\n' + data.message + '\n';
-                        if (returnCount === count) {
-                            showExport(combined);
+                var h = $(this).attr('href');
+                p = p.then(function () {
+                    return $.get(h, { 'ajax_request': true }, function (data) {
+                        returnCount++;
+                        if (data.success === true) {
+                            combined.message += '\n' + data.message + '\n';
+                            if (returnCount === count) {
+                                showExport(combined);
+                            }
+                        } else {
+                            // complain even if one export is failing
+                            combined.success = false;
+                            combined.error += '\n' + data.error + '\n';
+                            if (returnCount === count) {
+                                showExport(combined);
+                            }
                         }
-                    } else {
-                        // complain even if one export is failing
-                        combined.success = false;
-                        combined.error += '\n' + data.error + '\n';
-                        if (returnCount === count) {
-                            showExport(combined);
-                        }
-                    }
+                    });
                 });
             });
         } else {


### PR DESCRIPTION
Signed-off-by: Rajat Jain <rajatjain.ix@gmail.com>

### Description

Since multi-export of Routines makes use of multiple JS Promises, they are often combined out-of-order.
Fix is to use .then().

Fixes #16264 
Fixes #14795

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
