### PR TITLE
Use array_keys whenever only keys are needed in foreach

### DIFF
--- a/libraries/classes/BrowseForeigners.php
+++ b/libraries/classes/BrowseForeigners.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin;
 
 use function __;
+use function array_keys;
 use function asort;
 use function ceil;
 use function floor;
@@ -245,7 +246,7 @@ class BrowseForeigners
         $horizontalCount = 0;
         $indexByDescription = 0;
 
-        foreach ($keys as $indexByKeyname => $value) {
+        foreach (array_keys($keys) as $indexByKeyname) {
             [
                 $html,
                 $horizontalCount,

--- a/libraries/classes/Config/FormDisplay.php
+++ b/libraries/classes/Config/FormDisplay.php
@@ -536,7 +536,7 @@ class FormDisplay
         $valueCmp = is_bool($value)
             ? (int) $value
             : $value;
-        foreach ($allowed as $vk => $v) {
+        foreach (array_keys($allowed) as $vk) {
             // equality comparison only if both values are numeric or not numeric
             // (allows to skip 0 == 'string' equalling to true)
             // or identity (for string-string)

--- a/libraries/classes/Controllers/Setup/HomeController.php
+++ b/libraries/classes/Controllers/Setup/HomeController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Sanitize;
 use PhpMyAdmin\Setup\Index;
 
 use function __;
+use function array_keys;
 use function is_scalar;
 use function preg_replace;
 use function uniqid;
@@ -107,7 +108,7 @@ class HomeController extends AbstractController
         }
 
         $servers = [];
-        foreach ($this->config->getServers() as $id => $server) {
+        foreach (array_keys($this->config->getServers()) as $id) {
             $servers[$id] = [
                 'id' => $id,
                 'name' => $this->config->getServerName($id),

--- a/libraries/classes/Controllers/Table/ChartController.php
+++ b/libraries/classes/Controllers/Table/ChartController.php
@@ -127,7 +127,7 @@ class ChartController extends AbstractController
 
         $keys = array_keys($data[0]);
         $numericColumnFound = false;
-        foreach ($keys as $idx => $key) {
+        foreach (array_keys($keys) as $idx) {
             if (
                 isset($fields_meta[$idx]) && (
                 $fields_meta[$idx]->isType(FieldMetadata::TYPE_INT)

--- a/libraries/classes/Controllers/Table/ReplaceController.php
+++ b/libraries/classes/Controllers/Table/ReplaceController.php
@@ -22,6 +22,7 @@ use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Util;
 
 use function __;
+use function array_keys;
 use function array_values;
 use function class_exists;
 use function count;
@@ -246,7 +247,7 @@ final class ReplaceController extends AbstractController
 
             // When a select field is nullified, it's not present in $_POST
             // so initialize it; this way, the foreach($multi_edit_columns) will process it
-            foreach ($multi_edit_columns_name as $key => $val) {
+            foreach (array_keys($multi_edit_columns_name) as $key) {
                 if (isset($multi_edit_columns[$key])) {
                     continue;
                 }

--- a/libraries/classes/Database/CentralColumns.php
+++ b/libraries/classes/Database/CentralColumns.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function array_diff;
+use function array_keys;
 use function array_unique;
 use function array_values;
 use function bin2hex;
@@ -308,7 +309,7 @@ class CentralColumns
         if ($isTable) {
             foreach ($field_select as $table) {
                 $fields[$table] = $this->dbi->getColumns($db, $table, true);
-                foreach ($fields[$table] as $field => $def) {
+                foreach (array_keys($fields[$table]) as $field) {
                     $cols .= "'" . $this->dbi->escapeString($field) . "',";
                 }
             }

--- a/libraries/classes/Database/Designer/Common.php
+++ b/libraries/classes/Database/Designer/Common.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Utils\ForeignKey;
 
 use function __;
 use function _pgettext;
+use function array_keys;
 use function count;
 use function explode;
 use function in_array;
@@ -230,7 +231,7 @@ class Common
                 }
 
                 $columns = $index->getColumns();
-                foreach ($columns as $column_name => $dummy) {
+                foreach (array_keys($columns) as $column_name) {
                     $keys[$schema . '.' . $designerTable->getTableName() . '.' . $column_name] = 1;
                 }
             }

--- a/libraries/classes/Operations.php
+++ b/libraries/classes/Operations.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Partitioning\Partition;
 use PhpMyAdmin\Plugins\Export\ExportSql;
 
 use function __;
+use function array_keys;
 use function array_merge;
 use function count;
 use function explode;
@@ -134,7 +135,7 @@ class Operations
         $db
     ) {
         $views = [];
-        foreach ($tables_full as $each_table => $tmp) {
+        foreach (array_keys($tables_full) as $each_table) {
             // to be able to rename a db containing views,
             // first all the views are collected and a stand-in is created
             // the real views are created after the tables
@@ -175,7 +176,7 @@ class Operations
     public function copyTables(array $tables_full, $move, $db)
     {
         $sqlContraints = [];
-        foreach ($tables_full as $each_table => $tmp) {
+        foreach (array_keys($tables_full) as $each_table) {
             // skip the views; we have created stand-in definitions
             if ($this->dbi->getTable($db, (string) $each_table)->isView()) {
                 continue;

--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -23,6 +23,7 @@ use phpseclib3\Crypt\Random;
 use ReCaptcha;
 
 use function __;
+use function array_keys;
 use function base64_decode;
 use function base64_encode;
 use function class_exists;
@@ -896,7 +897,7 @@ class AuthenticationCookie extends AuthenticationPlugin
 
         // -> delete password cookie(s)
         if ($GLOBALS['cfg']['LoginCookieDeleteAll']) {
-            foreach ($GLOBALS['cfg']['Servers'] as $key => $val) {
+            foreach (array_keys($GLOBALS['cfg']['Servers']) as $key) {
                 $config->removeCookie('pmaAuth-' . $key);
                 if (! $config->issetCookie('pmaAuth-' . $key)) {
                     continue;

--- a/libraries/classes/Plugins/AuthenticationPlugin.php
+++ b/libraries/classes/Plugins/AuthenticationPlugin.php
@@ -19,6 +19,7 @@ use PhpMyAdmin\TwoFactor;
 use PhpMyAdmin\Url;
 
 use function __;
+use function array_keys;
 use function defined;
 use function htmlspecialchars;
 use function intval;
@@ -126,7 +127,7 @@ abstract class AuthenticationPlugin
          */
         $server = 0;
         if ($GLOBALS['cfg']['LoginCookieDeleteAll'] === false && $GLOBALS['cfg']['Server']['auth_type'] === 'cookie') {
-            foreach ($GLOBALS['cfg']['Servers'] as $key => $val) {
+            foreach (array_keys($GLOBALS['cfg']['Servers']) as $key) {
                 if (! $config->issetCookie('pmaAuth-' . $key)) {
                     continue;
                 }

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -30,6 +30,7 @@ use PhpMyAdmin\Util;
 use PhpMyAdmin\Version;
 
 use function __;
+use function array_keys;
 use function bin2hex;
 use function count;
 use function defined;
@@ -1148,7 +1149,7 @@ class ExportSql extends ExportPlugin
 
                 $result = $dbi->fetchResult($sqlQuery, 'page_nr', 'page_descr');
 
-                foreach ($result as $page => $name) {
+                foreach (array_keys($result) as $page) {
                     // insert row for pdf_page
                     $sqlQueryRow = 'SELECT `db_name`, `page_descr` FROM '
                         . Util::backquote($relationParameters->db)

--- a/libraries/classes/Plugins/Schema/TableStats.php
+++ b/libraries/classes/Plugins/Schema/TableStats.php
@@ -16,6 +16,7 @@ use PhpMyAdmin\Util;
 use function array_flip;
 use function array_keys;
 use function array_merge;
+use function is_array;
 use function rawurldecode;
 use function sprintf;
 
@@ -165,11 +166,11 @@ abstract class TableStats
      */
     protected function loadCoordinates(): void
     {
-        if (! isset($_POST['t_h'])) {
+        if (! isset($_POST['t_h']) || ! is_array($_POST['t_h'])) {
             return;
         }
 
-        foreach ($_POST['t_h'] as $key => $value) {
+        foreach (array_keys($_POST['t_h']) as $key) {
             $db = rawurldecode($_POST['t_db'][$key]);
             $tbl = rawurldecode($_POST['t_tbl'][$key]);
             if ($this->db . '.' . $this->tableName === $db . '.' . $tbl) {

--- a/libraries/classes/Server/UserGroups.php
+++ b/libraries/classes/Server/UserGroups.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
 use function __;
+use function array_keys;
 use function htmlspecialchars;
 use function implode;
 use function in_array;
@@ -337,8 +338,9 @@ class UserGroups
             . '(`usergroup`, `tab`, `allowed`)'
             . ' VALUES ';
         $first = true;
+        /** @var array<string, string> $tabGroup */
         foreach ($tabs as $tabGroupName => $tabGroup) {
-            foreach ($tabGroup as $tab => $tabName) {
+            foreach (array_keys($tabGroup) as $tab) {
                 if (! $first) {
                     $sql_query .= ', ';
                 }

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -16,6 +16,7 @@ use PhpMyAdmin\SqlParser\Utils\Query;
 use PhpMyAdmin\Utils\ForeignKey;
 
 use function __;
+use function array_keys;
 use function array_map;
 use function array_sum;
 use function bin2hex;
@@ -192,7 +193,7 @@ class Sql
 
             $indexColumns = $index->getColumns();
             $numberFound = 0;
-            foreach ($indexColumns as $indexColumnName => $dummy) {
+            foreach (array_keys($indexColumns) as $indexColumnName) {
                 if (in_array($indexColumnName, $resultSetColumnNames)) {
                     $numberFound++;
                 } elseif (! in_array($indexColumnName, $columns)) {

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -21,7 +21,9 @@ use Stringable;
 
 use function __;
 use function array_key_exists;
+use function array_keys;
 use function array_map;
+use function array_merge;
 use function count;
 use function end;
 use function explode;
@@ -2692,9 +2694,7 @@ class Table implements Stringable
             Index::getFromTableByChoice($this->name, $this->dbName, $types) as $index
         ) {
             $columns = $index->getColumns();
-            foreach ($columns as $columnName => $dummy) {
-                $columnsWithIndex[] = $columnName;
-            }
+            $columnsWithIndex = array_merge($columnsWithIndex, array_keys($columns));
         }
 
         return $columnsWithIndex;

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -18,6 +18,7 @@ use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
+use function array_keys;
 use function array_merge;
 use function bin2hex;
 use function count;
@@ -25,7 +26,6 @@ use function explode;
 use function in_array;
 use function intval;
 use function is_array;
-use function is_iterable;
 use function mb_strtoupper;
 use function preg_quote;
 use function preg_replace;
@@ -134,11 +134,11 @@ final class ColumnsDefinition
             'transformation',
         ];
         foreach ($mime_types as $mime_type) {
-            if (! isset($available_mime[$mime_type]) || ! is_iterable($available_mime[$mime_type])) {
+            if (! isset($available_mime[$mime_type]) || ! is_array($available_mime[$mime_type])) {
                 continue;
             }
 
-            foreach ($available_mime[$mime_type] as $mimekey => $transform) {
+            foreach (array_keys($available_mime[$mime_type]) as $mimekey) {
                 $available_mime[$mime_type . '_file_quoted'][$mimekey] = preg_quote(
                     $available_mime[$mime_type . '_file'][$mimekey],
                     '@'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -140,7 +140,7 @@
       <code>$relrow[$foreignData['foreign_display']]</code>
       <code>$relrow[$foreignData['foreign_field']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$descriptions[]</code>
       <code>$keys[]</code>
       <code>$leftKeyname</code>
@@ -148,7 +148,6 @@
       <code>$pos</code>
       <code>$relrow</code>
       <code>$rightKeyname</code>
-      <code>$value</code>
     </MixedAssignment>
     <MixedOperand occurrences="4">
       <code>$foreignData['the_total']</code>
@@ -162,9 +161,6 @@
       <code>(int) $cfg['MaxRows']</code>
       <code>(int) $cfg['RepeatCells']</code>
     </RedundantCast>
-    <UnusedForeachValue occurrences="1">
-      <code>$value</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Cache.php">
     <MixedAssignment occurrences="1">
@@ -676,7 +672,7 @@
       <code>$values[$path]</code>
       <code>$values[$systemPath]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="30">
+    <MixedAssignment occurrences="29">
       <code>$canonicalPath</code>
       <code>$errorList</code>
       <code>$errorList</code>
@@ -695,7 +691,6 @@
       <code>$toSave[$workPath]</code>
       <code>$translatedPath</code>
       <code>$userPrefsDisallow</code>
-      <code>$v</code>
       <code>$v</code>
       <code>$v</code>
       <code>$val</code>
@@ -737,9 +732,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$userprefsDisallow</code>
     </PropertyNotSetInConstructor>
-    <UnusedForeachValue occurrences="1">
-      <code>$v</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Config/FormDisplayTemplate.php">
     <MixedArgument occurrences="1">
@@ -2786,12 +2778,6 @@
       <code>$id</code>
       <code>$id</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
-      <code>$server</code>
-    </MixedAssignment>
-    <UnusedForeachValue occurrences="1">
-      <code>$server</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Controllers/Setup/ServersController.php">
     <PossiblyNullArgument occurrences="1">
@@ -3051,9 +3037,6 @@
       <code>$_REQUEST['pos']</code>
       <code>$_REQUEST['pos']</code>
     </MixedOperand>
-    <UnusedForeachValue occurrences="1">
-      <code>$key</code>
-    </UnusedForeachValue>
     <UnusedVariable occurrences="1">
       <code>$data_row_number</code>
     </UnusedVariable>
@@ -3465,7 +3448,7 @@
     <InvalidArgument occurrences="1">
       <code>$insert_errors</code>
     </InvalidArgument>
-    <MixedArgument occurrences="51">
+    <MixedArgument occurrences="47">
       <code>$_POST['db']</code>
       <code>$_POST['rel_fields_list']</code>
       <code>$_POST['table']</code>
@@ -3482,13 +3465,9 @@
       <code>$db</code>
       <code>$error_messages</code>
       <code>$extra_data</code>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$key</code>
       <code>$last_messages</code>
       <code>$mime_map[$column_name]['input_transformation_options']</code>
       <code>$multi_edit_auto_increment</code>
-      <code>$multi_edit_columns_name</code>
       <code>$multi_edit_columns_name</code>
       <code>$multi_edit_columns_null</code>
       <code>$multi_edit_columns_null</code>
@@ -3518,7 +3497,10 @@
       <code>$warning_messages</code>
       <code>$where_clause</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="3">
+    <MixedArgumentTypeCoercion occurrences="6">
+      <code>$key</code>
+      <code>$key</code>
+      <code>$key</code>
       <code>$query_values</code>
       <code>$query_values</code>
       <code>$rownumber</code>
@@ -3538,16 +3520,10 @@
       <code>$urlParams['after_insert']</code>
       <code>$urlParams['where_clause']</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="7">
+    <MixedArrayOffset occurrences="1">
       <code>$mime_map[$column_name]</code>
-      <code>$multi_edit_columns[$key]</code>
-      <code>$multi_edit_columns[$key]</code>
-      <code>$multi_edit_columns[$key]</code>
-      <code>$multi_edit_columns[$key]</code>
-      <code>$multi_edit_columns_null[$key]</code>
-      <code>$multi_edit_virtual[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="31">
+    <MixedAssignment occurrences="28">
       <code>$GLOBALS['cfg']['InsertRows']</code>
       <code>$GLOBALS['sql_query']</code>
       <code>$clauseIsUnique</code>
@@ -3558,8 +3534,6 @@
       <code>$current_value</code>
       <code>$extra_data['row_count']</code>
       <code>$insertRows</code>
-      <code>$key</code>
-      <code>$key</code>
       <code>$multi_edit_auto_increment</code>
       <code>$multi_edit_columns</code>
       <code>$multi_edit_columns_name</code>
@@ -3577,7 +3551,6 @@
       <code>$unsaved_values[$rownumber]</code>
       <code>$urlParams['after_insert']</code>
       <code>$urlParams['where_clause'][]</code>
-      <code>$val</code>
       <code>$where_clause</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
@@ -3601,9 +3574,6 @@
     <PossiblyUndefinedVariable occurrences="1">
       <code>$extra_data</code>
     </PossiblyUndefinedVariable>
-    <UnusedForeachValue occurrences="1">
-      <code>$val</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Controllers/Table/SearchController.php">
     <MixedArgument occurrences="13">
@@ -4701,9 +4671,6 @@
     <TypeDoesNotContainType occurrences="1">
       <code>$table == ''</code>
     </TypeDoesNotContainType>
-    <UnusedForeachValue occurrences="1">
-      <code>$def</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Database/DatabaseList.php">
     <DocblockTypeContradiction occurrences="1">
@@ -4888,9 +4855,6 @@
       <code>$con['SCN']</code>
       <code>$con['STN']</code>
     </PossiblyUndefinedArrayOffset>
-    <UnusedForeachValue occurrences="1">
-      <code>$dummy</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Database/Events.php">
     <MixedArgument occurrences="28">
@@ -9332,7 +9296,7 @@
       <code>$trigger['create']</code>
       <code>$trigger['create']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="18">
+    <MixedAssignment occurrences="16">
       <code>$arr</code>
       <code>$event_name</code>
       <code>$foreignTable</code>
@@ -9347,8 +9311,6 @@
       <code>$one_query</code>
       <code>$procedure_name</code>
       <code>$this_what</code>
-      <code>$tmp</code>
-      <code>$tmp</code>
       <code>$trigger</code>
       <code>$view</code>
     </MixedAssignment>
@@ -9402,10 +9364,6 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $pack_keys</code>
     </RedundantCastGivenDocblockType>
-    <UnusedForeachValue occurrences="2">
-      <code>$tmp</code>
-      <code>$tmp</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/OutputBuffering.php">
     <DocblockTypeContradiction occurrences="1">
@@ -9747,9 +9705,6 @@
       <code>(int) $GLOBALS['cfg']['LoginCookieStore']</code>
       <code>(string) $conn_error</code>
     </RedundantCast>
-    <UnusedForeachValue occurrences="1">
-      <code>$val</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Plugins/Auth/AuthenticationHttp.php">
     <MixedArgument occurrences="3">
@@ -9822,9 +9777,6 @@
     <PossiblyInvalidArgument occurrences="1">
       <code>$dbi_error</code>
     </PossiblyInvalidArgument>
-    <UnusedForeachValue occurrences="1">
-      <code>$val</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportCodegen.php">
     <MixedArgument occurrences="6">
@@ -10375,7 +10327,7 @@
       <code>$oneKey['ref_index_list'][$index]</code>
       <code>$values[$val]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="40">
+    <MixedAssignment occurrences="39">
       <code>$GLOBALS['old_tz']</code>
       <code>$colAlias</code>
       <code>$colAlias</code>
@@ -10394,7 +10346,6 @@
       <code>$index</code>
       <code>$mime</code>
       <code>$mimeField</code>
-      <code>$name</code>
       <code>$newDatabase</code>
       <code>$newTable</code>
       <code>$oneKey</code>
@@ -10490,9 +10441,6 @@
     <UnnecessaryVarAnnotation occurrences="1">
       <code>CreateDefinition</code>
     </UnnecessaryVarAnnotation>
-    <UnusedForeachValue occurrences="1">
-      <code>$name</code>
-    </UnusedForeachValue>
     <UnusedParam occurrences="1">
       <code>$crlf</code>
     </UnusedParam>
@@ -12166,21 +12114,10 @@
       <code>$_POST['t_x'][$key]</code>
       <code>$_POST['t_y'][$key]</code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="4">
-      <code>$_POST['t_db'][$key]</code>
-      <code>$_POST['t_tbl'][$key]</code>
-      <code>$_POST['t_x'][$key]</code>
-      <code>$_POST['t_y'][$key]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
-      <code>$key</code>
+    <MixedAssignment occurrences="2">
       <code>$result</code>
       <code>$result</code>
-      <code>$value</code>
     </MixedAssignment>
-    <UnusedForeachValue occurrences="1">
-      <code>$value</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Plugins/Transformations/Abs/Bool2TextTransformationsPlugin.php">
     <MixedArgumentTypeCoercion occurrences="1">
@@ -13832,7 +13769,7 @@
       <code>$userGroups[$groupName]</code>
       <code>$userGroups[$groupName]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="19">
+    <MixedAssignment occurrences="16">
       <code>$groupName</code>
       <code>$key</code>
       <code>$result</code>
@@ -13840,12 +13777,9 @@
       <code>$result</code>
       <code>$tab</code>
       <code>$tab</code>
-      <code>$tab</code>
       <code>$tabDetail['tab']</code>
       <code>$tabDetail['tab_name']</code>
-      <code>$tabGroup</code>
       <code>$tabGroupName</code>
-      <code>$tabName</code>
       <code>$tabName</code>
       <code>$tabName</code>
       <code>$tabNames[]</code>
@@ -13853,8 +13787,7 @@
       <code>$user['user']</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="4">
-      <code>$tab</code>
+    <MixedOperand occurrences="3">
       <code>$tab</code>
       <code>$tab</code>
       <code>$tabGroupName</code>
@@ -13869,9 +13802,6 @@
       <code>$tabs</code>
       <code>$tabs</code>
     </PossiblyNullIterator>
-    <UnusedForeachValue occurrences="1">
-      <code>$tabName</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Session.php">
     <MixedArgument occurrences="4">
@@ -14179,9 +14109,6 @@
       <code>''</code>
       <code>''</code>
     </TypeDoesNotContainNull>
-    <UnusedForeachValue occurrences="1">
-      <code>$dummy</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/SqlQueryForm.php">
     <MixedArgument occurrences="2">
@@ -14595,9 +14522,6 @@
     <TypeDoesNotContainType occurrences="1">
       <code>$rowFields[$key] != 'cc'</code>
     </TypeDoesNotContainType>
-    <UnusedForeachValue occurrences="1">
-      <code>$dummy</code>
-    </UnusedForeachValue>
     <UnusedVariable occurrences="3">
       <code>$idx</code>
       <code>$idx</code>
@@ -14665,16 +14589,14 @@
       <code>$mime_map[$columnMeta['Field']]</code>
       <code>$submit_fulltext[$fulltext_indexkey]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="7">
-      <code>$available_mime[$mime_type . '_file'][$mimekey]</code>
-      <code>$available_mime[$mime_type . '_file_quoted'][$mimekey]</code>
+    <MixedArrayOffset occurrences="5">
       <code>$comments_map[$columnMeta['Field']]</code>
       <code>$expressions[$columnMeta['Field']]</code>
       <code>$mime_map[$columnMeta['Field']]</code>
       <code>$mime_map[$columnMeta['Field']]</code>
       <code>$submit_fulltext[$fulltext_indexkey]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="25">
+    <MixedAssignment occurrences="23">
       <code>$columnMeta</code>
       <code>$columnMeta['Default']</code>
       <code>$columnMeta['Default']</code>
@@ -14693,12 +14615,10 @@
       <code>$fulltext_indexkey</code>
       <code>$length</code>
       <code>$length</code>
-      <code>$mimekey</code>
       <code>$move_columns</code>
       <code>$o_fld_val</code>
       <code>$submit_attribute</code>
       <code>$submit_fulltext[$fulltext_indexkey]</code>
-      <code>$transform</code>
       <code>$type</code>
     </MixedAssignment>
     <PossiblyUndefinedVariable occurrences="1">
@@ -14710,9 +14630,6 @@
       <code>isset($field_fulltext) &amp;&amp; is_array($field_fulltext)</code>
       <code>isset($selected) &amp;&amp; is_array($selected)</code>
     </RedundantConditionGivenDocblockType>
-    <UnusedForeachValue occurrences="1">
-      <code>$transform</code>
-    </UnusedForeachValue>
     <UnusedVariable occurrences="1">
       <code>$fulltext_nr</code>
     </UnusedVariable>
@@ -15696,12 +15613,6 @@
       <code>$http_response_code_param</code>
     </MixedAssignment>
   </file>
-  <file src="test/classes/AbstractTestCase.php">
-    <UnusedForeachValue occurrences="2">
-      <code>$val</code>
-      <code>$val</code>
-    </UnusedForeachValue>
-  </file>
   <file src="test/classes/AdvisorTest.php">
     <MixedInferredReturnType occurrences="2">
       <code>array</code>
@@ -15826,9 +15737,8 @@
     </MixedOperand>
   </file>
   <file src="test/classes/Config/DescriptionTest.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$second</code>
-      <code>$val</code>
       <code>$val</code>
       <code>$val2</code>
     </MixedAssignment>
@@ -15838,9 +15748,6 @@
     <MixedOperand occurrences="1">
       <code>$second</code>
     </MixedOperand>
-    <UnusedForeachValue occurrences="1">
-      <code>$val</code>
-    </UnusedForeachValue>
   </file>
   <file src="test/classes/Config/FormDisplayTest.php">
     <MixedArrayAccess occurrences="10">

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -18,6 +18,7 @@ use PhpMyAdmin\Utils\HttpRequest;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
+use function array_keys;
 use function in_array;
 
 use const DIRECTORY_SEPARATOR;
@@ -62,7 +63,7 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function setUp(): void
     {
-        foreach ($GLOBALS as $key => $val) {
+        foreach (array_keys($GLOBALS) as $key) {
             if (in_array($key, $this->globalsAllowList)) {
                 continue;
             }
@@ -238,12 +239,12 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * Desctroys the environment built for the test.
+     * Destroys the environment built for the test.
      * Clean all variables
      */
     protected function tearDown(): void
     {
-        foreach ($GLOBALS as $key => $val) {
+        foreach (array_keys($GLOBALS) as $key) {
             if (in_array($key, $this->globalsAllowList)) {
                 continue;
             }

--- a/test/classes/Config/DescriptionTest.php
+++ b/test/classes/Config/DescriptionTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Config\Descriptions;
 use PhpMyAdmin\Config\Settings;
 use PhpMyAdmin\Tests\AbstractTestCase;
 
+use function array_keys;
 use function in_array;
 
 /**
@@ -107,7 +108,7 @@ class DescriptionTest extends AbstractTestCase
                 }
             } elseif (in_array($key, $nested)) {
                 $this->assertIsArray($value);
-                foreach ($value as $item => $val) {
+                foreach (array_keys($value) as $item) {
                     $this->assertGet($key . '/' . $item);
                 }
             }


### PR DESCRIPTION
This is a global search for all possible places where `array_keys` could be used to simplify code and improve static analysis. There are a couple more `UnusedForeachValue` which are either FP or could not be easily replaced. 

In a couple of places I had to change the code more. I replaced a loop with `array_merge()`. Built-in functions are usually faster and simpler than loops. I changed `is_iterable` to `is_array` as it looks like it was a mistake. I added `! is_array()` in one place for improved validation of input. 