### PR TITLE
Fix `DEL` character in generated random strings

### DIFF
--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -3017,8 +3017,8 @@ class Util
             // Get random byte and strip highest bit
             // to get ASCII only range
             $byte = ord((string) $random_func(1)) & 0x7f;
-            // We want only ASCII chars
-            if ($byte <= 32) {
+            // We want only ASCII chars and no DEL character (127)
+            if ($byte <= 32 || $byte === 127) {
                 continue;
             }
 


### PR DESCRIPTION
### Description

Expands the prohibited ASCII characters for strings generated by `generateRandom()` to include the `DEL` character (127) in addition to the other control characters (0-31) and space (32).

Fixes #17054 