### PR TITLE
Use negative length with mb_substr where possible

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1860,11 +1860,7 @@ class Results
 
         // remove the comma from the last column name in the newly
         // constructed clause
-        $sortOrder = mb_substr(
-            $sortOrder,
-            0,
-            mb_strlen($sortOrder) - 2
-        );
+        $sortOrder = mb_substr($sortOrder, 0, -2);
         if (empty($orderImg)) {
             $orderImg = '';
         }

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -323,15 +323,9 @@ class Export
         // Grab basic dump extension and mime type
         // Check if the user already added extension;
         // get the substring where the extension would be if it was included
-        $extensionStartPos = mb_strlen($filename) - mb_strlen(
-            $exportPlugin->getProperties()->getExtension()
-        ) - 1;
-        $userExtension = mb_substr(
-            $filename,
-            $extensionStartPos,
-            mb_strlen($filename)
-        );
         $requiredExtension = '.' . $exportPlugin->getProperties()->getExtension();
+        $extensionLength = mb_strlen($requiredExtension);
+        $userExtension = mb_substr($filename, -$extensionLength);
         if (mb_strtolower($userExtension) != $requiredExtension) {
             $filename  .= $requiredExtension;
         }

--- a/libraries/classes/Gis/GisGeometry.php
+++ b/libraries/classes/Gis/GisGeometry.php
@@ -12,7 +12,6 @@ use TCPDF;
 use function explode;
 use function floatval;
 use function intval;
-use function mb_strlen;
 use function mb_strripos;
 use function mb_substr;
 use function mt_rand;
@@ -393,11 +392,7 @@ abstract class GisGeometry
             $ol_array .= $this->getPointForOpenLayers($point, $srid) . '.getCoordinates(), ';
         }
 
-        $ol_array = mb_substr(
-            $ol_array,
-            0,
-            mb_strlen($ol_array) - 2
-        );
+        $ol_array = mb_substr($ol_array, 0, -2);
 
         return $ol_array . ')';
     }

--- a/libraries/classes/Gis/GisGeometryCollection.php
+++ b/libraries/classes/Gis/GisGeometryCollection.php
@@ -11,7 +11,6 @@ use TCPDF;
 
 use function array_merge;
 use function count;
-use function mb_strlen;
 use function mb_strpos;
 use function mb_substr;
 use function str_split;
@@ -63,11 +62,7 @@ class GisGeometryCollection extends GisGeometry
         $min_max = [];
 
         // Trim to remove leading 'GEOMETRYCOLLECTION(' and trailing ')'
-        $goem_col = mb_substr(
-            $spatial,
-            19,
-            mb_strlen($spatial) - 20
-        );
+        $goem_col = mb_substr($spatial, 19, -1);
 
         // Split the geometry collection object to get its constituents.
         $sub_parts = $this->explodeGeomCol($goem_col);
