### PR TITLE
Fix: Fixing all the issues related to assigning privileges to databases with '_'

### DIFF
--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -229,7 +229,7 @@ class PrivilegesController extends AbstractController
                         ($username ?? ''),
                         ($hostname ?? ''),
                         ($tablename ?? ($routinename ?? '')),
-                        Util::unescapeMysqlWildcards($db_name ?? ''),
+                        ($db_name ?? ''),
                         $itemType
                     );
                 }

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -514,8 +514,7 @@ class Privileges
             return 'SELECT * FROM `mysql`.`db`'
                 . " WHERE `User` = '" . $this->dbi->escapeString($username) . "'"
                 . " AND `Host` = '" . $this->dbi->escapeString($hostname) . "'"
-                . " AND '" . $this->dbi->escapeString(Util::unescapeMysqlWildcards($db)) . "'"
-                . ' LIKE `Db`;';
+                . " AND `Db` = '" . $this->dbi->escapeString($db) . "'";
         }
 
         return 'SELECT `Table_priv`'
@@ -1589,12 +1588,12 @@ class Privileges
         ];
         switch ($linktype) {
             case 'edit':
-                $params['dbname'] = Util::escapeMysqlWildcards($dbname);
+                $params['dbname'] = $dbname;
                 $params['tablename'] = $tablename;
                 $params['routinename'] = $routinename;
                 break;
             case 'revoke':
-                $params['dbname'] = Util::escapeMysqlWildcards($dbname);
+                $params['dbname'] = $dbname;
                 $params['tablename'] = $tablename;
                 $params['routinename'] = $routinename;
                 $params['revokeall'] = 1;
@@ -2926,7 +2925,7 @@ class Privileges
             } else {
                 $unescaped_db = Util::unescapeMysqlWildcards($dbname);
                 $db_and_table = Util::backquote($unescaped_db) . '.';
-                $return_db = $unescaped_db;
+                $return_db = $dbname;
             }
             if (isset($tablename)) {
                 $db_and_table .= Util::backquote($tablename);

--- a/templates/server/privileges/privileges_summary.twig
+++ b/templates/server/privileges/privileges_summary.twig
@@ -56,7 +56,7 @@
             {%- if databases is not empty %}
                 <select name="pred_dbname[]" multiple="multiple">
                     {% for database in databases %}
-                        <option value="{{ escaped_databases[loop.index0]|escape_mysql_wildcards }}">
+                        <option value="{{ escaped_databases[loop.index0] }}">
                             {{ database }}
                         </option>
                     {% endfor %}


### PR DESCRIPTION
Signed-off-by: Fawzi E. Abdulfattah <iifawzie@gmail.com>

### Description

This PR fixes all the bugs discussed at https://github.com/phpmyadmin/phpmyadmin/pull/17010 and the bug mentioned in #16994. 

Fixes: 

- The grant/revoke queries will be escaped once - Previously, when single db is selected, no escaping at all, and when multiple db are selected got escaped twice -  
- All the UI that's responsible to show the databases names are unescaped for the user to see the actual names. 
- All the links to edit/revoke are fixed. 
- Multiple select list will only show the databases that aren't already granted privileges. 

<img width="1181" alt="Screen Shot 2021-07-16 at 12 37 43 AM" src="https://user-images.githubusercontent.com/46695441/125866562-8dcfc6ba-ef19-40e0-8b1c-baed901c9139.png">
<img width="1092" alt="Screen Shot 2021-07-16 at 12 37 06 AM" src="https://user-images.githubusercontent.com/46695441/125866565-beb6229c-6248-4c8e-9ee9-b5c2f12c6e3d.png">
<img width="873" alt="Screen Shot 2021-07-16 at 12 36 56 AM" src="https://user-images.githubusercontent.com/46695441/125866567-bc0f2b38-a460-4481-ab11-0d7617c9f388.png">
<img width="700" alt="Screen Shot 2021-07-16 at 12 47 11 AM" src="https://user-images.githubusercontent.com/46695441/125867358-4031dfde-8b3b-40e0-b916-8a285bc66687.png">
