### PR TITLE
Fix var annotation for Charset and Collation

### DIFF
--- a/libraries/classes/Charsets.php
+++ b/libraries/classes/Charsets.php
@@ -27,7 +27,7 @@ class Charsets
     /**
      * MySQL charsets map
      *
-     * @var array
+     * @var array<string, string>
      */
     public static $mysqlCharsetMap = [
         'big5' => 'big5',
@@ -192,7 +192,7 @@ class Charsets
      * @param DatabaseInterface $dbi       DatabaseInterface instance
      * @param bool              $disableIs Disable use of INFORMATION_SCHEMA
      *
-     * @return array
+     * @return array<string, Charset>
      */
     public static function getCharsets(DatabaseInterface $dbi, bool $disableIs): array
     {
@@ -207,7 +207,7 @@ class Charsets
      * @param DatabaseInterface $dbi       DatabaseInterface instance
      * @param bool              $disableIs Disable use of INFORMATION_SCHEMA
      *
-     * @return array
+     * @return array<string, array<string, Collation>>
      */
     public static function getCollations(DatabaseInterface $dbi, bool $disableIs): array
     {
@@ -223,12 +223,7 @@ class Charsets
      */
     public static function findCollationByName(DatabaseInterface $dbi, bool $disableIs, ?string $name): ?Collation
     {
-        $pieces = explode('_', (string) $name);
-        if ($pieces === false || ! isset($pieces[0])) {
-            return null;
-        }
-
-        $charset = $pieces[0];
+        $charset = explode('_', $name ?? '')[0];
         $collations = self::getCollations($dbi, $disableIs);
 
         return $collations[$charset][$name] ?? null;

--- a/libraries/classes/Charsets/Charset.php
+++ b/libraries/classes/Charsets/Charset.php
@@ -59,7 +59,8 @@ final class Charset
     }
 
     /**
-     * @param array $state State obtained from the database server
+     * @param string[] $state State obtained from the database server
+     * @psalm-param array{Charset?:string, Description?:string, 'Default collation'?:string, Maxlen?:string} $state
      *
      * @return Charset
      */

--- a/libraries/classes/Charsets/Collation.php
+++ b/libraries/classes/Charsets/Collation.php
@@ -103,7 +103,7 @@ final class Collation
     }
 
     /**
-     * @param array $state State obtained from the database server
+     * @param string[] $state State obtained from the database server
      */
     public static function fromServer(array $state): self
     {
@@ -250,6 +250,9 @@ final class Collation
         return $this->buildName($name, $variant, $suffixes);
     }
 
+    /**
+     * @param string[] $suffixes
+     */
     private function buildName(string $result, ?string $variant, array $suffixes): string
     {
         if ($variant !== null) {
@@ -283,6 +286,11 @@ final class Collation
         }
     }
 
+    /**
+     * @param string[] $suffixes
+     *
+     * @return string[]
+     */
     private function addSuffixes(array $suffixes, string $part): array
     {
         switch ($part) {

--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Database;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\Charsets\Charset;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Encoding;
@@ -85,15 +84,7 @@ final class ImportController extends AbstractController
         $localImportFile = $_REQUEST['local_import_file'] ?? null;
         $compressions = Import::getCompressions();
 
-        $allCharsets = Charsets::getCharsets($this->dbi, $cfg['Server']['DisableIS']);
-        $charsets = [];
-        /** @var Charset $charset */
-        foreach ($allCharsets as $charset) {
-            $charsets[] = [
-                'name' => $charset->getName(),
-                'description' => $charset->getDescription(),
-            ];
-        }
+        $charsets = Charsets::getCharsets($this->dbi, $cfg['Server']['DisableIS']);
 
         $idKey = $_SESSION[$SESSION_KEY]['handler']::getIdKey();
         $hiddenInputs = [

--- a/libraries/classes/Controllers/HomeController.php
+++ b/libraries/classes/Controllers/HomeController.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\Charsets\Charset;
-use PhpMyAdmin\Charsets\Collation;
 use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Config;
 use PhpMyAdmin\DatabaseInterface;
@@ -119,10 +117,8 @@ class HomeController extends AbstractController
                 $charsets = Charsets::getCharsets($this->dbi, $cfg['Server']['DisableIS']);
                 $collations = Charsets::getCollations($this->dbi, $cfg['Server']['DisableIS']);
                 $charsetsList = [];
-                /** @var Charset $charset */
                 foreach ($charsets as $charset) {
                     $collationsList = [];
-                    /** @var Collation $collation */
                     foreach ($collations[$charset->getName()] as $collation) {
                         $collationsList[] = [
                             'name' => $collation->getName(),

--- a/libraries/classes/Controllers/Server/CollationsController.php
+++ b/libraries/classes/Controllers/Server/CollationsController.php
@@ -18,18 +18,18 @@ use PhpMyAdmin\Url;
  */
 class CollationsController extends AbstractController
 {
-    /** @var array|null */
+    /** @var array<string, Charset> */
     private $charsets;
 
-    /** @var array|null */
+    /** @var array<string, array<string, Collation>> */
     private $collations;
 
     /** @var DatabaseInterface */
     private $dbi;
 
     /**
-     * @param array|null $charsets
-     * @param array|null $collations
+     * @param array<string, Charset>|null                  $charsets
+     * @param array<string, array<string, Collation>>|null $collations
      */
     public function __construct(
         ResponseRenderer $response,
@@ -58,10 +58,8 @@ class CollationsController extends AbstractController
         }
 
         $charsets = [];
-        /** @var Charset $charset */
         foreach ($this->charsets as $charset) {
             $charsetCollations = [];
-            /** @var Collation $collation */
             foreach ($this->collations[$charset->getName()] as $collation) {
                 $charsetCollations[] = [
                     'name' => $collation->getName(),

--- a/libraries/classes/Controllers/Server/DatabasesController.php
+++ b/libraries/classes/Controllers/Server/DatabasesController.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Server;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\Charsets\Charset;
-use PhpMyAdmin\Charsets\Collation;
 use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\DatabaseInterface;
@@ -135,10 +133,8 @@ class DatabasesController extends AbstractController
             $charsets = Charsets::getCharsets($this->dbi, $cfg['Server']['DisableIS']);
             $collations = Charsets::getCollations($this->dbi, $cfg['Server']['DisableIS']);
             $serverCollation = $this->dbi->getServerCollation();
-            /** @var Charset $charset */
             foreach ($charsets as $charset) {
                 $collationsList = [];
-                /** @var Collation $collation */
                 foreach ($collations[$charset->getName()] as $collation) {
                     $collationsList[] = [
                         'name' => $collation->getName(),

--- a/libraries/classes/Controllers/Server/ImportController.php
+++ b/libraries/classes/Controllers/Server/ImportController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Server;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\Charsets\Charset;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\DatabaseInterface;
@@ -71,15 +70,7 @@ final class ImportController extends AbstractController
         $localImportFile = $_REQUEST['local_import_file'] ?? null;
         $compressions = Import::getCompressions();
 
-        $allCharsets = Charsets::getCharsets($this->dbi, $cfg['Server']['DisableIS']);
-        $charsets = [];
-        /** @var Charset $charset */
-        foreach ($allCharsets as $charset) {
-            $charsets[] = [
-                'name' => $charset->getName(),
-                'description' => $charset->getDescription(),
-            ];
-        }
+        $charsets = Charsets::getCharsets($this->dbi, $cfg['Server']['DisableIS']);
 
         $idKey = $_SESSION[$SESSION_KEY]['handler']::getIdKey();
         $hiddenInputs = [

--- a/libraries/classes/Controllers/Table/ImportController.php
+++ b/libraries/classes/Controllers/Table/ImportController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers\Table;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\Charsets\Charset;
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\DbTableExists;
@@ -82,15 +81,7 @@ final class ImportController extends AbstractController
         $localImportFile = $_REQUEST['local_import_file'] ?? null;
         $compressions = Import::getCompressions();
 
-        $allCharsets = Charsets::getCharsets($this->dbi, $cfg['Server']['DisableIS']);
-        $charsets = [];
-        /** @var Charset $charset */
-        foreach ($allCharsets as $charset) {
-            $charsets[] = [
-                'name' => $charset->getName(),
-                'description' => $charset->getDescription(),
-            ];
-        }
+        $charsets = Charsets::getCharsets($this->dbi, $cfg['Server']['DisableIS']);
 
         $idKey = $_SESSION[$SESSION_KEY]['handler']::getIdKey();
         $hiddenInputs = [

--- a/libraries/classes/Database/CentralColumns.php
+++ b/libraries/classes/Database/CentralColumns.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Database;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\Charsets\Charset;
-use PhpMyAdmin\Charsets\Collation;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Relation;
@@ -977,10 +975,8 @@ class CentralColumns
         $charsets = Charsets::getCharsets($this->dbi, $this->disableIs);
         $collations = Charsets::getCollations($this->dbi, $this->disableIs);
         $charsetsList = [];
-        /** @var Charset $charset */
         foreach ($charsets as $charset) {
             $collationsList = [];
-            /** @var Collation $collation */
             foreach ($collations[$charset->getName()] as $collation) {
                 $collationsList[] = [
                     'name' => $collation->getName(),

--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Database;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\Charsets\Charset;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Message;
@@ -694,7 +693,6 @@ class Routines
 
         $allCharsets = Charsets::getCharsets($this->dbi, $GLOBALS['cfg']['Server']['DisableIS']);
         $charsets = [];
-        /** @var Charset $charset */
         foreach ($allCharsets as $charset) {
             $charsets[] = [
                 'name' => $charset->getName(),

--- a/libraries/classes/Normalization.php
+++ b/libraries/classes/Normalization.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
-use PhpMyAdmin\Charsets\Charset;
-use PhpMyAdmin\Charsets\Collation;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Query\Compatibility;
 
@@ -173,10 +171,8 @@ class Normalization
         $charsets = Charsets::getCharsets($this->dbi, $GLOBALS['cfg']['Server']['DisableIS']);
         $collations = Charsets::getCollations($this->dbi, $GLOBALS['cfg']['Server']['DisableIS']);
         $charsetsList = [];
-        /** @var Charset $charset */
         foreach ($charsets as $charset) {
             $collationsList = [];
-            /** @var Collation $collation */
             foreach ($collations[$charset->getName()] as $collation) {
                 $collationsList[] = [
                     'name' => $collation->getName(),

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Table;
 
 use PhpMyAdmin\Charsets;
-use PhpMyAdmin\Charsets\Charset;
-use PhpMyAdmin\Charsets\Collation;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Partitioning\Partition;
 use PhpMyAdmin\Partitioning\TablePartitionDefinition;
@@ -470,10 +468,8 @@ final class ColumnsDefinition
         $charsets = Charsets::getCharsets($dbi, $cfg['Server']['DisableIS']);
         $collations = Charsets::getCollations($dbi, $cfg['Server']['DisableIS']);
         $charsetsList = [];
-        /** @var Charset $charset */
         foreach ($charsets as $charset) {
             $collationsList = [];
-            /** @var Collation $collation */
             foreach ($collations[$charset->getName()] as $collation) {
                 $collationsList[] = [
                     'name' => $collation->getName(),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -111,16 +111,6 @@ parameters:
 			path: libraries/classes/BrowseForeigners.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Charsets\\:\\:getCharsets\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Charsets.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Charsets\\:\\:getCollations\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Charsets.php
-
-		-
 			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Charsets.php
@@ -129,41 +119,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Charsets.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Charsets\\:\\:\\$mysqlCharsetMap type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Charsets.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between non\\-empty\\-array\\<int, string\\> and false will always evaluate to false\\.$#"
-			count: 1
-			path: libraries/classes/Charsets.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Charsets\\\\Charset\\:\\:fromServer\\(\\) has parameter \\$state with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Charsets/Charset.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Charsets\\\\Collation\\:\\:addSuffixes\\(\\) has parameter \\$suffixes with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Charsets/Collation.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Charsets\\\\Collation\\:\\:addSuffixes\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Charsets/Collation.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Charsets\\\\Collation\\:\\:buildName\\(\\) has parameter \\$suffixes with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Charsets/Collation.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Charsets\\\\Collation\\:\\:fromServer\\(\\) has parameter \\$state with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Charsets/Collation.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\CheckUserPrivileges\\:\\:getItemsFromShowGrantsRow\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -1274,36 +1229,6 @@ parameters:
 			message: "#^Property PhpMyAdmin\\\\Controllers\\\\Server\\\\BinlogController\\:\\:\\$binaryLogs type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Server/BinlogController.php
-
-		-
-			message: "#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/CollationsController.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Server\\\\CollationsController\\:\\:__construct\\(\\) has parameter \\$charsets with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/CollationsController.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Server\\\\CollationsController\\:\\:__construct\\(\\) has parameter \\$collations with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/CollationsController.php
-
-		-
-			message: "#^Offset string does not exist on array\\|null\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/CollationsController.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Controllers\\\\Server\\\\CollationsController\\:\\:\\$charsets type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/CollationsController.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Controllers\\\\Server\\\\CollationsController\\:\\:\\$collations type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/CollationsController.php
 
 		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -174,6 +174,10 @@
       <code>$res</code>
       <code>$res</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$row</code>
+      <code>$row</code>
+    </MixedArgumentTypeCoercion>
     <MixedArrayOffset occurrences="3">
       <code>self::$charsets[$row['Charset']]</code>
       <code>self::$charsets[$serverCharset]</code>
@@ -188,36 +192,10 @@
       <code>$serverCharset</code>
       <code>$serverCharset</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>?Collation</code>
-    </MixedInferredReturnType>
     <MixedPropertyTypeCoercion occurrences="2">
       <code>self::$charsets</code>
       <code>self::$collations</code>
     </MixedPropertyTypeCoercion>
-    <MixedReturnStatement occurrences="1">
-      <code>$collations[$charset][$name] ?? null</code>
-    </MixedReturnStatement>
-    <TypeDoesNotContainType occurrences="1">
-      <code>$pieces === false</code>
-    </TypeDoesNotContainType>
-  </file>
-  <file src="libraries/classes/Charsets/Charset.php">
-    <MixedArgument occurrences="3">
-      <code>$state['Charset'] ?? ''</code>
-      <code>$state['Default collation'] ?? ''</code>
-      <code>$state['Description'] ?? ''</code>
-    </MixedArgument>
-  </file>
-  <file src="libraries/classes/Charsets/Collation.php">
-    <MixedArgument occurrences="3">
-      <code>$state['Charset'] ?? ''</code>
-      <code>$state['Collation'] ?? ''</code>
-      <code>$state['Pad_attribute'] ?? ''</code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$suffixes</code>
-    </MixedArgumentTypeCoercion>
   </file>
   <file src="libraries/classes/CheckUserPrivileges.php">
     <MixedArgument occurrences="6">
@@ -2269,18 +2247,8 @@
       <code>(int) $cfg['MaxRows']</code>
     </RedundantCast>
   </file>
-  <file src="libraries/classes/Controllers/Server/CollationsController.php">
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$this-&gt;collations[$charset-&gt;getName()]</code>
-    </PossiblyNullArrayAccess>
-    <PossiblyNullIterator occurrences="2">
-      <code>$this-&gt;charsets</code>
-      <code>$this-&gt;collations[$charset-&gt;getName()]</code>
-    </PossiblyNullIterator>
-  </file>
   <file src="libraries/classes/Controllers/Server/Databases/CreateController.php">
-    <MixedArgument occurrences="7">
-      <code>$collations[$databaseCharset]</code>
+    <MixedArgument occurrences="6">
       <code>$params['db_collation']</code>
       <code>$params['db_collation']</code>
       <code>$params['db_collation']</code>
@@ -10089,7 +10057,7 @@
       <code>$oneKey['ref_index_list'][$index]</code>
       <code>$values[$val]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="37">
+    <MixedAssignment occurrences="35">
       <code>$GLOBALS['old_tz']</code>
       <code>$colAlias</code>
       <code>$colAlias</code>
@@ -10117,8 +10085,6 @@
       <code>$result</code>
       <code>$result</code>
       <code>$routine</code>
-      <code>$setNames</code>
-      <code>$setNames</code>
       <code>$statement-&gt;name-&gt;database</code>
       <code>$statement-&gt;name-&gt;table</code>
       <code>$statement-&gt;table-&gt;table</code>
@@ -10128,7 +10094,7 @@
       <code>$values[$val]</code>
       <code>$values[]</code>
     </MixedAssignment>
-    <MixedOperand occurrences="40">
+    <MixedOperand occurrences="39">
       <code>$column['Collation']</code>
       <code>$column['Type']</code>
       <code>$crlf</code>
@@ -10164,7 +10130,6 @@
       <code>$crlf</code>
       <code>$crlf</code>
       <code>$definition['Type']</code>
-      <code>$setNames</code>
       <code>$statement-&gt;entityOptions-&gt;has('AUTO_INCREMENT')</code>
       <code>$tmpUniqueCondition</code>
       <code>$trigger['drop']</code>

--- a/templates/import.twig
+++ b/templates/import.twig
@@ -113,8 +113,8 @@
             <select class="form-select" lang="en" dir="ltr" name="charset_of_file" id="charset_of_file">
               <option value=""></option>
               {% for charset in charsets %}
-                <option value="{{ charset.name }}" title="{{ charset.description }}"{{ charset.name == 'utf8' ? ' selected' }}>
-                  {{- charset.name -}}
+                <option value="{{ charset.getName() }}" title="{{ charset.getDescription() }}"{{ charset.getName() == 'utf8' ? ' selected' }}>
+                  {{- charset.getName() -}}
                 </option>
               {% endfor %}
             </select>


### PR DESCRIPTION
This PR attempts to fix types annotated in phpdoc for these two classes. Instead of putting `@var` in many places, specify the right return types and parameter types. I also changed Twig template to call getters directly. This avoids unnecessary loops in the controllers. 

While changing this, I have noticed that findCollationByName() contains a redundant `if` statement. The result of `explode()` will always be `non-empty-list<string>` so that `if` statement does not apply.