### PR TITLE
Replace `vendor_config.php` constants with an array

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ if (PHP_VERSION_ID < 70205) {
 define('PHPMYADMIN', true);
 // phpcs:enable
 
-require_once ROOT_PATH . 'libraries/vendor_config.php';
+require_once ROOT_PATH . 'libraries/constants.php';
 
 /**
  * Activate autoloader

--- a/js/messages.php
+++ b/js/messages.php
@@ -23,7 +23,7 @@ if (PHP_VERSION_ID < 70205) {
 define('PHPMYADMIN', true);
 // phpcs:enable
 
-require_once ROOT_PATH . 'libraries/vendor_config.php';
+require_once ROOT_PATH . 'libraries/constants.php';
 
 /**
  * Activate autoloader

--- a/libraries/classes/Command/SetVersionCommand.php
+++ b/libraries/classes/Command/SetVersionCommand.php
@@ -36,7 +36,7 @@ use const VERSION_SUFFIX;
  */
 final class Version
 {
-    // The VERSION_SUFFIX constant is defined at libraries/vendor_config.php
+    // The VERSION_SUFFIX constant is defined at libraries/constants.php
     public const VERSION = '%1$u.%2$u.%3$u%4$s' . VERSION_SUFFIX;
     public const SERIES = '%1$u.%2$u';
     public const MAJOR = %1$u;

--- a/libraries/classes/Version.php
+++ b/libraries/classes/Version.php
@@ -13,7 +13,7 @@ use const VERSION_SUFFIX;
  */
 final class Version
 {
-    // The VERSION_SUFFIX constant is defined at libraries/vendor_config.php
+    // The VERSION_SUFFIX constant is defined at libraries/constants.php
     public const VERSION = '5.2.0-dev' . VERSION_SUFFIX;
     public const SERIES = '5.2';
     public const MAJOR = 5;

--- a/libraries/constants.php
+++ b/libraries/constants.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+if (! defined('PHPMYADMIN')) {
+    exit;
+}
+
+$vendorConfig = require_once ROOT_PATH . 'libraries/vendor_config.php';
+if (
+    ! is_array($vendorConfig) || ! isset(
+        $vendorConfig['autoloadFile'],
+        $vendorConfig['tempDir'],
+        $vendorConfig['changeLogFile'],
+        $vendorConfig['licenseFile'],
+        $vendorConfig['sqlDir'],
+        $vendorConfig['configFile'],
+        $vendorConfig['customHeaderFile'],
+        $vendorConfig['customFooterFile'],
+        $vendorConfig['versionCheckDefault'],
+        $vendorConfig['localePath'],
+        $vendorConfig['cacheDir'],
+        $vendorConfig['versionSuffix']
+    )
+) {
+    exit;
+}
+
+// phpcs:disable PSR1.Files.SideEffects
+define('AUTOLOAD_FILE', (string) $vendorConfig['autoloadFile']);
+define('TEMP_DIR', (string) $vendorConfig['tempDir']);
+define('CHANGELOG_FILE', (string) $vendorConfig['changeLogFile']);
+define('LICENSE_FILE', (string) $vendorConfig['licenseFile']);
+define('SQL_DIR', (string) $vendorConfig['sqlDir']);
+define('CONFIG_FILE', (string) $vendorConfig['configFile']);
+define('CUSTOM_HEADER_FILE', (string) $vendorConfig['customHeaderFile']);
+define('CUSTOM_FOOTER_FILE', (string) $vendorConfig['customFooterFile']);
+define('VERSION_CHECK_DEFAULT', (bool) $vendorConfig['versionCheckDefault']);
+define('LOCALE_PATH', (string) $vendorConfig['localePath']);
+define('CACHE_DIR', (string) $vendorConfig['cacheDir']);
+define('VERSION_SUFFIX', (string) $vendorConfig['versionSuffix']);
+
+/**
+ * TCPDF workaround. Avoid referring to nonexistent files (causes warnings when open_basedir is used).
+ * This is defined to avoid the TCPDF code to search for a directory outside of open_basedir.
+ * This value if not used but is useful, no header logic is used for PDF exports.
+ *
+ * @see https://github.com/phpmyadmin/phpmyadmin/issues/16709
+ */
+define('K_PATH_IMAGES', ROOT_PATH);
+// phpcs:enable
+
+unset($vendorConfig);

--- a/libraries/vendor_config.php
+++ b/libraries/vendor_config.php
@@ -9,88 +9,69 @@
 
 declare(strict_types=1);
 
-// phpcs:disable PSR1.Files.SideEffects
 if (! defined('PHPMYADMIN')) {
     exit;
 }
 
-// phpcs:enable
+return [
+    /**
+     * Path to vendor autoload file. Useful when you want to have vendor dependencies somewhere else.
+     */
+    'autoloadFile' => ROOT_PATH . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
 
-/**
- * Path to vendor autoload file. Useful when you want to
- * have have vendor dependencies somewhere else.
- */
-define('AUTOLOAD_FILE', ROOT_PATH . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php');
+    /**
+     * Directory where cache files are stored.
+     */
+    'tempDir' => ROOT_PATH . 'tmp' . DIRECTORY_SEPARATOR,
 
-/**
- * Directory where cache files are stored.
- */
-define('TEMP_DIR', ROOT_PATH . 'tmp' . DIRECTORY_SEPARATOR);
+    /**
+     * Path to changelog file, can be gzip compressed.
+     * Useful when you want to have documentation somewhere else, e.g. /usr/share/doc.
+     */
+    'changeLogFile' => ROOT_PATH . 'ChangeLog',
 
-/**
- * Path to changelog file, can be gzip compressed. Useful when you want to
- * have documentation somewhere else, eg. /usr/share/doc.
- */
-define('CHANGELOG_FILE', ROOT_PATH . 'ChangeLog');
+    /**
+     * Path to license file. Useful when you want to have documentation somewhere else, e.g. /usr/share/doc.
+     */
+    'licenseFile' => ROOT_PATH . 'LICENSE',
 
-/**
- * Path to license file. Useful when you want to have documentation somewhere
- * else, eg. /usr/share/doc.
- */
-define('LICENSE_FILE', ROOT_PATH . 'LICENSE');
+    /**
+     * Directory where SQL scripts to create/upgrade configuration storage reside.
+     */
+    'sqlDir' => ROOT_PATH . 'sql' . DIRECTORY_SEPARATOR,
 
-/**
- * Directory where SQL scripts to create/upgrade configuration storage reside.
- */
-define('SQL_DIR', ROOT_PATH . 'sql' . DIRECTORY_SEPARATOR);
+    /**
+     * Filename of a configuration file.
+     */
+    'configFile' => ROOT_PATH . 'config.inc.php',
 
-/**
- * Directory where configuration files are stored.
- * It is not used directly in code, just a convenient
- * define used further in this file.
- */
-define('CONFIG_DIR', ROOT_PATH);
+    /**
+     * Filename of custom header file.
+     */
+    'customHeaderFile' => ROOT_PATH . 'config.header.inc.php',
 
-/**
- * Filename of a configuration file.
- */
-define('CONFIG_FILE', CONFIG_DIR . 'config.inc.php');
+    /**
+     * Filename of custom footer file.
+     */
+    'customFooterFile' => ROOT_PATH . 'config.footer.inc.php',
 
-/**
- * Filename of custom header file.
- */
-define('CUSTOM_HEADER_FILE', CONFIG_DIR . 'config.header.inc.php');
+    /**
+     * Default value for check for version upgrades.
+     */
+    'versionCheckDefault' => true,
 
-/**
- * Filename of custom footer file.
- */
-define('CUSTOM_FOOTER_FILE', CONFIG_DIR . 'config.footer.inc.php');
+    /**
+     * Path to files with compiled locales (*.mo)
+     */
+    'localePath' => ROOT_PATH . 'locale' . DIRECTORY_SEPARATOR,
 
-/**
- * Default value for check for version upgrades.
- */
-define('VERSION_CHECK_DEFAULT', true);
+    /**
+     * Define the cache directory for routing cache and other cache files
+     */
+    'cacheDir' => ROOT_PATH . 'libraries' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR,
 
-/**
- * Path to files with compiled locales (*.mo)
- */
-define('LOCALE_PATH', ROOT_PATH . 'locale' . DIRECTORY_SEPARATOR);
-
-/**
- * Define the cache directory for routing cache an other cache files
- */
-define('CACHE_DIR', ROOT_PATH . 'libraries' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR);
-
-/**
- * Suffix to add to the phpMyAdmin version
- */
-define('VERSION_SUFFIX', '');
-
-/**
- * TCPDF workaround. Avoid referring to nonexistent files (causes warnings when open_basedir is used).
- * This is defined to avoid the TCPDF code to search for a directory outside of open_basedir.
- * This value if not used but is useful, no header logic is used for PDF exports.
- *
- * @see https://github.com/phpmyadmin/phpmyadmin/issues/16709
- */
-define('K_PATH_IMAGES', ROOT_PATH);
+    /**
+     * Suffix to add to the phpMyAdmin version
+     */
+    'versionSuffix' => '',
+];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,7 @@ parameters:
     paths:
         - .
     scanFiles:
-        - libraries/vendor_config.php
+        - libraries/constants.php
     bootstrapFiles:
         - test/phpstan-constants.php
     excludePaths:

--- a/scripts/console
+++ b/scripts/console
@@ -17,7 +17,7 @@ if (! defined('ROOT_PATH')) {
 }
 
 define('PHPMYADMIN', true);
-require_once ROOT_PATH . 'libraries/vendor_config.php';
+require_once ROOT_PATH . 'libraries/constants.php';
 require_once AUTOLOAD_FILE;
 
 if (! class_exists(Application::class)) {

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -357,7 +357,7 @@ fi
 
 if [ $do_daily -eq 1 ] ; then
     echo '* setting the version suffix for the snapshot'
-    sed -i "s/'VERSION_SUFFIX', '.*'/'VERSION_SUFFIX', '+$today_date.$git_head_short'/" libraries/vendor_config.php
+    sed -i "s/'versionSuffix' => '.*'/'versionSuffix' => '+$today_date.$git_head_short'/" libraries/vendor_config.php
     php -l libraries/vendor_config.php
 fi
 

--- a/setup/lib/common.inc.php
+++ b/setup/lib/common.inc.php
@@ -14,7 +14,7 @@ if (! defined('PHPMYADMIN')) {
     exit;
 }
 
-require_once ROOT_PATH . 'libraries/vendor_config.php';
+require_once ROOT_PATH . 'libraries/constants.php';
 
 /**
  * Activate autoloader

--- a/show_config_errors.php
+++ b/show_config_errors.php
@@ -28,7 +28,7 @@ header('Content-Type: text/html; charset=utf-8');
 define('PHPMYADMIN', true);
 // phpcs:enable
 
-require ROOT_PATH . 'libraries/vendor_config.php';
+require ROOT_PATH . 'libraries/constants.php';
 
 // issue #16256 - This only works with php 8.0+
 if (function_exists('error_reporting')) {

--- a/test/bootstrap-dist.php
+++ b/test/bootstrap-dist.php
@@ -21,5 +21,5 @@ error_reporting(E_ALL);
 // Ensure PHP has set timezone
 date_default_timezone_set('UTC');
 
-require_once ROOT_PATH . 'libraries/vendor_config.php';
+require_once ROOT_PATH . 'libraries/constants.php';
 require_once AUTOLOAD_FILE;// Some phpunit configurations will need it

--- a/test/bootstrap-static.php
+++ b/test/bootstrap-static.php
@@ -27,7 +27,7 @@ if (! defined('TESTSUITE')) {
 // phpcs:enable
 
 include_once ROOT_PATH . 'examples/signon-script.php';
-require_once ROOT_PATH . 'libraries/vendor_config.php';
+require_once ROOT_PATH . 'libraries/constants.php';
 require_once AUTOLOAD_FILE;
 
 $settings = new Settings([]);

--- a/test/classes/Command/SetVersionCommandTest.php
+++ b/test/classes/Command/SetVersionCommandTest.php
@@ -201,7 +201,7 @@ use const VERSION_SUFFIX;
  */
 final class Version
 {
-    // The VERSION_SUFFIX constant is defined at libraries/vendor_config.php
+    // The VERSION_SUFFIX constant is defined at libraries/constants.php
 %s
 }
 

--- a/url.php
+++ b/url.php
@@ -19,7 +19,7 @@ if (PHP_VERSION_ID < 70205) {
 define('PHPMYADMIN', true);
 // phpcs:enable
 
-require_once ROOT_PATH . 'libraries/vendor_config.php';
+require_once ROOT_PATH . 'libraries/constants.php';
 
 /**
  * Activate autoloader


### PR DESCRIPTION
Constants are hard to deal with, so this pull request replaces the constants in the `libraries/vendor_config.php` file with an array.

The constants have been moved to the `libraries/constants.php` file and can be removed later.

