### PR TITLE
Fix #11834 - Fixing the issues regarding granting/showing priv from priv tab

### DIFF
--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -25,6 +25,7 @@ use function is_array;
 use function ob_get_clean;
 use function ob_start;
 use function str_replace;
+use function strtolower;
 use function urlencode;
 
 /**
@@ -405,12 +406,12 @@ class PrivilegesController extends AbstractController
         if (isset($_GET['adduser']) || $_add_user_error === true) {
             // Add user
             $this->response->addHTML(
-                $serverPrivileges->getHtmlForAddUser(($dbname ?? ''))
+                $serverPrivileges->getHtmlForAddUser(Util::escapeMysqlWildcards($dbname ?? ''))
             );
         } elseif (isset($_GET['checkprivsdb'])) {
             if (isset($_GET['checkprivstable'])) {
                 $this->response->addHTML($tableController->index([
-                    'checkprivsdb' => $_GET['checkprivsdb'],
+                    'checkprivsdb' => strtolower($_GET['checkprivsdb']),
                     'checkprivstable' => $_GET['checkprivstable'],
                 ]));
             } elseif ($this->response->isAjax() === true && empty($_REQUEST['ajax_page_request'])) {
@@ -420,7 +421,7 @@ class PrivilegesController extends AbstractController
                 return;
             } else {
                 $this->response->addHTML($databaseController->index([
-                    'checkprivsdb' => $_GET['checkprivsdb'],
+                    'checkprivsdb' => strtolower($_GET['checkprivsdb']),
                 ]));
             }
         } else {

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -3578,7 +3578,7 @@ class Privileges
             // Grant all privileges on the specified database to the new user
             $q = 'GRANT ALL PRIVILEGES ON '
             . Util::backquote(
-                $this->dbi->escapeString($dbname)
+                $dbname
             ) . '.* TO \''
             . $this->dbi->escapeString($username)
             . '\'@\'' . $this->dbi->escapeString($hostname) . '\';';


### PR DESCRIPTION

Signed-off-by: Fawzi E. Abdulfattah <iifawzie@gmail.com>

### Description

This PR should fix the mentioned issue in #11834, and also fixes another issue regarding showing the granted users on an uppercased database `TEST_DB` OR `TESTDB`, previously, the granted users will not be shown in the `privileges` tab in that db, because the permissions are stored in lowercase in `mysql.db`, and we're fetching it uppercased if it's uppercased, I've just lowercased it to get the granted users correctly. 

Fixes #11834
