### PR TITLE
Remove $row_number from DatabaseInterface::fetchValue

### DIFF
--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -841,7 +841,7 @@ class Relation
             ORDER BY `timevalue` DESC
             LIMIT ' . $GLOBALS['cfg']['QueryHistoryMax'] . ', 1';
 
-        $max_time = $this->dbi->fetchValue($search_query, 0, 0, DatabaseInterface::CONNECT_CONTROL);
+        $max_time = $this->dbi->fetchValue($search_query, 0, DatabaseInterface::CONNECT_CONTROL);
 
         if (! $max_time) {
             return;

--- a/libraries/classes/Controllers/Server/UserGroupsFormController.php
+++ b/libraries/classes/Controllers/Server/UserGroupsFormController.php
@@ -81,7 +81,7 @@ final class UserGroupsFormController extends AbstractController
             $userTable,
             $this->dbi->escapeString($username)
         );
-        $userGroup = $this->dbi->fetchValue($sqlQuery, 0, 0, DatabaseInterface::CONNECT_CONTROL);
+        $userGroup = $this->dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL);
 
         $allUserGroups = [];
         $sqlQuery = 'SELECT DISTINCT `usergroup` FROM ' . $groupTable;

--- a/libraries/classes/Database/Events.php
+++ b/libraries/classes/Database/Events.php
@@ -479,7 +479,7 @@ class Events
 
     public function getEventSchedulerStatus(): bool
     {
-        $state = (string) $this->dbi->fetchValue('SHOW GLOBAL VARIABLES LIKE \'event_scheduler\'', 0, 1);
+        $state = (string) $this->dbi->fetchValue('SHOW GLOBAL VARIABLES LIKE \'event_scheduler\'', 1);
 
         return strtoupper($state) === 'ON' || $state === '1';
     }

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -1030,7 +1030,7 @@ class DatabaseInterface implements DbalInterface
                 $modifier = '';
         }
 
-        return $this->fetchValue('SHOW' . $modifier . ' VARIABLES LIKE \'' . $var . '\';', 0, 1, $link);
+        return $this->fetchValue('SHOW' . $modifier . ' VARIABLES LIKE \'' . $var . '\';', 1, $link);
     }
 
     /**
@@ -1200,18 +1200,15 @@ class DatabaseInterface implements DbalInterface
      * // $user_name = 'John Doe'
      * </code>
      *
-     * @param string     $query      The query to execute
-     * @param int        $row_number row to fetch the value from,
-     *                               starting at 0, with 0 being default
-     * @param int|string $field      field to fetch the value from,
-     *                               starting at 0, with 0 being default
-     * @param int        $link       link type
+     * @param string     $query The query to execute
+     * @param int|string $field field to fetch the value from,
+     *                          starting at 0, with 0 being default
+     * @param int        $link  link type
      *
      * @return mixed|false value of first field in first row from result or false if not found
      */
     public function fetchValue(
         string $query,
-        int $row_number = 0,
         $field = 0,
         $link = self::CONNECT_USER
     ) {
@@ -1220,14 +1217,7 @@ class DatabaseInterface implements DbalInterface
             return false;
         }
 
-        // return false if result is empty or false
-        // or requested row is larger than rows in result
-        if ($this->numRows($result) < $row_number + 1) {
-            return false;
-        }
-
         // get requested row
-        $this->dataSeek($result, $row_number);
         $row = $this->fetchByMode($result, is_int($field) ? self::FETCH_NUM : self::FETCH_ASSOC);
 
         // return requested field
@@ -1507,7 +1497,7 @@ class DatabaseInterface implements DbalInterface
         $query = 'SHOW CREATE ' . $which . ' '
             . Util::backquote($db) . '.'
             . Util::backquote($name);
-        $result = $this->fetchValue($query, 0, $returned_field[$which], $link);
+        $result = $this->fetchValue($query, $returned_field[$which], $link);
 
         return is_string($result) ? $result : null;
     }
