### PR TITLE
Simplify mysqli_get_client_info

### DIFF
--- a/libraries/classes/Dbal/DbiMysqli.php
+++ b/libraries/classes/Dbal/DbiMysqli.php
@@ -338,11 +338,6 @@ class DbiMysqli implements DbiExtension
      */
     public function getClientInfo($link)
     {
-        // See: https://github.com/phpmyadmin/phpmyadmin/issues/16911
-        if (PHP_VERSION_ID < 80100) {
-            return $link->get_client_info();
-        }
-
         return mysqli_get_client_info();
     }
 


### PR DESCRIPTION
See #16911

Removes PHP version check. Use either OO-style property or use the function without any arguments. 