### PR TITLE
Fix #14130 - Created new messages for U2F errors 

### DIFF
--- a/js/src/u2f.js
+++ b/js/src/u2f.js
@@ -12,21 +12,21 @@ AJAX.registerOnload('u2f.js', function () {
                 // Handle returning error data
                 if (data.errorCode && data.errorCode !== 0) {
                     switch (data.errorCode) {
-                        case 5:
-                            Functions.ajaxShowMessage(Messages.strU2FTimeout, false);
-                            break;
-                        case 4:
-                            Functions.ajaxShowMessage(Messages.strU2FErrorRegister, false);
-                            break;
-                        case 3:
-                            Functions.ajaxShowMessage(Messages.strU2FInvalidClient, false);
-                            break;
-                        case 2:
-                            Functions.ajaxShowMessage(Messages.strU2FBadRequest, false);
-                            break;
-                        default:
-                            Functions.ajaxShowMessage(Messages.strU2FUnknown, false);
-                            break;
+                    case 5:
+                        Functions.ajaxShowMessage(Messages.strU2FTimeout, false, 'error');
+                        break;
+                    case 4:
+                        Functions.ajaxShowMessage(Messages.strU2FErrorRegister, false, 'error');
+                        break;
+                    case 3:
+                        Functions.ajaxShowMessage(Messages.strU2FInvalidClient, false, 'error');
+                        break;
+                    case 2:
+                        Functions.ajaxShowMessage(Messages.strU2FBadRequest, false, 'error');
+                        break;
+                    default:
+                        Functions.ajaxShowMessage(Messages.strU2FUnknown, false, 'error');
+                        break;
                     }
                     return;
                 }
@@ -49,21 +49,21 @@ AJAX.registerOnload('u2f.js', function () {
                 // Handle returning error data
                 if (data.errorCode && data.errorCode !== 0) {
                     switch (data.errorCode) {
-                        case 5:
-                            Functions.ajaxShowMessage(Messages.strU2FTimeout, false);
-                            break;
-                        case 4:
-                            Functions.ajaxShowMessage(Messages.strU2FErrorAuthenticate, false);
-                            break;
-                        case 3:
-                            Functions.ajaxShowMessage(Messages.strU2FInvalidClient, false);
-                            break;
-                        case 2:
-                            Functions.ajaxShowMessage(Messages.strU2FBadRequest, false);
-                            break;
-                        default:
-                            Functions.ajaxShowMessage(Messages.strU2FUnknown, false);
-                            break;
+                    case 5:
+                        Functions.ajaxShowMessage(Messages.strU2FTimeout, false, 'error');
+                        break;
+                    case 4:
+                        Functions.ajaxShowMessage(Messages.strU2FErrorAuthenticate, false, 'error');
+                        break;
+                    case 3:
+                        Functions.ajaxShowMessage(Messages.strU2FInvalidClient, false, 'error');
+                        break;
+                    case 2:
+                        Functions.ajaxShowMessage(Messages.strU2FBadRequest, false, 'error');
+                        break;
+                    default:
+                        Functions.ajaxShowMessage(Messages.strU2FUnknown, false, 'error');
+                        break;
                     }
                     return;
                 }

--- a/js/src/u2f.js
+++ b/js/src/u2f.js
@@ -11,12 +11,22 @@ AJAX.registerOnload('u2f.js', function () {
             u2f.register(request.appId, [request], JSON.parse($inputReg.attr('data-signatures')), function (data) {
                 // Handle returning error data
                 if (data.errorCode && data.errorCode !== 0) {
-                    if (data.errorCode === 5) {
-                        Functions.ajaxShowMessage(Messages.strU2FTimeout, false);
-                    } else {
-                        Functions.ajaxShowMessage(
-                            Functions.sprintf(Messages.strU2FError, data.errorCode), false
-                        );
+                    switch (data.errorCode) {
+                        case 5:
+                            Functions.ajaxShowMessage(Messages.strU2FTimeout, false);
+                            break;
+                        case 4:
+                            Functions.ajaxShowMessage(Messages.strU2FErrorRegister, false);
+                            break;
+                        case 3:
+                            Functions.ajaxShowMessage(Messages.strU2FInvalidClient, false);
+                            break;
+                        case 2:
+                            Functions.ajaxShowMessage(Messages.strU2FBadRequest, false);
+                            break;
+                        default:
+                            Functions.ajaxShowMessage(Messages.strU2FUnknown, false);
+                            break;
                     }
                     return;
                 }
@@ -38,12 +48,22 @@ AJAX.registerOnload('u2f.js', function () {
             u2f.sign(request[0].appId, request[0].challenge, request, function (data) {
                 // Handle returning error data
                 if (data.errorCode && data.errorCode !== 0) {
-                    if (data.errorCode === 5) {
-                        Functions.ajaxShowMessage(Messages.strU2FTimeout, false);
-                    } else {
-                        Functions.ajaxShowMessage(
-                            Functions.sprintf(Messages.strU2FError, data.errorCode), false
-                        );
+                    switch (data.errorCode) {
+                        case 5:
+                            Functions.ajaxShowMessage(Messages.strU2FTimeout, false);
+                            break;
+                        case 4:
+                            Functions.ajaxShowMessage(Messages.strU2FErrorAuthenticate, false);
+                            break;
+                        case 3:
+                            Functions.ajaxShowMessage(Messages.strU2FInvalidClient, false);
+                            break;
+                        case 2:
+                            Functions.ajaxShowMessage(Messages.strU2FBadRequest, false);
+                            break;
+                        default:
+                            Functions.ajaxShowMessage(Messages.strU2FUnknown, false);
+                            break;
                     }
                     return;
                 }

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -711,7 +711,11 @@ final class JavaScriptMessagesController
 
             /* U2F errors */
             'strU2FTimeout' => __('Timed out waiting for security key activation.'),
-            'strU2FError' => __('Failed security key activation (%s).'),
+            'strU2FBadRequest' => __('Invalid request sent to security key.'),
+            'strU2FUnknown' => __('Unknown security key error.'),
+            'strU2FInvalidClient' => __('Client does not support security key.'),
+            'strU2FErrorRegister' => __('Failed security key activation.'),
+            'strU2FErrorAuthenticate' => __('Invalid security key.'),
 
             /* Designer */
             'strTableAlreadyExists' => _pgettext(


### PR DESCRIPTION
Signed-off-by: Quinn Zipse <qzipse@outlook.com>

### Description

This patch fixes the error codes displayed when you use the wrong key. It is now updated to have a new message for each error code in the Yubico specification [here](https://developers.yubico.com/U2F/Libraries/Client_error_codes.html).

Fixes #14130

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
