### PR TITLE
Fix type error when exporting triggers to ODF

### DIFF
--- a/libraries/classes/Plugins/Export/ExportOdt.php
+++ b/libraries/classes/Plugins/Export/ExportOdt.php
@@ -727,7 +727,7 @@ class ExportOdt extends ExportPlugin
                 );
                 break;
             case 'triggers':
-                $triggers = $dbi->getTriggers($db, $table, $aliases);
+                $triggers = $dbi->getTriggers($db, $table);
                 if ($triggers) {
                     $GLOBALS['odt_buffer']
                     .= '<text:h text:outline-level="2" text:style-name="Heading_2"'


### PR DESCRIPTION
I have not reproduced it, but `$aliases` is an array and `$dbi->getTriggers` is expecting a `$delimiter` (string) as the third parameter. 

Introduced by a78a7a0c9c0081f6bc19f9779cd4401bfa77a09d.
