### PR TITLE
drop nocache & server query string param from theme.css stylesheet

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -882,26 +882,6 @@ class Config
     }
 
     /**
-     * returns a unique value to force a CSS reload if either the config
-     * or the theme changes
-     *
-     * @return int Summary of unix timestamps, to be unique on theme parameters
-     *             change
-     */
-    public function getThemeUniqueValue(): int
-    {
-        global $theme;
-
-        return (int) (
-            $this->sourceMtime +
-            $this->defaultSourceMtime +
-            $this->get('user_preferences_mtime') +
-            ($theme->mtimeInfo ?? 0) +
-            ($theme->filesizeInfo ?? 0)
-        );
-    }
-
-    /**
      * checks if upload is enabled
      */
     public function checkUpload(): void

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -397,7 +397,6 @@ class Header
         $this->sendHttpHeaders();
 
         $baseDir = defined('PMA_PATH_TO_BASEDIR') ? PMA_PATH_TO_BASEDIR : '';
-        $uniqueValue = $GLOBALS['config']->getThemeUniqueValue();
         $themePath = $theme instanceof Theme ? $theme->getPath() : '';
         $version = self::getVersionParameter();
 
@@ -455,7 +454,6 @@ class Header
             'allow_third_party_framing' => $GLOBALS['cfg']['AllowThirdPartyFraming'],
             'is_print_view' => $this->isPrintView,
             'base_dir' => $baseDir,
-            'unique_value' => $uniqueValue,
             'theme_path' => $themePath,
             'version' => $version,
             'text_dir' => $GLOBALS['text_dir'],

--- a/templates/header.twig
+++ b/templates/header.twig
@@ -19,8 +19,7 @@
     <link rel="stylesheet" type="text/css" href="{{ base_dir }}js/vendor/codemirror/lib/codemirror.css?{{ version }}">
     <link rel="stylesheet" type="text/css" href="{{ base_dir }}js/vendor/codemirror/addon/hint/show-hint.css?{{ version }}">
     <link rel="stylesheet" type="text/css" href="{{ base_dir }}js/vendor/codemirror/addon/lint/lint.css?{{ version }}">
-    <link rel="stylesheet" type="text/css" href="{{ theme_path }}/css/theme{{ text_dir == 'rtl' ? '.rtl' }}.css?{{ version }}&nocache=
-      {{- unique_value }}{{ text_dir }}{% if server is not empty %}&server={{ server }}{% endif %}">
+    <link rel="stylesheet" type="text/css" href="{{ theme_path }}/css/theme{{ text_dir == 'rtl' ? '.rtl' }}.css?{{ version }}">
     <link rel="stylesheet" type="text/css" href="{{ theme_path }}/css/printview.css?{{ version }}" media="print" id="printcss">
   {% endif %}
   <title>{{ title }}</title>

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -943,24 +943,6 @@ class ConfigTest extends AbstractTestCase
     }
 
     /**
-     * Should test getting unique value for theme
-     *
-     * @group 32bit-incompatible
-     */
-    public function testGetThemeUniqueValue(): void
-    {
-        global $theme;
-
-        $partial_sum = $this->object->sourceMtime +
-            $this->object->defaultSourceMtime +
-            $this->object->get('user_preferences_mtime') +
-            $theme->mtimeInfo +
-            $theme->filesizeInfo;
-
-        $this->assertEquals($partial_sum, $this->object->getThemeUniqueValue());
-    }
-
-    /**
      * Should test checking of config permissions
      */
     public function testCheckPermissions(): void


### PR DESCRIPTION
I have noticed that theme.css file is outside of cache scope due to unique &nocache= being appended on every request.

This is not expected in releases to public, since file is not cachable then (and should be).

Version query string param is enough for this use case since file will be fresh on new phpmyadmin version install.

Maybe some variable based on devel/production flow is needed here to allow easier changes in devel.

### Description

Please describe your pull request.

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
