### PR TITLE
#16005 - performance improvement on the Import and Export pages

### DIFF
--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -2464,6 +2464,11 @@ class ExportSql extends ExportPlugin
             $separator = ';';
         }
 
+        $isBinaryField = [];
+        for ($j = 0; $j < $fields_cnt; $j++) {
+            $isBinaryField[$j] = stripos($field_flags[$j], 'BINARY') !== false;
+        }
+
         while ($row = $dbi->fetchRow($result)) {
             if ($current_row == 0) {
                 $head = $this->possibleCRLF()
@@ -2510,7 +2515,7 @@ class ExportSql extends ExportPlugin
                     // timestamp is numeric on some MySQL 4.1, BLOBs are
                     // sometimes numeric
                     $values[] = $row[$j];
-                } elseif (stripos($field_flags[$j], 'BINARY') !== false
+                } elseif ($isBinaryField[$j]
                     && isset($GLOBALS['sql_hex_for_binary'])
                 ) {
                     // a true BLOB

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -857,8 +857,6 @@ class Tracker
         if (! (substr($query, -1) === ';')) {
             $query .= ";\n";
         }
-        // Get some information about query
-        $result = self::parseQuery($query);
 
         // Get database name
         $dbname = trim($GLOBALS['db'] ?? '', '`');
@@ -867,6 +865,9 @@ class Tracker
         if (empty($dbname)) {
             return;
         }
+
+        // Get some information about query
+        $result = self::parseQuery($query);
 
         // If we found a valid statement
         if (! isset($result['identifier'])) {


### PR DESCRIPTION
The call did cost a lot of time on the import page, move it after the quick exit to gain time

Ref: #16005

### For export (1M rows dumped)

<details><summary>screenshots</summary>

Before:
![image](https://user-images.githubusercontent.com/7784660/145729330-f7b5cdd1-a82e-437a-a07d-f38c21c7313b.png)
After:
![image](https://user-images.githubusercontent.com/7784660/145729333-de14bad8-1f47-42fa-9263-1add5ab20b2d.png)


</details>