### PR TITLE
Fix #16138 - Ignore the length of the integer types and show a warning

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -484,6 +484,7 @@ Functions.hideShowExpression = function ($virtuality) {
 Functions.verifyColumnsProperties = function () {
     $('select.column_type').each(function () {
         Functions.showNoticeForEnum($(this));
+        Functions.showWarningForIntTypes();
     });
     $('select.default_type').each(function () {
         Functions.hideShowDefaultValue($(this));
@@ -2498,6 +2499,25 @@ Functions.showNoticeForEnum = function (selectElement) {
 };
 
 /**
+ * Hides/shows a warning message when LENGTH is used with inappropriate integer type
+ */
+Functions.showWarningForIntTypes = function () {
+    if ($('div#length_not_allowed').length) {
+        var lengthRestrictions = $('select.column_type option').map(function () {
+            return $(this).filter(':selected').attr('data-length-restricted');
+        }).get();
+
+        var restricationFound = lengthRestrictions.some(restriction => Number(restriction) === 1);
+
+        if (restricationFound) {
+            $('div#length_not_allowed').show();
+        } else {
+            $('div#length_not_allowed').hide();
+        }
+    }
+};
+
+/**
  * Creates a Profiling Chart. Used in sql.js
  * and in server/status/monitor.js
  *
@@ -3265,6 +3285,7 @@ AJAX.registerOnload('functions.js', function () {
     // needs on() to work also in the Create Table dialog
     $(document).on('change', 'select.column_type', function () {
         Functions.showNoticeForEnum($(this));
+        Functions.showWarningForIntTypes();
     });
     $(document).on('change', 'select.default_type', function () {
         Functions.hideShowDefaultValue($(this));

--- a/libraries/classes/Html/Generator.php
+++ b/libraries/classes/Html/Generator.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\Core;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Profiling;
 use PhpMyAdmin\Providers\ServerVariables\ServerVariablesProvider;
+use PhpMyAdmin\Query\Compatibility;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sanitize;
 use PhpMyAdmin\SqlParser\Lexer;
@@ -1357,9 +1358,11 @@ class Generator
             if (is_array($value)) {
                 $retval .= '<optgroup label="' . htmlspecialchars($key) . '">';
                 foreach ($value as $subvalue) {
+                    $isLengthRestricted = Compatibility::isIntegersSupportLength($subvalue, '2', $dbi) === true ? 0 : 1;
                     if ($subvalue == $selected) {
                         $retval .= sprintf(
-                            '<option selected="selected" title="%s">%s</option>',
+                            '<option data-length-restricted="%b" selected="selected" title="%s">%s</option>',
+                            $isLengthRestricted,
                             $dbi->types->getTypeDescription($subvalue),
                             $subvalue
                         );
@@ -1369,7 +1372,8 @@ class Generator
                         $retval .= '</option>';
                     } else {
                         $retval .= sprintf(
-                            '<option title="%s">%s</option>',
+                            '<option data-length-restricted="%b" title="%s">%s</option>',
+                            $isLengthRestricted,
                             $dbi->types->getTypeDescription($subvalue),
                             $subvalue
                         );
@@ -1377,18 +1381,23 @@ class Generator
                 }
 
                 $retval .= '</optgroup>';
-            } elseif ($selected == $value) {
-                $retval .= sprintf(
-                    '<option selected="selected" title="%s">%s</option>',
-                    $dbi->types->getTypeDescription($value),
-                    $value
-                );
             } else {
-                $retval .= sprintf(
-                    '<option title="%s">%s</option>',
-                    $dbi->types->getTypeDescription($value),
-                    $value
-                );
+                $isLengthRestricted = Compatibility::isIntegersSupportLength($value, '2', $dbi) === true ? 0 : 1;
+                if ($selected == $value) {
+                    $retval .= sprintf(
+                        '<option data-length-restricted="%b" selected="selected" title="%s">%s</option>',
+                        $isLengthRestricted,
+                        $dbi->types->getTypeDescription($value),
+                        $value
+                    );
+                } else {
+                    $retval .= sprintf(
+                        '<option data-length-restricted="%b" title="%s">%s</option>',
+                        $isLengthRestricted,
+                        $dbi->types->getTypeDescription($value),
+                        $value
+                    );
+                }
             }
         }
 

--- a/libraries/classes/Html/Generator.php
+++ b/libraries/classes/Html/Generator.php
@@ -1358,47 +1358,35 @@ class Generator
             if (is_array($value)) {
                 $retval .= '<optgroup label="' . htmlspecialchars($key) . '">';
                 foreach ($value as $subvalue) {
-                    $isLengthRestricted = Compatibility::isIntegersSupportLength($subvalue, '2', $dbi) === true ? 0 : 1;
-                    if ($subvalue == $selected) {
-                        $retval .= sprintf(
-                            '<option data-length-restricted="%b" selected="selected" title="%s">%s</option>',
-                            $isLengthRestricted,
-                            $dbi->types->getTypeDescription($subvalue),
-                            $subvalue
-                        );
-                    } elseif ($subvalue === '-') {
+                    if ($subvalue === '-') {
                         $retval .= '<option disabled="disabled">';
                         $retval .= $subvalue;
                         $retval .= '</option>';
-                    } else {
-                        $retval .= sprintf(
-                            '<option data-length-restricted="%b" title="%s">%s</option>',
-                            $isLengthRestricted,
-                            $dbi->types->getTypeDescription($subvalue),
-                            $subvalue
-                        );
+                        continue;
                     }
+
+                    $isLengthRestricted = Compatibility::isIntegersSupportLength($subvalue, '2', $dbi);
+                    $retval .= sprintf(
+                        '<option data-length-restricted="%b" %s title="%s">%s</option>',
+                        $isLengthRestricted ? 0 : 1,
+                        $selected === $subvalue ? 'selected="selected"' : '',
+                        $dbi->types->getTypeDescription($subvalue),
+                        $subvalue
+                    );
                 }
 
                 $retval .= '</optgroup>';
-            } else {
-                $isLengthRestricted = Compatibility::isIntegersSupportLength($value, '2', $dbi) === true ? 0 : 1;
-                if ($selected == $value) {
-                    $retval .= sprintf(
-                        '<option data-length-restricted="%b" selected="selected" title="%s">%s</option>',
-                        $isLengthRestricted,
-                        $dbi->types->getTypeDescription($value),
-                        $value
-                    );
-                } else {
-                    $retval .= sprintf(
-                        '<option data-length-restricted="%b" title="%s">%s</option>',
-                        $isLengthRestricted,
-                        $dbi->types->getTypeDescription($value),
-                        $value
-                    );
-                }
+                continue;
             }
+
+            $isLengthRestricted = Compatibility::isIntegersSupportLength($value, '2', $dbi);
+            $retval .= sprintf(
+                '<option data-length-restricted="%b" %s title="%s">%s</option>',
+                $isLengthRestricted ? 0 : 1,
+                $selected === $value ? 'selected="selected"' : '',
+                $dbi->types->getTypeDescription($value),
+                $value
+            );
         }
 
         return $retval;

--- a/libraries/classes/Query/Compatibility.php
+++ b/libraries/classes/Query/Compatibility.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Query;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Util;
 
+use function in_array;
 use function is_string;
 use function strlen;
 use function strpos;
@@ -166,6 +167,16 @@ class Compatibility
         return false;
     }
 
+    public static function isIntegersLengthRestricted(DatabaseInterface $dbi): bool
+    {
+        // MySQL made restrictions on the integer types' length from versions >= 8.0.18
+        // See: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html
+        $serverType = Util::getServerType();
+        $serverVersion = $dbi->getVersion();
+
+        return $serverType === 'MySQL' && $serverVersion >= 80018;
+    }
+
     public static function supportsReferencesPrivilege(DatabaseInterface $dbi): bool
     {
         // See: https://mariadb.com/kb/en/grant/#table-privileges
@@ -180,6 +191,17 @@ class Compatibility
         // requires at least one of the SELECT, INSERT, UPDATE, DELETE,
         // or REFERENCES privileges for the parent table.
         return $dbi->getVersion() >= 50622;
+    }
+
+    public static function isIntegersSupportLength(string $type, string $length, DatabaseInterface $dbi): bool
+    {
+        // MySQL Removed the Integer types' length from versions >= 8.0.18
+        // except TINYINT(1).
+        // See: https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html
+        $integerTypes = ['SMALLINT', 'MEDIUMINT', 'INT', 'BIGINT'];
+        $typeLengthNotAllowed = in_array($type, $integerTypes) || $type === 'TINYINT' && $length !== '1';
+
+        return ! (self::isIntegersLengthRestricted($dbi) && $typeLengthNotAllowed);
     }
 
     /**

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -532,6 +532,7 @@ class Table implements Stringable
     ) {
         global $dbi;
 
+        $strLength = strlen($length);
         $isTimestamp = mb_stripos($type, 'TIMESTAMP') !== false;
 
         $query = Util::backquote($name) . ' ' . $type;
@@ -543,7 +544,11 @@ class Table implements Stringable
         // see https://dev.mysql.com/doc/refman/5.5/en/floating-point-types.html
         $pattern = '@^(DATE|TINYBLOB|TINYTEXT|BLOB|TEXT|'
             . 'MEDIUMBLOB|MEDIUMTEXT|LONGBLOB|LONGTEXT|SERIAL|BOOLEAN|UUID|JSON)$@i';
-        if (strlen($length) !== 0 && ! preg_match($pattern, $type)) {
+        if (
+            $strLength !== 0
+            && ! preg_match($pattern, $type)
+            && Compatibility::isIntegersSupportLength($type, $length, $dbi)
+        ) {
             // Note: The variable $length here can contain several other things
             // besides length - ENUM/SET value or length of DECIMAL (eg. 12,3)
             // so we can't just convert it to integer
@@ -556,7 +561,7 @@ class Table implements Stringable
             if (
                 $isTimestamp
                 && stripos($attribute, 'TIMESTAMP') !== false
-                && strlen($length) !== 0
+                && $strLength !== 0
                 && $length !== 0
             ) {
                 $query .= '(' . $length . ')';
@@ -644,7 +649,7 @@ class Table implements Stringable
                         $query .= ' DEFAULT ' . $defaultType;
 
                         if (
-                            strlen($length) !== 0
+                            $strLength !== 0
                             && $length !== 0
                             && $isTimestamp
                             && $defaultType !== 'NULL' // Not to be added in case of NULL

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -522,6 +522,7 @@ final class ColumnsDefinition
         }
 
         $storageEngines = StorageEngine::getArray();
+        $isIntegersLengthRestricted = Compatibility::isIntegersLengthRestricted($dbi);
 
         return [
             'is_backup' => $is_backup,
@@ -545,6 +546,7 @@ final class ColumnsDefinition
             'connection' => $_POST['connection'] ?? null,
             'change_column' => $_POST['change_column'] ?? $_GET['change_column'] ?? null,
             'is_virtual_columns_supported' => Compatibility::isVirtualColumnsSupported($dbi->getVersion()),
+            'is_integers_length_restricted' => $isIntegersLengthRestricted,
             'browse_mime' => $cfg['BrowseMIME'] ?? null,
             'supports_stored_keyword' => Compatibility::supportsStoredKeywordForVirtualColumns($dbi->getVersion()),
             'server_version' => $dbi->getVersion(),

--- a/templates/columns_definitions/column_definitions_form.twig
+++ b/templates/columns_definitions/column_definitions_form.twig
@@ -160,4 +160,11 @@
             value="{% trans 'Save' %}">
     </fieldset>
     <div id="properties_message"></div>
+     {% if is_integers_length_restricted %}
+        <div class="alert alert-primary" id="length_not_allowed" role="alert">
+            {{ get_image('s_notice') }}
+            {% trans %}The column width of integer types is ignored in your MySQL version unless defining a TINYINT(1) column{% endtrans %}
+            {{ show_mysql_docu('', false, 'https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html') }}
+        </div>
+     {% endif %}
 </form>


### PR DESCRIPTION
Signed-off-by: Fawzi E. Abdulfattah <iifawzie@gmail.com>

### Description

- If the server is `MySQL`, and the version is `8.0.18` or higher, the length of (`SMALLINT`, `MEDIUMINT`, `INT`, `BIGINT`,
or `TINYINT` **with a length not equal to 1** ) will be ignored, I haven't checked whether `ZEROFILL` attribute is specified or not, since it's deprecated and wouldn't make a difference I think. (#16742)  
- A warning will be shown as following, whenever any integer type is selected in `MySQL` with a version >= `8.0.18`
![Screen Shot 2021-03-27 at 4 18 51 PM](https://user-images.githubusercontent.com/46695441/112723704-982cec00-8f18-11eb-9fa5-786ebf5560fe.png)


Fixes #16138 