@@ -130,11 +125,7 @@ class GisGeometryCollection extends GisGeometry
     public function prepareRowAsPng($spatial, ?string $label, $color, array $scale_data, $image)
     {
         // Trim to remove leading 'GEOMETRYCOLLECTION(' and trailing ')'
-        $goem_col = mb_substr(
-            $spatial,
-            19,
-            mb_strlen($spatial) - 20
-        );
+        $goem_col = mb_substr($spatial, 19, -1);
         // Split the geometry collection object to get its constituents.
         $sub_parts = $this->explodeGeomCol($goem_col);
 
@@ -179,11 +170,7 @@ class GisGeometryCollection extends GisGeometry
     public function prepareRowAsPdf($spatial, ?string $label, $color, array $scale_data, $pdf)
     {
         // Trim to remove leading 'GEOMETRYCOLLECTION(' and trailing ')'
-        $goem_col = mb_substr(
-            $spatial,
-            19,
-            mb_strlen($spatial) - 20
-        );
+        $goem_col = mb_substr($spatial, 19, -1);
         // Split the geometry collection object to get its constituents.
         $sub_parts = $this->explodeGeomCol($goem_col);
 
@@ -229,11 +216,7 @@ class GisGeometryCollection extends GisGeometry
         $row = '';
 
         // Trim to remove leading 'GEOMETRYCOLLECTION(' and trailing ')'
-        $goem_col = mb_substr(
-            $spatial,
-            19,
-            mb_strlen($spatial) - 20
-        );
+        $goem_col = mb_substr($spatial, 19, -1);
         // Split the geometry collection object to get its constituents.
         $sub_parts = $this->explodeGeomCol($goem_col);
 
@@ -280,11 +263,7 @@ class GisGeometryCollection extends GisGeometry
         $row = '';
 
         // Trim to remove leading 'GEOMETRYCOLLECTION(' and trailing ')'
-        $goem_col = mb_substr(
-            $spatial,
-            19,
-            mb_strlen($spatial) - 20
-        );
+        $goem_col = mb_substr($spatial, 19, -1);
         // Split the geometry collection object to get its constituents.
         $sub_parts = $this->explodeGeomCol($goem_col);
 
@@ -379,11 +358,7 @@ class GisGeometryCollection extends GisGeometry
         }
 
         if (isset($gis_data[0]['gis_type'])) {
-            $wkt = mb_substr(
-                $wkt,
-                0,
-                mb_strlen($wkt) - 1
-            );
+            $wkt = mb_substr($wkt, 0, -1);
         }
 
         return $wkt . ')';
@@ -406,11 +381,7 @@ class GisGeometryCollection extends GisGeometry
         $wkt = $data['wkt'];
 
         // Trim to remove leading 'GEOMETRYCOLLECTION(' and trailing ')'
-        $goem_col = mb_substr(
-            $wkt,
-            19,
-            mb_strlen($wkt) - 20
-        );
+        $goem_col = mb_substr($wkt, 19, -1);
         // Split the geometry collection object to get its constituents.
         $sub_parts = $this->explodeGeomCol($goem_col);
         $params['GEOMETRYCOLLECTION']['geom_count'] = count($sub_parts);

--- a/libraries/classes/Gis/GisLineString.php
+++ b/libraries/classes/Gis/GisLineString.php
@@ -15,7 +15,6 @@ use function imagecolorallocate;
 use function imageline;
 use function imagestring;
 use function json_encode;
-use function mb_strlen;
 use function mb_substr;
 use function trim;
 
@@ -64,11 +63,7 @@ class GisLineString extends GisGeometry
     public function scaleRow($spatial)
     {
         // Trim to remove leading 'LINESTRING(' and trailing ')'
-        $linestring = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $linestring = mb_substr($spatial, 11, -1);
 
         return $this->setMinMax($linestring, []);
     }
@@ -101,11 +96,7 @@ class GisLineString extends GisGeometry
         $color = imagecolorallocate($image, $red, $green, $blue);
 
         // Trim to remove leading 'LINESTRING(' and trailing ')'
-        $linesrting = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $linesrting = mb_substr($spatial, 11, -1);
         $points_arr = $this->extractPoints($linesrting, $scale_data);
 
         foreach ($points_arr as $point) {
@@ -169,11 +160,7 @@ class GisLineString extends GisGeometry
         ];
 
         // Trim to remove leading 'LINESTRING(' and trailing ')'
-        $linesrting = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $linesrting = mb_substr($spatial, 11, -1);
         $points_arr = $this->extractPoints($linesrting, $scale_data);
 
         foreach ($points_arr as $point) {
@@ -226,11 +213,7 @@ class GisLineString extends GisGeometry
         ];
 
         // Trim to remove leading 'LINESTRING(' and trailing ')'
-        $linesrting = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $linesrting = mb_substr($spatial, 11, -1);
         $points_arr = $this->extractPoints($linesrting, $scale_data);
 
         $row = '<polyline points="';
@@ -285,11 +268,7 @@ class GisLineString extends GisGeometry
         $result .= $this->getBoundsForOl($srid, $scale_data);
 
         // Trim to remove leading 'LINESTRING(' and trailing ')'
-        $linesrting = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $linesrting = mb_substr($spatial, 11, -1);
         $points_arr = $this->extractPoints($linesrting, null);
 
         return $result . 'var line = new ol.Feature({geometry: '
@@ -326,11 +305,7 @@ class GisLineString extends GisGeometry
                     ? $gis_data[$index]['LINESTRING'][$i]['y'] : $empty) . ',';
         }
 
