### PR TITLE
Fix #16245 Failed Zoom search clears existing values

### DIFF
--- a/templates/table/search/rows_zoom.twig
+++ b/templates/table/search/rows_zoom.twig
@@ -37,10 +37,10 @@
             and criteria_column_names[i] != 'pma_null' %}
             {% set key = keys[criteria_column_names[i]] %}
             {% set properties = self.getColumnProperties(i, key) %}
-            {% set type = type|merge({i: properties['type']}) %}
-            {% set collation = collation|merge({i: properties['collation']}) %}
-            {% set func = func|merge({i: properties['func']}) %}
-            {% set value = value|merge({i: properties['value']}) %}
+            {% set type = type|merge({(i): properties['type']}) %}
+            {% set collation = collation|merge({(i): properties['collation']}) %}
+            {% set func = func|merge({(i): properties['func']}) %}
+            {% set value = value|merge({(i): properties['value']}) %}
         {% endif %}
         {# Column type #}
         <td dir="ltr">
@@ -56,9 +56,9 @@
         </td>
         {# Inputbox for search criteria value #}
         <td>
+            {{ value[i] is defined ? value[i]|raw }}
         </td>
         <td>
-            {{ value[i] is defined ? value[i]|raw }}
             {# Displays hidden fields #}
             <input type="hidden"
                 name="criteriaColumnTypes[{{ i }}]"


### PR DESCRIPTION
Signed-off-by: Petr Duda <petrduda@seznam.cz>

### Description

Wrapped the numeric key variable in round brackets so that it is used as intended in the Twig merge filter (as a numeric key, not as a string key).

Fixes #16245 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
