### PR TITLE
Skip testImportOsm and testDoImport on 32-bit/s390x arch

### DIFF
--- a/test/classes/Plugins/Import/ImportShpTest.php
+++ b/test/classes/Plugins/Import/ImportShpTest.php
@@ -117,6 +117,7 @@ class ImportShpTest extends AbstractTestCase
      * Test for doImport with complex data
      *
      * @group medium
+     * @group 32bit-incompatible
      */
     public function testImportOsm(): void
     {
@@ -151,6 +152,7 @@ class ImportShpTest extends AbstractTestCase
      * Test for doImport
      *
      * @group medium
+     * @group 32bit-incompatible
      */
     public function testDoImport(): void
     {


### PR DESCRIPTION
These two tests fail on s390x machines, looks like some
32-bit issues we already have. Probably worth skipping
these on 32-bit/s390x arch.

Test logs on Ubuntu: https://autopkgtest.ubuntu.com/results/autopkgtest-impish/impish/s390x/p/phpmyadmin/20210516_212523_5cd19@/log.gz