### PR TITLE
Add backward compatibility for DefaultTabServer, DefaultTabDatabase, DefaultTabTable, NavigationTreeDefaultTabTable and NavigationTreeDefaultTabTable2

### DIFF
--- a/libraries/classes/Menu.php
+++ b/libraries/classes/Menu.php
@@ -201,20 +201,20 @@ class Menu
         $server['url'] = Util::getUrlForOption(
             $cfg['DefaultTabServer'],
             'server'
-        );
+        ) ?? '/';
 
         if (strlen($this->db) > 0) {
             $database['name'] = $this->db;
             $database['url'] = Util::getUrlForOption(
                 $cfg['DefaultTabDatabase'],
                 'database'
-            );
+            ) ?? '/';
             if (strlen((string) $this->table) > 0) {
                 $table['name'] = $this->table;
                 $table['url'] = Util::getUrlForOption(
                     $cfg['DefaultTabTable'],
                     'table'
-                );
+                ) ?? '/';
                 /** @var Table $tableObj */
                 $tableObj = $dbi->getTable($this->db, $this->table);
                 $table['is_view'] = $tableObj->isView();

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1767,26 +1767,35 @@ class Util
             // Values for $cfg['DefaultTabServer']
             switch ($target) {
                 case 'welcome':
+                case 'index.php':
                     return '/';
                 case 'databases':
+                case 'server_databases.php':
                     return '/server/databases';
                 case 'status':
+                case 'server_status.php':
                     return '/server/status';
                 case 'variables':
+                case 'server_variables.php':
                     return '/server/variables';
                 case 'privileges':
+                case 'server_privileges.php':
                     return '/server/privileges';
             }
         } elseif ($location === 'database') {
             // Values for $cfg['DefaultTabDatabase']
             switch ($target) {
                 case 'structure':
+                case 'db_structure.php':
                     return '/database/structure';
                 case 'sql':
+                case 'db_sql.php':
                     return '/database/sql';
                 case 'search':
+                case 'db_search.php':
                     return '/database/search';
                 case 'operations':
+                case 'db_operations.php':
                     return '/database/operations';
             }
         } elseif ($location === 'table') {
@@ -1795,14 +1804,19 @@ class Util
             // $cfg['NavigationTreeDefaultTabTable2']
             switch ($target) {
                 case 'structure':
+                case 'tbl_structure.php':
                     return '/table/structure';
                 case 'sql':
+                case 'tbl_sql.php':
                     return '/table/sql';
                 case 'search':
+                case 'tbl_select.php':
                     return '/table/search';
                 case 'insert':
+                case 'tbl_change.php':
                     return '/table/change';
                 case 'browse':
+                case 'sql.php':
                     return '/sql';
             }
         }

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1742,7 +1742,7 @@ class Util
     {
         $url = self::getUrlForOption($target, $location);
         if ($url === null) {
-            return '/';
+            return './';
         }
 
         return Url::getFromRoute($url);

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -2600,4 +2600,177 @@ class UtilTest extends AbstractTestCase
         $this->assertFalse(Util::currentUserHasPrivilege('EVENT', 'my_data_base', 'my_data_table'));
         $GLOBALS['dbi'] = $oldDbi;
     }
