### PR TITLE
Do not remove a non existing cookie

### DIFF
--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -1364,7 +1364,9 @@ class Core
             $container->setParameter('goto', $goto);
             $container->setParameter('url_params', $url_params);
         } else {
-            $config->removeCookie('goto');
+            if ($config->issetCookie('goto')) {
+                $config->removeCookie('goto');
+            }
             unset($_REQUEST['goto'], $_GET['goto'], $_POST['goto']);
         }
 
@@ -1373,7 +1375,9 @@ class Core
             $back = $_REQUEST['back'];
             $container->setParameter('back', $back);
         } else {
-            $config->removeCookie('back');
+            if ($config->issetCookie('back')) {
+                $config->removeCookie('back');
+            }
             unset($_REQUEST['back'], $_GET['back'], $_POST['back']);
         }
     }


### PR DESCRIPTION
We add remove cookie instructions for `goto` and `back`.
I think this is useless and created un-needed data on each request.
Just remove them when the cookie exists.