### PR TITLE
Refactor results.php

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -1725,7 +1725,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
 
             // make sure we have more than one column
             if ($firstRowCols.length > 1) {
-                var $colVisibTh = $(g.t).find('th:not(.draggable)');
+                var $colVisibTh = $(g.t).find('th:not(.draggable)').slice(0, 1);
                 Functions.tooltip(
                     $colVisibTh,
                     'th',

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -4243,8 +4243,6 @@ class Results
         string $printLink,
         array $analyzedSqlResults
     ): array {
-        global $printview;
-
         $urlParams = [
             'db' => $this->properties['db'],
             'table' => $this->properties['table'],
@@ -4262,7 +4260,6 @@ class Results
         // display the Export link).
         if (
             ($analyzedSqlResults['querytype'] === self::QUERY_TYPE_SELECT)
-            && ! isset($printview)
             && empty($analyzedSqlResults['procedure'])
         ) {
             if (count($analyzedSqlResults['select_tables']) === 1) {
@@ -4302,7 +4299,7 @@ class Results
             'has_procedure' => ! empty($analyzedSqlResults['procedure']),
             'has_geometry' => $geometryFound,
             'has_print_link' => $printLink == '1',
-            'has_export_link' => $analyzedSqlResults['querytype'] === self::QUERY_TYPE_SELECT && ! isset($printview),
+            'has_export_link' => $analyzedSqlResults['querytype'] === self::QUERY_TYPE_SELECT,
             'url_params' => $urlParams,
         ];
     }

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -2295,8 +2295,8 @@ class Results
         while ($row = $this->dbi->fetchRow($dtResult)) {
             // add repeating headers
             if (
-                ($rowNumber != 0) && ($_SESSION['tmpval']['repeat_cells'] != 0)
-                && ! $rowNumber % $_SESSION['tmpval']['repeat_cells']
+                ($rowNumber !== 0) && ($_SESSION['tmpval']['repeat_cells'] > 0)
+                && ($rowNumber % $_SESSION['tmpval']['repeat_cells']) === 0
             ) {
                 $tableBodyHtml .= $this->getRepeatingHeaders($displayParams);
             }

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1693,6 +1693,7 @@ class Sql
         }
 
         $displayResultsObject = new DisplayResults(
+            $GLOBALS['dbi'],
             $GLOBALS['db'],
             $GLOBALS['table'],
             $GLOBALS['server'],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3216,11 +3216,6 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getClassForNumericColumnType\\(\\) has parameter \\$thClass with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getColumnAtRightSide\\(\\) has parameter \\$displayParts with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
@@ -3567,16 +3562,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:setParamForLinkForeignKeyRelatedTables\\(\\) should return array\\<string, array\\<string\\>\\> but returns array\\<int\\|string, array\\>\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Parameter \\#1 \\$colVisib of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDraggableClassForNonSortableColumns\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Parameter \\#2 \\$colVisibElement of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDraggableClassForNonSortableColumns\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -10289,11 +10274,6 @@ parameters:
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Dbal\\\\DbiDummyTest\\:\\:schemaData\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Dbal/DbiDummyTest.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Display\\\\ResultsTest\\:\\:dataProviderForTestGetClassesForColumn\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Display/ResultsTest.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Display\\\\ResultsTest\\:\\:dataProviderForTestGetDataCellForNonNumericColumns\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3201,12 +3201,17 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getBulkLinks\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
+			message: "#^Cannot access offset int on mixed\\.$#"
+			count: 2
+			path: libraries/classes/Display/Results.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getBulkLinks\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getBulkLinks\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3226,22 +3231,12 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getColumnParams\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getCommentForRow\\(\\) has parameter \\$commentsMap with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDataCellForGeometryColumns\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDataCellForGeometryColumns\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3261,11 +3256,6 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDataCellForNonNumericColumns\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDataCellForNonNumericColumns\\(\\) has parameter \\$transformOptions with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
@@ -3277,11 +3267,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDataCellForNumericColumns\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDataCellForNumericColumns\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3301,37 +3286,7 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDeleteAndKillLinks\\(\\) has parameter \\$row with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDeleteAndKillLinks\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDraggableClassForNonSortableColumns\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getFieldVisibilityParams\\(\\) has parameter \\$displayParts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getFieldVisibilityParams\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getFromForeign\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getHtmlPageSelector\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3351,42 +3306,12 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getOrderLinkAndSortedHeaderHtml\\(\\) has parameter \\$sortExpressionNoDirection with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getOrderLinkAndSortedHeaderHtml\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getPartialText\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRepeatingHeaders\\(\\) has parameter \\$displayParams with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getResultsOperations\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getResultsOperations\\(\\) has parameter \\$displayParts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowData\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowData\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3406,11 +3331,6 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowInfoForSpecialLinks\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowValues\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
@@ -3426,32 +3346,12 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowValues\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowValues\\(\\) has parameter \\$row with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSingleAndMultiSortUrls\\(\\) has parameter \\$sortDirection with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSingleAndMultiSortUrls\\(\\) has parameter \\$sortExpression with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSingleAndMultiSortUrls\\(\\) has parameter \\$sortExpressionNoDirection with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSingleAndMultiSortUrls\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3462,21 +3362,11 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSortByKeyDropDown\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
+			count: 2
 			path: libraries/classes/Display/Results.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSortOrderHiddenInputs\\(\\) has parameter \\$multipleUrlParams with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSortingUrlParams\\(\\) has parameter \\$sortDirection with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSortingUrlParams\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3502,11 +3392,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTableBody\\(\\) has parameter \\$displayParts with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTableBody\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3541,13 +3426,8 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTableHeaders\\(\\) has parameter \\$sortExpressionNoDirection with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTableHeaders\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
+			count: 2
 			path: libraries/classes/Display/Results.php
 
 		-
@@ -3567,11 +3447,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTableHeadersForColumns\\(\\) has parameter \\$sortExpression with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTableHeadersForColumns\\(\\) has parameter \\$sortExpressionNoDirection with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3597,7 +3472,7 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getUnsortedSqlAndSortByKeyDropDown\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
+			count: 2
 			path: libraries/classes/Display/Results.php
 
 		-
@@ -3691,27 +3566,42 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:setParamForLinkForeignKeyRelatedTables\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:setParamForLinkForeignKeyRelatedTables\\(\\) should return array\\<string, array\\<string\\>\\> but returns array\\<int\\|string, array\\>\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Parameter \\#2 \\$sortOrder of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSortingUrlParams\\(\\) expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$colVisib of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDraggableClassForNonSortableColumns\\(\\) expects bool, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Parameter \\#3 \\$value of method PhpMyAdmin\\\\Display\\\\Results\\:\\:buildValueDisplay\\(\\) expects string, mixed given\\.$#"
-			count: 3
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Parameter \\#4 \\$sortExpressionNoDirection of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTableHeadersForColumns\\(\\) expects array, array\\|string given\\.$#"
+			message: "#^Parameter \\#2 \\$colVisibElement of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getDraggableClassForNonSortableColumns\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Parameter \\#7 \\$displayedData of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowData\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$offset of method PhpMyAdmin\\\\DatabaseInterface\\:\\:dataSeek\\(\\) expects int, float\\|int given\\.$#"
+			count: 2
+			path: libraries/classes/Display/Results.php
+
+		-
+			message: "#^Parameter \\#3 \\$colOrder of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowValues\\(\\) expects array\\|false, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Display/Results.php
+
+		-
+			message: "#^Parameter \\#6 \\$colVisib of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getRowValues\\(\\) expects array\\|bool\\|string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Display/Results.php
+
+		-
+			message: "#^Parameter \\#8 \\$colVisib of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getOrderLinkAndSortedHeaderHtml\\(\\) expects bool, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Display/Results.php
+
+		-
+			message: "#^Parameter \\#9 \\$colVisibElement of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getOrderLinkAndSortedHeaderHtml\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -3721,22 +3611,7 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\FieldMetadata\\:\\:\\$decimals \\(int\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 2
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\FieldMetadata\\:\\:\\$internalMediaType \\(string\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\FieldMetadata\\:\\:\\$name \\(string\\) on left side of \\?\\? is not nullable\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\FieldMetadata\\:\\:\\$table \\(string\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
 
@@ -8616,6 +8491,16 @@ parameters:
 			path: libraries/classes/Sql.php
 
 		-
+			message: "#^Parameter \\#1 \\$dtResult of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTable\\(\\) expects object, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Sql.php
+
+		-
+			message: "#^Parameter \\#1 \\$dtResult of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTable\\(\\) expects object, object\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Sql.php
+
+		-
 			message: "#^Parameter \\#1 \\$messageToShow of method PhpMyAdmin\\\\Sql\\:\\:getMessageForNoRowsReturned\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
@@ -8623,6 +8508,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$numberOfLine of method PhpMyAdmin\\\\Sql\\:\\:getStartPosToDisplayRow\\(\\) expects int, mixed given\\.$#"
 			count: 2
+			path: libraries/classes/Sql.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, bool\\|object\\|null given\\.$#"
+			count: 1
 			path: libraries/classes/Sql.php
 
 		-
@@ -10542,6 +10432,11 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Display\\\\ResultsTest\\:\\:testSetHighlightedColumnGlobalField\\(\\) has parameter \\$output with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: test/classes/Display/ResultsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$dtResult of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTable\\(\\) expects object, mixed given\\.$#"
 			count: 1
 			path: test/classes/Display/ResultsTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3456,21 +3456,6 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getUnsortedSqlAndSortByKeyDropDown\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getUnsortedSqlAndSortByKeyDropDown\\(\\) has parameter \\$sortExpression with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getUnsortedSqlAndSortByKeyDropDown\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 2
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Display\\\\Results\\:\\:getUrlSqlQuery\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5919,9 +5919,6 @@
       <code>-1</code>
       <code>[]</code>
     </DocblockTypeContradiction>
-    <FalseOperand occurrences="1">
-      <code>! $rowNumber</code>
-    </FalseOperand>
     <InvalidArgument occurrences="1">
       <code>$added[$orgFullTableName]</code>
     </InvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5919,7 +5919,7 @@
     <InvalidArgument occurrences="1">
       <code>$added[$orgFullTableName]</code>
     </InvalidArgument>
-    <MixedArgument occurrences="57">
+    <MixedArgument occurrences="55">
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['pos'] / $_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['query']</code>
@@ -5938,8 +5938,6 @@
       <code>$colOrder</code>
       <code>$colVisib</code>
       <code>$colVisib</code>
-      <code>$colVisib</code>
-      <code>$colVisibCurrent</code>
       <code>$colVisibCurrent</code>
       <code>$displayParams['desc']</code>
       <code>$displayParams['emptyafter']</code>
@@ -6229,10 +6227,8 @@
       <code>$this-&gt;properties['num_rows'] &gt; 0 ? $this-&gt;properties['num_rows'] - 1 : 0</code>
       <code>$this-&gt;properties['num_rows'] &gt; 0 ? $this-&gt;properties['num_rows'] - 1 : 0</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument occurrences="1">
       <code>$colVisibCurrent</code>
-      <code>$colVisibCurrent</code>
-      <code>$isFieldTruncated</code>
     </PossiblyNullArgument>
     <PossiblyNullOperand occurrences="2">
       <code>$dispval</code>
@@ -15781,8 +15777,7 @@
       <code>$output</code>
       <code>$output</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="8">
-      <code>array</code>
+    <MixedInferredReturnType occurrences="7">
       <code>array</code>
       <code>array</code>
       <code>array</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5922,16 +5922,8 @@
     <FalseOperand occurrences="1">
       <code>! $rowNumber</code>
     </FalseOperand>
-    <InvalidArgument occurrences="9">
+    <InvalidArgument occurrences="1">
       <code>$added[$orgFullTableName]</code>
-      <code>$dtResult</code>
-      <code>$dtResult</code>
-      <code>$dtResult</code>
-      <code>$dtResult</code>
-      <code>$dtResult</code>
-      <code>$dtResult</code>
-      <code>$dtResult</code>
-      <code>$dtResult</code>
     </InvalidArgument>
     <InvalidOperand occurrences="1">
       <code>$index</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5912,23 +5912,14 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="libraries/classes/Display/Results.php">
-    <DocblockTypeContradiction occurrences="5">
+    <DocblockTypeContradiction occurrences="2">
       <code>$displayParts['nav_bar'] == '1' &amp;&amp; $statement !== null &amp;&amp; empty($statement-&gt;limit)</code>
-      <code>''</code>
-      <code>'-1'</code>
-      <code>-1</code>
       <code>[]</code>
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="1">
       <code>$added[$orgFullTableName]</code>
     </InvalidArgument>
-    <InvalidOperand occurrences="1">
-      <code>$index</code>
-    </InvalidOperand>
-    <InvalidScalarArgument occurrences="1">
-      <code>$originalLength</code>
-    </InvalidScalarArgument>
-    <MixedArgument occurrences="84">
+    <MixedArgument occurrences="57">
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['pos'] / $_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['query']</code>
@@ -5950,81 +5941,53 @@
       <code>$colVisib</code>
       <code>$colVisibCurrent</code>
       <code>$colVisibCurrent</code>
-      <code>$colspan</code>
-      <code>$column</code>
-      <code>$column</code>
+      <code>$displayParams['desc']</code>
+      <code>$displayParams['emptyafter']</code>
+      <code>$displayParams['emptypre']</code>
       <code>$displayParts</code>
       <code>$displayParts['del_lnk']</code>
       <code>$displayParts['del_lnk']</code>
-      <code>$displayedColumn</code>
-      <code>$displayedColumn</code>
-      <code>$displayedColumn</code>
-      <code>$displayedColumn</code>
-      <code>$dispresult</code>
-      <code>$dispresult</code>
-      <code>$dispresult</code>
+      <code>$displayParts['pview_lnk']</code>
       <code>$expr-&gt;alias</code>
       <code>$field-&gt;table</code>
-      <code>$geometryText</code>
-      <code>$isFieldTruncated</code>
-      <code>$isFieldTruncated</code>
-      <code>$isFieldTruncated</code>
-      <code>$isFieldTruncated</code>
-      <code>$map[$meta-&gt;name][0]</code>
-      <code>$map[$meta-&gt;name][0]</code>
-      <code>$map[$meta-&gt;name][1]</code>
-      <code>$map[$meta-&gt;name][1]</code>
-      <code>$map[$meta-&gt;name][2]</code>
-      <code>$map[$meta-&gt;name][3]</code>
-      <code>$map[$meta-&gt;name][3]</code>
       <code>$mediaTypeMap[$orgFullColName]['mimetype']</code>
       <code>$mediaTypeMap[$orgFullColName]['transformation_options'] ?? ''</code>
       <code>$mediaTypeMap[$orgFullColName]['transformation_options'] ?? ''</code>
       <code>$multipleUrlParams['sql_query']</code>
       <code>$multipleUrlParams['sql_query']</code>
-      <code>$nameToUseInSort</code>
       <code>$newSortExpressionNoDirection</code>
       <code>$oneKey['ref_db_name'] ?? $GLOBALS['db']</code>
       <code>$oneKey['ref_table_name']</code>
-      <code>$orderImg</code>
-      <code>$originalLength</code>
       <code>$rel['foreign_db']</code>
       <code>$rel['foreign_table']</code>
+      <code>$row ? $row[$sortedColumnIndex] : ''</code>
+      <code>$row ? $row[$sortedColumnIndex] : ''</code>
       <code>$row[$i]</code>
       <code>$row[$i]</code>
-      <code>$row[$sortedColumnIndex]</code>
-      <code>$row[$sortedColumnIndex]</code>
       <code>$sessionMaxRows</code>
-      <code>$sortByKeyData</code>
-      <code>$sortDirection[$index]</code>
-      <code>$sortDirection[$index]</code>
-      <code>$sortDirection[$index]</code>
       <code>$sortExpressionNoDirection[$indexInExpression]</code>
       <code>$sortExpressionNoDirection[$indexInExpression]</code>
       <code>$sortExpressionNoDirection[$indexInExpression]</code>
       <code>$sqlQuery</code>
       <code>$this-&gt;properties['unlim_num_rows'] / $_SESSION['tmpval']['max_rows']</code>
       <code>$total</code>
-      <code>$unsortedSqlQuery</code>
       <code>$urlParams['where_clause']</code>
       <code>$whereClause</code>
       <code>$whereClause</code>
       <code>$whereClauseMap[$rowNumber][$meta-&gt;orgtable]</code>
-      <code>$wkbval</code>
       <code>empty($field-&gt;database) ? $this-&gt;properties['db'] : $field-&gt;database</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="9">
+    <MixedArgumentTypeCoercion occurrences="8">
       <code>$analyzedSqlResults</code>
-      <code>$index</code>
-      <code>$index</code>
       <code>$linkingUrlParams</code>
       <code>$row</code>
       <code>$row</code>
       <code>$row</code>
+      <code>$sortDirection</code>
       <code>$sortExpression</code>
       <code>$urlParams</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="76">
+    <MixedArrayAccess occurrences="68">
       <code>$_SESSION['tmpval']['display_binary']</code>
       <code>$_SESSION['tmpval']['display_binary']</code>
       <code>$_SESSION['tmpval']['display_binary']</code>
@@ -6066,20 +6029,12 @@
       <code>$_SESSION['tmpval']['relational_display']</code>
       <code>$_SESSION['tmpval']['repeat_cells']</code>
       <code>$colOrder[$j]</code>
+      <code>$colVisib[$j]</code>
       <code>$displayParams['data'][$rowNumber]</code>
       <code>$displayParts['nav_bar']</code>
       <code>$displayParts['nav_bar']</code>
       <code>$displayParts['nav_bar']</code>
       <code>$displayParts['sort_lnk']</code>
-      <code>$map[$meta-&gt;name][0]</code>
-      <code>$map[$meta-&gt;name][0]</code>
-      <code>$map[$meta-&gt;name][0]</code>
-      <code>$map[$meta-&gt;name][1]</code>
-      <code>$map[$meta-&gt;name][1]</code>
-      <code>$map[$meta-&gt;name][2]</code>
-      <code>$map[$meta-&gt;name][3]</code>
-      <code>$map[$meta-&gt;name][3]</code>
-      <code>$map[$meta-&gt;name][3]</code>
       <code>$oneKey['index_list']</code>
       <code>$oneKey['ref_db_name']</code>
       <code>$oneKey['ref_db_name']</code>
@@ -6173,7 +6128,7 @@
       <code>$row[$i]</code>
       <code>$row[$m]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="64">
+    <MixedAssignment occurrences="52">
       <code>$_SESSION['tmpval']['geoOption']</code>
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['pftext']</code>
@@ -6186,21 +6141,14 @@
       <code>$colVisib</code>
       <code>$colVisibCurrent</code>
       <code>$columnForFirstRow</code>
-      <code>$columnForFirstRow</code>
       <code>$columnForLastRow</code>
-      <code>$columnForLastRow</code>
-      <code>$columns[]</code>
-      <code>$displayedColumn</code>
-      <code>$dispresult</code>
       <code>$expr</code>
       <code>$expr</code>
-      <code>$expression</code>
       <code>$field</code>
       <code>$file</code>
       <code>$firstShownRec</code>
       <code>$firstShownRec</code>
       <code>$firstShownRec</code>
-      <code>$geometryText</code>
       <code>$hiddenFields['session_max_rows']</code>
       <code>$i</code>
       <code>$i</code>
@@ -6208,17 +6156,14 @@
       <code>$index</code>
       <code>$lastShownRec</code>
       <code>$lastShownRec</code>
-      <code>$linkingUrlParams[$urlParameterName]</code>
+      <code>$linkingUrlParams[$new_param['param_info']]</code>
       <code>$m</code>
       <code>$meta-&gt;name</code>
       <code>$multipleUrlParams['sql_query']</code>
       <code>$multipleUrlParams['sql_query']</code>
-      <code>$nameToUseInSort</code>
       <code>$newSortExpressionNoDirection</code>
       <code>$oneField</code>
       <code>$oneKey</code>
-      <code>$posNext</code>
-      <code>$posPrev</code>
       <code>$query</code>
       <code>$query['geoOption']</code>
       <code>$query['pftext']</code>
@@ -6233,43 +6178,28 @@
       <code>$sqlQueryAdd</code>
       <code>$tableCreateTime</code>
       <code>$theTotal</code>
-      <code>$val</code>
       <code>$value</code>
       <code>$whereClauseMap[$rowNumber][$meta-&gt;orgtable]</code>
       <code>$whereClauseMap[$rowNumber][$this-&gt;properties['table']]</code>
-      <code>$wkbval</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>string|null</code>
-    </MixedInferredReturnType>
     <MixedMethodCall occurrences="2">
       <code>new $className()</code>
       <code>new $this-&gt;transformationInfo[$dbLower][$tblLower][$nameLower][1]()</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="23">
+    <MixedOperand occurrences="13">
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['pos']</code>
       <code>$_SESSION['tmpval']['pos']</code>
       <code>$_SESSION['tmpval']['pos']</code>
-      <code>$displayParams['emptyafter']</code>
-      <code>$displayParams['emptypre']</code>
+      <code>$_SESSION['tmpval']['repeat_cells']</code>
       <code>$displayParams['rowdata'][$i][$rowNumber]</code>
       <code>$displaySize[0]</code>
       <code>$displaySize[1]</code>
       <code>$file</code>
       <code>$firstShownRec</code>
       <code>$firstShownRec</code>
-      <code>$multiSortOrder</code>
-      <code>$multiSortOrder</code>
-      <code>$orderImg</code>
-      <code>$orderLink</code>
-      <code>$result</code>
-      <code>$singleSortOrder</code>
-      <code>$singleSortOrder</code>
       <code>$sortExpressionNoDirection[$indexInExpression]</code>
-      <code>$sortOrder</code>
-      <code>$val</code>
     </MixedOperand>
     <MixedPropertyFetch occurrences="16">
       <code>$analyzedSqlResults['parser']-&gt;list</code>
@@ -6289,30 +6219,21 @@
       <code>$field-&gt;database</code>
       <code>$field-&gt;table</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="1">
-      <code>$dispval</code>
-    </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="2">
+    <MixedReturnTypeCoercion occurrences="6">
+      <code>$map</code>
+      <code>array&lt;string, string[]&gt;</code>
       <code>int[]</code>
+      <code>string[]</code>
     </MixedReturnTypeCoercion>
-    <PossiblyInvalidArgument occurrences="5">
-      <code>$colVisib</code>
-      <code>$colVisib</code>
-      <code>$sortExpressionNoDirection</code>
+    <PossiblyInvalidArgument occurrences="2">
       <code>$this-&gt;properties['num_rows'] &gt; 0 ? $this-&gt;properties['num_rows'] - 1 : 0</code>
       <code>$this-&gt;properties['num_rows'] &gt; 0 ? $this-&gt;properties['num_rows'] - 1 : 0</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="4">
+    <PossiblyNullArgument occurrences="3">
       <code>$colVisibCurrent</code>
       <code>$colVisibCurrent</code>
-      <code>$isFieldTruncated</code>
       <code>$isFieldTruncated</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="3">
-      <code>$dispval</code>
-      <code>$row[$sortedColumnIndex]</code>
-      <code>$row[$sortedColumnIndex]</code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullOperand occurrences="2">
       <code>$dispval</code>
       <code>$this-&gt;getSortedColumnMessage($dtResult, $sortExpressionNoDirection[$i])</code>
@@ -6327,12 +6248,8 @@
       <code>(string) $fieldsMeta[$i]-&gt;name</code>
       <code>(string) $fieldsMeta[$i]-&gt;name</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="6">
-      <code>$fieldsMeta-&gt;name</code>
+    <RedundantConditionGivenDocblockType occurrences="2">
       <code>$firstStatement-&gt;order</code>
-      <code>$meta-&gt;decimals</code>
-      <code>$meta-&gt;decimals</code>
-      <code>isset($fieldsMeta-&gt;table)</code>
       <code>isset($meta-&gt;internalMediaType)</code>
     </RedundantConditionGivenDocblockType>
   </file>
@@ -13521,10 +13438,6 @@
     </MixedOperand>
   </file>
   <file src="libraries/classes/Sql.php">
-    <InvalidArgument occurrences="2">
-      <code>$result</code>
-      <code>$result</code>
-    </InvalidArgument>
     <InvalidScalarArgument occurrences="2">
       <code>$error</code>
       <code>''</code>
@@ -13696,12 +13609,13 @@
       <code>$result</code>
       <code>$result</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="12">
+    <PossiblyNullArgument occurrences="13">
       <code>$_POST['purge'] ?? null</code>
       <code>$db</code>
       <code>$db</code>
       <code>$extraData ?? null</code>
       <code>$messageToShow ?? null</code>
+      <code>$result</code>
       <code>$result ?? null</code>
       <code>$row[0]</code>
       <code>$sqlData ?? null</code>

--- a/templates/display/results/empty_display.twig
+++ b/templates/display/results/empty_display.twig
@@ -1,1 +1,1 @@
-<td {{ align }} class="{{ classes }}"></td>
+<td class="{{ classes }}"></td>

--- a/templates/display/results/null_display.twig
+++ b/templates/display/results/null_display.twig
@@ -1,5 +1,4 @@
-<td {{ align }}
-    data-decimals="{{ data_decimals }}"
+<td data-decimals="{{ data_decimals }}"
     data-type="{{ data_type }}"
     {# The null class is needed for grid editing #}
     class="{{ classes }} null">

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -152,63 +152,6 @@ class ResultsTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * Data provider for testGetClassesForColumn
-     *
-     * @return array parameters and output
-     */
-    public function dataProviderForTestGetClassesForColumn(): array
-    {
-        return [
-            [
-                'grid_edit',
-                'not_null',
-                '',
-                '',
-                '',
-                'data grid_edit not_null   ',
-            ],
-        ];
-    }
-
-    /**
-     * @param string $grid_edit_class  the class for all editable columns
-     * @param string $not_null_class   the class for not null columns
-     * @param string $relation_class   the class for relations in a column
-     * @param string $hide_class       the class for visibility of a column
-     * @param string $field_type_class the class related to type of the field
-     * @param string $output           output of__getResettedClassForInlineEdit
-     *
-     * @dataProvider dataProviderForTestGetClassesForColumn
-     */
-    public function testGetClassesForColumn(
-        string $grid_edit_class,
-        string $not_null_class,
-        string $relation_class,
-        string $hide_class,
-        string $field_type_class,
-        string $output
-    ): void {
-        $GLOBALS['cfg']['BrowsePointerEnable'] = true;
-        $GLOBALS['cfg']['BrowseMarkerEnable'] = true;
-
-        $this->assertEquals(
-            $output,
-            $this->callFunction(
-                $this->object,
-                DisplayResults::class,
-                'getClassesForColumn',
-                [
-                    $grid_edit_class,
-                    $not_null_class,
-                    $relation_class,
-                    $hide_class,
-                    $field_type_class,
-                ]
-            )
-        );
-    }
-
     public function testGetClassForDateTimeRelatedFieldsCase1(): void
     {
         $this->assertEquals(
@@ -744,10 +687,7 @@ class ResultsTest extends AbstractTestCase
      *   bool,
      *   TransformationsPlugin|null,
      *   array,
-     *   bool,
      *   array,
-     *   int,
-     *   int|string,
      *   string
      * }}
      */
@@ -798,10 +738,7 @@ class ResultsTest extends AbstractTestCase
                 false,
                 null,
                 ['https://www.example.com/'],
-                false,
                 [],
-                0,
-                'binary',
                 'class="disableAjax">[BLOB - 4 B]</a>'
                 . '</td>' . "\n",
             ],
@@ -815,11 +752,8 @@ class ResultsTest extends AbstractTestCase
                 false,
                 $transformation_plugin,
                 [],
-                false,
                 [],
-                0,
-                'binary',
-                '<td class="text-start grid_edit  transformed hex">'
+                '<td class="text-start grid_edit transformed hex">'
                 . '1001'
                 . '</td>' . "\n",
             ],
@@ -833,14 +767,10 @@ class ResultsTest extends AbstractTestCase
                 false,
                 $transformation_plugin,
                 [],
-                false,
                 [],
-                0,
-                '',
-                '<td ' . "\n"
-                . '    data-decimals="0"' . "\n"
+                '<td data-decimals="0"' . "\n"
                 . '    data-type="string"' . "\n"
-                . '        class="grid_edit  null">' . "\n"
+                . '        class="grid_edit null">' . "\n"
                 . '    <em>NULL</em>' . "\n"
                 . '</td>' . "\n",
             ],
@@ -854,10 +784,7 @@ class ResultsTest extends AbstractTestCase
                 false,
                 null,
                 [],
-                false,
                 [],
-                0,
-                '',
                 '<td data-decimals="0" data-type="string" '
                 . 'data-originallength="11" '
                 . 'class="grid_edit pre_wrap">foo bar baz</td>' . "\n",
@@ -872,10 +799,7 @@ class ResultsTest extends AbstractTestCase
                 false,
                 $transformation_plugin_external,
                 [],
-                false,
                 [],
-                0,
-                '',
                 '<td data-decimals="0" data-type="string" '
                 . 'data-originallength="11" '
                 . 'class="grid_edit text-nowrap transformed">foo bar baz</td>' . "\n",
@@ -890,10 +814,7 @@ class ResultsTest extends AbstractTestCase
                 false,
                 null,
                 [],
-                false,
                 [],
-                0,
-                '',
                 '<td data-decimals="0" data-type="datetime" '
                 . 'data-originallength="19" '
                 . 'class="grid_edit text-nowrap">2020-09-20 16:35:00</td>' . "\n",
@@ -910,10 +831,7 @@ class ResultsTest extends AbstractTestCase
      * @param array       $_url_params          the parameters for generate url
      * @param bool        $condition_field      the column should highlighted or not
      * @param array       $transform_options    the transformation parameters
-     * @param bool        $is_field_truncated   is data truncated due to LimitChars
      * @param array       $analyzed_sql_results the analyzed query
-     * @param int         $dt_result            the link id associated to the query which results have to be displayed
-     * @param int|string  $col_index            the column index
      * @param string      $output               the output of this function
      *
      * @dataProvider dataProviderForTestGetDataCellForNonNumericColumns
@@ -928,10 +846,7 @@ class ResultsTest extends AbstractTestCase
         bool $condition_field,
         ?TransformationsPlugin $transformation_plugin,
         array $transform_options,
-        bool $is_field_truncated,
         array $analyzed_sql_results,
-        int $dt_result,
-        $col_index,
         string $output
     ): void {
         $_SESSION['tmpval']['display_binary'] = true;
@@ -954,10 +869,7 @@ class ResultsTest extends AbstractTestCase
                     $condition_field,
                     $transformation_plugin,
                     $transform_options,
-                    $is_field_truncated,
                     $analyzed_sql_results,
-                    &$dt_result,
-                    $col_index,
                 ]
             )
         );
@@ -1669,28 +1581,28 @@ class ResultsTest extends AbstractTestCase
                 'has_bulk_actions_form' => false,
                 'button' => '<thead class="table-light"><tr>' . "\n",
                 'table_headers_for_columns' => $tableHeadersForColumns,
-                'column_at_right_side' => "\n" . '<td class="d-print-none" ></td>',
+                'column_at_right_side' => "\n" . '<td class="d-print-none"></td>',
             ],
