### PR TITLE
Modified CSS value font-size to revert instead of 1em.

### DIFF
--- a/themes/metro/scss/_reboot.scss
+++ b/themes/metro/scss/_reboot.scss
@@ -13,11 +13,11 @@ body {
 // Forms
 
 input,
-select,
-textarea {
+select {
   font-size: 1em;
 }
 
 textarea {
   font-family: $font-family-monospace;
+  font-size: 1.2em;
 }

--- a/themes/original/scss/_reboot.scss
+++ b/themes/original/scss/_reboot.scss
@@ -7,11 +7,11 @@ body {
 // Forms
 
 input,
-select,
-textarea {
+select {
   font-size: 1em;
 }
 
 textarea {
   font-family: $font-family-monospace;
+  font-size: 1.2em;
 }

--- a/themes/pmahomme/scss/_reboot.scss
+++ b/themes/pmahomme/scss/_reboot.scss
@@ -7,11 +7,11 @@ body {
 // Forms
 
 input,
-select,
-textarea {
+select {
   font-size: 1em;
 }
 
 textarea {
   font-family: $font-family-monospace;
+  font-size: 1.2em;
 }


### PR DESCRIPTION
Signed-off-by: Rajat Jain <rajatjain.ix@gmail.com>

### Description

Please describe your pull request.
I have modified the property `font-size` for `textarea` to value `revert` instead of `1em` in ALL themes.

Fixes #16252 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
