### PR TITLE
Make $subPart non-nullable and remove redundant ?? when it's not null

### DIFF
--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -73,7 +73,7 @@ final class ExportController extends AbstractController
             $tooltip_truename,
             $tooltip_aliasname,
             $pos,
-        ] = Util::getDbInfo($db, $sub_part ?? '');
+        ] = Util::getDbInfo($db, $sub_part);
 
         // exit if no tables in db found
         if ($num_tables < 1) {

--- a/libraries/classes/Controllers/Database/Operations/CollationController.php
+++ b/libraries/classes/Controllers/Database/Operations/CollationController.php
@@ -68,7 +68,7 @@ final class CollationController extends AbstractController
          * Changes tables charset if requested by the user
          */
         if (isset($_POST['change_all_tables_collations']) && $_POST['change_all_tables_collations'] === 'on') {
-            [$tables] = Util::getDbInfo($db, null);
+            [$tables] = Util::getDbInfo($db, '');
             foreach ($tables as $tableName => $data) {
                 if ($this->dbi->getTable($db, $tableName)->isView()) {
                     // Skip views, we can not change the collation of a view.

--- a/libraries/classes/Controllers/Database/OperationsController.php
+++ b/libraries/classes/Controllers/Database/OperationsController.php
@@ -259,7 +259,7 @@ class OperationsController extends AbstractController
             $tooltip_truename,
             $tooltip_aliasname,
             $pos,
-        ] = Util::getDbInfo($db, $sub_part ?? '');
+        ] = Util::getDbInfo($db, $sub_part);
 
         $oldMessage = '';
         if (isset($message)) {

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -155,7 +155,7 @@ class QueryByExampleController extends AbstractController
             $tooltip_truename,
             $tooltip_aliasname,
             $pos,
-        ] = Util::getDbInfo($db, $sub_part ?? '');
+        ] = Util::getDbInfo($db, $sub_part);
 
         $databaseQbe = new Qbe($this->relation, $this->template, $this->dbi, $db, $savedSearchList, $savedSearch);
 

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -75,7 +75,7 @@ class TrackingController extends AbstractController
             $tooltip_truename,
             $tooltip_aliasname,
             $pos,
-        ] = Util::getDbInfo($db, $sub_part ?? '');
+        ] = Util::getDbInfo($db, $sub_part);
 
         if (isset($_POST['delete_tracking'], $_POST['table'])) {
             Tracker::deleteTracking($db, $_POST['table']);

--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -364,7 +364,7 @@ class PrivilegesController extends AbstractController
                 $tooltip_truename,
                 $tooltip_aliasname,
                 $pos,
-            ] = Util::getDbInfo($db, $sub_part ?? '');
+            ] = Util::getDbInfo($db, $sub_part);
 
             $content = ob_get_clean();
             $this->response->addHTML($content . "\n");

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2161,12 +2161,12 @@ class Util
      * Gets the list of tables in the current db and information about these
      * tables if possible
      *
-     * @param string      $db      database name
-     * @param string|null $subPart part of script name
+     * @param string $db      database name
+     * @param string $subPart part of script name
      *
      * @return array
      */
