### PR TITLE
Fix #16067 - Make select elements where multiple items can be selected resizable

### DIFF
--- a/templates/database/qbe/selection_form.twig
+++ b/templates/database/qbe/selection_form.twig
@@ -85,7 +85,7 @@
     <fieldset>
       <legend>{% trans 'Use tables' %}</legend>
 
-      <select name="TableList[]" id="listTable" size="{{ criteria_tables|length > 30 ? '15' : '7' }}" aria-label="{% trans 'Use tables' %}" multiple>
+      <select class="resize-vertical" name="TableList[]" id="listTable" size="{{ criteria_tables|length > 30 ? '15' : '7' }}" aria-label="{% trans 'Use tables' %}" multiple>
         {% for table, selected in criteria_tables %}
           <option value="{{ table }}"{{ selected|raw }}>{{ table }}</option>
         {% endfor %}

--- a/templates/database/search/main.twig
+++ b/templates/database/search/main.twig
@@ -46,7 +46,7 @@
                     {% trans 'Unselect all' %}
                 </a>
             </p>
-            <select name="criteriaTables[]" multiple>
+            <select class="resize-vertical" name="criteriaTables[]" multiple>
                 {% for each_table in tables_names_only %}
                     <option value="{{ each_table }}"
                             {% if criteria_tables|length > 0 %}

--- a/templates/server/export/index.twig
+++ b/templates/server/export/index.twig
@@ -17,7 +17,7 @@
         </a>
       </p>
 
-      <select name="db_select[]" id="db_select" size="10" multiple>
+      <select class="resize-vertical" name="db_select[]" id="db_select" size="10" multiple>
         {% for database in databases %}
           <option value="{{ database.name }}"{{ database.is_selected ? ' selected' }}>
             {{ database.name }}

--- a/templates/server/privileges/privileges_summary.twig
+++ b/templates/server/privileges/privileges_summary.twig
@@ -54,7 +54,7 @@
             <label for="text_dbname">{% trans 'Add privileges on the following database(s):' %}</label>
 
             {%- if databases is not empty %}
-                <select name="pred_dbname[]" multiple="multiple">
+                <select class="resize-vertical" name="pred_dbname[]" multiple="multiple">
                     {% for database in databases %}
                         <option value="{{ escaped_databases[loop.index0] }}">
                             {{ database }}

--- a/templates/server/privileges/privileges_table.twig
+++ b/templates/server/privileges/privileges_table.twig
@@ -15,7 +15,7 @@
         <code><dfn title="{% trans 'Allows reading data.' %}">SELECT</dfn></code>
       </label>
 
-      <select id="select_select_priv" name="Select_priv[]" size="8" multiple>
+      <select class="resize-vertical" id="select_select_priv" name="Select_priv[]" size="8" multiple>
         {% for curr_col, curr_col_privs in columns %}
           <option value="{{ curr_col }}"{{ row['Select_priv'] == 'Y' or curr_col_privs['Select'] ? ' selected' }}>
             {{ curr_col }}
@@ -36,7 +36,7 @@
         <code><dfn title="{% trans 'Allows inserting and replacing data.' %}">INSERT</dfn></code>
       </label>
 
-      <select id="select_insert_priv" name="Insert_priv[]" size="8" multiple>
+      <select class="resize-vertical" id="select_insert_priv" name="Insert_priv[]" size="8" multiple>
         {% for curr_col, curr_col_privs in columns %}
           <option value="{{ curr_col }}"{{ row['Insert_priv'] == 'Y' or curr_col_privs['Insert'] ? ' selected' }}>
             {{ curr_col }}
@@ -57,7 +57,7 @@
         <code><dfn title="{% trans 'Allows changing data.' %}">UPDATE</dfn></code>
       </label>
 
-      <select id="select_update_priv" name="Update_priv[]" size="8" multiple>
+      <select class="resize-vertical" id="select_update_priv" name="Update_priv[]" size="8" multiple>
         {% for curr_col, curr_col_privs in columns %}
           <option value="{{ curr_col }}"{{ row['Update_priv'] == 'Y' or curr_col_privs['Update'] ? ' selected' }}>
             {{ curr_col }}
@@ -78,7 +78,7 @@
         <code><dfn title="{% trans 'Has no effect in this MySQL version.' %}">REFERENCES</dfn></code>
       </label>
 
-      <select id="select_references_priv" name="References_priv[]" size="8" multiple>
+      <select class="resize-vertical" id="select_references_priv" name="References_priv[]" size="8" multiple>
         {% for curr_col, curr_col_privs in columns %}
           <option value="{{ curr_col }}"{{ row['References_priv'] == 'Y' or curr_col_privs['References'] ? ' selected' }}>
             {{ curr_col }}

--- a/templates/server/replication/database_multibox.twig
+++ b/templates/server/replication/database_multibox.twig
@@ -1,4 +1,4 @@
-<select id="db_select" class="width96" name="db_select[]" size="6" multiple>
+<select class="width96 resize-vertical" id="db_select" name="db_select[]" size="6" multiple>
   {% for database in databases %}
     <option value="{{ database }}">{{ database }}</option>
   {% endfor %}

