### PR TITLE
Remove phpMyAdmin repo from `composer.json` on Scrutinizer CI

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -23,9 +23,10 @@ build:
     analysis:
       environment:
         php: 7.2
-        node: 10
+        node: 12
       dependencies:
         before:
+          - composer config --unset repositories.0
           - composer install
           - composer require tecnickcom/tcpdf pragmarx/google2fa-qrcode bacon/bacon-qr-code samyoul/u2f-php-server
       tests:


### PR DESCRIPTION
Scrutinizer CI builds are failing because its CA certificates are outdated.

- #17167