-        $wkt = mb_substr(
-            $wkt,
-            0,
-            mb_strlen($wkt) - 1
-        );
+        $wkt = mb_substr($wkt, 0, -1);
 
         return $wkt . ')';
     }
@@ -359,11 +334,7 @@ class GisLineString extends GisGeometry
         }
 
         // Trim to remove leading 'LINESTRING(' and trailing ')'
-        $linestring = mb_substr(
-            $wkt,
-            11,
-            mb_strlen($wkt) - 12
-        );
+        $linestring = mb_substr($wkt, 11, -1);
         $points_arr = $this->extractPoints($linestring, null);
 
         $no_of_points = count($points_arr);

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -16,7 +16,6 @@ use function imagecolorallocate;
 use function imageline;
 use function imagestring;
 use function json_encode;
-use function mb_strlen;
 use function mb_substr;
 use function trim;
 
@@ -67,11 +66,7 @@ class GisMultiLineString extends GisGeometry
         $min_max = [];
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
-        $multilinestirng = mb_substr(
-            $spatial,
-            17,
-            mb_strlen($spatial) - 19
-        );
+        $multilinestirng = mb_substr($spatial, 17, -2);
         // Separate each linestring
         $linestirngs = explode('),(', $multilinestirng);
 
@@ -110,11 +105,7 @@ class GisMultiLineString extends GisGeometry
         $color = imagecolorallocate($image, $red, $green, $blue);
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
-        $multilinestirng = mb_substr(
-            $spatial,
-            17,
-            mb_strlen($spatial) - 19
-        );
+        $multilinestirng = mb_substr($spatial, 17, -2);
         // Separate each linestring
         $linestirngs = explode('),(', $multilinestirng);
 
@@ -186,11 +177,7 @@ class GisMultiLineString extends GisGeometry
         ];
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
-        $multilinestirng = mb_substr(
-            $spatial,
-            17,
-            mb_strlen($spatial) - 19
-        );
+        $multilinestirng = mb_substr($spatial, 17, -2);
         // Separate each linestring
         $linestirngs = explode('),(', $multilinestirng);
 
@@ -250,11 +237,7 @@ class GisMultiLineString extends GisGeometry
         ];
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
-        $multilinestirng = mb_substr(
-            $spatial,
-            17,
-            mb_strlen($spatial) - 19
-        );
+        $multilinestirng = mb_substr($spatial, 17, -2);
         // Separate each linestring
         $linestirngs = explode('),(', $multilinestirng);
 
@@ -316,11 +299,7 @@ class GisMultiLineString extends GisGeometry
         $row .= $this->getBoundsForOl($srid, $scale_data);
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
-        $multilinestirng = mb_substr(
-            $spatial,
-            17,
-            mb_strlen($spatial) - 19
-        );
+        $multilinestirng = mb_substr($spatial, 17, -2);
         // Separate each linestring
         $linestirngs = explode('),(', $multilinestirng);
 
@@ -368,19 +347,11 @@ class GisMultiLineString extends GisGeometry
                         ? $data_row[$i][$j]['y'] : $empty) . ',';
             }
 
-            $wkt = mb_substr(
-                $wkt,
-                0,
-                mb_strlen($wkt) - 1
-            );
+            $wkt = mb_substr($wkt, 0, -1);
             $wkt .= '),';
         }
 
-        $wkt = mb_substr(
-            $wkt,
-            0,
-            mb_strlen($wkt) - 1
-        );
+        $wkt = mb_substr($wkt, 0, -1);
 
         return $wkt . ')';
     }
@@ -403,19 +374,11 @@ class GisMultiLineString extends GisGeometry
                 $wkt .= $point['x'] . ' ' . $point['y'] . ',';
             }
 
