### PR TITLE
Fix Metro theme text color for buttons in the browse table navigation bar

### DIFF
--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -2522,6 +2522,7 @@ form.append_fields_form .tblFooters {
   input {
     &[type="submit"] {
       background: $navi-background;
+      color: $navi-color;
       border: none;
       filter: none;
       margin: 5px;


### PR DESCRIPTION
### Description

In the Metro theme, when columns in a table were reordered by dragging their headers in the browse view, the text color in the "Restore column order" button was the same as the navigation background.

Before fix:
![image](https://user-images.githubusercontent.com/59065888/128643365-32872c24-37a2-42c5-9365-ee59b50b72d7.png)

After fix:
![image](https://user-images.githubusercontent.com/59065888/128643399-d04e642b-b061-47c0-ab98-458ab9fc1557.png)