### PR TITLE
Fixed typo in events editor

### DIFF
--- a/templates/database/events/editor_form.twig
+++ b/templates/database/events/editor_form.twig
@@ -9,7 +9,7 @@
     <legend>{% trans 'Details' %}</legend>
     <table class="rte_table table table-borderless table-sm">
       <tr>
-        <td>{% trans 'Details' %}</td>
+        <td>{% trans 'Event name' %}</td>
         <td>
           <input type="text" name="item_name" value="{{ event.item_name }}" maxlength="64">
         </td>


### PR DESCRIPTION
### Description

There is a typo in the events editor in QA_5_1, that does not exist in QA_5_0.
The `Event name` is mistakenly named `Details`.

### FROM QA_5_1

<img width="810" alt="Screenshot 2021-01-13 at 19 57 04" src="https://user-images.githubusercontent.com/1194964/104503995-b9e52b00-55d9-11eb-93bb-73e9cc30deb2.png">

### FROM QA_5_0

<img width="810" alt="Screenshot 2021-01-13 at 19 52 32" src="https://user-images.githubusercontent.com/1194964/104504026-c36e9300-55d9-11eb-9294-0526428795d8.png">

### After this fix

<img width="810" alt="Screenshot 2021-01-13 at 20 00 42" src="https://user-images.githubusercontent.com/1194964/104504235-0d577900-55da-11eb-9d9b-4efb87dc2147.png">
