### PR TITLE
Add padding to textarea (.edit_box)

### DIFF
--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -2309,7 +2309,7 @@ input#auto_increment_opt {
   .edit_box {
     overflow-x: hidden;
     overflow-y: scroll;
-    padding: 0;
+    padding: 3px;
     margin: 0;
   }
 


### PR DESCRIPTION
Signed-off-by: Scott Vivian <scott.vivian+pma@gmail.com>

### Description

This adds a small amount of padding to the textarea when editing a field inline. Without this, the cursor is not visible in Chrome (Mac) when it is at the start of a line. Tested in multiple browsers and saw no adverse effects.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
