### PR TITLE
Remove most `sleep` calls from Selenium tests

### DIFF
--- a/test/selenium/Database/EventsTest.php
+++ b/test/selenium/Database/EventsTest.php
@@ -113,8 +113,6 @@ class EventsTest extends TestBase
 
         $this->byXPath("//button[contains(., 'Go')]")->click();
 
-        sleep(1);
-
         $this->waitForElement(
             'xpath',
             '//div[@class=\'alert alert-success\' and contains(., \'Event `test_event` has been created\')]'

--- a/test/selenium/Database/OperationsTest.php
+++ b/test/selenium/Database/OperationsTest.php
@@ -6,8 +6,6 @@ namespace PhpMyAdmin\Tests\Selenium\Database;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 
-use function sleep;
-
 /**
  * @coversNothing
  */
@@ -110,8 +108,6 @@ class OperationsTest extends TestBase
         $this->byCssSelector('form#copy_db_form input[name=newname]')
             ->sendKeys($new_db_name);
 
-        $this->scrollIntoView('copy_db_form', -150);
-        sleep(1);
         $this->scrollIntoView('copy_db_form', -150);
         $this->byCssSelector('form#copy_db_form input[name="submit_copy"]')->click();
 

--- a/test/selenium/Database/QueryByExampleTest.php
+++ b/test/selenium/Database/QueryByExampleTest.php
@@ -6,7 +6,6 @@ namespace PhpMyAdmin\Tests\Selenium\Database;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 
-use function sleep;
 use function trim;
 
 /**
@@ -116,9 +115,7 @@ class QueryByExampleTest extends TestBase
 
         /* Submit the query */
         $submitButton = $this->waitForElement('cssSelector', '#tblQbeFooters > input[type=submit]');
-        sleep(1);
         $this->scrollToElement($submitButton);
-        sleep(1);
         $submitButton->click();
         $this->waitAjax();
 

--- a/test/selenium/ExportTest.php
+++ b/test/selenium/ExportTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Selenium;
 
-use function sleep;
-
 /**
  * @coversNothing
  */
@@ -132,14 +130,9 @@ class ExportTest extends TestBase
         $this->waitForElement('id', 'quick_or_custom');
         $this->byCssSelector('label[for=radio_custom_export]')->click();
 
-        $this->selectByLabel(
-            $this->byId('plugins'),
-            $plugin
-        );
+        $this->selectByLabel($this->byId('plugins'), $plugin);
 
         if ($type === 'server') {
-            $this->scrollIntoView('databases_and_tables', 200);
-            sleep(1);
             $this->scrollIntoView('databases_and_tables', 200);
             $this->byId('db_unselect_all')->click();
 
@@ -155,20 +148,14 @@ class ExportTest extends TestBase
         }
 
         $this->scrollIntoView('radio_view_as_text');
-        sleep(1);
-        $this->scrollIntoView('radio_view_as_text');
         $this->byCssSelector('label[for=radio_view_as_text]')->click();
 
         if ($plugin === 'SQL') {
             if ($type !== 'db') {
                 $this->scrollIntoView('radio_sql_structure_or_data_structure_and_data');
-                sleep(1);
-                $this->scrollIntoView('radio_sql_structure_or_data_structure_and_data');
                 $this->byCssSelector('label[for=radio_sql_structure_or_data_structure_and_data]')->click();
             }
 
-            $this->scrollIntoView('checkbox_sql_if_not_exists');
-            sleep(1);
             $this->scrollIntoView('checkbox_sql_if_not_exists');
             $ele = $this->byId('checkbox_sql_if_not_exists');
             if (! $ele->isSelected()) {
@@ -177,13 +164,9 @@ class ExportTest extends TestBase
         }
 
         $this->scrollToBottom();
-        sleep(1);
-        $this->scrollToBottom();
 
         $this->byId('buttonGo')->click();
         $this->waitAjax();
-
-        sleep(1);
 
         return $this->waitForElement('id', 'textSQLDUMP')->getText();
     }

--- a/test/selenium/ImportTest.php
+++ b/test/selenium/ImportTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Selenium;
 
-use function sleep;
-
 /**
  * @coversNothing
  */
@@ -99,32 +97,18 @@ class ImportTest extends TestBase
     {
         $this->waitForElement('partialLinkText', 'Import')->click();
         $this->waitAjax();
-        $this->waitForElement('id', 'input_import_file');
 
         $this->waitForElement('id', 'localFileTab')->click();
-
-        $this->selectByValue(
-            $this->byName('local_import_file'),
-            $type . '_import.sql'
-        );
-
-        $this->webDriver->wait(5);
-
-        $this->webDriver->executeScript(
-            'window.scrollTo(0,' .
-            $this->byId('buttonGo')->getLocation()->getY()
-            . ')'
-        );
-        $this->webDriver->wait(5);
+        $this->waitForElement('id', 'input_import_file');
+        $this->selectByValue($this->byName('local_import_file'), $type . '_import.sql');
 
         $this->scrollToBottom();
         $this->waitUntilElementIsVisible('id', 'sql_options', 30);
-        $this->scrollToBottom();
-        sleep(2);
+
         $this->scrollToBottom();
         $this->waitUntilElementIsVisible('id', 'buttonGo', 30);
         $this->byId('buttonGo')->click();
-        sleep(2);
+
         $this->waitUntilElementIsVisible(
             'xpath',
             "//div[@class='alert alert-success' and contains(., 'Import has been successfully')]",

--- a/test/selenium/LoginTest.php
+++ b/test/selenium/LoginTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Selenium;
 
-use function sleep;
-
 /**
  * @coversNothing
  */
@@ -45,7 +43,6 @@ class LoginTest extends TestBase
     public function testLoginWithWrongPassword(): void
     {
         $this->login('Admin', 'Admin');
-        sleep(1);
         $this->waitForElement('xpath', '//*[@class="alert alert-danger" and contains(.,\'Access denied for\')]');
         $this->assertTrue($this->isUnsuccessLogin());
     }

--- a/test/selenium/Table/OperationsTest.php
+++ b/test/selenium/Table/OperationsTest.php
@@ -6,8 +6,6 @@ namespace PhpMyAdmin\Tests\Selenium\Table;
 
 use PhpMyAdmin\Tests\Selenium\TestBase;
 
-use function sleep;
-
 /**
  * @coversNothing
  */
@@ -126,8 +124,6 @@ class OperationsTest extends TestBase
         $this->byName('comment')->sendKeys('foobar');
 
         $this->scrollIntoView('tableOptionsForm');
-        sleep(1);
-        $this->scrollIntoView('tableOptionsForm');
         $this->waitUntilElementIsVisible('cssSelector', 'form#tableOptionsForm', 30);
         $this->byCssSelector("form#tableOptionsForm input[type='submit']")->click();
         $this->waitAjax();
@@ -155,8 +151,6 @@ class OperationsTest extends TestBase
      */
     public function testCopyTable(): void
     {
-        $this->scrollIntoView('copyTable');
-        sleep(1);
         $this->scrollIntoView('copyTable');
         $this->waitUntilElementIsVisible('cssSelector', 'form#copyTable', 30);
         $this->byCssSelector("form#copyTable input[name='new_name']")->sendKeys('2');
@@ -189,8 +183,6 @@ class OperationsTest extends TestBase
     public function testTruncateTable(): void
     {
         $this->scrollToBottom();
-        sleep(1);
-        $this->scrollToBottom();
         $this->waitUntilElementIsVisible('id', 'drop_tbl_anchor', 30);
         $this->byId('truncate_tbl_anchor')->click();
         $this->byCssSelector('button.submitOK')->click();
@@ -218,8 +210,6 @@ class OperationsTest extends TestBase
     public function testDropTable(): void
     {
         $dropLink = $this->waitUntilElementIsVisible('partialLinkText', 'Delete the table (DROP)', 30);
-        $this->scrollToBottom();
-        sleep(1);
         $this->scrollToBottom();
         $dropLink->click();
         $this->byCssSelector('button.submitOK')->click();

--- a/test/selenium/TestBase.php
+++ b/test/selenium/TestBase.php
@@ -672,8 +672,6 @@ abstract class TestBase extends TestCase
             }
         }
 
-        // echo PHP_EOL . 'Query: ' . $query . ', out: ' . (($didSucceed) ? 'yes' : 'no') . PHP_EOL;
-
         reset($handles);
         $lastWindow = current($handles);
         $this->webDriver->switchTo()->window($lastWindow);
@@ -1015,17 +1013,19 @@ abstract class TestBase extends TestCase
     /**
      * Scrolls to a coordinate such that the element with given id is visible
      *
-     * @param string $element_id Id of the element
-     * @param int    $y_offset   Offset from Y-coordinate of element
+     * @param string $elementId Id of the element
+     * @param int    $yOffset   Offset from Y-coordinate of element
      */
-    public function scrollIntoView(string $element_id, int $y_offset = 70): void
+    public function scrollIntoView(string $elementId, int $yOffset = 70): void
     {
         // 70pt offset by-default so that the topmenu does not cover the element
-        $this->webDriver->executeScript(
-            'var position = document.getElementById("'
-            . $element_id . '").getBoundingClientRect();'
-            . 'window.scrollBy(0, position.top-(' . $y_offset . '));'
-        );
+        $script = <<<'JS'
+const elementId = arguments[0];
+const yOffset = arguments[1];
+const position = document.getElementById(elementId).getBoundingClientRect();
+window.scrollBy({left: 0, top: position.top - yOffset, behavior: 'instant'});
+JS;
+        $this->webDriver->executeScript($script, [$elementId, $yOffset]);
     }
 
     /**
@@ -1037,10 +1037,15 @@ abstract class TestBase extends TestCase
      */
     public function scrollToElement(WebDriverElement $element, int $xOffset = 0, int $yOffset = 0): void
     {
-        $this->webDriver->executeScript(
-            'window.scrollBy(' . ($element->getLocation()->getX() + $xOffset)
-            . ', ' . ($element->getLocation()->getY() + $yOffset) . ');'
-        );
+        $script = <<<'JS'
+const leftValue = arguments[0];
+const topValue = arguments[1];
+window.scrollBy({left: leftValue, top: topValue, behavior: 'instant'});
+JS;
+        $this->webDriver->executeScript($script, [
+            $element->getLocation()->getX() + $xOffset,
+            $element->getLocation()->getY() + $yOffset,
+        ]);
     }
 
     /**
@@ -1048,7 +1053,10 @@ abstract class TestBase extends TestCase
      */
     public function scrollToBottom(): void
     {
-        $this->webDriver->executeScript('window.scrollTo(0,document.body.scrollHeight);');
+        $script = <<<'JS'
+window.scrollTo({left: 0, top: document.body.scrollHeight, behavior: 'instant'});
+JS;
+        $this->webDriver->executeScript($script);
     }
 
     /**


### PR DESCRIPTION
Uses `instant` scrolls instead of `smooth` scrolls.
