### PR TITLE
Fix #16804 - table CSS for number alignment

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -2082,7 +2082,7 @@ class Results
             return;
         }
 
-        $th_class[] = 'right';
+        $th_class[] = 'text-right';
     }
 
     /**
@@ -3498,7 +3498,7 @@ class Results
     ) {
         if (! isset($column) || $column === null) {
             $cell = $this->buildNullDisplay(
-                'right ' . $class,
+                'text-right ' . $class,
                 $condition_field,
                 $meta,
                 ''
@@ -3508,7 +3508,7 @@ class Results
             $where_comparison = ' = ' . $column;
 
             $cell = $this->getRowData(
-                'right ' . $class,
+                'text-right ' . $class,
                 $condition_field,
                 $analyzed_sql_results,
                 $meta,
@@ -3525,7 +3525,7 @@ class Results
             );
         } else {
             $cell = $this->buildEmptyDisplay(
-                'right ' . $class,
+                'text-right ' . $class,
                 $condition_field,
                 $meta,
                 ''

--- a/templates/database/tracking/tables.twig
+++ b/templates/database/tracking/tables.twig
@@ -32,7 +32,7 @@
                                     {{ version.table_name }}
                                 </label>
                             </th>
-                            <td class="right">
+                            <td class="text-right">
                                 {{ version.version }}
                             </td>
                             <td>

--- a/templates/table/structure/display_structure.twig
+++ b/templates/table/structure/display_structure.twig
@@ -52,7 +52,7 @@
             <td class="text-center print_ignore">
                 <input type="checkbox" class="checkall" name="selected_fld[]" value="{{ row['Field'] }}" id="checkbox_row_{{ rownum }}">
             </td>
-            <td class="right">{{ rownum }}</td>
+            <td class="text-right">{{ rownum }}</td>
             <th class="nowrap">
                 <label for="checkbox_row_{{ rownum }}">
                     {% if displayed_fields[rownum].comment is defined %}

--- a/templates/table/tracking/report_table.twig
+++ b/templates/table/tracking/report_table.twig
@@ -11,7 +11,7 @@
     <tbody>
         {% for entry in entries %}
             <tr class="noclick">
-                <td class="right"><small>{{ entry.line_number }}</small></td>
+                <td class="text-right"><small>{{ entry.line_number }}</small></td>
                 <td><small>{{ entry.date }}</small></td>
                 <td><small>{{ entry.username }}</small></td>
                 <td>{{ entry.formated_statement|raw }}</td>


### PR DESCRIPTION
### Description

The tables generated by the `makeGrid` JS function used the `pma_table` CSS class instead of `pma-table` as used throughout the CSS styles, so many CSS rules were not being applied to these tables. In addition, the only two `pma_table` rules in each theme were also changed to `pma-table`.

Fixes #16804
