### PR TITLE
Do not convert errors to exceptions for PHP 8.1 tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,8 +67,13 @@ jobs:
                 php-version: ["7.2", "7.3", "7.4", "8.0"]
                 experimental: [false]
                 os: [ubuntu-latest]
+                phpunit-options: ['--exclude-group selenium']
                 include:
-                    - { php-version: '8.1', composer-options: '--ignore-platform-req=php', experimental: true, os: ubuntu-latest }
+                  - php-version: '8.1'
+                    experimental: true
+                    os: ubuntu-latest
+                    phpunit-options: '--configuration test/phpunit-php-nightly.xml'
+                    composer-options: '--ignore-platform-req=php'
         steps:
             - uses: actions/checkout@v2
             - name: Install gettext
@@ -98,7 +103,7 @@ jobs:
             - name: Install dependencies
               run: composer install --no-interaction ${{ matrix.composer-options }}
             - name: Run php tests
-              run: composer run phpunit --  --exclude-group selenium
+              run: composer run phpunit -- ${{ matrix.phpunit-options }}
             - name: Send coverage
               uses: codecov/codecov-action@v1
               with:

--- a/test/phpunit-php-nightly.xml
+++ b/test/phpunit-php-nightly.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+    bootstrap="bootstrap-dist.php"
+    convertDeprecationsToExceptions="false"
+    convertNoticesToExceptions="false"
+    convertWarningsToExceptions="false"
+    convertErrorsToExceptions="false"
+    forceCoversAnnotation="true"
+    executionOrder="random"
+    colors="true"
+    verbose="true">
+
+    <php>
+        <const name="PHPMYADMIN" value="1"/>
+        <const name="TESTSUITE" value="1"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">classes</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">.</directory>
+            <exclude>
+                <directory>../examples</directory>
+                <directory>../libraries/cache</directory>
+                <directory>../node_modules</directory>
+                <directory>../test</directory>
+                <directory>../tmp</directory>
+                <directory>../vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
```xml
    convertDeprecationsToExceptions="false"
    convertNoticesToExceptions="false"
    convertWarningsToExceptions="false"
    convertErrorsToExceptions="false"
```