### PR TITLE
Major refactoring of Dbal pt.1

### DIFF
--- a/libraries/classes/Charsets.php
+++ b/libraries/classes/Charsets.php
@@ -94,11 +94,9 @@ class Charsets
         $res = $dbi->query($sql);
 
         self::$charsets = [];
-        while ($row = $dbi->fetchAssoc($res)) {
+        foreach ($res as $row) {
             self::$charsets[$row['Charset']] = Charset::fromServer($row);
         }
-
-        $dbi->freeResult($res);
 
         ksort(self::$charsets, SORT_STRING);
     }
@@ -131,11 +129,9 @@ class Charsets
         $res = $dbi->query($sql);
 
         self::$collations = [];
-        while ($row = $dbi->fetchAssoc($res)) {
+        foreach ($res as $row) {
             self::$collations[$row['Charset']][$row['Collation']] = Collation::fromServer($row);
         }
-
-        $dbi->freeResult($res);
 
         foreach (array_keys(self::$collations) as $charset) {
             ksort(self::$collations[$charset], SORT_STRING);

--- a/libraries/classes/CheckUserPrivileges.php
+++ b/libraries/classes/CheckUserPrivileges.php
@@ -284,8 +284,6 @@ class CheckUserPrivileges
              //break;
         }
 
-        $this->dbi->freeResult($showGrantsResult);
-
         // must also cacheUnset() them in
         // PhpMyAdmin\Plugins\Auth\AuthenticationCookie
         SessionCache::set('is_create_db_priv', $GLOBALS['is_create_db_priv']);

--- a/libraries/classes/Controllers/Server/BinlogController.php
+++ b/libraries/classes/Controllers/Server/BinlogController.php
@@ -75,10 +75,7 @@ class BinlogController extends AbstractController
         $sqlQuery = $this->getSqlQuery($params['log'] ?? '', $position, (int) $cfg['MaxRows']);
         $result = $this->dbi->query($sqlQuery);
 
-        $numRows = 0;
-        if (isset($result) && $result) {
-            $numRows = $this->dbi->numRows($result);
-        }
+        $numRows = $result->numRows();
 
         $previousParams = $urlParams;
         $fullQueriesParams = $urlParams;
@@ -99,10 +96,7 @@ class BinlogController extends AbstractController
             $nextParams['pos'] = $position + $cfg['MaxRows'];
         }
 
