### PR TITLE
Use refreshed cache data

### DIFF
--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -330,6 +330,7 @@ class Table
             || count($cachedResult) === 1
         ) {
             $this->dbi->getTablesFull($db, $table);
+            $cachedResult = $this->dbi->getCache()->getCachedTableContent([$db, $table]);
         }
 
         if ($cachedResult === null) {


### PR DESCRIPTION
Clean install from git.
InnoDB table but cannot see "foreign key constraints" section in table "relation view".

The problem is that the cache is refreshed but the local copy of the cache wasn't refreshed.
So calling getStatusInfo('Engine') was returning null, instead of "InnoDB"
