### PR TITLE
Bug fix: Fix triple HTML encoding

### DIFF
--- a/js/src/indexes.js
+++ b/js/src/indexes.js
@@ -640,11 +640,9 @@ AJAX.registerOnload('indexes.js', function () {
             $rowsToHide = $rowsToHide.add($lastRow);
         }
 
-        var question = Functions.escapeHtml(
-            $currRow.children('td')
-                .children('.drop_primary_key_index_msg')
-                .val()
-        );
+        var question = $currRow.children('td')
+            .children('.drop_primary_key_index_msg')
+            .val();
 
         Functions.confirmPreviewSql(question, $anchor.attr('href'), function (url) {
             var $msg = Functions.ajaxShowMessage(Messages.strDroppingPrimaryKeyIndex, false);

--- a/libraries/classes/Controllers/Table/RelationController.php
+++ b/libraries/classes/Controllers/Table/RelationController.php
@@ -16,7 +16,6 @@ use PhpMyAdmin\Util;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
-use function htmlspecialchars;
 use function mb_strtoupper;
 use function md5;
 use function strtoupper;
@@ -322,14 +321,11 @@ final class RelationController extends AbstractController
         } else {
             $columnList = $table_obj->getIndexedColumns(false, false);
         }
-        $columns = [];
-        foreach ($columnList as $column) {
-            $columns[] = htmlspecialchars($column);
-        }
         if ($GLOBALS['cfg']['NaturalOrder']) {
-            usort($columns, 'strnatcasecmp');
+            usort($columnList, 'strnatcasecmp');
         }
-        $this->response->addJSON('columns', $columns);
+
+        $this->response->addJSON('columns', $columnList);
 
         // @todo should be: $server->db($db)->table($table)->primary()
         $primary = Index::getPrimary($foreignTable, $_POST['foreignDb']);
@@ -366,7 +362,7 @@ final class RelationController extends AbstractController
                     continue;
                 }
 
-                $tables[] = htmlspecialchars($row['Name']);
+                $tables[] = $row['Name'];
             }
         } else {
             $query = 'SHOW TABLES FROM '
@@ -377,7 +373,7 @@ final class RelationController extends AbstractController
                 DatabaseInterface::QUERY_STORE
             );
             while ($row = $this->dbi->fetchArray($tables_rs)) {
-                $tables[] = htmlspecialchars($row[0]);
+                $tables[] = $row[0];
             }
         }
         if ($GLOBALS['cfg']['NaturalOrder']) {

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3329,8 +3329,8 @@ class Results
             ];
             $del_url  = Url::getFromRoute('/sql', $_url_params);
 
-            $js_conf  = 'DELETE FROM ' . Sanitize::jsFormat($this->properties['table'])
-                . ' WHERE ' . Sanitize::jsFormat($where_clause, false)
+            $js_conf  = 'DELETE FROM ' . $this->properties['table']
+                . ' WHERE ' . $where_clause
                 . ($clause_is_unique ? '' : ' LIMIT 1');
 
             $del_str = $this->getActionLinkContent('b_drop', __('Delete'));

--- a/templates/indexes.twig
+++ b/templates/indexes.twig
@@ -51,7 +51,7 @@
                   } %}
                 {% endif %}
 
-                <input type="hidden" class="drop_primary_key_index_msg" value="{{ index_params.sql_query|js_format(false) }}">
+                <input type="hidden" class="drop_primary_key_index_msg" value="{{ index_params.sql_query }}">
                 {{ link_or_button(
                   url('/sql', url_params|merge(index_params)),
                   get_icon('b_drop', 'Drop'|trans),

--- a/templates/server/databases/index.twig
+++ b/templates/server/databases/index.twig
@@ -238,7 +238,7 @@
 
                 <td class="tool">
                   <a class="server_databases" data="
-                    {{- database.name|js_format }}" href="{{ url('/server/privileges', {
+                    {{- database.name }}" href="{{ url('/server/privileges', {
                       'db': database.name,
                       'checkprivsdb': database.name
                     }) }}" title="

--- a/templates/table/relation/foreign_key_row.twig
+++ b/templates/table/relation/foreign_key_row.twig
@@ -17,7 +17,7 @@
                     one_key['constraint']
                 )
             } %}
-            {% set js_msg = 'ALTER TABLE ' ~ db ~ '.' ~ table ~ ' DROP FOREIGN KEY ' ~ one_key['constraint'] ~ ';'|js_format %}
+            {% set js_msg = 'ALTER TABLE ' ~ db ~ '.' ~ table ~ ' DROP FOREIGN KEY ' ~ one_key['constraint'] ~ ';' %}
         {% endif %}
         {% if one_key['constraint'] is defined %}
             <input type="hidden" class="drop_foreign_key_msg" value="

--- a/templates/table/structure/display_structure.twig
+++ b/templates/table/structure/display_structure.twig
@@ -458,7 +458,7 @@
                     } %}
                   {% endif %}
 
-                  <input type="hidden" class="drop_primary_key_index_msg" value="{{ index_params.sql_query|js_format(false) }}">
+                  <input type="hidden" class="drop_primary_key_index_msg" value="{{ index_params.sql_query }}">
                   {{ link_or_button(
                     url('/sql', index_params|merge({'db': db, 'table': table})),
                     get_icon('b_drop', 'Drop'|trans),


### PR DESCRIPTION
Some values were double or even triple encoded in the HTML/JS. This resulted in garbled up text. This PR removed HTML escaping from places where it is not needed.

Cherry-picked from #17246 onto QA_5_1 branch