-    public static function getDbInfo($db, ?string $subPart)
+    public static function getDbInfo($db, string $subPart)
     {
         global $cfg, $dbi;
 
@@ -2285,7 +2285,7 @@ class Util
                 //  (needed for proper working of the MaxTableList feature)
                 $tables = $dbi->getTables($db);
                 $totalNumTables = count($tables);
-                if (! (isset($subPart) && $subPart === '_export')) {
+                if ($subPart !== '_export') {
                     // fetch the details for a possible limited subset
                     $limitOffset = $pos;
                     $limitCount = true;
@@ -2317,7 +2317,7 @@ class Util
          * If coming from a Show MySQL link on the home page,
          * put something in $sub_part
          */
-        if (empty($subPart)) {
+        if ($subPart === '') {
             $subPart = '_structure';
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -986,29 +986,14 @@ parameters:
 			path: libraries/classes/Controllers/Database/DesignerController.php
 
 		-
-			message: "#^Variable \\$sub_part on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/ExportController.php
-
-		-
 			message: "#^Negated boolean expression is always true\\.$#"
 			count: 6
-			path: libraries/classes/Controllers/Database/OperationsController.php
-
-		-
-			message: "#^Variable \\$sub_part on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
 			path: libraries/classes/Controllers/Database/OperationsController.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Database\\\\PrivilegesController\\:\\:__invoke\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/PrivilegesController.php
-
-		-
-			message: "#^Variable \\$sub_part on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/QueryByExampleController.php
 
 		-
 			message: "#^Cannot access offset string on mixed\\.$#"
@@ -1168,11 +1153,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
 			count: 2
-			path: libraries/classes/Controllers/Database/TrackingController.php
-
-		-
-			message: "#^Variable \\$sub_part on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
 			path: libraries/classes/Controllers/Database/TrackingController.php
 
 		-
@@ -1379,11 +1359,6 @@ parameters:
 			message: "#^Property PhpMyAdmin\\\\Controllers\\\\Server\\\\DatabasesController\\:\\:\\$transformations is never read, only written\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Server/DatabasesController.php
-
-		-
-			message: "#^Variable \\$sub_part on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/PrivilegesController.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Server\\\\Status\\\\Processes\\\\KillController\\:\\:__invoke\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1138,12 +1138,6 @@
       <code>$each_table</code>
       <code>$table_select</code>
     </MixedAssignment>
-    <RedundantCondition occurrences="1">
-      <code>$sub_part</code>
-    </RedundantCondition>
-    <TypeDoesNotContainNull occurrences="1">
-      <code>''</code>
-    </TypeDoesNotContainNull>
   </file>
   <file src="libraries/classes/Controllers/Database/ImportController.php">
     <MixedArgument occurrences="2">
@@ -1237,7 +1231,7 @@
       <code>$db</code>
       <code>$db</code>
     </MixedAssignment>
-    <RedundantCondition occurrences="11">
+    <RedundantCondition occurrences="10">
       <code>! $_error</code>
       <code>! $_error</code>
       <code>! $_error</code>
@@ -1248,11 +1242,7 @@
       <code>! $_error</code>
       <code>! $_error</code>
       <code>$_error</code>
-      <code>$sub_part</code>
     </RedundantCondition>
-    <TypeDoesNotContainNull occurrences="1">
-      <code>''</code>
-    </TypeDoesNotContainNull>
   </file>
   <file src="libraries/classes/Controllers/Database/PrivilegesController.php">
     <MixedArgument occurrences="1">
@@ -1278,12 +1268,6 @@
     <MixedArrayAssignment occurrences="1">
       <code>$urlParams['goto']</code>
     </MixedArrayAssignment>
-    <RedundantCondition occurrences="1">
-      <code>$sub_part</code>
-    </RedundantCondition>
-    <TypeDoesNotContainNull occurrences="1">
-      <code>''</code>
-    </TypeDoesNotContainNull>
   </file>
   <file src="libraries/classes/Controllers/Database/RoutinesController.php">
     <MixedArgument occurrences="8">
@@ -1782,12 +1766,6 @@
       <code>$entry['statement']</code>
       <code>$entry['username']</code>
     </MixedOperand>
-    <RedundantCondition occurrences="1">
-      <code>$sub_part</code>
-    </RedundantCondition>
-    <TypeDoesNotContainNull occurrences="1">
-      <code>''</code>
-    </TypeDoesNotContainNull>
   </file>
   <file src="libraries/classes/Controllers/Database/TriggersController.php">
     <MixedArgument occurrences="4">
@@ -2494,12 +2472,6 @@
       <code>$export</code>
       <code>$title</code>
     </MixedOperand>
-    <RedundantCondition occurrences="1">
-      <code>$sub_part</code>
-    </RedundantCondition>
-    <TypeDoesNotContainNull occurrences="1">
-      <code>''</code>
-    </TypeDoesNotContainNull>
     <UnusedVariable occurrences="1">
       <code>$key</code>
     </UnusedVariable>


### PR DESCRIPTION
The whole global `$sub_part` looks fishy, but I wasn't able to identify what purpose it actually fulfils as a global. To remove static analysis issues I removed `??` in places where it was clearly defined and made the parameter non-nullable. According to my analysis it was set to null only in a single place where it was not used anyway. 

Side note: I have been running Psalm and PHPStan with PHP 8.0 until now but recent changes have made it unmanageable so I had to downgrade to PHP 7.4. 7d3c84a88163237211b9908978d473e91657ce3f has reversed psalm-baseline.xml update so when I run `-set-baseline=` again it added the same lines once more. I don't know if it was intentional or not. 