### PR TITLE
Fix #16095 Leading space not shown in a CHAR column

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3780,13 +3780,14 @@ class Results
         $function_nowrap = 'applyTransformationNoWrap';
 
         $bool_nowrap = ($default_function != $transformation_plugin)
-            && function_exists((string) $transformation_plugin->$function_nowrap())
+            && method_exists($transformation_plugin, $function_nowrap)
             ? $transformation_plugin->$function_nowrap($transform_options)
             : false;
 
-        // do not wrap if date field type
+        // do not wrap if date field type or if no-wrapping enabled by transform functions
+        // otherwise, preserve whitespaces and wrap
         $nowrap = preg_match('@DATE|TIME@i', $meta->type)
-            || $bool_nowrap ? ' nowrap' : '';
+            || $bool_nowrap ? 'nowrap' : 'pre_wrap';
 
         $where_comparison = ' = \''
             . $dbi->escapeString($column)

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Display\Results as DisplayResults;
 use PhpMyAdmin\Plugins\Transformations\Text_Plain_Link;
+use PhpMyAdmin\Plugins\Transformations\Output\Text_Plain_External;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Utils\Query;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -827,6 +828,8 @@ class ResultsTest extends AbstractTestCase
     public function dataProviderForTestGetDataCellForNonNumericColumns(): array
     {
         $transformation_plugin = new Text_Plain_Link();
+        $transformation_plugin_external = new Text_Plain_External();
+
         $meta = new stdClass();
         $meta->db = 'foo';
         $meta->table = 'tbl';
@@ -845,6 +848,17 @@ class ResultsTest extends AbstractTestCase
         $meta2->decimals = 0;
         $meta2->name = 'varchar';
         $meta2->orgname = 'varchar';
+
+        $meta3 = new stdClass();
+        $meta3->db = 'foo';
+        $meta3->table = 'tbl';
+        $meta3->orgtable = 'tbl';
+        $meta3->type = 'datetime';
+        $meta3->flags = '';
+        $meta3->decimals = 0;
+        $meta3->name = 'datetime';
+        $meta3->orgname = 'datetime';
+
         $url_params = [
             'db' => 'foo',
             'table' => 'tbl',
@@ -947,6 +961,53 @@ class ResultsTest extends AbstractTestCase
                 '<td data-decimals="0" data-type="string" '
                 . 'data-originallength="11" '
                 . 'class="grid_edit pre_wrap">foo bar baz</td>' . "\n",
+            ],
+            [
+                'all',
+                'foo bar baz',
+                'grid_edit',
+                $meta2,
+                [],
+                $url_params,
+                false,
+                $transformation_plugin_external,
+                [
+                    Core::class,
+                    'mimeDefaultFunction',
+                ],
+                [],
+                false,
+                [],
+                0,
+                '',
+                '<td data-decimals="0" data-type="string" '
+                . 'data-originallength="11" '
+                . 'class="grid_edit nowrap transformed">foo bar baz</td>' . "\n",
+            ],
+            [
+                'all',
+                '2020-09-20 16:35:00',
+                'grid_edit',
+                $meta3,
+                [],
+                $url_params,
+                false,
+                [
+                    Core::class,
+                    'mimeDefaultFunction',
+                ],
+                [
+                    Core::class,
+                    'mimeDefaultFunction',
+                ],
+                [],
+                false,
+                [],
+                0,
+                '',
+                '<td data-decimals="0" data-type="datetime" '
+                . 'data-originallength="19" '
+                . 'class="grid_edit nowrap">2020-09-20 16:35:00</td>' . "\n",
             ],
         ];
     }

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -946,7 +946,7 @@ class ResultsTest extends AbstractTestCase
                 '',
                 '<td data-decimals="0" data-type="string" '
                 . 'data-originallength="11" '
-                . 'class="grid_edit ">foo bar baz</td>' . "\n",
+                . 'class="grid_edit pre_wrap">foo bar baz</td>' . "\n",
             ],
         ];
     }

--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -915,6 +915,10 @@ td.disabled {
   white-space: nowrap;
 }
 
+.pre_wrap {
+  white-space: pre-wrap;
+}
+
 .font_weight_bold {
   font-weight: bold;
 }

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -577,6 +577,10 @@ td.disabled {
   white-space: nowrap;
 }
 
+.pre_wrap {
+  white-space: pre-wrap;
+}
+
 /**
  * zoom search
  */

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -836,6 +836,10 @@ td.disabled {
   white-space: nowrap;
 }
 
+.pre_wrap {
+  white-space: pre-wrap;
+}
+
 /**
  * login form
  */


### PR DESCRIPTION
### Description

Add "white-space: pre-wrap;" css styling to value cells of non-numeric columns other than date types, provided that no-wrapping is not enabled by transform functions.

Fixes #16095

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
