### PR TITLE
Fix gis visualization save file

### DIFF
--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -88,8 +88,11 @@ final class GisVisualizationController extends AbstractController
 
         // Get settings if any posted
         $visualizationSettings = [];
+        // Download as PNG/SVG/PDF use _GET and the normal form uses _POST
         if (Core::isValid($_POST['visualizationSettings'], 'array')) {
             $visualizationSettings = $_POST['visualizationSettings'];
+        } elseif (Core::isValid($_GET['visualizationSettings'], 'array')) {
+            $visualizationSettings = $_GET['visualizationSettings'];
         }
 
         // Check mysql version
@@ -174,6 +177,8 @@ final class GisVisualizationController extends AbstractController
                 'saveToFile' => true,
                 'session_max_rows' => $rows,
                 'pos' => $pos,
+                'visualizationSettings[spatialColumn]' => $visualizationSettings['spatialColumn'],
+                'visualizationSettings[labelColumn]' => $visualizationSettings['labelColumn'],
             ]
         ));
         $html = $this->template->render('table/gis_visualization/gis_visualization', [

--- a/libraries/classes/Gis/GisLineString.php
+++ b/libraries/classes/Gis/GisLineString.php
@@ -16,6 +16,7 @@ use function imagestring;
 use function json_encode;
 use function mb_strlen;
 use function mb_substr;
+use function round;
 use function trim;
 
 /**
@@ -110,28 +111,26 @@ class GisLineString extends GisGeometry
         $points_arr = $this->extractPoints($linesrting, $scale_data);
 
         foreach ($points_arr as $point) {
-            if (! isset($temp_point)) {
-                $temp_point = $point;
-            } else {
+            if (isset($temp_point)) {
                 // draw line section
                 imageline(
                     $image,
-                    (int) $temp_point[0],
-                    (int) $temp_point[1],
-                    (int) $point[0],
-                    (int) $point[1],
+                    (int) round($temp_point[0]),
+                    (int) round($temp_point[1]),
+                    (int) round($point[0]),
+                    (int) round($point[1]),
                     $color
                 );
-                $temp_point = $point;
             }
+            $temp_point = $point;
         }
         // print label if applicable
         if (isset($label) && trim($label) != '') {
             imagestring(
                 $image,
                 1,
-                $points_arr[1][0],
-                $points_arr[1][1],
+                (int) round($points_arr[1][0]),
+                (int) round($points_arr[1][1]),
                 trim($label),
                 $black
             );
@@ -178,9 +177,7 @@ class GisLineString extends GisGeometry
         $points_arr = $this->extractPoints($linesrting, $scale_data);
 
         foreach ($points_arr as $point) {
-            if (! isset($temp_point)) {
-                $temp_point = $point;
-            } else {
+            if (isset($temp_point)) {
                 // draw line section
                 $pdf->Line(
                     $temp_point[0],
@@ -189,8 +186,8 @@ class GisLineString extends GisGeometry
                     $point[1],
                     $line
                 );
-                $temp_point = $point;
             }
+            $temp_point = $point;
         }
         // print label
         if (isset($label) && trim($label) != '') {

--- a/libraries/classes/Gis/GisLineString.php
+++ b/libraries/classes/Gis/GisLineString.php
@@ -267,8 +267,8 @@ class GisLineString extends GisGeometry
 
         $result =  'var style = new ol.style.Style({'
             . 'stroke: new ol.style.Stroke(' . json_encode($stroke_style) . ')';
-        if ($label) {
-            $text_style = ['text' => $label];
+        if (trim($label) !== '') {
+            $text_style = ['text' => trim($label)];
             $result .= ', text: new ol.style.Text(' . json_encode($text_style) . ')';
         }
 

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -296,8 +296,8 @@ class GisMultiLineString extends GisGeometry
 
         $row =  'var style = new ol.style.Style({'
             . 'stroke: new ol.style.Stroke(' . json_encode($stroke_style) . ')';
-        if ($label) {
-            $text_style = ['text' => $label];
+        if (trim($label) !== '') {
+            $text_style = ['text' => trim($label)];
             $row .= ', text: new ol.style.Text(' . json_encode($text_style) . ')';
         }
 

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -17,6 +17,7 @@ use function imagestring;
 use function json_encode;
 use function mb_strlen;
 use function mb_substr;
+use function round;
 use function trim;
 
 /**
@@ -123,20 +124,18 @@ class GisMultiLineString extends GisGeometry
         foreach ($linestirngs as $linestring) {
             $points_arr = $this->extractPoints($linestring, $scale_data);
             foreach ($points_arr as $point) {
-                if (! isset($temp_point)) {
-                    $temp_point = $point;
-                } else {
+                if (isset($temp_point)) {
                     // draw line section
                     imageline(
                         $image,
-                        (int) $temp_point[0],
-                        (int) $temp_point[1],
-                        (int) $point[0],
-                        (int) $point[1],
+                        (int) round($temp_point[0]),
+                        (int) round($temp_point[1]),
+                        (int) round($point[0]),
+                        (int) round($point[1]),
                         $color
                     );
-                    $temp_point = $point;
                 }
+                $temp_point = $point;
             }
             unset($temp_point);
             // print label if applicable
@@ -144,8 +143,8 @@ class GisMultiLineString extends GisGeometry
                 imagestring(
                     $image,
                     1,
-                    $points_arr[1][0],
-                    $points_arr[1][1],
+                    (int) round($points_arr[1][0]),
+                    (int) round($points_arr[1][1]),
                     trim($label),
                     $black
                 );
@@ -198,9 +197,7 @@ class GisMultiLineString extends GisGeometry
         foreach ($linestirngs as $linestring) {
             $points_arr = $this->extractPoints($linestring, $scale_data);
             foreach ($points_arr as $point) {
-                if (! isset($temp_point)) {
-                    $temp_point = $point;
-                } else {
+                if (isset($temp_point)) {
                     // draw line section
                     $pdf->Line(
                         $temp_point[0],
@@ -209,8 +206,8 @@ class GisMultiLineString extends GisGeometry
                         $point[1],
                         $line
                     );
-                    $temp_point = $point;
                 }
+                $temp_point = $point;
             }
             unset($temp_point);
             // print label

--- a/libraries/classes/Gis/GisMultiPoint.php
+++ b/libraries/classes/Gis/GisMultiPoint.php
@@ -292,9 +292,9 @@ class GisMultiPoint extends GisGeometry
             . 'fill: fill,'
             . 'stroke: stroke';
 
-        if ($label) {
+        if (trim($label) !== '') {
             $text_style = [
-                'text' => $label,
+                'text' => trim($label),
                 'offsetY' => -9,
             ];
             $result .= ',text: new ol.style.Text(' . json_encode($text_style) . ')';

--- a/libraries/classes/Gis/GisMultiPoint.php
+++ b/libraries/classes/Gis/GisMultiPoint.php
@@ -16,6 +16,7 @@ use function imagestring;
 use function json_encode;
 use function mb_strlen;
 use function mb_substr;
+use function round;
 use function trim;
 
 /**
@@ -115,7 +116,16 @@ class GisMultiPoint extends GisGeometry
                 continue;
             }
 
-            imagearc($image, (int) $point[0], (int) $point[1], 7, 7, 0, 360, $color);
+            imagearc(
+                $image,
+                (int) round($point[0]),
+                (int) round($point[1]),
+                7,
+                7,
+                0,
+                360,
+                $color
+            );
         }
         // print label for each point
         if ((isset($label) && trim($label) != '')
@@ -124,8 +134,8 @@ class GisMultiPoint extends GisGeometry
             imagestring(
                 $image,
                 1,
-                $points_arr[0][0],
-                $points_arr[0][1],
+                (int) round($points_arr[0][0]),
+                (int) round($points_arr[0][1]),
                 trim($label),
                 $black
             );

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -348,8 +348,8 @@ class GisMultiPolygon extends GisGeometry
             . 'fill: new ol.style.Fill(' . json_encode($fill_style) . '),'
             . 'stroke: new ol.style.Stroke(' . json_encode($stroke_style) . ')';
 
-        if ($label) {
-            $text_style = ['text' => $label];
+        if (trim($label) !== '') {
+            $text_style = ['text' => trim($label)];
             $row .= ',text: new ol.style.Text(' . json_encode($text_style) . ')';
         }
 

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -21,6 +21,7 @@ use function json_encode;
 use function mb_strlen;
 use function mb_strpos;
 use function mb_substr;
+use function round;
 use function trim;
 
 /**
@@ -168,8 +169,8 @@ class GisMultiPolygon extends GisGeometry
             imagestring(
                 $image,
                 1,
-                $points_arr[2],
-                $points_arr[3],
+                (int) round($label_point[0]),
+                (int) round($label_point[1]),
                 trim((string) $label),
                 $black
             );

--- a/libraries/classes/Gis/GisPoint.php
+++ b/libraries/classes/Gis/GisPoint.php
@@ -283,9 +283,9 @@ class GisPoint extends GisGeometry
             . 'fill: fill,'
             . 'stroke: stroke';
 
-        if ($label) {
+        if (trim($label) !== '') {
             $text_style = [
-                'text' => $label,
+                'text' => trim($label),
                 'offsetY' => -9,
             ];
             $result .= ',text: new ol.style.Text(' . json_encode($text_style) . ')';

--- a/libraries/classes/Gis/GisPoint.php
+++ b/libraries/classes/Gis/GisPoint.php
@@ -15,6 +15,7 @@ use function imagestring;
 use function json_encode;
 use function mb_strlen;
 use function mb_substr;
+use function round;
 use function trim;
 
 /**
@@ -112,8 +113,8 @@ class GisPoint extends GisGeometry
         if ($points_arr[0][0] != '' && $points_arr[0][1] != '') {
             imagearc(
                 $image,
-                (int) $points_arr[0][0],
-                (int) $points_arr[0][1],
+                (int) round($points_arr[0][0]),
+                (int) round($points_arr[0][1]),
                 7,
                 7,
                 0,
@@ -125,8 +126,8 @@ class GisPoint extends GisGeometry
                 imagestring(
                     $image,
                     1,
-                    $points_arr[0][0],
-                    $points_arr[0][1],
+                    (int) round($points_arr[0][0]),
+                    (int) round($points_arr[0][1]),
                     trim($label),
                     $black
                 );

--- a/libraries/classes/Gis/GisPolygon.php
+++ b/libraries/classes/Gis/GisPolygon.php
@@ -24,6 +24,7 @@ use function mb_strpos;
 use function mb_substr;
 use function min;
 use function pow;
+use function round;
 use function sqrt;
 use function trim;
 
@@ -150,8 +151,8 @@ class GisPolygon extends GisGeometry
             imagestring(
                 $image,
                 1,
-                $points_arr[2],
-                $points_arr[3],
+                (int) round($points_arr[2]),
+                (int) round($points_arr[3]),
                 trim($label),
                 $black
             );

--- a/libraries/classes/Gis/GisPolygon.php
+++ b/libraries/classes/Gis/GisPolygon.php
@@ -310,8 +310,8 @@ class GisPolygon extends GisGeometry
         $row =  'var style = new ol.style.Style({'
             . 'fill: new ol.style.Fill(' . json_encode($fill_style) . '),'
             . 'stroke: new ol.style.Stroke(' . json_encode($stroke_style) . ')';
-        if ($label) {
-            $text_style = ['text' => $label];
+        if (trim($label) !== '') {
+            $text_style = ['text' => trim($label)];
             $row .= ',text: new ol.style.Text(' . json_encode($text_style) . ')';
         }
         $row .= '});';


### PR DESCRIPTION
- The GIS visualization can now be saved with a different label / column, before it always used the first spatial column and no label.
- Saving image as png works with label, the coordinates need to be `int` instead of `float` and should be rounded before casting to int
- If a label is just the number zero, it was treated as no label in the OpenLayers map.

Signed-off-by: Maximilian Krög <maxi_kroeg@web.de>