### PR TITLE
Prevent default when scrolling in gis visualization

### DIFF
--- a/js/src/config.js
+++ b/js/src/config.js
@@ -2,6 +2,8 @@
  * Functions used in configuration forms and on user preferences pages
  */
 
+/* exported PASSIVE_EVENT_LISTENERS */
+
 var configInlineParams;
 var configScriptLoaded;
 
@@ -877,3 +879,23 @@ function offerPrefsAutoimport () {
     });
     $cnt.show();
 }
+
+/**
+ * @type {boolean} Support for passive event listener option
+ */
+var PASSIVE_EVENT_LISTENERS = (function () {
+    var passive = false;
+    try {
+        var options = Object.defineProperty({}, 'passive', {
+            get: function () {
+                return (passive = true);
+            },
+        });
+
+        window.addEventListener('_', null, options);
+        window.removeEventListener('_', null, options);
+    } catch (error) {
+        // passive not supported
+    }
+    return passive;
+}());


### PR DESCRIPTION
The page scrolls when zooming in GIS visualization via mouse wheel because preventDefault is not called, 
It was mistakenly removed in 2839b306d5a84b31339f83fa6f38c101f4573202 instead of using `{ passive: false }` with the addEventListener call. Doesn't seem like jquery has an interface for it, so this PR does not use jquery for the wheel event (https://github.com/jquery/jquery/issues/2871).

Passive event detection copied from https://github.com/openlayers/openlayers/blob/82956aaf5e5c8ced63612a89ef4b8e81052c4817/src/ol/has.js#L61-L79 (https://github.com/openlayers/openlayers/pull/10286)

Browser support for wheel event:
https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event#browser_compatibility
Passive option, default passive for wheel event:
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#browser_compatibility

Please tell me if I should rebase.

Signed-off-by: Maximilian Krög <maxi_kroeg@web.de>