-        $values = [];
-        while ($value = $this->dbi->fetchAssoc($result)) {
-            $values[] = $value;
-        }
+        $values = $result->fetchAllAssoc();
 
         $this->render('server/binlog/index', [
             'url_params' => $urlParams,

--- a/libraries/classes/Controllers/Server/UserGroupsFormController.php
+++ b/libraries/classes/Controllers/Server/UserGroupsFormController.php
@@ -90,12 +90,10 @@ final class UserGroupsFormController extends AbstractController
         $sqlQuery = 'SELECT DISTINCT `usergroup` FROM ' . $groupTable;
         $result = $this->relation->queryAsControlUser($sqlQuery, false);
         if ($result) {
-            while ($row = $this->dbi->fetchRow($result)) {
+            while ($row = $result->fetchRow()) {
                 $allUserGroups[$row[0]] = $row[0];
             }
         }
-
-        $this->dbi->freeResult($result);
 
         return $this->template->render('server/privileges/choose_user_group', [
             'all_user_groups' => $allUserGroups,

--- a/libraries/classes/Controllers/Server/Variables/SetVariableController.php
+++ b/libraries/classes/Controllers/Server/Variables/SetVariableController.php
@@ -72,10 +72,8 @@ final class SetVariableController extends AbstractController
         }
 
         $json = [];
-        if (
-            ! preg_match('/[^a-zA-Z0-9_]+/', $variableName)
-            && $this->dbi->query('SET GLOBAL ' . $variableName . ' = ' . $value)
-        ) {
+        if (! preg_match('/[^a-zA-Z0-9_]+/', $variableName)) {
+            $this->dbi->query('SET GLOBAL ' . $variableName . ' = ' . $value);
             // Some values are rounded down etc.
             $varValue = $this->dbi->fetchSingleRow(
                 'SHOW GLOBAL VARIABLES WHERE Variable_name="'

--- a/libraries/classes/Controllers/Server/VariablesController.php
+++ b/libraries/classes/Controllers/Server/VariablesController.php
@@ -52,12 +52,9 @@ class VariablesController extends AbstractController
         $variables = [];
         $serverVarsResult = $this->dbi->tryQuery('SHOW SESSION VARIABLES;');
         if ($serverVarsResult !== false) {
-            $serverVarsSession = [];
-            while ($arr = $this->dbi->fetchRow($serverVarsResult)) {
-                $serverVarsSession[$arr[0]] = $arr[1];
-            }
+            $serverVarsSession = $serverVarsResult->fetchAllKeyPair();
 
-            $this->dbi->freeResult($serverVarsResult);
+            unset($serverVarsResult);
 
             $serverVars = $this->dbi->fetchResult('SHOW GLOBAL VARIABLES;', 0, 1);
 

--- a/libraries/classes/Controllers/Table/ChartController.php
+++ b/libraries/classes/Controllers/Table/ChartController.php
@@ -117,15 +117,14 @@ class ChartController extends AbstractController
             }
         }
 
-        $data = [];
-
         $result = $this->dbi->tryQuery($sql_query);
-        $fields_meta = $this->dbi->getFieldsMeta($result) ?? [];
-        while ($row = $this->dbi->fetchAssoc($result)) {
-            $data[] = $row;
+        $fields_meta = $row = [];
+        if ($result !== false) {
+            $fields_meta = $this->dbi->getFieldsMeta($result);
+            $row = $result->fetchAssoc();
         }
 
-        $keys = array_keys($data[0]);
+        $keys = array_keys($row);
         $numericColumnFound = false;
         foreach (array_keys($keys) as $idx) {
             if (
@@ -198,13 +197,13 @@ class ChartController extends AbstractController
 
         $sql_with_limit = $statement->build();
 
-        $data = [];
         $result = $this->dbi->tryQuery($sql_with_limit);
-        while ($row = $this->dbi->fetchAssoc($result)) {
-            $data[] = $row;
+        $data = [];
+        if ($result !== false) {
+            $data = $result->fetchAllAssoc();
         }
 
-        if (empty($data)) {
+        if ($data === []) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No data to display'));
 

--- a/libraries/classes/Controllers/Table/FindReplaceController.php
+++ b/libraries/classes/Controllers/Table/FindReplaceController.php
@@ -56,7 +56,7 @@ class FindReplaceController extends AbstractController
         $this->columnNames = [];
         $this->columnTypes = [];
         $this->loadTableInfo();
-        $this->connectionCharSet = $this->dbi->fetchValue('SELECT @@character_set_connection');
+        $this->connectionCharSet = (string) $this->dbi->fetchValue('SELECT @@character_set_connection');
     }
 
     public function __invoke(): void

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -76,7 +76,10 @@ final class GisVisualizationController extends AbstractController
         // Execute the query and return the result
         $result = $this->dbi->tryQuery($sqlQuery);
         // Get the meta data of results
-        $meta = $this->dbi->getFieldsMeta($result) ?? [];
+        $meta = [];
+        if ($result !== false) {
+            $meta = $this->dbi->getFieldsMeta($result);
+        }
 
         // Find the candidate fields for label column and spatial column
         $labelCandidates = [];

--- a/libraries/classes/Controllers/Table/RelationController.php
+++ b/libraries/classes/Controllers/Table/RelationController.php
@@ -175,9 +175,7 @@ final class RelationController extends AbstractController
      */
     private function updateForDisplayField(Table $table, DisplayFeature $displayFeature): void
     {
-        if (! $table->updateDisplayField($_POST['display_field'], $displayFeature)) {
-            return;
-        }
+        $table->updateDisplayField($_POST['display_field'], $displayFeature);
 
         $this->response->addHTML(
             Generator::getMessage(
@@ -326,7 +324,7 @@ final class RelationController extends AbstractController
                 . Util::backquote($_POST['foreignDb']);
             $tables_rs = $this->dbi->query($query, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
 
-            while ($row = $this->dbi->fetchArray($tables_rs)) {
+            foreach ($tables_rs as $row) {
                 if (! isset($row['Engine']) || mb_strtoupper($row['Engine']) != $storageEngine) {
                     continue;
                 }
@@ -337,9 +335,7 @@ final class RelationController extends AbstractController
             $query = 'SHOW TABLES FROM '
                 . Util::backquote($_POST['foreignDb']);
             $tables_rs = $this->dbi->query($query, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
-            while ($row = $this->dbi->fetchArray($tables_rs)) {
-                $tables[] = $row[0];
-            }
+            $tables = $tables_rs->fetchAllColumn();
         }
 
         if ($GLOBALS['cfg']['NaturalOrder']) {

--- a/libraries/classes/Controllers/Table/Structure/PrimaryController.php
+++ b/libraries/classes/Controllers/Table/Structure/PrimaryController.php
@@ -121,7 +121,7 @@ final class PrimaryController extends AbstractController
             'SHOW KEYS FROM ' . Util::backquote($this->table) . ';'
         );
         $primary = '';
-        while ($row = $this->dbi->fetchAssoc($result)) {
+        foreach ($result as $row) {
             // Backups the list of primary keys
             if ($row['Key_name'] !== 'PRIMARY') {
                 continue;
@@ -129,8 +129,6 @@ final class PrimaryController extends AbstractController
 
             $primary .= $row['Column_name'] . ', ';
         }
-
-        $this->dbi->freeResult($result);
 
         return $primary;
     }

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -41,7 +41,7 @@ final class TrackingController extends AbstractController
     {
         global $text_dir, $urlParams, $msg, $errorUrl;
         global $data, $entries, $filter_ts_from, $filter_ts_to, $filter_users, $selection_schema;
-        global $selection_data, $selection_both, $sql_result, $db, $table, $cfg;
+        global $selection_data, $selection_both, $db, $table, $cfg;
 
         $this->addScriptFiles(['vendor/jquery/jquery.tablesorter.js', 'table/tracking.js']);
 
@@ -170,7 +170,7 @@ final class TrackingController extends AbstractController
         // Export as SQL execution
         $message = '';
         if (isset($_POST['report_export']) && $_POST['export_type'] === 'execution') {
-            $sql_result = $this->tracking->exportAsSqlExecution($entries);
+            $this->tracking->exportAsSqlExecution($entries);
             $msg = Message::success(__('SQL statements executed.'));
             $message = $msg->getDisplay();
         }

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -283,7 +283,7 @@ class ZoomSearchController extends AbstractController
             DatabaseInterface::CONNECT_USER,
             DatabaseInterface::QUERY_STORE
         );
-        $fields_meta = $this->dbi->getFieldsMeta($result) ?? [];
+        $fields_meta = $this->dbi->getFieldsMeta($result);
         while ($row = $this->dbi->fetchAssoc($result)) {
             // for bit fields we need to convert them to printable form
             $i = 0;
@@ -344,7 +344,7 @@ class ZoomSearchController extends AbstractController
 
         //Query execution part
         $result = $this->dbi->query($sql_query . ';', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
-        $fields_meta = $this->dbi->getFieldsMeta($result) ?? [];
+        $fields_meta = $this->dbi->getFieldsMeta($result);
         $data = [];
         while ($row = $this->dbi->fetchAssoc($result)) {
             //Need a row with indexes as 0,1,2 for the getUniqueCondition

--- a/libraries/classes/Controllers/Transformation/WrapperController.php
+++ b/libraries/classes/Controllers/Transformation/WrapperController.php
@@ -111,18 +111,18 @@ class WrapperController extends AbstractController
                 DatabaseInterface::CONNECT_USER,
                 DatabaseInterface::QUERY_STORE
             );
-            $row = $this->dbi->fetchAssoc($result);
+            $row = $result->fetchAssoc();
         } else {
             $result = $this->dbi->query(
                 'SELECT * FROM ' . Util::backquote($table) . ' LIMIT 1;',
                 DatabaseInterface::CONNECT_USER,
                 DatabaseInterface::QUERY_STORE
             );
-            $row = $this->dbi->fetchAssoc($result);
+            $row = $result->fetchAssoc();
         }
 
         // No row returned
-        if (! $row) {
+        if ($row === []) {
             return;
         }
 

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -232,10 +232,7 @@ class Core
         );
 
         if ($tables) {
-            $numTables = $dbi->numRows($tables);
-            $dbi->freeResult($tables);
-
-            return $numTables;
+            return $tables->numRows();
         }
 
         return 0;

--- a/libraries/classes/Database/Designer.php
+++ b/libraries/classes/Database/Designer.php
@@ -106,8 +106,12 @@ class Designer
             . ' ORDER BY `page_descr`';
         $page_rs = $this->relation->queryAsControlUser($page_query, false, DatabaseInterface::QUERY_STORE);
 
+        if (! $page_rs) {
+            return [];
+        }
+
         $result = [];
-        while ($curr_page = $this->dbi->fetchAssoc($page_rs)) {
+        while ($curr_page = $page_rs->fetchAssoc()) {
             $result[intval($curr_page['page_nr'])] = $curr_page['page_descr'];
         }
 

--- a/libraries/classes/Database/Events.php
+++ b/libraries/classes/Database/Events.php
@@ -118,7 +118,9 @@ class Events
                             // We dropped the old item, but were unable to create
                             // the new one. Try to restore the backup query
                             $result = $this->dbi->tryQuery($create_item);
-                            $errors = $this->checkResult($result, $create_item, $errors);
+                            if (! $result) {
+                                $errors = $this->checkResult($create_item, $errors);
+                            }
                         } else {
                             $message = Message::success(
                                 __('Event %1$s has been modified.')
@@ -485,18 +487,13 @@ class Events
     }
 
     /**
-     * @param resource|bool $result          Query result
-     * @param string|null   $createStatement Query
-     * @param array         $errors          Errors
+     * @param string|null $createStatement Query
+     * @param array       $errors          Errors
      *
      * @return array
      */
-    private function checkResult($result, $createStatement, array $errors)
+    private function checkResult($createStatement, array $errors)
     {
-        if ($result) {
-            return $errors;
-        }
-
         // OMG, this is really bad! We dropped the query,
         // failed to create a new one
         // and now even the backup query does not execute!

--- a/libraries/classes/Database/Qbe.php
+++ b/libraries/classes/Database/Qbe.php
@@ -321,14 +321,14 @@ class Qbe
             DatabaseInterface::CONNECT_USER,
             DatabaseInterface::QUERY_STORE
         );
-        $allTablesCount = $this->dbi->numRows($allTables);
+        $allTablesCount = $allTables->numRows();
         if ($allTablesCount == 0) {
             echo Message::error(__('No tables found in database.'))->getDisplay();
             exit;
         }
 
         // The tables list gets from MySQL
-        while ([$table] = $this->dbi->fetchRow($allTables)) {
+        foreach ($allTables->fetchAllColumn() as $table) {
             $columns = $this->dbi->getColumns($this->db, $table);
 
             if (empty($this->criteriaTables[$table]) && ! empty($_POST['TableList'])) {
@@ -355,8 +355,6 @@ class Qbe
                 );
             }
         }
-
-        $this->dbi->freeResult($allTables);
 
         // sets the largest width found
         $this->realwidth = $this->formColumnWidth . 'ex';

--- a/libraries/classes/Database/Search.php
+++ b/libraries/classes/Database/Search.php
@@ -160,7 +160,6 @@ class Search
      *
      * @todo    can we make use of fulltextsearch IN BOOLEAN MODE for this?
      * PMA_backquote
-     * DatabaseInterface::freeResult
      * DatabaseInterface::fetchAssoc
      * $GLOBALS['db']
      * explode

--- a/libraries/classes/Database/Triggers.php
+++ b/libraries/classes/Database/Triggers.php
@@ -132,7 +132,9 @@ class Triggers
                             // new one. Try to restore the backup query.
                             $result = $this->dbi->tryQuery($create_item);
 
-                            $errors = $this->checkResult($result, $create_item, $errors);
+                            if (! $result) {
+                                $errors = $this->checkResult($create_item, $errors);
+                            }
                         } else {
                             $message = Message::success(
                                 __('Trigger %1$s has been modified.')
@@ -417,18 +419,13 @@ class Triggers
     }
 
     /**
-     * @param resource|bool $result          Query result
-     * @param string        $createStatement Query
-     * @param array         $errors          Errors
+     * @param string $createStatement Query
+     * @param array  $errors          Errors
      *
      * @return array
      */
-    private function checkResult($result, $createStatement, array $errors)
+    private function checkResult($createStatement, array $errors)
     {
-        if ($result) {
-            return $errors;
-        }
-
         // OMG, this is really bad! We dropped the query,
         // failed to create a new one
         // and now even the backup query does not execute!

--- a/libraries/classes/DbTableExists.php
+++ b/libraries/classes/DbTableExists.php
@@ -89,8 +89,7 @@ final class DbTableExists
                 DatabaseInterface::CONNECT_USER,
                 DatabaseInterface::QUERY_STORE
             );
-            $is_table = @$dbi->numRows($result);
-            $dbi->freeResult($result);
+            $is_table = $result && $result->numRows();
         }
 
         if ($is_table) {
@@ -111,8 +110,7 @@ final class DbTableExists
                 DatabaseInterface::CONNECT_USER,
                 DatabaseInterface::QUERY_STORE
             );
-            $is_table = ($result && @$dbi->numRows($result));
-            $dbi->freeResult($result);
+            $is_table = $result && $result->numRows();
         }
 
         if ($is_table) {

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -17,7 +17,6 @@ interface DbalInterface
 {
     public const FETCH_NUM = 'NUM';
     public const FETCH_ASSOC = 'ASSOC';
-    public const FETCH_BOTH = 'BOTH';
 
     /**
      * runs a query
@@ -26,15 +25,13 @@ interface DbalInterface
      * @param mixed  $link                optional database link to use
      * @param int    $options             optional query options
      * @param bool   $cache_affected_rows whether to cache affected rows
-     *
-     * @return mixed
      */
     public function query(
         string $query,
         $link = DatabaseInterface::CONNECT_USER,
         int $options = 0,
         bool $cache_affected_rows = true
-    );
+    ): ResultInterface;
 
     /**
      * runs a query and returns the result
@@ -308,7 +305,7 @@ interface DbalInterface
      *                          default
      * @param int        $link  link type
      *
-     * @return mixed value of first field in first row from result
+     * @return string|false|null value of first field in first row from result
      *               or false if not found
      */
     public function fetchValue(
@@ -328,10 +325,10 @@ interface DbalInterface
      * </code>
      *
      * @param string $query The query to execute
-     * @param string $type  NUM|ASSOC|BOTH returned array should either numeric
+     * @param string $type  NUM|ASSOC returned array should either numeric
      *                      associative or both
      * @param int    $link  link type
-     * @psalm-param  self::FETCH_NUM|self::FETCH_ASSOC|self::FETCH_BOTH $type
+     * @psalm-param  self::FETCH_NUM|self::FETCH_ASSOC $type
      */
     public function fetchSingleRow(
         string $query,
@@ -511,7 +508,7 @@ interface DbalInterface
     /**
      * Returns value for lower_case_table_names variable
      *
-     * @return string|bool
+     * @return string
      */
     public function getLowerCaseNames();
 
@@ -536,40 +533,26 @@ interface DbalInterface
     public function selectDb($dbname, $link = DatabaseInterface::CONNECT_USER): bool;
 
     /**
-     * returns array of rows with associative and numeric keys from $result
-     *
-     * @param object $result result set identifier
-     */
-    public function fetchArray($result): ?array;
-
-    /**
      * returns array of rows with associative keys from $result
      *
-     * @param object $result result set identifier
+     * @param ResultInterface $result result set identifier
      */
-    public function fetchAssoc($result): ?array;
+    public function fetchAssoc(ResultInterface $result): array;
 
     /**
      * returns array of rows with numeric keys from $result
      *
-     * @param object $result result set identifier
+     * @param ResultInterface $result result set identifier
      */
-    public function fetchRow($result): ?array;
+    public function fetchRow(ResultInterface $result): array;
 
     /**
      * Adjusts the result pointer to an arbitrary row in the result
      *
-     * @param object $result database result
-     * @param int    $offset offset to seek
+     * @param ResultInterface $result database result
+     * @param int             $offset offset to seek
      */
-    public function dataSeek($result, int $offset): bool;
-
-    /**
-     * Frees memory associated with the result
-     *
-     * @param object $result database result
-     */
-    public function freeResult($result): void;
+    public function dataSeek(ResultInterface $result, int $offset): bool;
 
     /**
      * Check if there are any more query results from a multi query
@@ -628,13 +611,14 @@ interface DbalInterface
 
     /**
      * returns the number of rows returned by last query
+     * used with tryQuery as it accepts false
      *
-     * @param object|bool $result result set identifier
+     * @param string $query query to run
      *
      * @return string|int
      * @psalm-return int|numeric-string
      */
-    public function numRows($result);
+    public function queryAndGetNumRows(string $query);
 
     /**
      * returns last inserted auto_increment id for given $link
@@ -642,7 +626,7 @@ interface DbalInterface
      *
      * @param int $link link type
      *
-     * @return int|bool
+     * @return int
      */
     public function insertId($link = DatabaseInterface::CONNECT_USER);
 
@@ -660,40 +644,20 @@ interface DbalInterface
     /**
      * returns metainfo for fields in $result
      *
-     * @param object $result result set identifier
+     * @param ResultInterface $result result set identifier
      *
-     * @return FieldMetadata[]|null meta info for fields in $result
+     * @return FieldMetadata[] meta info for fields in $result
      */
-    public function getFieldsMeta($result): ?array;
+    public function getFieldsMeta(ResultInterface $result): array;
 
     /**
      * return number of fields in given $result
      *
-     * @param object $result result set identifier
+     * @param ResultInterface $result result set identifier
      *
      * @return int field count
      */
-    public function numFields($result): int;
-
-    /**
-     * returns the length of the given field $i in $result
-     *
-     * @param object $result result set identifier
-     * @param int    $i      field
-     *
-     * @return int|bool length of field
-     */
-    public function fieldLen($result, int $i);
-
-    /**
-     * returns name of $i. field in $result
-     *
-     * @param object $result result set identifier
-     * @param int    $i      field
-     *
-     * @return string name of $i. field in $result
-     */
-    public function fieldName($result, int $i): string;
+    public function numFields(ResultInterface $result): int;
 
     /**
      * returns properly escaped string for use in MySQL queries

--- a/libraries/classes/Dbal/DbiExtension.php
+++ b/libraries/classes/Dbal/DbiExtension.php
@@ -7,8 +7,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Dbal;
 
-use PhpMyAdmin\FieldMetadata;
-
 /**
  * Contract for every database extension supported by phpMyAdmin
  */
@@ -44,9 +42,9 @@ interface DbiExtension
      * @param object $link    connection object
      * @param int    $options query options
      *
-     * @return mixed result
+     * @return ResultInterface|false result
      */
-    public function realQuery($query, $link, $options);
+    public function realQuery(string $query, $link, int $options);
 
     /**
      * Run the multi query and output the results
@@ -57,42 +55,6 @@ interface DbiExtension
      * @return bool
      */
     public function realMultiQuery($link, $query);
-
-    /**
-     * returns array of rows with associative and numeric keys from $result
-     *
-     * @param object $result result set identifier
-     */
-    public function fetchArray($result): ?array;
-
-    /**
-     * returns array of rows with associative keys from $result
-     *
-     * @param object $result result set identifier
-     */
-    public function fetchAssoc($result): ?array;
-
-    /**
-     * returns array of rows with numeric keys from $result
-     *
-     * @param object $result result set identifier
-     */
-    public function fetchRow($result): ?array;
-
-    /**
-     * Adjusts the result pointer to an arbitrary row in the result
-     *
-     * @param object $result database result
-     * @param int    $offset offset to seek
-     */
-    public function dataSeek($result, $offset): bool;
-
-    /**
-     * Frees memory associated with the result
-     *
-     * @param object $result database result
-     */
-    public function freeResult($result): void;
 
     /**
      * Check if there are any more query results from a multi query
@@ -113,7 +75,7 @@ interface DbiExtension
      *
      * @param object $link mysql link
      *
-     * @return mixed false when empty results / result set when not empty
+     * @return ResultInterface|false false when empty results / result set when not empty
      */
     public function storeResult($link);
 
@@ -150,16 +112,6 @@ interface DbiExtension
     public function getError($link): string;
 
     /**
-     * returns the number of rows returned by last query
-     *
-     * @param object|bool $result result set identifier
-     *
-     * @return string|int
-     * @psalm-return int|numeric-string
-     */
-    public function numRows($result);
-
-    /**
      * returns the number of rows affected by last query
      *
      * @param object $link the connection object
@@ -168,44 +120,6 @@ interface DbiExtension
      * @psalm-return int|numeric-string
      */
     public function affectedRows($link);
-
-    /**
-     * returns metainfo for fields in $result
-     *
-     * @param object $result result set identifier
-     *
-     * @return FieldMetadata[]|null meta info for fields in $result
-     */
-    public function getFieldsMeta($result): ?array;
-
-    /**
-     * return number of fields in given $result
-     *
-     * @param object $result result set identifier
-     *
-     * @return int field count
-     */
-    public function numFields($result);
-
-    /**
-     * returns the length of the given field $i in $result
-     *
-     * @param object $result result set identifier
-     * @param int    $i      field
-     *
-     * @return int|bool length of field
-     */
-    public function fieldLen($result, $i);
-
-    /**
-     * returns name of $i. field in $result
-     *
-     * @param object $result result set identifier
-     * @param int    $i      field
-     *
-     * @return string name of $i. field in $result
-     */
-    public function fieldName($result, $i);
 
     /**
      * returns properly escaped string for use in MySQL queries

--- a/libraries/classes/Dbal/MysqliResult.php
+++ b/libraries/classes/Dbal/MysqliResult.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Extension independent database result
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal;
+
+use Generator;
+use mysqli_result;
+use PhpMyAdmin\FieldMetadata;
+use Webmozart\Assert\Assert;
+
+use function array_column;
+use function is_array;
+use function is_bool;
+use function is_string;
+use function method_exists;
+
+use const MYSQLI_ASSOC;
+
+/**
+ * Extension independent database result
+ */
+final class MysqliResult implements ResultInterface
+{
+    /**
+     * The result identifier produced by the DBiExtension
+     *
+     * @var mysqli_result|null $result
+     */
+    private $result;
+
+    /**
+     * @param mysqli_result|bool $result
+     */
+    public function __construct($result)
+    {
+        $this->result = is_bool($result) ? null : $result;
+    }
+
+    /**
+     * Returns a generator that traverses through the whole result set
+     * and returns each row as an associative array
+     *
+     * @return Generator<int, array<string, string|null>, mixed, void>
+     */
+    public function getIterator(): Generator
+    {
+        if (! $this->result) {
+            return;
+        }
+
+        $this->result->data_seek(0);
+        /** @var array<string, string|null> $row */
+        foreach ($this->result as $row) {
+            yield $row;
+        }
+    }
+
+    /**
+     * Returns the next row of the result with associative keys
+     *
+     * @return array<string,string|null>
+     */
+    public function fetchAssoc(): array
+    {
+        if (! $this->result) {
+            return [];
+        }
+
+        $row = $this->result->fetch_assoc();
+
+        return is_array($row) ? $row : [];
+    }
+
+    /**
+     * Returns the next row of the result with numeric keys
+     *
+     * @return array<int,string|null>
+     */
+    public function fetchRow(): array
+    {
+        if (! $this->result) {
+            return [];
+        }
+
+        $row = $this->result->fetch_row();
+
+        return is_array($row) ? $row : [];
+    }
+
+    /**
+     * Returns a single value from the given result; false on error
+     *
+     * @param int|string $field
+     *
+     * @return string|false|null
+     */
+    public function fetchValue($field = 0)
+    {
+        if (is_string($field)) {
+            $row = $this->fetchAssoc();
+        } else {
+            $row = $this->fetchRow();
+        }
+
+        return $row[$field] ?? false;
+    }
+
+    /**
+     * Returns all rows of the result
+     *
+     * @return array<int, array<string,string|null>>
+     */
+    public function fetchAllAssoc(): array
+    {
+        if (! $this->result) {
+            return [];
+        }
+
+        // This function should return all rows, not only the remaining rows
+        $this->result->data_seek(0);
+
+        // Pre PHP 8.1 when compiled against libmysql doesn't support fetch_all
+        if (method_exists($this->result, 'fetch_all')) {
+            return $this->result->fetch_all(MYSQLI_ASSOC);
+        }
+
+        $rows = [];
+        while ($row = $this->result->fetch_assoc()) {
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Returns values from the first column of each row
+     *
+     * @return array<int, string|null>
+     */
+    public function fetchAllColumn(): array
+    {
+        if (! $this->result) {
+            return [];
+        }
+
+        // This function should return all rows, not only the remaining rows
+        $this->result->data_seek(0);
+
+        // Pre PHP 8.1 when compiled against libmysql doesn't support fetch_all
+        if (method_exists($this->result, 'fetch_all')) {
+            return array_column($this->result->fetch_all(), 0);
+        }
+
+        $rows = [];
+        while ($row = $this->result->fetch_row()) {
+            $rows[] = $row[0];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Returns values as single dimensional array where the key is the first column
+     * and the value is the second column, e.g.
+     * SELECT id, name FROM users
+     * produces: ['123' => 'John', '124' => 'Jane']
+     *
+     * @return array<string, string|null>
+     */
+    public function fetchAllKeyPair(): array
+    {
+        if (! $this->result) {
+            return [];
+        }
+
+        Assert::greaterThanEq($this->result->field_count, 2);
+
+        // This function should return all rows, not only the remaining rows
+        $this->result->data_seek(0);
+
+        // Pre PHP 8.1 when compiled against libmysql doesn't support fetch_all
+        if (method_exists($this->result, 'fetch_all')) {
+            return array_column($this->result->fetch_all(), 1, 0);
+        }
+
+        $rows = [];
+        while ($row = $this->result->fetch_row()) {
+            $rows[$row[0] ?? ''] = $row[1];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Returns the number of fields in the result
+     */
+    public function numFields(): int
+    {
+        if (! $this->result) {
+            return 0;
+        }
+
+        return $this->result->field_count;
+    }
+
+    /**
+     * Returns the number of rows in the result
+     *
+     * @return string|int
+     * @psalm-return int|numeric-string
+     */
+    public function numRows()
+    {
+        if (! $this->result) {
+            return 0;
+        }
+
+        return $this->result->num_rows;
+    }
+
+    /**
+     * Adjusts the result pointer to an arbitrary row in the result
+     *
+     * @param int $offset offset to seek
+     *
+     * @return bool True if the offset exists, false otherwise
+     */
+    public function seek(int $offset): bool
+    {
+        if (! $this->result) {
+            return false;
+        }
+
+        return $this->result->data_seek($offset);
+    }
+
+    /**
+     * returns meta info for fields in $result
+     *
+     * @return array<int, FieldMetadata> meta info for fields in $result
+     */
+    public function getFieldsMeta(): array
+    {
+        if (! $this->result) {
+            return [];
+        }
+
+        $fields = [];
+        foreach ($this->result->fetch_fields() as $k => $field) {
+            $fields[$k] = new FieldMetadata($field->type, $field->flags, $field);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Returns the names of the fields in the result
+     *
+     * @return array<int, string> Fields names
+     */
+    public function getFieldNames(): array
+    {
+        if (! $this->result) {
+            return [];
+        }
+
+        /** @var list<string> $column */
+        $column = array_column($this->result->fetch_fields(), 'name');
+
+        return $column;
+    }
+}

--- a/libraries/classes/Dbal/ResultInterface.php
+++ b/libraries/classes/Dbal/ResultInterface.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Extension independent database result interface
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Dbal;
+
+use Generator;
+use IteratorAggregate;
+use PhpMyAdmin\FieldMetadata;
+
+/**
+ * Extension independent database result interface
+ *
+ * @extends IteratorAggregate<array<string, (string|null)>>
+ */
+interface ResultInterface extends IteratorAggregate
+{
+    /**
+     * Returns a generator that traverses through the whole result set
+     * and returns each row as an associative array
+     *
+     * @return Generator<int, array<string, string|null>, mixed, void>
+     */
+    public function getIterator(): Generator;
+
+    /**
+     * Returns the next row of the result with associative keys
+     *
+     * @return array<string,string|null>
+     */
+    public function fetchAssoc(): array;
+
+    /**
+     * Returns the next row of the result with numeric keys
+     *
+     * @return array<int,string|null>
+     */
+    public function fetchRow(): array;
+
+    /**
+     * Returns a single value from the given result; false on error
+     *
+     * @param int|string $field
+     *
+     * @return string|false|null
+     */
+    public function fetchValue($field = 0);
+
+    /**
+     * Returns all rows of the result
+     *
+     * @return array<int, array<string,string|null>>
+     */
+    public function fetchAllAssoc(): array;
+
+    /**
+     * Returns values from the first column of each row
+     *
+     * @return array<int, string|null>
+     */
+    public function fetchAllColumn(): array;
+
+    /**
+     * Returns values as single dimensional array where the key is the first column
+     * and the value is the second column,
+     * e.g. "SELECT id, name FROM users"
+     * produces: ['123' => 'John', '124' => 'Jane']
+     *
+     * @return array<string, string|null>
+     */
+    public function fetchAllKeyPair(): array;
+
+    /**
+     * Returns the number of fields in the result
+     */
+    public function numFields(): int;
+
+    /**
+     * Returns the number of rows in the result
+     *
+     * @return string|int
+     * @psalm-return int|numeric-string
+     */
+    public function numRows();
+
+    /**
+     * Adjusts the result pointer to an arbitrary row in the result
+     *
+     * @param int $offset offset to seek
+     *
+     * @return bool True if the offset exists, false otherwise
+     */
+    public function seek(int $offset): bool;
+
+    /**
+     * Returns meta info for fields in $result
+     *
+     * @return array<int, FieldMetadata> meta info for fields in $result
+     */
+    public function getFieldsMeta(): array;
+
+    /**
+     * Returns the names of the fields in the result
+     *
+     * @return array<int, string> Fields names
+     */
+    public function getFieldNames(): array;
+}

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -290,7 +290,7 @@ class Innodb extends StorageEngine
     {
         global $dbi;
 
-        return $dbi->fetchValue('SELECT @@innodb_version;');
+        return $dbi->fetchValue('SELECT @@innodb_version;') ?: '';
     }
 
     /**

--- a/libraries/classes/Export/TemplateModel.php
+++ b/libraries/classes/Export/TemplateModel.php
@@ -76,11 +76,9 @@ final class TemplateModel
         }
 
         $data = [];
-        while ($row = $this->dbi->fetchAssoc($result)) {
+        while ($row = $result->fetchAssoc()) {
             $data = $row;
         }
-
-        $this->dbi->freeResult($result);
 
         return Template::fromArray([
             'id' => (int) $data['id'],
@@ -127,7 +125,7 @@ final class TemplateModel
         }
 
         $templates = [];
-        while ($row = $this->dbi->fetchAssoc($result)) {
+        while ($row = $result->fetchAssoc()) {
             $templates[] = Template::fromArray([
                 'id' => (int) $row['id'],
                 'username' => $row['username'],
@@ -136,8 +134,6 @@ final class TemplateModel
                 'data' => $row['template_data'],
             ]);
         }
-
-        $this->dbi->freeResult($result);
 
         return $templates;
     }

--- a/libraries/classes/Html/Generator.php
+++ b/libraries/classes/Html/Generator.php
@@ -463,33 +463,31 @@ class Generator
 
         $ret = '';
         $result = $dbi->query($sqlQuery);
-        if ($result) {
-            $devider = '+';
-            $columnNames = '|';
-            $fieldsMeta = $dbi->getFieldsMeta($result);
-            foreach ($fieldsMeta as $meta) {
-                $devider .= '---+';
-                $columnNames .= ' ' . $meta->name . ' |';
-            }
+        $devider = '+';
+        $columnNames = '|';
+        $fieldsMeta = $dbi->getFieldsMeta($result);
+        foreach ($fieldsMeta as $meta) {
+            $devider .= '---+';
+            $columnNames .= ' ' . $meta->name . ' |';
+        }
 
-            $devider .= "\n";
+        $devider .= "\n";
 
-            $ret .= $devider . $columnNames . "\n" . $devider;
-            while ($row = $dbi->fetchRow($result)) {
-                $values = '|';
-                foreach ($row as $value) {
-                    if ($value === null) {
-                        $value = 'NULL';
-                    }
-
-                    $values .= ' ' . $value . ' |';
+        $ret .= $devider . $columnNames . "\n" . $devider;
+        while ($row = $dbi->fetchRow($result)) {
+            $values = '|';
+            foreach ($row as $value) {
+                if ($value === null) {
+                    $value = 'NULL';
                 }
 
-                $ret .= $values . "\n";
+                $values .= ' ' . $value . ' |';
             }
 
-            $ret .= $devider;
+            $ret .= $values . "\n";
         }
+
+        $ret .= $devider;
 
         return $ret;
     }

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -138,7 +138,7 @@ class Import
                 return;
             }
         } else {
-            $aNumRows = (int) @$dbi->numRows($result);
+            $aNumRows = (int) $result->numRows();
             $aAffectedRows = (int) @$dbi->affectedRows();
             if ($aNumRows > 0) {
                 $msg .= __('Rows') . ': ' . $aNumRows;
@@ -1478,7 +1478,7 @@ class Import
 
         $result = $dbi->tryQuery($checkQuery);
 
-        return $dbi->numRows($result) == 1;
+        return $result && $result->numRows() == 1;
     }
 
     /** @return string[] */

--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -81,10 +81,12 @@ final class SimulateDml
         $this->dbi->selectDb($GLOBALS['db']);
         // Execute the query.
         $result = $this->dbi->tryQuery($matchedRowQuery);
-        // Count the number of rows in the result set.
-        $result = $this->dbi->numRows($result);
+        if (! $result) {
+            return 0;
+        }
 
-        return $result;
+        // Count the number of rows in the result set.
+        return $result->numRows();
     }
 
     /**

--- a/libraries/classes/Navigation/Navigation.php
+++ b/libraries/classes/Navigation/Navigation.php
@@ -270,7 +270,7 @@ class Navigation
 
         $hidden = [];
         if ($result) {
-            while ($row = $this->dbi->fetchArray($result)) {
+            foreach ($result as $row) {
                 $type = $row['item_type'];
                 if (! isset($hidden[$type])) {
                     $hidden[$type] = [];
@@ -279,8 +279,6 @@ class Navigation
                 $hidden[$type][] = $row['item_name'];
             }
         }
-
-        $this->dbi->freeResult($result);
 
         return $hidden;
     }

--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -251,14 +251,14 @@ class NavigationTree
         if ($GLOBALS['dbs_to_test'] === false) {
             $handle = $this->dbi->tryQuery('SHOW DATABASES');
             if ($handle !== false) {
-                while ($arr = $this->dbi->fetchArray($handle)) {
-                    if (strcasecmp($arr[0], $GLOBALS['db']) >= 0) {
+                while ($database = $handle->fetchValue()) {
+                    if (strcasecmp($database, $GLOBALS['db']) >= 0) {
                         break;
                     }
 
-                    $prefix = strstr($arr[0], $GLOBALS['cfg']['NavigationTreeDbSeparator'], true);
+                    $prefix = strstr($database, $GLOBALS['cfg']['NavigationTreeDbSeparator'], true);
                     if ($prefix === false) {
-                        $prefix = $arr[0];
+                        $prefix = $database;
                     }
 
                     $prefixMap[$prefix] = 1;
@@ -273,9 +273,7 @@ class NavigationTree
                     continue;
                 }
 
-                while ($arr = $this->dbi->fetchArray($handle)) {
-                    $databases[] = $arr[0];
-                }
+                $databases = array_merge($databases, $handle->fetchAllColumn());
             }
 
             sort($databases);

--- a/libraries/classes/Navigation/Nodes/Node.php
+++ b/libraries/classes/Navigation/Nodes/Node.php
@@ -412,17 +412,13 @@ class Node
                 $query = 'SHOW DATABASES ';
                 $query .= $this->getWhereClause('Database', $searchClause);
 
-                return $dbi->numRows(
-                    $dbi->tryQuery($query)
-                );
+                return (int) $dbi->queryAndGetNumRows($query);
             }
 
             $retval = 0;
             foreach ($this->getDatabasesToSearch($searchClause) as $db) {
                 $query = "SHOW DATABASES LIKE '" . $db . "'";
-                $retval += $dbi->numRows(
-                    $dbi->tryQuery($query)
-                );
+                $retval += (int) $dbi->queryAndGetNumRows($query);
             }
 
             return $retval;
@@ -451,7 +447,7 @@ class Node
                     continue;
                 }
 
-                while ($arr = $dbi->fetchArray($handle)) {
+                while ($arr = $handle->fetchRow()) {
                     if ($this->isHideDb($arr[0])) {
                         continue;
                     }
@@ -473,7 +469,7 @@ class Node
         $query .= $this->getWhereClause('Database', $searchClause);
         $handle = $dbi->tryQuery($query);
         if ($handle !== false) {
-            while ($arr = $dbi->fetchArray($handle)) {
+            while ($arr = $handle->fetchRow()) {
                 $prefix = strstr($arr[0], $dbSeparator, true);
                 if ($prefix === false) {
                     $prefix = $arr[0];
@@ -723,7 +719,7 @@ class Node
                 return $retval;
             }
 
-            while ($arr = $dbi->fetchArray($handle)) {
+            while ($arr = $handle->fetchRow()) {
                 if ($count >= $maxItems) {
                     break;
                 }
@@ -744,7 +740,7 @@ class Node
         if ($handle !== false) {
             $prefixMap = [];
             $total = $pos + $maxItems;
-            while ($arr = $dbi->fetchArray($handle)) {
+            while ($arr = $handle->fetchRow()) {
                 $prefix = strstr($arr[0], $dbSeparator, true);
                 if ($prefix === false) {
                     $prefix = $arr[0];
@@ -797,7 +793,7 @@ class Node
                     continue;
                 }
 
-                while ($arr = $dbi->fetchArray($handle)) {
+                while ($arr = $handle->fetchRow()) {
                     if ($this->isHideDb($arr[0])) {
                         continue;
                     }
@@ -830,7 +826,7 @@ class Node
                 continue;
             }
 
-            while ($arr = $dbi->fetchArray($handle)) {
+            while ($arr = $handle->fetchRow()) {
                 if ($this->isHideDb($arr[0])) {
                     continue;
                 }
@@ -855,7 +851,7 @@ class Node
                 continue;
             }
 
-            while ($arr = $dbi->fetchArray($handle)) {
+            while ($arr = $handle->fetchRow()) {
                 if ($this->isHideDb($arr[0])) {
                     continue;
                 }

--- a/libraries/classes/Navigation/Nodes/NodeDatabase.php
+++ b/libraries/classes/Navigation/Nodes/NodeDatabase.php
@@ -135,9 +135,7 @@ class NodeDatabase extends Node
                 $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, $singleItem, 'Tables_in_' . $db);
             }
 
-            $retval = $dbi->numRows(
-                $dbi->tryQuery($query)
-            );
+            $retval = $dbi->queryAndGetNumRows($query);
         }
 
         return $retval;
@@ -207,9 +205,7 @@ class NodeDatabase extends Node
                 $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, $singleItem, 'Name');
             }
 
-            $retval = $dbi->numRows(
-                $dbi->tryQuery($query)
-            );
+            $retval = $dbi->queryAndGetNumRows($query);
         }
 
         return $retval;
@@ -249,9 +245,7 @@ class NodeDatabase extends Node
                 $query .= 'AND ' . $this->getWhereClauseForSearch($searchClause, $singleItem, 'Name');
             }
 
-            $retval = $dbi->numRows(
-                $dbi->tryQuery($query)
-            );
+            $retval = $dbi->queryAndGetNumRows($query);
         }
 
         return $retval;
@@ -290,9 +284,7 @@ class NodeDatabase extends Node
                 $query .= 'WHERE ' . $this->getWhereClauseForSearch($searchClause, $singleItem, 'Name');
             }
 
-            $retval = $dbi->numRows(
-                $dbi->tryQuery($query)
-            );
+            $retval = $dbi->queryAndGetNumRows($query);
         }
 
         return $retval;
@@ -405,16 +397,11 @@ class NodeDatabase extends Node
             . "' AND `db_name`='" . $dbi->escapeString($db)
             . "'";
         $result = $this->relation->queryAsControlUser($sqlQuery, false);
-        $hiddenItems = [];
         if ($result) {
-            while ($row = $dbi->fetchArray($result)) {
-                $hiddenItems[] = $row[0];
-            }
+            return $result->fetchAllColumn();
         }
 
-        $dbi->freeResult($result);
-
-        return $hiddenItems;
+        return [];
     }
 
     /**
@@ -468,7 +455,7 @@ class NodeDatabase extends Node
             if ($handle !== false) {
                 $count = 0;
                 if ($dbi->dataSeek($handle, $pos)) {
-                    while ($arr = $dbi->fetchArray($handle)) {
+                    while ($arr = $handle->fetchRow()) {
                         if ($count >= $maxItems) {
                             break;
                         }
@@ -553,8 +540,8 @@ class NodeDatabase extends Node
             $handle = $dbi->tryQuery($query);
             if ($handle !== false) {
                 $count = 0;
-                if ($dbi->dataSeek($handle, $pos)) {
-                    while ($arr = $dbi->fetchArray($handle)) {
+                if ($handle->seek($pos)) {
+                    while ($arr = $handle->fetchAssoc()) {
                         if ($count >= $maxItems) {
                             break;
                         }
@@ -637,8 +624,8 @@ class NodeDatabase extends Node
             $handle = $dbi->tryQuery($query);
             if ($handle !== false) {
                 $count = 0;
-                if ($dbi->dataSeek($handle, $pos)) {
-                    while ($arr = $dbi->fetchArray($handle)) {
+                if ($handle->seek($pos)) {
+                    while ($arr = $handle->fetchAssoc()) {
                         if ($count >= $maxItems) {
                             break;
                         }

--- a/libraries/classes/Navigation/Nodes/NodeTable.php
+++ b/libraries/classes/Navigation/Nodes/NodeTable.php
@@ -102,9 +102,7 @@ class NodeTable extends NodeDatabaseChild
                     $db = Util::backquote($db);
                     $table = Util::backquote($table);
                     $query = 'SHOW COLUMNS FROM ' . $table . ' FROM ' . $db . '';
-                    $retval = (int) $dbi->numRows(
-                        $dbi->tryQuery($query)
-                    );
+                    $retval = (int) $dbi->queryAndGetNumRows($query);
                 }
 
                 break;
@@ -112,9 +110,7 @@ class NodeTable extends NodeDatabaseChild
                 $db = Util::backquote($db);
                 $table = Util::backquote($table);
                 $query = 'SHOW INDEXES FROM ' . $table . ' FROM ' . $db;
-                $retval = (int) $dbi->numRows(
-                    $dbi->tryQuery($query)
-                );
+                $retval = (int) $dbi->queryAndGetNumRows($query);
                 break;
             case 'triggers':
                 if (! $GLOBALS['cfg']['Server']['DisableIS']) {
@@ -131,9 +127,7 @@ class NodeTable extends NodeDatabaseChild
                     $db = Util::backquote($db);
                     $table = $dbi->escapeString($table);
                     $query = 'SHOW TRIGGERS FROM ' . $db . " WHERE `Table` = '" . $table . "'";
-                    $retval = (int) $dbi->numRows(
-                        $dbi->tryQuery($query)
-                    );
+                    $retval = (int) $dbi->queryAndGetNumRows($query);
                 }
 
                 break;
@@ -192,8 +186,8 @@ class NodeTable extends NodeDatabaseChild
                 }
 
                 $count = 0;
-                if ($dbi->dataSeek($handle, $pos)) {
-                    while ($arr = $dbi->fetchArray($handle)) {
+                if ($handle->seek($pos)) {
+                    while ($arr = $handle->fetchAssoc()) {
                         if ($count >= $maxItems) {
                             break;
                         }
@@ -220,7 +214,7 @@ class NodeTable extends NodeDatabaseChild
                 }
 
                 $count = 0;
-                while ($arr = $dbi->fetchArray($handle)) {
+                foreach ($handle as $arr) {
                     if (in_array($arr['Key_name'], $retval)) {
                         continue;
                     }
@@ -259,8 +253,8 @@ class NodeTable extends NodeDatabaseChild
                 }
 
                 $count = 0;
-                if ($dbi->dataSeek($handle, $pos)) {
-                    while ($arr = $dbi->fetchArray($handle)) {
+                if ($handle->seek($pos)) {
+                    while ($arr = $handle->fetchAssoc()) {
                         if ($count >= $maxItems) {
                             break;
                         }

--- a/libraries/classes/Plugins/Export/ExportCsv.php
+++ b/libraries/classes/Plugins/Export/ExportCsv.php
@@ -223,13 +223,12 @@ class ExportCsv extends ExportPlugin
 
         // Gets the data from the database
         $result = $dbi->query($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
-        $fields_cnt = $dbi->numFields($result);
+        $fields_cnt = $result->numFields();
 
         // If required, get fields name at the first line
         if (isset($GLOBALS['csv_columns'])) {
             $schema_insert = '';
-            for ($i = 0; $i < $fields_cnt; $i++) {
-                $col_as = $dbi->fieldName($result, $i);
+            foreach ($result->getFieldNames() as $col_as) {
                 if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])) {
                     $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
                 }
@@ -253,7 +252,7 @@ class ExportCsv extends ExportPlugin
         }
 
         // Format the data
-        while ($row = $dbi->fetchRow($result)) {
+        while ($row = $result->fetchRow()) {
             $schema_insert = '';
             for ($j = 0; $j < $fields_cnt; $j++) {
                 if (! isset($row[$j])) {
@@ -314,8 +313,6 @@ class ExportCsv extends ExportPlugin
                 return false;
             }
         }
-
-        $dbi->freeResult($result);
 
         return true;
     }

--- a/libraries/classes/Plugins/Export/ExportHtmlword.php
+++ b/libraries/classes/Plugins/Export/ExportHtmlword.php
@@ -204,13 +204,12 @@ class ExportHtmlword extends ExportPlugin
 
         // Gets the data from the database
         $result = $dbi->query($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
-        $fields_cnt = $dbi->numFields($result);
+        $fields_cnt = $result->numFields();
 
         // If required, get fields name at the first line
         if (isset($GLOBALS['htmlword_columns'])) {
             $schema_insert = '<tr class="print-category">';
-            for ($i = 0; $i < $fields_cnt; $i++) {
-                $col_as = $dbi->fieldName($result, $i);
+            foreach ($result->getFieldNames() as $col_as) {
                 if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])) {
                     $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
                 }
@@ -228,7 +227,7 @@ class ExportHtmlword extends ExportPlugin
         }
 
         // Format the data
-        while ($row = $dbi->fetchRow($result)) {
+        while ($row = $result->fetchRow()) {
             $schema_insert = '<tr class="print-category">';
             for ($j = 0; $j < $fields_cnt; $j++) {
                 if (! isset($row[$j])) {
@@ -249,8 +248,6 @@ class ExportHtmlword extends ExportPlugin
                 return false;
             }
         }
-
-        $dbi->freeResult($result);
 
         return $this->export->outputHandler('</table>');
     }

--- a/libraries/classes/Plugins/Export/ExportJson.php
+++ b/libraries/classes/Plugins/Export/ExportJson.php
@@ -250,12 +250,12 @@ class ExportJson extends ExportPlugin
         }
 
         $result = $dbi->query($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
-        $columns_cnt = $dbi->numFields($result);
-        $fieldsMeta = $dbi->getFieldsMeta($result) ?? [];
+        $columns_cnt = $result->numFields();
+        $fieldsMeta = $dbi->getFieldsMeta($result);
 
         $columns = [];
-        for ($i = 0; $i < $columns_cnt; $i++) {
-            $col_as = $dbi->fieldName($result, $i);
+        foreach ($fieldsMeta as $i => $field) {
+            $col_as = $field->name;
             if (
                 $db !== null && $table !== null && $aliases !== null
                 && ! empty($aliases[$db]['tables'][$table]['columns'][$col_as])
@@ -267,7 +267,7 @@ class ExportJson extends ExportPlugin
         }
 
         $record_cnt = 0;
-        while ($record = $dbi->fetchRow($result)) {
+        while ($record = $result->fetchRow()) {
             $record_cnt++;
 
             // Output table name as comment if this is the first record of the table
@@ -314,13 +314,7 @@ class ExportJson extends ExportPlugin
             }
         }
 
-        if (! $this->export->outputHandler($crlf . ']' . $crlf . $footer . $crlf)) {
-            return false;
-        }
-
-        $dbi->freeResult($result);
-
-        return true;
+        return $this->export->outputHandler($crlf . ']' . $crlf . $footer . $crlf);
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportLatex.php
+++ b/libraries/classes/Plugins/Export/ExportLatex.php
@@ -300,8 +300,8 @@ class ExportLatex extends ExportPlugin
         $columns_cnt = $dbi->numFields($result);
         $columns = [];
         $columns_alias = [];
-        for ($i = 0; $i < $columns_cnt; $i++) {
-            $columns[$i] = $col_as = $dbi->fieldName($result, $i);
+        foreach ($result->getFieldNames() as $i => $col_as) {
+            $columns[$i] = $col_as;
             if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])) {
                 $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
             }
@@ -393,7 +393,7 @@ class ExportLatex extends ExportPlugin
         }
 
         // print the whole table
-        while ($record = $dbi->fetchAssoc($result)) {
+        while ($record = $result->fetchAssoc()) {
             $buffer = '';
             // print each row
             for ($i = 0; $i < $columns_cnt; $i++) {
@@ -420,13 +420,8 @@ class ExportLatex extends ExportPlugin
         }
 
         $buffer = ' \\end{longtable}' . $crlf;
-        if (! $this->export->outputHandler($buffer)) {
-            return false;
-        }
 
-        $dbi->freeResult($result);
-
-        return true;
+        return $this->export->outputHandler($buffer);
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportPhparray.php
+++ b/libraries/classes/Plugins/Export/ExportPhparray.php
@@ -168,10 +168,9 @@ class ExportPhparray extends ExportPlugin
 
         $result = $dbi->query($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
 
-        $columns_cnt = $dbi->numFields($result);
+        $columns_cnt = $result->numFields();
         $columns = [];
-        for ($i = 0; $i < $columns_cnt; $i++) {
-            $col_as = $dbi->fieldName($result, $i);
+        foreach ($result->getFieldNames() as $i => $col_as) {
             if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])) {
                 $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
             }
@@ -207,7 +206,7 @@ class ExportPhparray extends ExportPlugin
 
         // Reset the buffer
         $buffer = '';
-        while ($record = $dbi->fetchRow($result)) {
+        while ($record = $result->fetchRow()) {
             $record_cnt++;
 
             if ($record_cnt == 1) {
@@ -232,13 +231,8 @@ class ExportPhparray extends ExportPlugin
         }
 
         $buffer .= $crlf . ');' . $crlf;
-        if (! $this->export->outputHandler($buffer)) {
-            return false;
-        }
 
-        $dbi->freeResult($result);
-
-        return true;
+        return $this->export->outputHandler($buffer);
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -1429,8 +1429,6 @@ class ExportSql extends ExportPlugin
             $compat = 'NONE';
         }
 
-        // need to use PhpMyAdmin\DatabaseInterface::QUERY_STORE
-        // with $dbi->numRows() in mysqli
         $result = $dbi->tryQuery(
             'SHOW TABLE STATUS FROM ' . Util::backquote($db)
             . ' WHERE Name = \'' . $dbi->escapeString((string) $table) . '\'',
@@ -1438,8 +1436,8 @@ class ExportSql extends ExportPlugin
             DatabaseInterface::QUERY_STORE
         );
         if ($result != false) {
-            if ($dbi->numRows($result) > 0) {
-                $tmpres = $dbi->fetchAssoc($result);
+            if ($result->numRows() > 0) {
+                $tmpres = $result->fetchAssoc();
 
                 if ($showDates && isset($tmpres['Create_time']) && ! empty($tmpres['Create_time'])) {
                     $schemaCreate .= $this->exportComment(
@@ -1471,8 +1469,6 @@ class ExportSql extends ExportPlugin
                     $newCrlf = $this->exportComment() . $crlf;
                 }
             }
-
-            $dbi->freeResult($result);
         }
 
         $schemaCreate .= $newCrlf;
@@ -1532,7 +1528,7 @@ class ExportSql extends ExportPlugin
 
         $row = null;
         if ($result !== false) {
-            $row = $dbi->fetchRow($result);
+            $row = $result->fetchRow();
         }
 
         if ($row) {
@@ -1853,8 +1849,6 @@ class ExportSql extends ExportPlugin
 
             $schemaCreate .= $createQuery;
         }
-
-        $dbi->freeResult($result);
 
         // Restoring old mode.
         Context::$MODE = $oldMode;
@@ -2237,13 +2231,11 @@ class ExportSql extends ExportPlugin
             );
         }
 
-        if ($result == false) {
-            $dbi->freeResult($result);// This makes no sense
-
+        if ($result === false) {
             return true;
         }
 
-        $fieldsCnt = $dbi->numFields($result);
+        $fieldsCnt = $result->numFields();
 
         // Get field information
         /** @var FieldMetadata[] $fieldsMeta */
@@ -2333,7 +2325,7 @@ class ExportSql extends ExportPlugin
             $separator = ';';
         }
 
-        while ($row = $dbi->fetchRow($result)) {
+        while ($row = $result->fetchRow()) {
             if ($current_row == 0) {
                 $head = $this->possibleCRLF()
                     . $this->exportComment()
@@ -2501,8 +2493,6 @@ class ExportSql extends ExportPlugin
                 return false;
             }
         }
-
-        $dbi->freeResult($result);
 
         return true;
     }

--- a/libraries/classes/Plugins/Export/ExportTexytext.php
+++ b/libraries/classes/Plugins/Export/ExportTexytext.php
@@ -184,13 +184,12 @@ class ExportTexytext extends ExportPlugin
 
         // Gets the data from the database
         $result = $dbi->query($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
-        $fields_cnt = $dbi->numFields($result);
+        $fields_cnt = $result->numFields();
 
         // If required, get fields name at the first line
         if (isset($GLOBALS[$what . '_columns'])) {
             $text_output = "|------\n";
-            for ($i = 0; $i < $fields_cnt; $i++) {
-                $col_as = $dbi->fieldName($result, $i);
+            foreach ($result->getFieldNames() as $col_as) {
                 if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])) {
                     $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
                 }
@@ -206,7 +205,7 @@ class ExportTexytext extends ExportPlugin
         }
 
         // Format the data
-        while ($row = $dbi->fetchRow($result)) {
+        while ($row = $result->fetchRow()) {
             $text_output = '';
             for ($j = 0; $j < $fields_cnt; $j++) {
                 if (! isset($row[$j])) {
@@ -230,8 +229,6 @@ class ExportTexytext extends ExportPlugin
                 return false;
             }
         }
-
-        $dbi->freeResult($result);
 
         return true;
     }

--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -457,13 +457,11 @@ class ExportXml extends ExportPlugin
         if (isset($GLOBALS['xml_export_contents']) && $GLOBALS['xml_export_contents']) {
             $result = $dbi->query($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
 
-            $columns_cnt = $dbi->numFields($result);
+            $columns_cnt = $result->numFields();
             $columns = [];
-            for ($i = 0; $i < $columns_cnt; $i++) {
-                $columns[$i] = stripslashes($dbi->fieldName($result, $i));
+            foreach ($result->getFieldNames() as $column) {
+                $columns[] = stripslashes($column);
             }
-
-            unset($i);
 
             $buffer = '        <!-- ' . __('Table') . ' '
                 . htmlspecialchars($table_alias) . ' -->' . $crlf;
@@ -471,7 +469,7 @@ class ExportXml extends ExportPlugin
                 return false;
             }
 
-            while ($record = $dbi->fetchRow($result)) {
+            while ($record = $result->fetchRow()) {
                 $buffer = '        <table name="'
                     . htmlspecialchars($table_alias) . '">' . $crlf;
                 for ($i = 0; $i < $columns_cnt; $i++) {
@@ -498,8 +496,6 @@ class ExportXml extends ExportPlugin
                     return false;
                 }
             }
-
-            $dbi->freeResult($result);
         }
 
         return true;

--- a/libraries/classes/Plugins/Export/ExportYaml.php
+++ b/libraries/classes/Plugins/Export/ExportYaml.php
@@ -140,12 +140,12 @@ class ExportYaml extends ExportPlugin
         $this->initAlias($aliases, $db_alias, $table_alias);
         $result = $dbi->query($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
 
-        $columns_cnt = $dbi->numFields($result);
-        $fieldsMeta = $dbi->getFieldsMeta($result) ?? [];
+        $columns_cnt = $result->numFields();
+        $fieldsMeta = $dbi->getFieldsMeta($result);
 
         $columns = [];
-        for ($i = 0; $i < $columns_cnt; $i++) {
-            $col_as = $dbi->fieldName($result, $i);
+        foreach ($fieldsMeta as $i => $field) {
+            $col_as = $field->name;
             if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])) {
                 $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
             }
@@ -154,7 +154,7 @@ class ExportYaml extends ExportPlugin
         }
 
         $record_cnt = 0;
-        while ($record = $dbi->fetchRow($result)) {
+        while ($record = $result->fetchRow()) {
             $record_cnt++;
 
             // Output table name as comment if this is the first record of the table
@@ -203,8 +203,6 @@ class ExportYaml extends ExportPlugin
                 return false;
             }
         }
-
-        $dbi->freeResult($result);
 
         return true;
     }

--- a/libraries/classes/Plugins/Export/Helpers/Pdf.php
+++ b/libraries/classes/Plugins/Export/Helpers/Pdf.php
@@ -722,8 +722,8 @@ class Pdf extends PdfLib
          * Pass 1 for column widths
          */
         $this->results = $dbi->query($query, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
-        $this->numFields = $dbi->numFields($this->results);
-        $this->fields = $dbi->getFieldsMeta($this->results) ?? [];
+        $this->numFields = $this->results->numFields();
+        $this->fields = $dbi->getFieldsMeta($this->results);
 
         // sColWidth = starting col width (an average size width)
         $availableWidth = $this->w - $this->lMargin - $this->rMargin;
@@ -848,8 +848,6 @@ class Pdf extends PdfLib
 
         ksort($this->tablewidths);
 
-        $dbi->freeResult($this->results);
-
         // Pass 2
 
         $this->results = $dbi->query($query, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
@@ -858,7 +856,6 @@ class Pdf extends PdfLib
         $this->SetFont(PdfLib::PMA_PDF_FONT, '', 9);
         // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
         $this->morepagestable($this->FontSizePt);
-        $dbi->freeResult($this->results);
     }
 
     public function setTitleFontSize(int $titleFontSize): void

--- a/libraries/classes/Plugins/Import/ImportLdi.php
+++ b/libraries/classes/Plugins/Import/ImportLdi.php
@@ -197,13 +197,15 @@ class ImportLdi extends AbstractImportCsv
         $GLOBALS['cfg']['Import']['ldi_local_option'] = false;
         $result = $dbi->tryQuery('SELECT @@local_infile;');
 
-        if ($result != false && $dbi->numRows($result) > 0) {
-            $tmp = $dbi->fetchRow($result);
-            if ($tmp[0] === 'ON' || $tmp[0] === '1') {
-                $GLOBALS['cfg']['Import']['ldi_local_option'] = true;
-            }
+        if ($result === false || $result->numRows() <= 0) {
+            return;
         }
 
-        $dbi->freeResult($result);
+        $tmp = $result->fetchValue();
+        if ($tmp !== 'ON' && $tmp !== '1') {
+            return;
+        }
+
+        $GLOBALS['cfg']['Import']['ldi_local_option'] = true;
     }
 }

--- a/libraries/classes/Plugins/Schema/Pdf/Pdf.php
+++ b/libraries/classes/Plugins/Schema/Pdf/Pdf.php
@@ -14,7 +14,6 @@ use PhpMyAdmin\Util;
 use function __;
 use function count;
 use function getcwd;
-use function is_array;
 use function max;
 use function mb_ord;
 use function str_replace;
@@ -280,7 +279,7 @@ class Pdf extends PdfLib
             $test_rs = $this->relation->queryAsControlUser($test_query);
             $pageDesc = '';
             $pages = $dbi->fetchAssoc($test_rs);
-            if (is_array($pages)) {
+            if ($pages !== []) {
                 $pageDesc = (string) $pages['page_descr'];
             }
 

--- a/libraries/classes/Plugins/Schema/TableStats.php
+++ b/libraries/classes/Plugins/Schema/TableStats.php
@@ -132,7 +132,7 @@ abstract class TableStats
 
         $sql = 'DESCRIBE ' . Util::backquote($this->tableName);
         $result = $dbi->tryQuery($sql, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
-        if (! $result || ! $dbi->numRows($result)) {
+        if (! $result || ! $result->numRows()) {
             $this->showMissingTableError();
         }
 
@@ -201,11 +201,11 @@ abstract class TableStats
             DatabaseInterface::CONNECT_USER,
             DatabaseInterface::QUERY_STORE
         );
-        if ($dbi->numRows($result) <= 0) {
+        if ($result->numRows() <= 0) {
             return;
         }
 
-        while ($row = $dbi->fetchAssoc($result)) {
+        while ($row = $result->fetchAssoc()) {
             if ($row['Key_name'] !== 'PRIMARY') {
                 continue;
             }

--- a/libraries/classes/RecentFavoriteTable.php
+++ b/libraries/classes/RecentFavoriteTable.php
@@ -16,6 +16,7 @@ use function array_pop;
 use function array_unique;
 use function array_unshift;
 use function count;
+use function is_string;
 use function json_decode;
 use function json_encode;
 use function max;
@@ -122,16 +123,15 @@ class RecentFavoriteTable
         $sql_query = ' SELECT `tables` FROM ' . $this->getPmaTable() .
             " WHERE `username` = '" . $dbi->escapeString($GLOBALS['cfg']['Server']['user']) . "'";
 
-        $return = [];
         $result = $this->relation->queryAsControlUser($sql_query, false);
         if ($result) {
-            $row = $dbi->fetchArray($result);
-            if (isset($row[0])) {
-                $return = json_decode($row[0], true);
+            $value = $result->fetchValue();
+            if (is_string($value)) {
+                return json_decode($value, true);
             }
         }
 
-        return $return;
+        return [];
     }
 
     /**

--- a/libraries/classes/Replication.php
+++ b/libraries/classes/Replication.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use PhpMyAdmin\Dbal\ResultInterface;
+
 use function explode;
 use function mb_strtoupper;
 
@@ -43,7 +45,7 @@ class Replication
      *                             SQL_THREAD and IO_THREAD
      * @param int         $link    mysql link
      *
-     * @return mixed|int output of DatabaseInterface::tryQuery
+     * @return ResultInterface|false|int output of DatabaseInterface::tryQuery
      */
     public function replicaControl(string $action, ?string $control, int $link)
     {
@@ -75,7 +77,7 @@ class Replication
      * @param bool   $start    shall we start replica?
      * @param int    $link     mysql link
      *
-     * @return string output of CHANGE MASTER mysql command
+     * @return ResultInterface|false output of CHANGE MASTER mysql command
      */
     public function replicaChangePrimary(
         $user,

--- a/libraries/classes/ReplicationGui.php
+++ b/libraries/classes/ReplicationGui.php
@@ -572,7 +572,7 @@ class ReplicationGui
             $qStart = $this->replication->replicaControl('START', null, DatabaseInterface::CONNECT_USER);
 
             $result = $qStop !== false && $qStop !== -1 &&
-                $qReset !== false && $qReset !== -1 &&
+                $qReset !== false &&
                 $qStart !== false && $qStart !== -1;
         } else {
             $qControl = $this->replication->replicaControl(
@@ -601,7 +601,7 @@ class ReplicationGui
         $qStart = $this->replication->replicaControl('START', null, DatabaseInterface::CONNECT_USER);
 
         return $qStop !== false && $qStop !== -1 &&
-            $qSkip !== false && $qSkip !== -1 &&
+            $qSkip !== false &&
             $qStart !== false && $qStart !== -1;
     }
 }

--- a/libraries/classes/SavedSearches.php
+++ b/libraries/classes/SavedSearches.php
@@ -391,9 +391,9 @@ class SavedSearches
             . "WHERE id = '" . $dbi->escapeString((string) $this->getId()) . "' ";
 
         $resList = $this->relation->queryAsControlUser($sqlQuery);
-        $oneResult = $dbi->fetchArray($resList);
+        $oneResult = $resList->fetchAssoc();
 
-        if ($oneResult === false) {
+        if ($oneResult === []) {
             $message = Message::error(__('Error while loading the search.'));
             $response = ResponseRenderer::getInstance();
             $response->setRequestStatus($message->isSuccess());
@@ -440,11 +440,6 @@ class SavedSearches
 
         $resList = $this->relation->queryAsControlUser($sqlQuery);
 
-        $list = [];
-        while ($oneResult = $dbi->fetchArray($resList)) {
-            $list[$oneResult['id']] = $oneResult['search_name'];
-        }
-
-        return $list;
+        return $resList->fetchAllKeyPair();
     }
 }

--- a/libraries/classes/Server/Plugins.php
+++ b/libraries/classes/Server/Plugins.php
@@ -35,11 +35,9 @@ class Plugins
 
         $result = $this->dbi->query($sql);
         $plugins = [];
-        while ($row = $this->dbi->fetchAssoc($result)) {
+        while ($row = $result->fetchAssoc()) {
             $plugins[] = $this->mapRowToPlugin($row);
         }
-
-        $this->dbi->freeResult($result);
 
         return $plugins;
     }

--- a/libraries/classes/Server/Privileges/AccountLocking.php
+++ b/libraries/classes/Server/Privileges/AccountLocking.php
@@ -35,7 +35,7 @@ final class AccountLocking
             $this->dbi->escapeString($user),
             $this->dbi->escapeString($host)
         );
-        if ($this->dbi->tryQuery($statement) === true) {
+        if ($this->dbi->tryQuery($statement) !== false) {
             return;
         }
 
@@ -56,7 +56,7 @@ final class AccountLocking
             $this->dbi->escapeString($user),
             $this->dbi->escapeString($host)
         );
-        if ($this->dbi->tryQuery($statement) === true) {
+        if ($this->dbi->tryQuery($statement) !== false) {
             return;
         }
 

--- a/libraries/classes/Server/Status/Data.php
+++ b/libraries/classes/Server/Status/Data.php
@@ -361,16 +361,13 @@ class Data
 
         // get status from server
         $server_status_result = $dbi->tryQuery('SHOW GLOBAL STATUS');
-        $server_status = [];
         if ($server_status_result === false) {
+            $server_status = [];
             $this->dataLoaded = false;
         } else {
             $this->dataLoaded = true;
-            while ($arr = $dbi->fetchRow($server_status_result)) {
-                $server_status[$arr[0]] = $arr[1];
-            }
-
-            $dbi->freeResult($server_status_result);
+            $server_status = $server_status_result->fetchAllKeyPair();
+            unset($server_status_result);
         }
 
         // for some calculations we require also some server settings

--- a/libraries/classes/StorageEngine.php
+++ b/libraries/classes/StorageEngine.php
@@ -415,7 +415,7 @@ class StorageEngine
 
         $sql_query = 'SHOW GLOBAL VARIABLES ' . $like . ';';
         $res = $dbi->query($sql_query);
-        while ($row = $dbi->fetchAssoc($res)) {
+        foreach ($res as $row) {
             if (isset($variables[$row['Variable_name']])) {
                 $mysql_vars[$row['Variable_name']] = $variables[$row['Variable_name']];
             } elseif (! $like && mb_stripos($row['Variable_name'], $this->engine) !== 0) {
@@ -434,8 +434,6 @@ class StorageEngine
 
             $mysql_vars[$row['Variable_name']]['type'] = self::DETAILS_TYPE_PLAINTEXT;
         }
-
-        $dbi->freeResult($res);
 
         return $mysql_vars;
     }

--- a/libraries/classes/SystemDatabase.php
+++ b/libraries/classes/SystemDatabase.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
-use mysqli_result;
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Dbal\ResultInterface;
 
 use function count;
 use function sprintf;
@@ -35,7 +35,7 @@ class SystemDatabase
      *
      * @param string $db Database name looking for
      *
-     * @return mysqli_result|false Result of executed SQL query
+     * @return ResultInterface|false Result of executed SQL query
      */
     public function getExistingTransformationData($db)
     {
@@ -59,10 +59,10 @@ class SystemDatabase
     /**
      * Get SQL query for store new transformation details of a VIEW
      *
-     * @param object $transformationData Result set of SQL execution
-     * @param array  $columnMap          Details of VIEW columns
-     * @param string $viewName           Name of the VIEW
-     * @param string $db                 Database name of the VIEW
+     * @param ResultInterface $transformationData Result set of SQL execution
+     * @param array           $columnMap          Details of VIEW columns
+     * @param string          $viewName           Name of the VIEW
+     * @param string          $db                 Database name of the VIEW
      *
      * @return string SQL query for new transformations
      */

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -22,6 +22,7 @@ use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use function array_values;
 use function count;
 use function explode;
+use function intval;
 use function is_array;
 use function mb_strpos;
 use function mb_strstr;
@@ -274,14 +275,10 @@ class Tracker
             $dbi->escapeString($trackingSet)
         );
 
-        $result = (bool) $relation->queryAsControlUser($sqlQuery);
+        $relation->queryAsControlUser($sqlQuery);
 
-        if ($result) {
-            // Deactivate previous version
-            self::deactivateTracking($dbName, $tableName, (int) $version - 1);
-        }
-
-        return $result;
+        // Deactivate previous version
+        return self::deactivateTracking($dbName, $tableName, (int) $version - 1);
     }
 
     /**
@@ -537,9 +534,9 @@ class Tracker
             return -1;
         }
 
-        $row = $dbi->fetchArray($result);
+        $row = $result->fetchRow();
 
-        return $row[0] ?? -1;
+        return intval($row[0] ?? -1);
     }
 
     /**
@@ -581,7 +578,7 @@ class Tracker
         $mixed = $dbi->fetchAssoc($relation->queryAsControlUser($sqlQuery));
 
         // PHP 7.4 fix for accessing array offset on null
-        if (! is_array($mixed)) {
+        if ($mixed === []) {
             $mixed = [
                 'schema_sql' => null,
                 'data_sql' => null,

--- a/libraries/classes/Transformations.php
+++ b/libraries/classes/Transformations.php
@@ -392,9 +392,8 @@ class Transformations
 
         $test_rs = $relation->queryAsControlUser($test_qry, true, DatabaseInterface::QUERY_STORE);
 
-        if ($test_rs && $dbi->numRows($test_rs) > 0) {
-            $row = @$dbi->fetchAssoc($test_rs);
-            $dbi->freeResult($test_rs);
+        if ($test_rs->numRows() > 0) {
+            $row = $test_rs->fetchAssoc();
 
             if (! $forcedelete && ($has_value || strlen($row['comment']) > 0)) {
                 $upd_query = 'UPDATE '

--- a/libraries/classes/Utils/ForeignKey.php
+++ b/libraries/classes/Utils/ForeignKey.php
@@ -27,7 +27,7 @@ final class ForeignKey
 
         if ($engine === 'NDBCLUSTER' || $engine === 'NDB') {
             $ndbver = strtolower(
-                $dbi->fetchValue('SELECT @@ndb_version_string')
+                $dbi->fetchValue('SELECT @@ndb_version_string') ?: ''
             );
             if (substr($ndbver, 0, 4) === 'ndb-') {
                 $ndbver = substr($ndbver, 4);

--- a/libraries/classes/Utils/Gis.php
+++ b/libraries/classes/Utils/Gis.php
@@ -45,15 +45,17 @@ final class Gis
         }
 
         $wktresult = $dbi->tryQuery($wktsql);
-        $wktarr = $dbi->fetchRow($wktresult);
+        $wktarr = [];
+        if ($wktresult) {
+            $wktarr = $wktresult->fetchRow();
+        }
+
         $wktval = $wktarr[0] ?? '';
 
         if ($includeSRID) {
             $srid = $wktarr[1] ?? null;
             $wktval = "'" . $wktval . "'," . $srid;
         }
-
-        @$dbi->freeResult($wktresult);
 
         return $wktval;
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -101,27 +101,17 @@ parameters:
 			path: libraries/classes/BrowseForeigners.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 2
+			message: "#^Parameter \\#1 \\$state of static method PhpMyAdmin\\\\Charsets\\\\Charset\\:\\:fromServer\\(\\) expects array\\{Charset\\?\\: string, Description\\?\\: string, Default collation\\?\\: string, Maxlen\\?\\: string\\}, array\\<string, string\\|null\\> given\\.$#"
+			count: 1
 			path: libraries/classes/Charsets.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 2
+			message: "#^Parameter \\#1 \\$state of static method PhpMyAdmin\\\\Charsets\\\\Collation\\:\\:fromServer\\(\\) expects array\\<string\\>, array\\<string, string\\|null\\> given\\.$#"
+			count: 1
 			path: libraries/classes/Charsets.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\CheckUserPrivileges\\:\\:getItemsFromShowGrantsRow\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchRow\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/CheckUserPrivileges.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/CheckUserPrivileges.php
 
@@ -906,6 +896,11 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
+			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getForeignData\\(\\) should return array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, non\\-empty\\-array\\>\\|null, foreign_field\\: mixed\\} but returns array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, array\\<string, string\\|null\\>\\>\\|null, foreign_field\\: mixed\\}\\.$#"
+			count: 1
+			path: libraries/classes/ConfigStorage/Relation.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getForeigners\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
@@ -936,11 +931,6 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Offset 'comment' does not exist on array\\|null\\.$#"
-			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
 			message: "#^Parameter \\#1 \\$foreigners of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:searchColumnInForeigners\\(\\) expects array, array\\|true given\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
@@ -948,26 +938,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$list of class PhpMyAdmin\\\\SqlParser\\\\Parser constructor expects PhpMyAdmin\\\\SqlParser\\\\TokensList\\|PhpMyAdmin\\\\SqlParser\\\\UtfString\\|string\\|null, mixed given\\.$#"
 			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 3
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchRow\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 4
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 4
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
@@ -983,6 +953,16 @@ parameters:
 		-
 			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\UserGroups\\:\\:getTabList\\(\\) has parameter \\$selected with no value type specified in iterable type array\\.$#"
 			count: 1
+			path: libraries/classes/ConfigStorage/UserGroups.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|null given\\.$#"
+			count: 3
+			path: libraries/classes/ConfigStorage/UserGroups.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|null given\\.$#"
+			count: 3
 			path: libraries/classes/ConfigStorage/UserGroups.php
 
 		-
@@ -1346,16 +1326,6 @@ parameters:
 			path: libraries/classes/Controllers/Preferences/ManageController.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/BinlogController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/BinlogController.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\Controllers\\\\Server\\\\BinlogController\\:\\:\\$binaryLogs type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Server/BinlogController.php
@@ -1406,11 +1376,6 @@ parameters:
 			path: libraries/classes/Controllers/Server/Status/Processes/KillController.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/Status/StatusController.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Server\\\\Status\\\\StatusController\\:\\:getConnectionsInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Server/Status/StatusController.php
@@ -1429,16 +1394,6 @@ parameters:
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Server\\\\Status\\\\VariablesController\\:\\:getDescriptions\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Server/Status/VariablesController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchRow\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/UserGroupsFormController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/UserGroupsFormController.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Server\\\\Variables\\\\GetVariableController\\:\\:__invoke\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
@@ -1476,12 +1431,7 @@ parameters:
 			path: libraries/classes/Controllers/Server/VariablesController.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchRow\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Server/VariablesController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$value of method PhpMyAdmin\\\\Controllers\\\\Server\\\\VariablesController\\:\\:formatVariable\\(\\) expects int\\|string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Server/VariablesController.php
 
@@ -1526,16 +1476,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/ChangeController.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Controllers/Table/ChartController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/ChartController.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\SelectStatement\\:\\:\\$limit \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/ChartController.php
@@ -1554,16 +1494,6 @@ parameters:
 			message: "#^Property PhpMyAdmin\\\\Controllers\\\\Table\\\\FindReplaceController\\:\\:\\$columnTypes type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/FindReplaceController.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Controllers\\\\Table\\\\FindReplaceController\\:\\:\\$connectionCharSet \\(string\\) does not accept mixed\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/FindReplaceController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/GisVisualizationController.php
 
 		-
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
@@ -1601,12 +1531,12 @@ parameters:
 			path: libraries/classes/Controllers/Table/RelationController.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchArray\\(\\) expects object, mixed given\\.$#"
-			count: 2
+			message: "#^Parameter \\#2 \\$callback of function uksort expects callable\\(int\\|string, int\\|string\\)\\: int, 'strnatcasecmp' given\\.$#"
+			count: 1
 			path: libraries/classes/Controllers/Table/RelationController.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function uksort expects callable\\(int\\|string, int\\|string\\)\\: int, 'strnatcasecmp' given\\.$#"
+			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(string\\|null, string\\|null\\)\\: int, 'strnatcasecmp' given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/RelationController.php
 
@@ -1627,16 +1557,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Table\\\\SearchController\\:\\:getColumnProperties\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/SearchController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/SearchController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/SearchController.php
 
@@ -1699,16 +1619,6 @@ parameters:
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\CreateStatement\\:\\:\\$subpartitionsNum \\(int\\) on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/Structure/PartitioningController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/PrimaryController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/PrimaryController.php
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
@@ -1821,16 +1731,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Controllers/Table/ZoomSearchController.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Controllers/Table/ZoomSearchController.php
-
-		-
 			message: "#^Parameter \\#2 \\$column_index of method PhpMyAdmin\\\\Controllers\\\\Table\\\\ZoomSearchController\\:\\:getColumnProperties\\(\\) expects int, int\\|string\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -1866,8 +1766,13 @@ parameters:
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 2
+			message: "#^Parameter \\#1 \\$data of static method PhpMyAdmin\\\\Image\\\\ImageWrapper\\:\\:fromString\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Transformation/WrapperController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|null given\\.$#"
+			count: 1
 			path: libraries/classes/Controllers/Transformation/WrapperController.php
 
 		-
@@ -2091,11 +1996,6 @@ parameters:
 			path: libraries/classes/Database/Designer.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Designer.php
-
-		-
 			message: "#^Cannot access offset string on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Database/Designer/Common.php
@@ -2156,26 +2056,6 @@ parameters:
 			path: libraries/classes/Database/Designer/Common.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 3
-			path: libraries/classes/Database/Designer/Common.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchRow\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Designer/Common.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Database/Designer/Common.php
-
-		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: libraries/classes/Database/Events.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Database\\\\Events\\:\\:checkResult\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Database/Events.php
@@ -2211,19 +2091,9 @@ parameters:
 			path: libraries/classes/Database/Events.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\Database\\\\Events\\:\\:checkResult\\(\\) expects bool\\|resource, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Events.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\Database\\\\MultiTableQuery\\:\\:\\$tables type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Database/MultiTableQuery.php
-
-		-
-			message: "#^Cannot use array destructuring on array\\|null\\.$#"
-			count: 1
-			path: libraries/classes/Database/Qbe.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Database\\\\Qbe\\:\\:__construct\\(\\) has parameter \\$savedSearchList with no value type specified in iterable type array\\.$#"
@@ -2366,22 +2236,12 @@ parameters:
 			path: libraries/classes/Database/Qbe.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchRow\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Qbe.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Qbe.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Qbe.php
-
-		-
 			message: "#^Parameter \\#2 \\$sortOrder of method PhpMyAdmin\\\\Database\\\\Qbe\\:\\:getSortOrderSelectCell\\(\\) expects int, null given\\.$#"
+			count: 1
+			path: libraries/classes/Database/Qbe.php
+
+		-
+			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumns\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Database/Qbe.php
 
@@ -2601,37 +2461,7 @@ parameters:
 			path: libraries/classes/Database/Routines.php
 
 		-
-			message: "#^Parameter \\#1 \\$flushPrivileges of method PhpMyAdmin\\\\Database\\\\Routines\\:\\:flushPrivileges\\(\\) expects bool, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
 			message: "#^Parameter \\#1 \\$mode of method PhpMyAdmin\\\\Database\\\\Routines\\:\\:getEditorForm\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Routines.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\Database\\\\Routines\\:\\:checkResult\\(\\) expects bool\\|resource, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Database/Routines.php
 
@@ -2716,13 +2546,8 @@ parameters:
 			path: libraries/classes/Database/Triggers.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\Database\\\\Triggers\\:\\:checkResult\\(\\) expects bool\\|resource, mixed given\\.$#"
+			message: "#^Binary operation \"\\+\" between string\\|null and string\\|null results in an error\\.$#"
 			count: 1
-			path: libraries/classes/Database/Triggers.php
-
-		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 4
 			path: libraries/classes/DatabaseInterface.php
 
 		-
@@ -2742,11 +2567,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:connect\\(\\) has parameter \\$server with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
@@ -2812,7 +2632,12 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getCurrentUser\\(\\) should return string but returns mixed\\.$#"
-			count: 2
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getCurrentUser\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
 		-
@@ -2832,11 +2657,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getEvents\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getLowerCaseNames\\(\\) should return bool\\|string but returns mixed\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
@@ -2881,11 +2701,6 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:insertId\\(\\) should return int\\|false but returns mixed\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
 			message: "#^PHPDoc tag @var for variable \\$fields has no value type specified in iterable type array\\.$#"
 			count: 2
 			path: libraries/classes/DatabaseInterface.php
@@ -2901,42 +2716,12 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchByMode\\(\\) expects object, mixed given\\.$#"
-			count: 5
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numFields\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 3
-			path: libraries/classes/DatabaseInterface.php
-
-		-
 			message: "#^Parameter \\#2 \\$table of method PhpMyAdmin\\\\Query\\\\Cache\\:\\:cacheTableData\\(\\) expects bool\\|string, array\\|string given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
 		-
 			message: "#^Parameter \\#3 \\$link of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchValue\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Parameter \\#3 \\$result of static method PhpMyAdmin\\\\Query\\\\Utilities\\:\\:debugLogQueryIntoSession\\(\\) expects bool\\|object, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
@@ -2966,17 +2751,7 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\DatabaseInterface\\:\\:\\$lowerCaseTableNames \\(string\\|null\\) does not accept mixed\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbalInterface\\:\\:connect\\(\\) has parameter \\$server with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbalInterface.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbalInterface\\:\\:fetchArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Dbal/DbalInterface.php
 
@@ -3096,99 +2871,24 @@ parameters:
 			path: libraries/classes/Dbal/DbiExtension.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiExtension\\:\\:fetchArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiExtension.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiExtension\\:\\:fetchAssoc\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiExtension.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiExtension\\:\\:fetchRow\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiExtension.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:connect\\(\\) has parameter \\$server with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Dbal/DbiMysqli.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:dataSeek\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:__construct\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
 			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
+			path: libraries/classes/Dbal/MysqliResult.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:fetchArray\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:fetchAllKeyPair\\(\\) should return array\\<string, string\\|null\\> but returns array\\<int\\|string, mixed\\>\\.$#"
 			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
+			path: libraries/classes/Dbal/MysqliResult.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:fetchArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Property PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:\\$result type has no value type specified in iterable type mysqli_result\\.$#"
 			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:fetchAssoc\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:fetchAssoc\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:fetchRow\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:fetchRow\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:fieldLen\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:fieldName\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:freeResult\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:getFieldsMeta\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:numFields\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:numRows\\(\\) has parameter \\$result with no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:realQuery\\(\\) return type has no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:storeResult\\(\\) return type has no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/DbiMysqli.php
+			path: libraries/classes/Dbal/MysqliResult.php
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
@@ -3198,11 +2898,6 @@ parameters:
 		-
 			message: "#^Cannot access offset int on mixed\\.$#"
 			count: 2
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
 			path: libraries/classes/Display/Results.php
 
 		-
@@ -3546,7 +3241,7 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Parameter \\#2 \\$offset of method PhpMyAdmin\\\\DatabaseInterface\\:\\:dataSeek\\(\\) expects int, float\\|int given\\.$#"
+			message: "#^Parameter \\#1 \\$offset of method PhpMyAdmin\\\\Dbal\\\\ResultInterface\\:\\:seek\\(\\) expects int, float\\|int given\\.$#"
 			count: 2
 			path: libraries/classes/Display/Results.php
 
@@ -3736,11 +3431,6 @@ parameters:
 			path: libraries/classes/ErrorReport.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: libraries/classes/Export.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Export\\:\\:compress\\(\\) has parameter \\$dumpBuffer with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Export.php
@@ -3869,16 +3559,6 @@ parameters:
 			message: "#^Parameter \\#5 \\$data of class PhpMyAdmin\\\\Export\\\\Template constructor expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Export/Template.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Export/TemplateModel.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Export/TemplateModel.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\FieldMetadata\\:\\:getTypeMap\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -4836,11 +4516,6 @@ parameters:
 			path: libraries/classes/Import/Ajax.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Import/SimulateDml.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\SqlParser\\\\Statements\\\\DeleteStatement\\:\\:\\$limit \\(PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: libraries/classes/Import/SimulateDml.php
@@ -4899,11 +4574,6 @@ parameters:
 			message: "#^Method PhpMyAdmin\\\\IndexColumn\\:\\:set\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/IndexColumn.php
-
-		-
-			message: "#^Cannot use array destructuring on array\\|null\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
 
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
@@ -5311,11 +4981,6 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:showEmptyResultMessageOrSetUniqueCondition\\(\\) has parameter \\$result with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:showEmptyResultMessageOrSetUniqueCondition\\(\\) has parameter \\$rows with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
@@ -5371,32 +5036,17 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchRow\\(\\) expects object, mixed given\\.$#"
-			count: 3
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 3
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$data of function bin2hex expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
 		-
 			message: "#^Parameter \\#1 \\$str of function stripslashes expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of static method PhpMyAdmin\\\\Util\\:\\:addMicroseconds\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -5551,11 +5201,6 @@ parameters:
 			path: libraries/classes/Menu.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Menu.php
-
-		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 2
 			path: libraries/classes/Message.php
@@ -5616,21 +5261,6 @@ parameters:
 			path: libraries/classes/Navigation/Navigation.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchArray\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Navigation/Navigation.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Navigation/Navigation.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: libraries/classes/Navigation/NavigationTree.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Navigation\\\\NavigationTree\\:\\:addDbContainers\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Navigation/NavigationTree.php
@@ -5666,8 +5296,13 @@ parameters:
 			path: libraries/classes/Navigation/NavigationTree.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchArray\\(\\) expects object, mixed given\\.$#"
-			count: 2
+			message: "#^Parameter \\#1 \\$haystack of function strstr expects string, string\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Navigation/NavigationTree.php
+
+		-
+			message: "#^Parameter \\#1 \\$str1 of function strcasecmp expects string, string\\|null given\\.$#"
+			count: 1
 			path: libraries/classes/Navigation/NavigationTree.php
 
 		-
@@ -6182,31 +5817,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Export\\\\ExportJson\\:\\:exportData\\(\\) has parameter \\$aliases with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/ExportJson.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchRow\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/ExportJson.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fieldName\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/ExportJson.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/ExportJson.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/ExportJson.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numFields\\(\\) expects object, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/ExportJson.php
 
@@ -7546,6 +7156,16 @@ parameters:
 			path: libraries/classes/SavedSearches.php
 
 		-
+			message: "#^Cannot call method fetchAllKeyPair\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
+			count: 1
+			path: libraries/classes/SavedSearches.php
+
+		-
+			message: "#^Cannot call method fetchAssoc\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
+			count: 1
+			path: libraries/classes/SavedSearches.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\SavedSearches\\:\\:getCriterias\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/SavedSearches.php
@@ -7567,6 +7187,16 @@ parameters:
 
 		-
 			message: "#^Offset non\\-empty\\-string does not exist on array\\|string\\.$#"
+			count: 1
+			path: libraries/classes/SavedSearches.php
+
+		-
+			message: "#^Parameter \\#1 \\$criterias of method PhpMyAdmin\\\\SavedSearches\\:\\:setCriterias\\(\\) expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/SavedSearches.php
+
+		-
+			message: "#^Parameter \\#1 \\$searchName of method PhpMyAdmin\\\\SavedSearches\\:\\:setSearchName\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/SavedSearches.php
 
@@ -7594,26 +7224,6 @@ parameters:
 			message: "#^Method PhpMyAdmin\\\\Server\\\\Plugins\\:\\:mapRowToPlugin\\(\\) has parameter \\$row with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Server/Plugins.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Server/Plugins.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Server/Plugins.php
-
-		-
-			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: libraries/classes/Server/Privileges.php
-
-		-
-			message: "#^Cannot use array destructuring on array\\|null\\.$#"
-			count: 1
-			path: libraries/classes/Server/Privileges.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:addUser\\(\\) has parameter \\$dbname with no value type specified in iterable type array\\.$#"
@@ -7831,52 +7441,37 @@ parameters:
 			path: libraries/classes/Server/Privileges.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function mb_strrpos expects string, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Server/Privileges.php
-
-		-
-			message: "#^Parameter \\#1 \\$privs of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:parseProcPriv\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$name of static method PhpMyAdmin\\\\Util\\:\\:escapeMysqlWildcards\\(\\) expects string, array\\<int, string\\>\\|string\\|true\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Server/Privileges.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 10
-			path: libraries/classes/Server/Privileges.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchRow\\(\\) expects object, mixed given\\.$#"
-			count: 6
-			path: libraries/classes/Server/Privileges.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$privs of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:parseProcPriv\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Server/Privileges.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 11
+			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|null given\\.$#"
+			count: 3
 			path: libraries/classes/Server/Privileges.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Server/Privileges.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:getUsersOverview\\(\\) expects object, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$str of function explode expects string, string\\|null given\\.$#"
 			count: 1
-			path: libraries/classes/Server/Privileges.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, mixed given\\.$#"
-			count: 2
 			path: libraries/classes/Server/Privileges.php
 
 		-
 			message: "#^Parameter \\#6 \\$dbname of method PhpMyAdmin\\\\Server\\\\Privileges\\:\\:addUserAndCreateDatabase\\(\\) expects string, array\\|string\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Server/Privileges.php
+
+		-
+			message: "#^Possibly invalid array key type array\\<int, string\\>\\|string\\|null\\.$#"
+			count: 1
+			path: libraries/classes/Server/Privileges.php
+
+		-
+			message: "#^Possibly invalid array key type array\\<int, string\\>\\|string\\|true\\|null\\.$#"
 			count: 1
 			path: libraries/classes/Server/Privileges.php
 
@@ -8091,18 +7686,8 @@ parameters:
 			path: libraries/classes/Server/Status/Monitor.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
-			count: 4
-			path: libraries/classes/Server/Status/Monitor.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 4
-			path: libraries/classes/Server/Status/Monitor.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 1
+			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects PhpMyAdmin\\\\Dbal\\\\ResultInterface, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
+			count: 2
 			path: libraries/classes/Server/Status/Monitor.php
 
 		-
@@ -8127,11 +7712,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Server\\\\Status\\\\Processes\\:\\:getSortableColumnsForProcessList\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Server/Status/Processes.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchAssoc\\(\\) expects object, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Server/Status/Processes.php
 
@@ -8276,11 +7856,6 @@ parameters:
 			path: libraries/classes/Sql.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Sql\\:\\:executeQueryAndMeasureTime\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Sql.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Sql\\:\\:executeQueryAndSendQueryResponse\\(\\) has parameter \\$analyzedSqlResults with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
@@ -8421,17 +7996,12 @@ parameters:
 			path: libraries/classes/Sql.php
 
 		-
-			message: "#^Offset 0 does not exist on array\\|null\\.$#"
-			count: 2
-			path: libraries/classes/Sql.php
-
-		-
-			message: "#^Parameter \\#1 \\$dtResult of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTable\\(\\) expects object, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$data of function bin2hex expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
 
 		-
-			message: "#^Parameter \\#1 \\$dtResult of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTable\\(\\) expects object, object\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$dtResult of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTable\\(\\) expects PhpMyAdmin\\\\Dbal\\\\ResultInterface, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
 
@@ -8442,26 +8012,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$numberOfLine of method PhpMyAdmin\\\\Sql\\:\\:getStartPosToDisplayRow\\(\\) expects int, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Sql.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, bool\\|object\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Sql.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Sql.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Sql.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Sql.php
 
@@ -8581,22 +8131,17 @@ parameters:
 			path: libraries/classes/StorageEngine.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\SystemDatabase\\:\\:getExistingTransformationData\\(\\) return type has no value type specified in iterable type mysqli_result\\.$#"
-			count: 1
-			path: libraries/classes/SystemDatabase.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\SystemDatabase\\:\\:getExistingTransformationData\\(\\) should return mysqli_result\\|false but returns mixed\\.$#"
-			count: 1
-			path: libraries/classes/SystemDatabase.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SystemDatabase\\:\\:getNewTransformationDataSql\\(\\) has parameter \\$columnMap with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/SystemDatabase.php
 
 		-
-			message: "#^Cannot cast mixed to int\\.$#"
+			message: "#^Argument of an invalid type PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 2
+			path: libraries/classes/Table.php
+
+		-
+			message: "#^Cannot call method fetchValue\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
 			count: 1
 			path: libraries/classes/Table.php
 
@@ -8796,28 +8341,13 @@ parameters:
 			path: libraries/classes/Table.php
 
 		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: libraries/classes/Table.php
+
+		-
 			message: "#^Parameter \\#1 \\$list of class PhpMyAdmin\\\\SqlParser\\\\Parser constructor expects PhpMyAdmin\\\\SqlParser\\\\TokensList\\|PhpMyAdmin\\\\SqlParser\\\\UtfString\\|string\\|null, mixed given\\.$#"
 			count: 1
-			path: libraries/classes/Table.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchArray\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Table.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:freeResult\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Table.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getFieldsMeta\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Table.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
-			count: 2
 			path: libraries/classes/Table.php
 
 		-
@@ -9041,6 +8571,16 @@ parameters:
 			path: libraries/classes/Tracking.php
 
 		-
+			message: "#^Cannot call method fetchAssoc\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
+			count: 1
+			path: libraries/classes/Tracking.php
+
+		-
+			message: "#^Cannot call method fetchRow\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
+			count: 1
+			path: libraries/classes/Tracking.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\Tracking\\:\\:createTrackingForMultipleTables\\(\\) has parameter \\$selected with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Tracking.php
@@ -9067,16 +8607,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tracking\\:\\:exportAsSqlExecution\\(\\) has parameter \\$entries with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Tracking.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tracking\\:\\:exportAsSqlExecution\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Tracking.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tracking\\:\\:exportAsSqlExecution\\(\\) should return array but returns mixed\\.$#"
 			count: 1
 			path: libraries/classes/Tracking.php
 
@@ -9241,11 +8771,6 @@ parameters:
 			path: libraries/classes/Tracking.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Tracking\\:\\:getListOfVersionsOfTable\\(\\) should return object\\|false but returns mixed\\.$#"
-			count: 1
-			path: libraries/classes/Tracking.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tracking\\:\\:getUntrackedTables\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Tracking.php
@@ -9261,6 +8786,11 @@ parameters:
 			path: libraries/classes/Tracking.php
 
 		-
+			message: "#^Parameter \\#1 \\$dbName of static method PhpMyAdmin\\\\Tracker\\:\\:isTracked\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Tracking.php
+
+		-
 			message: "#^Parameter \\#1 \\$haystack of function mb_strstr expects string, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Tracking.php
@@ -9271,12 +8801,7 @@ parameters:
 			path: libraries/classes/Tracking.php
 
 		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:fetchArray\\(\\) expects object, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Tracking.php
-
-		-
-			message: "#^Parameter \\#1 \\$result of method PhpMyAdmin\\\\DatabaseInterface\\:\\:numRows\\(\\) expects bool\\|object, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Tracking.php
 
@@ -9291,6 +8816,21 @@ parameters:
 			path: libraries/classes/Tracking.php
 
 		-
+			message: "#^Parameter \\#2 \\$tableName of static method PhpMyAdmin\\\\Tracker\\:\\:isTracked\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Tracking.php
+
+		-
+			message: "#^Cannot call method fetchAssoc\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
+			count: 1
+			path: libraries/classes/Transformations.php
+
+		-
+			message: "#^Cannot call method numRows\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
+			count: 1
+			path: libraries/classes/Transformations.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\Transformations\\:\\:getAvailableMimeTypes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Transformations.php
@@ -9302,6 +8842,11 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Transformations\\:\\:getOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: libraries/classes/Transformations.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Transformations.php
 
@@ -10351,11 +9896,6 @@ parameters:
 			path: test/classes/Display/ResultsTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$dtResult of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTable\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: test/classes/Display/ResultsTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars_decode expects string, mixed given\\.$#"
 			count: 1
 			path: test/classes/Display/ResultsTest.php
@@ -11311,11 +10851,6 @@ parameters:
 			path: test/classes/Stubs/DbiDummy.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:fetchArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:fetchAssoc\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Stubs/DbiDummy.php
@@ -11424,11 +10959,6 @@ parameters:
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\TrackerTest\\:\\:testGetTrackedData\\(\\) has parameter \\$fetchArrayReturn with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/TrackerTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$sql_result of method PhpMyAdmin\\\\Tracking\\:\\:getTableLastVersionNumber\\(\\) expects object, mixed given\\.$#"
-			count: 1
-			path: test/classes/TrackingTest.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\TransformationsTest\\:\\:fixupData\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -152,45 +152,30 @@
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Charsets.php">
-    <MixedArgument occurrences="4">
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <InvalidArgument occurrences="2">
       <code>$row</code>
       <code>$row</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayOffset occurrences="3">
-      <code>self::$charsets[$row['Charset']]</code>
-      <code>self::$charsets[$serverCharset]</code>
-      <code>self::$collations[$row['Charset']]</code>
-    </MixedArrayOffset>
-    <MixedArrayTypeCoercion occurrences="1">
-      <code>self::$charsets[$serverCharset]</code>
-    </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="4">
-      <code>$res</code>
-      <code>$res</code>
-      <code>$serverCharset</code>
-      <code>$serverCharset</code>
-    </MixedAssignment>
-    <MixedPropertyTypeCoercion occurrences="2">
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="2">
       <code>self::$charsets</code>
       <code>self::$collations</code>
-    </MixedPropertyTypeCoercion>
+    </InvalidPropertyAssignmentValue>
+    <MixedAssignment occurrences="1">
+      <code>$serverCharset</code>
+    </MixedAssignment>
+    <PossiblyNullArrayOffset occurrences="2">
+      <code>self::$charsets</code>
+      <code>self::$collations</code>
+    </PossiblyNullArrayOffset>
   </file>
   <file src="libraries/classes/CheckUserPrivileges.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="4">
       <code>$row[0]</code>
       <code>$showGrantsDbName</code>
-      <code>$showGrantsResult</code>
-      <code>$showGrantsResult</code>
       <code>$showGrantsString</code>
       <code>$showGrantsTableName</code>
     </MixedArgument>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment occurrences="10">
       <code>$GLOBALS['col_priv']</code>
       <code>$GLOBALS['db_priv']</code>
       <code>$GLOBALS['db_to_create']</code>
@@ -201,7 +186,6 @@
       <code>$GLOBALS['is_reload_priv']</code>
       <code>$GLOBALS['proc_priv']</code>
       <code>$GLOBALS['table_priv']</code>
-      <code>$showGrantsResult</code>
     </MixedAssignment>
     <PossiblyFalseOperand occurrences="6">
       <code>$tableNameEndOffset</code>
@@ -841,7 +825,9 @@
     </PossiblyInvalidCast>
   </file>
   <file src="libraries/classes/ConfigStorage/Relation.php">
-    <MixedArgument occurrences="32">
+    <InvalidReturnStatement occurrences="1"/>
+    <InvalidReturnType occurrences="1"/>
+    <MixedArgument occurrences="19">
       <code>$_SESSION['sql_history']</code>
       <code>$_SESSION['sql_history']</code>
       <code>$_SESSION['sql_history']</code>
@@ -850,14 +836,6 @@
       <code>$column['DATA_TYPE']</code>
       <code>$columns['table_name']</code>
       <code>$columns['table_schema']</code>
-      <code>$com_rs</code>
-      <code>$com_rs</code>
-      <code>$com_rs</code>
-      <code>$com_rs</code>
-      <code>$com_rs</code>
-      <code>$disp</code>
-      <code>$disp</code>
-      <code>$disp</code>
       <code>$foreign[$field]</code>
       <code>$foreign_db</code>
       <code>$foreign_db</code>
@@ -866,14 +844,9 @@
       <code>$foreign_table</code>
       <code>$foreign_table</code>
       <code>$one_key['index_list']</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$row[1]</code>
       <code>$show_create_table</code>
       <code>$tableNameReplacements[$tableName]</code>
-      <code>$tableRes</code>
-      <code>$tableRes</code>
-      <code>$tablesRows</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
       <code>uksort($foreign, 'strnatcasecmp')</code>
@@ -899,23 +872,18 @@
       <code>$_SESSION['tmpval']['favoriteTables']</code>
       <code>$_SESSION['tmpval']['recentTables']</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="6">
+    <MixedArrayOffset occurrences="5">
       <code>$comments[$column['Field']]</code>
-      <code>$comments[$row['db_name']]</code>
       <code>$foreign[$field]</code>
       <code>$foreign[$field]</code>
       <code>$foreign[$key]</code>
       <code>$one_key['ref_index_list'][$column_index]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="38">
+    <MixedAssignment occurrences="26">
       <code>$child_references</code>
       <code>$column</code>
       <code>$columns</code>
-      <code>$com_rs</code>
-      <code>$com_rs</code>
       <code>$comments[$column['Field']]</code>
-      <code>$comments[$row['db_name']]</code>
-      <code>$disp</code>
       <code>$field</code>
       <code>$foreign[$field]</code>
       <code>$foreign[$key]</code>
@@ -931,18 +899,10 @@
       <code>$foreigners[$column]</code>
       <code>$foreigners['foreign_keys_data']</code>
       <code>$key</code>
-      <code>$max_time</code>
       <code>$one_key</code>
       <code>$relations</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$show_create_table</code>
-      <code>$tableRes</code>
-      <code>$tablesRows</code>
       <code>$tables[]</code>
-      <code>$the_total</code>
       <code>$the_total</code>
       <code>$value</code>
       <code>$value</code>
@@ -951,9 +911,6 @@
       <code>array|false</code>
       <code>string|false</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="1">
-      <code>$max_time</code>
-    </MixedOperand>
     <MixedReturnStatement occurrences="3">
       <code>$column['COLUMN_NAME']</code>
       <code>$foreigners[$column]</code>
@@ -966,15 +923,9 @@
       <code>$GLOBALS['cfg']['Server']['pmadb']</code>
       <code>$GLOBALS['cfg']['Server']['pmadb']</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="4">
-      <code>$com_rs</code>
-      <code>$com_rs</code>
+    <PossiblyInvalidArgument occurrences="1">
       <code>$foreigners</code>
-      <code>$result</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$row['comment']</code>
-    </PossiblyNullArrayAccess>
     <RedundantCast occurrences="6">
       <code>(int) $GLOBALS['cfg']['LimitChars']</code>
       <code>(string) $GLOBALS['cfg']['ForeignKeyDropdownOrder'][0]</code>
@@ -995,31 +946,10 @@
     </RedundantCondition>
   </file>
   <file src="libraries/classes/ConfigStorage/UserGroups.php">
-    <MixedArgument occurrences="9">
-      <code>$key</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$tabNames</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayOffset occurrences="3">
-      <code>$userGroups[$groupName]</code>
-      <code>$userGroups[$groupName]</code>
-      <code>$userGroups[$groupName]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="16">
-      <code>$groupName</code>
-      <code>$key</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
+    <MixedAssignment occurrences="8">
       <code>$tab</code>
       <code>$tab</code>
       <code>$tabDetail['tab']</code>
@@ -1028,20 +958,19 @@
       <code>$tabName</code>
       <code>$tabName</code>
       <code>$tabNames[]</code>
-      <code>$userGroups[$groupName][$row['tab']]</code>
-      <code>$user['user']</code>
-      <code>$value</code>
     </MixedAssignment>
     <MixedOperand occurrences="3">
       <code>$tab</code>
       <code>$tab</code>
       <code>$tabGroupName</code>
     </MixedOperand>
-    <PossiblyInvalidArgument occurrences="3">
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$key</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="2">
+      <code>$userGroups</code>
+      <code>$userGroups</code>
+    </PossiblyNullArrayOffset>
     <PossiblyNullIterator occurrences="3">
       <code>$tabs</code>
       <code>$tabs</code>
@@ -1614,12 +1543,10 @@
       <code>$_SESSION['tmpval']['table_limit_offset_db']</code>
       <code>$selected[$i]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="4">
       <code>$current</code>
       <code>$multBtn</code>
       <code>$reload</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$selected</code>
     </MixedAssignment>
   </file>
@@ -2418,14 +2345,11 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="libraries/classes/Controllers/Server/BinlogController.php">
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="2">
       <code>$params['log']</code>
       <code>$params['log'] ?? ''</code>
-      <code>$result</code>
-      <code>$result</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$result</code>
+    <MixedAssignment occurrences="1">
       <code>$urlParams['log']</code>
     </MixedAssignment>
     <RedundantCast occurrences="1">
@@ -2444,9 +2368,8 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>['db' =&gt; $params['new_db']]</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$db</code>
-      <code>$result</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Server/Databases/DestroyController.php">
@@ -2728,23 +2651,15 @@
     </MixedArgument>
   </file>
   <file src="libraries/classes/Controllers/Server/UserGroupsFormController.php">
-    <MixedArgument occurrences="3">
-      <code>$result</code>
-      <code>$result</code>
+    <MixedArgument occurrences="1">
       <code>$username</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$allUserGroups[$row[0]]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
-      <code>$allUserGroups[$row[0]]</code>
-      <code>$result</code>
-      <code>$userGroup</code>
+    <MixedAssignment occurrences="1">
       <code>$username</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$result</code>
-    </PossiblyInvalidArgument>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$allUserGroups</code>
+    </PossiblyNullArrayOffset>
   </file>
   <file src="libraries/classes/Controllers/Server/Variables/GetVariableController.php">
     <MixedArgument occurrences="3">
@@ -2772,10 +2687,7 @@
     </PossiblyNullArrayAccess>
   </file>
   <file src="libraries/classes/Controllers/Server/VariablesController.php">
-    <MixedArgument occurrences="4">
-      <code>$serverVarsResult</code>
-      <code>$serverVarsResult</code>
-      <code>$serverVarsSession[$name]</code>
+    <MixedArgument occurrences="1">
       <code>$value</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="5">
@@ -2785,13 +2697,11 @@
       <code>$name</code>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayOffset occurrences="1">
-      <code>$serverVarsSession[$arr[0]]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedArrayTypeCoercion occurrences="1">
+      <code>$serverVarsSession[$name]</code>
+    </MixedArrayTypeCoercion>
+    <MixedAssignment occurrences="2">
       <code>$filterValue</code>
-      <code>$serverVarsResult</code>
-      <code>$serverVarsSession[$arr[0]]</code>
       <code>$value</code>
     </MixedAssignment>
   </file>
@@ -3026,16 +2936,12 @@
     <DocblockTypeContradiction occurrences="1">
       <code>empty($statement-&gt;limit)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="15">
+    <MixedArgument occurrences="11">
       <code>$_REQUEST['pos']</code>
       <code>$_REQUEST['session_max_rows']</code>
-      <code>$data_value</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$rows</code>
       <code>$sql_query</code>
       <code>$sql_query</code>
@@ -3043,14 +2949,10 @@
       <code>$table</code>
       <code>$table</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
-      <code>$data_column</code>
+    <MixedArgumentTypeCoercion occurrences="1">
       <code>$url_params</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="6">
-      <code>$data_value</code>
-      <code>$result</code>
-      <code>$result</code>
+    <MixedAssignment occurrences="3">
       <code>$rows</code>
       <code>$start</code>
       <code>$url_params['db']</code>
@@ -3078,9 +2980,8 @@
       <code>$_POST['field_transformation'][$fieldindex]</code>
       <code>$_POST['field_transformation_options'][$fieldindex]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$mimetype</code>
-      <code>$result</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/DeleteConfirmController.php">
@@ -3121,9 +3022,8 @@
       <code>$message-&gt;getMessage()</code>
       <code>$selected</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$field</code>
-      <code>$result</code>
       <code>$selected</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="2">
@@ -3202,40 +3102,37 @@
     <MixedArrayOffset occurrences="1">
       <code>$types[$column_names[$i]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$column</code>
       <code>$column</code>
       <code>$column</code>
       <code>$row</code>
       <code>$row</code>
-      <code>$this-&gt;connectionCharSet</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/GetFieldController.php">
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="7">
       <code>$_GET['transform_key']</code>
       <code>$_GET['where_clause']</code>
       <code>$_GET['where_clause_sign']</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
-      <code>$result</code>
       <code>$table</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$result</code>
-    </MixedAssignment>
     <MixedOperand occurrences="2">
       <code>$_GET['transform_key']</code>
       <code>$_GET['where_clause']</code>
     </MixedOperand>
+    <PossiblyNullArgument occurrences="1">
+      <code>$result</code>
+    </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/GisVisualizationController.php">
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="6">
       <code>$_GET['fileFormat']</code>
       <code>$_GET['sql_query']</code>
       <code>$_GET['sql_signature']</code>
-      <code>$result</code>
       <code>$sqlQuery</code>
       <code>$urlParams</code>
       <code>$visualizationSettings['spatialColumn']</code>
@@ -3253,8 +3150,7 @@
       <code>$urlParams['sql_query']</code>
       <code>$urlParams['sql_signature']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="5">
-      <code>$result</code>
+    <MixedAssignment occurrences="4">
       <code>$sqlQuery</code>
       <code>$sqlQuery</code>
       <code>$val</code>
@@ -3356,7 +3252,7 @@
     <MixedArrayAccess occurrences="1">
       <code>$GLOBALS['showtable']['Row_format']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment occurrences="8">
       <code>$GLOBALS['showtable']</code>
       <code>$GLOBALS['showtable']</code>
       <code>$create_options['page_checksum']</code>
@@ -3364,8 +3260,6 @@
       <code>$databaseList</code>
       <code>$db</code>
       <code>$reread_info</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$row_format</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
@@ -3413,7 +3307,10 @@
     </MixedArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/RelationController.php">
-    <MixedArgument occurrences="21">
+    <InvalidArgument occurrences="1">
+      <code>usort($tables, 'strnatcasecmp')</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="18">
       <code>$_POST['destination_column']</code>
       <code>$_POST['destination_db']</code>
       <code>$_POST['destination_foreign_column']</code>
@@ -3431,29 +3328,21 @@
       <code>$multi_edit_columns_name</code>
       <code>$multi_edit_columns_name</code>
       <code>$preview_sql_data</code>
-      <code>$row['Engine']</code>
-      <code>$tables_rs</code>
-      <code>$tables_rs</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="3">
+    <MixedArgumentTypeCoercion occurrences="2">
       <code>uksort($column_array, 'strnatcasecmp')</code>
       <code>usort($columnList, 'strnatcasecmp')</code>
-      <code>usort($tables, 'strnatcasecmp')</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayOffset occurrences="2">
       <code>$column_array[$column['Field']]</code>
       <code>$column_hash_array[$column['Field']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['display_query']</code>
       <code>$column_array[$column['Field']]</code>
       <code>$foreignTable</code>
       <code>$multi_edit_columns_name</code>
       <code>$multi_edit_columns_name</code>
-      <code>$tables[]</code>
-      <code>$tables[]</code>
-      <code>$tables_rs</code>
-      <code>$tables_rs</code>
     </MixedAssignment>
     <PossiblyNullArgument occurrences="2">
       <code>$multi_edit_columns_name</code>
@@ -3592,14 +3481,12 @@
     </PossiblyUndefinedVariable>
   </file>
   <file src="libraries/classes/Controllers/Table/SearchController.php">
-    <MixedArgument occurrences="13">
+    <MixedArgument occurrences="11">
       <code>$_POST['column']</code>
       <code>$_POST['db']</code>
       <code>$_POST['table']</code>
       <code>$_POST['where_clause']</code>
       <code>$_POST['where_clause_sign']</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$selected_operator</code>
       <code>$this-&gt;columnNames[$column_index]</code>
       <code>$this-&gt;columnNames[$column_index]</code>
@@ -3610,11 +3497,10 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$urlParams</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$collation</code>
       <code>$entered_value</code>
       <code>$is_unsigned</code>
-      <code>$result</code>
       <code>$selected_operator</code>
       <code>$type</code>
       <code>$val</code>
@@ -3644,9 +3530,8 @@
       <code>$selected</code>
       <code>$table</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$field</code>
-      <code>$result</code>
       <code>$selected</code>
     </MixedAssignment>
   </file>
@@ -3697,9 +3582,8 @@
       <code>$selected</code>
       <code>$table</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$field</code>
-      <code>$result</code>
       <code>$selected</code>
     </MixedAssignment>
   </file>
@@ -3760,9 +3644,8 @@
     <MixedArgument occurrences="1">
       <code>$createTable</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$createTable</code>
-      <code>$result</code>
     </MixedAssignment>
     <RedundantConditionGivenDocblockType occurrences="2">
       <code>$stmt-&gt;partitionsNum</code>
@@ -3770,29 +3653,25 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/PrimaryController.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="4">
       <code>$db</code>
       <code>$field</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$selected</code>
       <code>$table</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$urlParams</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="5">
       <code>$field</code>
       <code>$mult_btn</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$selected</code>
       <code>$selected</code>
       <code>$selected_fld</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
+    <PossiblyNullOperand occurrences="1">
       <code>$row['Column_name']</code>
-    </MixedOperand>
+    </PossiblyNullOperand>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/ReservedWordCheckController.php">
     <MixedArgument occurrences="1">
@@ -3888,12 +3767,11 @@
     <MixedArrayOffset occurrences="1">
       <code>$adjust_privileges[$_POST['field_orig'][$i]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$adjust_privileges[$_POST['field_orig'][$i]]</code>
       <code>$fieldcontent</code>
       <code>$mimetype</code>
       <code>$newCol</code>
-      <code>$result</code>
       <code>$sorted_col</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">
@@ -3908,9 +3786,8 @@
       <code>$selected</code>
       <code>$table</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$field</code>
-      <code>$result</code>
       <code>$selected</code>
     </MixedAssignment>
   </file>
@@ -3921,9 +3798,8 @@
       <code>$selected</code>
       <code>$table</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$field</code>
-      <code>$result</code>
       <code>$selected</code>
     </MixedAssignment>
   </file>
@@ -4054,7 +3930,7 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="libraries/classes/Controllers/Table/ZoomSearchController.php">
-    <MixedArgument occurrences="21">
+    <MixedArgument occurrences="17">
       <code>$_POST['db']</code>
       <code>$_POST['table']</code>
       <code>$_POST['where_clause']</code>
@@ -4064,10 +3940,6 @@
       <code>$dataLabel</code>
       <code>$goto</code>
       <code>$properties['type']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$selected_operator</code>
       <code>$this-&gt;columnNames[$column_index]</code>
       <code>$this-&gt;columnNames[$column_index]</code>
@@ -4095,7 +3967,7 @@
       <code>$row[$_POST['criteriaColumnNames'][0]]</code>
       <code>$row[$_POST['criteriaColumnNames'][1]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="14">
+    <MixedAssignment occurrences="12">
       <code>$collation</code>
       <code>$columnName</code>
       <code>$criteria_column_names</code>
@@ -4103,8 +3975,6 @@
       <code>$entered_value</code>
       <code>$field</code>
       <code>$is_unsigned</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$row['where_clause']</code>
       <code>$selected_operator</code>
       <code>$tmpData[$dataLabel]</code>
@@ -4159,7 +4029,7 @@
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Transformation/WrapperController.php">
-    <MixedArgument occurrences="20">
+    <MixedArgument occurrences="15">
       <code>$_GET['where_clause_sign'] ?? ''</code>
       <code>$cn ?? ''</code>
       <code>$db</code>
@@ -4169,11 +4039,6 @@
       <code>$mime_type ?? ''</code>
       <code>$mime_type ?? ''</code>
       <code>$option</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$row[$transform_key]</code>
-      <code>$row[$transform_key]</code>
-      <code>$row[$transform_key]</code>
       <code>$srcHeight / $ratioWidth</code>
       <code>$srcWidth / $ratioHeight</code>
       <code>$table</code>
@@ -4193,14 +4058,12 @@
       <code>$row[$transform_key]</code>
       <code>$row[$transform_key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS[$one_request_param]</code>
       <code>$mime_type</code>
       <code>$option</code>
       <code>$ratioHeight</code>
       <code>$ratioWidth</code>
-      <code>$result</code>
-      <code>$result</code>
     </MixedAssignment>
     <MixedOperand occurrences="6">
       <code>$_REQUEST['newHeight']</code>
@@ -4210,6 +4073,10 @@
       <code>$ratioWidth</code>
       <code>$where_clause</code>
     </MixedOperand>
+    <PossiblyNullArgument occurrences="2">
+      <code>$row[$transform_key]</code>
+      <code>$row[$transform_key]</code>
+    </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Controllers/UserPasswordController.php">
     <MixedArgument occurrences="6">
@@ -4316,7 +4183,7 @@
       <code>$matches[1]</code>
     </InvalidOperand>
     <InvalidReturnStatement occurrences="1">
-      <code>$numTables</code>
+      <code>$tables-&gt;numRows()</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="1">
       <code>int</code>
@@ -4327,14 +4194,12 @@
       <code>$i</code>
       <code>$i</code>
     </LoopInvalidation>
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="5">
       <code>$GLOBALS[$post_key]</code>
       <code>$GLOBALS['cfg']['TrustedProxies'][$direct_ip]</code>
       <code>$one_post_pattern</code>
       <code>$path[$depth + 1]</code>
       <code>$query</code>
-      <code>$tables</code>
-      <code>$tables</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
       <code>$post_key</code>
@@ -4353,7 +4218,7 @@
     <MixedArrayOffset occurrences="1">
       <code>$GLOBALS['cfg']['TrustedProxies'][$direct_ip]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment occurrences="10">
       <code>$GLOBALS[$post_key]</code>
       <code>$a</code>
       <code>$a[$last_key]</code>
@@ -4363,7 +4228,6 @@
       <code>$query</code>
       <code>$secret</code>
       <code>$secret</code>
-      <code>$tables</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="2">
@@ -4682,8 +4546,7 @@
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="libraries/classes/Database/Designer.php">
-    <MixedArgument occurrences="21">
-      <code>$page_rs</code>
+    <MixedArgument occurrences="20">
       <code>$tabColumn[$tableName]['COLUMN_ID']</code>
       <code>$tabColumn[$tableName]['TYPE'][$j]</code>
       <code>$tabColumn[$tableName]['TYPE'][$j]</code>
@@ -4729,10 +4592,8 @@
       <code>$tab_column[$table_name]['TYPE']</code>
       <code>$tab_column[$table_name]['TYPE']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
-      <code>$page_rs</code>
+    <MixedAssignment occurrences="1">
       <code>$params</code>
-      <code>$result[intval($curr_page['page_nr'])]</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
@@ -4750,13 +4611,11 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Database/Designer/Common.php">
-    <MixedArgument occurrences="25">
+    <MixedArgument occurrences="17">
       <code>$DB</code>
       <code>$TAB</code>
       <code>$_POST['t_x'][$key]</code>
       <code>$_POST['t_y'][$key]</code>
-      <code>$alltab_rs</code>
-      <code>$fieldsRs</code>
       <code>$foreigner['constraint']</code>
       <code>$one_field</code>
       <code>$one_key['constraint']</code>
@@ -4764,16 +4623,10 @@
       <code>$one_table['TABLE_NAME']</code>
       <code>$one_table['TABLE_NAME']</code>
       <code>$orig_data['settings_data']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$tables[$T1]['ENGINE']</code>
       <code>$tables[$T1]['ENGINE'] ?? ''</code>
       <code>$tables[$T2]['ENGINE']</code>
       <code>$tables[$T2]['ENGINE'] ?? ''</code>
-      <code>$val[0]</code>
-      <code>$val[0]</code>
       <code>$value['foreign_field']</code>
       <code>is_string($one_table['ENGINE']) ? $one_table['ENGINE'] : ''</code>
     </MixedArgument>
@@ -4800,20 +4653,16 @@
     <MixedArrayAssignment occurrences="1">
       <code>$orig_data[$index]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="7">
+    <MixedArrayOffset occurrences="5">
       <code>$_POST['t_db'][$key]</code>
       <code>$_POST['t_tbl'][$key]</code>
       <code>$_POST['t_x'][$key]</code>
       <code>$_POST['t_y'][$key]</code>
-      <code>$index_array1[$row['Column_name']]</code>
-      <code>$index_array2[$row['Column_name']]</code>
       <code>$one_key['ref_index_list'][$index]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="25">
+    <MixedAssignment occurrences="14">
       <code>$DB</code>
       <code>$TAB</code>
-      <code>$alltab_rs</code>
-      <code>$fieldsRs</code>
       <code>$index</code>
       <code>$key</code>
       <code>$one_field</code>
@@ -4821,15 +4670,6 @@
       <code>$one_table</code>
       <code>$orig_data</code>
       <code>$page_no</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$success</code>
-      <code>$success</code>
-      <code>$success</code>
-      <code>$success</code>
       <code>$tabColumn[$designerTable-&gt;getDbTableString()]['COLUMN_NAME'][$j]</code>
       <code>$tabColumn[$designerTable-&gt;getDbTableString()]['NULLABLE'][$j]</code>
       <code>$tabColumn[$designerTable-&gt;getDbTableString()]['TYPE'][$j]</code>
@@ -4839,17 +4679,19 @@
     <MixedInferredReturnType occurrences="1">
       <code>string|null</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="6">
+    <MixedOperand occurrences="4">
       <code>$one_key['ref_db_name'] ?? $GLOBALS['db']</code>
       <code>$one_key['ref_table_name']</code>
-      <code>$val[0]</code>
-      <code>$val[0]</code>
       <code>$value['foreign_db']</code>
       <code>$value['foreign_table']</code>
     </MixedOperand>
     <MixedReturnStatement occurrences="1">
       <code>$page_name[0] ?? null</code>
     </MixedReturnStatement>
+    <PossiblyNullArrayOffset occurrences="2">
+      <code>$index_array1</code>
+      <code>$index_array2</code>
+    </PossiblyNullArrayOffset>
     <PossiblyUndefinedArrayOffset occurrences="4">
       <code>$con['DCN']</code>
       <code>$con['DTN']</code>
@@ -4858,7 +4700,7 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="libraries/classes/Database/Events.php">
-    <MixedArgument occurrences="28">
+    <MixedArgument occurrences="27">
       <code>$_POST['item_comment']</code>
       <code>$_POST['item_definer']</code>
       <code>$_POST['item_definer']</code>
@@ -4886,7 +4728,6 @@
       <code>$event['name']</code>
       <code>$itemName</code>
       <code>$message</code>
-      <code>$result</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="1">
       <code>$event['name']</code>
@@ -4902,14 +4743,10 @@
       <code>$errors[]</code>
       <code>$errors[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="20">
+    <MixedAssignment occurrences="16">
       <code>$event</code>
       <code>$itemName</code>
       <code>$item['item_original_name']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$retval[$index]</code>
       <code>$retval['item_comment']</code>
       <code>$retval['item_definer']</code>
@@ -4953,12 +4790,9 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;currentSearch-&gt;getCriterias() === null</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="39">
+    <MixedArgument occurrences="35">
       <code>$_POST['criteriaColumn'][$colInd]</code>
       <code>$_POST['criteriaColumn'][$columnIndex]</code>
-      <code>$allTables</code>
-      <code>$allTables</code>
-      <code>$allTables</code>
       <code>$column</code>
       <code>$columns[$columnIndex]</code>
       <code>$eachColumn['Field']</code>
@@ -4974,7 +4808,6 @@
       <code>$oneTable</code>
       <code>$selected</code>
       <code>$sortOrder</code>
-      <code>$table</code>
       <code>$table</code>
       <code>$table</code>
       <code>$table</code>
@@ -5044,9 +4877,8 @@
       <code>$tsize[$table]</code>
       <code>$tsize[$table]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="52">
+    <MixedAssignment occurrences="51">
       <code>$GLOBALS[${'cur' . $or}][$newColumnCount]</code>
-      <code>$allTables</code>
       <code>$clause</code>
       <code>$clause</code>
       <code>$column</code>
@@ -5131,9 +4963,6 @@
       <code>$sortOrder</code>
       <code>$table</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$table</code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
@@ -5156,7 +4985,7 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="libraries/classes/Database/Routines.php">
-    <MixedArgument occurrences="84">
+    <MixedArgument occurrences="78">
       <code>$_GET['item_name']</code>
       <code>$_GET['item_name']</code>
       <code>$_GET['item_name']</code>
@@ -5205,12 +5034,6 @@
       <code>$itemType</code>
       <code>$message</code>
       <code>$newErrors</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$resultAdjust</code>
       <code>$routine</code>
       <code>$routine['ROUTINE_TYPE']</code>
       <code>$routine['SPECIFIC_NAME']</code>
@@ -5329,7 +5152,7 @@
       <code>$routine['item_param_type'][$i]</code>
       <code>$routine['item_param_type'][$routine['item_num_params'] - 1]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="49">
+    <MixedAssignment occurrences="42">
       <code>$i</code>
       <code>$itemDefiner</code>
       <code>$itemDefinition</code>
@@ -5345,12 +5168,6 @@
       <code>$opt</code>
       <code>$options[]</code>
       <code>$priv</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$resultAdjust</code>
       <code>$retval[$index]</code>
       <code>$retval['item_comment']</code>
       <code>$retval['item_definer']</code>
@@ -5368,7 +5185,6 @@
       <code>$retval['item_sqldataaccess']</code>
       <code>$retval['item_type']</code>
       <code>$routine</code>
-      <code>$routineDefiner</code>
       <code>$routine['item_num_params']</code>
       <code>$routine['item_num_params']</code>
       <code>$routine['item_original_name']</code>
@@ -5456,7 +5272,7 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="libraries/classes/Database/Triggers.php">
-    <MixedArgument occurrences="31">
+    <MixedArgument occurrences="30">
       <code>$_POST['item_definer']</code>
       <code>$_POST['item_definer']</code>
       <code>$_POST['item_name']</code>
@@ -5482,7 +5298,6 @@
       <code>$itemName</code>
       <code>$itemName</code>
       <code>$message</code>
-      <code>$result</code>
       <code>$table</code>
       <code>$table</code>
       <code>$table</code>
@@ -5515,16 +5330,12 @@
       <code>$errors[]</code>
       <code>$errors[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="24">
+    <MixedAssignment occurrences="20">
       <code>$create_item</code>
       <code>$exportData</code>
       <code>$item</code>
       <code>$itemName</code>
       <code>$item['item_original_name']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$retval[$index]</code>
       <code>$retval['create']</code>
       <code>$retval['drop']</code>
@@ -5566,6 +5377,14 @@
     <EmptyArrayAccess occurrences="1">
       <code>$result_target[]</code>
     </EmptyArrayAccess>
+    <InvalidOperand occurrences="6">
+      <code>$row['Data_free']</code>
+      <code>$row['Data_length']</code>
+      <code>$row['Data_length']</code>
+      <code>$row['Index_length']</code>
+      <code>$row['Max_data_length']</code>
+      <code>$row['Rows']</code>
+    </InvalidOperand>
     <InvalidReturnStatement occurrences="1">
       <code>$this-&gt;extension-&gt;getProtoInfo($this-&gt;links[$link])</code>
     </InvalidReturnStatement>
@@ -5576,7 +5395,7 @@
       <code>$a</code>
       <code>$b</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="63">
+    <MixedArgument occurrences="51">
       <code>$_SERVER['SCRIPT_NAME']</code>
       <code>$a</code>
       <code>$arrayKeys</code>
@@ -5604,18 +5423,6 @@
       <code>$one_database_tables</code>
       <code>$one_table_name</code>
       <code>$password</code>
-      <code>$res</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$server</code>
       <code>$sql</code>
       <code>$table</code>
@@ -5703,19 +5510,13 @@
       <code>$this-&gt;links[$link]</code>
       <code>$this-&gt;links[$link]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="62">
+    <MixedAssignment occurrences="43">
       <code>$aLength</code>
       <code>$bLength</code>
       <code>$current_value</code>
       <code>$database</code>
       <code>$database_name</code>
-      <code>$databases[$database_name]['SCHEMA_DATA_FREE']</code>
-      <code>$databases[$database_name]['SCHEMA_DATA_LENGTH']</code>
-      <code>$databases[$database_name]['SCHEMA_INDEX_LENGTH']</code>
-      <code>$databases[$database_name]['SCHEMA_LENGTH']</code>
-      <code>$databases[$database_name]['SCHEMA_MAX_DATA_LENGTH']</code>
       <code>$databases[$database_name]['SCHEMA_NAME']</code>
-      <code>$databases[$database_name]['SCHEMA_TABLE_ROWS']</code>
       <code>$event</code>
       <code>$grant</code>
       <code>$grant</code>
@@ -5733,18 +5534,6 @@
       <code>$one_show</code>
       <code>$one_table_data</code>
       <code>$one_table_name</code>
-      <code>$res</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$result</code>
       <code>$result[]</code>
       <code>$result_target</code>
@@ -5755,7 +5544,6 @@
       <code>$table_data</code>
       <code>$table_data</code>
       <code>$table_data</code>
-      <code>$this-&gt;lowerCaseTableNames</code>
       <code>$this-&gt;versionComment</code>
       <code>$this-&gt;versionString</code>
       <code>$trigger</code>
@@ -5767,22 +5555,14 @@
       <code>$trigger['TRIGGER_NAME']</code>
       <code>$warningsCount</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="5">
+    <MixedInferredReturnType occurrences="3">
       <code>array</code>
       <code>array</code>
-      <code>int|false</code>
       <code>string</code>
-      <code>string|bool</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="12">
+    <MixedOperand occurrences="6">
       <code>$a['Data_length']</code>
       <code>$b['Data_length']</code>
-      <code>$row['Data_free']</code>
-      <code>$row['Data_length']</code>
-      <code>$row['Data_length']</code>
-      <code>$row['Index_length']</code>
-      <code>$row['Max_data_length']</code>
-      <code>$row['Rows']</code>
       <code>$table_data['Data_length']</code>
       <code>$trigger['ACTION_STATEMENT']</code>
       <code>$trigger['ACTION_TIMING']</code>
@@ -5791,12 +5571,9 @@
     <MixedPropertyFetch occurrences="1">
       <code>$this-&gt;links[$link]-&gt;warning_count</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="7">
+    <MixedReturnStatement occurrences="4">
       <code>$tables[$database]</code>
       <code>$tables[mb_strtolower($database)]</code>
-      <code>$this-&gt;fetchValue('SELECT LAST_INSERT_ID();', 0, $link)</code>
-      <code>$this-&gt;lowerCaseTableNames</code>
-      <code>$user</code>
       <code>SessionCache::get('mysql_cur_user')</code>
       <code>reset($columns)</code>
     </MixedReturnStatement>
@@ -5804,7 +5581,8 @@
       <code>$this-&gt;fetchResult($sql, null, 'Field', $link)</code>
       <code>string[]</code>
     </MixedReturnTypeCoercion>
-    <NullableReturnStatement occurrences="1">
+    <NullableReturnStatement occurrences="2">
+      <code>$user</code>
       <code>SessionCache::get('mysql_cur_user')</code>
     </NullableReturnStatement>
     <PossiblyInvalidArgument occurrences="1">
@@ -5813,6 +5591,15 @@
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>$row[$value]</code>
     </PossiblyInvalidArrayOffset>
+    <PossiblyNullOperand occurrences="7">
+      <code>$row['Data_free']</code>
+      <code>$row['Data_length']</code>
+      <code>$row['Data_length']</code>
+      <code>$row['Index_length']</code>
+      <code>$row['Index_length']</code>
+      <code>$row['Max_data_length']</code>
+      <code>$row['Rows']</code>
+    </PossiblyNullOperand>
     <PossiblyUndefinedArrayOffset occurrences="7">
       <code>$databases[$database_name]['SCHEMA_DATA_FREE']</code>
       <code>$databases[$database_name]['SCHEMA_DATA_LENGTH']</code>
@@ -5824,30 +5611,22 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="libraries/classes/DbTableExists.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="2">
       <code>$db</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$table</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$urlParams</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="4">
       <code>$is_table</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$urlParams['message']</code>
       <code>$urlParams['show_as_php']</code>
       <code>$urlParams['sql_query']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Dbal/DbiMysqli.php">
-    <MixedArgument occurrences="9">
-      <code>$field-&gt;flags</code>
-      <code>$field-&gt;type</code>
+    <MixedArgument occurrences="7">
       <code>$host</code>
       <code>$server['port']</code>
       <code>$server['ssl_ca'] ?? ''</code>
@@ -5863,7 +5642,7 @@
     <MixedOperand occurrences="1">
       <code>$server['host']</code>
     </MixedOperand>
-    <MoreSpecificImplementedParamType occurrences="22">
+    <MoreSpecificImplementedParamType occurrences="12">
       <code>$link</code>
       <code>$link</code>
       <code>$link</code>
@@ -5876,17 +5655,34 @@
       <code>$link</code>
       <code>$link</code>
       <code>$link</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
     </MoreSpecificImplementedParamType>
+  </file>
+  <file src="libraries/classes/Dbal/MysqliResult.php">
+    <InvalidReturnStatement occurrences="6">
+      <code>$rows</code>
+      <code>$rows</code>
+      <code>$rows</code>
+      <code>$this-&gt;result-&gt;fetch_all(MYSQLI_ASSOC)</code>
+      <code>is_array($row) ? $row : []</code>
+      <code>is_array($row) ? $row : []</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="5">
+      <code>array&lt;int, array&lt;string,string|null&gt;&gt;</code>
+      <code>array&lt;int, string|null&gt;</code>
+      <code>array&lt;int,string|null&gt;</code>
+      <code>array&lt;string, string|null&gt;</code>
+      <code>array&lt;string,string|null&gt;</code>
+    </InvalidReturnType>
+    <MixedArgument occurrences="2">
+      <code>$field-&gt;flags</code>
+      <code>$field-&gt;type</code>
+    </MixedArgument>
+    <MixedReturnTypeCoercion occurrences="4">
+      <code>$fields</code>
+      <code>array&lt;int, FieldMetadata&gt;</code>
+      <code>array_column($this-&gt;result-&gt;fetch_all(), 0)</code>
+      <code>array_column($this-&gt;result-&gt;fetch_all(), 1, 0)</code>
+    </MixedReturnTypeCoercion>
   </file>
   <file src="libraries/classes/Display/Results.php">
     <DocblockTypeContradiction occurrences="2">
@@ -5896,7 +5692,7 @@
     <InvalidArgument occurrences="1">
       <code>$added[$orgFullTableName]</code>
     </InvalidArgument>
-    <MixedArgument occurrences="55">
+    <MixedArgument occurrences="53">
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['pos'] / $_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['query']</code>
@@ -5935,8 +5731,6 @@
       <code>$oneKey['ref_table_name']</code>
       <code>$rel['foreign_db']</code>
       <code>$rel['foreign_table']</code>
-      <code>$row ? $row[$sortedColumnIndex] : ''</code>
-      <code>$row ? $row[$sortedColumnIndex] : ''</code>
       <code>$row[$i]</code>
       <code>$row[$i]</code>
       <code>$sessionMaxRows</code>
@@ -5952,11 +5746,9 @@
       <code>$whereClauseMap[$rowNumber][$meta-&gt;orgtable]</code>
       <code>empty($field-&gt;database) ? $this-&gt;properties['db'] : $field-&gt;database</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="8">
+    <MixedArgumentTypeCoercion occurrences="6">
       <code>$analyzedSqlResults</code>
       <code>$linkingUrlParams</code>
-      <code>$row</code>
-      <code>$row</code>
       <code>$row</code>
       <code>$sortDirection</code>
       <code>$sortExpression</code>
@@ -6092,7 +5884,7 @@
       <code>$row[$i]</code>
       <code>$row[$m]</code>
     </MixedArrayOffset>
-    <MixedArrayTypeCoercion occurrences="9">
+    <MixedArrayTypeCoercion occurrences="13">
       <code>$fieldsMeta[$i]</code>
       <code>$fieldsMeta[$i]</code>
       <code>$fieldsMeta[$m]</code>
@@ -6102,8 +5894,12 @@
       <code>$row[$i]</code>
       <code>$row[$i]</code>
       <code>$row[$m]</code>
+      <code>$row[$sortedColumnIndex]</code>
+      <code>$row[$sortedColumnIndex]</code>
+      <code>$row[$sortedColumnIndex]</code>
+      <code>$row[$sortedColumnIndex]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="52">
+    <MixedAssignment occurrences="50">
       <code>$_SESSION['tmpval']['geoOption']</code>
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['pftext']</code>
@@ -6115,8 +5911,6 @@
       <code>$colOrder</code>
       <code>$colVisib</code>
       <code>$colVisibCurrent</code>
-      <code>$columnForFirstRow</code>
-      <code>$columnForLastRow</code>
       <code>$expr</code>
       <code>$expr</code>
       <code>$field</code>
@@ -6269,9 +6063,6 @@
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="libraries/classes/Engines/Innodb.php">
-    <FalsableReturnStatement occurrences="1">
-      <code>$dbi-&gt;fetchValue('SELECT @@innodb_version;')</code>
-    </FalsableReturnStatement>
     <LessSpecificImplementedReturnType occurrences="1">
       <code>array</code>
     </LessSpecificImplementedReturnType>
@@ -6289,20 +6080,11 @@
       <code>$status['Innodb_buffer_pool_wait_free']</code>
       <code>$status['Innodb_buffer_pool_write_requests']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$value</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
     <MixedOperand occurrences="3">
       <code>$status['Innodb_buffer_pool_pages_total']</code>
       <code>$status['Innodb_buffer_pool_reads']</code>
       <code>$status['Innodb_buffer_pool_wait_free']</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
-      <code>$dbi-&gt;fetchValue('SELECT @@innodb_version;')</code>
-    </MixedReturnStatement>
   </file>
   <file src="libraries/classes/Engines/Pbxt.php">
     <LessSpecificImplementedReturnType occurrences="1">
@@ -6537,18 +6319,6 @@
       <code>$state['name'] ?? ''</code>
       <code>$state['username']</code>
     </MixedArgument>
-  </file>
-  <file src="libraries/classes/Export/TemplateModel.php">
-    <MixedArgument occurrences="4">
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$result</code>
-      <code>$result</code>
-    </MixedAssignment>
   </file>
   <file src="libraries/classes/FieldMetadata.php">
     <MixedAssignment occurrences="8">
@@ -7334,12 +7104,11 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;userSpecifiedSettings === null</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="21">
+    <MixedArgument occurrences="20">
       <code>$label</code>
       <code>$label</code>
       <code>$label</code>
       <code>$label</code>
-      <code>$modified_result</code>
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
@@ -7384,9 +7153,8 @@
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="16">
+    <MixedAssignment occurrences="15">
       <code>$label</code>
-      <code>$modified_result</code>
       <code>$pdf</code>
       <code>$plot_height</code>
       <code>$plot_width</code>
@@ -7543,7 +7311,7 @@
       <code>$server['ssl']</code>
       <code>$server['ssl_verify']</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="25">
+    <MixedArgument occurrences="23">
       <code>$GLOBALS['special_message']</code>
       <code>$GLOBALS['special_message']</code>
       <code>$alt</code>
@@ -7554,8 +7322,6 @@
       <code>$queryBase</code>
       <code>$queryBase</code>
       <code>$queryBase</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$sqlQuery</code>
       <code>$sqlQuery</code>
       <code>$sqlQuery</code>
@@ -7586,15 +7352,13 @@
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['pos']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="16">
+    <MixedAssignment occurrences="14">
       <code>$alt</code>
       <code>$defaultFunction</code>
       <code>$defaultFunction</code>
       <code>$defaultFunction</code>
-      <code>$meta</code>
       <code>$paramValue</code>
       <code>$queryBase</code>
-      <code>$result</code>
       <code>$sqlQuery</code>
       <code>$subvalue</code>
       <code>$title</code>
@@ -7610,23 +7374,16 @@
     <MixedMethodCall occurrences="1">
       <code>getDisplay</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="6">
+    <MixedOperand occurrences="5">
       <code>$GLOBALS['using_bookmark_message']-&gt;getDisplay()</code>
       <code>$attributes['class']</code>
-      <code>$meta-&gt;name</code>
       <code>$sqlQuery</code>
       <code>$value</code>
       <code>$value</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="1">
-      <code>$meta-&gt;name</code>
-    </MixedPropertyFetch>
     <MixedReturnStatement occurrences="1">
       <code>$defaultFunction</code>
     </MixedReturnStatement>
-    <PossiblyNullIterator occurrences="1">
-      <code>$fieldsMeta</code>
-    </PossiblyNullIterator>
     <RedundantCast occurrences="2">
       <code>(int) $GLOBALS['cfg']['MaxRows']</code>
       <code>(string) $GLOBALS['db']</code>
@@ -7641,7 +7398,7 @@
     </TooFewArguments>
   </file>
   <file src="libraries/classes/Import.php">
-    <MixedArgument occurrences="42">
+    <MixedArgument occurrences="40">
       <code>$active</code>
       <code>$additionalSql[$i]</code>
       <code>$additionalSql[$i]</code>
@@ -7657,8 +7414,6 @@
       <code>$import_run_buffer['sql']</code>
       <code>$queries[$i]</code>
       <code>$reload</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$size</code>
       <code>$size</code>
       <code>$size</code>
@@ -7723,7 +7478,7 @@
     <MixedArrayOffset occurrences="1">
       <code>$typeArray[$analyses[$i][self::TYPES][$j]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="31">
+    <MixedAssignment occurrences="28">
       <code>$GLOBALS['offset']</code>
       <code>$active</code>
       <code>$cellValue</code>
@@ -7740,9 +7495,6 @@
       <code>$queries</code>
       <code>$queries</code>
       <code>$read_multiply</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$size</code>
       <code>$size</code>
       <code>$skip_queries</code>
@@ -7828,16 +7580,10 @@
     </MixedMethodCall>
   </file>
   <file src="libraries/classes/Import/SimulateDml.php">
-    <MixedArgument occurrences="1">
-      <code>$result</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
       <code>$tableReferences</code>
       <code>$tableReferences</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
-      <code>$result</code>
-    </MixedAssignment>
   </file>
   <file src="libraries/classes/Index.php">
     <DocblockTypeContradiction occurrences="1">
@@ -7929,7 +7675,7 @@
     </MixedAssignment>
   </file>
   <file src="libraries/classes/InsertEdit.php">
-    <MixedArgument occurrences="98">
+    <MixedArgument occurrences="85">
       <code>$_POST['fields']['multi_edit']</code>
       <code>$_POST['fields']['multi_edit'][$rownumber][$key]</code>
       <code>$backupField</code>
@@ -7980,9 +7726,6 @@
       <code>$data</code>
       <code>$data</code>
       <code>$data</code>
-      <code>$dispresult</code>
-      <code>$dispresult</code>
-      <code>$dispresult</code>
       <code>$extractedColumnspec['enum_set_values']</code>
       <code>$extractedColumnspec['enum_set_values']</code>
       <code>$extractedColumnspec['spec_in_brackets']</code>
@@ -8000,17 +7743,7 @@
       <code>$multiEditColumnsName[$key]</code>
       <code>$multiEditColumnsPrev[$key]</code>
       <code>$multiEditSalt[$key]</code>
-      <code>$newValue</code>
-      <code>$newValue</code>
       <code>$protectedRow[$multiEditColumnsName[$key]]</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result[$keyId]</code>
-      <code>$result[$keyId]</code>
       <code>$rows[$keyId]</code>
       <code>$singleQuery</code>
       <code>$singleQuery</code>
@@ -8029,11 +7762,10 @@
       <code>$whereClause</code>
       <code>min(max($column['len'], 4), $GLOBALS['cfg']['LimitChars'])</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="9">
+    <MixedArgumentTypeCoercion occurrences="8">
       <code>$keyId</code>
       <code>$query</code>
       <code>$queryFields</code>
-      <code>$row</code>
       <code>$thisUrlParams</code>
       <code>$thisUrlParams</code>
       <code>$urlParams</code>
@@ -8084,7 +7816,7 @@
       <code>$mimeMap[$tableColumn['Field']]</code>
       <code>$protectedRow[$multiEditColumnsName[$key]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="48">
+    <MixedAssignment occurrences="38">
       <code>$GLOBALS['cfg']['ShowFieldTypesInDataEditView']</code>
       <code>$GLOBALS['cfg']['ShowFunctionFields']</code>
       <code>$_SESSION['edit_next']</code>
@@ -8101,23 +7833,14 @@
       <code>$data</code>
       <code>$data</code>
       <code>$data</code>
-      <code>$dispresult</code>
       <code>$enumSelectedValue</code>
       <code>$enumValue</code>
-      <code>$extraData['truncatableFieldValue']</code>
       <code>$fieldsize</code>
       <code>$file</code>
       <code>$formParams['clause_is_unique']</code>
       <code>$isUnsigned</code>
       <code>$maxlength</code>
       <code>$maxlength</code>
-      <code>$newValue</code>
-      <code>$res</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result[$keyId]</code>
       <code>$singleQuery</code>
       <code>$specialChars</code>
       <code>$tmp['Default']</code>
@@ -8125,7 +7848,6 @@
       <code>$trueType</code>
       <code>$type</code>
       <code>$urlParams['sql_query']</code>
-      <code>$uuid</code>
       <code>$whereClause</code>
       <code>$whereClause</code>
       <code>$whereClause</code>
@@ -8134,9 +7856,8 @@
       <code>$whereClause</code>
       <code>$whereClause</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="4">
+    <MixedInferredReturnType occurrences="3">
       <code>int</code>
-      <code>string</code>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
@@ -8144,7 +7865,7 @@
       <code>new $className()</code>
       <code>new $className()</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="11">
+    <MixedOperand occurrences="10">
       <code>$_POST['where_clause'][0]</code>
       <code>$column['Field_html']</code>
       <code>$column['pma_type']</code>
@@ -8154,20 +7875,16 @@
       <code>$multiEditFuncs[$key]</code>
       <code>$multiEditFuncs[$key]</code>
       <code>$multiEditFuncs[$key]</code>
-      <code>$uuid</code>
       <code>$whereClause</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="4">
+    <MixedReturnStatement occurrences="3">
       <code>$_POST['err_url']</code>
       <code>$column['Field_html']</code>
-      <code>$dispval</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
-      <code>$dispval</code>
-    </NullableReturnStatement>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$dispval</code>
-    </PossiblyNullArrayAccess>
+    <PossiblyNullArgument occurrences="2">
+      <code>$newValue</code>
+      <code>$newValue</code>
+    </PossiblyNullArgument>
     <PossiblyUndefinedVariable occurrences="1">
       <code>$protectedRow</code>
     </PossiblyUndefinedVariable>
@@ -8312,12 +8029,8 @@
     </UnusedFunctionCall>
   </file>
   <file src="libraries/classes/Menu.php">
-    <MixedArgument occurrences="1">
-      <code>$result</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$binaryLogs</code>
-      <code>$result</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
@@ -8331,9 +8044,6 @@
     <PossiblyFalseOperand occurrences="1">
       <code>mb_strpos($tab, '_')</code>
     </PossiblyFalseOperand>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$result</code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="libraries/classes/Message.php">
     <DocblockTypeContradiction occurrences="1">
@@ -8380,23 +8090,10 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/Navigation/Navigation.php">
-    <MixedArgument occurrences="2">
-      <code>$result</code>
-      <code>$result</code>
-    </MixedArgument>
-    <MixedArrayOffset occurrences="3">
-      <code>$hidden[$type]</code>
-      <code>$hidden[$type]</code>
-      <code>$hidden[$type]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="3">
-      <code>$hidden[$type][]</code>
-      <code>$result</code>
-      <code>$type</code>
-    </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$result</code>
-    </PossiblyInvalidArgument>
+    <PossiblyNullArrayOffset occurrences="2">
+      <code>$hidden</code>
+      <code>$hidden</code>
+    </PossiblyNullArrayOffset>
     <RedundantCast occurrences="2">
       <code>(string) $cfg['NavigationLogoLink']</code>
       <code>(string) $cfg['NavigationLogoLink']</code>
@@ -8407,20 +8104,14 @@
       <code>''</code>
       <code>isset($this-&gt;pos)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="40">
+    <MixedArgument occurrences="34">
       <code>$_POST['n' . $count . '_aPath']</code>
       <code>$_POST['n' . $count . '_vPath']</code>
       <code>$_REQUEST['aPath']</code>
       <code>$_REQUEST['vPath']</code>
-      <code>$arr[0]</code>
-      <code>$arr[0]</code>
       <code>$container-&gt;children</code>
       <code>$container-&gt;realName</code>
-      <code>$database</code>
-      <code>$database</code>
       <code>$db</code>
-      <code>$handle</code>
-      <code>$handle</code>
       <code>$hiddenCounts[$db]</code>
       <code>$item</code>
       <code>$item</code>
@@ -8462,24 +8153,18 @@
       <code>$paths['aPath_clean'][4]</code>
       <code>$paths['aPath_clean'][4]</code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="2">
+    <MixedArrayOffset occurrences="1">
       <code>$hiddenCounts[$db]</code>
-      <code>$prefixMap[$prefix]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="22">
+    <MixedAssignment occurrences="17">
       <code>$container</code>
-      <code>$database</code>
-      <code>$databases[]</code>
       <code>$db</code>
-      <code>$handle</code>
-      <code>$handle</code>
       <code>$item</code>
       <code>$item</code>
       <code>$part</code>
       <code>$path</code>
       <code>$path</code>
       <code>$path</code>
-      <code>$prefix</code>
       <code>$retval</code>
       <code>$retval</code>
       <code>$separator</code>
@@ -8530,8 +8215,9 @@
     <PossiblyFalseReference occurrences="1">
       <code>getPresence</code>
     </PossiblyFalseReference>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="3">
       <code>$container-&gt;realName</code>
+      <code>$database</code>
       <code>$table</code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyFetch occurrences="2">
@@ -8566,76 +8252,47 @@
     </MixedMethodCall>
   </file>
   <file src="libraries/classes/Navigation/Nodes/Node.php">
-    <InvalidReturnStatement occurrences="2">
-      <code>$retval</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>int</code>
-    </InvalidReturnType>
-    <MixedArgument occurrences="23">
+    <MixedArgument occurrences="5">
       <code>$GLOBALS['cfg']['Server']['hide_db']</code>
-      <code>$arr[0]</code>
-      <code>$arr[0]</code>
-      <code>$arr[0]</code>
-      <code>$arr[0]</code>
-      <code>$arr[0]</code>
-      <code>$arr[0]</code>
-      <code>$arr[0]</code>
-      <code>$arr[0]</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
-      <code>$dbi-&gt;tryQuery($query)</code>
-      <code>$dbi-&gt;tryQuery($query)</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
       <code>$paths['aPath_clean']</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="4">
-      <code>$prefixMap[$prefix]</code>
-      <code>$prefixMap[$prefix]</code>
-      <code>$prefixMap[$prefix]</code>
-      <code>$prefixMap[$prefix]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="21">
+    <MixedAssignment occurrences="5">
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
-      <code>$retval[]</code>
-      <code>$retval[]</code>
-      <code>$retval[]</code>
     </MixedAssignment>
-    <MixedOperand occurrences="5">
+    <MixedOperand occurrences="3">
       <code>$GLOBALS['cfg']['Server']['hide_db']</code>
-      <code>$arr[0]</code>
       <code>$db</code>
       <code>$db</code>
-      <code>$prefix</code>
     </MixedOperand>
     <PossiblyInvalidArgument occurrences="1">
       <code>$databases</code>
     </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="8">
+      <code>$arr[0]</code>
+      <code>$arr[0]</code>
+      <code>$arr[0]</code>
+      <code>$arr[0]</code>
+      <code>$arr[0]</code>
+      <code>$arr[0]</code>
+      <code>$arr[0]</code>
+      <code>$arr[0]</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="4">
+      <code>$prefixMap</code>
+      <code>$prefixMap</code>
+      <code>$prefixMap</code>
+      <code>$prefixMap</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullOperand occurrences="1">
+      <code>$arr[0]</code>
+    </PossiblyNullOperand>
     <PropertyNotSetInConstructor occurrences="3">
       <code>$displayName</code>
       <code>$parent</code>
@@ -8691,34 +8348,9 @@
       <code>int</code>
       <code>int</code>
     </InvalidReturnType>
-    <MixedArgument occurrences="12">
-      <code>$dbi-&gt;tryQuery($query)</code>
-      <code>$dbi-&gt;tryQuery($query)</code>
-      <code>$dbi-&gt;tryQuery($query)</code>
-      <code>$dbi-&gt;tryQuery($query)</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$result</code>
-      <code>$result</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="9">
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$hiddenItems[]</code>
+    <MixedAssignment occurrences="1">
       <code>$item</code>
-      <code>$result</code>
-      <code>$retval[]</code>
-      <code>$retval[]</code>
-      <code>$retval[]</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$result</code>
-    </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor occurrences="3">
       <code>NodeDatabase</code>
       <code>NodeDatabase</code>
@@ -8807,28 +8439,13 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="libraries/classes/Navigation/Nodes/NodeTable.php">
-    <MixedArgument occurrences="9">
-      <code>$arr['Type']</code>
-      <code>$dbi-&gt;tryQuery($query)</code>
-      <code>$dbi-&gt;tryQuery($query)</code>
-      <code>$dbi-&gt;tryQuery($query)</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="5">
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$handle</code>
-      <code>$retval[]</code>
-      <code>$retval[]</code>
-    </MixedAssignment>
     <PossiblyInvalidPropertyFetch occurrences="2">
       <code>$this-&gt;realParent()-&gt;realName</code>
       <code>$this-&gt;realParent()-&gt;realName</code>
     </PossiblyInvalidPropertyFetch>
+    <PossiblyNullArgument occurrences="1">
+      <code>$arr['Type']</code>
+    </PossiblyNullArgument>
     <PropertyNotSetInConstructor occurrences="2">
       <code>NodeTable</code>
       <code>NodeTable</code>
@@ -9182,10 +8799,7 @@
       <code>$rows[$row['Table']]</code>
       <code>$rows[$row['Table']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="11">
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
+    <MixedAssignment occurrences="8">
       <code>$row</code>
       <code>$row</code>
       <code>$row</code>
@@ -9548,19 +9162,9 @@
     </MixedMethodCall>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportCodegen.php">
-    <MixedArgument occurrences="6">
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
+    <PossiblyNullArgument occurrences="4">
       <code>$row[0]</code>
       <code>$row[0]</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$result</code>
-      <code>$result</code>
-    </MixedAssignment>
-    <PossiblyNullArgument occurrences="2">
       <code>$table_alias</code>
       <code>$table_alias</code>
     </PossiblyNullArgument>
@@ -9575,7 +9179,7 @@
     </RedundantCondition>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportCsv.php">
-    <MixedArgument occurrences="16">
+    <MixedArgument occurrences="8">
       <code>$col_as</code>
       <code>$csv_enclosed</code>
       <code>$csv_enclosed</code>
@@ -9584,20 +9188,11 @@
       <code>$csv_separator</code>
       <code>$csv_terminated</code>
       <code>$csv_terminated</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$col_as</code>
-      <code>$result</code>
     </MixedAssignment>
-    <MixedOperand occurrences="18">
+    <MixedOperand occurrences="17">
       <code>$csv_enclosed</code>
       <code>$csv_enclosed</code>
       <code>$csv_enclosed</code>
@@ -9612,7 +9207,6 @@
       <code>$csv_separator</code>
       <code>$csv_terminated</code>
       <code>$csv_terminated</code>
-      <code>$row[$j]</code>
       <code>$what</code>
       <code>$what</code>
       <code>$what</code>
@@ -9622,7 +9216,7 @@
     </PossiblyNullOperand>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportHtmlword.php">
-    <MixedArgument occurrences="18">
+    <MixedArgument occurrences="14">
       <code>$col_alias</code>
       <code>$col_as</code>
       <code>$col_as</code>
@@ -9633,10 +9227,6 @@
       <code>$extracted_columnspec['print_type']</code>
       <code>$field_name</code>
       <code>$mime_map[$field_name]['mimetype']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$trigger['action_timing']</code>
       <code>$trigger['definition']</code>
       <code>$trigger['event_manipulation']</code>
@@ -9660,7 +9250,7 @@
       <code>$comments[$field_name]</code>
       <code>$mime_map[$field_name]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="15">
+    <MixedAssignment occurrences="13">
       <code>$col_alias</code>
       <code>$col_as</code>
       <code>$col_as</code>
@@ -9670,11 +9260,9 @@
       <code>$field_name</code>
       <code>$key</code>
       <code>$key</code>
-      <code>$result</code>
       <code>$trigger</code>
       <code>$unique_keys[]</code>
       <code>$unique_keys[]</code>
-      <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">
@@ -9702,19 +9290,11 @@
     </PossiblyUndefinedVariable>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportJson.php">
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="1">
       <code>$col_as</code>
-      <code>$record[$i]</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="1">
       <code>$col_as</code>
-      <code>$data[$columns[$i]]</code>
-      <code>$result</code>
     </MixedAssignment>
     <MixedOperand occurrences="4">
       <code>$crlf</code>
@@ -9724,15 +9304,10 @@
     </MixedOperand>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportLatex.php">
-    <MixedArgument occurrences="9">
+    <MixedArgument occurrences="4">
       <code>$columns_alias[$i]</code>
       <code>$field_name</code>
       <code>$mime_map[$field_name]['mimetype']</code>
-      <code>$record[$columns[$i]]</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$row['Type']</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="5">
@@ -9745,14 +9320,13 @@
     <MixedArrayOffset occurrences="1">
       <code>$aliases[$db]['tables'][$table]['columns'][$col_as]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="8">
       <code>$col_as</code>
       <code>$col_as</code>
       <code>$col_as</code>
       <code>$columns_alias[$i]</code>
       <code>$field_name</code>
       <code>$key</code>
-      <code>$result</code>
       <code>$type</code>
       <code>$unique_keys[]</code>
     </MixedAssignment>
@@ -9778,24 +9352,28 @@
       <code>$do_mime</code>
       <code>$do_relation</code>
     </ParamNameMismatch>
+    <PossiblyFalseArgument occurrences="1">
+      <code>$result</code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseReference occurrences="1">
+      <code>getFieldNames</code>
+    </PossiblyFalseReference>
+    <PossiblyNullArgument occurrences="1">
+      <code>$record[$columns[$i]]</code>
+    </PossiblyNullArgument>
     <PossiblyNullOperand occurrences="2">
       <code>$table_alias</code>
       <code>$table_alias</code>
     </PossiblyNullOperand>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportMediawiki.php">
-    <MixedArgument occurrences="2">
-      <code>$result</code>
-      <code>$result</code>
-    </MixedArgument>
     <MixedArrayOffset occurrences="1">
       <code>$aliases[$db]['tables'][$table]['columns'][$col_as]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$col_as</code>
       <code>$col_as</code>
       <code>$column</code>
-      <code>$result</code>
     </MixedAssignment>
     <MixedOperand occurrences="7">
       <code>$col_as</code>
@@ -9820,41 +9398,29 @@
     <InvalidArgument occurrences="1">
       <code>$GLOBALS[$what . '_null']</code>
     </InvalidArgument>
-    <MixedArgument occurrences="15">
+    <MixedArgument occurrences="1">
       <code>$col_as</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$col_as</code>
-      <code>$result</code>
     </MixedAssignment>
-    <MixedOperand occurrences="3">
-      <code>$row[$j]</code>
+    <MixedOperand occurrences="2">
       <code>$what</code>
       <code>$what</code>
     </MixedOperand>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument occurrences="2">
+      <code>$row[$j]</code>
       <code>$table_alias</code>
     </PossiblyNullArgument>
+    <UnnecessaryVarAnnotation occurrences="1">
+      <code>FieldMetadata[]</code>
+    </UnnecessaryVarAnnotation>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportOdt.php">
     <InvalidArgument occurrences="1">
       <code>$GLOBALS[$what . '_null']</code>
     </InvalidArgument>
-    <MixedArgument occurrences="22">
+    <MixedArgument occurrences="14">
       <code>$col_as</code>
       <code>$col_as</code>
       <code>$col_as</code>
@@ -9865,14 +9431,6 @@
       <code>$extracted_columnspec['print_type']</code>
       <code>$field_name</code>
       <code>$mime_map[$field_name]['mimetype']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
       <code>$trigger['action_timing']</code>
       <code>$trigger['definition']</code>
       <code>$trigger['event_manipulation']</code>
@@ -9893,7 +9451,7 @@
       <code>$aliases[$db]['tables'][$table]['columns'][$col_as]</code>
       <code>$aliases[$db]['tables'][$view]['columns'][$col_as]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment occurrences="12">
       <code>$col_as</code>
       <code>$col_as</code>
       <code>$col_as</code>
@@ -9901,16 +9459,14 @@
       <code>$col_as</code>
       <code>$col_as</code>
       <code>$field_name</code>
-      <code>$result</code>
       <code>$rfield</code>
       <code>$rfield</code>
       <code>$rtable</code>
       <code>$rtable</code>
       <code>$trigger</code>
     </MixedAssignment>
-    <MixedOperand occurrences="5">
+    <MixedOperand occurrences="4">
       <code>$rfield</code>
-      <code>$row[$j]</code>
       <code>$rtable</code>
       <code>$what</code>
       <code>$what</code>
@@ -9920,8 +9476,9 @@
       <code>$do_mime</code>
       <code>$do_relation</code>
     </ParamNameMismatch>
-    <PossiblyNullArgument occurrences="9">
+    <PossiblyNullArgument occurrences="10">
       <code>$col_as</code>
+      <code>$row[$j]</code>
       <code>$table_alias</code>
       <code>$table_alias</code>
       <code>$table_alias</code>
@@ -9931,6 +9488,9 @@
       <code>$table_alias</code>
       <code>$view_alias</code>
     </PossiblyNullArgument>
+    <UnnecessaryVarAnnotation occurrences="1">
+      <code>FieldMetadata[]</code>
+    </UnnecessaryVarAnnotation>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportPdf.php">
     <MixedArgument occurrences="1">
@@ -9949,16 +9509,11 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportPhparray.php">
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="1">
       <code>$col_as</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$col_as</code>
-      <code>$result</code>
     </MixedAssignment>
     <PossiblyNullArgument occurrences="1">
       <code>$table_alias</code>
@@ -9973,7 +9528,7 @@
       <code>$GLOBALS['asfile']</code>
       <code>$GLOBALS['sql_if_not_exists']</code>
     </InvalidArgument>
-    <MixedArgument occurrences="75">
+    <MixedArgument occurrences="51">
       <code>$GLOBALS['sql_auto_increments']</code>
       <code>$GLOBALS['sql_header_comment']</code>
       <code>$GLOBALS['sql_indexes']</code>
@@ -9984,14 +9539,6 @@
       <code>$column['Comment']</code>
       <code>$column['Default']</code>
       <code>$column['Type']</code>
-      <code>$createQuery</code>
-      <code>$createQuery</code>
-      <code>$createQuery</code>
-      <code>$createQuery</code>
-      <code>$createQuery</code>
-      <code>$createQuery</code>
-      <code>$createQuery</code>
-      <code>$createQuery</code>
       <code>$engine</code>
       <code>$eventName</code>
       <code>$eventName</code>
@@ -10004,21 +9551,8 @@
       <code>$relFieldAlias</code>
       <code>$rel['foreign_field']</code>
       <code>$rel['foreign_table']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$routine</code>
       <code>$routine</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
-      <code>$row[$j]</code>
       <code>$sql_auto_increments</code>
       <code>$sql_backquotes</code>
       <code>$sql_backquotes</code>
@@ -10044,22 +9578,15 @@
       <code>$sql_constraints</code>
       <code>$sql_indexes</code>
       <code>$table</code>
-      <code>$tmpres['Check_time']</code>
-      <code>$tmpres['Create_time']</code>
-      <code>$tmpres['Update_time']</code>
       <code>$token-&gt;value</code>
       <code>$trigger['create']</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="9">
+    <MixedArgumentTypeCoercion occurrences="5">
       <code>$autoIncrement</code>
       <code>$constraints</code>
       <code>$dropped</code>
       <code>$indexes</code>
       <code>$indexesFulltext</code>
-      <code>$row</code>
-      <code>$values</code>
-      <code>$values</code>
-      <code>$values</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="16">
       <code>$aliases[$oldDatabase]['tables']</code>
@@ -10086,15 +9613,13 @@
       <code>$oneKey['ref_index_list'][$index]</code>
       <code>$values[$val]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="35">
-      <code>$GLOBALS['old_tz']</code>
+    <MixedAssignment occurrences="29">
       <code>$colAlias</code>
       <code>$colAlias</code>
       <code>$colAlias</code>
       <code>$colAs</code>
       <code>$column</code>
       <code>$columnAliases</code>
-      <code>$createQuery</code>
       <code>$definition</code>
       <code>$engine</code>
       <code>$eventName</code>
@@ -10110,9 +9635,6 @@
       <code>$rel</code>
       <code>$relFieldAlias</code>
       <code>$relFieldAlias</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$routine</code>
       <code>$statement-&gt;name-&gt;database</code>
       <code>$statement-&gt;name-&gt;table</code>
@@ -10121,9 +9643,8 @@
       <code>$trigger</code>
       <code>$val</code>
       <code>$values[$val]</code>
-      <code>$values[]</code>
     </MixedAssignment>
-    <MixedOperand occurrences="39">
+    <MixedOperand occurrences="38">
       <code>$column['Collation']</code>
       <code>$column['Type']</code>
       <code>$crlf</code>
@@ -10162,7 +9683,6 @@
       <code>$statement-&gt;entityOptions-&gt;has('AUTO_INCREMENT')</code>
       <code>$tmpUniqueCondition</code>
       <code>$trigger['drop']</code>
-      <code>$values[$i]</code>
     </MixedOperand>
     <PossiblyInvalidOperand occurrences="1">
       <code>Context::escape($field-&gt;name)</code>
@@ -10170,7 +9690,8 @@
     <PossiblyInvalidPropertyAssignmentValue occurrences="1">
       <code>Context::escape($alias)</code>
     </PossiblyInvalidPropertyAssignmentValue>
-    <PossiblyNullArgument occurrences="4">
+    <PossiblyNullArgument occurrences="5">
+      <code>$createQuery</code>
       <code>$dbi-&gt;getDefinition($db, $type, $routine)</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
@@ -10194,12 +9715,16 @@
       <code>return $sqlQuery;</code>
       <code>return $statement-&gt;build();</code>
     </ReferenceConstraintViolation>
-    <UnnecessaryVarAnnotation occurrences="1">
+    <UnnecessaryVarAnnotation occurrences="2">
       <code>CreateDefinition</code>
+      <code>FieldMetadata[]</code>
     </UnnecessaryVarAnnotation>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportTexytext.php">
-    <MixedArgument occurrences="16">
+    <InvalidArgument occurrences="1">
+      <code>$value</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="11">
       <code>$col_alias</code>
       <code>$col_as</code>
       <code>$col_as</code>
@@ -10209,13 +9734,8 @@
       <code>$comments[$field_name]</code>
       <code>$field_name</code>
       <code>$mime_map[$field_name]['mimetype']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$trigger['definition']</code>
       <code>$type</code>
-      <code>$value</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="10">
       <code>$comments[$field_name]</code>
@@ -10235,7 +9755,7 @@
       <code>$comments[$field_name]</code>
       <code>$mime_map[$field_name]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="15">
+    <MixedAssignment occurrences="13">
       <code>$col_alias</code>
       <code>$col_as</code>
       <code>$col_as</code>
@@ -10245,12 +9765,10 @@
       <code>$field_name</code>
       <code>$key</code>
       <code>$key</code>
-      <code>$result</code>
       <code>$trigger</code>
       <code>$type</code>
       <code>$unique_keys[]</code>
       <code>$unique_keys[]</code>
-      <code>$value</code>
     </MixedAssignment>
     <MixedOperand occurrences="5">
       <code>$trigger['action_timing']</code>
@@ -10264,9 +9782,6 @@
       <code>$do_mime</code>
       <code>$do_relation</code>
     </ParamNameMismatch>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$value</code>
-    </PossiblyInvalidArgument>
     <PossiblyNullArgument occurrences="1">
       <code>$col_as</code>
     </PossiblyNullArgument>
@@ -10282,7 +9797,7 @@
     </PossiblyUndefinedVariable>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportXml.php">
-    <MixedArgument occurrences="15">
+    <MixedArgument occurrences="11">
       <code>$code</code>
       <code>$col_as</code>
       <code>$db</code>
@@ -10290,10 +9805,6 @@
       <code>$db_charset</code>
       <code>$db_collation</code>
       <code>$name</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$table</code>
       <code>$table</code>
       <code>$table</code>
@@ -10312,13 +9823,12 @@
     <MixedArrayTypeCoercion occurrences="1">
       <code>$result[$table]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$code</code>
       <code>$col_as</code>
       <code>$db_charset</code>
       <code>$db_collation</code>
       <code>$name</code>
-      <code>$result</code>
       <code>$table</code>
       <code>$trigger</code>
     </MixedAssignment>
@@ -10366,27 +9876,23 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$table</code>
     </PropertyNotSetInConstructor>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $record[$i]</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportYaml.php">
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="1">
       <code>$col_as</code>
-      <code>$record[$i]</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$col_as</code>
-      <code>$result</code>
     </MixedAssignment>
     <PossiblyNullOperand occurrences="1">
       <code>$table_alias</code>
     </PossiblyNullOperand>
   </file>
   <file src="libraries/classes/Plugins/Export/Helpers/Pdf.php">
-    <MixedArgument occurrences="87">
+    <MixedArgument occurrences="82">
       <code>$col_as</code>
       <code>$column['Type']</code>
       <code>$fullwidth + $l</code>
@@ -10446,11 +9952,6 @@
       <code>$this-&gt;colAlign[$col]</code>
       <code>$this-&gt;colAlign[$col]</code>
       <code>$this-&gt;lMargin</code>
-      <code>$this-&gt;results</code>
-      <code>$this-&gt;results</code>
-      <code>$this-&gt;results</code>
-      <code>$this-&gt;results</code>
-      <code>$this-&gt;results</code>
       <code>$this-&gt;results</code>
       <code>$this-&gt;tMargin</code>
       <code>$this-&gt;tMargin</code>
@@ -10802,27 +10303,18 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="libraries/classes/Plugins/Import/ImportLdi.php">
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="5">
       <code>$import_file</code>
       <code>$ldi_columns</code>
       <code>$ldi_enclosed</code>
       <code>$ldi_escaped</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$table</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$result</code>
-    </MixedAssignment>
     <MixedOperand occurrences="3">
       <code>$ldi_new_line</code>
       <code>$ldi_terminated</code>
       <code>$skip_queries</code>
     </MixedOperand>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$tmp[0]</code>
-    </PossiblyNullArrayAccess>
   </file>
   <file src="libraries/classes/Plugins/Import/ImportMediawiki.php">
     <MixedArgument occurrences="7">
@@ -11327,8 +10819,7 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Plugins/Schema/ExportRelationSchema.php">
-    <MixedArgument occurrences="2">
-      <code>$_name_rs</code>
+    <MixedArgument occurrences="1">
       <code>$table</code>
     </MixedArgument>
     <MixedAssignment occurrences="1">
@@ -11337,12 +10828,9 @@
     <MixedOperand occurrences="1">
       <code>$_name_row[0]</code>
     </MixedOperand>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$_name_row[0]</code>
-    </PossiblyNullArrayAccess>
   </file>
   <file src="libraries/classes/Plugins/Schema/Pdf/Pdf.php">
-    <MixedArgument occurrences="13">
+    <MixedArgument occurrences="12">
       <code>$data[$i]</code>
       <code>$data[$i]</code>
       <code>$h</code>
@@ -11350,7 +10838,6 @@
       <code>$h</code>
       <code>$h</code>
       <code>$il + 1</code>
-      <code>$test_rs</code>
       <code>$this-&gt;widths[$i]</code>
       <code>$w</code>
       <code>$w</code>
@@ -11361,12 +10848,11 @@
       <code>$cw[mb_ord($c)]</code>
       <code>$this-&gt;CurrentFont['cw']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$cw</code>
       <code>$h</code>
       <code>$il</code>
       <code>$l</code>
-      <code>$test_rs</code>
       <code>$w</code>
       <code>$w</code>
       <code>$wmax</code>
@@ -11834,13 +11320,9 @@
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Plugins/Schema/TableStats.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="2">
       <code>$_POST['t_db'][$key]</code>
       <code>$_POST['t_tbl'][$key]</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="4">
       <code>$_POST['t_db'][$key]</code>
@@ -11848,10 +11330,9 @@
       <code>$_POST['t_x'][$key]</code>
       <code>$_POST['t_y'][$key]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <PossiblyFalseArgument occurrences="1">
       <code>$result</code>
-      <code>$result</code>
-    </MixedAssignment>
+    </PossiblyFalseArgument>
   </file>
   <file src="libraries/classes/Plugins/Transformations/Abs/Bool2TextTransformationsPlugin.php">
     <MixedArgumentTypeCoercion occurrences="1">
@@ -12269,9 +11750,7 @@
     </MixedArrayAssignment>
   </file>
   <file src="libraries/classes/RecentFavoriteTable.php">
-    <MixedArgument occurrences="6">
-      <code>$result</code>
-      <code>$row[0]</code>
+    <MixedArgument occurrences="4">
       <code>$tbl['db']</code>
       <code>$tbl['db']</code>
       <code>$tbl['table']</code>
@@ -12299,10 +11778,7 @@
     <MixedArrayAssignment occurrences="1">
       <code>$_SESSION['tmpval'][$this-&gt;tableType . 'Tables']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="8">
-      <code>$result</code>
-      <code>$return</code>
-      <code>$success</code>
+    <MixedAssignment occurrences="5">
       <code>$table</code>
       <code>$table</code>
       <code>$tbl</code>
@@ -12317,11 +11793,8 @@
       <code>$table['table']</code>
     </MixedOperand>
     <MixedReturnStatement occurrences="1">
-      <code>$return</code>
+      <code>json_decode($value, true)</code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$result</code>
-    </PossiblyInvalidArgument>
     <PossiblyNullOperand occurrences="2">
       <code>$this-&gt;getPmaTable()</code>
       <code>$this-&gt;getPmaTable()</code>
@@ -12335,21 +11808,14 @@
       <code>$data[0]['File']</code>
       <code>$data[0]['Position']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
-      <code>$out</code>
+    <MixedAssignment occurrences="2">
       <code>$output['File']</code>
       <code>$output['Position']</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
     <MixedOperand occurrences="2">
       <code>$pos['File']</code>
       <code>$pos['Position']</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
-      <code>$out</code>
-    </MixedReturnStatement>
     <MoreSpecificReturnType occurrences="1">
       <code>array{'File'?: string, 'Position'?: string}</code>
     </MoreSpecificReturnType>
@@ -12358,7 +11824,7 @@
     </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/ReplicationGui.php">
-    <MixedArgument occurrences="16">
+    <MixedArgument occurrences="14">
       <code>$_POST['hostname']</code>
       <code>$_POST['hostname']</code>
       <code>$_POST['pma_pw']</code>
@@ -12367,8 +11833,6 @@
       <code>$_POST['text_port']</code>
       <code>$_POST['username']</code>
       <code>$_POST['username']</code>
-      <code>$currentUser</code>
-      <code>$currentUser</code>
       <code>$database</code>
       <code>$errorMessage</code>
       <code>$serverReplicationVariable</code>
@@ -12410,19 +11874,11 @@
       <code>$_SESSION['replication']['sr_action_status']</code>
       <code>$_SESSION['replication']['sr_action_status']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="15">
+    <MixedAssignment occurrences="7">
       <code>$count</code>
-      <code>$currentUser</code>
       <code>$database</code>
       <code>$errorMessage</code>
       <code>$linkToPrimary</code>
-      <code>$qControl</code>
-      <code>$qReset</code>
-      <code>$qSkip</code>
-      <code>$qStart</code>
-      <code>$qStart</code>
-      <code>$qStop</code>
-      <code>$qStop</code>
       <code>$serverReplicationVariable</code>
       <code>$successMessage</code>
       <code>$username</code>
@@ -12515,27 +11971,14 @@
     </RedundantCondition>
   </file>
   <file src="libraries/classes/SavedSearches.php">
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="1">
       <code>$criterias['criteriaColumn']</code>
-      <code>$oneResult['search_data']</code>
-      <code>$oneResult['search_name']</code>
-      <code>$resList</code>
-      <code>$resList</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$list[$oneResult['id']]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="3">
       <code>$data[$field]</code>
       <code>$data['Or' . $i]</code>
-      <code>$list[$oneResult['id']]</code>
-      <code>$resList</code>
-      <code>$resList</code>
       <code>$this-&gt;criterias</code>
     </MixedAssignment>
-    <PossiblyFalseArgument occurrences="1">
-      <code>$dbi-&gt;insertId()</code>
-    </PossiblyFalseArgument>
     <PossiblyInvalidArrayOffset occurrences="2">
       <code>$criterias['Or' . $i]</code>
       <code>$criterias['criteriaColumn']</code>
@@ -12544,10 +11987,6 @@
       <code>$oneResult['search_data']</code>
       <code>$oneResult['search_name']</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="2">
-      <code>$oneResult['search_data']</code>
-      <code>$oneResult['search_name']</code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullOperand occurrences="2">
       <code>$this-&gt;getId()</code>
       <code>$this-&gt;getId()</code>
@@ -12558,9 +11997,6 @@
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <TypeDoesNotContainType occurrences="1">
-      <code>$oneResult === false</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="libraries/classes/Server/Plugin.php">
     <MixedArgument occurrences="13">
@@ -12580,25 +12016,24 @@
     </MixedArgument>
   </file>
   <file src="libraries/classes/Server/Plugins.php">
-    <MixedArgument occurrences="4">
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
+    <MixedArgument occurrences="1">
       <code>$row['PLUGIN_DESCRIPTION']</code>
     </MixedArgument>
     <MixedArrayOffset occurrences="1">
       <code>$plugins[$row['PLUGIN_NAME']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="2">
-      <code>$result</code>
-      <code>$result</code>
-    </MixedAssignment>
   </file>
   <file src="libraries/classes/Server/Privileges.php">
     <DocblockTypeContradiction occurrences="1">
       <code>''</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="118">
+    <InvalidReturnStatement occurrences="1">
+      <code>$dbRights</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
+    <MixedArgument occurrences="76">
       <code>$GLOBALS['dbname']</code>
       <code>$_GET['initial']</code>
       <code>$_GET['initial']</code>
@@ -12629,15 +12064,6 @@
       <code>$arr['x509_subject']</code>
       <code>$createUserReal</code>
       <code>$currentDb</code>
-      <code>$currentUser</code>
-      <code>$currentUser</code>
-      <code>$currentUserName</code>
-      <code>$currentUserName</code>
-      <code>$dbRightsResult</code>
-      <code>$dbRightsResult</code>
-      <code>$dbRightsResult</code>
-      <code>$dbRightsResult</code>
-      <code>$dbRightsRow['Db']</code>
       <code>$eachUser</code>
       <code>$exportUser</code>
       <code>$exportUser</code>
@@ -12646,7 +12072,6 @@
       <code>$hashedPassword</code>
       <code>$hostname</code>
       <code>$hostname</code>
-      <code>$initials</code>
       <code>$oldUserGroup</code>
       <code>$paramDbName</code>
       <code>$paramDbName</code>
@@ -12656,34 +12081,7 @@
       <code>$paramTableName</code>
       <code>$passwordSetReal</code>
       <code>$privilege</code>
-      <code>$privileges</code>
       <code>$realSqlQuery</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res2</code>
-      <code>$resAll</code>
-      <code>$resAll</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$routine['name']</code>
       <code>$row</code>
       <code>$row</code>
@@ -12691,12 +12089,7 @@
       <code>$row1['Type']</code>
       <code>$row1['Type']</code>
       <code>$row1['Type']</code>
-      <code>$row1[0]</code>
-      <code>$row1[0]</code>
-      <code>$row1[0]</code>
-      <code>$row1[1]</code>
       <code>$row2['Column_priv']</code>
-      <code>$row['Db']</code>
       <code>$row['Db']</code>
       <code>$row['Db']</code>
       <code>$row['Proc_priv']</code>
@@ -12791,7 +12184,7 @@
       <code>$columns[$row1[0]]</code>
       <code>$dbRights[$row['User']][$row['Host']]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="27">
+    <MixedArrayOffset occurrences="13">
       <code>$GLOBALS[$currentGrant[0]]</code>
       <code>$GLOBALS[$currentGrant[0]]</code>
       <code>$GLOBALS[$currentGrant[0]]</code>
@@ -12799,28 +12192,14 @@
       <code>$GLOBALS[$currentGrant[0]]</code>
       <code>$GLOBALS[$currentGrant[0]]</code>
       <code>$GLOBALS[$currentGrant[0]]</code>
-      <code>$arrayInitials[$tmpInitial]</code>
-      <code>$columns[$row1[0]]</code>
-      <code>$columns[$row1[0]]</code>
-      <code>$dbRights[$dbRightsRow[$dbOrTableName]]</code>
-      <code>$dbRights[$dbRightsRow['User']]</code>
-      <code>$dbRights[$row[$dbOrTableName]]</code>
-      <code>$dbRights[$row[$dbOrTableName]]</code>
-      <code>$dbRights[$row[$dbOrTableName]]</code>
-      <code>$dbRights[$row[$dbOrTableName]]</code>
-      <code>$dbRights[$row['Db']]</code>
-      <code>$dbRights[$row['User']]</code>
+      <code>$arrayInitials[$tmpInitial[0]]</code>
       <code>$groupAssignment[$host['User']]</code>
-      <code>$groupAssignment[$row['username']]</code>
       <code>$row[$currentGrant[0]]</code>
       <code>$row[$currentGrant[0]]</code>
-      <code>$row[$row1[0]]</code>
-      <code>$row[$row1[0]]</code>
-      <code>$row[$row1[0]]</code>
       <code>$specificPrivileges[$grant[0]]</code>
       <code>$specificPrivileges[$grant[0]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="90">
+    <MixedAssignment occurrences="64">
       <code>$GLOBALS[$key]</code>
       <code>$account</code>
       <code>$authenticationPlugin</code>
@@ -12829,25 +12208,18 @@
       <code>$authenticationPlugin</code>
       <code>$currentDb</code>
       <code>$currentGrant</code>
-      <code>$currentUser</code>
-      <code>$currentUserName</code>
       <code>$databases[]</code>
-      <code>$dbRightsResult</code>
-      <code>$dbRightsResult</code>
       <code>$eachUser</code>
       <code>$exportUser</code>
       <code>$extraData['db_wildcard_privs']</code>
       <code>$foundRows[]</code>
       <code>$grant</code>
-      <code>$groupAssignment[$row['username']]</code>
       <code>$hashedPassword</code>
       <code>$host</code>
       <code>$hostnameLength</code>
-      <code>$initials</code>
       <code>$name</code>
       <code>$name</code>
       <code>$name</code>
-      <code>$oldUserGroup</code>
       <code>$oldUserGroup</code>
       <code>$oneGrant</code>
       <code>$onePrivilege['name']</code>
@@ -12861,7 +12233,6 @@
       <code>$privilege</code>
       <code>$privilege['routine']</code>
       <code>$privilege['table']</code>
-      <code>$privileges</code>
       <code>$privs[]</code>
       <code>$queriesForDisplay[$tmpCount - 1]</code>
       <code>$queriesForDisplay[$tmpCount - 1]</code>
@@ -12872,22 +12243,6 @@
       <code>$queries[]</code>
       <code>$queries[]</code>
       <code>$queries[]</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res</code>
-      <code>$res2</code>
-      <code>$resAll</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$right</code>
       <code>$routine</code>
       <code>$routine</code>
@@ -12900,14 +12255,12 @@
       <code>$selectedUsr</code>
       <code>$sqlQuery</code>
       <code>$sqlQuery</code>
-      <code>$tables[]</code>
       <code>$tmpPrivs2['Insert'][]</code>
       <code>$tmpPrivs2['References'][]</code>
       <code>$tmpPrivs2['Select'][]</code>
       <code>$tmpPrivs2['Update'][]</code>
       <code>$user</code>
       <code>$userGroup</code>
-      <code>$usergroup</code>
       <code>$usernameLength</code>
       <code>$val</code>
       <code>$value</code>
@@ -12966,35 +12319,50 @@
       <code>$GLOBALS[$currentGrant[0]]</code>
       <code>$dbRightsRow['Db']</code>
       <code>$dbname</code>
-      <code>$result</code>
+      <code>$user</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast occurrences="2">
       <code>$dbRightsRow['Db']</code>
       <code>$dbname</code>
     </PossiblyInvalidCast>
-    <PossiblyNullArgument occurrences="5">
+    <PossiblyNullArgument occurrences="10">
       <code>$oldUserGroup</code>
+      <code>$privileges</code>
       <code>$row1['Type']</code>
       <code>$row1['Type']</code>
       <code>$row1['Type']</code>
       <code>$row1['Type']</code>
+      <code>$row1[0]</code>
+      <code>$row1[0]</code>
+      <code>$row1[0]</code>
+      <code>$row1[1]</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="4">
+    <PossiblyNullArrayAccess occurrences="3">
       <code>$result['password']</code>
       <code>$row1['Type']</code>
       <code>$row['@@old_passwords']</code>
-      <code>$tmpInitial</code>
     </PossiblyNullArrayAccess>
-    <PossiblyNullArrayOffset occurrences="1">
-      <code>$arrayInitials</code>
+    <PossiblyNullArrayOffset occurrences="13">
+      <code>$columns</code>
+      <code>$columns</code>
+      <code>$dbRights</code>
+      <code>$dbRights</code>
+      <code>$dbRights</code>
+      <code>$dbRights</code>
+      <code>$dbRights</code>
+      <code>$dbRights</code>
+      <code>$dbRights</code>
+      <code>$groupAssignment</code>
+      <code>$row</code>
+      <code>$row</code>
+      <code>$row</code>
     </PossiblyNullArrayOffset>
     <PossiblyNullOperand occurrences="3">
       <code>$alterUserQuery</code>
       <code>$alterUserQuery</code>
       <code>$alterUserQuery</code>
     </PossiblyNullOperand>
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(bool) ! $this-&gt;dbi-&gt;fetchValue($sql)</code>
+    <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $privs</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType occurrences="1">
@@ -13023,10 +12391,8 @@
     </RedundantCast>
   </file>
   <file src="libraries/classes/Server/Status/Data.php">
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="1">
       <code>$_POST['primary_connection'] ?? null</code>
-      <code>$server_status_result</code>
-      <code>$server_status_result</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="2">
       <code>$filter</code>
@@ -13035,24 +12401,21 @@
     <MixedArrayAccess occurrences="1">
       <code>$used_queries['Com_admin_commands']</code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="2">
+    <MixedArrayOffset occurrences="1">
       <code>$sectionUsed[$section]</code>
-      <code>$server_status[$arr[0]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="18">
+    <MixedAssignment occurrences="16">
       <code>$allocationMap[$name]</code>
       <code>$key_read_requests</code>
       <code>$key_reads</code>
       <code>$key_write_requests</code>
       <code>$key_writes</code>
       <code>$section</code>
-      <code>$server_status[$arr[0]]</code>
       <code>$server_status['Key_buffer_fraction_%']</code>
       <code>$server_status['Key_buffer_fraction_%']</code>
       <code>$server_status['Key_read_ratio_%']</code>
       <code>$server_status['Key_write_ratio_%']</code>
       <code>$server_status['Threads_cache_hitrate_%']</code>
-      <code>$server_status_result</code>
       <code>$this-&gt;allocationMap</code>
       <code>$this-&gt;sectionUsed</code>
       <code>$this-&gt;usedQueries</code>
@@ -13073,18 +12436,9 @@
     </RedundantCast>
   </file>
   <file src="libraries/classes/Server/Status/Monitor.php">
-    <MixedArgument occurrences="31">
+    <MixedArgument occurrences="22">
       <code>$dataPoint['name']</code>
       <code>$dataPoint['type']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$ret</code>
       <code>$ret</code>
       <code>$ret[$chartId][$nodeId][$pointId]</code>
@@ -13130,7 +12484,7 @@
       <code>$serverVarValues[$dataPoint['name']]</code>
       <code>$statusVarValues[$dataPoint['name']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="31">
+    <MixedAssignment occurrences="26">
       <code>$chartNodes</code>
       <code>$chartNodes</code>
       <code>$cpuload</code>
@@ -13145,11 +12499,6 @@
       <code>$node_id</code>
       <code>$pointId</code>
       <code>$point_id</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$ret</code>
       <code>$ret[$chart_id][$node_id][$point_id]['value']</code>
       <code>$ret[$chart_id][$node_id][$point_id]['value']</code>
@@ -13174,20 +12523,22 @@
       <code>$row['#']</code>
       <code>$row['#']</code>
     </MixedOperand>
+    <PossiblyFalseArgument occurrences="2">
+      <code>$result</code>
+      <code>$result</code>
+    </PossiblyFalseArgument>
   </file>
   <file src="libraries/classes/Server/Status/Processes.php">
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="3">
       <code>$params['order_by_field']</code>
       <code>$process['Info']</code>
       <code>$process['db']</code>
-      <code>$result</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$process[$newKey]</code>
-      <code>$result</code>
       <code>$urlParams['order_by_field']</code>
       <code>$urlParams['showExecuting']</code>
       <code>$urlParams['sort_order']</code>
@@ -13355,7 +12706,10 @@
     <InvalidScalarArgument occurrences="1">
       <code>''</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="62">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$unlimNumRows</code>
+    </LessSpecificReturnStatement>
+    <MixedArgument occurrences="56">
       <code>$_POST[$requestIndex]</code>
       <code>$_POST['bkm_label']</code>
       <code>$_POST['dropped_column'] ?? null</code>
@@ -13404,12 +12758,6 @@
       <code>$profilingResults</code>
       <code>$result</code>
       <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result ?? null</code>
-      <code>$result ?? null</code>
-      <code>$row[0]</code>
       <code>$sortCol</code>
       <code>$statement</code>
       <code>$table</code>
@@ -13450,8 +12798,7 @@
     <MixedArrayTypeCoercion occurrences="1">
       <code>$columns[$indexColumnName]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="25">
-      <code>$currentDb</code>
+    <MixedAssignment occurrences="21">
       <code>$maxRows</code>
       <code>$oneFieldMeta</code>
       <code>$oneMeta</code>
@@ -13461,8 +12808,6 @@
       <code>$profiling['chart'][$status]</code>
       <code>$profiling['chart'][$status]</code>
       <code>$profiling['total_time']</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$resultSetColumnNames[]</code>
       <code>$sortCol</code>
       <code>$statement</code>
@@ -13470,7 +12815,6 @@
       <code>$statement</code>
       <code>$table</code>
       <code>$tokenList</code>
-      <code>$unlimNumRows</code>
       <code>$unlimNumRows</code>
       <code>$unlimNumRows</code>
       <code>$unlimNumRows</code>
@@ -13514,21 +12858,19 @@
       <code>$profiling</code>
       <code>array&lt;string, int|array&gt;</code>
     </MixedReturnTypeCoercion>
+    <NullableReturnStatement occurrences="1">
+      <code>$unlimNumRows</code>
+    </NullableReturnStatement>
     <PossiblyFalseReference occurrences="1">
       <code>save</code>
     </PossiblyFalseReference>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$result</code>
-      <code>$result</code>
-    </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="13">
+    <PossiblyNullArgument occurrences="12">
       <code>$_POST['purge'] ?? null</code>
       <code>$db</code>
       <code>$db</code>
       <code>$extraData ?? null</code>
       <code>$messageToShow ?? null</code>
       <code>$result</code>
-      <code>$result ?? null</code>
       <code>$row[0]</code>
       <code>$sqlData ?? null</code>
       <code>$sqlQueryForBookmark ?? null</code>
@@ -13536,10 +12878,6 @@
       <code>$table</code>
       <code>$table</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="2">
-      <code>$row[0]</code>
-      <code>$row[0]</code>
-    </PossiblyNullArrayAccess>
     <RedundantCast occurrences="1">
       <code>(bool) $GLOBALS['cfg']['ShowSQL']</code>
     </RedundantCast>
@@ -13568,17 +12906,14 @@
     </PossiblyFalseArgument>
   </file>
   <file src="libraries/classes/StorageEngine.php">
-    <MixedArgument occurrences="10">
+    <MixedArgument occurrences="7">
       <code>$details['desc']</code>
       <code>$details['title']</code>
       <code>$details['value']</code>
       <code>$details['value']</code>
       <code>$details['value']</code>
-      <code>$res</code>
-      <code>$res</code>
       <code>$result[0] ?? ''</code>
       <code>$result[0] ?? ''</code>
-      <code>$row['Variable_name']</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="9">
       <code>$decodedData['disk_usage']</code>
@@ -13597,27 +12932,16 @@
       <code>$mysql_vars[$row['Variable_name']]['value']</code>
       <code>$storage_engines[$engine]['Support']</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="9">
+    <MixedArrayOffset occurrences="1">
       <code>$engines[$details['Engine']]</code>
-      <code>$mysql_vars[$row['Variable_name']]</code>
-      <code>$mysql_vars[$row['Variable_name']]</code>
-      <code>$mysql_vars[$row['Variable_name']]</code>
-      <code>$mysql_vars[$row['Variable_name']]</code>
-      <code>$mysql_vars[$row['Variable_name']]</code>
-      <code>$mysql_vars[$row['Variable_name']]</code>
-      <code>$variables[$row['Variable_name']]</code>
-      <code>$variables[$row['Variable_name']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment occurrences="8">
       <code>$dataLength</code>
       <code>$decodedData</code>
       <code>$details</code>
       <code>$indexLength</code>
       <code>$mroongaData</code>
       <code>$mysql_vars[$row['Variable_name']]</code>
-      <code>$mysql_vars[$row['Variable_name']]['title']</code>
-      <code>$mysql_vars[$row['Variable_name']]['value']</code>
-      <code>$res</code>
       <code>$this-&gt;comment</code>
       <code>$this-&gt;title</code>
     </MixedAssignment>
@@ -13639,6 +12963,14 @@
       <code>[$dataLength, $indexLength]</code>
       <code>int[]</code>
     </MixedReturnTypeCoercion>
+    <PossiblyNullArgument occurrences="1">
+      <code>$row['Variable_name']</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="3">
+      <code>$mysql_vars</code>
+      <code>$mysql_vars</code>
+      <code>$variables</code>
+    </PossiblyNullArrayOffset>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>self::SUPPORT_NO</code>
     </RedundantConditionGivenDocblockType>
@@ -13660,12 +12992,6 @@
     <MixedAssignment occurrences="1">
       <code>$column</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>mysqli_result|false</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;dbi-&gt;tryQuery($transformationSql)</code>
-    </MixedReturnStatement>
   </file>
   <file src="libraries/classes/Table.php">
     <DocblockTypeContradiction occurrences="3">
@@ -13676,7 +13002,7 @@
     <InvalidReturnStatement occurrences="1">
       <code>$tableAutoIncrement ?? ''</code>
     </InvalidReturnStatement>
-    <MixedArgument occurrences="67">
+    <MixedArgument occurrences="51">
       <code>$GLOBALS['sql_auto_increments']</code>
       <code>$GLOBALS['sql_indexes']</code>
       <code>$_POST['constraint_name'][$masterFieldMd5]</code>
@@ -13687,13 +13013,6 @@
       <code>$column['Extra']</code>
       <code>$column['Extra']</code>
       <code>$column['Extra']</code>
-      <code>$commentsCopyRow['column_name']</code>
-      <code>$commentsCopyRow['comment']</code>
-      <code>$commentsCopyRow['mimetype']</code>
-      <code>$commentsCopyRow['transformation']</code>
-      <code>$commentsCopyRow['transformation_options']</code>
-      <code>$commentsCopyRs</code>
-      <code>$commentsCopyRs</code>
       <code>$createTable</code>
       <code>$eachCol</code>
       <code>$eachCol</code>
@@ -13720,7 +13039,6 @@
       <code>$masterField</code>
       <code>$masterField</code>
       <code>$masterField</code>
-      <code>$moveColumnsSqlResult</code>
       <code>$oldIndex</code>
       <code>$oneField</code>
       <code>$oneField</code>
@@ -13729,20 +13047,12 @@
       <code>$optionsArray[$existrelForeign[$masterFieldMd5]['on_delete'] ?? ''] ?? null</code>
       <code>$optionsArray[$existrelForeign[$masterFieldMd5]['on_update'] ?? ''] ?? null</code>
       <code>$options['expr']</code>
-      <code>$res</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$row['Type']</code>
-      <code>$row[0]</code>
-      <code>$tableCopyRs</code>
-      <code>$tableCopyRs</code>
       <code>$tableOptions</code>
-      <code>$this-&gt;relation-&gt;queryAsControlUser($sqlQuery)</code>
       <code>$this-&gt;uiprefs[$property]</code>
       <code>$this-&gt;uiprefs[$property]</code>
       <code>$trigger['create']</code>
       <code>$trigger['name']</code>
-      <code>$val</code>
       <code>$value</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="9">
@@ -13820,7 +13130,7 @@
       <code>$optionsArray[$existrelForeign[$masterFieldMd5]['on_delete'] ?? '']</code>
       <code>$optionsArray[$existrelForeign[$masterFieldMd5]['on_update'] ?? '']</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="57">
+    <MixedAssignment occurrences="49">
       <code>$GLOBALS['sql_auto_increment']</code>
       <code>$cachedResult</code>
       <code>$cachedResult</code>
@@ -13828,7 +13138,6 @@
       <code>$column</code>
       <code>$column</code>
       <code>$columns[$row['Field']]</code>
-      <code>$commentsCopyRs</code>
       <code>$constraintName</code>
       <code>$createTable</code>
       <code>$currCreateTime</code>
@@ -13853,18 +13162,12 @@
       <code>$oneField</code>
       <code>$options</code>
       <code>$refDbName</code>
-      <code>$res</code>
-      <code>$result</code>
       <code>$ret[]</code>
       <code>$row</code>
       <code>$rowCount</code>
-      <code>$rowCount</code>
-      <code>$success</code>
-      <code>$success</code>
       <code>$tableAutoIncrement</code>
       <code>$tableCollation</code>
       <code>$tableComment</code>
-      <code>$tableCopyRs</code>
       <code>$tableNumRowInfo</code>
       <code>$tableNumRowInfo</code>
       <code>$tableOptions</code>
@@ -13874,7 +13177,6 @@
       <code>$trigger</code>
       <code>$trigger</code>
       <code>$type</code>
-      <code>$val</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -13907,13 +13209,19 @@
       <code>$tableRowFormat</code>
       <code>end($this-&gt;errors)</code>
       <code>end($this-&gt;messages)</code>
-      <code>json_decode($row[0], true)</code>
+      <code>json_decode($value, true)</code>
     </MixedReturnStatement>
-    <PossiblyNullArgument occurrences="4">
+    <PossiblyNullArgument occurrences="10">
       <code>$GLOBALS['showtable']['Name']</code>
+      <code>$commentsCopyRow['column_name']</code>
+      <code>$commentsCopyRow['comment']</code>
+      <code>$commentsCopyRow['mimetype']</code>
+      <code>$commentsCopyRow['transformation']</code>
+      <code>$commentsCopyRow['transformation_options']</code>
       <code>$existrelForeign[$masterFieldMd5]['ref_db_name']</code>
       <code>$existrelForeign[$masterFieldMd5]['ref_index_list']</code>
       <code>$existrelForeign[$masterFieldMd5]['ref_table_name']</code>
+      <code>$val</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="7">
       <code>$existrelForeign[$masterFieldMd5]['constraint']</code>
@@ -13963,7 +13271,8 @@
     <ReferenceConstraintViolation occurrences="1">
       <code>return $sqlQuery;</code>
     </ReferenceConstraintViolation>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType occurrences="2">
+      <code>! $this-&gt;dbi-&gt;query($GLOBALS['sql_query'])</code>
       <code>$rowFields[$key] != 'cc'</code>
     </TypeDoesNotContainType>
     <UnusedVariable occurrences="1">
@@ -14036,7 +13345,7 @@
       <code>$mime_map[$columnMeta['Field']]</code>
       <code>$mime_map[$columnMeta['Field']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="21">
+    <MixedAssignment occurrences="20">
       <code>$columnMeta</code>
       <code>$columnMeta['Default']</code>
       <code>$columnMeta['Default']</code>
@@ -14054,7 +13363,6 @@
       <code>$form_params['table']</code>
       <code>$length</code>
       <code>$length</code>
-      <code>$move_columns</code>
       <code>$o_fld_val</code>
       <code>$submit_attribute</code>
       <code>$type</code>
@@ -14195,10 +13503,8 @@
     <InvalidScalarArgument occurrences="1">
       <code>(int) $version - 1</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="10">
+    <MixedArgument occurrences="8">
       <code>$data['statement']</code>
-      <code>$relation-&gt;queryAsControlUser($sqlQuery)</code>
-      <code>$result</code>
       <code>$result['identifier']</code>
       <code>$result['tablename']</code>
       <code>$result['tablename']</code>
@@ -14214,20 +13520,17 @@
     <MixedArrayAssignment occurrences="1">
       <code>self::$trackingCache[$dbName][$tableName]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['db']</code>
       <code>$data</code>
       <code>$data['schema_snapshot']</code>
       <code>$data['tracking']</code>
-      <code>$result</code>
-      <code>$result</code>
       <code>$result['tablename']</code>
       <code>$trackingEnabled</code>
       <code>$trackingEnabled</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="1">
       <code>bool</code>
-      <code>int</code>
     </MixedInferredReturnType>
     <MixedOperand occurrences="2">
       <code>$data['username']</code>
@@ -14237,8 +13540,7 @@
       <code>$tokens[0]-&gt;value</code>
       <code>$tokens[2]-&gt;value</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="2">
-      <code>$row[0] ?? -1</code>
+    <MixedReturnStatement occurrences="1">
       <code>self::$trackingCache[$dbName][$tableName]</code>
     </MixedReturnStatement>
     <PossiblyFalseOperand occurrences="2">
@@ -14274,7 +13576,7 @@
     </TypeDoesNotContainNull>
   </file>
   <file src="libraries/classes/Tracking.php">
-    <MixedArgument occurrences="53">
+    <MixedArgument occurrences="47">
       <code>$_POST['date_from']</code>
       <code>$_POST['date_to']</code>
       <code>$_POST['db']</code>
@@ -14306,13 +13608,9 @@
       <code>$drop_create_statements</code>
       <code>$entry['date']</code>
       <code>$entry['date']</code>
-      <code>$entry['db_name']</code>
       <code>$entry['statement']</code>
-      <code>$entry['table_name']</code>
       <code>$indexes</code>
       <code>$indexes</code>
-      <code>$selectableTablesSqlResult</code>
-      <code>$selectableTablesSqlResult</code>
       <code>$selected_table</code>
       <code>$selected_table</code>
       <code>$str1</code>
@@ -14325,8 +13623,6 @@
       <code>$str4</code>
       <code>$str5</code>
       <code>$str5</code>
-      <code>$tableName</code>
-      <code>$tableResult</code>
       <code>$value['Name']</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1"/>
@@ -14362,8 +13658,7 @@
     <MixedArrayOffset occurrences="1">
       <code>$data[$which_log][$delete_id]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="24">
-      <code>$allTablesResult</code>
+    <MixedAssignment occurrences="20">
       <code>$columns</code>
       <code>$data</code>
       <code>$delete_id</code>
@@ -14377,34 +13672,26 @@
       <code>$ids[$key]</code>
       <code>$indexes</code>
       <code>$row</code>
-      <code>$selectableTablesSqlResult</code>
       <code>$selected_table</code>
-      <code>$sql_result</code>
       <code>$statements[$key]</code>
-      <code>$tableResult</code>
       <code>$temp</code>
       <code>$timestamps[$key]</code>
       <code>$untracked_tables[]</code>
       <code>$usernames[$key]</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
-      <code>array</code>
-      <code>object|false</code>
+    <MixedInferredReturnType occurrences="1">
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="6">
+    <MixedOperand occurrences="5">
       <code>$drop_create_statements</code>
       <code>$entry['statement']</code>
       <code>$entry['statement']</code>
       <code>$entry['statement']</code>
       <code>$temp</code>
-      <code>$versionNumber</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="3">
+    <MixedReturnStatement occurrences="1">
       <code>$html</code>
-      <code>$sql_result</code>
-      <code>$this-&gt;dbi-&gt;query($query, DatabaseInterface::CONNECT_CONTROL, 0, false)</code>
     </MixedReturnStatement>
     <PossiblyFalseOperand occurrences="2">
       <code>$sep</code>
@@ -14414,13 +13701,17 @@
       <code>$sep</code>
       <code>$sep</code>
     </PossiblyInvalidOperand>
+    <PossiblyNullArgument occurrences="3">
+      <code>$entry['db_name']</code>
+      <code>$entry['table_name']</code>
+      <code>$tableName</code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand occurrences="1">
+      <code>$versionNumber</code>
+    </PossiblyNullOperand>
   </file>
   <file src="libraries/classes/Transformations.php">
-    <MixedArgument occurrences="8">
-      <code>$row['comment']</code>
-      <code>$test_rs</code>
-      <code>$test_rs</code>
-      <code>$test_rs</code>
+    <MixedArgument occurrences="4">
       <code>$upd_query</code>
       <code>$values['mimetype']</code>
       <code>$values['transformation']</code>
@@ -14437,9 +13728,8 @@
       <code>$values['transformation']</code>
       <code>$values['transformation']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$result[$column]</code>
-      <code>$test_rs</code>
       <code>$values</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
@@ -14448,16 +13738,9 @@
     <MixedReturnStatement occurrences="1">
       <code>$stack</code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$test_rs</code>
-      <code>$test_rs</code>
-    </PossiblyInvalidArgument>
     <PossiblyNullArgument occurrences="1">
       <code>$row['comment']</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$row['comment']</code>
-    </PossiblyNullArrayAccess>
   </file>
   <file src="libraries/classes/TwoFactor.php">
     <InvalidPropertyFetch occurrences="1">
@@ -14581,8 +13864,7 @@
       <code>$allowList[$path]</code>
       <code>$excludeList[$path]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="3">
-      <code>$has_config</code>
+    <MixedAssignment occurrences="2">
       <code>$prefs['config_data'][$path]</code>
       <code>$value</code>
     </MixedAssignment>
@@ -14601,13 +13883,7 @@
       <code>$table['disp_name']</code>
       <code>$units[$d]</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="17">
-      <code>$dbInfoResult</code>
-      <code>$dbInfoResult</code>
-      <code>$dbInfoResult</code>
-      <code>$dbInfoResult</code>
-      <code>$dbInfoResult</code>
-      <code>$dbInfoResult</code>
+    <MixedArgument occurrences="11">
       <code>$host</code>
       <code>$limitOffset</code>
       <code>$maxSize</code>
@@ -14655,7 +13931,7 @@
       <code>$_SESSION['tmpval']['table_limit_offset']</code>
       <code>$_SESSION['tmpval']['table_limit_offset_db']</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="13">
+    <MixedArrayOffset occurrences="10">
       <code>$array[$p]</code>
       <code>$indexesData[$row['Key_name']]</code>
       <code>$indexesData[$row['Key_name']]</code>
@@ -14666,19 +13942,14 @@
       <code>$pkArray[$row['Column_name']]</code>
       <code>$sortableNameMappings[$_REQUEST['sort']]</code>
       <code>$sortableNameMappings[$_REQUEST['sort']]</code>
-      <code>$sotCache[$tmp['Table']]</code>
-      <code>$sotCache[$tmp[0]]</code>
-      <code>$tables[$tmp[0]]</code>
     </MixedArrayOffset>
     <MixedArrayTypeCoercion occurrences="1">
       <code>$array[$p]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="43">
+    <MixedAssignment occurrences="37">
       <code>$array</code>
       <code>$columnNames[]</code>
       <code>$columnNames[]</code>
-      <code>$dbInfoResult</code>
-      <code>$dbInfoResult</code>
       <code>$escapeMethod</code>
       <code>$group[$groupName]['tab' . $sep . 'count']</code>
       <code>$indexesData[$row['Key_name']][$row['Seq_in_index']]['Column_name']</code>
@@ -14690,7 +13961,6 @@
       <code>$indexes[]</code>
       <code>$lastIndex</code>
       <code>$limitOffset</code>
-      <code>$names[]</code>
       <code>$p</code>
       <code>$p</code>
       <code>$pos</code>
@@ -14702,17 +13972,14 @@
       <code>$retval[]</code>
       <code>$row</code>
       <code>$rowCount</code>
-      <code>$schemaPrivileges</code>
       <code>$subvalue</code>
       <code>$table</code>
       <code>$tableGroup</code>
-      <code>$tablePrivileges</code>
       <code>$tableType</code>
       <code>$table['disp_name']</code>
       <code>$unit</code>
       <code>$urlParams['tbl_group']</code>
       <code>$urlParams['tbl_type']</code>
-      <code>$userPrivileges</code>
       <code>$val</code>
       <code>$value</code>
       <code>$value</code>
@@ -14786,6 +14053,10 @@
       <code>$maxSize</code>
       <code>$maxUnit</code>
     </PossiblyNullArrayAccess>
+    <PossiblyNullArrayOffset occurrences="2">
+      <code>$sotCache</code>
+      <code>$tables</code>
+    </PossiblyNullArrayOffset>
     <RedundantCast occurrences="2">
       <code>(int) $GLOBALS['cfg']['ExecTimeLimit']</code>
       <code>(int) $GLOBALS['cfg']['LimitChars']</code>
@@ -14804,12 +14075,6 @@
     </RedundantCondition>
   </file>
   <file src="libraries/classes/Utils/ForeignKey.php">
-    <MixedArgument occurrences="1">
-      <code>$dbi-&gt;fetchValue('SELECT @@ndb_version_string')</code>
-    </MixedArgument>
-    <PossiblyFalseArgument occurrences="1">
-      <code>$dbi-&gt;fetchValue('SELECT @@ndb_version_string')</code>
-    </PossiblyFalseArgument>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $engine</code>
     </RedundantCastGivenDocblockType>
@@ -14836,25 +14101,9 @@
     </RedundantCast>
   </file>
   <file src="libraries/classes/Utils/Gis.php">
-    <MixedArgument occurrences="2">
-      <code>$wktresult</code>
-      <code>$wktresult</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <PossiblyNullOperand occurrences="1">
       <code>$srid</code>
-      <code>$wktresult</code>
-      <code>$wktval</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedOperand occurrences="2">
-      <code>$srid</code>
-      <code>$wktval</code>
-    </MixedOperand>
-    <MixedReturnStatement occurrences="1">
-      <code>$wktval</code>
-    </MixedReturnStatement>
+    </PossiblyNullOperand>
   </file>
   <file src="libraries/classes/Utils/HttpRequest.php">
     <MixedArgument occurrences="1">
@@ -15410,10 +14659,6 @@
     </UndefinedMethod>
   </file>
   <file src="test/classes/Controllers/Table/RelationControllerTest.php">
-    <MixedAssignment occurrences="2">
-      <code>$count</code>
-      <code>$count</code>
-    </MixedAssignment>
     <MixedMethodCall occurrences="8">
       <code>method</code>
       <code>method</code>
@@ -15424,10 +14669,6 @@
       <code>will</code>
       <code>will</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="2">
-      <code>$count</code>
-      <code>$count</code>
-    </MixedOperand>
     <UndefinedMethod occurrences="4">
       <code>expects</code>
       <code>expects</code>
@@ -15627,19 +14868,13 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/classes/Dbal/DbiDummyTest.php">
-    <MixedArgument occurrences="1">
-      <code>$result</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$result</code>
-    </MixedAssignment>
     <MixedInferredReturnType occurrences="2">
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
   </file>
   <file src="test/classes/Display/ResultsTest.php">
-    <MixedArgument occurrences="14">
+    <MixedArgument occurrences="13">
       <code>$actual</code>
       <code>$analyzedSqlResults</code>
       <code>$analyzedSqlResults['is_analyse']</code>
@@ -15649,7 +14884,6 @@
       <code>$analyzedSqlResults['is_func']</code>
       <code>$analyzedSqlResults['is_maint']</code>
       <code>$analyzedSqlResults['is_show']</code>
-      <code>$dtResult</code>
       <code>$output</code>
       <code>$output</code>
     </MixedArgument>
@@ -15674,9 +14908,8 @@
       <code>$_SESSION['tmpval']['relational_display']</code>
       <code>$_SESSION['tmpval']['relational_display']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$actual</code>
-      <code>$dtResult</code>
       <code>$output</code>
       <code>$output</code>
       <code>$output</code>
@@ -15959,10 +15192,9 @@
       <code>$_SESSION['tmpval']['relational_display']</code>
       <code>$_SESSION['tmpval']['relational_display']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="30">
+    <MixedAssignment occurrences="29">
       <code>$actual</code>
       <code>$actual</code>
-      <code>$result</code>
       <code>$result</code>
       <code>$result</code>
       <code>$result</code>
@@ -16672,16 +15904,14 @@
       <code>$filoQueries</code>
     </MissingPropertyType>
     <MixedArgument occurrences="5">
-      <code>$query_data['columns']</code>
+      <code>$query_data['columns'] ?? []</code>
       <code>$query_data['result']</code>
       <code>$query_data['result']</code>
       <code>$this-&gt;dummyQueries</code>
       <code>$this-&gt;filoQueries</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="14">
+    <MixedArrayAccess occurrences="12">
       <code>$query['used']</code>
-      <code>$query_data['columns'][$i]</code>
-      <code>$query_data['columns'][$key]</code>
       <code>$query_data['columns'][$key]</code>
       <code>$query_data['result'][$query_data['pos']]</code>
       <code>$this-&gt;dummyQueries[$i]</code>
@@ -16700,35 +15930,28 @@
       <code>$this-&gt;filoQueries[$i]</code>
       <code>$this-&gt;filoQueries[]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="3">
-      <code>$data[$query_data['columns'][$key]]</code>
+    <MixedArrayOffset occurrences="2">
       <code>$query_data['result'][$query_data['pos']]</code>
       <code>$ret[$query_data['columns'][$key]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="8">
-      <code>$data[$query_data['columns'][$key]]</code>
+    <MixedAssignment occurrences="6">
       <code>$query</code>
       <code>$query_data['pos']</code>
       <code>$ret</code>
       <code>$ret[$query_data['columns'][$key]]</code>
       <code>$unUsed[]</code>
       <code>$val</code>
-      <code>$val</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="5">
+    <MixedInferredReturnType occurrences="3">
       <code>?array</code>
-      <code>FieldMetadata[]|null</code>
       <code>array</code>
       <code>int|numeric-string</code>
-      <code>string</code>
     </MixedInferredReturnType>
     <MixedOperand occurrences="1">
       <code>$query_data['pos']</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="6">
+    <MixedReturnStatement occurrences="4">
       <code>$cached_affected_rows ?? 0</code>
-      <code>$query_data['columns'][$i]</code>
-      <code>$query_data['metadata']</code>
       <code>$ret</code>
       <code>$this-&gt;dummyQueries[$result - self::OFFSET_GLOBAL]</code>
       <code>$this-&gt;filoQueries[$result]</code>
@@ -16736,6 +15959,16 @@
     <MixedReturnTypeCoercion occurrences="2">
       <code>$unUsed</code>
       <code>array[]</code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="test/classes/Stubs/DummyResult.php">
+    <MixedReturnTypeCoercion occurrences="6">
+      <code>$this-&gt;link-&gt;fetchAssoc($this-&gt;result) ?? []</code>
+      <code>$this-&gt;link-&gt;fetchRow($this-&gt;result) ?? []</code>
+      <code>$this-&gt;link-&gt;getFieldsMeta($this-&gt;result)</code>
+      <code>array&lt;int, FieldMetadata&gt;</code>
+      <code>array&lt;int,string|null&gt;</code>
+      <code>array&lt;string,string|null&gt;</code>
     </MixedReturnTypeCoercion>
   </file>
   <file src="test/classes/Stubs/ResponseRenderer.php">
@@ -16800,8 +16033,7 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/classes/TrackerTest.php">
-    <MixedAssignment occurrences="2">
-      <code>$result</code>
+    <MixedAssignment occurrences="1">
       <code>$result</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="3">
@@ -16811,9 +16043,8 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/classes/TrackingTest.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$html</code>
-      <code>$sql_result</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="4">
       <code>$entries[0]['statement']</code>
@@ -16821,10 +16052,6 @@
       <code>$ret[0]['statement']</code>
       <code>$ret[0]['username']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
-      <code>$ret</code>
-      <code>$sql_result</code>
-    </MixedAssignment>
   </file>
   <file src="test/classes/TransformationsTest.php">
     <MixedInferredReturnType occurrences="4">

--- a/templates/server/user_groups/user_groups.twig
+++ b/templates/server/user_groups/user_groups.twig
@@ -1,5 +1,5 @@
 <div class="row"><h2>{% trans 'User groups' %}</h2></div>
-{% if  has_rows > 0 %}
+{% if  has_rows %}
     <form name="userGroupsForm" id="userGroupsForm" action="{{ action|raw }}" method="post">
         {{ hidden_inputs|raw  }}
         <table class="table table-light table-striped table-hover">

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 
 use function implode;
 
@@ -45,28 +46,31 @@ class RelationTest extends AbstractTestCase
      */
     public function testPMAQueryAsControlUser(): void
     {
+        $resultStub1 = $this->createMock(DummyResult::class);
+        $resultStub2 = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $dbi->expects($this->once())
             ->method('query')
-            ->will($this->returnValue('executeResult1'));
+            ->will($this->returnValue($resultStub1));
 
         $dbi->expects($this->once())
             ->method('tryQuery')
-            ->will($this->returnValue('executeResult2'));
+            ->will($this->returnValue($resultStub2));
 
         $GLOBALS['dbi'] = $dbi;
         $this->relation->dbi = $GLOBALS['dbi'];
 
         $sql = 'insert into PMA_bookmark A,B values(1, 2)';
-        $this->assertEquals(
-            'executeResult1',
+        $this->assertSame(
+            $resultStub1,
             $this->relation->queryAsControlUser($sql)
         );
-        $this->assertEquals(
-            'executeResult2',
+        $this->assertSame(
+            $resultStub2,
             $this->relation->queryAsControlUser($sql, false)
         );
     }
@@ -150,13 +154,15 @@ class RelationTest extends AbstractTestCase
      */
     public function testPMATryUpgradeTransformations(): void
     {
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->any())
             ->method('tryQuery')
-            ->will($this->returnValue(true));
-        $dbi->expects($this->any())
+            ->will($this->returnValue($resultStub));
+        $resultStub->expects($this->any())
             ->method('numRows')
             ->will($this->returnValue(0));
         $dbi->expects($this->any())

--- a/test/classes/Controllers/Server/PluginsControllerTest.php
+++ b/test/classes/Controllers/Server/PluginsControllerTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Server\Plugins;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 
 /**
@@ -51,18 +52,17 @@ class PluginsControllerTest extends AbstractTestCase
             'PLUGIN_STATUS' => 'ACTIVE',
         ];
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->once())
             ->method('query')
-            ->will($this->returnValue(true));
-        $dbi->expects($this->exactly(2))
+            ->will($this->returnValue($resultStub));
+        $resultStub->expects($this->exactly(2))
             ->method('fetchAssoc')
-            ->will($this->onConsecutiveCalls($row, null));
-        $dbi->expects($this->once())
-            ->method('freeResult')
-            ->will($this->returnValue(true));
+            ->will($this->onConsecutiveCalls($row, []));
 
         $response = new ResponseRenderer();
 

--- a/test/classes/Controllers/Server/VariablesControllerTest.php
+++ b/test/classes/Controllers/Server/VariablesControllerTest.php
@@ -12,7 +12,9 @@ use PhpMyAdmin\Providers\ServerVariables\VoidProvider as ServerVariablesVoidProv
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseStub;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionProperty;
 
 use function __;
@@ -85,7 +87,16 @@ class VariablesControllerTest extends AbstractTestCase
     {
         $response = new ResponseStub();
 
-        $controller = new VariablesController($response, new Template(), $GLOBALS['dbi']);
+        $resultStub = $this->createMock(DummyResult::class);
+
+        /** @var MockObject&DatabaseInterface $dbi */
+        $dbi = $GLOBALS['dbi'];
+        $dbi->expects($this->once())
+            ->method('tryQuery')
+            ->with('SHOW SESSION VARIABLES;')
+            ->willReturn($resultStub);
+
+        $controller = new VariablesController($response, new Template(), $dbi);
 
         $controller();
         $html = $response->getHTMLResult();

--- a/test/classes/Database/Designer/CommonTest.php
+++ b/test/classes/Database/Designer/CommonTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\Database\Designer\Common;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Version;
 
 use function sprintf;
@@ -119,13 +120,15 @@ class CommonTest extends AbstractTestCase
     {
         $pg = 1;
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $dbi->expects($this->exactly(2))
             ->method('query')
-            ->willReturnOnConsecutiveCalls(true, true);
+            ->willReturnOnConsecutiveCalls($resultStub, $resultStub);
         $dbi->expects($this->any())->method('escapeString')
             ->will($this->returnArgument(0));
 

--- a/test/classes/Database/DesignerTest.php
+++ b/test/classes/Database/DesignerTest.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Database\Designer;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Version;
 use ReflectionMethod;
 
@@ -58,6 +59,8 @@ class DesignerTest extends AbstractTestCase
      */
     private function mockDatabaseInteraction(string $db): void
     {
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -71,9 +74,9 @@ class DesignerTest extends AbstractTestCase
                 DatabaseInterface::QUERY_STORE,
                 false
             )
-            ->will($this->returnValue('dummyRS'));
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->exactly(3))
+        $resultStub->expects($this->exactly(3))
             ->method('fetchAssoc')
             ->willReturnOnConsecutiveCalls(
                 [
@@ -84,7 +87,7 @@ class DesignerTest extends AbstractTestCase
                     'page_nr' => '2',
                     'page_descr' => 'page2',
                 ],
-                null
+                []
             );
 
         $dbi->expects($this->any())

--- a/test/classes/Dbal/DbiDummyTest.php
+++ b/test/classes/Dbal/DbiDummyTest.php
@@ -6,23 +6,19 @@ namespace PhpMyAdmin\Tests\Dbal;
 
 use PhpMyAdmin\Query\Utilities;
 use PhpMyAdmin\Tests\AbstractTestCase;
-use PhpMyAdmin\Tests\Stubs\DbiDummy;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 
 /**
  * @coversNothing
  */
 class DbiDummyTest extends AbstractTestCase
 {
-    /** @var DbiDummy */
-    protected $object;
-
     /**
      * Configures test parameters.
      */
     protected function setUp(): void
     {
         parent::setUp();
-        $this->object = new DbiDummy();
         $GLOBALS['cfg']['DBG']['sql'] = false;
         $GLOBALS['cfg']['IconvExtraParams'] = '';
         $GLOBALS['server'] = 1;
@@ -30,9 +26,9 @@ class DbiDummyTest extends AbstractTestCase
 
     public function testGetClientInfo(): void
     {
-        $this->assertNotEmpty($this->object->getClientInfo());
+        $this->assertNotEmpty($this->dummyDbi->getClientInfo());
         // Call the DatabaseInterface
-        $this->assertSame($GLOBALS['dbi']->getClientInfo(), $this->object->getClientInfo());
+        $this->assertSame($this->dbi->getClientInfo(), $this->dummyDbi->getClientInfo());
     }
 
     /**
@@ -42,7 +38,7 @@ class DbiDummyTest extends AbstractTestCase
      */
     public function testQuery(): void
     {
-        $this->assertEquals(1000, $GLOBALS['dbi']->tryQuery('SELECT 1'));
+        $this->assertInstanceOf(DummyResult::class, $this->dbi->tryQuery('SELECT 1'));
     }
 
     /**
@@ -52,8 +48,9 @@ class DbiDummyTest extends AbstractTestCase
      */
     public function testFetch(): void
     {
-        $result = $GLOBALS['dbi']->tryQuery('SELECT 1');
-        $this->assertEquals(['1'], $GLOBALS['dbi']->fetchArray($result));
+        $result = $this->dbi->tryQuery('SELECT 1');
+        $this->assertNotFalse($result);
+        $this->assertSame(['1'], $this->dbi->fetchRow($result));
     }
 
     /**
@@ -136,11 +133,11 @@ class DbiDummyTest extends AbstractTestCase
     {
         $this->assertEquals(
             'a',
-            $GLOBALS['dbi']->escapeString('a')
+            $this->dbi->escapeString('a')
         );
         $this->assertEquals(
             'a\\\'',
-            $GLOBALS['dbi']->escapeString('a\'')
+            $this->dbi->escapeString('a\'')
         );
     }
 }

--- a/test/classes/Dbal/DbiMysqliTest.php
+++ b/test/classes/Dbal/DbiMysqliTest.php
@@ -7,11 +7,8 @@ namespace PhpMyAdmin\Tests\Dbal;
 use mysqli;
 use mysqli_result;
 use PhpMyAdmin\Dbal\DbiMysqli;
+use PhpMyAdmin\Dbal\MysqliResult;
 use PhpMyAdmin\Tests\AbstractTestCase;
-
-use const MYSQLI_ASSOC;
-use const MYSQLI_BOTH;
-use const MYSQLI_NUM;
 
 /**
  * @covers \PhpMyAdmin\Dbal\DbiMysqli
@@ -67,75 +64,19 @@ class DbiMysqliTest extends AbstractTestCase
     }
 
     /**
-     * Test for fetchArray
+     * Test for realQuery
      */
-    public function testFetchArray(): void
+    public function testrealQuery(): void
     {
-        $expected = [];
-        $result = $this->createMock(mysqli_result::class);
-        $result->expects($this->once())
-            ->method('fetch_array')
-            ->with($this->equalTo(MYSQLI_BOTH))
-            ->willReturn($expected);
+        $query = 'test';
+        $mysqliResult = $this->createMock(mysqli_result::class);
+        $mysqli = $this->createMock(mysqli::class);
+        $mysqli->expects($this->once())
+            ->method('query')
+            ->with($this->equalTo($query))
+            ->willReturn($mysqliResult);
 
-        $this->assertEquals($expected, $this->object->fetchArray($result));
-    }
-
-    /**
-     * Test for fetchAssoc
-     */
-    public function testFetchAssoc(): void
-    {
-        $expected = [];
-        $result = $this->createMock(mysqli_result::class);
-        $result->expects($this->once())
-            ->method('fetch_array')
-            ->with($this->equalTo(MYSQLI_ASSOC))
-            ->willReturn($expected);
-
-        $this->assertEquals($expected, $this->object->fetchAssoc($result));
-    }
-
-    /**
-     * Test for fetchRow
-     */
-    public function testFetchRow(): void
-    {
-        $expected = [];
-        $result = $this->createMock(mysqli_result::class);
-        $result->expects($this->once())
-            ->method('fetch_array')
-            ->with($this->equalTo(MYSQLI_NUM))
-            ->willReturn($expected);
-
-        $this->assertEquals($expected, $this->object->fetchRow($result));
-    }
-
-    /**
-     * Test for dataSeek
-     */
-    public function testDataSeek(): void
-    {
-        $offset = 1;
-        $result = $this->createMock(mysqli_result::class);
-        $result->expects($this->once())
-            ->method('data_seek')
-            ->with($this->equalTo($offset))
-            ->willReturn(true);
-
-        $this->assertTrue($this->object->dataSeek($result, $offset));
-    }
-
-    /**
-     * Test for freeResult
-     */
-    public function testFreeResult(): void
-    {
-        $result = $this->createMock(mysqli_result::class);
-        $result->expects($this->once())
-            ->method('close');
-
-        $this->object->freeResult($result);
+        $this->assertInstanceOf(MysqliResult::class, $this->object->realQuery($query, $mysqli, 0));
     }
 
     /**
@@ -175,15 +116,7 @@ class DbiMysqliTest extends AbstractTestCase
             ->method('store_result')
             ->willReturn($mysqliResult);
 
-        $this->assertInstanceOf(mysqli_result::class, $this->object->storeResult($mysqli));
-    }
-
-    /**
-     * Test for numRows
-     */
-    public function testNumRows(): void
-    {
-        $this->assertEquals(0, $this->object->numRows(false));
+        $this->assertInstanceOf(MysqliResult::class, $this->object->storeResult($mysqli));
     }
 
     /**

--- a/test/classes/Dbal/MysqliResultTest.php
+++ b/test/classes/Dbal/MysqliResultTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Dbal;
+
+use mysqli_result;
+use PhpMyAdmin\Dbal\MysqliResult;
+use PhpMyAdmin\Tests\AbstractTestCase;
+
+/**
+ * @covers \PhpMyAdmin\Dbal\DbiMysqli
+ */
+class MysqliResultTest extends AbstractTestCase
+{
+    /**
+     * Test for fetchAssoc
+     */
+    public function testFetchAssoc(): void
+    {
+        $expected = [['foo' => 'bar'], null];
+        $mysqliResult = $this->createMock(mysqli_result::class);
+        $mysqliResult->expects($this->exactly(2))
+            ->method('fetch_assoc')
+            ->willReturnOnConsecutiveCalls(...$expected);
+
+        $result = new MysqliResult($mysqliResult);
+
+        $this->assertSame(['foo' => 'bar'], $result->fetchAssoc());
+        $this->assertSame([], $result->fetchAssoc());
+    }
+
+    /**
+     * Test for fetchRow
+     */
+    public function testFetchRow(): void
+    {
+        $expected = [['bar'], null];
+        $mysqliResult = $this->createMock(mysqli_result::class);
+        $mysqliResult->expects($this->exactly(2))
+            ->method('fetch_row')
+            ->willReturnOnConsecutiveCalls(...$expected);
+
+        $result = new MysqliResult($mysqliResult);
+
+        $this->assertSame(['bar'], $result->fetchRow());
+        $this->assertSame([], $result->fetchRow());
+    }
+
+    /**
+     * Test for dataSeek
+     */
+    public function testDataSeek(): void
+    {
+        $offset = 1;
+        $mysqliResult = $this->createMock(mysqli_result::class);
+        $mysqliResult->expects($this->once())
+            ->method('data_seek')
+            ->with($this->equalTo($offset))
+            ->willReturn(true);
+
+        $result = new MysqliResult($mysqliResult);
+
+        $this->assertTrue($result->seek($offset));
+    }
+}

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -1429,6 +1429,7 @@ class ResultsTest extends AbstractTestCase
             'text_btn' => '0',
             'pview_lnk' => '1',
         ];
+        $this->assertNotFalse($dtResult);
         $actual = $object->getTable($dtResult, $displayParts, $analyzedSqlResults);
 
         $template = new Template();

--- a/test/classes/Navigation/Nodes/NodeTest.php
+++ b/test/classes/Navigation/Nodes/NodeTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Navigation\NodeFactory;
 use PhpMyAdmin\Navigation\Nodes\Node;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use ReflectionMethod;
 
 /**
@@ -388,19 +389,21 @@ class NodeTest extends AbstractTestCase
 
         $node = NodeFactory::getInstance();
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->once())
             ->method('tryQuery')
             ->with("SHOW DATABASES WHERE TRUE AND `Database` LIKE '%db%' ")
-            ->will($this->returnValue(true));
-        $dbi->expects($this->exactly(3))
-            ->method('fetchArray')
+            ->will($this->returnValue($resultStub));
+        $resultStub->expects($this->exactly(3))
+            ->method('fetchRow')
             ->willReturnOnConsecutiveCalls(
                 ['0' => 'db'],
                 ['0' => 'aa_db'],
-                null
+                []
             );
 
         $dbi->expects($this->once())
@@ -484,13 +487,16 @@ class NodeTest extends AbstractTestCase
 
         $node = NodeFactory::getInstance();
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         // test with no search clause
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->once())
             ->method('tryQuery')
-            ->with('SHOW DATABASES WHERE TRUE ');
+            ->with('SHOW DATABASES WHERE TRUE ')
+            ->will($this->returnValue($resultStub));
         $dbi->expects($this->any())->method('escapeString')
             ->will($this->returnArgument(0));
 
@@ -503,7 +509,8 @@ class NodeTest extends AbstractTestCase
             ->getMock();
         $dbi->expects($this->once())
             ->method('tryQuery')
-            ->with("SHOW DATABASES WHERE TRUE AND `Database` LIKE '%dbname%' ");
+            ->with("SHOW DATABASES WHERE TRUE AND `Database` LIKE '%dbname%' ")
+            ->will($this->returnValue($resultStub));
         $dbi->expects($this->any())->method('escapeString')
             ->will($this->returnArgument(0));
 

--- a/test/classes/Plugins/Export/ExportHtmlwordTest.php
+++ b/test/classes/Plugins/Export/ExportHtmlwordTest.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Properties\Options\Items\RadioPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
 use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -381,6 +382,8 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         // case 1
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -409,23 +412,18 @@ class ExportHtmlwordTest extends AbstractTestCase
             ->with('database', '')
             ->will($this->returnValue([$columns]));
 
-        $dbi->expects($this->any())
-            ->method('query')
-            ->will($this->returnValue(true));
+        $dbi->expects($this->once())
+            ->method('tryQuery')
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('numRows')
             ->will($this->returnValue(1));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('fetchAssoc')
-            ->will(
-                $this->returnValue(
-                    [
-                        'comment' => ['fieldname' => 'testComment'],
-                    ]
-                )
-            );
+            ->will($this->returnValue(['comment' => 'testComment']));
+
         $dbi->expects($this->any())->method('escapeString')
             ->will($this->returnArgument(0));
 
@@ -463,6 +461,8 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         // case 2
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -497,23 +497,18 @@ class ExportHtmlwordTest extends AbstractTestCase
             ->with('database', '')
             ->will($this->returnValue([$columns]));
 
-        $dbi->expects($this->any())
-            ->method('query')
-            ->will($this->returnValue(true));
+        $dbi->expects($this->once())
+            ->method('tryQuery')
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('numRows')
             ->will($this->returnValue(1));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('fetchAssoc')
-            ->will(
-                $this->returnValue(
-                    [
-                        'comment' => ['field' => 'testComment'],
-                    ]
-                )
-            );
+            ->will($this->returnValue(['comment' => 'testComment']));
+
         $dbi->expects($this->any())->method('escapeString')
             ->will($this->returnArgument(0));
 
@@ -536,7 +531,7 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         $this->assertStringContainsString('<td class="print"></td><td class="print"></td>', $result);
 
-         // case 3
+        // case 3
 
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
@@ -554,23 +549,9 @@ class ExportHtmlwordTest extends AbstractTestCase
             ->with('database', '')
             ->will($this->returnValue([$columns]));
 
-        $dbi->expects($this->any())
-            ->method('query')
-            ->will($this->returnValue(true));
+        $dbi->expects($this->never())
+            ->method('tryQuery');
 
-        $dbi->expects($this->any())
-            ->method('numRows')
-            ->will($this->returnValue(1));
-
-        $dbi->expects($this->any())
-            ->method('fetchAssoc')
-            ->will(
-                $this->returnValue(
-                    [
-                        'comment' => ['field' => 'testComment'],
-                    ]
-                )
-            );
         $dbi->expects($this->any())->method('escapeString')
             ->will($this->returnArgument(0));
 

--- a/test/classes/Plugins/Export/ExportLatexTest.php
+++ b/test/classes/Plugins/Export/ExportLatexTest.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Properties\Options\Items\RadioPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
 use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use ReflectionMethod;
 
 use function __;
@@ -542,6 +543,8 @@ class ExportLatexTest extends AbstractTestCase
 
         // case 1
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -584,23 +587,17 @@ class ExportLatexTest extends AbstractTestCase
             ->with('database', '')
             ->will($this->returnValue($columns));
 
-        $dbi->expects($this->any())
-            ->method('query')
-            ->will($this->returnValue(true));
+        $dbi->expects($this->once())
+            ->method('tryQuery')
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('numRows')
             ->will($this->returnValue(1));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('fetchAssoc')
-            ->will(
-                $this->returnValue(
-                    [
-                        'comment' => ['name1' => 'testComment'],
-                    ]
-                )
-            );
+            ->will($this->returnValue(['comment' => 'testComment']));
 
         $GLOBALS['dbi'] = $dbi;
         $this->object->relation = new Relation($dbi);
@@ -660,6 +657,8 @@ class ExportLatexTest extends AbstractTestCase
 
         // case 2
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -693,23 +692,17 @@ class ExportLatexTest extends AbstractTestCase
             ->with('database', '')
             ->will($this->returnValue($columns));
 
-        $dbi->expects($this->any())
-            ->method('query')
-            ->will($this->returnValue(true));
+        $dbi->expects($this->once())
+            ->method('tryQuery')
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('numRows')
             ->will($this->returnValue(1));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('fetchAssoc')
-            ->will(
-                $this->returnValue(
-                    [
-                        'comment' => ['field' => 'testComment'],
-                    ]
-                )
-            );
+            ->will($this->returnValue(['comment' => 'testComment']));
 
         $GLOBALS['dbi'] = $dbi;
         $this->object->relation = new Relation($dbi);
@@ -764,23 +757,8 @@ class ExportLatexTest extends AbstractTestCase
             ->with('database', '')
             ->will($this->returnValue($columns));
 
-        $dbi->expects($this->any())
-            ->method('query')
-            ->will($this->returnValue(true));
-
-        $dbi->expects($this->any())
-            ->method('numRows')
-            ->will($this->returnValue(1));
-
-        $dbi->expects($this->any())
-            ->method('fetchAssoc')
-            ->will(
-                $this->returnValue(
-                    [
-                        'comment' => ['field' => 'testComment'],
-                    ]
-                )
-            );
+        $dbi->expects($this->never())
+            ->method('tryQuery');
 
         $GLOBALS['dbi'] = $dbi;
 

--- a/test/classes/Plugins/Export/ExportOdsTest.php
+++ b/test/classes/Plugins/Export/ExportOdsTest.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Properties\Options\Items\HiddenPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
 use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use ReflectionMethod;
 use ReflectionProperty;
 use stdClass;
@@ -232,22 +233,23 @@ class ExportOdsTest extends AbstractTestCase
 
         $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) []);
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
-            ->with(true)
+            ->with($resultStub)
             ->will($this->returnValue($flags));
 
         $dbi->expects($this->once())
             ->method('query')
             ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
-            ->will($this->returnValue(true));
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numFields')
-            ->with(true)
             ->will($this->returnValue(8));
 
-        $dbi->expects($this->exactly(2))
+        $resultStub->expects($this->exactly(2))
             ->method('fetchRow')
             ->willReturnOnConsecutiveCalls(
                 [
@@ -259,7 +261,8 @@ class ExportOdsTest extends AbstractTestCase
                     't>s',
                     'a&b',
                     '<',
-                ]
+                ],
+                []
             );
 
         $GLOBALS['dbi'] = $dbi;
@@ -315,33 +318,25 @@ class ExportOdsTest extends AbstractTestCase
         $b->length = 20;
         $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $b);
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
-            ->with(true)
+            ->with($resultStub)
             ->will($this->returnValue($flags));
 
         $dbi->expects($this->once())
             ->method('query')
             ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
-            ->will($this->returnValue(true));
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numFields')
-            ->with(true)
             ->will($this->returnValue(2));
 
-        $dbi->expects($this->exactly(2))
-            ->method('fieldName')
-            ->willReturnOnConsecutiveCalls('fna\"me', 'fnam/<e2');
-
-        $dbi->expects($this->exactly(1))
+        $resultStub->expects($this->exactly(1))
             ->method('fetchRow')
-            ->with(true)
-            ->will(
-                $this->returnValue(
-                    null
-                )
-            );
+            ->will($this->returnValue([]));
 
         $GLOBALS['dbi'] = $dbi;
         $GLOBALS['mediawiki_caption'] = true;
@@ -376,29 +371,25 @@ class ExportOdsTest extends AbstractTestCase
 
         $flags = [];
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
-            ->with(true)
+            ->with($resultStub)
             ->will($this->returnValue($flags));
 
         $dbi->expects($this->once())
             ->method('query')
             ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
-            ->will($this->returnValue(true));
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numFields')
-            ->with(true)
             ->will($this->returnValue(0));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('fetchRow')
-            ->with(true)
-            ->will(
-                $this->returnValue(
-                    null
-                )
-            );
+            ->will($this->returnValue([]));
 
         $GLOBALS['dbi'] = $dbi;
         $GLOBALS['mediawiki_caption'] = true;

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -16,6 +16,7 @@ use PhpMyAdmin\Properties\Options\Items\RadioPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
 use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use ReflectionMethod;
 use stdClass;
 
@@ -353,22 +354,23 @@ class ExportOdtTest extends AbstractTestCase
 
         $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) []);
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
-            ->with(true)
+            ->with($resultStub)
             ->will($this->returnValue($flags));
 
         $dbi->expects($this->once())
             ->method('query')
             ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
-            ->will($this->returnValue(true));
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numFields')
-            ->with(true)
             ->will($this->returnValue(4));
 
-        $dbi->expects($this->exactly(2))
+        $resultStub->expects($this->exactly(2))
             ->method('fetchRow')
             ->willReturnOnConsecutiveCalls(
                 [
@@ -377,7 +379,7 @@ class ExportOdtTest extends AbstractTestCase
                     'a>b',
                     'a&b',
                 ],
-                null
+                []
             );
 
         $GLOBALS['dbi'] = $dbi;
@@ -427,33 +429,25 @@ class ExportOdtTest extends AbstractTestCase
         $b->length = 20;
         $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $b);
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
-            ->with(true)
+            ->with($resultStub)
             ->will($this->returnValue($flags));
 
         $dbi->expects($this->once())
             ->method('query')
             ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
-            ->will($this->returnValue(true));
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numFields')
-            ->with(true)
             ->will($this->returnValue(2));
 
-        $dbi->expects($this->exactly(2))
-            ->method('fieldName')
-            ->willReturnOnConsecutiveCalls('fna\"me', 'fnam/<e2');
-
-        $dbi->expects($this->exactly(1))
+        $resultStub->expects($this->exactly(1))
             ->method('fetchRow')
-            ->with(true)
-            ->will(
-                $this->returnValue(
-                    null
-                )
-            );
+            ->will($this->returnValue([]));
 
         $GLOBALS['dbi'] = $dbi;
         $GLOBALS['what'] = 'foo';
@@ -488,29 +482,25 @@ class ExportOdtTest extends AbstractTestCase
 
         $flags = [];
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
-            ->with(true)
+            ->with($resultStub)
             ->will($this->returnValue($flags));
 
         $dbi->expects($this->once())
             ->method('query')
             ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
-            ->will($this->returnValue(true));
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numFields')
-            ->with(true)
             ->will($this->returnValue(0));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('fetchRow')
-            ->with(true)
-            ->will(
-                $this->returnValue(
-                    null
-                )
-            );
+            ->will($this->returnValue([]));
 
         $GLOBALS['dbi'] = $dbi;
         $GLOBALS['mediawiki_caption'] = true;
@@ -583,6 +573,8 @@ class ExportOdtTest extends AbstractTestCase
 
         // case 1
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -606,23 +598,17 @@ class ExportOdtTest extends AbstractTestCase
             ->with('database', '')
             ->will($this->returnValue([$columns]));
 
-        $dbi->expects($this->any())
-            ->method('query')
-            ->will($this->returnValue(true));
+        $dbi->expects($this->once())
+            ->method('tryQuery')
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('numRows')
             ->will($this->returnValue(1));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('fetchAssoc')
-            ->will(
-                $this->returnValue(
-                    [
-                        'comment' => ['fieldname' => 'testComment'],
-                    ]
-                )
-            );
+            ->will($this->returnValue(['comment' => 'testComment']));
 
         $GLOBALS['dbi'] = $dbi;
         $this->object->relation = new Relation($dbi);
@@ -679,6 +665,8 @@ class ExportOdtTest extends AbstractTestCase
 
         // case 2
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -708,23 +696,17 @@ class ExportOdtTest extends AbstractTestCase
             ->with('database', '')
             ->will($this->returnValue([$columns]));
 
-        $dbi->expects($this->any())
-            ->method('query')
-            ->will($this->returnValue(true));
+        $dbi->expects($this->once())
+            ->method('tryQuery')
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('numRows')
             ->will($this->returnValue(1));
 
-        $dbi->expects($this->any())
+        $resultStub->expects($this->once())
             ->method('fetchAssoc')
-            ->will(
-                $this->returnValue(
-                    [
-                        'comment' => ['field' => 'testComment'],
-                    ]
-                )
-            );
+            ->will($this->returnValue(['comment' => 'testComment']));
 
         $GLOBALS['dbi'] = $dbi;
         $this->object->relation = new Relation($dbi);

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -20,6 +20,7 @@ use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
 use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Table;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use ReflectionMethod;
 use stdClass;
 
@@ -764,20 +765,21 @@ class ExportSqlTest extends AbstractTestCase
             unset($GLOBALS['no_constraints_comments']);
         }
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $dbi->expects($this->any())
             ->method('query')
-            ->will($this->returnValue('res'));
+            ->will($this->returnValue($resultStub));
 
         $dbi->expects($this->never())
             ->method('fetchSingleRow');
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numRows')
-            ->with('res')
             ->will($this->returnValue(1));
 
         $dbi->expects($this->any())
@@ -791,9 +793,8 @@ class ExportSqlTest extends AbstractTestCase
             'Check_time' => '2000-01-02 13:00:00',
         ];
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('fetchAssoc')
-            ->with('res')
             ->will($this->returnValue($tmpres));
 
         $dbi->expects($this->exactly(3))
@@ -803,7 +804,7 @@ class ExportSqlTest extends AbstractTestCase
                 ['USE `db`'],
                 ['SHOW CREATE TABLE `db`.`table`']
             )
-            ->willReturnOnConsecutiveCalls('res', 'res', 'res');
+            ->willReturnOnConsecutiveCalls($resultStub, $resultStub, $resultStub);
 
         $row = [
             '',
@@ -828,18 +829,10 @@ class ExportSqlTest extends AbstractTestCase
             ") ENGINE=InnoDB AUTO_INCREMENT=16050 DEFAULT CHARSET=utf8\n",
         ];
 
-        $dbi->expects($this->exactly(1))
+        $resultStub->expects($this->exactly(1))
             ->method('fetchRow')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        [
-                            'res',
-                            $row,
-                        ],
-                    ]
-                )
-            );
+            ->will($this->returnValue($row));
+
         $dbi->expects($this->exactly(2))
             ->method('getTable')
             ->will($this->returnValue(new Table('table', 'db', $dbi)));
@@ -896,20 +889,21 @@ class ExportSqlTest extends AbstractTestCase
             unset($GLOBALS['no_constraints_comments']);
         }
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $dbi->expects($this->any())
             ->method('query')
-            ->will($this->returnValue('res'));
+            ->will($this->returnValue($resultStub));
 
         $dbi->expects($this->never())
             ->method('fetchSingleRow');
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numRows')
-            ->with('res')
             ->will($this->returnValue(2));
 
         $dbi->expects($this->any())
@@ -923,9 +917,8 @@ class ExportSqlTest extends AbstractTestCase
             'Check_time' => '2000-01-02 13:00:00',
         ];
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('fetchAssoc')
-            ->with('res')
             ->will($this->returnValue($tmpres));
 
         $dbi->expects($this->exactly(3))
@@ -935,7 +928,7 @@ class ExportSqlTest extends AbstractTestCase
                 ['USE `db`'],
                 ['SHOW CREATE TABLE `db`.`table`']
             )
-            ->willReturnOnConsecutiveCalls('res', 'res', 'res');
+            ->willReturnOnConsecutiveCalls($resultStub, $resultStub, $resultStub);
 
         $dbi->expects($this->once())
             ->method('getError')
@@ -1175,22 +1168,23 @@ class ExportSqlTest extends AbstractTestCase
         $a->charsetnr = 63;
         $flags[] = new FieldMetadata(MYSQLI_TYPE_BLOB, 0, $a);
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
-            ->with('res')
+            ->with($resultStub)
             ->will($this->returnValue($flags));
 
         $dbi->expects($this->once())
             ->method('tryQuery')
             ->with('SELECT a FROM b WHERE 1', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
-            ->will($this->returnValue('res'));
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numFields')
-            ->with('res')
             ->will($this->returnValue(5));
 
-        $dbi->expects($this->exactly(2))
+        $resultStub->expects($this->exactly(2))
             ->method('fetchRow')
             ->willReturnOnConsecutiveCalls(
                 [
@@ -1200,7 +1194,7 @@ class ExportSqlTest extends AbstractTestCase
                     '6',
                     "\x00\x0a\x0d\x1a",
                 ],
-                null
+                []
             );
         $dbi->expects($this->any())->method('escapeString')
             ->will($this->returnArgument(0));
@@ -1280,29 +1274,30 @@ class ExportSqlTest extends AbstractTestCase
         $a->length = 2;
         $flags[] = new FieldMetadata(MYSQLI_TYPE_FLOAT, MYSQLI_UNIQUE_KEY_FLAG, $a);
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
-            ->with('res')
+            ->with($resultStub)
             ->will($this->returnValue($flags));
 
         $dbi->expects($this->once())
             ->method('tryQuery')
             ->with('SELECT a FROM b WHERE 1', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
-            ->will($this->returnValue('res'));
+            ->will($this->returnValue($resultStub));
 
-        $dbi->expects($this->once())
+        $resultStub->expects($this->once())
             ->method('numFields')
-            ->with('res')
             ->will($this->returnValue(2));
 
-        $dbi->expects($this->exactly(2))
+        $resultStub->expects($this->exactly(2))
             ->method('fetchRow')
             ->willReturnOnConsecutiveCalls(
                 [
                     null,
                     null,
                 ],
-                null
+                []
             );
 
         $_table = $this->getMockBuilder(Table::class)

--- a/test/classes/Plugins/Import/ImportLdiTest.php
+++ b/test/classes/Plugins/Import/ImportLdiTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\File;
 use PhpMyAdmin\Plugins\Import\ImportLdi;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PHPUnit\Framework\MockObject\MockObject;
 
 use function __;
@@ -104,16 +105,17 @@ class ImportLdiTest extends AbstractTestCase
          * @var MockObject $dbi
          */
         $dbi = $this->dbi;
+
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->any())->method('tryQuery')
-            ->will($this->returnValue(true));
-        $dbi->expects($this->any())->method('numRows')
+            ->will($this->returnValue($resultStub));
+
+        $resultStub->expects($this->any())->method('numRows')
             ->will($this->returnValue(10));
 
-        $fetchRowResult = ['ON'];
-        $dbi->expects($this->any())->method('fetchRow')
-            ->will($this->returnValue($fetchRowResult));
-
-        $GLOBALS['dbi'] = $dbi;
+        $resultStub->expects($this->any())->method('fetchValue')
+            ->will($this->returnValue('ON'));
 
         $GLOBALS['cfg']['Import']['ldi_local_option'] = 'auto';
         $this->object = new ImportLdi();

--- a/test/classes/Stubs/DummyResult.php
+++ b/test/classes/Stubs/DummyResult.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Extension independent database result
+ */
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Stubs;
+
+use Generator;
+use PhpMyAdmin\Dbal\ResultInterface;
+use PhpMyAdmin\FieldMetadata;
+
+use function array_column;
+use function is_string;
+
+/**
+ * Extension independent database result
+ */
+class DummyResult implements ResultInterface
+{
+    /**
+     * The result identifier produced by the DBiExtension
+     *
+     * @var int|false $result
+     */
+    private $result;
+
+    /**
+     * Link to DbiDummy instance
+     *
+     * @var DbiDummy
+     */
+    private $link;
+
+    /**
+     * @param int|false $result
+     */
+    public function __construct(DbiDummy $link, $result)
+    {
+        $this->link = $link;
+        $this->result = $result;
+    }
+
+    /**
+     * Returns a generator that traverses through the whole result set
+     * and returns each row as an associative array
+     *
+     * @return Generator<int, array<string, string|null>, mixed, void>
+     */
+    public function getIterator(): Generator
+    {
+        if ($this->result === false) {
+            return;
+        }
+
+        $this->seek(0);
+        while ($row = $this->fetchAssoc()) {
+            yield $row;
+        }
+    }
+
+    /**
+     * Returns the next row of the result with associative keys
+     *
+     * @return array<string,string|null>
+     */
+    public function fetchAssoc(): array
+    {
+        if ($this->result === false) {
+            return [];
+        }
+
+        return $this->link->fetchAssoc($this->result) ?? [];
+    }
+
+    /**
+     * Returns the next row of the result with numeric keys
+     *
+     * @return array<int,string|null>
+     */
+    public function fetchRow(): array
+    {
+        if ($this->result === false) {
+            return [];
+        }
+
+        return $this->link->fetchRow($this->result) ?? [];
+    }
+
+    /**
+     * Returns a single value from the given result; false on error
+     *
+     * @param int|string $field
+     *
+     * @return string|false|null
+     */
+    public function fetchValue($field = 0)
+    {
+        if (is_string($field)) {
+            $row = $this->fetchAssoc();
+        } else {
+            $row = $this->fetchRow();
+        }
+
+        return $row[$field] ?? false;
+    }
+
+    /**
+     * Returns all rows of the result
+     *
+     * @return array<int, array<string,string|null>>
+     */
+    public function fetchAllAssoc(): array
+    {
+        if ($this->result === false) {
+            return [];
+        }
+
+        // This function should return all rows, not only the remaining rows
+        $this->seek(0);
+
+        $rows = [];
+        while ($row = $this->fetchAssoc()) {
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Returns values from the first column of each row
+     *
+     * @return array<int, string|null>
+     */
+    public function fetchAllColumn(): array
+    {
+        if ($this->result === false) {
+            return [];
+        }
+
+        // This function should return all rows, not only the remaining rows
+        $this->seek(0);
+
+        $rows = [];
+        while ($row = $this->fetchRow()) {
+            $rows[] = $row[0];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Returns values as single dimensional array where the key is the first column
+     * and the value is the second column, e.g.
+     * SELECT id, name FROM users
+     * produces: ['123' => 'John', '124' => 'Jane']
+     *
+     * @return array<string, string|null>
+     */
+    public function fetchAllKeyPair(): array
+    {
+        if ($this->result === false) {
+            return [];
+        }
+
+        // This function should return all rows, not only the remaining rows
+        $this->seek(0);
+
+        $rows = [];
+        while ($row = $this->fetchRow()) {
+            $rows[$row[0] ?? ''] = $row[1];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Returns the number of fields in the result
+     */
+    public function numFields(): int
+    {
+        if ($this->result === false) {
+            return 0;
+        }
+
+        return $this->link->numFields($this->result);
+    }
+
+    /**
+     * Returns the number of rows in the result
+     *
+     * @return string|int
+     * @psalm-return int|numeric-string
+     */
+    public function numRows()
+    {
+        return $this->link->numRows($this->result);
+    }
+
+    /**
+     * Adjusts the result pointer to an arbitrary row in the result
+     *
+     * @param int $offset offset to seek
+     *
+     * @return bool True if the offset exists, false otherwise
+     */
+    public function seek(int $offset): bool
+    {
+        if ($this->result === false) {
+            return false;
+        }
+
+        return $this->link->dataSeek($this->result, $offset);
+    }
+
+    /**
+     * returns meta info for fields in $result
+     *
+     * @return array<int, FieldMetadata> meta info for fields in $result
+     */
+    public function getFieldsMeta(): array
+    {
+        if ($this->result === false) {
+            return [];
+        }
+
+        return $this->link->getFieldsMeta($this->result);
+    }
+
+    /**
+     * Returns the names of the fields in the result
+     *
+     * @return array<int, string> Fields names
+     */
+    public function getFieldNames(): array
+    {
+        if ($this->result === false) {
+            return [];
+        }
+
+        return array_column($this->link->getFieldsMeta($this->result), 'name');
+    }
+}

--- a/test/classes/SystemDatabaseTest.php
+++ b/test/classes/SystemDatabaseTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\SystemDatabase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 
 /**
  * @covers \PhpMyAdmin\SystemDatabase
@@ -98,8 +99,10 @@ class SystemDatabaseTest extends AbstractTestCase
         ];
         $view_name = 'view_name';
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $ret = $this->sysDb->getNewTransformationDataSql(
-            (object) [],
+            $resultStub,
             $column_map,
             $view_name,
             $db

--- a/test/classes/TableTest.php
+++ b/test/classes/TableTest.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Index;
 use PhpMyAdmin\Query\Cache;
 use PhpMyAdmin\Table;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use stdClass;
 
 /**
@@ -208,6 +209,8 @@ class TableTest extends AbstractTestCase
             ],
         ];
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -241,11 +244,12 @@ class TableTest extends AbstractTestCase
         $dbi->expects($this->any())->method('getTablesFull')
             ->will($this->returnValue($databases));
 
-        $dbi->expects($this->any())->method('numRows')
+        $resultStub->expects($this->any())
+            ->method('numRows')
             ->will($this->returnValue(20));
 
         $dbi->expects($this->any())->method('tryQuery')
-            ->will($this->returnValue(10));
+            ->will($this->returnValue($resultStub));
 
         $triggers = [
             [
@@ -265,11 +269,8 @@ class TableTest extends AbstractTestCase
         $dbi->expects($this->any())->method('getTriggers')
             ->will($this->returnValue($triggers));
 
-        $create_sql = 'CREATE TABLE `PMA`.`PMA_BookMark_2` (
-                    `id` int(11) NOT NULL AUTO_INCREMENT,
-                    `username` text NOT NULL';
         $dbi->expects($this->any())->method('query')
-            ->will($this->returnValue($create_sql));
+            ->will($this->returnValue($resultStub));
 
         $dbi->expects($this->any())->method('insertId')
             ->will($this->returnValue(10));
@@ -1133,14 +1134,16 @@ class TableTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi->expects($this->once())
             ->method('tryQuery')
             ->with('SELECT * FROM `db`.`table` LIMIT 1')
-            ->will($this->returnValue('v1'));
+            ->will($this->returnValue($resultStub));
 
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
-            ->with('v1')
+            ->with($resultStub)
             ->will($this->returnValue(['aNonValidExampleToRefactor']));
 
         $GLOBALS['dbi'] = $dbi;
@@ -1279,13 +1282,16 @@ class TableTest extends AbstractTestCase
     public function testCheckIfMinRecordsExist(): void
     {
         $old_dbi = $GLOBALS['dbi'];
+
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->any())
             ->method('tryQuery')
-            ->will($this->returnValue('res'));
-        $dbi->expects($this->any())
+            ->will($this->returnValue($resultStub));
+        $resultStub->expects($this->any())
             ->method('numRows')
             ->willReturnOnConsecutiveCalls(0, 10, 200);
         $dbi->expects($this->any())

--- a/test/classes/TrackingTest.php
+++ b/test/classes/TrackingTest.php
@@ -143,9 +143,10 @@ class TrackingTest extends AbstractTestCase
     public function testGetTableLastVersionNumber(): void
     {
         $sql_result = $this->tracking->getSqlResultForSelectableTables('PMA_db');
-        $last_version = $this->tracking->getTableLastVersionNumber($sql_result);
+        $this->assertNotFalse($sql_result);
 
-        $this->assertEquals('10', $last_version);
+        $last_version = $this->tracking->getTableLastVersionNumber($sql_result);
+        $this->assertSame(10, $last_version);
     }
 
     /**

--- a/test/classes/Utils/GisTest.php
+++ b/test/classes/Utils/GisTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests\Utils;
 
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Utils\Gis;
 
 use function hex2bin;
@@ -30,6 +31,8 @@ class GisTest extends AbstractTestCase
         bool $SRIDOption,
         int $mysqlVersion
     ): void {
+        $resultStub = $this->createMock(DummyResult::class);
+
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -41,9 +44,9 @@ class GisTest extends AbstractTestCase
         $dbi->expects($SRIDOption ? $this->once() : $this->exactly(2))
             ->method('tryQuery')
             ->with($expectedQuery)
-            ->will($this->returnValue([]));// Omit the real object
+            ->will($this->returnValue($resultStub));// Omit the real object
 
-        $dbi->expects($SRIDOption ? $this->once() : $this->exactly(2))
+        $resultStub->expects($SRIDOption ? $this->once() : $this->exactly(2))
             ->method('fetchRow')
             ->will($this->returnValue($returnData));
 


### PR DESCRIPTION
Primary goal: Abstract `mysqli_result` class by providing a new contract for accessing the query results.

Secondary goals:
- Provide reasonable type hinting for Dbal results
- Remove less useful functions
  - `fetchArray` isn't very useful and most uses can be replaced with either fetchAssoc or fetchRow
  - `freeResult` is not utilized properly. There's usually no need to free the internal mysqli result set. The only possible situation I can think of would be if there's a chance the object is leaked out of scope and the unbuffered queries are used. `mysqli_result::close()` would fetch all remaining rows from MySQL and immediately discard them, thus freeing the connection, but I haven't observed any such use in this project. `unset` can be used in places where it might have had some sense to use that function before. 
  - `fieldName` does exactly what `getFieldsMeta` does but only for a single field. Yet, all uses of it are done in a loop for all fields
  - `fieldLen` is used only once in the whole project and does the same thing as `getFieldsMeta`. For a single usage, a tiny bit of performance can be sacrificed
- Add new helper methods to abstract a little bit of common functionality related to fetching results. This is inspired by PDO
- Make the result set iterable. `mysqli_result` is natively iterable, but due to the way it was used in phpMyAdmin, one could never use `foreach`
- Reduce union types with false and null. e.g. `getFieldsMeta` was usually used with `?? []`, so why doesn't it just always return an array? `fetchAssoc` was usually used in `while` loop where an empty array is coerced into `false` just as `null` is. Many of `DbalInterface` functions took `false` as a possible argument, e.g. `numRows`. The union types made it more difficult to spot problems. Nonetheless, the goal is to cause as little disruption as possible.
- Replace `mixed` with proper types in some places, e.g. `fetchValue` or `query`
- Reveal all places where a deprecation notice might be raised in PHP 8.1. 

The PR grew significantly in size, which is I decided to split it into smaller parts. This is the main change that prepares further changes I have planned. As I have seen the project uses mostly textual API to MySQL and relies on implicit setting `MYSQLI_OPT_INT_AND_FLOAT_NATIVE` to be off. Changing this would be way too disruptive as would be switching over to prepared statements. For this reason, the values are typed as `string|null`. If prepared statements would be used we would have to think about handling `string|int|float|null`. 

Prepared statements are used in one place. I decided to use `MysqliResult` there as well, despite the problem stated above. I don't think this should be an issue though. In the future, the project should consider some ways of dealing with this. 

Mysqli is used with error reporting disabled. I will investigate the possibility of enabling error reporting as it should be relatively simple. A simple try-catch should solve the problem. The native error reporting is usually better. 

The problems faced with this PR:
- `DbiDummy` produces a message "Not supported query" in one place. I wasn't able to fix it, but it doesn't cause a test failure. I have no idea what I messed up there...
- The tests are less than ideal. I think I had the biggest problem getting `InsertEditTest` to work properly. This is testing just way too much of functionality. In general, tests are testing too much, which means that some paths are not covered or are ignored. `assertEquals` is used in many places instead of `assertSame` and `expects($this->any())` is used a lot. This makes it difficult to understand what exactly the test is meant to validate. 
- Tests provide wrong value types in many instances. `query` returned strings or ints instead of real objects. Some tests relied on implicit `null` return values. Some tests expected an int but the function produced a string. etc. 
- PHP has a weird feature that allows you to destructure null values as if they were arrays. https://3v4l.org/DMa69 This meant that achieving one of my secondary goals was challenging. `while([$someValue] = $dbi->fetchRow($result))` worked perfectly fine, but when replaced with `while([$someValue] = $result->fetchRow())` would throw an error. 
- `tryQuery` might produce `false` but the code doesn't check for it in some places. 
- I have absolutely no idea what `TrackerTest` is testing for. I made the test execute again, but I think it should be improved. 
- `Relation::queryAsControlUser` is a method that should belong to `DatabaseInterface` and should be split into two separate methods. Type hinting it for Psalm and PHPStan proved to be impossible. Next PR should solve this issue. 

I understand this PR is not perfect and I would really appreciate how it can be improved. Nonetheless, I think this is an overall improvement to the project. 