+
+    /**
+     * @return array[]
+     */
+    public function dataProviderScriptNames(): array
+    {
+        // target
+        // location
+        // function output
+        return [
+            [
+                'structure', // Notice the typo on db_structure.php
+                'databasesss',
+                './',// Fallback to a relative path, impossible to build a valid route link
+            ],
+            [
+                'db_structures.php', // Notice the typo on databases
+                'database',
+                './',// Fallback to a relative path, impossible to build a valid route link
+            ],
+            [
+                'tbl_structure.php', // Support the legacy value
+                'table',
+                'index.php?route=/table/structure&amp;lang=en',
+            ],
+            [
+                'structure',
+                'table',
+                'index.php?route=/table/structure&amp;lang=en',
+            ],
+            [
+                'tbl_sql.php', // Support the legacy value
+                'table',
+                'index.php?route=/table/sql&amp;lang=en',
+            ],
+            [
+                'sql',
+                'table',
+                'index.php?route=/table/sql&amp;lang=en',
+            ],
+            [
+                'tbl_select.php', // Support the legacy value
+                'table',
+                'index.php?route=/table/search&amp;lang=en',
+            ],
+            [
+                'search',
+                'table',
+                'index.php?route=/table/search&amp;lang=en',
+            ],
+            [
+                'tbl_change.php', // Support the legacy value
+                'table',
+                'index.php?route=/table/change&amp;lang=en',
+            ],
+            [
+                'insert',
+                'table',
+                'index.php?route=/table/change&amp;lang=en',
+            ],
+            [
+                'sql.php', // Support the legacy value
+                'table',
+                'index.php?route=/sql&amp;lang=en',
+            ],
+            [
+                'browse',
+                'table',
+                'index.php?route=/sql&amp;lang=en',
+            ],
+            [
+                'db_structure.php', // Support the legacy value
+                'database',
+                'index.php?route=/database/structure&amp;lang=en',
+            ],
+            [
+                'structure',
+                'database',
+                'index.php?route=/database/structure&amp;lang=en',
+            ],
+            [
+                'db_sql.php', // Support the legacy value
+                'database',
+                'index.php?route=/database/sql&amp;lang=en',
+            ],
+            [
+                'sql',
+                'database',
+                'index.php?route=/database/sql&amp;lang=en',
+            ],
+            [
+                'db_search.php', // Support the legacy value
+                'database',
+                'index.php?route=/database/search&amp;lang=en',
+            ],
+            [
+                'search',
+                'database',
+                'index.php?route=/database/search&amp;lang=en',
+            ],
+            [
+                'db_operations.php', // Support the legacy value
+                'database',
+                'index.php?route=/database/operations&amp;lang=en',
+            ],
+            [
+                'operations',
+                'database',
+                'index.php?route=/database/operations&amp;lang=en',
+            ],
+            [
+                'index.php', // Support the legacy value
+                'server',
+                'index.php?route=/&amp;lang=en',
+            ],
+            [
+                'welcome',
+                'server',
+                'index.php?route=/&amp;lang=en',
+            ],
+            [
+                'server_databases.php', // Support the legacy value
+                'server',
+                'index.php?route=/server/databases&amp;lang=en',
+            ],
+            [
+                'databases',
+                'server',
+                'index.php?route=/server/databases&amp;lang=en',
+            ],
+            [
+                'server_status.php', // Support the legacy value
+                'server',
+                'index.php?route=/server/status&amp;lang=en',
+            ],
+            [
+                'status',
+                'server',
+                'index.php?route=/server/status&amp;lang=en',
+            ],
+            [
+                'server_variables.php', // Support the legacy value
+                'server',
+                'index.php?route=/server/variables&amp;lang=en',
+            ],
+            [
+                'variables',
+                'server',
+                'index.php?route=/server/variables&amp;lang=en',
+            ],
+            [
+                'server_privileges.php', // Support the legacy value
+                'server',
+                'index.php?route=/server/privileges&amp;lang=en',
+            ],
+            [
+                'privileges',
+                'server',
+                'index.php?route=/server/privileges&amp;lang=en',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderScriptNames
+     */
+    public function testGetScriptNameForOption(string $target, string $location, string $finalLink): void
+    {
+        $this->assertSame(
+            $finalLink,
+            Util::getScriptNameForOption($target, $location)
+        );
+    }
 }


### PR DESCRIPTION
### Description

if a user has a legacy setting for DefaultTabServer, DefaultTabDatabase, DefaultTabTable, NavigationTreeDefaultTabTable and NavigationTreeDefaultTabTable2 don't provide a broken fallback, but mimic the old behavior.

Fixes #16698
Fixes #16713

This affects 5.1.0 and maybe other versions.

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [X] Any new functionality is covered by tests.
