### PR TITLE
Fix #16585 - BLOB JPG preview thumbnail

### DIFF
--- a/libraries/classes/Controllers/TransformationWrapperController.php
+++ b/libraries/classes/Controllers/TransformationWrapperController.php
@@ -168,10 +168,10 @@ class TransformationWrapperController extends AbstractController
                 . ($mime_options['charset'] ?? '');
         }
 
-        Core::downloadHeader($cn, $mime_type);
+        Core::downloadHeader($cn ?? '', $mime_type ?? '');
 
         if (! isset($_REQUEST['resize'])) {
-            if (stripos($mime_type, 'html') === false) {
+            if (stripos($mime_type ?? '', 'html') === false) {
                 echo $row[$transform_key];
             } else {
                 echo htmlspecialchars($row[$transform_key]);

--- a/libraries/classes/Controllers/TransformationWrapperController.php
+++ b/libraries/classes/Controllers/TransformationWrapperController.php
@@ -24,6 +24,7 @@ use function imagesx;
 use function imagesy;
 use function in_array;
 use function intval;
+use function round;
 use function str_replace;
 use function stripos;
 use function substr;
@@ -194,11 +195,11 @@ class TransformationWrapperController extends AbstractController
             $ratioHeight = $srcHeight / $_REQUEST['newHeight'];
 
             if ($ratioWidth < $ratioHeight) {
-                $destWidth = $srcWidth / $ratioHeight;
-                $destHeight = $_REQUEST['newHeight'];
+                $destWidth = intval(round($srcWidth / $ratioHeight));
+                $destHeight = intval($_REQUEST['newHeight']);
             } else {
-                $destWidth = $_REQUEST['newWidth'];
-                $destHeight = $srcHeight / $ratioWidth;
+                $destWidth = intval($_REQUEST['newWidth']);
+                $destHeight = intval(round($srcHeight / $ratioWidth));
             }
 
             if ($_REQUEST['resize']) {


### PR DESCRIPTION
Thumbnails are broken because imagecreatetruecolor() is expecting int but the params are either strings (from query string) or float. This PR fixes both issues.

Addresses the broken thumbnail mentioned in #16585 

Fixes: #16585