### PR TITLE
Fix #16671 by using .last() properly

### DIFF
--- a/js/src/table/change.js
+++ b/js/src/table/change.js
@@ -740,7 +740,7 @@ function addNewContinueInsertionFields (event) {
             // Insert/Clone the ignore checkboxes
             if (currRows === 1) {
                 $('<input id="insert_ignore_1" type="checkbox" name="insert_ignore_1" checked="checked">')
-                    .insertBefore('table.insertRowTable').last()
+                    .insertBefore($('table.insertRowTable').last())
                     .after('<label for="insert_ignore_1">' + Messages.strIgnore + '</label>');
             } else {
                 /**
@@ -756,21 +756,21 @@ function addNewContinueInsertionFields (event) {
                 var newName = lastCheckboxName.replace(/\d+/, lastCheckboxIndex + 1);
 
                 $('<br><div class="clearfloat"></div>')
-                    .insertBefore('table.insertRowTable').last();
+                    .insertBefore($('table.insertRowTable').last());
 
                 $lastCheckbox
                     .clone()
                     .attr({ 'id': newName, 'name': newName })
                     .prop('checked', true)
-                    .insertBefore('table.insertRowTable').last();
+                    .insertBefore($('table.insertRowTable').last());
 
                 $('label[for^=insert_ignore]').last()
                     .clone()
                     .attr('for', newName)
-                    .insertBefore('table.insertRowTable').last();
+                    .insertBefore($('table.insertRowTable').last());
 
                 $('<br>')
-                    .insertBefore('table.insertRowTable').last();
+                    .insertBefore($('table.insertRowTable').last());
             }
             currRows++;
         }


### PR DESCRIPTION
### Description

During the change from :last to .last() some logical erros where made. This commit fixes these errors by restoring the original intended functionality.

Fixes #16671 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
