### PR TITLE
Bump PHP minimum version to 7.2

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -41,10 +41,10 @@ jobs:
             - uses: actions/checkout@v2
             - name: Lint PHP files
               run: ./test/ci-phplint
-            - name: Use php 7.1
+            - name: Use php 7.2
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.1
+                  php-version: 7.2
                   extensions: mbstring, iconv, mysqli, zip, gd
                   tools: composer:v2
             - name: Validate composer.json and composer.lock

--- a/.github/workflows/other-tools.yml
+++ b/.github/workflows/other-tools.yml
@@ -27,10 +27,10 @@ jobs:
         if: "!contains(github.event.head_commit.message, '[ci skip]')"
         steps:
             - uses: actions/checkout@v2
-            - name: Use php 7.1
+            - name: Use php 7.2
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.1
+                  php-version: 7.2
                   extensions: mbstring, iconv, mysqli, zip, gd
                   tools: composer:v2
             - name: Cache module

--- a/.github/workflows/test-selenium.yml
+++ b/.github/workflows/test-selenium.yml
@@ -49,7 +49,7 @@ jobs:
               --restart on-failure
         strategy:
             matrix:
-                php-version: ["7.1"]
+                php-version: ["7.2"]
                 os: [ubuntu-latest]
                 db-server: ["mysql:5.7"]
         steps:
@@ -87,13 +87,13 @@ jobs:
             - name: Install modules
               run: yarn install --non-interactive --production
             - name: Install nginx and php-fpm
-              run: sudo apt-get install -y nginx php7.1-fpm
+              run: sudo apt-get install -y nginx php7.2-fpm
             - name: Copy the config
               run: cp test/config.e2e.inc.php config.inc.php
             - name: Start server
               env:
                 CI_MODE: selenium
-                FPM_PATH: php-fpm7.1
+                FPM_PATH: php-fpm7.2
                 SKIP_STANDALONE: 1
               run: |
                 ./test/start-local-server

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                php-version: ["7.1", "7.2", "7.3", "7.4", "8.0"]
+                php-version: ["7.2", "7.3", "7.4", "8.0"]
                 os: [ubuntu-latest]
         steps:
             - uses: actions/checkout@v2
@@ -64,7 +64,7 @@ jobs:
         if: "!contains(github.event.head_commit.message, '[ci skip]')"
         strategy:
             matrix:
-                php-version: ["7.1"]
+                php-version: ["7.2"]
                 os: [ubuntu-latest]
         steps:
             - uses: actions/checkout@v2
@@ -92,7 +92,7 @@ jobs:
               uses: codecov/codecov-action@v1
               with:
                 flags: dbase-extension
-                name: php-7.1-dbase-enabled
+                name: php-7.2-dbase-enabled
             - name: Send coverage to Scrutinizer
               uses: sudo-bot/action-scrutinizer@latest
               # Upload can fail on forks
@@ -113,7 +113,7 @@ jobs:
         if: "!contains(github.event.head_commit.message, '[ci skip]')"
         strategy:
             matrix:
-                php-version: ["7.1"]
+                php-version: ["7.2"]
                 os: [ubuntu-latest]
         steps:
             - uses: actions/checkout@v2
@@ -141,7 +141,7 @@ jobs:
               uses: codecov/codecov-action@v1
               with:
                 flags: recode-extension
-                name: php-7.1-recode-enabled
+                name: php-7.2-recode-enabled
             - name: Send coverage to Scrutinizer
               uses: sudo-bot/action-scrutinizer@latest
               # Upload can fail on forks

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -22,7 +22,7 @@ build:
   nodes:
     analysis:
       environment:
-        php: 7.1
+        php: 7.2
         node: 10
       dependencies:
         before:

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3 || ^8.0",
+        "php": "^7.2.5 || ^8.0",
         "ext-hash": "*",
         "ext-iconv": "*",
         "ext-json": "*",
@@ -57,7 +57,7 @@
         "symfony/expression-language": "^4.4.9",
         "symfony/polyfill-ctype": "^1.17.0",
         "symfony/polyfill-mbstring": "^1.17.0",
-        "twig/twig": "^2.9 || ^3",
+        "twig/twig": "^3.0.1",
         "williamdes/mariadb-mysql-kbs": "^1.2"
     },
     "conflict": {
@@ -86,7 +86,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^0.12.77",
         "phpstan/phpstan-phpunit": "^0.12.17",
-        "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^8.0 || ^9.0",
         "pragmarx/google2fa-qrcode": "^1.0.1",
         "samyoul/u2f-php-server": "^1.1",
         "symfony/console": "^4.4",

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -436,6 +436,7 @@ PHP 7.2 is supported since 4.7.4.
 HHVM is supported up to phpMyAdmin 4.8.
 
 Since release 5.0, phpMyAdmin supports only PHP 7.1 and newer.
+Since release 5.2, phpMyAdmin supports only PHP 7.2 and newer.
 
 .. _faq1_32:
 

--- a/doc/require.rst
+++ b/doc/require.rst
@@ -12,7 +12,7 @@ web server (such as Apache, nginx, :term:`IIS`) to install phpMyAdmin's files in
 PHP
 ---
 
-* You need PHP 7.1.3 or newer, with ``session`` support, the Standard PHP Library
+* You need PHP 7.2.5 or newer, with ``session`` support, the Standard PHP Library
   (SPL) extension, hash, ctype, and JSON support.
 
 * The ``mbstring`` extension (see :term:`mbstring`) is strongly recommended

--- a/libraries/common.inc.php
+++ b/libraries/common.inc.php
@@ -65,9 +65,9 @@ if (getcwd() == __DIR__) {
  * Minimum PHP version; can't call Core::fatalError() which uses a
  * PHP 5 function, so cannot easily localize this message.
  */
-if (PHP_VERSION_ID < 70103) {
+if (PHP_VERSION_ID < 70205) {
     die(
-        '<p>PHP 7.1.3+ is required.</p>'
+        '<p>PHP 7.2.5+ is required.</p>'
         . '<p>Currently installed version is: ' . PHP_VERSION . '</p>'
     );
 }

--- a/test/classes/EnvironmentTest.php
+++ b/test/classes/EnvironmentTest.php
@@ -21,8 +21,8 @@ class EnvironmentTest extends AbstractTestCase
     public function testPhpVersion(): void
     {
         $this->assertTrue(
-            version_compare('7.1.3', PHP_VERSION, '<='),
-            'phpMyAdmin requires PHP 7.1.3 or above'
+            version_compare('7.2.5', PHP_VERSION, '<='),
+            'phpMyAdmin requires PHP 7.2.5 or above'
         );
     }
 }


### PR DESCRIPTION
PHP officially [ended support for PHP 7.2](https://www.php.net/eol.php) on 2020-11-30. So it is safe to bump the minimum version to PHP 7.2 for phpMyAdmin 5.2, which is likely to be released only in the second half of 2021.

Related to #15607.