-            $wkt = mb_substr(
-                $wkt,
-                0,
-                mb_strlen($wkt) - 1
-            );
+            $wkt = mb_substr($wkt, 0, -1);
             $wkt .= '),';
         }
 
-        $wkt = mb_substr(
-            $wkt,
-            0,
-            mb_strlen($wkt) - 1
-        );
+        $wkt = mb_substr($wkt, 0, -1);
 
         return $wkt . ')';
     }
@@ -444,11 +407,7 @@ class GisMultiLineString extends GisGeometry
         }
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
-        $multilinestirng = mb_substr(
-            $wkt,
-            17,
-            mb_strlen($wkt) - 19
-        );
+        $multilinestirng = mb_substr($wkt, 17, -2);
         // Separate each linestring
         $linestirngs = explode('),(', $multilinestirng);
         $params[$index]['MULTILINESTRING']['no_of_lines'] = count($linestirngs);

--- a/libraries/classes/Gis/GisMultiPoint.php
+++ b/libraries/classes/Gis/GisMultiPoint.php
@@ -15,7 +15,6 @@ use function imagearc;
 use function imagecolorallocate;
 use function imagestring;
 use function json_encode;
-use function mb_strlen;
 use function mb_substr;
 use function trim;
 
@@ -64,11 +63,7 @@ class GisMultiPoint extends GisGeometry
     public function scaleRow($spatial)
     {
         // Trim to remove leading 'MULTIPOINT(' and trailing ')'
-        $multipoint = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $multipoint = mb_substr($spatial, 11, -1);
 
         return $this->setMinMax($multipoint, []);
     }
@@ -101,11 +96,7 @@ class GisMultiPoint extends GisGeometry
         $color = imagecolorallocate($image, $red, $green, $blue);
 
         // Trim to remove leading 'MULTIPOINT(' and trailing ')'
-        $multipoint = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $multipoint = mb_substr($spatial, 11, -1);
         $points_arr = $this->extractPoints($multipoint, $scale_data);
 
         foreach ($points_arr as $point) {
@@ -169,11 +160,7 @@ class GisMultiPoint extends GisGeometry
         ];
 
         // Trim to remove leading 'MULTIPOINT(' and trailing ')'
-        $multipoint = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $multipoint = mb_substr($spatial, 11, -1);
         $points_arr = $this->extractPoints($multipoint, $scale_data);
 
         foreach ($points_arr as $point) {
@@ -221,11 +208,7 @@ class GisMultiPoint extends GisGeometry
         ];
 
         // Trim to remove leading 'MULTIPOINT(' and trailing ')'
-        $multipoint = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $multipoint = mb_substr($spatial, 11, -1);
         $points_arr = $this->extractPoints($multipoint, $scale_data);
 
         $row = '';
@@ -301,11 +284,7 @@ class GisMultiPoint extends GisGeometry
         $result .= $this->getBoundsForOl($srid, $scale_data);
 
         // Trim to remove leading 'MULTIPOINT(' and trailing ')'
-        $multipoint = mb_substr(
-            $spatial,
-            11,
-            mb_strlen($spatial) - 12
-        );
+        $multipoint = mb_substr($spatial, 11, -1);
         $points_arr = $this->extractPoints($multipoint, null);
 
         return $result . 'var multiPoint = new ol.geom.MultiPoint('
@@ -343,11 +322,7 @@ class GisMultiPoint extends GisGeometry
                     ? $gis_data[$index]['MULTIPOINT'][$i]['y'] : '') . ',';
         }
 
-        $wkt = mb_substr(
-            $wkt,
-            0,
-            mb_strlen($wkt) - 1
-        );
+        $wkt = mb_substr($wkt, 0, -1);
 
         return $wkt . ')';
     }
@@ -369,11 +344,7 @@ class GisMultiPoint extends GisGeometry
                 . $row_data['points'][$i]['y'] . ',';
         }
 
-        $wkt = mb_substr(
-            $wkt,
-            0,
-            mb_strlen($wkt) - 1
-        );
+        $wkt = mb_substr($wkt, 0, -1);
 
         return $wkt . ')';
     }
