### PR TITLE
Fix wrong logic introduced by #15823

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -3332,8 +3332,8 @@ AJAX.registerOnload('functions.js', function () {
  */
 Functions.hideShowConnection = function ($engineSelector) {
     var $connection = $('.create_table_form input[name=connection]');
-    var index = $connection.parent('td').index() + 1;
-    var $labelTh = $connection.parents('tr').prev('tr').children(document.querySelectorAll('th:nth-child(' + index + ')'));
+    var index = $connection.parent('td').index();
+    var $labelTh = $connection.parents('tr').prev('tr').children('th').eq(index);
     if ($engineSelector.val() !== 'FEDERATED') {
         $connection
             .prop('disabled', true)

--- a/js/src/indexes.js
+++ b/js/src/indexes.js
@@ -57,7 +57,7 @@ Indexes.checkIndexType = function () {
     /**
      * @var Object Table header for the size column.
      */
-    var $sizeHeader = $('#index_columns').find(document.querySelectorAll('thead tr th:nth-child(2)'));
+    var $sizeHeader = $('#index_columns').find('thead tr').children('th').eq(1);
     /**
      * @var Object Inputs to specify the columns for the index.
      */

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -1382,8 +1382,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                                     var $existingQuery = $(g.o).find('.result_query');
                                     // If two query box exists update query in second else add a second box
                                     if ($existingQuery.find('div.sqlOuter').length > 1) {
-                                        $existingQuery.children(document.querySelectorAll(':nth-child(4)')).remove();
-                                        $existingQuery.children(document.querySelectorAll(':nth-child(4)')).remove();
+                                        $existingQuery.children().eq(3).remove();
+                                        $existingQuery.children().eq(3).remove();
                                         $existingQuery.append(sqlOuter + tools);
                                     } else {
                                         $existingQuery.append(sqlOuter + tools);

--- a/js/src/server/status/monitor.js
+++ b/js/src/server/status/monitor.js
@@ -1051,10 +1051,10 @@ AJAX.registerOnload('server/status/monitor.js', function () {
         /* Calculate how much spacing there is between each chart */
         $('#chartGrid').html('<tr><td></td><td></td></tr><tr><td></td><td></td></tr>');
         chartSpacing = {
-            width: $('#chartGrid').find(document.querySelectorAll('td:nth-child(2)')).offset().left -
-                $('#chartGrid').find(document.querySelectorAll('td:nth-child(1)')).offset().left,
-            height: $('#chartGrid').find(document.querySelectorAll('td:nth-child(2) td:nth-child(2)')).offset().top -
-                $('#chartGrid').find(document.querySelectorAll('td:nth-child(1) td:nth-child(1)')).offset().top
+            width: $('#chartGrid').find('td').eq(1).offset().left -
+                $('#chartGrid').find('td').eq(0).offset().left,
+            height: $('#chartGrid').find('tr').eq(1).find('td').eq(1).offset().top -
+               $('#chartGrid').find('tr').eq(0).find('td').eq(0).offset().top
         };
         $('#chartGrid').html('');
 
@@ -1807,7 +1807,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
             };
 
             // We just assume the sql text is always in the second last column, and that the total count is right of it
-            $('#logTable').find(document.querySelectorAll('table tbody tr td:nth-child(' + (runtime.logDataCols.length - 1) + ')')).each(function () {
+            $('#logTable').find('table tbody tr').children('td').eq(runtime.logDataCols.length - 2).each(function () {
                 var $t = $(this);
                 // If query is a SELECT and user enabled or disabled to group
                 // queries ignoring data in where statements, we
@@ -1843,10 +1843,10 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                         $t.next().text(rowData[sumColumnName]);
                         // Restore slow log columns
                         if (isSlowLog) {
-                            $t.parent().children(document.querySelectorAll('td:nth-child(3)')).text(rowData.query_time);
-                            $t.parent().children(document.querySelectorAll('td:nth-child(4)')).text(rowData.lock_time);
-                            $t.parent().children(document.querySelectorAll('td:nth-child(5)')).text(rowData.rows_sent);
-                            $t.parent().children(document.querySelectorAll('td:nth-child(6)')).text(rowData.rows_examined);
+                            $t.parent().children('td').eq(2).text(rowData.query_time);
+                            $t.parent().children('td').eq(3).text(rowData.lock_time);
+                            $t.parent().children('td').eq(4).text(rowData.rows_sent);
+                            $t.parent().children('td').eq(5).text(rowData.rows_examined);
                         }
                     }
                 }
@@ -1881,15 +1881,15 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                             return;
                         }
 
-                        row =  $table.children(document.querySelectorAll('td:nth-child(' + (value + 1) + ')'));
-                        numCol = row.children(':nth-child(' + (runtime.logDataCols.length) + ')');
+                        row =  $table.children('tr').eq(value);
+                        numCol = row.children().eq(runtime.logDataCols.length - 1);
                         numCol.text(filteredQueries[key]);
 
                         if (isSlowLog) {
-                            row.children(document.querySelectorAll('td:nth-child(3)')).text(secToTime(columnSums[key][0]));
-                            row.children(document.querySelectorAll('td:nth-child(4)')).text(secToTime(columnSums[key][1]));
-                            row.children(document.querySelectorAll('td:nth-child(5)')).text(columnSums[key][2]);
-                            row.children(document.querySelectorAll('td:nth-child(6)')).text(columnSums[key][3]);
+                            row.children('td').eq(2).text(secToTime(columnSums[key][0]));
+                            row.children('td').eq(3).text(secToTime(columnSums[key][1]));
+                            row.children('td').eq(4).text(columnSums[key][2]);
+                            row.children('td').eq(5).text(columnSums[key][3]);
                         }
                     });
                 }

--- a/js/src/table/gis_visualization.js
+++ b/js/src/table/gis_visualization.js
@@ -99,7 +99,7 @@ function loadSVG () {
     });
 
     // Removes the second SVG element unnecessarily added due to the above command
-    $placeholder.find(document.querySelectorAll('svg:nth-child(2)')).remove();
+    $placeholder.find('svg').eq(1).remove();
 }
 
 /**

--- a/js/src/table/select.js
+++ b/js/src/table/select.js
@@ -226,7 +226,7 @@ AJAX.registerOnload('table/select.js', function () {
         var outputGeomFunctions = binaryFunctions.concat(tempArray);
 
         // If the chosen function takes two geometry objects as parameters
-        var $operator = $geomFuncSelector.parents('tr').find(document.querySelectorAll('td:nth-child(5)')).find('select');
+        var $operator = $geomFuncSelector.parents('tr').find('td').eq(4).find('select');
         if ($.inArray($geomFuncSelector.val(), binaryFunctions) >= 0) {
             $operator.prop('readonly', true);
         } else {

--- a/js/src/table/structure.js
+++ b/js/src/table/structure.js
@@ -203,8 +203,8 @@ AJAX.registerOnload('table/structure.js', function () {
                     }
                     // Adjust the row numbers
                     for (var $row = $currRow.next(); $row.length > 0; $row = $row.next()) {
-                        var newVal = parseInt($row.find(document.querySelectorAll('td:nth-child(2)')).text(), 10) - 1;
-                        $row.find(document.querySelectorAll('td:nth-child(2)')).text(newVal);
+                        var newVal = parseInt($row.find('td').eq(1).text(), 10) - 1;
+                        $row.find('td').eq(1).text(newVal);
                     }
                     $afterFieldItem.remove();
                     $currRow.hide('medium').remove();
@@ -338,7 +338,7 @@ AJAX.registerOnload('table/structure.js', function () {
                     // Adjust the row numbers and colors
                     for (var $row = $firstrow; $row.length > 0; $row = $row.next()) {
                         $row
-                            .find(document.querySelectorAll('td:nth-child(2)'))
+                            .find('td').eq(1)
                             .text($row.index() + 1)
                             .end()
                             .removeClass('odd even')


### PR DESCRIPTION
Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

### Description

#15823 changed some selectors to avoid using deprecated jQuery functions. The issue here was that on some rows `document.querySelectorAll` was used in a filtered context which did not result in the expected, pre change, results. My change now reverts the code to the old expected behaviour but without using the deprecated functions.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
