### PR TITLE
Fix #14502 - Triggered the on-change event on the input field to uncheck the "ignore" checkbox 

### DIFF
--- a/js/src/sql.js
+++ b/js/src/sql.js
@@ -937,6 +937,9 @@ Sql.browseForeignDialog = function ($thisA) {
             }
             // Set selected value as input value
             $input.val($(this).data('key'));
+            // Unchecks the Ignore checkbox for the current row
+            $input.trigger('change');
+
             $dialog.dialog('close');
         });
         $(formId).on('click', showAllId, function () {

--- a/js/src/table/change.js
+++ b/js/src/table/change.js
@@ -525,8 +525,13 @@ AJAX.registerOnload('table/change.js', function () {
      */
     $(document).on('click', 'input[name=\'gis_data[save]\']', function () {
         var inputName = $('form#gis_data_editor_form').find('input[name=\'input_name\']').val();
-        var $nullCheckbox = $('input[name=\'' + inputName + '\']').parents('tr').find('.checkbox_null');
+        var currentRow = $('input[name=\'' + inputName + '\']').parents('tr');
+        var $nullCheckbox = currentRow.find('.checkbox_null');
         $nullCheckbox.prop('checked', false);
+        var rowId = currentRow.find('.open_gis_editor').data('row-id');
+
+        // Unchecks the Ignore checkbox for the current row
+        $('input[name=\'insert_ignore_' + rowId + '\']').prop('checked', false);
     });
 
     /**

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -858,7 +858,7 @@ class InsertEdit
         }
 
         if (in_array($column['pma_type'], $gis_data_types)) {
-            $html_output .= $this->getHtmlForGisDataTypes();
+            $html_output .= $this->getHtmlForGisDataTypes((int) $rownumber);
         }
 
         return $html_output;
@@ -1781,11 +1781,11 @@ class InsertEdit
      *
      * @return string an html snippet
      */
-    private function getHtmlForGisDataTypes()
+    private function getHtmlForGisDataTypes(int $rowId): string
     {
         $edit_str = Generator::getIcon('b_edit', __('Edit/Insert'));
 
-        return '<span class="open_gis_editor">'
+        return '<span class="open_gis_editor" data-row-id="' . $rowId . '">'
             . Generator::linkOrButton(
                 '#',
                 $edit_str,

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -2303,16 +2303,21 @@ class InsertEditTest extends AbstractTestCase
     {
         $GLOBALS['cfg']['ActionLinksMode'] = 'icons';
         $GLOBALS['cfg']['LinkLengthLimit'] = 2;
+        $htmlContent = $this->callFunction(
+            $this->insertEdit,
+            InsertEdit::class,
+            'getHtmlForGisDataTypes',
+            [4]
+        );
+        $this->assertStringContainsString(
+            '<span class="open_gis_editor" data-row-id="4">',
+            $htmlContent
+        );
         $this->assertStringContainsString(
             '<a href="#" target="_blank"><span class="nowrap"><img src="themes/dot.'
             . 'gif" title="Edit/Insert" alt="Edit/Insert" class="icon ic_b_edit">'
             . '</span></a>',
-            $this->callFunction(
-                $this->insertEdit,
-                InsertEdit::class,
-                'getHtmlForGisDataTypes',
-                []
-            )
+            $htmlContent
         );
     }
 


### PR DESCRIPTION
### Description
The "Ignore" checkbox doesn't uncheck when fields are filled using the pop up modal

Fixes: #14502