### PR TITLE
Add DatabaseName value object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "symfony/polyfill-ctype": "^1.17.0",
         "symfony/polyfill-mbstring": "^1.17.0",
         "twig/twig": "^3.0.1",
+        "webmozart/assert": "^1.10",
         "williamdes/mariadb-mysql-kbs": "^1.2"
     },
     "conflict": {

--- a/libraries/classes/Controllers/Table/PartitionController.php
+++ b/libraries/classes/Controllers/Table/PartitionController.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Table;
 
+use PhpMyAdmin\Dbal\DatabaseName;
 use PhpMyAdmin\Html\Generator;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Table\Partition;
 use PhpMyAdmin\Template;
+use Throwable;
 
 use function strlen;
 
@@ -36,7 +39,14 @@ final class PartitionController extends AbstractController
             return;
         }
 
-        [$rows, $query] = $this->model->analyze($this->db, $this->table, $partitionName);
+        try {
+            [$rows, $query] = $this->model->analyze(new DatabaseName($this->db), $this->table, $partitionName);
+        } catch (Throwable $e) {
+            $message = Message::error($e->getMessage());
+            $this->response->addHTML($message->getDisplay());
+
+            return;
+        }
 
         $message = Generator::getMessage(
             __('Your SQL query has been executed successfully.'),

--- a/libraries/classes/Dbal/DatabaseName.php
+++ b/libraries/classes/Dbal/DatabaseName.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal;
+
+use Webmozart\Assert\Assert;
+
+/** @psalm-immutable */
+final class DatabaseName
+{
+    /**
+     * @see https://dev.mysql.com/doc/refman/en/identifier-length.html
+     * @see https://mariadb.com/kb/en/identifier-names/#maximum-length
+     */
+    private const MAX_LENGTH = 64;
+
+    /**
+     * @var string
+     * @psalm-var non-empty-string
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        Assert::stringNotEmpty($name);
+        Assert::maxLength($name, self::MAX_LENGTH);
+        Assert::notEndsWith($name, ' ');
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/libraries/classes/Table/Partition.php
+++ b/libraries/classes/Table/Partition.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Table;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\DatabaseName;
 use PhpMyAdmin\Util;
 
 use function sprintf;
@@ -19,7 +20,7 @@ final class Partition
         $this->dbi = $dbi;
     }
 
-    public function analyze(string $db, string $table, string $partition): array
+    public function analyze(DatabaseName $db, string $table, string $partition): array
     {
         $query = sprintf(
             'ALTER TABLE %s ANALYZE PARTITION %s;',
@@ -27,7 +28,7 @@ final class Partition
             Util::backquote($partition)
         );
 
-        $this->dbi->selectDb($db);
+        $this->dbi->selectDb($db->getName());
         $result = $this->dbi->fetchResult($query);
 
         $rows = [];

--- a/test/classes/Dbal/DatabaseNameTest.php
+++ b/test/classes/Dbal/DatabaseNameTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Dbal;
+
+use InvalidArgumentException;
+use PhpMyAdmin\Dbal\DatabaseName;
+use PHPUnit\Framework\TestCase;
+
+use function str_repeat;
+
+class DatabaseNameTest extends TestCase
+{
+    public function testEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected a different value than "".');
+        new DatabaseName('');
+    }
+
+    public function testNameWithTrailingWhitespace(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected a value not to end with " ". Got: "a "');
+        new DatabaseName('a ');
+    }
+
+    public function testLongName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Expected a value to contain at most 64 characters. Got: '
+            . '"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'
+        );
+        new DatabaseName(str_repeat('a', 65));
+    }
+
+    public function testValidName(): void
+    {
+        $name = new DatabaseName('name');
+        $this->assertEquals('name', $name->getName());
+        $this->assertEquals('name', (string) $name);
+    }
+}


### PR DESCRIPTION
The idea is to replace the `$db` string with the _DatabaseName_ value object to avoid having to validate the value multiple times.