### PR TITLE
Fix #17003: Consolidate nested groups in navigation tree

### DIFF
--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -835,11 +835,13 @@ class NavigationTree
             unset($prefixes[$key]);
         }
 
+        $numChildren = count($node->children);
+
         // rfe #1634 Don't group if there's only one group and no other items
         if (count($prefixes) === 1) {
             $keys = array_keys($prefixes);
             $key = $keys[0];
-            if ($prefixes[$key] == count($node->children) - 1) {
+            if ($prefixes[$key] == $numChildren - 1) {
                 unset($prefixes[$key]);
             }
         }
@@ -864,33 +866,7 @@ class NavigationTree
                 $this->largeGroupWarning = true;
             }
 
-            $groups[$key] = new Node(
-                htmlspecialchars((string) $key),
-                Node::CONTAINER,
-                true
-            );
-            $groups[$key]->separator = $node->separator;
-            $groups[$key]->separatorDepth = $node->separatorDepth - 1;
-            $groups[$key]->icon = ['image' => 'b_group', 'title' => __('Groups')];
-            $groups[$key]->pos2 = $node->pos2;
-            $groups[$key]->pos3 = $node->pos3;
-            if (
-                $node instanceof NodeTableContainer
-                || $node instanceof NodeViewContainer
-            ) {
-                $groups[$key]->links = [
-                    'text' => [
-                        'route' => $node->links['text']['route'],
-                        'params' => array_merge($node->links['text']['params'], ['tbl_group' => $key]),
-                    ],
-                    'icon' => [
-                        'route' => $node->links['icon']['route'],
-                        'params' => array_merge($node->links['icon']['params'], ['tbl_group' => $key]),
-                    ],
-                ];
-            }
-
-            $node->addChild($groups[$key]);
+            $newChildren = [];
             foreach ($separators as $separator) {
                 $separatorLength = strlen($separator);
                 // FIXME: this could be more efficient
@@ -932,19 +908,77 @@ class NavigationTree
                     $newChild->links = $child->links;
                     $newChild->pos2 = $child->pos2;
                     $newChild->pos3 = $child->pos3;
-                    $groups[$key]->addChild($newChild);
                     foreach ($child->children as $elm) {
                         $newChild->addChild($elm);
                     }
 
-                    $node->removeChild($child->name);
+                    $newChildren[] = [
+                        'node' => $newChild,
+                        'replaces_name' => $child->name,
+                    ];
+                }
+            }
+
+            if (count($newChildren) === 0) {
+                continue;
+            }
+
+            // If the current node is a standard group (not NodeTableContainer, etc.)
+            // and the new group contains all of the current node's children, combine them
+            $class = get_class($node);
+            if (
+                count($newChildren) === $numChildren
+                && substr($class, strrpos($class, '\\') + 1) === 'Node'
+            ) {
+                $node->name .= $separators[0] . htmlspecialchars((string) $key);
+                $node->realName .= $separators[0] . htmlspecialchars((string) $key);
+                $node->separatorDepth--;
+                foreach ($newChildren as $newChild) {
+                    $node->removeChild($newChild['replaces_name']);
+                    $node->addChild($newChild['node']);
+                }
+            } else {
+                $groups[$key] = new Node(
+                    htmlspecialchars((string) $key),
+                    Node::CONTAINER,
+                    true
+                );
+                $groups[$key]->separator = $node->separator;
+                $groups[$key]->separatorDepth = $node->separatorDepth - 1;
+                $groups[$key]->icon = ['image' => 'b_group', 'title' => __('Groups')];
+                $groups[$key]->pos2 = $node->pos2;
+                $groups[$key]->pos3 = $node->pos3;
+                if (
+                    $node instanceof NodeTableContainer
+                    || $node instanceof NodeViewContainer
+                ) {
+                    $groups[$key]->links = [
+                        'text' => [
+                            'route' => $node->links['text']['route'],
+                            'params' => array_merge($node->links['text']['params'], ['tbl_group' => $key]),
+                        ],
+                        'icon' => [
+                            'route' => $node->links['icon']['route'],
+                            'params' => array_merge($node->links['icon']['params'], ['tbl_group' => $key]),
+                        ],
+                    ];
+                }
+
+                foreach ($newChildren as $newChild) {
+                    $node->removeChild($newChild['replaces_name']);
+                    $groups[$key]->addChild($newChild['node']);
                 }
             }
         }
 
-        foreach ($prefixes as $key => $value) {
-            $this->groupNode($groups[$key]);
-            $groups[$key]->classes = 'navGroup';
+        foreach ($groups as $group) {
+            if (count($group->children) === 0) {
+                continue;
+            }
+
+            $node->addChild($group);
+            $this->groupNode($group);
+            $group->classes = 'navGroup';
         }
     }
 

--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -1143,10 +1143,18 @@ class NavigationTree
         $controlButtons = '';
         $paths = $node->getPaths();
         $nodeIsContainer = $node->type === Node::CONTAINER;
-        $hasSiblingsOrIsNotRoot = $node->hasSiblings() || $node->realParent() === false;
         $liClasses = '';
 
-        if ($hasSiblingsOrIsNotRoot) {
+        // Whether to show the node in the tree (true for all nodes but root)
+        // If false, the node's children will still be shown, but as children of the node's parent
+        $showNode = $node->hasSiblings() || count($node->parents(false, true)) > 0;
+
+        // Don't show the 'Tables' node under each database unless it has 'Views', etc. as a sibling
+        if ($node instanceof NodeTableContainer && ! $node->hasSiblings()) {
+            $showNode = false;
+        }
+
+        if ($showNode) {
             $response = ResponseRenderer::getInstance();
             if ($nodeIsContainer && count($node->children) === 0 && ! $response->isAjax()) {
                 return '';
@@ -1262,7 +1270,7 @@ class NavigationTree
         return $this->template->render('navigation/tree/node', [
             'node' => $node,
             'class' => $class,
-            'has_siblings_or_is_not_root' => $hasSiblingsOrIsNotRoot,
+            'show_node' => $showNode,
             'has_siblings' => $node->hasSiblings(),
             'li_classes' => $liClasses,
             'control_buttons' => $controlButtons,

--- a/templates/navigation/tree/node.twig
+++ b/templates/navigation/tree/node.twig
@@ -1,4 +1,4 @@
-{% if has_siblings_or_is_not_root %}
+{% if show_node %}
   <li class="{{ li_classes }}">
     <div class="block">
       <i{{ class == 'first' ? ' class="first"' }}></i>


### PR DESCRIPTION
### Description

When a group only has one child which is also a group, they will now be combined into a single node.

Before:
![image](https://user-images.githubusercontent.com/59065888/129430269-0458ec89-892f-4dba-b7d1-21f01b1e93e3.png)

After:
![image](https://user-images.githubusercontent.com/59065888/129430318-b7a78348-e5dd-44a1-aaa7-462f1d187604.png)

Dependent on PR #17076

Fixes #17003