### PR TITLE
Fix #17017 - creation of unpartitioned tables

### DIFF
--- a/templates/columns_definitions/partitions.twig
+++ b/templates/columns_definitions/partitions.twig
@@ -37,7 +37,7 @@
         <td><label for="partition_count">{% trans 'Partitions:' %}</label></td>
         <td colspan="2">
             <input name="partition_count" type="number" min="2"
-                value="{{ partition_details['partition_count'] }}">
+                value="{{ partition_details['partition_count'] ?: '' }}">
         </td>
     </tr>
     {% if partition_details['can_have_subpartitions'] %}
@@ -65,7 +65,7 @@
             <td><label for="subpartition_count">{% trans 'Subpartitions:' %}</label></td>
             <td colspan="2">
                 <input name="subpartition_count" type="number" min="2"
-                       value="{{ partition_details['subpartition_count'] }}">
+                    value="{{ partition_details['subpartition_count'] ?: '' }}">
             </td>
         </tr>
     {% endif %}


### PR DESCRIPTION
### Description

To fix the inability to create an unpartitioned table, the default value for the partition count input is now 1 instead of empty (0). Therefore, the input's minimum value is now 1 (instead of 2, which caused #17017). Partitions can still be created by increasing the value to 2 or greater, and partitioning can be easily canceled by decreasing the value back to 1. In prior versions, partitioning could only be canceled by manually typing '0' into the input, but with this change it can also be canceled using the arrows built into the number input element.

This fix also applies to creating subpartitions.

I have not been able to find any issues arising from `partition_count` being 1 instead of empty, since all uses of `partition_count` or `subpartition_count` that I have found check if it is greater than 1 before using it.

Fixes #17017
