### PR TITLE
16485 fix visual query button missing

### DIFF
--- a/templates/database/designer/main.twig
+++ b/templates/database/designer/main.twig
@@ -155,23 +155,19 @@ var designerConfig = {{ designer_config|raw }};
             {% trans 'Toggle relationship lines' %}
         </span>
     </a>
+    <a id="build_query_button" class="M_butt" href="#">
+        <img title="{% trans 'Build Query' %}"
+                src="{{ theme.getImgPath('designer/query_builder.png') }}">
+        <span class="hide hidable">
+            {% trans 'Build Query' %}
+        </span>
+    </a>
     {% if not visual_builder %}
         <a href="#" id="exportPages" class="M_butt" >
             <img title="{% trans 'Export schema' %}"
                  src="{{ theme.getImgPath('designer/export.png') }}">
             <span class="hide hidable">
                 {% trans 'Export schema' %}
-            </span>
-        </a>
-    {% else %}
-        <a id="build_query_button"
-           class="M_butt"
-           href="#"
-           class="M_butt">
-            <img title="{% trans 'Build Query' %}"
-                 src="{{ theme.getImgPath('designer/query_builder.png') }}">
-            <span class="hide hidable">
-                {% trans 'Build Query' %}
             </span>
         </a>
     {% endif %}


### PR DESCRIPTION
### Description

Added the Build Query Button by removing the button from the else logic of `{% if not visual_builder %}`.

I did a search to lookup what **`visual_builder`** means and from I could find it's not used anywhere. 
Side Note: Is there documentation available for the twig vari ables.

Fixes #16485

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
