### PR TITLE
Add target and rel to phpMyAdmin configuration storage link

### DIFF
--- a/templates/database/designer/main.twig
+++ b/templates/database/designer/main.twig
@@ -108,9 +108,7 @@ var designerConfig = {{ designer_config|raw }};
                 {% trans 'Reload' %}
             </span>
         </a>
-        <a href="{{ get_docu_link('faq', 'faq6-31') }}"
-           target="documentation"
-           class="M_butt">
+        <a href="{{ get_docu_link('faq', 'faq6-31') }}" target="_blank" rel="noopener noreferrer" class="M_butt">
             <img title="{% trans 'Help' %}"
                  src="{{ theme.getImgPath('designer/help.png') }}">
             <span class="hide hidable">

--- a/templates/navigation/main.twig
+++ b/templates/navigation/main.twig
@@ -32,7 +32,7 @@
             </a>
           {% endif %}
 
-          <a href="{{ get_docu_link('index') }}" title="{% trans 'phpMyAdmin documentation' %}" target="_blank" rel="noopener">
+          <a href="{{ get_docu_link('index') }}" title="{% trans 'phpMyAdmin documentation' %}" target="_blank" rel="noopener noreferrer">
             {{- get_image('b_docs', 'phpMyAdmin documentation'|trans) -}}
           </a>
 

--- a/templates/preferences/header.twig
+++ b/templates/preferences/header.twig
@@ -56,7 +56,7 @@
   {% endif %}
 
   {% if not has_config_storage %}
-    {% apply format('<a href="' ~ get_docu_link('setup', 'linked-tables') ~ '">', '</a>')|notice %}
+    {% apply format('<a href="' ~ get_docu_link('setup', 'linked-tables') ~ '" target="_blank" rel="noopener noreferrer">', '</a>')|notice %}
       {% trans 'Your preferences will be saved for current session only. Storing them permanently requires %sphpMyAdmin configuration storage%s.' %}
     {% endapply %}
   {% endif %}


### PR DESCRIPTION
Signed-off-by: Liviu-Mihail Concioiu <liviu.concioiu@gmail.com>

### Description

If you go to https://demo.phpmyadmin.net/QA_5_1/index.php?route=/preferences/manage and click on `phpMyAdmin configuration storage`, won't work. I've added target and rel.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
