### PR TITLE
Fix grouping of tables in navigation tree if `$cfg['NavigationTreeTableLevel'] > 1`

### DIFF
--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -1143,10 +1143,18 @@ class NavigationTree
         $controlButtons = '';
         $paths = $node->getPaths();
         $nodeIsContainer = $node->type === Node::CONTAINER;
-        $hasSiblingsOrIsNotRoot = $node->hasSiblings() || $node->realParent() === false;
         $liClasses = '';
 
-        if ($hasSiblingsOrIsNotRoot) {
+        // Whether to show the node in the tree (true for all nodes but root)
+        // If false, the node's children will still be shown, but as children of the node's parent
+        $showNode = $node->hasSiblings() || count($node->parents(false, true)) > 0;
+
+        // Don't show the 'Tables' node under each database unless it has 'Views', etc. as a sibling
+        if ($node instanceof NodeTableContainer && ! $node->hasSiblings()) {
+            $showNode = false;
+        }
+
+        if ($showNode) {
             $response = ResponseRenderer::getInstance();
             if ($nodeIsContainer && count($node->children) === 0 && ! $response->isAjax()) {
                 return '';
@@ -1262,7 +1270,7 @@ class NavigationTree
         return $this->template->render('navigation/tree/node', [
             'node' => $node,
             'class' => $class,
-            'has_siblings_or_is_not_root' => $hasSiblingsOrIsNotRoot,
+            'show_node' => $showNode,
             'has_siblings' => $node->hasSiblings(),
             'li_classes' => $liClasses,
             'control_buttons' => $controlButtons,

--- a/templates/navigation/tree/node.twig
+++ b/templates/navigation/tree/node.twig
@@ -1,4 +1,4 @@
-{% if has_siblings_or_is_not_root %}
+{% if show_node %}
   <li class="{{ li_classes }}">
     <div class="block">
       <i{{ class == 'first' ? ' class="first"' }}></i>


### PR DESCRIPTION
### Description

The contents in the `if` statement were not being run for nodes that have a real parent (ex. a database) but do not have siblings in the navigation tree. This caused an issue where, if `$cfg['NavigationTreeTableLevel']` is set to a value greater than the default of 1 (so that nested groups can exist), group nodes in the navigation tree that do not have a sibling would not be shown. See the pictures below: note that the group `with` was incorrectly not being shown.

Before fix:
![image](https://user-images.githubusercontent.com/59065888/129142795-d8829951-1c53-4459-99f9-f46f2409a1eb.png)

After fix:
![image](https://user-images.githubusercontent.com/59065888/129312743-63afc527-ddaa-4691-beab-ed5fead7ef27.png)



Fixes: #17003