### PR TITLE
Fix #13614 - escaping the database names when granting privileges on tables

### DIFF
--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -452,7 +452,7 @@ class PrivilegesController extends AbstractController
                         $hostname ?? '',
                         $dbname,
                         $routinename,
-                        $url_dbname ?? ''
+                        Util::escapeMysqlWildcards($url_dbname ?? '')
                     )
                 );
             } else {
@@ -465,7 +465,7 @@ class PrivilegesController extends AbstractController
                 $this->response->addHTML(
                     $serverPrivileges->getHtmlForUserProperties(
                         $dbname_is_wildcard,
-                        $url_dbname ?? '',
+                        Util::escapeMysqlWildcards($url_dbname ?? ''),
                         $username,
                         $hostname ?? '',
                         $dbname ?? '',

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -1994,7 +1994,7 @@ class Privileges
                 $onePrivilege['column_privs']  = ! empty($row['Column_priv']);
                 $onePrivilege['privileges'] = implode(',', $this->extractPrivInfo($row, true));
 
-                $paramDbName = $dbname;
+                $paramDbName = Util::escapeMysqlWildcards($dbname);
                 $paramTableName = $row['Table_name'];
             } else { // routine
                 $name = $row['Routine_name'];
@@ -2009,7 +2009,7 @@ class Privileges
                     $this->extractPrivInfo($privs, true)
                 );
 
-                $paramDbName = $dbname;
+                $paramDbName = Util::escapeMysqlWildcards($dbname);
                 $paramRoutineName = $row['Routine_name'];
             }
 

--- a/templates/server/privileges/privileges_summary.twig
+++ b/templates/server/privileges/privileges_summary.twig
@@ -66,7 +66,7 @@
             <input type="text" id="text_dbname" name="dbname">
             {{ show_hint("Wildcards % and _ should be escaped with a \\ to use them literally."|trans) }}
         {% elseif type == 'table' %}
-            <input type="hidden" name="dbname" value="{{ database }}">
+            <input type="hidden" name="dbname" value="{{ database|escape_mysql_wildcards }}">
 
             <label for="text_tablename">{% trans 'Add privileges on the following table:' %}</label>
 
@@ -81,7 +81,7 @@
 
             <input type="text" id="text_tablename" name="tablename">
         {% else %}
-            <input type="hidden" name="dbname" value="{{ database }}">
+            <input type="hidden" name="dbname" value="{{ database|escape_mysql_wildcards }}">
 
             <label for="text_routinename">{% trans 'Add privileges on the following routine:' %}</label>
 


### PR DESCRIPTION
Signed-off-by: Fawzi E. Abdulfattah <iifawzie@gmail.com>

### Description
Fixes #13614