@@ -402,11 +373,7 @@ class GisMultiPoint extends GisGeometry
         }
 
         // Trim to remove leading 'MULTIPOINT(' and trailing ')'
-        $points = mb_substr(
-            $wkt,
-            11,
-            mb_strlen($wkt) - 12
-        );
+        $points = mb_substr($wkt, 11, -1);
         $points_arr = $this->extractPoints($points, null);
 
         $no_of_points = count($points_arr);
@@ -441,9 +408,8 @@ class GisMultiPoint extends GisGeometry
             $ol_array .= $this->getPointForOpenLayers($point, $srid) . '.getCoordinates(), ';
         }
 
-        $olArrayLength = mb_strlen($ol_array);
-        if (mb_substr($ol_array, $olArrayLength - 2) === ', ') {
-            $ol_array = mb_substr($ol_array, 0, $olArrayLength - 2);
+        if (mb_substr($ol_array, -2) === ', ') {
+            $ol_array = mb_substr($ol_array, 0, -2);
         }
 
         return $ol_array . ')';

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -19,7 +19,6 @@ use function imagecolorallocate;
 use function imagefilledpolygon;
 use function imagestring;
 use function json_encode;
-use function mb_strlen;
 use function mb_substr;
 use function str_contains;
 use function trim;
@@ -71,11 +70,7 @@ class GisMultiPolygon extends GisGeometry
         $min_max = [];
 
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
-        $multipolygon = mb_substr(
-            $spatial,
-            15,
-            mb_strlen($spatial) - 18
-        );
+        $multipolygon = mb_substr($spatial, 15, -3);
         // Separate each polygon
         $polygons = explode(')),((', $multipolygon);
 
@@ -123,11 +118,7 @@ class GisMultiPolygon extends GisGeometry
         $color = imagecolorallocate($image, $red, $green, $blue);
 
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
-        $multipolygon = mb_substr(
-            $spatial,
-            15,
-            mb_strlen($spatial) - 18
-        );
+        $multipolygon = mb_substr($spatial, 15, -3);
         // Separate each polygon
         $polygons = explode(')),((', $multipolygon);
 
@@ -207,11 +198,7 @@ class GisMultiPolygon extends GisGeometry
         ];
 
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
-        $multipolygon = mb_substr(
-            $spatial,
-            15,
-            mb_strlen($spatial) - 18
-        );
+        $multipolygon = mb_substr($spatial, 15, -3);
         // Separate each polygon
         $polygons = explode(')),((', $multipolygon);
 
@@ -286,11 +273,7 @@ class GisMultiPolygon extends GisGeometry
         $row = '';
 
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
-        $multipolygon = mb_substr(
-            $spatial,
-            15,
-            mb_strlen($spatial) - 18
-        );
+        $multipolygon = mb_substr($spatial, 15, -3);
         // Separate each polygon
         $polygons = explode(')),((', $multipolygon);
 
@@ -366,11 +349,7 @@ class GisMultiPolygon extends GisGeometry
         $row .= $this->getBoundsForOl($srid, $scale_data);
 
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
-        $multipolygon = mb_substr(
-            $spatial,
-            15,
-            mb_strlen($spatial) - 18
-        );
+        $multipolygon = mb_substr($spatial, 15, -3);
         // Separate each polygon
         $polygons = explode(')),((', $multipolygon);
 
@@ -450,27 +429,15 @@ class GisMultiPolygon extends GisGeometry
                             ? $data_row[$k][$i][$j]['y'] : $empty) . ',';
                 }
 
-                $wkt = mb_substr(
-                    $wkt,
-                    0,
-                    mb_strlen($wkt) - 1
-                );
+                $wkt = mb_substr($wkt, 0, -1);
                 $wkt .= '),';
             }
 
-            $wkt = mb_substr(
-                $wkt,
-                0,
-                mb_strlen($wkt) - 1
-            );
+            $wkt = mb_substr($wkt, 0, -1);
             $wkt .= '),';
         }
 
