### PR TITLE
Set autocomplete off for 'change password' and 'login information' forms

### DIFF
--- a/templates/server/privileges/change_password.twig
+++ b/templates/server/privileges/change_password.twig
@@ -1,5 +1,5 @@
 <form method="post" id="change_password_form" action="
-  {{- is_privileges ? url('/server/privileges') : url('/user-password') }}" name="chgPassword" class="{{ is_privileges ? 'submenu-item' }}">
+  {{- is_privileges ? url('/server/privileges') : url('/user-password') }}" name="chgPassword" class="{{ is_privileges ? 'submenu-item' }}" autocomplete="off">
   {{ get_hidden_inputs() }}
   {% if is_privileges %}
     <input type="hidden" name="username" value="{{ username }}">

--- a/templates/server/privileges/user_properties.twig
+++ b/templates/server/privileges/user_properties.twig
@@ -94,7 +94,7 @@
 
   {{ change_password|raw }}
 
-  <form action="{{ url('/server/privileges') }}" id="copyUserForm" method="post" class="copyUserForm submenu-item">
+  <form action="{{ url('/server/privileges') }}" id="copyUserForm" method="post" class="copyUserForm submenu-item" autocomplete="off">
     {{ get_hidden_inputs() }}
     <input type="hidden" name="old_username" value="{{ username }}">
     <input type="hidden" name="old_hostname" value="{{ hostname }}">


### PR DESCRIPTION
Signed-off-by: jonahtanjz <jonahtanjz8@gmail.com>

### Description

Add the `autocomplete="off"` attribute to the "change password" and "login information" forms as described here https://github.com/phpmyadmin/phpmyadmin/issues/17163#issuecomment-950285524


Fixes #17163 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
