### PR TITLE
Fix db selection when nav tree is disabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -109,6 +109,7 @@ phpMyAdmin - ChangeLog
 - issue #12753 Show table structure after adding a new column
 - issue        Fix a PHP notice when logging out
 - issue #17090 Fix bbcode not rendered for error messages on setup
+- issue #17198 Fix the database selection when the navigation tree is disabled
 
 5.1.1 (2021-06-04)
 - issue #13325 Fixed created procedure shows up in triggers and events and vice-versa

--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -19,6 +19,7 @@ use PhpMyAdmin\RecentFavoriteTable;
 use PhpMyAdmin\Response;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
+use PhpMyAdmin\Util;
 use const E_USER_WARNING;
 use function array_key_exists;
 use function array_keys;
@@ -1351,12 +1352,15 @@ class NavigationTree
             }
         }
 
+        $databaseUrl = Util::getScriptNameForOption($GLOBALS['cfg']['DefaultTabDatabase'], 'database');
+
         return $this->template->render('navigation/tree/database_select', [
             'quick_warp' => $quickWarp,
             'list_navigator' => $listNavigator,
             'server' => $GLOBALS['server'],
             'options' => $options,
             'nodes' => $nodes,
+            'database_url' => $databaseUrl,
         ]);
     }
 

--- a/templates/navigation/tree/database_select.twig
+++ b/templates/navigation/tree/database_select.twig
@@ -4,11 +4,10 @@
   {{ list_navigator|raw }}
 
   <div id="pma_navigation_db_select">
-    <form action="{{ url('/') }}">
+    <form action="{{ database_url }}" method="get">
       {{ get_hidden_fields({'server': server}) }}
 
-      <select name="db" class="hide" id="navi_db_select">
-        <option value="" dir="{{ text_dir }}">{% trans 'Databases' %}…</option>
+      <select name="db" class="hide" id="navi_db_select" aria-label="{% trans 'Databases' %}">
         {% for option in options %}
           <option value="{{ option.name }}" title="{{ option.title }}"
             data-apath="{{ option.data.apath }}"


### PR DESCRIPTION
```php
$cfg['ShowDatabasesNavigationAsTree'] = false;
```

After selecting a database when the navigation tree is disabled, it is not possible to select another database.


