### PR TITLE
Fix column definition form not showing default value

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -60,6 +60,7 @@ phpMyAdmin - ChangeLog
 - issue #15634 Only use session_set_cookie_params once on PHP >= 7.3.0 versions for single signon auth
 - issue #14698 Fixed database named as 'New' (language variable) causes PHP fatal error
 - issue #16355 Make textareas both sides resizable
+- issue #16366 Fix column definition form not showing default value
 
 5.0.2 (2020-03-20)
 - issue        Fixed deprecation warning "implode(): Passing glue string after array is deprecated." function on export page

--- a/libraries/tbl_columns_definition_form.inc.php
+++ b/libraries/tbl_columns_definition_form.inc.php
@@ -462,7 +462,7 @@ for ($columnNumber = 0; $columnNumber < $num_fields; $columnNumber++) {
     if (isset($columnMeta['DefaultValue'])) {
         $default_value = $columnMeta['DefaultValue'];
     }
-    if ($type_upper == 'BIN)') {
+    if ($type_upper == 'BIT') {
         $default_value = Util::convertBitDefaultValue($columnMeta['DefaultValue']);
     } elseif ($type_upper == 'BINARY' || $type_upper == 'VARBINARY') {
         $default_value = bin2hex($columnMeta['DefaultValue']);

--- a/templates/columns_definitions/column_attributes.twig
+++ b/templates/columns_definitions/column_attributes.twig
@@ -46,7 +46,6 @@
         'ci': ci,
         'ci_offset': ci_offset,
         'column_meta': column_meta,
-        'type_upper': type_upper,
         'default_value': default_value,
         'char_editing': char_editing
     } only %}

--- a/templates/database/central_columns/main.twig
+++ b/templates/database/central_columns/main.twig
@@ -85,7 +85,7 @@
                                 'column_number': 0,
                                 'ci': 3,
                                 'ci_offset': 0,
-                                'type_upper': '',
+                                'default_value': '',
                                 'column_meta': {},
                                 'char_editing': char_editing,
                             } only %}
@@ -333,7 +333,7 @@
                                     'column_number': row_num,
                                     'ci': 3,
                                     'ci_offset': 0,
-                                    'type_upper': types_upper[row_num],
+                                    'default_value': default_values[row_num],
                                     'column_meta': rows_meta[row_num],
                                     'char_editing': char_editing,
                                 } only %}


### PR DESCRIPTION
To reproduce: 
Add a column that has an user defined default value to the central columns, then try to bulk edit that central column. The input field for the default value will be empty.

Introduced by 5d0fd81e674464c4ba79f40a84974b1129b350e4.