### PR TITLE
Add post-create-project-cmd Composer script command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,11 @@
             "@phpunit"
         ],
         "update:baselines": "phpstan analyse --generate-baseline && psalm --set-baseline=psalm-baseline.xml",
-        "twig-lint": "php scripts/console lint:twig templates --ansi --show-deprecations"
+        "twig-lint": "php scripts/console lint:twig templates --ansi --show-deprecations",
+        "post-create-project-cmd": [
+            "yarn install --non-interactive --silent",
+            "scripts/generate-mo --quiet"
+        ]
     },
     "config":{
         "sort-packages": true


### PR DESCRIPTION
phpMyAdmin have a dedicated [Composer repository](https://github.com/phpmyadmin/composer) to allow users to install it and be ready to use.

To make it ready to use, we use the [`daily-composer` script](https://github.com/phpmyadmin/scripts/blob/master/website/daily-composer) that runs the needed install steps for the user.

To [install phpMyAdmin using Composer](https://docs.phpmyadmin.net/en/latest/setup.html#installing-using-composer), you have to run this command:
```
composer create-project phpmyadmin/phpmyadmin
```

And according to the [Composer documentation](https://getcomposer.org/doc/articles/scripts.md#command-events):
> **post-create-project-cmd**: occurs after the `create-project` command has been executed.

So we can add the needed install steps to the `post-create-project-cmd` command event instead of running them using `daily-composer` script. This could make the dedicated Composer repository obsolete.

The cons of this change is that the user will need to have Yarn installed on their machine as well.