### PR TITLE
Fix #17228 - Resolve formatting of copy to clipboard with NULL values

### DIFF
--- a/js/src/sql.js
+++ b/js/src/sql.js
@@ -376,7 +376,9 @@ AJAX.registerOnload('sql.js', function () {
         textArea.value += '\n';
         $('.table_results tbody tr').each(function () {
             $(this).find('.data span').each(function () {
-                textArea.value += $(this).text() + '\t';
+                // Extract <em> tag for NULL values before converting to string to not mess up formatting
+                var data = $(this).find('em').length !== 0 ? $(this).find('em')[0] : this;
+                textArea.value += $(data).text() + '\t';
             });
             textArea.value += '\n';
         });


### PR DESCRIPTION
Signed-off-by: jonahtanjz <jonahtanjz8@gmail.com>

### Description

`NULL` values are nested in an `<em>` tag which causes the formatting to be off when `text()` method is called on the parent tag, `<span>`. If a `<span>` contains `<em>` tag, call the `text()` method on the `<em>` tag instead to resolve the formatting issue.

Before:
![image](https://user-images.githubusercontent.com/47470981/145242054-84d85448-31ac-4ad1-9136-384b85dbf733.png)

After:
![image](https://user-images.githubusercontent.com/47470981/145242106-71b8879a-aa5f-4380-b808-cf5497294855.png)


Fixes #17228 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
