### PR TITLE
Replace / with DIRECTORY_SEPARATOR

### DIFF
--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -2748,7 +2748,7 @@ $cfg['SaveDir'] = '';
 if (defined('TEMP_DIR')) {
     $cfg['TempDir'] = TEMP_DIR;
 } else {
-    $cfg['TempDir'] = ROOT_PATH . 'tmp/';
+    $cfg['TempDir'] = ROOT_PATH . 'tmp' . DIRECTORY_SEPARATOR;
 }
 
 

--- a/libraries/vendor_config.php
+++ b/libraries/vendor_config.php
@@ -19,12 +19,12 @@ if (! defined('PHPMYADMIN')) {
  * Path to vendor autoload file. Useful when you want to
  * have have vendor dependencies somewhere else.
  */
-define('AUTOLOAD_FILE', ROOT_PATH . 'vendor/autoload.php');
+define('AUTOLOAD_FILE', ROOT_PATH . 'vendor'. DIRECTORY_SEPARATOR .'autoload.php');
 
 /**
  * Directory where cache files are stored.
  */
-define('TEMP_DIR', ROOT_PATH . 'tmp/');
+define('TEMP_DIR', ROOT_PATH . 'tmp' . DIRECTORY_SEPARATOR);
 
 /**
  * Path to changelog file, can be gzip compressed. Useful when you want to
@@ -41,7 +41,7 @@ define('LICENSE_FILE', ROOT_PATH . 'LICENSE');
 /**
  * Directory where SQL scripts to create/upgrade configuration storage reside.
  */
-define('SQL_DIR', ROOT_PATH . 'sql/');
+define('SQL_DIR', ROOT_PATH . 'sql' . DIRECTORY_SEPARATOR);
 
 /**
  * Directory where configuration files are stored.
@@ -73,9 +73,9 @@ define('VERSION_CHECK_DEFAULT', true);
 /**
  * Path to files with compiled locales (*.mo)
  */
-define('LOCALE_PATH', ROOT_PATH . 'locale/');
+define('LOCALE_PATH', ROOT_PATH . 'locale' . DIRECTORY_SEPARATOR);
 
 /**
  * Define the cache directory for routing cache an other cache files
  */
-define('CACHE_DIR', ROOT_PATH . 'libraries/cache/');
+define('CACHE_DIR', ROOT_PATH . 'libraries'. DIRECTORY_SEPARATOR .'cache' . DIRECTORY_SEPARATOR);


### PR DESCRIPTION
Signed-off-by: Niko Halink <nhalink@gmail.com>

### Description

This PR fixes incorrect usage of frontslash (depending on OS) by replacing it with `DIRECTORY_SEPARATOR` for:
* TempDir in the `$cfg` array
* Several constant definitions

Fixes #16430 

Before submitting pull request, please review the following checklist:
- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
