### PR TITLE
Fix #16420, Revert #14411 - Single clicking on row starts editing even if GridEditing is set to double-click

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -2048,13 +2048,6 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             // start grid-editing
                             startGridEditing(e, this);
                         }
-                    } else {// If it is not a link or it is a double tap then call startGridEditing
-                        // this is a double click, cancel the single click timer
-                        // and make the click count 0
-                        clearTimeout($cell.data('timer'));
-                        $cell.data('clicks', 0);
-                        // start grid-editing
-                        startGridEditing(e, this);
                     }
                 })
                 .on('dblclick', function (e) {


### PR DESCRIPTION
Signed-off-by: Rajat Jain <rajatjain.ix@gmail.com>

### Description

There already existed a `dblclick` function but there seems to be an old piece of code that executes instead.

Fixes #16420 
Reverts #14411

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
