### PR TITLE
Increase password characters limit during login

### DIFF
--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -335,8 +335,11 @@ class AuthenticationCookie extends AuthenticationPlugin
             $this->user = Core::sanitizeMySQLUser($_POST['pma_username']);
 
             $password = $_POST['pma_password'] ?? '';
-            if (strlen($password) > 256) {
-                $password = substr($password, 0, 256);
+            if (strlen($password) > 1000) {
+                $conn_error = __('Your password is too long. To prevent denial-of-service attacks, ' .
+                    'phpMyAdmin restricts passwords to less than 1000 characters.');
+
+                return false;
             }
             $this->password = $password;
 


### PR DESCRIPTION
### Description

- allow logging in with longer passwords, for example tokens generated by AWS RDS IAM authentication

- show error message when the limit is reached instead of silently trimming the password to avoid confusion

Fixes https://github.com/phpmyadmin/phpmyadmin/issues/16451

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
