### PR TITLE
Fix Uncaught TypeError: array_fill(): Argument #2 ($count) must be of type int, string

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -267,7 +267,8 @@ class InsertEdit
             DatabaseInterface::CONNECT_USER,
             DatabaseInterface::QUERY_STORE
         );
-        $rows = array_fill(0, $GLOBALS['cfg']['InsertRows'], false);
+        // Can be a string on some old configuration storage settings
+        $rows = array_fill(0, (int) $GLOBALS['cfg']['InsertRows'], false);
 
         return [
             $result,

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -294,12 +294,52 @@ class InsertEditTest extends AbstractTestCase
         $this->assertFalse($result);
     }
 
+    public function dataProviderConfigValueInsertRows(): array
+    {
+        return [
+            [
+                2,
+                [
+                    false,
+                    false,
+                ],
+            ],
+            [
+                '2',
+                [
+                    false,
+                    false,
+                ],
+            ],
+            [
+                3,
+                [
+                    false,
+                    false,
+                    false,
+                ],
+            ],
+            [
+                '3',
+                [
+                    false,
+                    false,
+                    false,
+                ],
+            ],
+        ];
+    }
+
     /**
      * Test for loadFirstRow
+     *
+     * @param string|int $configValue
+     *
+     * @dataProvider dataProviderConfigValueInsertRows
      */
-    public function testLoadFirstRow(): void
+    public function testLoadFirstRow($configValue, array $rowsValue): void
     {
-        $GLOBALS['cfg']['InsertRows'] = 2;
+        $GLOBALS['cfg']['InsertRows'] = $configValue;
 
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
@@ -327,10 +367,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals(
             [
                 'result1',
-                [
-                    false,
-                    false,
-                ],
+                $rowsValue,
             ],
             $result
         );


### PR DESCRIPTION
### Description

This PR resolving following issue:

PHP Fatal error:  
```
Uncaught TypeError: array_fill(): Argument #2 ($count) must be of type int, string given in .../libraries/classes/InsertEdit.php:273
```

```
Stack trace:
#0 .../libraries/classes/InsertEdit.php(273): array_fill()
#1 .../libraries/classes/InsertEdit.php(2247): PhpMyAdmin\\InsertEdit->loadFirstRow()
#2 .../libraries/classes/Controllers/Table/ChangeController.php(79): PhpMyAdmin\\InsertEdit->determineInsertOrEdit()
#3 .../libraries/classes/Routing.php(189): PhpMyAdmin\\Controllers\\Table\\ChangeController->index()
#4 .../index.php(18): PhpMyAdmin\\Routing::callControllerForRoute()
#5 {main}\n  thrown in .../libraries/classes/InsertEdit.php on line 273
```