### PR TITLE
Fix #17014 - column names in first row when importing from CSV where the first line contains column names

### DIFF
--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -16,6 +16,8 @@ use PhpMyAdmin\Properties\Options\Items\BoolPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\NumberPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
 use PhpMyAdmin\Util;
+
+use function array_shift;
 use function array_splice;
 use function basename;
 use function count;
@@ -572,6 +574,12 @@ class ImportCsv extends AbstractImportCsv
             }
 
             $col_names = $this->getColumnNames($col_names, $max_cols, $rows);
+
+            /* Remove the first row if it contains the column names */
+            if (isset($_REQUEST['csv_col_names'])) {
+                array_shift($rows);
+            }
+
             $tbl_name = $this->getTableNameFromImport((string) $db);
 
             $tables[] = [


### PR DESCRIPTION
### Description

When importing data from a CSV file where the first line is the column names, the row of names would be read but not removed from the rows of data. Now, the row of names is removed right after the column names are read and before analyzing the table for data types.

Fixes #17014
