### PR TITLE
Force BINARY comparison when looking at privileges.

### DIFF
--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -1423,23 +1423,23 @@ class Privileges
             `Event_priv`,
             `Trigger_priv`,';
 
-        $listOfComparedPrivileges = '`Select_priv` = \'N\' AND
-            `Insert_priv` = \'N\' AND
-            `Update_priv` = \'N\' AND
-            `Delete_priv` = \'N\' AND
-            `Create_priv` = \'N\' AND
-            `Drop_priv` = \'N\' AND
-            `Grant_priv` = \'N\' AND
-            `References_priv` = \'N\' AND
-            `Create_tmp_table_priv` = \'N\' AND
-            `Lock_tables_priv` = \'N\' AND
-            `Create_view_priv` = \'N\' AND
-            `Show_view_priv` = \'N\' AND
-            `Create_routine_priv` = \'N\' AND
-            `Alter_routine_priv` = \'N\' AND
-            `Execute_priv` = \'N\' AND
-            `Event_priv` = \'N\' AND
-            `Trigger_priv` = \'N\'';
+        $listOfComparedPrivileges = 'BINARY `Select_priv` = \'N\' AND
+            BINARY `Insert_priv` = \'N\' AND
+            BINARY `Update_priv` = \'N\' AND
+            BINARY `Delete_priv` = \'N\' AND
+            BINARY `Create_priv` = \'N\' AND
+            BINARY `Drop_priv` = \'N\' AND
+            BINARY `Grant_priv` = \'N\' AND
+            BINARY `References_priv` = \'N\' AND
+            BINARY `Create_tmp_table_priv` = \'N\' AND
+            BINARY `Lock_tables_priv` = \'N\' AND
+            BINARY `Create_view_priv` = \'N\' AND
+            BINARY `Show_view_priv` = \'N\' AND
+            BINARY `Create_routine_priv` = \'N\' AND
+            BINARY `Alter_routine_priv` = \'N\' AND
+            BINARY `Execute_priv` = \'N\' AND
+            BINARY `Event_priv` = \'N\' AND
+            BINARY `Trigger_priv` = \'N\'';
 
         $query = '
             (


### PR DESCRIPTION
Otherwise, a mismatch between the "Server connection collation" dropdown
and the system tables/views causes an error message.

Fixes: #15463

Signed-off-by: Isaac Bennetch <bennetch@gmail.com>


- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
