### PR TITLE
Fix #16994 - Fixing the issue when assigning database to user with '_'

### DIFF
--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -229,7 +229,7 @@ class PrivilegesController extends AbstractController
                         ($username ?? ''),
                         ($hostname ?? ''),
                         ($tablename ?? ($routinename ?? '')),
-                        ($db_name ?? ''),
+                        (Util::unescapeMysqlWildcards($db_name) ?? ''),
                         $itemType
                     );
                 }


### PR DESCRIPTION
Signed-off-by: Fawzi E. Abdulfattah <iifawzie@gmail.com>

### Description
The problem was that if multiple databases were chosen, they were not unescaped and will be added as they are to `mysql`.`db`, that's why they appear with the backslash in the privileges view

Fixes #16994