@@ -2113,7 +2103,7 @@ class DatabaseInterface implements DbalInterface
         // When no controluser is defined, using mysqli_insert_id($link)
         // does not always return the last insert id due to a mixup with
         // the tracking mechanism, but this works:
-        return $this->fetchValue('SELECT LAST_INSERT_ID();', 0, 0, $link);
+        return $this->fetchValue('SELECT LAST_INSERT_ID();', 0, $link);
     }
 
     /**

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -302,21 +302,17 @@ interface DbalInterface
      * // $user_name = 'John Doe'
      * </code>
      *
-     * @param string     $query      The query to execute
-     * @param int        $row_number row to fetch the value from,
-     *                               starting at 0, with 0 being
-     *                               default
-     * @param int|string $field      field to fetch the value from,
-     *                               starting at 0, with 0 being
-     *                               default
-     * @param int        $link       link type
+     * @param string     $query The query to execute
+     * @param int|string $field field to fetch the value from,
+     *                          starting at 0, with 0 being
+     *                          default
+     * @param int        $link  link type
      *
      * @return mixed value of first field in first row from result
      *               or false if not found
      */
     public function fetchValue(
         string $query,
-        int $row_number = 0,
         $field = 0,
         $link = DatabaseInterface::CONNECT_USER
     );

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -266,7 +266,6 @@ class Innodb extends StorageEngine
         return '<pre id="pre_innodb_status">' . "\n"
             . htmlspecialchars((string) $dbi->fetchValue(
                 'SHOW ENGINE INNODB STATUS;',
-                0,
                 'Status'
             )) . "\n" . '</pre>' . "\n";
     }
@@ -305,7 +304,7 @@ class Innodb extends StorageEngine
     {
         global $dbi;
 
-        $value = $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 0, 1);
+        $value = $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_format';", 1);
 
         if ($value === false) {
             // This variable does not exist anymore on MariaDB >= 10.6.0
@@ -325,6 +324,6 @@ class Innodb extends StorageEngine
     {
         global $dbi;
 
-        return $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_per_table';", 0, 1) === 'ON';
+        return $dbi->fetchValue("SHOW GLOBAL VARIABLES LIKE 'innodb_file_per_table';", 1) === 'ON';
     }
 }

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -561,7 +561,7 @@ class Privileges
 
         $sqlQuery = 'SELECT `usergroup` FROM ' . $userTable
             . " WHERE `username` = '" . $this->dbi->escapeString($username) . "'";
