### PR TITLE
Static analysis 3

### DIFF
--- a/libraries/classes/Controllers/Table/Structure/ChangeController.php
+++ b/libraries/classes/Controllers/Table/Structure/ChangeController.php
@@ -69,7 +69,7 @@ final class ChangeController extends AbstractController
      *
      * @param array|null $selected the selected columns
      */
-    private function displayHtmlForColumnChange($selected): void
+    private function displayHtmlForColumnChange(?array $selected): void
     {
         global $action, $num_fields;
 

--- a/libraries/classes/Controllers/Table/Structure/PrimaryController.php
+++ b/libraries/classes/Controllers/Table/Structure/PrimaryController.php
@@ -16,7 +16,6 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function count;
-use function is_array;
 
 final class PrimaryController extends AbstractController
 {
@@ -124,7 +123,7 @@ final class PrimaryController extends AbstractController
         $primary = '';
         while ($row = $this->dbi->fetchAssoc($result)) {
             // Backups the list of primary keys
-            if (! is_array($row) || $row['Key_name'] !== 'PRIMARY') {
+            if ($row['Key_name'] !== 'PRIMARY') {
                 continue;
             }
 

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -869,10 +869,6 @@ class Core
      */
     public static function safeUnserialize(string $data)
     {
-        if (! is_string($data)) {
-            return null;
-        }
-
         /* validate serialized data */
         $length = strlen($data);
         $depth = 0;

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -101,7 +101,7 @@ class Core
          * (this can happen on early fatal error)
          */
         if (
-            isset($dbi, $GLOBALS['config']) && $dbi !== null
+            isset($dbi, $GLOBALS['config'])
             && $GLOBALS['config']->get('is_setup') === false
             && ResponseRenderer::getInstance()->isAjax()
         ) {
@@ -494,8 +494,7 @@ class Core
         // inform the server that compression has been done,
         // to avoid a double compression (for example with Apache + mod_deflate)
         $notChromeOrLessThan43 = $GLOBALS['config']->get('PMA_USR_BROWSER_AGENT') !== 'CHROME' // see bug #4942
-            || ($GLOBALS['config']->get('PMA_USR_BROWSER_AGENT') === 'CHROME'
-                && $GLOBALS['config']->get('PMA_USR_BROWSER_VER') < 43);
+            || $GLOBALS['config']->get('PMA_USR_BROWSER_VER') < 43;
 
         if (str_contains($mimetype, 'gzip') && $notChromeOrLessThan43) {
             $headers['Content-Encoding'] = 'gzip';

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -491,12 +491,10 @@ class Core
         }
 
         $headers['Content-Type'] = $mimetype;
+
         // inform the server that compression has been done,
         // to avoid a double compression (for example with Apache + mod_deflate)
-        $notChromeOrLessThan43 = $GLOBALS['config']->get('PMA_USR_BROWSER_AGENT') !== 'CHROME' // see bug #4942
-            || $GLOBALS['config']->get('PMA_USR_BROWSER_VER') < 43;
-
-        if (str_contains($mimetype, 'gzip') && $notChromeOrLessThan43) {
+        if (str_contains($mimetype, 'gzip') && $GLOBALS['config']->get('PMA_USR_BROWSER_AGENT') !== 'CHROME') {
             $headers['Content-Encoding'] = 'gzip';
         }
 

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -483,8 +483,7 @@ class Results
         $bIsProcessList = isset($which[1]);
         if ($bIsProcessList) {
             $str = ' ' . strtoupper($which[1]);
-            $bIsProcessList = $bIsProcessList
-                && strpos($str, 'PROCESSLIST') > 0;
+            $bIsProcessList = strpos($str, 'PROCESSLIST') > 0;
         }
 
         if ($bIsProcessList) {
@@ -3852,7 +3851,7 @@ class Results
 
         // 2.1 Prepares a messages with position information
         $sqlQueryMessage = '';
-        if (($displayParts['nav_bar'] == '1') && $posNext !== null) {
+        if (($displayParts['nav_bar'] == '1')) {
             $message = $this->setMessageInformation(
                 $sortedColumnMessage,
                 $analyzedSqlResults,
@@ -4134,7 +4133,7 @@ class Results
      * @access private
      */
     private function setMessageInformation(
-        $sortedColumnMessage,
+        string $sortedColumnMessage,
         array $analyzedSqlResults,
         $total,
         $posNext,
@@ -4211,9 +4210,7 @@ class Results
         $messageQueryTime->addParam($this->properties['querytime']);
 
         $message->addMessage($messageQueryTime, '');
-        if ($sortedColumnMessage !== null) {
-            $message->addHtml($sortedColumnMessage, '');
-        }
+        $message->addHtml($sortedColumnMessage, '');
 
         return $message;
     }

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -2305,10 +2305,6 @@ class Results
 
         $displayParams = $this->properties['display_params'];
 
-        if (! is_array($map)) {
-            $map = [];
-        }
-
         $rowNumber = 0;
         $displayParams['edit'] = [];
         $displayParams['copy'] = [];

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -110,14 +110,11 @@ class Export
          * and gz compression was not asked via $cfg['OBGzip']
          * but transparent compression does not apply when saving to server
          */
-        $chromeAndGreaterThan43 = $GLOBALS['config']->get('PMA_USR_BROWSER_AGENT') == 'CHROME'
-            && $GLOBALS['config']->get('PMA_USR_BROWSER_VER') >= 43; // see bug #4942
-
         return function_exists('gzencode')
             && ((! ini_get('zlib.output_compression')
                     && ! $this->isGzHandlerEnabled())
                 || $GLOBALS['save_on_server']
-                || $chromeAndGreaterThan43);
+                || $GLOBALS['config']->get('PMA_USR_BROWSER_AGENT') === 'CHROME');
     }
 
     /**

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -31,7 +31,6 @@ use function ini_get;
 use function is_array;
 use function is_file;
 use function is_numeric;
-use function is_object;
 use function is_string;
 use function is_writable;
 use function mb_strlen;
@@ -1332,7 +1331,7 @@ class Export
         $exportPlugin = Plugins::getPlugin('schema', $exportType);
 
         // Check schema export type
-        if ($exportPlugin === null || ! is_object($exportPlugin)) {
+        if ($exportPlugin === null) {
             Core::fatalError(__('Bad type!'));
         }
 

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -930,8 +930,7 @@ class Import
 
         /* If the passed array is not of the correct form, do not process it */
         if (
-            ! is_array($table)
-            || is_array($table[self::TBL_NAME])
+            is_array($table[self::TBL_NAME])
             || ! is_array($table[self::COL_NAMES])
             || ! is_array($table[self::ROWS])
         ) {

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -1024,23 +1024,9 @@ class Import
         $import_notice = null;
 
         /* Take care of the options */
-        if (isset($options['db_collation']) && $options['db_collation'] !== null) {
-            $collation = $options['db_collation'];
-        } else {
-            $collation = 'utf8_general_ci';
-        }
-
-        if (isset($options['db_charset']) && $options['db_charset'] !== null) {
-            $charset = $options['db_charset'];
-        } else {
-            $charset = 'utf8';
-        }
-
-        if (isset($options['create_db'])) {
-            $createDb = $options['create_db'];
-        } else {
-            $createDb = true;
-        }
+        $collation = $options['db_collation'] ?? 'utf8_general_ci';
+        $charset = $options['db_charset'] ?? 'utf8';
+        $createDb = $options['create_db'] ?? true;
 
         /**
          * Create SQL code to handle the database

--- a/libraries/classes/Normalization.php
+++ b/libraries/classes/Normalization.php
@@ -146,10 +146,7 @@ class Normalization
         $mimeMap = [];
         if ($relationParameters->mimework && $GLOBALS['cfg']['BrowseMIME']) {
             $mimeMap = $this->transformations->getMime($db, $table);
-            $availableMimeTypes = $this->transformations->getAvailableMimeTypes();
-            if ($availableMimeTypes !== null) {
-                $availableMime = $availableMimeTypes;
-            }
+            $availableMime = $this->transformations->getAvailableMimeTypes();
         }
 
         $relationParams = $relationParameters->toArray();

--- a/libraries/classes/ReplicationGui.php
+++ b/libraries/classes/ReplicationGui.php
@@ -12,7 +12,6 @@ use PhpMyAdmin\Query\Utilities;
 use function __;
 use function htmlspecialchars;
 use function in_array;
-use function is_array;
 use function mb_strrpos;
 use function mb_strtolower;
 use function mb_substr;
@@ -281,7 +280,7 @@ class ReplicationGui
 
         $variables = [];
         foreach ($replicationVariables as $variable) {
-            $serverReplicationVariable = is_array($serverReplication) && isset($serverReplication[0])
+            $serverReplicationVariable = isset($serverReplication[0])
                 ? $serverReplication[0][$variable]
                 : '';
 

--- a/libraries/classes/ReplicationInfo.php
+++ b/libraries/classes/ReplicationInfo.php
@@ -103,10 +103,7 @@ final class ReplicationInfo
         $this->primaryStatus = $this->dbi->fetchResult('SHOW MASTER STATUS');
     }
 
-    /**
-     * @return array
-     */
-    public function getPrimaryStatus()
+    public function getPrimaryStatus(): array
     {
         return $this->primaryStatus;
     }
@@ -116,10 +113,7 @@ final class ReplicationInfo
         $this->replicaStatus = $this->dbi->fetchResult('SHOW SLAVE STATUS');
     }
 
-    /**
-     * @return array
-     */
-    public function getReplicaStatus()
+    public function getReplicaStatus(): array
     {
         return $this->replicaStatus;
     }

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -602,8 +602,6 @@ class Privileges
         $table = '*',
         $submit = true
     ) {
-        $sqlQuery = '';
-
         if ($db === '*') {
             $table = '*';
         }
@@ -621,11 +619,7 @@ class Privileges
         if (empty($row)) {
             if ($table === '*' && $this->dbi->isSuperUser()) {
                 $row = [];
-                if ($db === '*') {
-                    $sqlQuery = 'SHOW COLUMNS FROM `mysql`.`user`;';
-                } elseif ($table === '*') {
-                    $sqlQuery = 'SHOW COLUMNS FROM `mysql`.`db`;';
-                }
+                $sqlQuery = 'SHOW COLUMNS FROM `mysql`.' . ($db === '*' ? '`user`' : '`db`') . ';';
 
                 $res = $this->dbi->query($sqlQuery);
                 while ($row1 = $this->dbi->fetchRow($res)) {

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -732,7 +732,7 @@ class Sql
             // "Showing rows..." message
             // $_SESSION['tmpval']['max_rows'] = 'all';
             $unlimNumRows = $numRows;
-        } elseif ($this->isAppendLimitClause($analyzedSqlResults) && $_SESSION['tmpval']['max_rows'] > $numRows) {
+        } elseif ($_SESSION['tmpval']['max_rows'] > $numRows) {
             // When user has not defined a limit in query and total rows in
             // result are less than max_rows to display, there is no need
             // to count total rows for that query again

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -48,7 +48,6 @@ final class ColumnsDefinition
      * @param string|null       $regenerate      Use regeneration
      * @param array|null        $selected        Selected
      * @param array|null        $fields_meta     Fields meta
-     * @param array|null        $field_fulltext  Fields full text
      *
      * @return array<string, mixed>
      */
@@ -59,9 +58,8 @@ final class ColumnsDefinition
         string $action,
         $num_fields = 0,
         $regenerate = null,
-        $selected = null,
-        $fields_meta = null,
-        $field_fulltext = null
+        ?array $selected = null,
+        $fields_meta = null
     ): array {
         global $db, $table, $cfg, $col_priv, $is_reload_priv, $mime_map;
 
@@ -105,7 +103,7 @@ final class ColumnsDefinition
             ]
         );
 
-        if (isset($selected) && is_array($selected)) {
+        if (is_array($selected)) {
             foreach ($selected as $o_fld_nr => $o_fld_val) {
                 $form_params['selected[' . $o_fld_nr . ']'] = $o_fld_val;
             }
@@ -143,15 +141,6 @@ final class ColumnsDefinition
                     $available_mime[$mime_type . '_file'][$mimekey],
                     '@'
                 );
-            }
-        }
-
-        //  workaround for field_fulltext, because its submitted indices contain
-        //  the index as a value, not a key. Inserted here for easier maintenance
-        //  and less code to change in existing files.
-        if (isset($field_fulltext) && is_array($field_fulltext)) {
-            foreach ($field_fulltext as $fulltext_indexkey) {
-                $submit_fulltext[$fulltext_indexkey] = $fulltext_indexkey;
             }
         }
 
@@ -247,9 +236,7 @@ final class ColumnsDefinition
                     );
                 }
 
-                $columnMeta['Comment'] = isset($submit_fulltext[$columnNumber])
-                && ($submit_fulltext[$columnNumber] == $columnNumber)
-                    ? 'FULLTEXT' : false;
+                $columnMeta['Comment'] = false;
 
                 switch ($columnMeta['DefaultType']) {
                     case 'NONE':

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -81,13 +81,8 @@ class Tracker
         $relationParameters = $relation->getRelationParameters();
         /* Restore original state */
         Cache::set(self::TRACKER_ENABLED_CACHE_KEY, true);
-        if (! $relationParameters->trackingwork) {
-            return false;
-        }
 
-        $table = self::getTrackingTable();
-
-        return $table !== null;
+        return $relationParameters->trackingwork;
     }
 
     /**
@@ -936,10 +931,8 @@ class Tracker
 
     /**
      * Returns the tracking table
-     *
-     * @return string tracking table
      */
-    private static function getTrackingTable()
+    private static function getTrackingTable(): string
     {
         global $dbi;
 

--- a/libraries/classes/Transformations.php
+++ b/libraries/classes/Transformations.php
@@ -110,7 +110,7 @@ class Transformations
      * @staticvar array $stack
      * @access public
      */
-    public function getAvailableMimeTypes()
+    public function getAvailableMimeTypes(): array
     {
         static $stack = null;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3956,11 +3956,6 @@ parameters:
 			path: libraries/classes/Export.php
 
 		-
-			message: "#^Result of \\|\\| is always false\\.$#"
-			count: 1
-			path: libraries/classes/Export.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between PhpMyAdmin\\\\Plugins\\\\SchemaPlugin and null will always evaluate to false\\.$#"
 			count: 1
 			path: libraries/classes/Export.php
@@ -9159,11 +9154,6 @@ parameters:
 			message: "#^Property PhpMyAdmin\\\\Table\\:\\:\\$uiprefs type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Table.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Table\\\\ColumnsDefinition\\:\\:displayForm\\(\\) has parameter \\$field_fulltext with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Table/ColumnsDefinition.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Table\\\\ColumnsDefinition\\:\\:displayForm\\(\\) has parameter \\$fields_meta with no value type specified in iterable type array\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3166,11 +3166,6 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Left side of && is always true\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getBulkLinks\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
@@ -8557,11 +8552,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method save\\(\\) on PhpMyAdmin\\\\Bookmark\\|false\\.$#"
-			count: 1
-			path: libraries/classes/Sql.php
-
-		-
-			message: "#^Left side of && is always true\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3641,9 +3641,6 @@
     <MixedOperand occurrences="1">
       <code>$row['Column_name']</code>
     </MixedOperand>
-    <TypeDoesNotContainType occurrences="1">
-      <code>! is_array($row)</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/ReservedWordCheckController.php">
     <MixedArgument occurrences="1">
@@ -4240,9 +4237,6 @@
       <code>$GLOBALS['config'] !== null</code>
       <code>isset($dbi, $GLOBALS['config'])</code>
     </RedundantCondition>
-    <TypeDoesNotContainType occurrences="1">
-      <code>is_string($data)</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="libraries/classes/CreateAddField.php">
     <MixedArgument occurrences="39">
@@ -6182,9 +6176,6 @@
       <code>isset($fieldsMeta-&gt;table)</code>
       <code>isset($meta-&gt;internalMediaType)</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
-      <code>is_array($map)</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="libraries/classes/Encoding.php">
     <DocblockTypeContradiction occurrences="3">
@@ -6385,8 +6376,7 @@
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Export.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_object($exportPlugin)</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>$exportPlugin === null</code>
     </DocblockTypeContradiction>
     <InvalidReturnStatement occurrences="1">
@@ -7835,9 +7825,6 @@
       <code>(string) $cell</code>
       <code>(string) $cell</code>
     </RedundantCast>
-    <TypeDoesNotContainType occurrences="1">
-      <code>! is_array($table)</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="libraries/classes/Import/Ajax.php">
     <MixedArrayAccess occurrences="1">
@@ -12626,9 +12613,6 @@
     <PossiblyFalseOperand occurrences="1">
       <code>mb_strrpos($currentUser, '@')</code>
     </PossiblyFalseOperand>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>is_array($serverReplication)</code>
-    </RedundantConditionGivenDocblockType>
     <UnusedFunctionCall occurrences="2">
       <code>strtok</code>
       <code>strtok</code>
@@ -14267,7 +14251,7 @@
       <code>$columnMeta['column_status']['isEditable']</code>
       <code>$mime_map[$columnMeta['Field']]</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="16">
+    <MixedArrayAssignment occurrences="15">
       <code>$available_mime[$mime_type . '_file_quoted'][$mimekey]</code>
       <code>$columnMeta['Default']</code>
       <code>$columnMeta['DefaultType']</code>
@@ -14283,16 +14267,14 @@
       <code>$columnMeta['Expression']</code>
       <code>$columnMeta['Type']</code>
       <code>$mime_map[$columnMeta['Field']]</code>
-      <code>$submit_fulltext[$fulltext_indexkey]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="5">
+    <MixedArrayOffset occurrences="4">
       <code>$comments_map[$columnMeta['Field']]</code>
       <code>$expressions[$columnMeta['Field']]</code>
       <code>$mime_map[$columnMeta['Field']]</code>
       <code>$mime_map[$columnMeta['Field']]</code>
-      <code>$submit_fulltext[$fulltext_indexkey]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="23">
+    <MixedAssignment occurrences="21">
       <code>$columnMeta</code>
       <code>$columnMeta['Default']</code>
       <code>$columnMeta['Default']</code>
@@ -14308,24 +14290,13 @@
       <code>$form_params['field_orig[' . $columnNumber . ']']</code>
       <code>$form_params['selected[' . $o_fld_nr . ']']</code>
       <code>$form_params['table']</code>
-      <code>$fulltext_indexkey</code>
       <code>$length</code>
       <code>$length</code>
       <code>$move_columns</code>
       <code>$o_fld_val</code>
       <code>$submit_attribute</code>
-      <code>$submit_fulltext[$fulltext_indexkey]</code>
       <code>$type</code>
     </MixedAssignment>
-    <PossiblyUndefinedVariable occurrences="1">
-      <code>$submit_fulltext</code>
-    </PossiblyUndefinedVariable>
-    <RedundantConditionGivenDocblockType occurrences="4">
-      <code>is_array($field_fulltext)</code>
-      <code>is_array($selected)</code>
-      <code>isset($field_fulltext) &amp;&amp; is_array($field_fulltext)</code>
-      <code>isset($selected) &amp;&amp; is_array($selected)</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/Table/Indexes.php">
     <MixedArgument occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4236,9 +4236,8 @@
     <RedundantCast occurrences="1">
       <code>(string) gmdate(DATE_RFC1123)</code>
     </RedundantCast>
-    <RedundantCondition occurrences="4">
+    <RedundantCondition occurrences="2">
       <code>$GLOBALS['config'] !== null</code>
-      <code>$dbi !== null</code>
       <code>isset($dbi, $GLOBALS['config'])</code>
     </RedundantCondition>
     <TypeDoesNotContainType occurrences="1">
@@ -6175,17 +6174,11 @@
       <code>(string) $fieldsMeta[$i]-&gt;name</code>
       <code>(string) $fieldsMeta[$i]-&gt;name</code>
     </RedundantCastGivenDocblockType>
-    <RedundantCondition occurrences="1">
-      <code>$bIsProcessList</code>
-    </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="9">
+    <RedundantConditionGivenDocblockType occurrences="6">
       <code>$fieldsMeta-&gt;name</code>
       <code>$firstStatement-&gt;order</code>
       <code>$meta-&gt;decimals</code>
       <code>$meta-&gt;decimals</code>
-      <code>$posNext !== null</code>
-      <code>$sortedColumnMessage !== null</code>
-      <code>($displayParts['nav_bar'] == '1') &amp;&amp; $posNext !== null</code>
       <code>isset($fieldsMeta-&gt;table)</code>
       <code>isset($meta-&gt;internalMediaType)</code>
     </RedundantConditionGivenDocblockType>
@@ -8985,9 +8978,6 @@
     <RedundantCast occurrences="1">
       <code>(array) $partialDependencies</code>
     </RedundantCast>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$availableMimeTypes !== null</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/OpenDocument.php">
     <InvalidReturnStatement occurrences="1">
@@ -13200,9 +13190,6 @@
       <code>(bool) ! $this-&gt;dbi-&gt;fetchValue($sql)</code>
       <code>(string) $privs</code>
     </RedundantCastGivenDocblockType>
-    <RedundantCondition occurrences="1">
-      <code>$table === '*'</code>
-    </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$userGroup</code>
     </RedundantConditionGivenDocblockType>
@@ -14549,10 +14536,9 @@
     <RedundantCondition occurrences="1">
       <code>$dbname</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="5">
+    <RedundantConditionGivenDocblockType occurrences="4">
       <code>$statement-&gt;name !== null</code>
       <code>$statement-&gt;name !== null</code>
-      <code>$table !== null</code>
       <code>$version</code>
       <code>isset($statement-&gt;options)</code>
     </RedundantConditionGivenDocblockType>

--- a/test/selenium/TestBase.php
+++ b/test/selenium/TestBase.php
@@ -1146,7 +1146,7 @@ abstract class TestBase extends TestCase
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         curl_exec($ch);
-        if ($ch !== false && curl_errno($ch)) {
+        if (curl_errno($ch)) {
             echo 'Error: ' . curl_error($ch) . PHP_EOL;
         }
 
@@ -1181,7 +1181,7 @@ abstract class TestBase extends TestCase
             echo 'Test failed, get more information here: ' . $proj->automation_session->public_url . PHP_EOL;
         }
 
-        if ($ch !== false && curl_errno($ch)) {
+        if (curl_errno($ch)) {
             echo 'Error: ' . curl_error($ch) . PHP_EOL;
         }
 


### PR DESCRIPTION
This is another one of static analysis fixes. This time I have executed the optional PHPStan checks `checkAlwaysTrueCheckTypeFunctionCall` and `checkAlwaysTrueStrictComparison`. The fixes below are mostly from these two checks. I have left many others unfixed as they were either false positives or not so easy to fix. 

There are a couple of changes here that I am unsure about:
- `getTrackingTable()` looks like it might be having side effects, but its return value is not used meaningfully. I wasn't sure if it can be removed or not. 
- parameter `$field_fulltext` in `ColumnDefinition::displayForm()` has never been used in the code. Therefore the whole functionality looks to be unused. I removed it, but maybe it was a bug and the functionality is needed just not used currently. 
- on line 1330 in Export.php there is a `@var` annotation that isn't correct. It's possible that `Core::fatalError` should be marked as terminating in Psalm and PHPStan config and then the `@var` annotation should contain `null` type as well. I couldn't decide on the right choice of action and left it as it is now. 

Please let me know if I should revert some of these changes. 