### PR TITLE
Bug fix: Fix triple HTML encoding

### DIFF
--- a/js/src/indexes.js
+++ b/js/src/indexes.js
@@ -641,11 +641,9 @@ AJAX.registerOnload('indexes.js', function () {
             $rowsToHide = $rowsToHide.add($lastRow);
         }
 
-        var question = Functions.escapeHtml(
-            $currRow.children('td')
-                .children('.drop_primary_key_index_msg')
-                .val()
-        );
+        var question = $currRow.children('td')
+            .children('.drop_primary_key_index_msg')
+            .val();
 
         Functions.confirmPreviewSql(question, $anchor.attr('href'), function (url) {
             var $msg = Functions.ajaxShowMessage(Messages.strDroppingPrimaryKeyIndex, false);

--- a/libraries/classes/Controllers/Table/RelationController.php
+++ b/libraries/classes/Controllers/Table/RelationController.php
@@ -20,7 +20,6 @@ use function __;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
-use function htmlspecialchars;
 use function mb_strtoupper;
 use function md5;
 use function strtoupper;
@@ -296,16 +295,11 @@ final class RelationController extends AbstractController
             $columnList = $table_obj->getIndexedColumns(false, false);
         }
 
-        $columns = [];
-        foreach ($columnList as $column) {
-            $columns[] = htmlspecialchars($column);
-        }
-
         if ($GLOBALS['cfg']['NaturalOrder']) {
-            usort($columns, 'strnatcasecmp');
+            usort($columnList, 'strnatcasecmp');
         }
 
-        $this->response->addJSON('columns', $columns);
+        $this->response->addJSON('columns', $columnList);
 
         // @todo should be: $server->db($db)->table($table)->primary()
         $primary = Index::getPrimary($foreignTable, $_POST['foreignDb']);
@@ -327,8 +321,7 @@ final class RelationController extends AbstractController
         $foreign = isset($_POST['foreign']) && $_POST['foreign'] === 'true';
 
         if ($foreign) {
-            $query = 'SHOW TABLE STATUS FROM '
-                . Util::backquote($_POST['foreignDb']);
+            $query = 'SHOW TABLE STATUS FROM ' . Util::backquote($_POST['foreignDb']);
             $tables_rs = $this->dbi->query($query, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
 
             while ($row = $this->dbi->fetchArray($tables_rs)) {
@@ -336,14 +329,14 @@ final class RelationController extends AbstractController
                     continue;
                 }
 
-                $tables[] = htmlspecialchars($row['Name']);
+                $tables[] = $row['Name'];
             }
         } else {
             $query = 'SHOW TABLES FROM '
                 . Util::backquote($_POST['foreignDb']);
             $tables_rs = $this->dbi->query($query, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
             while ($row = $this->dbi->fetchArray($tables_rs)) {
-                $tables[] = htmlspecialchars($row[0]);
+                $tables[] = $row[0];
             }
         }
 

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3154,8 +3154,8 @@ class Results
             ];
             $deleteUrl = Url::getFromRoute('/sql', $urlParams);
 
-            $jsConf = 'DELETE FROM ' . Sanitize::jsFormat($this->properties['table'])
-                . ' WHERE ' . Sanitize::jsFormat($whereClause, false)
+            $jsConf = 'DELETE FROM ' . $this->properties['table']
+                . ' WHERE ' . $whereClause
                 . ($clauseIsUnique ? '' : ' LIMIT 1');
 
             $deleteString = $this->getActionLinkContent('b_drop', __('Delete'));

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3228,7 +3228,7 @@
     </MixedArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/RelationController.php">
-    <MixedArgument occurrences="24">
+    <MixedArgument occurrences="21">
       <code>$_POST['destination_column']</code>
       <code>$_POST['destination_db']</code>
       <code>$_POST['destination_foreign_column']</code>
@@ -3240,7 +3240,6 @@
       <code>$_POST['foreignDb']</code>
       <code>$_POST['foreignDb']</code>
       <code>$_POST['foreignDb']</code>
-      <code>$column</code>
       <code>$column['Field']</code>
       <code>$foreignTable</code>
       <code>$html</code>
@@ -3248,25 +3247,26 @@
       <code>$multi_edit_columns_name</code>
       <code>$preview_sql_data</code>
       <code>$row['Engine']</code>
-      <code>$row['Name']</code>
-      <code>$row[0]</code>
       <code>$tables_rs</code>
       <code>$tables_rs</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion occurrences="3">
       <code>uksort($column_array, 'strnatcasecmp')</code>
+      <code>usort($columnList, 'strnatcasecmp')</code>
+      <code>usort($tables, 'strnatcasecmp')</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayOffset occurrences="2">
       <code>$column_array[$column['Field']]</code>
       <code>$column_hash_array[$column['Field']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="9">
       <code>$GLOBALS['display_query']</code>
-      <code>$column</code>
       <code>$column_array[$column['Field']]</code>
       <code>$foreignTable</code>
       <code>$multi_edit_columns_name</code>
       <code>$multi_edit_columns_name</code>
+      <code>$tables[]</code>
+      <code>$tables[]</code>
       <code>$tables_rs</code>
       <code>$tables_rs</code>
     </MixedAssignment>

--- a/templates/indexes.twig
+++ b/templates/indexes.twig
@@ -52,7 +52,7 @@
                   } %}
                 {% endif %}
 
-                <input type="hidden" class="drop_primary_key_index_msg" value="{{ index_params.sql_query|js_format(false) }}">
+                <input type="hidden" class="drop_primary_key_index_msg" value="{{ index_params.sql_query }}">
                 {{ link_or_button(
                   url('/sql', url_params|merge(index_params)),
                   get_icon('b_drop', 'Drop'|trans),

--- a/templates/server/databases/index.twig
+++ b/templates/server/databases/index.twig
@@ -235,7 +235,7 @@
 
                 <td class="tool">
                   <a class="server_databases" data="
-                    {{- database.name|js_format }}" href="{{ url('/server/privileges', {
+                    {{- database.name }}" href="{{ url('/server/privileges', {
                       'db': database.name,
                       'checkprivsdb': database.name
                     }) }}" title="

--- a/templates/table/relation/foreign_key_row.twig
+++ b/templates/table/relation/foreign_key_row.twig
@@ -17,7 +17,7 @@
                     one_key['constraint']
                 )
             } %}
-            {% set js_msg = 'ALTER TABLE ' ~ db ~ '.' ~ table ~ ' DROP FOREIGN KEY ' ~ one_key['constraint'] ~ ';'|js_format %}
+            {% set js_msg = 'ALTER TABLE ' ~ db ~ '.' ~ table ~ ' DROP FOREIGN KEY ' ~ one_key['constraint'] ~ ';' %}
         {% endif %}
         {% if one_key['constraint'] is defined %}
             <input type="hidden" class="drop_foreign_key_msg" value="

--- a/templates/table/structure/display_structure.twig
+++ b/templates/table/structure/display_structure.twig
@@ -501,7 +501,7 @@
                     } %}
                   {% endif %}
 
-                  <input type="hidden" class="drop_primary_key_index_msg" value="{{ index_params.sql_query|js_format(false) }}">
+                  <input type="hidden" class="drop_primary_key_index_msg" value="{{ index_params.sql_query }}">
                   {{ link_or_button(
                     url('/sql', index_params|merge({'db': db, 'table': table})),
                     get_icon('b_drop', 'Drop'|trans),


### PR DESCRIPTION
Some values were double or even triple encoded in the HTML/JS. This resulted in garbled up text. This PR removed HTML escaping from places where it is not needed. 