### PR TITLE
FR: Improve performance of Config classes

### DIFF
--- a/libraries/classes/Config/Descriptions.php
+++ b/libraries/classes/Config/Descriptions.php
@@ -54,18 +54,38 @@ class Descriptions
         return Sanitize::sanitizeMessage($value);
     }
 
+    /**
+     * @return array<string, string>
+     */
     private static function getComments(): array
     {
-        return [
+        /** @var array<string, string> $commentsMap */
+        static $commentsMap = [];
+
+        if ($commentsMap !== []) {
+            return $commentsMap;
+        }
+
+        return $commentsMap = [
             'MaxDbList_cmt' => __('Users cannot set a higher value'),
             'MaxTableList_cmt' => __('Users cannot set a higher value'),
             'QueryHistoryMax_cmt' => __('Users cannot set a higher value'),
         ];
     }
 
+    /**
+     * @return array<string, string>
+     */
     private static function getDescriptions(): array
     {
-        return [
+        /** @var array<string, string> $descriptionsMap */
+        static $descriptionsMap = [];
+
+        if ($descriptionsMap !== []) {
+            return $descriptionsMap;
+        }
+
+        return $descriptionsMap = [
             'AllowArbitraryServer_desc' => __(
                 'If enabled, user can enter any MySQL server in login form for cookie auth.'
             ),
@@ -582,9 +602,19 @@ class Descriptions
         ];
     }
 
+    /**
+     * @return array<string, string>
+     */
     private static function getNames(): array
     {
-        return [
+        /** @var array<string, string> $namesMap */
+        static $namesMap = [];
+
+        if ($namesMap !== []) {
+            return $namesMap;
+        }
+
+        return $namesMap = [
             'AllowArbitraryServer_name' => __('Allow login to any MySQL server'),
             'ArbitraryServerRegexp_name' => __('Restrict login to MySQL server'),
             'AllowThirdPartyFraming_name' => __('Allow third party framing'),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -281,11 +281,6 @@ parameters:
 			path: libraries/classes/Config.php
 
 		-
-			message: "#^Empty array passed to foreach\\.$#"
-			count: 1
-			path: libraries/classes/Config/ConfigFile.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Config\\\\ConfigFile\\:\\:__construct\\(\\) has parameter \\$baseConfig with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Config/ConfigFile.php
@@ -302,6 +297,16 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Config\\\\ConfigFile\\:\\:getConfigArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: libraries/classes/Config/ConfigFile.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\Config\\\\ConfigFile\\:\\:getFlatArray\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: libraries/classes/Config/ConfigFile.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\Config\\\\ConfigFile\\:\\:getFlatArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Config/ConfigFile.php
 
@@ -372,11 +377,6 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\Config\\\\ConfigFile\\:\\:\\$defaultCfg type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Config/ConfigFile.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Config\\\\ConfigFile\\:\\:\\$flattenArrayResult type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Config/ConfigFile.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -391,21 +391,6 @@ parameters:
 			path: libraries/classes/Config/ConfigFile.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Config\\\\Descriptions\\:\\:getComments\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Config/Descriptions.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Config\\\\Descriptions\\:\\:getDescriptions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Config/Descriptions.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Config\\\\Descriptions\\:\\:getNames\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Config/Descriptions.php
-
-		-
 			message: "#^Empty array passed to foreach\\.$#"
 			count: 1
 			path: libraries/classes/Config/Form.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -547,14 +547,6 @@
       <code>count($this-&gt;cfgDb['_overrides'])</code>
     </TypeDoesNotContainType>
   </file>
-  <file src="libraries/classes/Config/Descriptions.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string|null</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$descriptions[$key] ?? null</code>
-    </MixedReturnStatement>
-  </file>
   <file src="libraries/classes/Config/Form.php">
     <MissingClosureParamType occurrences="6">
       <code>$key</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -457,20 +457,6 @@
     <InvalidIterator occurrences="1">
       <code>$this-&gt;cfgDb['_overrides']</code>
     </InvalidIterator>
-    <MissingClosureParamType occurrences="12">
-      <code>$key</code>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingClosureParamType>
     <MixedArgument occurrences="12">
       <code>$_SESSION[$this-&gt;id]</code>
       <code>$_SESSION[$this-&gt;id]</code>
@@ -497,11 +483,10 @@
     <MixedArrayAssignment occurrences="1">
       <code>$_SESSION[$this-&gt;id]['Servers'][$i]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="2">
+    <MixedArrayOffset occurrences="1">
       <code>$c[$mapFrom]</code>
-      <code>$this-&gt;cfgUpdateReadMapping[$path]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="16">
+    <MixedAssignment occurrences="17">
       <code>$_SESSION[$this-&gt;id]['Servers'][$i]</code>
       <code>$c</code>
       <code>$c[$k]</code>
@@ -513,8 +498,9 @@
       <code>$mapFrom</code>
       <code>$path</code>
       <code>$path</code>
-      <code>$path</code>
       <code>$port</code>
+      <code>$result[$prefix . $key]</code>
+      <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$verbose</code>
@@ -524,11 +510,8 @@
       <code>array</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="7">
-      <code>$key</code>
+    <MixedOperand occurrences="4">
       <code>$port</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
       <code>$this-&gt;getValue($path . '/host')</code>
       <code>$this-&gt;getValue($path . '/socket')</code>
       <code>$this-&gt;getValue($path . '/user')</code>


### PR DESCRIPTION
This PR is a feature request for a very simple performance improvement. It contains two unrelated changes:

1. In the Descriptions.php class there are 3 methods that are providing an array of descriptions in the currently selected language. They are calling `__()` internally which proves to be very expensive. It essentially calls a number of functions for each text multiple times. To avoid this, we call `__()` once for each string and buffer the results in a static variable. When the array is requested again, we provide buffered results. The assumption here is that the results of `__()` should not change in between. 
2. The functionality for flattening array is usually complex. It uses private property, multiple `array_walk`s, recursive functions, and unnecessary closures. I have considered using `RecursiveIteratorIterator` but due to the `! isset($value[0])` I couldn't use it, and it was also slower than current implementation. The next best thing was a simple loop with a recursive call. This proved to be 50%-90% faster than current implementation and much simpler. 

Altogether, these improvements reduced page load time on my development machine by 30% without any regressions. I hope the performance improves in other environments too.

Ref: #16005