-        $wkt = mb_substr(
-            $wkt,
-            0,
-            mb_strlen($wkt) - 1
-        );
+        $wkt = mb_substr($wkt, 0, -1);
 
         return $wkt . ')';
     }
@@ -546,11 +513,7 @@ class GisMultiPolygon extends GisGeometry
                 $wkt .= $point['x'] . ' ' . $point['y'] . ',';
             }
 
-            $wkt = mb_substr(
-                $wkt,
-                0,
-                mb_strlen($wkt) - 1
-            );
+            $wkt = mb_substr($wkt, 0, -1);
             $wkt .= ')'; // end of outer ring
 
             // inner rings if any
@@ -561,11 +524,7 @@ class GisMultiPolygon extends GisGeometry
                         $wkt .= $innerPoint['x'] . ' ' . $innerPoint['y'] . ',';
                     }
 
-                    $wkt = mb_substr(
-                        $wkt,
-                        0,
-                        mb_strlen($wkt) - 1
-                    );
+                    $wkt = mb_substr($wkt, 0, -1);
                     $wkt .= ')';  // end of inner ring
                 }
             }
@@ -573,11 +532,7 @@ class GisMultiPolygon extends GisGeometry
             $wkt .= '),'; // end of polygon
         }
 
-        $wkt = mb_substr(
-            $wkt,
-            0,
-            mb_strlen($wkt) - 1
-        );
+        $wkt = mb_substr($wkt, 0, -1);
 
         return $wkt . ')';
     }
@@ -606,11 +561,7 @@ class GisMultiPolygon extends GisGeometry
         }
 
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
-        $multipolygon = mb_substr(
-            $wkt,
-            15,
-            mb_strlen($wkt) - 18
-        );
+        $multipolygon = mb_substr($wkt, 15, -3);
         // Separate each polygon
         $polygons = explode(')),((', $multipolygon);
 

--- a/libraries/classes/Gis/GisPoint.php
+++ b/libraries/classes/Gis/GisPoint.php
@@ -14,7 +14,6 @@ use function imagearc;
 use function imagecolorallocate;
 use function imagestring;
 use function json_encode;
-use function mb_strlen;
 use function mb_substr;
 use function trim;
 
@@ -63,11 +62,7 @@ class GisPoint extends GisGeometry
     public function scaleRow($spatial)
     {
         // Trim to remove leading 'POINT(' and trailing ')'
-        $point = mb_substr(
-            $spatial,
-            6,
-            mb_strlen($spatial) - 7
-        );
+        $point = mb_substr($spatial, 6, -1);
 
         return $this->setMinMax($point, []);
     }
@@ -100,11 +95,7 @@ class GisPoint extends GisGeometry
         $color = imagecolorallocate($image, $red, $green, $blue);
 
         // Trim to remove leading 'POINT(' and trailing ')'
-        $point = mb_substr(
-            $spatial,
-            6,
-            mb_strlen($spatial) - 7
-        );
+        $point = mb_substr($spatial, 6, -1);
         $points_arr = $this->extractPoints($point, $scale_data);
 
         // draw a small circle to mark the point
@@ -169,11 +160,7 @@ class GisPoint extends GisGeometry
         ];
 
         // Trim to remove leading 'POINT(' and trailing ')'
-        $point = mb_substr(
-            $spatial,
-            6,
-            mb_strlen($spatial) - 7
-        );
+        $point = mb_substr($spatial, 6, -1);
         $points_arr = $this->extractPoints($point, $scale_data);
 
         // draw a small circle to mark the point
@@ -222,11 +209,7 @@ class GisPoint extends GisGeometry
         ];
 
         // Trim to remove leading 'POINT(' and trailing ')'
-        $point = mb_substr(
-            $spatial,
-            6,
-            mb_strlen($spatial) - 7
-        );
+        $point = mb_substr($spatial, 6, -1);
         $points_arr = $this->extractPoints($point, $scale_data);
 
         $row = '';
@@ -297,11 +280,7 @@ class GisPoint extends GisGeometry
         $result .= $this->getBoundsForOl($srid, $scale_data);
 
         // Trim to remove leading 'POINT(' and trailing ')'
