### PR TITLE
Fix password management for Percona Server lacking PASSWORD function.

### DIFF
--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -1038,7 +1038,8 @@ class Privileges
                 ));
 
             // Use 'ALTER USER ...' syntax for MySQL 5.7.6+
-            if ($serverType === 'MySQL'
+            if (
+                in_array($serverType, ['MySQL', 'Percona Server'], true)
                 && $serverVersion >= 50706
             ) {
                 if ($authentication_plugin !== 'mysql_old_password') {


### PR DESCRIPTION
### Description

When using Percona Server for MySQL 8.0, trying to change a user password results in an error from MySQL, e.g.:
```
#1064 - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'PASSWORD('I love seeing my password in clear text :-D')' at line 1
```
This affects both `server_privileges.php` and `user_password.php` pages so this MR tries to fix both :-)

Since Percona Server is meant to be fully API compatible with the MySQL version it is based on, I think we can simply do the same as for MySQL (I manually tested the patch I submit in my setup and it fixes the issues).

 FTR, some likely useless details on the setup I saw the issue on:
- Percona Server 8.0.18-9
- PhpMyAdmin 5.0.4
- PHP 7.4.16, Apache


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
