### PR TITLE
Fix #15994 - Attribute bug when default current_timestamp used with on update current_timestamp

### DIFF
--- a/templates/columns_definitions/column_attribute.twig
+++ b/templates/columns_definitions/column_attribute.twig
@@ -1,7 +1,8 @@
 {% if submit_attribute is defined and submit_attribute != false %}
     {% set attribute = submit_attribute %}
+    {# MariaDB has additional parentheses #}
 {% elseif column_meta['Extra'] is defined
-    and column_meta['Extra'] == 'on update CURRENT_TIMESTAMP' %}
+    and ('on update CURRENT_TIMESTAMP' in column_meta['Extra'] or 'on update CURRENT_TIMESTAMP()' in column_meta['Extra']) %}
     {% set attribute = 'on update CURRENT_TIMESTAMP' %}
 {% elseif extracted_columnspec['attribute'] is defined %}
     {% set attribute = extracted_columnspec['attribute'] %}


### PR DESCRIPTION
Signed-off-by: Fawzi E. Abdulfattah <iifawzie@gmail.com>

### Description
It seems like the bug in #15994 is occurred **ONLY** in the following case: 
-  when the default attribute is set to `CURRENT_TIMESTAMP` and an `on update CURRENT_TIMESTAMP` is used, this leads to generate the following **Extra** field: `DEFAULT_GENERATED ON UPDATE CURRENT_TIMESTAMP` as shown below (tested on the PMA demo with version 5.2.0-dev)
![Screen Shot 2021-02-15 at 9 18 47 PM](https://user-images.githubusercontent.com/46695441/107987081-158a4600-6fd6-11eb-8bb8-820dc653198c.png)

which fails this check: 
https://github.com/phpmyadmin/phpmyadmin/blob/c1a66adcc7b5d3f1273f38c4f7ab898e0deeb4bf/templates/columns_definitions/column_attribute.twig#L4-L5

i've changed it to check if the extra field contains `on update CURRENT_TIMESTAMP` or not.

Fixes #15994 