### PR TITLE
Inject the error report modal on each request to error reports

### DIFF
--- a/js/src/error_report.js
+++ b/js/src/error_report.js
@@ -98,12 +98,18 @@ var ErrorReport = {
         };
 
         $.post('index.php?route=/error-report', reportData).done(function (data) {
+            // Delete the modal to refresh it in case the user changed SendErrorReports value
+            if (document.getElementById('errorReportModal') !== null) {
+                $('#errorReportModal').remove();
+            }
+
+            $('body').append($(data.report_modal));
             const $errorReportModal = $('#errorReportModal');
             $errorReportModal.on('show.bs.modal', function () {
                 // Prevents multiple onClick events
                 $('#errorReportModalConfirm').off('click', sendErrorReport);
                 $('#errorReportModalConfirm').on('click', sendErrorReport);
-                this.querySelector('.modal-body').innerHTML = data.message;
+                $('#errorReportModal .modal-body').html(data.message);
             });
             $errorReportModal.modal('show');
         });

--- a/libraries/classes/Controllers/ErrorReportController.php
+++ b/libraries/classes/Controllers/ErrorReportController.php
@@ -162,6 +162,7 @@ class ErrorReportController extends AbstractController
         } elseif (! empty($_POST['get_settings'])) {
             $this->response->addJSON('report_setting', $cfg['SendErrorReports']);
         } elseif ($_POST['exception_type'] === 'js') {
+            $this->response->addJSON('report_modal', $this->errorReport->getEmptyModal());
             $this->response->addHTML($this->errorReport->getForm());
         } else {
             // clear previous errors & save new ones.

--- a/libraries/classes/ErrorReport.php
+++ b/libraries/classes/ErrorReport.php
@@ -287,6 +287,7 @@ class ErrorReport
             'report_data' => $reportData,
             'hidden_inputs' => Url::getHiddenInputs(),
             'hidden_fields' => null,
+            'allowed_to_send_error_reports' => $this->config->get('SendErrorReports') !== 'never',
         ];
 
         if (! empty($reportData)) {
@@ -294,5 +295,12 @@ class ErrorReport
         }
 
         return $this->template->render('error/report_form', $datas);
+    }
+
+    public function getEmptyModal(): string
+    {
+        return $this->template->render('error/report_modal', [
+            'allowed_to_send_error_reports' => $this->config->get('SendErrorReports') !== 'never',
+        ]);
     }
 }

--- a/libraries/classes/Footer.php
+++ b/libraries/classes/Footer.php
@@ -363,7 +363,6 @@ class Footer
                 'is_demo' => $GLOBALS['cfg']['DBG']['demo'],
                 'demo_message' => $demoMessage ?? '',
                 'footer' => $footer ?? '',
-                'has_error_report_modal' => $GLOBALS['cfg']['SendErrorReports'] !== 'never',
             ]);
         }
 

--- a/templates/error/report_form.twig
+++ b/templates/error/report_form.twig
@@ -1,3 +1,4 @@
+{% if allowed_to_send_error_reports %}
 <p>
   {% trans %}
     This report automatically includes data about the error and information about relevant configuration settings. It will be sent to the phpMyAdmin team for debugging the error.
@@ -28,3 +29,8 @@
   {{ hidden_inputs|raw }}
   {{ hidden_fields|raw }}
 </form>
+{% else %}
+<div class="mb-3">
+  <pre class="pre-scrollable">{{ report_data|json_encode(constant('JSON_PRETTY_PRINT') b-or constant('JSON_UNESCAPED_SLASHES')) }}</pre>
+</div>
+{% endif %}

--- a/templates/error/report_modal.twig
+++ b/templates/error/report_modal.twig
@@ -1,0 +1,19 @@
+<div class="modal fade" id="errorReportModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="errorReportModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="errorReportModalLabel">{% trans 'Submit error report' %}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Cancel' %}"></button>
+      </div>
+      <div class="modal-body"></div>
+      <div class="modal-footer">
+        {% if allowed_to_send_error_reports %}
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
+          <button type="button" class="btn btn-primary" id="errorReportModalConfirm">{% trans 'Send error report' %}</button>
+        {% else %}
+          <button type="button" class="btn btn-primary" data-bs-dismiss="modal">{% trans 'Close' %}</button>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/footer.twig
+++ b/templates/footer.twig
@@ -16,24 +16,6 @@
     </div>
   {% endif %}
 
-  {% if has_error_report_modal %}
-    <div class="modal fade" id="errorReportModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="errorReportModalLabel" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-scrollable modal-lg">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="errorReportModalLabel">{% trans 'Submit error report' %}</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Cancel' %}"></button>
-          </div>
-          <div class="modal-body"></div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
-            <button type="button" class="btn btn-primary" id="errorReportModalConfirm">{% trans 'Send error report' %}</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  {% endif %}
-
   {{ footer|raw }}
 {% endif %}
 {% if not is_ajax %}


### PR DESCRIPTION
Inject the error report modal on each request to error reports

Some UIs remove all the content and that prevents the modal to open
![image](https://user-images.githubusercontent.com/7784660/111194678-b5c69100-85bb-11eb-8ec8-221717979401.png)
