### PR TITLE
Fix #15225 - Command+click on macOS opens links in same tab

### DIFF
--- a/js/src/ajax.js
+++ b/js/src/ajax.js
@@ -233,7 +233,7 @@ var AJAX = {
         // leave the browser deal with it natively (e.g: file download)
         // or leave an existing ajax event handler present elsewhere deal with it
         var href = $(this).attr('href');
-        if (typeof event !== 'undefined' && (event.shiftKey || event.ctrlKey)) {
+        if (typeof event !== 'undefined' && (event.shiftKey || event.ctrlKey || event.metaKey)) {
             return true;
         } else if ($(this).attr('target')) {
             return true;


### PR DESCRIPTION
### Description

Both the control and shift keys were accounted for in b5089cf908a1c506546f43482fe2e836836a81cb, but not the "meta" key (Command key on Mac or Windows key).

Fixes #15225
