### PR TITLE
Fix #17055 - missing navigation buttons on views

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -870,7 +870,7 @@ class Results
         // Move to the next page or to the last one
         $moveForwardButtons = '';
         if (
-            $this->properties['unlim_num_rows'] === -1 // view with unknown number of rows
+            $this->properties['unlim_num_rows'] === false // view with unknown number of rows
             || (! $isShowingAll
             && intval($_SESSION['tmpval']['pos']) + intval($_SESSION['tmpval']['max_rows'])
                 < $this->properties['unlim_num_rows']


### PR DESCRIPTION
### Description

Corrects an if-condition in getTableNavigation. Property 'unlim_num_rows' cannot get -1. Instead 'unlim_num_rows' is set to false in countRecords(), if a VIEW was queried and the config 'MaxExactCountViews' is set to 0, which is the default setting.
So the if-condition results in a positive number (for tables) or false (for tables).

The correct if-condition lived in QA_5_1 for quite some time, but has never been merged into the master branch obviously.

Fixes #17055

This fix does not make appear the page selector for VIEWS. Displaying the page selector is only possible, if the number of records in the query result will be obtained in countRecords() - rather than skipping the counting (and returning false). After having checked the respective code section I conclude that it is intended to not show the page selector for views. Returning the actual number of records could bring down the server for complex views, the code comment says.
