### PR TITLE
Use correct min MySQL version for axis-order (8.0.1)

### DIFF
--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -211,8 +211,8 @@ class GisVisualization
             $spatialSrid = 'ST_SRID';
         }
 
-        // If MYSQL version >= 8.1 override default axis order
-        if ($this->userSpecifiedSettings['mysqlVersion'] >= 80010 && ! $isMariaDb) {
+        // If MYSQL version >= 8.0.1 override default axis order
+        if ($this->userSpecifiedSettings['mysqlVersion'] >= 80001 && ! $isMariaDb) {
             $axisOrder = ', \'axis-order=long-lat\'';
         }
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1662,7 +1662,7 @@ class Util
             $spatialSrid = 'ST_SRID';
         }
 
-        if ($mysqlVersionInt >= 80010 && ! $dbi->isMariaDb()) {
+        if ($mysqlVersionInt >= 80001 && ! $dbi->isMariaDb()) {
             $axisOrder = ', \'axis-order=long-lat\'';
         }
 

--- a/test/classes/Gis/GisVisualizationTest.php
+++ b/test/classes/Gis/GisVisualizationTest.php
@@ -132,13 +132,13 @@ class GisVisualizationTest extends AbstractTestCase
     }
 
     /**
-     * Modify the query for an MySQL 8.1 version
+     * Modify the query for an MySQL 8.0.1 version
      */
     public function testModifyQueryVersion8(): void
     {
         $queryString = $this->callFunction(
             GisVisualization::getByData([], [
-                'mysqlVersion' => 80010,
+                'mysqlVersion' => 80001,
                 'spatialColumn' => 'abc',
                 'isMariaDB' => false,
             ]),

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -2267,7 +2267,7 @@ class UtilTest extends AbstractTestCase
                 ],
                 '\'POINT(1 1)\',0',
                 true,
-                80010,
+                80001,
             ],
             [
                 'SELECT ST_ASTEXT(x\'000000000101000000000000000000f03f000000000000f03f\'),'
@@ -2288,7 +2288,7 @@ class UtilTest extends AbstractTestCase
                 ],
                 'POINT(1 1)',
                 false,
-                80010,
+                80001,
             ],
             [
                 'SELECT ST_ASTEXT(x\'000000000101000000000000000000f03f000000000000f03f\')',


### PR DESCRIPTION
There was no version 8.0.10 (`80010`), axis-order was introduced in MySQL 8.0.1
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html

Please tell me if  you want me to rebase this on a different branch as a bugfix

Signed-off-by: Maximilian Krög <maxi_kroeg@web.de>