-            'body' => '<tr   ><td data-decimals="0" data-type="real" class="'
-                . 'text-end data  not_null     text-nowrap">1</td>' . "\n"
+            'body' => '<tr><td data-decimals="0" data-type="real" class="'
+                . 'text-end data not_null text-nowrap">1</td>' . "\n"
                 . '<td data-decimals="0" data-type="string" data-originallength="4" class="'
-                . 'data  not_null   text pre_wrap">abcd</td>' . "\n"
+                . 'data not_null text pre_wrap">abcd</td>' . "\n"
                 . '<td data-decimals="0" data-type="datetime" data-originallength="19" class="'
-                . 'data  not_null   datetimefield text-nowrap">2011-01-20 02:00:02</td>' . "\n"
+                . 'data not_null datetimefield text-nowrap">2011-01-20 02:00:02</td>' . "\n"
                 . '</tr>' . "\n"
-                . '<tr   ><td data-decimals="0" data-type="real" class="'
-                . 'text-end data  not_null     text-nowrap">2</td>' . "\n"
+                . '<tr><td data-decimals="0" data-type="real" class="'
+                . 'text-end data not_null text-nowrap">2</td>' . "\n"
                 . '<td data-decimals="0" data-type="string" data-originallength="3" class="'
-                . 'data  not_null   text pre_wrap">foo</td>' . "\n"
+                . 'data not_null text pre_wrap">foo</td>' . "\n"
                 . '<td data-decimals="0" data-type="datetime" data-originallength="19" class="'