--- a/templates/sql/query.twig
+++ b/templates/sql/query.twig
@@ -61,7 +61,7 @@
               <div class="col-xl-2 col-lg-3">
                 <div class="form-group">
                   <label class="sr-only" for="fieldsSelect">{% trans 'Columns' %}</label>
-                  <select class="form-control" id="fieldsSelect" name="dummy" size="{{ textarea_rows }}" ondblclick="Functions.insertValueQuery()" multiple>
+                  <select class="form-control resize-vertical" id="fieldsSelect" name="dummy" size="{{ textarea_rows }}" ondblclick="Functions.insertValueQuery()" multiple>
                     {% for field in columns_list %}
                       <option value="{{ backquote(field['Field']) }}"
                         {{- field['Field'] is not null and field['Comment'] is not null and field['Field']|length > 0 ? ' title="' ~ field['Comment'] ~ '"' }}>

--- a/templates/sql/set_column.twig
+++ b/templates/sql/set_column.twig
@@ -1,6 +1,6 @@
 {% set values_amount = values|length %}
 {% set selected_values = current_values|split(',') %}
-<select size="{{ values_amount < 10 ? values_amount : 10 }}" multiple>
+<select class="resize-vertical" size="{{ values_amount < 10 ? values_amount : 10 }}" multiple>
   {% for value in values %}
     <option value="{{ value|raw }}"{{ value in selected_values ? ' selected' }}>{{ value|raw }}</option>
   {% endfor %}

--- a/templates/table/chart/tbl_chart.twig
+++ b/templates/table/chart/tbl_chart.twig
@@ -67,7 +67,7 @@
                 <label for="select_chartSeries">
                     {% trans 'Series:' %}
                 </label>
-                <select name="chartSeries" id="select_chartSeries" multiple="multiple">
+                <select class="resize-vertical" name="chartSeries" id="select_chartSeries" multiple="multiple">
                     {% for idx, key in keys %}
                         {% if fields_meta[idx].type in numeric_types %}
                             {% if idx == xaxis and numeric_column_count > 1 %}

--- a/templates/table/operations/index.twig
+++ b/templates/table/operations/index.twig
@@ -434,7 +434,7 @@
       <div class="card-body">
         <div class="form-group">
           <label for="partition_name">{% trans 'Partition' %}</label>
-          <select class="form-control" id="partition_name" name="partition_name[]" multiple required>
+          <select class="form-control resize-vertical" id="partition_name" name="partition_name[]" multiple required>
             {% for partition in partitions %}
               <option value="{{ partition }}"{{ loop.first ? ' selected' }}>{{ partition }}</option>
             {% endfor %}

--- a/templates/table/search/index.twig
+++ b/templates/table/search/index.twig
@@ -105,7 +105,7 @@
       <legend>
         {% trans 'Select columns (at least one):' %}
       </legend>
-      <select name="columnsToDisplay[]" size="{{ min(column_names|length, 10) }}" multiple>
+      <select class="resize-vertical" name="columnsToDisplay[]" size="{{ min(column_names|length, 10) }}" multiple>
         {% for each_field in column_names %}
           <option value="{{ each_field }}" selected>
             {{ each_field }}

--- a/test/classes/Controllers/SqlControllerTest.php
+++ b/test/classes/Controllers/SqlControllerTest.php
@@ -102,7 +102,7 @@ class SqlControllerTest extends AbstractTestCase
 
         $this->assertSame(
             [
-                'select' => '<select size="5" multiple>' . "\n"
+                'select' => '<select class="resize-vertical" size="5" multiple>' . "\n"
                 . '      <option value="&lt;script&gt;alert(&quot;ok&quot;)&lt;/script&gt;">'
                 . '&lt;script&gt;alert(&quot;ok&quot;)&lt;/script&gt;</option>' . "\n"
                 . '      <option value="a&amp;b">a&amp;b</option>' . "\n"

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -3675,3 +3675,7 @@ body .ui-dialog {
     text-align: #{$left};
   }
 }
+
+.resize-vertical {
+  resize: vertical;
+}

--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -3567,3 +3567,7 @@ body {
     top: 0;
   }
 }
+
+.resize-vertical {
+  resize: vertical;
+}

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -3373,3 +3373,7 @@ body {
     text-align: #{$left};
   }
 }
+
+.resize-vertical {
+  resize: vertical;
+}

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -3732,3 +3732,7 @@ body .ui-dialog {
     text-align: #{$left};
   }
 }
+
+.resize-vertical {
+  resize: vertical;
+}


### PR DESCRIPTION
### Description

`<select multiple>` elements can now be resized vertically to make it easier to select multiple items.

![nNfrrIEBA4](https://user-images.githubusercontent.com/59065888/128964538-fa5b2b53-1eac-41b8-bcba-0c96ad2d8a40.gif)

Fixes #16067