### PR TITLE
Removed anchor from breadcrumb table name item for easier copy pasting

### DIFF
--- a/templates/menu/breadcrumbs.twig
+++ b/templates/menu/breadcrumbs.twig
@@ -21,7 +21,7 @@
       {% if table is not empty %}
         <li class="breadcrumb-item">
           {{ show_icons('TabsMode') ? get_image(table.is_view ? 'b_views' : 's_tbl') }}
-          <a href="{{ url(table.url, {'db': database.name, 'table': table.name}) }}" data-raw-text="{{ table.name }}">
+          <span data-raw-text="{{ table.name }}">
             {% if show_text('TabsMode') %}
               {% if table.is_view %}
                 {% trans 'View:' %}
@@ -30,7 +30,7 @@
               {% endif %}
             {% endif %}
             {{ table.name }}
-          </a>
+          </span>
         </li>
 
         {% if table.comment is not empty %}

--- a/themes/pmahomme/scss/_breadcrumb.scss
+++ b/themes/pmahomme/scss/_breadcrumb.scss
@@ -8,7 +8,8 @@
       padding-left: 0.5rem;
     }
 
-    a {
+    a,
+    & {
       color: #fff;
     }
   }


### PR DESCRIPTION
Removes anchor for breadcrumb table/view item, and fixes color of the breadcrumb item after removal of anchor

Ref: #17095