### PR TITLE
Fix #17062 - Pagination issues when working with identically named tables in separate databases

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1014,7 +1014,10 @@ class Results
 
         // required to generate sort links that will remember whether the
         // "Show all" button has been clicked
-        $sql_md5 = md5($this->properties['sql_query']);
+        $sql_md5 = md5($this->properties['server']
+            . $this->properties['db']
+            . $this->properties['sql_query']
+        );
         $session_max_rows = $is_limited_display
             ? 0
             : $_SESSION['tmpval']['query'][$sql_md5]['max_rows'];
@@ -3874,7 +3877,10 @@ class Results
      */
     public function setConfigParamsForDisplayTable()
     {
-        $sql_md5 = md5($this->properties['sql_query']);
+        $sql_md5 = md5($this->properties['server']
+            . $this->properties['db']
+            . $this->properties['sql_query']
+        );
         $query = [];
         if (isset($_SESSION['tmpval']['query'][$sql_md5])) {
             $query = $_SESSION['tmpval']['query'][$sql_md5];


### PR DESCRIPTION
### Description

Certain details, including the position in the table, are kept in `$_SESSION['tmpval']['query']` under the md5 hash of the SQL query. Since a query for any table named `test` (no matter which database) is `SELECT * FROM 'test'`, the query hash is identical for each table, even though they are in different databases. My change makes the hash dependent on the server and database as well, not just the query, so the hashes are no longer identical.

Fixes #17062

This PR should be merged into `master` because `$sqlMd5` is named `$sql_md5` in `QA_5_1`.