### PR TITLE
Fix datetime decimal displayed after edit

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -688,7 +688,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         newHtml = newHtml.replace(/\n/g, '<br>\n');
 
                         // remove decimal places if column type not supported
-                        if (($thisField.attr('data-decimals') === 0) && ($thisField.attr('data-type').indexOf('time') !== -1)) {
+                        if (($thisField.attr('data-decimals') == 0) && ($thisField.attr('data-type').indexOf('time') !== -1)) {
                             newHtml = newHtml.substring(0, newHtml.indexOf('.'));
                         }
 


### PR DESCRIPTION
### Description

Fix datetime decimal displayed after edit.
Other possible fix:
`parseInt($thisField.attr('data-decimals')) === 0`

Fixes phpmyadmin/phpmyadmin#15629

Signed-off-by: Romain Lapoux <manus@manusfreedom.com>