### PR TITLE
Fixed classes and selectors for routines, triggers and events data table

### DIFF
--- a/js/src/rte.js
+++ b/js/src/rte.js
@@ -413,7 +413,7 @@ RTE.COMMON = {
                      * @var $table Object containing reference
                      *             to the main list of elements
                      */
-                    var $table = $currRow.parent();
+                    var $table = $currRow.parent().parent();
                     // Check how many rows will be left after we remove
                     // the one that the user has requested us to remove
                     if ($table.find('tr').length === 3) {
@@ -489,7 +489,7 @@ RTE.COMMON = {
                          * @var $table Object containing reference
                          *             to the main list of elements
                          */
-                        var $table = $currRow.parent();
+                        var $table = $currRow.parent().parent();
                         // Check how many rows will be left after we remove
                         // the one that the user has requested us to remove
                         if ($table.find('tr').length === 3) {

--- a/templates/database/events/index.twig
+++ b/templates/database/events/index.twig
@@ -11,7 +11,7 @@
       {% trans 'There are no events to display.' %}
     </div>
 
-    <table class="table table-light table-striped table-hover{{ items is empty ? ' hide' }}">
+    <table class="table table-light table-striped table-hover{{ items is empty ? ' hide' }} data">
       <thead class="thead-light">
       <tr>
         <th></th>

--- a/templates/database/routines/index.twig
+++ b/templates/database/routines/index.twig
@@ -23,7 +23,7 @@
       {% trans 'There are no routines to display.' %}
     </div>
 
-    <table class="table table-light table-striped table-hover{{ items is empty ? ' hide' }}">
+    <table class="table table-light table-striped table-hover{{ items is empty ? ' hide' }} data">
       <thead class="thead-light">
       <tr>
         <th></th>

--- a/templates/database/triggers/list.twig
+++ b/templates/database/triggers/list.twig
@@ -11,7 +11,7 @@
       {% trans 'There are no triggers to display.' %}
     </div>
 
-    <table class="table table-light table-striped table-hover{{ items is empty ? ' hide' }}">
+    <table class="table table-light table-striped table-hover{{ items is empty ? ' hide' }} data">
       <thead class="thead-light">
       <tr>
         <th></th>


### PR DESCRIPTION
### Description

Fixes #16570

### Issue 1
It looks like the `data` class went missing for the routines, triggers and events table.
This is used in [`rte.js`](https://github.com/phpmyadmin/phpmyadmin/blob/QA_5_1/js/src/rte.js) as a selector.

### Issue 2
It looks like the routines, triggers and events table has had a `thead` and `tbody` tags added to it.
This broke the `tr.parent()` selector.