### PR TITLE
Fix "PHP message: PHP Fatal error:  Uncaught TypeError: htmlspecialch…

### DIFF
--- a/libraries/classes/Config/FormDisplayTemplate.php
+++ b/libraries/classes/Config/FormDisplayTemplate.php
@@ -277,7 +277,7 @@ class FormDisplayTemplate
                 // As seen in the reporting server (#15042) we sometimes receive
                 // an array here. No clue about its origin nor content, so let's avoid
                 // a notice on htmlspecialchars().
-                if (! is_array($value)) {
+                if (is_string($value)) {
                     $htmlOutput .= '<input type="text" size="25" ' . $nameId
                     . $fieldClass . ' value="' . htmlspecialchars($value)
                     . '">';


### PR DESCRIPTION
…ars() expects parameter 1 to be string, bool given in /usr/share/phpmyadmin/libraries/classes/Config/FormDisplayTemplate.php:306

During login to PHPMyadmin we got the white screen of death. In our logs we found:
`
"PHP message: PHP Fatal error:  Uncaught TypeError: htmlspecialchars() expects parameter 1 to be string, bool given in /usr/share/phpmyadmin/libraries/classes/Config/FormDisplayTemplate.php:306`

The patch above solves the problem, but we are unsure if there is a better way to handle this.

Ref: https://github.com/phpmyadmin/phpmyadmin/issues/11505