### PR TITLE
Fix #17121 - remove single quote and escaped value before hashing password

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1634,6 +1634,10 @@ class InsertEdit
         }
 
         if ($multiEditFuncs[$key] === 'PHP_PASSWORD_HASH') {
+            // Remove single quote and escaped value
+            $currentValue = mb_substr($currentValue, 1, -1);
+            $currentValue = stripslashes($currentValue);
+
             /**
              * @see https://github.com/vimeo/psalm/issues/3350
              *


### PR DESCRIPTION
Signed-off-by: Hidayatullah <ayat.kyo@gmail.com>

### Description

Remove single quote and escaped value before hashing value using `password_hash`.

In current version, value with quote and escaped will be send to `password_hash` function, so `password_verify` will always return `false`.

For example my password is `super_secret` and select **The PHP function password_hash() with default options.** function, then **Go** to save it.

Using this code will return `false`
```php
password_verify("super_secret", "PASSWORD_HASH");
```

but using this code will return `true` because i wrap with `'`
```php
password_verify("'super_secret'", "PASSWORD_HASH");
```

Fixes #17121

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
