### PR TITLE
Fix #16463 - 'REFERENCES' privilege checkbox's title

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -2407,6 +2407,8 @@ class DatabaseInterface implements DbalInterface
 
     /**
      * Server version as number
+     *
+     * @example 80011
      */
     public function getVersion(): int
     {

--- a/libraries/classes/Query/Compatibility.php
+++ b/libraries/classes/Query/Compatibility.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Query;
 
+use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Util;
 use function is_string;
 use function strlen;
@@ -184,5 +185,21 @@ class Compatibility
         }
 
         return false;
+    }
+
+    public static function supportsReferencesPrivilege(DatabaseInterface $dbi): bool
+    {
+        // See: https://mariadb.com/kb/en/grant/#table-privileges
+        // Unused
+        if ($dbi->isMariaDB()) {
+            return false;
+        }
+
+        // https://dev.mysql.com/doc/refman/5.6/en/privileges-provided.html#priv_references
+        // This privilege is unused before MySQL 5.6.22.
+        // As of 5.6.22, creation of a foreign key constraint
+        // requires at least one of the SELECT, INSERT, UPDATE, DELETE,
+        // or REFERENCES privileges for the parent table.
+        return $dbi->getVersion() >= 50622;
     }
 }

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Html\MySQLDocumentation;
 use PhpMyAdmin\Message;
+use PhpMyAdmin\Query\Compatibility;
 use PhpMyAdmin\Relation;
 use PhpMyAdmin\RelationCleanup;
 use PhpMyAdmin\Response;
@@ -736,6 +737,8 @@ class Privileges
             'row' => $row,
             'columns' => $columns ?? [],
             'has_submit' => $submit,
+            'supports_references_privilege' => Compatibility::supportsReferencesPrivilege($this->dbi),
+            'is_mariadb' => $this->dbi->isMariaDB(),
         ]);
     }
 

--- a/templates/server/privileges/privileges_table.twig
+++ b/templates/server/privileges/privileges_table.twig
@@ -642,7 +642,8 @@
         {%- trans 'Has no effect in this MySQL version.' %}"{{ row['References_priv'] == 'Y' ? ' checked' }}>
       <label for="checkbox_References_priv">
         <code>
-          <dfn title="{% trans 'Has no effect in this MySQL version.' %}">
+          {# l10n: The "REFERENCES" privilege when granting privileges #}
+          <dfn title="{{ supports_references_privilege ? 'Allows creating foreign key relations.'|trans : (is_mariadb ? 'Not used on MariaDB.'|trans: 'Not used for this MySQL version.'|trans) }}">
             REFERENCES
           </dfn>
         </code>


### PR DESCRIPTION
### Description

Sets different title messages depending on database and database version for 'REFERENCES' checkbox in user 'Edit Preferences' form.

Fixes #16463

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