-                . 'data  not_null   datetimefield text-nowrap">2010-01-20 02:00:02</td>' . "\n"
+                . 'data not_null datetimefield text-nowrap">2010-01-20 02:00:02</td>' . "\n"
                 . '</tr>' . "\n"
-                . '<tr   ><td data-decimals="0" data-type="real" class="'
-                . 'text-end data  not_null     text-nowrap">3</td>' . "\n"
+                . '<tr><td data-decimals="0" data-type="real" class="'
+                . 'text-end data not_null text-nowrap">3</td>' . "\n"
                 . '<td data-decimals="0" data-type="string" data-originallength="4" class="'
-                . 'data  not_null   text pre_wrap">Abcd</td>' . "\n"
+                . 'data not_null text pre_wrap">Abcd</td>' . "\n"
                 . '<td data-decimals="0" data-type="datetime" data-originallength="19" class="'
-                . 'data  not_null   datetimefield text-nowrap">2012-01-20 02:00:02</td>' . "\n"
+                . 'data not_null datetimefield text-nowrap">2012-01-20 02:00:02</td>' . "\n"
                 . '</tr>' . "\n",
             'bulk_links' => [],
             'operations' => [

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -59,16 +59,10 @@ class ResultsTest extends AbstractTestCase
         $GLOBALS['db'] = 'db';
         $GLOBALS['table'] = 'table';
         $GLOBALS['PMA_PHP_SELF'] = 'index.php';
-        $this->object = new DisplayResults('as', '', 0, '', '');
+        $this->object = new DisplayResults($this->dbi, 'as', '', 0, '', '');
         $GLOBALS['text_dir'] = 'ltr';
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $_SESSION[' HMAC_secret '] = 'test';
-
-        $dbi = $this->getMockBuilder(DatabaseInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $GLOBALS['dbi'] = $dbi;
     }
 
     /**
@@ -1241,7 +1235,7 @@ class ResultsTest extends AbstractTestCase
         $table = 'test_table';
         $query = 'SELECT * FROM `test_db`.`test_table`;';
 
-        $object = new DisplayResults($db, $table, 1, '', $query);
+        $object = new DisplayResults($this->dbi, $db, $table, 1, '', $query);
         $object->setConfigParamsForDisplayTable();
 
         $this->assertArrayHasKey('tmpval', $_SESSION);
@@ -1457,17 +1451,15 @@ class ResultsTest extends AbstractTestCase
 
     public function testGetTable(): void
     {
-        global $db, $table, $dbi;
+        global $db, $table;
 
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
-
-        $dbi = $this->dbi;
 
         $db = 'test_db';
         $table = 'test_table';
         $query = 'SELECT * FROM `test_db`.`test_table`;';
 
-        $object = new DisplayResults($db, $table, 1, '', $query);
+        $object = new DisplayResults($this->dbi, $db, $table, 1, '', $query);
         $object->properties['unique_id'] = 1234567890;
 
         [$analyzedSqlResults] = ParseAnalyze::sqlQuery($query, $db);


### PR DESCRIPTION
This PR is a little chaotic as I wasn't very organized when refactoring this class. The goal was to reduce complexity. I removed redundant code, checks, temporary variables and unnecessary parameters. I added type hints, type declarations, stricter conditions, early returns, etc. 

This PR contains 2 bug fixes:
- Bug #17239, which should be fixed in full. I wasn't able to determine if one of the existing unit tests should cover this. Can someone suggest which test to modify?
- Undocumented bug related to sorting functionality. When using dynamic column names (e.g. ``SELECT CONCAT(table.col1, table1.`col2`)``) the sorting wouldn't work. The logic still seems flaky, but at least that small inconsistency is fixed. 

I have removed some methods that didn't look useful at all. I have completely redesigned or changed the signatures of a few other methods. 

I decided to remove unnecessary whitespace from HTML. HTML ignores contiguous whitespace. This should reduce slightly the length of the HTML output. I had to adjust unit tests to account for the removed whitespace. A lot of the functionality involved in the generation of CSS classes was outdated and no longer required. 

While the goal wasn't to reduce the length of code, this PR reduced it by 157 lines. It also got rid of many Psalm and PHPStan issues. I tested it by running PHPUnit locally and performing UAT myself. I haven't noticed any accidental regressions. 

P.S. This will probably be the last one of the small refactorings for some time. I will try to spend some time on more meaningful fixes or refactorings. For example, the master branch contains few issues related to PHP 8.1 changes. I will try to hunt them down and fix them. 