### PR TITLE
Fix #17084 - ErrorHandler sliceErrors not returning errors

### DIFF
--- a/libraries/classes/ErrorHandler.php
+++ b/libraries/classes/ErrorHandler.php
@@ -151,13 +151,19 @@ class ErrorHandler
     /**
      * Pops recent errors from the storage
      *
-     * @param int $count Old error count
+     * @param int $count Old error count (amount of errors to splice)
      *
-     * @return Error[]
+     * @return Error[] The non spliced elements (total-$count)
      */
     public function sliceErrors(int $count): array
     {
+        // store the errors before any operation, example number of items: 10
         $errors = $this->getErrors(false);
+
+        // before array_splice $this->errors has 10 elements
+        // cut out $count items out, let's say $count = 9
+        // $errors will now contain 10 - 9 = 1 elements
+        // $this->errors will contain the 9 elements left
         $this->errors = array_splice($errors, 0, $count);
 
         return $errors;

--- a/libraries/classes/ErrorHandler.php
+++ b/libraries/classes/ErrorHandler.php
@@ -160,7 +160,7 @@ class ErrorHandler
         $errors = $this->getErrors(false);
         $this->errors = array_splice($errors, 0, $count);
 
-        return array_splice($errors, $count);
+        return $errors;
     }
 
     /**

--- a/test/classes/ErrorHandlerTest.php
+++ b/test/classes/ErrorHandlerTest.php
@@ -187,24 +187,30 @@ class ErrorHandlerTest extends AbstractTestCase
             'error.txt',
             15
         );
+        $this->object->addError(
+            'Compile Error',
+            E_WARNING,
+            'error.txt',
+            15
+        );
         $this->assertEquals(
-            1,
+            2,
             $this->object->countErrors()
         );
         $this->assertEquals(
             [],
-            $this->object->sliceErrors(1)
+            $this->object->sliceErrors(2)
         );
         $this->assertEquals(
-            1,
+            2,
             $this->object->countErrors()
         );
         $this->assertCount(
             1,
-            $this->object->sliceErrors(0)
+            $this->object->sliceErrors(1)
         );
         $this->assertEquals(
-            0,
+            1,
             $this->object->countErrors()
         );
     }

--- a/test/classes/ErrorHandlerTest.php
+++ b/test/classes/ErrorHandlerTest.php
@@ -12,6 +12,8 @@ use const E_RECOVERABLE_ERROR;
 use const E_USER_NOTICE;
 use const E_USER_WARNING;
 use const E_WARNING;
+use function count;
+use function array_keys;
 
 class ErrorHandlerTest extends AbstractTestCase
 {
@@ -191,7 +193,7 @@ class ErrorHandlerTest extends AbstractTestCase
             'Compile Error',
             E_WARNING,
             'error.txt',
-            15
+            16
         );
         $this->assertEquals(
             2,
@@ -213,6 +215,53 @@ class ErrorHandlerTest extends AbstractTestCase
             1,
             $this->object->countErrors()
         );
+    }
+
+    /**
+     * Test for sliceErrors with 10 elements as an example
+     *
+     * @group medium
+     */
+    public function testSliceErrorsOtherExample(): void
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->object->addError(
+                'Compile Error',
+                E_WARNING,
+                'error.txt',
+                $i
+            );
+        }
+
+        // 10 initial items
+        $this->assertEquals(10, $this->object->countErrors());
+        $this->assertEquals(10, count($this->object->getCurrentErrors()));
+
+        // slice 9 elements, returns one 10 - 9
+        $elements = $this->object->sliceErrors(9);
+        $firstKey = array_keys($elements)[0];
+
+        // Gives the last element
+        $this->assertEquals(
+            [
+                $firstKey => $elements[$firstKey],
+            ],
+            $elements
+        );
+        $this->assertEquals(9, count($this->object->getCurrentErrors()));
+        $this->assertEquals(9, $this->object->countErrors());
+
+        // Slice as much as there is (9), does nothing
+        $elements = $this->object->sliceErrors(9);
+        $this->assertEquals([], $elements);
+        $this->assertEquals(9, count($this->object->getCurrentErrors()));
+        $this->assertEquals(9, $this->object->countErrors());
+
+        // Slice 0, removes everything
+        $elements = $this->object->sliceErrors(0);
+        $this->assertEquals(9, count($elements));
+        $this->assertEquals(0, count($this->object->getCurrentErrors()));
+        $this->assertEquals(0, $this->object->countErrors());
     }
 
     /**


### PR DESCRIPTION
### Description

ErrorHandler class' sliceErrors method was failing to return the correct errors from the error array according to the passed $count argument. This was due to an extra array_splice being performed on $errors, which has already had the errors before $count removed in the first array_splice, and so the index of the remaining errors had changed.

This probably wasn't noticed before because the test case only slices from index 0, and you need to sliceErrors from an index > 0 for the bug to occur. I've fixed this to return all leftover errors after $count index, and updated the ErrorHandlerTest's testSliceErrors to better test this method.

Fixes #17084