### PR TITLE
Replace Export privileges group dialog with a modal

### DIFF
--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -415,6 +415,7 @@ class PrivilegesController extends AbstractController
                     'checkprivsdb' => $_GET['checkprivsdb'],
                     'checkprivstable' => $_GET['checkprivstable'],
                 ]));
+                $this->render('export_modal');
             } elseif ($this->response->isAjax() === true && empty($_REQUEST['ajax_page_request'])) {
                 $message = Message::success(__('User has been added.'));
                 $this->response->addJSON('message', $message);
@@ -424,6 +425,7 @@ class PrivilegesController extends AbstractController
                 $this->response->addHTML($databaseController->index([
                     'checkprivsdb' => $_GET['checkprivsdb'],
                 ]));
+                $this->render('export_modal');
             }
         } else {
             if (isset($dbname) && ! is_array($dbname)) {

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -3170,6 +3170,7 @@ class Privileges
                     $dbRights,
                     $textDir
                 );
+                $usersOverview .= $this->template->render('export_modal');
             }
 
             $response = Response::getInstance();

--- a/templates/export_modal.twig
+++ b/templates/export_modal.twig
@@ -1,0 +1,14 @@
+<div class="modal fade" id="exportPrivilegesModal" tabindex="-1" aria-labelledby="exportPrivilegesModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exportPrivilegesModalLabel">{% trans 'Loading' %}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+      </div>
+      <div class="modal-body"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans 'Close' %}</button>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### Description

Replaces the export privileges group jQuery UI dialog with a Bootstrap modal.

![Screenshot from 2021-05-28 22-18-58](https://user-images.githubusercontent.com/22860775/120016864-c4411800-c002-11eb-96b5-3ffab2ec019b.png)


Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
