### PR TITLE
Run PHPUnit test in random order by default

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -72,8 +72,6 @@ jobs:
           CHANGED_FILES=$(git diff origin/$GITHUB_BASE_REF --diff-filter=AM --name-only | grep libraries/classes/ | paste -sd "," -);
           ./build/tools/infection -j$(nproc) --skip-initial-tests --no-interaction --no-progress --coverage=build/logs \
             --ignore-msi-with-no-mutations \
-            --git-diff-filter=AM \
-            --git-diff-base=origin/${{ github.base_ref }}
             --filter=$CHANGED_FILES
         env:
           INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,46 +181,6 @@ jobs:
                 project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
                 coverage-reports: build/logs/clover.xml
 
-    test-php-random:
-        name: Test (random) on php ${{ matrix.php-version }} and ${{ matrix.os }}
-        runs-on: ${{ matrix.os }}
-        if: "!contains(github.event.head_commit.message, '[ci skip]')"
-        strategy:
-            matrix:
-                php-version: ["7.4"]
-                os: [ubuntu-latest]
-        steps:
-            - uses: actions/checkout@v2
-            - name: Install gettext
-              run: sudo apt-get install -y gettext
-            - name: Generate mo files
-              run: ./scripts/generate-mo --quiet
-            - name: Use php ${{ matrix.php-version }}
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php-version }}
-                  extensions: mbstring, iconv, mysqli, zip, gd, bz2
-
-            - name: Get Composer cache directory
-              id: composer-cache
-              run: |
-                echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            - name: Cache dependencies
-              uses: actions/cache@v2
-              with:
-                path: ${{ steps.composer-cache.outputs.dir }}
-                key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ hashFiles('**/composer.*') }}
-                restore-keys: |
-                  composer-${{ runner.os }}-${{ matrix.php-version }}-
-
-            - name: Install dependencies
-              run: composer install
-            - name: Run random php tests
-              # This one is allowed to fail, but we hope it will not
-              continue-on-error: true
-              run: composer run phpunit --  --exclude-group selenium --order-by=random --stop-on-failure
-
     test-js:
         name: Test javascript files
         runs-on: ubuntu-latest

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -285,7 +285,15 @@ class Core
             $response = Response::getInstance();
             $response->setRequestStatus(false);
             $response->addJSON('message', Message::error($error_message));
-        } elseif (! empty($_REQUEST['ajax_request'])) {
+
+            if (! defined('TESTSUITE')) {
+                exit;
+            }
+
+            return;
+        }
+
+        if (! empty($_REQUEST['ajax_request'])) {
             // Generate JSON manually
             self::headerJSON();
             echo json_encode(
@@ -294,16 +302,22 @@ class Core
                     'message' => Message::error($error_message)->getDisplay(),
                 ]
             );
-        } else {
-            $error_message = strtr($error_message, ['<br>' => '[br]']);
-            $template = new Template();
 
-            echo $template->render('error/generic', [
-                'lang' => $GLOBALS['lang'] ?? 'en',
-                'dir' => $GLOBALS['text_dir'] ?? 'ltr',
-                'error_message' => Sanitize::sanitizeMessage($error_message),
-            ]);
+            if (! defined('TESTSUITE')) {
+                exit;
+            }
+
+            return;
         }
+
+        $error_message = strtr($error_message, ['<br>' => '[br]']);
+        $template = new Template();
+
+        echo $template->render('error/generic', [
+            'lang' => $GLOBALS['lang'] ?? 'en',
+            'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+            'error_message' => Sanitize::sanitizeMessage($error_message),
+        ]);
 
         if (! defined('TESTSUITE')) {
             exit;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
     bootstrap="test/bootstrap-dist.php"
-    forceCoversAnnotation="true"
     colors="true"
-    verbose="true">
-
+    forceCoversAnnotation="true"
+    verbose="true"
+    executionOrder="random"
+>
     <php>
         <const name="PHPMYADMIN" value="1"/>
         <const name="TESTSUITE" value="1"/>

--- a/test/classes/CoreTest.php
+++ b/test/classes/CoreTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Core;
+use PhpMyAdmin\Response;
 use PhpMyAdmin\Sanitize;
 use stdClass;
 
@@ -446,6 +447,9 @@ class CoreTest extends AbstractNetworkTestCase
      */
     public function testFatalErrorMessage(): void
     {
+        $_REQUEST = [];
+        Response::getInstance()->setAjax(false);
+
         $this->expectOutputRegex('/FatalError!/');
         Core::fatalError('FatalError!');
     }
@@ -455,6 +459,9 @@ class CoreTest extends AbstractNetworkTestCase
      */
     public function testFatalErrorMessageWithArgs(): void
     {
+        $_REQUEST = [];
+        Response::getInstance()->setAjax(false);
+
         $message = 'Fatal error #%d in file %s.';
         $params = [
             1,

--- a/test/classes/Database/EventsTest.php
+++ b/test/classes/Database/EventsTest.php
@@ -151,6 +151,7 @@ class EventsTest extends AbstractTestCase
      */
     public function testGetEditorFormAdd(array $data, string $matcher): void
     {
+        Response::getInstance()->setAjax(false);
         $this->assertStringContainsString(
             $matcher,
             $this->events->getEditorForm('add', 'change', $data)
@@ -205,6 +206,7 @@ class EventsTest extends AbstractTestCase
      */
     public function testGetEditorFormEdit(array $data, string $matcher): void
     {
+        Response::getInstance()->setAjax(false);
         $this->assertStringContainsString(
             $matcher,
             $this->events->getEditorForm('edit', 'change', $data)

--- a/test/classes/Plugins/Auth/AuthenticationHttpTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationHttpTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Footer;
 use PhpMyAdmin\Header;
 use PhpMyAdmin\Plugins\Auth\AuthenticationHttp;
+use PhpMyAdmin\Response;
 use PhpMyAdmin\Tests\AbstractNetworkTestCase;
 
 use function base64_encode;
@@ -382,6 +383,9 @@ class AuthenticationHttpTest extends AbstractNetworkTestCase
      */
     public function testAuthFails(): void
     {
+        $_REQUEST = [];
+        Response::getInstance()->setAjax(false);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/test/classes/Plugins/Auth/AuthenticationSignonTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationSignonTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests\Plugins\Auth;
 
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Plugins\Auth\AuthenticationSignon;
+use PhpMyAdmin\Response;
 use PhpMyAdmin\Tests\AbstractNetworkTestCase;
 
 use function ob_get_clean;
@@ -53,6 +54,8 @@ class AuthenticationSignonTest extends AbstractNetworkTestCase
     public function testAuth(): void
     {
         $GLOBALS['cfg']['Server']['SignonURL'] = '';
+        $_REQUEST = [];
+        Response::getInstance()->setAjax(false);
 
         ob_start();
         $this->object->showLoginForm();


### PR DESCRIPTION
This prevents tests having hidden dependencies on each other.