### PR TITLE
Add a page to check `config.inc.php` for errors

### DIFF
--- a/libraries/classes/Controllers/CheckConfigErrorsController.php
+++ b/libraries/classes/Controllers/CheckConfigErrorsController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Controllers;
+
+use PhpMyAdmin\Config\Settings;
+
+use function get_debug_type;
+use function is_array;
+use function is_readable;
+
+use const CONFIG_FILE;
+
+final class CheckConfigErrorsController extends AbstractController
+{
+    public function __invoke(): void
+    {
+        /** @var array<int|string, mixed> $cfg */
+        $cfg = [];
+
+        if (is_readable(CONFIG_FILE)) {
+            include CONFIG_FILE;
+        }
+
+        $settings = new Settings($cfg);
+
+        $errors = [];
+        foreach ($cfg as $key => $value) {
+            if (
+                $key === 'Servers' || $key === 'Server' || $key === 'Export'
+                || $key === 'Import' || $key === 'Schema' || $key === 'DefaultTransformations'
+            ) {
+                continue;
+            }
+
+            if ($settings->$key === $value) {
+                continue;
+            }
+
+            if (is_array($settings->$key) && is_array($value)) {
+                foreach ($value as $key2 => $value2) {
+                    if ($settings->$key[$key2] === $value2) {
+                        continue;
+                    }
+
+                    $errors[] = [
+                        'keys' => [$key, $key2],
+                        'expected' => [
+                            'value' => $settings->$key[$key2],
+                            'type' => get_debug_type($settings->$key[$key2]),
+                        ],
+                        'actual' => ['value' => $value2, 'type' => get_debug_type($value2)],
+                    ];
+                }
+
+                continue;
+            }
+
+            $errors[] = [
+                'keys' => [$key],
+                'expected' => ['value' => $settings->$key, 'type' => get_debug_type($settings->$key)],
+                'actual' => ['value' => $value, 'type' => get_debug_type($value)],
+            ];
+        }
+
+        $this->render('check_config_errors', ['errors' => $errors]);
+    }
+}

--- a/libraries/classes/Routing.php
+++ b/libraries/classes/Routing.php
@@ -19,6 +19,7 @@ use function file_put_contents;
 use function htmlspecialchars;
 use function is_array;
 use function is_readable;
+use function is_string;
 use function is_writable;
 use function mb_strlen;
 use function rawurldecode;
@@ -175,7 +176,17 @@ class Routing
             return;
         }
 
-        [$controllerName, $action] = $routeInfo[1];
+        /** @psalm-var class-string|callable-array $handler */
+        $handler = $routeInfo[1];
+        if (is_string($handler)) {
+            $controllerName = $handler;
+            $controller = $container->get($controllerName);
+            $controller($request, $routeInfo[2]);
+
+            return;
+        }
+
+        [$controllerName, $action] = $handler;
         $controller = $container->get($controllerName);
         $controller->$action($request, $routeInfo[2]);
     }

--- a/libraries/routes.php
+++ b/libraries/routes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use FastRoute\RouteCollector;
 use PhpMyAdmin\Controllers\BrowseForeignersController;
 use PhpMyAdmin\Controllers\ChangeLogController;
+use PhpMyAdmin\Controllers\CheckConfigErrorsController;
 use PhpMyAdmin\Controllers\CheckRelationsController;
 use PhpMyAdmin\Controllers\ColumnController;
 use PhpMyAdmin\Controllers\ConfigController;
@@ -114,6 +115,7 @@ return static function (RouteCollector $routes): void {
     });
     $routes->addRoute(['GET', 'POST'], '/browse-foreigners', [BrowseForeignersController::class, 'index']);
     $routes->get('/changelog', [ChangeLogController::class, 'index']);
+    $routes->get('/check-config-errors', CheckConfigErrorsController::class);
     $routes->addRoute(['GET', 'POST'], '/check-relations', [CheckRelationsController::class, 'index']);
     $routes->post('/columns', [ColumnController::class, 'all']);
     $routes->addGroup('/config', static function (RouteCollector $routes): void {

--- a/libraries/services_controllers.php
+++ b/libraries/services_controllers.php
@@ -20,6 +20,13 @@ return [
                 '$template' => '@template',
             ],
         ],
+        PhpMyAdmin\Controllers\CheckConfigErrorsController::class => [
+            'class' => PhpMyAdmin\Controllers\CheckConfigErrorsController::class,
+            'arguments' => [
+                '$response' => '@response',
+                '$template' => '@template',
+            ],
+        ],
         PhpMyAdmin\Controllers\CheckRelationsController::class => [
             'class' => PhpMyAdmin\Controllers\CheckRelationsController::class,
             'arguments' => [

--- a/templates/check_config_errors.twig
+++ b/templates/check_config_errors.twig
@@ -1,0 +1,37 @@
+<div class="container">
+  <h2>{% trans 'Check config errors' %}</h2>
+
+  {% for error in errors %}
+    <div class="alert alert-danger" role="alert">
+      <code>$cfg['{{ error.keys[0] }}']{% if error.keys[1] is defined %}['{{ error.keys[1] }}']{% endif %}</code>
+      <ul class="mb-0">
+        <li>
+          Expected:
+          <span class="fst-italic">{{ error.expected.type }}</span>
+          <code>
+            {% if error.expected.type == 'bool' %}
+              {{ error.expected.value ? 'true' : 'false' }}
+            {% elseif error.expected.type == 'string' %}
+              '{{ error.expected.value }}'
+            {% else %}
+              {{ error.expected.value }}
+            {% endif %}
+          </code>
+        </li>
+        <li>
+          Actual:
+          <span class="fst-italic">{{ error.actual.type }}</span>
+          <code>
+            {% if error.actual.type == 'bool' %}
+              {{ error.actual.value ? 'true' : 'false' }}
+            {% elseif error.actual.type == 'string' %}
+              '{{ error.actual.value }}'
+            {% else %}
+              {{ error.actual.value }}
+            {% endif %}
+          </code>
+        </li>
+      </ul>
+    </div>
+  {% endfor %}
+</div>

--- a/templates/preferences/manage/main.twig
+++ b/templates/preferences/manage/main.twig
@@ -61,6 +61,15 @@
               </div>
             </div>
         {% endif %}
+
+      <div class="card mt-4">
+        <div class="card-header">
+          {% trans 'Check config errors' %}
+        </div>
+        <div class="card-body">
+          <a href="{{ url('/check-config-errors') }}">{% trans 'Check config errors' %}</a>
+        </div>
+      </div>
     </div>
     <div class="col-12 col-md-5">
         <div class="card mt-4">


### PR DESCRIPTION
Adds a page that analyze the `config.inc.php` file and shows possible errors and mistakes like using a deprecated directive, or using a invalid value, or a valid value but with the wrong value type.

![Screenshot_2021-07-30 localhost 8000 localhost phpMyAdmin 5 2 0-dev](https://user-images.githubusercontent.com/120970/127711157-92ff4ecb-2919-40af-9bc7-01bd471c6e07.png)

- https://github.com/phpmyadmin/phpmyadmin/pull/17025#issuecomment-890152699