### PR TITLE
FIX #16641 - Fixing query generation bug which allows specifying length for JSON field

### DIFF
--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -534,7 +534,7 @@ class Table
         // MySQL permits a non-standard syntax for FLOAT and DOUBLE,
         // see https://dev.mysql.com/doc/refman/5.5/en/floating-point-types.html
         $pattern = '@^(DATE|TINYBLOB|TINYTEXT|BLOB|TEXT|'
-            . 'MEDIUMBLOB|MEDIUMTEXT|LONGBLOB|LONGTEXT|SERIAL|BOOLEAN|UUID)$@i';
+            . 'MEDIUMBLOB|MEDIUMTEXT|LONGBLOB|LONGTEXT|SERIAL|BOOLEAN|UUID|JSON)$@i';
         if (strlen($length) !== 0 && ! preg_match($pattern, $type)) {
             // Note: The variable $length here can contain several other things
             // besides length - ENUM/SET value or length of DECIMAL (eg. 12,3)


### PR DESCRIPTION
Fixes: #16641
Signed-off-by: Fawzi E. Abdulfattah <iifawzie@gmail.com>

For testing, i've noticed that the case which is only tested is when the type is `BOOLEAN`, for that reason I didn't add a test for this specifically, if you do prefer to make one, I will do. 



