### PR TITLE
Set MySQLi error reporting mode

### DIFF
--- a/libraries/classes/Config/Validator.php
+++ b/libraries/classes/Config/Validator.php
@@ -9,9 +9,11 @@ namespace PhpMyAdmin\Config;
 
 use PhpMyAdmin\Core;
 use PhpMyAdmin\Util;
+use function mysqli_report;
 use const FILTER_FLAG_IPV4;
 use const FILTER_FLAG_IPV6;
 use const FILTER_VALIDATE_IP;
+use const MYSQLI_REPORT_OFF;
 use const PHP_INT_MAX;
 use function array_map;
 use function array_merge;
@@ -228,6 +230,8 @@ class Validator
 
         $socket = empty($socket) ? null : $socket;
         $port = empty($port) ? null : $port;
+
+        mysqli_report(MYSQLI_REPORT_OFF);
 
         $conn = @mysqli_connect($host, $user, (string) $pass, '', $port, (string) $socket);
         if (! $conn) {

--- a/libraries/classes/Dbal/DbiMysqli.php
+++ b/libraries/classes/Dbal/DbiMysqli.php
@@ -13,6 +13,7 @@ use mysqli_stmt;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Query\Utilities;
 use stdClass;
+use function mysqli_report;
 use const E_USER_WARNING;
 use const MYSQLI_ASSOC;
 use const MYSQLI_AUTO_INCREMENT_FLAG;
@@ -30,6 +31,7 @@ use const MYSQLI_OPT_LOCAL_INFILE;
 use const MYSQLI_OPT_SSL_VERIFY_SERVER_CERT;
 use const MYSQLI_PART_KEY_FLAG;
 use const MYSQLI_PRI_KEY_FLAG;
+use const MYSQLI_REPORT_OFF;
 use const MYSQLI_SET_FLAG;
 use const MYSQLI_STORE_RESULT;
 use const MYSQLI_TIMESTAMP_FLAG;
@@ -111,6 +113,8 @@ class DbiMysqli implements DbiExtension
                 ? 'localhost'
                 : $server['host'];
         }
+
+        mysqli_report(MYSQLI_REPORT_OFF);
 
         $mysqli = mysqli_init();
 


### PR DESCRIPTION
Explicitly sets the MySQLi error reporting mode to the current default to avoid possibly future changes.

Fixes https://github.com/phpmyadmin/phpmyadmin/issues/16589