-        $oldUserGroup = $this->dbi->fetchValue($sqlQuery, 0, 0, DatabaseInterface::CONNECT_CONTROL);
+        $oldUserGroup = $this->dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL);
 
         if ($oldUserGroup === false) {
             $updQuery = 'INSERT INTO ' . $userTable . '(`username`, `usergroup`)'
@@ -1557,7 +1557,7 @@ class Privileges
             . '.' . Util::backquote($relationParameters->usergroups);
         $sqlQuery = 'SELECT COUNT(*) FROM ' . $userGroupTable;
 
-        return (int) $this->dbi->fetchValue($sqlQuery, 0, 0, DatabaseInterface::CONNECT_CONTROL);
+        return (int) $this->dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL);
     }
 
     /**
@@ -1581,7 +1581,7 @@ class Privileges
             . ' WHERE `username` = \'' . $username . '\''
             . ' LIMIT 1';
 
-        $usergroup = $this->dbi->fetchValue($sqlQuery, 0, 0, DatabaseInterface::CONNECT_CONTROL);
+        $usergroup = $this->dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL);
 
         if ($usergroup === false) {
             return null;

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -2616,7 +2616,6 @@ class Table implements Stringable
         return $this->dbi->fetchValue(
             'SHOW CREATE TABLE ' . Util::backquote($this->dbName) . '.'
             . Util::backquote($this->name),
-            0,
             1
         );
     }

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -151,7 +151,7 @@ class Tracker
         " AND table_name = '" . $dbi->escapeString($tableName) . "' " .
         ' ORDER BY version DESC LIMIT 1';
 
-        $result = $dbi->fetchValue($sqlQuery, 0, 0, DatabaseInterface::CONNECT_CONTROL) == 1;
+        $result = $dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL) == 1;
 
         self::$trackingCache[$dbName][$tableName] = $result;
 

--- a/libraries/classes/UserPreferences.php
+++ b/libraries/classes/UserPreferences.php
@@ -141,7 +141,7 @@ class UserPreferences
             . $dbi->escapeString($relationParameters->user)
             . '\'';
 
-        $has_config = $dbi->fetchValue($query, 0, 0, DatabaseInterface::CONNECT_CONTROL);
+        $has_config = $dbi->fetchValue($query, 0, DatabaseInterface::CONNECT_CONTROL);
         $config_data = json_encode($config_array);
         if ($has_config) {
             $query = 'UPDATE ' . $query_table

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2906,11 +2906,6 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:dataSeek\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
 			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
@@ -2932,11 +2927,16 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 4
+			count: 3
 			path: libraries/classes/DatabaseInterface.php
 
 		-
 			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\Query\\\\Cache\\:\\:cacheTableData\\(\\) expects bool\\|string, array\\|string given\\.$#"
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
+			message: "#^Parameter \\#3 \\$link of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchValue\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
@@ -2953,11 +2953,6 @@ parameters:
 		-
 			message: "#^Parameter \\#4 \\$link of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchResult\\(\\) expects int, mixed given\\.$#"
 			count: 7
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Parameter \\#4 \\$link of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchValue\\(\\) expects int, mixed given\\.$#"
-			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5600,7 +5600,7 @@
       <code>$a</code>
       <code>$b</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="65">
+    <MixedArgument occurrences="63">
       <code>$_SERVER['SCRIPT_NAME']</code>
       <code>$a</code>
       <code>$arrayKeys</code>
@@ -5629,8 +5629,6 @@
       <code>$one_table_name</code>
       <code>$password</code>
       <code>$res</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$result</code>
       <code>$result</code>
       <code>$result</code>
@@ -5820,7 +5818,7 @@
     <MixedReturnStatement occurrences="7">
       <code>$tables[$database]</code>
       <code>$tables[mb_strtolower($database)]</code>
-      <code>$this-&gt;fetchValue('SELECT LAST_INSERT_ID();', 0, 0, $link)</code>
+      <code>$this-&gt;fetchValue('SELECT LAST_INSERT_ID();', 0, $link)</code>
       <code>$this-&gt;lowerCaseTableNames</code>
       <code>$user</code>
       <code>SessionCache::get('mysql_cur_user')</code>

--- a/test/classes/Database/QbeTest.php
+++ b/test/classes/Database/QbeTest.php
@@ -44,7 +44,7 @@ class QbeTest extends AbstractTestCase
 
         $dbi->expects($this->any())
             ->method('fetchValue')
-            ->with('SHOW CREATE TABLE `pma_test`.`table1`', 0, 1)
+            ->with('SHOW CREATE TABLE `pma_test`.`table1`', 1)
             ->will($this->returnValue($create_table));
 
         $dbi->expects($this->any())

--- a/test/classes/UserPreferencesTest.php
+++ b/test/classes/UserPreferencesTest.php
@@ -193,7 +193,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
 
         $dbi->expects($this->once())
             ->method('fetchValue')
-            ->with($query1, 0, 0, DatabaseInterface::CONNECT_CONTROL)
+            ->with($query1, 0, DatabaseInterface::CONNECT_CONTROL)
             ->will($this->returnValue(true));
 
         $dbi->expects($this->once())
@@ -224,7 +224,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
 
         $dbi->expects($this->once())
             ->method('fetchValue')
-            ->with($query1, 0, 0, DatabaseInterface::CONNECT_CONTROL)
+            ->with($query1, 0, DatabaseInterface::CONNECT_CONTROL)
             ->will($this->returnValue(false));
 
         $dbi->expects($this->once())


### PR DESCRIPTION
The parameter is not used anywhere. It is always set to 0. This doesn't sound particularly useful. It's most likely a remnant from PHP 4 era, where existed a function called `mysqli_result`. 

Removing this parameter helps with further changes I have planned. 