### PR TITLE
Added pydata-sphinx-theme in conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,7 +98,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Added **pydata-sphinx-theme** for the rst documentation of phpmyadmin

Whenever someone goes to any phpmyadmin's documentation page, it's difficult to track "**Table of Content**" for that page 

It will be great to introduce "pydata-sphinx-theme" which offers **"On this page" feature**  in the right side of the page which will be helpful for anyone traversing the documentation and finding or looking for the features of phpmyadmin 

Reference Link for theme : https://github.com/pandas-dev/pydata-sphinx-theme

![Screenshot from 2021-01-21 19-55-58](https://user-images.githubusercontent.com/64489116/105365779-a4e54900-5c24-11eb-8151-d156283e8855.png)

