### PR TITLE
Fix #16810 - SQL query shown twice on central columns actions

### DIFF
--- a/libraries/classes/Controllers/Table/StructureController.php
+++ b/libraries/classes/Controllers/Table/StructureController.php
@@ -264,9 +264,6 @@ class StructureController extends AbstractController
         if (empty($message)) {
             $message = Message::success();
         }
-        $this->response->addHTML(
-            Generator::getMessage($message, $sql_query)
-        );
 
         $this->index();
     }
@@ -298,9 +295,6 @@ class StructureController extends AbstractController
         if (empty($message)) {
             $message = Message::success();
         }
-        $this->response->addHTML(
-            Generator::getMessage($message, $sql_query)
-        );
 
         $this->index();
     }
@@ -337,9 +331,6 @@ class StructureController extends AbstractController
         if (empty($message)) {
             $message = Message::success();
         }
-        $this->response->addHTML(
-            Generator::getMessage($message, $sql_query)
-        );
 
         $this->index();
     }
@@ -376,9 +367,6 @@ class StructureController extends AbstractController
         if (empty($message)) {
             $message = Message::success();
         }
-        $this->response->addHTML(
-            Generator::getMessage($message, $sql_query)
-        );
 
         $this->index();
     }
@@ -415,9 +403,6 @@ class StructureController extends AbstractController
         if (empty($message)) {
             $message = Message::success();
         }
-        $this->response->addHTML(
-            Generator::getMessage($message, $sql_query)
-        );
 
         $this->index();
     }
@@ -454,9 +439,6 @@ class StructureController extends AbstractController
         if (empty($message)) {
             $message = Message::success();
         }
-        $this->response->addHTML(
-            Generator::getMessage($message, $sql_query)
-        );
 
         $this->index();
     }
@@ -527,9 +509,6 @@ class StructureController extends AbstractController
         if (empty($message)) {
             $message = Message::success();
         }
-        $this->response->addHTML(
-            Generator::getMessage($message, $sql_query)
-        );
 
         $this->index();
     }


### PR DESCRIPTION
Signed-off-by: Liviu Concioiu liviu.concioiu@gmail.com


### Description

Fix SQL query shown twice on PRIMARY, UNIQUE, INDEX, SPATIAL, FULLTEXT, add to central columns, remove from central columns

Fixes #16810 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
