### PR TITLE
Fix #17019 - table tabs in header when the table has not yet been created

### DIFF
--- a/libraries/classes/Controllers/Table/CreateController.php
+++ b/libraries/classes/Controllers/Table/CreateController.php
@@ -165,8 +165,8 @@ class CreateController extends AbstractController
             return;
         }
 
-        // This global variable needs to be reset for the header class to function properly
-        $table = '';
+        // Do not display the table in the header since it hasn't been created yet
+        $this->response->getHeader()->getMenu()->setTable('');
 
         $this->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js', 'indexes.js']);
 


### PR DESCRIPTION
### Description

The `$table` global variable was being set to empty to try to fix the issue in #17019, but that only happens _after_ the menu was already created using the previous value of `$table`. This fix takes advantage of the existing `setTable` function to change the value in the existing menu.

Fixes #17019 