-        $point = mb_substr(
-            $spatial,
-            6,
-            mb_strlen($spatial) - 7
-        );
+        $point = mb_substr($spatial, 6, -1);
         $points_arr = $this->extractPoints($point, null);
 
         if ($points_arr[0][0] != '' && $points_arr[0][1] != '') {
@@ -376,11 +355,7 @@ class GisPoint extends GisGeometry
         }
 
         // Trim to remove leading 'POINT(' and trailing ')'
-        $point = mb_substr(
-            $wkt,
-            6,
-            mb_strlen($wkt) - 7
-        );
+        $point = mb_substr($wkt, 6, -1);
         $points_arr = $this->extractPoints($point, null);
 
         $params[$index]['POINT']['x'] = $points_arr[0][0];

--- a/libraries/classes/Gis/GisPolygon.php
+++ b/libraries/classes/Gis/GisPolygon.php
@@ -20,7 +20,6 @@ use function imagefilledpolygon;
 use function imagestring;
 use function json_encode;
 use function max;
-use function mb_strlen;
 use function mb_substr;
 use function min;
 use function pow;
@@ -73,11 +72,7 @@ class GisPolygon extends GisGeometry
     public function scaleRow($spatial)
     {
         // Trim to remove leading 'POLYGON((' and trailing '))'
-        $polygon = mb_substr(
-            $spatial,
-            9,
-            mb_strlen($spatial) - 11
-        );
+        $polygon = mb_substr($spatial, 9, -2);
 
         // If the polygon doesn't have an inner ring, use polygon itself
         if (! str_contains($polygon, '),(')) {
@@ -119,11 +114,7 @@ class GisPolygon extends GisGeometry
         $color = imagecolorallocate($image, $red, $green, $blue);
 
         // Trim to remove leading 'POLYGON((' and trailing '))'
-        $polygon = mb_substr(
-            $spatial,
-            9,
-            mb_strlen($spatial) - 11
-        );
+        $polygon = mb_substr($spatial, 9, -2);
 
         // If the polygon doesn't have an inner polygon
         if (! str_contains($polygon, '),(')) {
@@ -187,11 +178,7 @@ class GisPolygon extends GisGeometry
         ];
 
         // Trim to remove leading 'POLYGON((' and trailing '))'
-        $polygon = mb_substr(
-            $spatial,
-            9,
-            mb_strlen($spatial) - 11
-        );
+        $polygon = mb_substr($spatial, 9, -2);
 
         // If the polygon doesn't have an inner polygon
         if (! str_contains($polygon, '),(')) {
@@ -250,11 +237,7 @@ class GisPolygon extends GisGeometry
         ];
 
         // Trim to remove leading 'POLYGON((' and trailing '))'
-        $polygon = mb_substr(
-            $spatial,
-            9,
-            mb_strlen($spatial) - 11
-        );
+        $polygon = mb_substr($spatial, 9, -2);
 
         $row = '<path d="';
 
@@ -324,11 +307,7 @@ class GisPolygon extends GisGeometry
         $row .= $this->getBoundsForOl($srid, $scale_data);
 
         // Trim to remove leading 'POLYGON((' and trailing '))'
-        $polygon = mb_substr(
-            $spatial,
-            9,
-            mb_strlen($spatial) - 11
-        );
+        $polygon = mb_substr($spatial, 9, -2);
 
         // Separate outer and inner polygons
         $parts = explode('),(', $polygon);
@@ -399,19 +378,11 @@ class GisPolygon extends GisGeometry
                         ? $gis_data[$index]['POLYGON'][$i][$j]['y'] : $empty) . ',';
             }
 
-            $wkt = mb_substr(
-                $wkt,
-                0,
-                mb_strlen($wkt) - 1
-            );
+            $wkt = mb_substr($wkt, 0, -1);
             $wkt .= '),';
         }
 
-        $wkt = mb_substr(
-            $wkt,
-            0,
-            mb_strlen($wkt) - 1
-        );
+        $wkt = mb_substr($wkt, 0, -1);
 
         return $wkt . ')';
     }
