### PR TITLE
Fix #16975 - Fixing the null issue with datetime in insert mode

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -3297,7 +3297,7 @@ class InsertEdit
         // in the name attribute (see bug #1746964 )
         $column_name_appendix = $vkey . '[' . $column['Field_md5'] . ']';
 
-        if ($column['Type'] === 'datetime' && ! isset($column['Default']) && $insert_mode) {
+        if ($column['Type'] === 'datetime' && $column['Null'] !== 'YES' && ! isset($column['Default']) && $insert_mode) {
             $column['Default'] = date('Y-m-d H:i:s', time());
         }
 


### PR DESCRIPTION
Signed-off-by: Fawzi E. Abdulfattah <iifawzie@gmail.com>

### Description

Hi, The issue was happening due to filling the `default` value, regardless of the Null constraint, which was leading to go over this if statement and not changing the `$real_null_value` to true, which's used to determine if the `checkbox` will be `checked` or not. 

https://github.com/phpmyadmin/phpmyadmin/blob/749fc55fedade3c5f0349632cc68ab0da4445df6/libraries/classes/InsertEdit.php#L2141-L2151

I've just added a check, to check whether the Null constraint is set or not before setting a default value. 

Fixes #16975 
