### PR TITLE
Fix #16504 - Create view dialog is too big and won't scroll

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -4661,6 +4661,7 @@ Functions.createViewDialog = function ($this) {
             var $dialog = $('<div></div>').attr('id', 'createViewDialog').append(data.message).dialog({
                 width: 600,
                 minWidth: 400,
+                height: $(window).height(),
                 modal: true,
                 buttons: buttonOptions,
                 title: Messages.strCreateView,


### PR DESCRIPTION
Signed-off-by: Shinya Nishimura <georgia6954@gmail.com>

### Description

I add createViewDialog's style to current window height.

Fixes #16504

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
