### PR TITLE
Add button next to table name to copy it to the clipboard

### DIFF
--- a/js/src/breadcrumbs.js
+++ b/js/src/breadcrumbs.js
@@ -1,0 +1,22 @@
+/**
+ * @fileoverview This file includes logic to deal with breadcrums
+ *
+ * @requires js/functions.js
+ * @requires js/ajax.js
+ * @requires jQuery
+ */
+
+$(function () {
+    function performCopy () {
+        Functions.copyToClipboard($(this).data('copy-text'));
+        Functions.ajaxShowMessage(Messages.strCopiedTableNameToClipboard, 1500, 'success');
+    }
+
+    AJAX.registerOnload('breadcrumbs.js', function () {
+        $('.breadcrumb').on('click', '.breadcrumb-table-copy-button', performCopy);
+    });
+
+    AJAX.registerTeardown('breadcrumbs.js', function () {
+        $('.breadcrumb').off('click', '.breadcrumb-table-copy-button', performCopy);
+    });
+});

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -706,6 +706,9 @@ final class JavaScriptMessagesController
             'strHide' => __('Hide'),
             'strShow' => __('Show'),
             'strStructure' => __('Structure'),
+
+            // For breadcrumbs.js
+            'strCopiedTableNameToClipboard' => __('Copied table name to clipboard.')
         ];
     }
 }

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -173,6 +173,7 @@ class Header
         $this->scripts->addFile('vendor/jquery/jquery-ui-timepicker-addon.js');
         $this->scripts->addFile('vendor/jquery/jquery.debounce-1.0.6.js');
         $this->scripts->addFile('menu_resizer.js');
+        $this->scripts->addFile('breadcrumbs.js');
 
         // Cross-framing protection
         if ($GLOBALS['cfg']['AllowThirdPartyFraming'] === false) {

--- a/templates/menu/breadcrumbs.twig
+++ b/templates/menu/breadcrumbs.twig
@@ -31,6 +31,9 @@
             {% endif %}
             {{ table.name }}
           </a>
+
+          <button class="breadcrumb-table-copy-button ic_s_link" data-copy-text="{{ table.name }}">
+          </button>
         </li>
 
         {% if table.comment is not empty %}

--- a/themes/bootstrap/scss/_breadcrumb.scss
+++ b/themes/bootstrap/scss/_breadcrumb.scss
@@ -12,4 +12,13 @@
       margin: 0;
     }
   }
+
+  .breadcrumb-table-copy-button {
+    background-color: transparent;
+    border: none;
+    padding: 0;
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+  }
 }


### PR DESCRIPTION
Signed-off-by: RVxLab <richard@rvx.works>

### Description

This PR adds a button next to the table name so it can be easily copies, as was previously mentioned in #17095

From my end, there is 1 open question still, which is regarding the button's graphic. As I can't find a suitable icon in the current set and my severe lack of designing skills I opted to use `s_link.png` for the time being. Surely we don't want to keep it at this.

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
