### PR TITLE
Fix #16979 - CSS broken and missing icons

### DIFF
--- a/themes/pmahomme/scss/_variables.scss
+++ b/themes/pmahomme/scss/_variables.scss
@@ -81,7 +81,6 @@ $table-cell-padding-sm: $table-cell-padding;
 $table-head-bg: #fff;
 $table-head-color: $th-color;
 $table-striped-order: even;
-$table-accent-bg: #dfdfdf;
 $table-hover-color: $browse-pointer-color;
 $table-border-color: #fff;
 $table-border-width: 0;


### PR DESCRIPTION
### Description
This is the issue: CSS broken and missing icons on 5.2.0-dev c8a5cd4 #16979

Fixes #16979

Only removed line #84 ($table-accent-bg: #dfdfdf;) in \themes\pmahomme\scss\_variables.scss | That value seemed to override the "background-image" property for the icons. Now the $table-accent-bg is still NOT gone for the build process still adds $table-accent-bg: transparent; , though now the icons/menu look fine.

Signed-off-by: Angelo Grebenarov <grebenarov@gmail.com>

