### PR TITLE
Fix #17188 - GIS visualization with edited query

### DIFF
--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -237,7 +237,7 @@ class GisVisualization
             . ') AS ' . Util::backquote('srid') . ' ';
 
         // Append the original query as the inner query
-        $modified_query .= 'FROM (' . $sql_query . ') AS '
+        $modified_query .= 'FROM (' . rtrim($sql_query, ';') . ') AS '
             . Util::backquote('temp_gis');
 
         // LIMIT clause


### PR DESCRIPTION
Strip semicolon at end of original query when it is used as a subquery
Fixes #17188

Signed-off-by: Maximilian Krög <maxi_kroeg@web.de>