@@ -623,11 +594,7 @@ class GisPolygon extends GisGeometry
         }
 
         // Trim to remove leading 'POLYGON((' and trailing '))'
-        $polygon = mb_substr(
-            $wkt,
-            9,
-            mb_strlen($wkt) - 11
-        );
+        $polygon = mb_substr($wkt, 9, -2);
         // Separate each linestring
         $linerings = explode('),(', $polygon);
         $params[$index]['POLYGON']['no_of_lines'] = count($linerings);

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -315,13 +315,9 @@ class GisVisualization
 
         // Check if the user already added extension;
         // get the substring where the extension would be if it was included
-        $extension_start_pos = mb_strlen($file_name) - mb_strlen($ext) - 1;
-        $user_extension = mb_substr(
-            $file_name,
-            $extension_start_pos,
-            mb_strlen($file_name)
-        );
         $required_extension = '.' . $ext;
+        $extension_length = mb_strlen($required_extension);
+        $user_extension = mb_substr($file_name, -$extension_length);
         if (mb_strtolower($user_extension) != $required_extension) {
             $file_name .= $required_extension;
         }

--- a/libraries/classes/Plugins/Import/ImportShp.php
+++ b/libraries/classes/Plugins/Import/ImportShp.php
@@ -26,7 +26,6 @@ use function count;
 use function extension_loaded;
 use function file_exists;
 use function file_put_contents;
-use function mb_strlen;
 use function mb_substr;
 use function method_exists;
 use function pathinfo;
@@ -161,12 +160,7 @@ class ImportShp extends ImportPlugin
                 // to load extra data.
                 // Replace the .shp with .*,
                 // so the bsShapeFiles library correctly locates .dbf file.
-                $file_name = mb_substr(
-                    $import_file,
-                    0,
-                    mb_strlen($import_file) - 4
-                ) . '.*';
-                $shp->fileName = $file_name;
+                $shp->fileName = mb_substr($import_file, 0, -4) . '.*';
             }
         }
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8804,7 +8804,7 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$gis_obj</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="21">
+    <MixedArgument occurrences="20">
       <code>$sub_part</code>
       <code>$sub_part</code>
       <code>$sub_part</code>
@@ -8848,7 +8848,7 @@
       <code>$srid</code>
       <code>$srid</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="3">
       <code>$points_arr[1][0]</code>
       <code>$points_arr[1][1]</code>
       <code>$wkt</code>
@@ -8911,7 +8911,7 @@
       <code>$srid</code>
       <code>$srid</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="3">
       <code>$points_arr[1][0]</code>
       <code>$points_arr[1][1]</code>
       <code>$wkt</code>
@@ -8985,7 +8985,7 @@
       <code>$srid</code>
       <code>$srid</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="4">
       <code>$point</code>
       <code>$points_arr[0][0]</code>
       <code>$points_arr[0][1]</code>
@@ -9054,7 +9054,7 @@
       <code>$srid</code>
       <code>$srid</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="7">
       <code>$points_arr[2]</code>
       <code>$points_arr[3]</code>
       <code>$ring1['pointOnSurface']</code>
@@ -9183,7 +9183,7 @@
       <code>$srid</code>
       <code>$srid</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="4">
       <code>$points_arr[0]</code>
       <code>$points_arr[0][0]</code>
       <code>$points_arr[0][1]</code>
@@ -9242,7 +9242,7 @@
       <code>$srid</code>
       <code>$srid</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="5">
       <code>$points_arr[2]</code>
       <code>$points_arr[3]</code>
       <code>$wkt</code>
@@ -14131,7 +14131,7 @@
     </UnnecessaryVarAnnotation>
   </file>
   <file src="libraries/classes/Plugins/Import/ImportShp.php">
-    <MixedArgument occurrences="10">
+    <MixedArgument occurrences="9">
       <code>$buffer</code>
       <code>$dbf_file_name</code>
       <code>$dbf_file_path</code>


### PR DESCRIPTION
Use negative length parameter to simplify mb_substr calls.

Signed-off-by: Maximilian Krög <maxi_kroeg@web.de>
