### PR TITLE
Major refactoring of Dbal pt.2

### DIFF
--- a/libraries/classes/Bookmark.php
+++ b/libraries/classes/Bookmark.php
@@ -259,8 +259,7 @@ class Bookmark
             $query,
             null,
             null,
-            DatabaseInterface::CONNECT_CONTROL,
-            DatabaseInterface::QUERY_STORE
+            DatabaseInterface::CONNECT_CONTROL
         );
 
         if (! empty($result)) {

--- a/libraries/classes/Controllers/Database/MultiTableQuery/TablesController.php
+++ b/libraries/classes/Controllers/Database/MultiTableQuery/TablesController.php
@@ -41,11 +41,7 @@ final class TablesController extends AbstractController
             QueryGenerator::getInformationSchemaForeignKeyConstraintsRequest(
                 $this->dbi->escapeString($params['db']),
                 $tablesListForQuery
-            ),
-            null,
-            null,
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
+            )
         );
         $this->response->addJSON(['foreignKeyConstrains' => $constrains]);
     }

--- a/libraries/classes/Controllers/Server/BinlogController.php
+++ b/libraries/classes/Controllers/Server/BinlogController.php
@@ -37,10 +37,7 @@ class BinlogController extends AbstractController
 
         $this->binaryLogs = $this->dbi->fetchResult(
             'SHOW MASTER LOGS',
-            'Log_name',
-            null,
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
+            'Log_name'
         );
     }
 

--- a/libraries/classes/Controllers/Table/FindReplaceController.php
+++ b/libraries/classes/Controllers/Table/FindReplaceController.php
@@ -354,7 +354,7 @@ class FindReplaceController extends AbstractController
             // is case sensitive
         }
 
-        $this->dbi->query($sql_query, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
+        $this->dbi->query($sql_query);
         $GLOBALS['sql_query'] = $sql_query;
     }
 }

--- a/libraries/classes/Controllers/Table/RelationController.php
+++ b/libraries/classes/Controllers/Table/RelationController.php
@@ -126,7 +126,7 @@ final class RelationController extends AbstractController
          * Dialog
          */
         // Now find out the columns of our $table
-        // need to use DatabaseInterface::QUERY_STORE with $this->dbi->numRows()
+        // need to use DatabaseInterface::QUERY_BUFFERED with $this->dbi->numRows()
         // in mysqli
         $columns = $this->dbi->getColumns($this->db, $this->table);
 
@@ -322,7 +322,7 @@ final class RelationController extends AbstractController
         if ($foreign) {
             $query = 'SHOW TABLE STATUS FROM '
                 . Util::backquote($_POST['foreignDb']);
-            $tables_rs = $this->dbi->query($query, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
+            $tables_rs = $this->dbi->query($query);
 
             foreach ($tables_rs as $row) {
                 if (! isset($row['Engine']) || mb_strtoupper($row['Engine']) != $storageEngine) {
@@ -334,7 +334,7 @@ final class RelationController extends AbstractController
         } else {
             $query = 'SHOW TABLES FROM '
                 . Util::backquote($_POST['foreignDb']);
-            $tables_rs = $this->dbi->query($query, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
+            $tables_rs = $this->dbi->query($query);
             $tables = $tables_rs->fetchAllColumn();
         }
 

--- a/libraries/classes/Controllers/Table/SearchController.php
+++ b/libraries/classes/Controllers/Table/SearchController.php
@@ -220,11 +220,7 @@ class SearchController extends AbstractController
         $extra_data = [];
         $row_info_query = 'SELECT * FROM ' . Util::backquote($_POST['db']) . '.'
             . Util::backquote($_POST['table']) . ' WHERE ' . $_POST['where_clause'];
-        $result = $this->dbi->query(
-            $row_info_query . ';',
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
-        );
+        $result = $this->dbi->query($row_info_query . ';');
         $fields_meta = $this->dbi->getFieldsMeta($result);
         while ($row = $this->dbi->fetchAssoc($result)) {
             // for bit fields we need to convert them to printable form

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -278,11 +278,7 @@ class ZoomSearchController extends AbstractController
         $extra_data = [];
         $row_info_query = 'SELECT * FROM ' . Util::backquote($_POST['db']) . '.'
             . Util::backquote($_POST['table']) . ' WHERE ' . $_POST['where_clause'];
-        $result = $this->dbi->query(
-            $row_info_query . ';',
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
-        );
+        $result = $this->dbi->query($row_info_query . ';');
         $fields_meta = $this->dbi->getFieldsMeta($result);
         while ($row = $this->dbi->fetchAssoc($result)) {
             // for bit fields we need to convert them to printable form
@@ -343,7 +339,7 @@ class ZoomSearchController extends AbstractController
         $sql_query .= ' LIMIT ' . $_POST['maxPlotLimit'];
 
         //Query execution part
-        $result = $this->dbi->query($sql_query . ';', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
+        $result = $this->dbi->query($sql_query . ';');
         $fields_meta = $this->dbi->getFieldsMeta($result);
         $data = [];
         while ($row = $this->dbi->fetchAssoc($result)) {

--- a/libraries/classes/Controllers/Transformation/WrapperController.php
+++ b/libraries/classes/Controllers/Transformation/WrapperController.php
@@ -107,16 +107,12 @@ class WrapperController extends AbstractController
 
             $result = $this->dbi->query(
                 'SELECT * FROM ' . Util::backquote($table)
-                . ' WHERE ' . $where_clause . ';',
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
+                . ' WHERE ' . $where_clause . ';'
             );
             $row = $result->fetchAssoc();
         } else {
             $result = $this->dbi->query(
-                'SELECT * FROM ' . Util::backquote($table) . ' LIMIT 1;',
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
+                'SELECT * FROM ' . Util::backquote($table) . ' LIMIT 1;'
             );
             $row = $result->fetchAssoc();
         }

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -225,11 +225,7 @@ class Core
     {
         global $dbi;
 
-        $tables = $dbi->tryQuery(
-            'SHOW TABLES FROM ' . Util::backquote($db) . ';',
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
-        );
+        $tables = $dbi->tryQuery('SHOW TABLES FROM ' . Util::backquote($db) . ';');
 
         if ($tables) {
             return $tables->numRows();

--- a/libraries/classes/Database/Designer.php
+++ b/libraries/classes/Database/Designer.php
@@ -104,7 +104,7 @@ class Designer
             . Util::backquote($pdfFeature->pdfPages)
             . " WHERE db_name = '" . $this->dbi->escapeString($db) . "'"
             . ' ORDER BY `page_descr`';
-        $page_rs = $this->relation->queryAsControlUser($page_query, false, DatabaseInterface::QUERY_STORE);
+        $page_rs = $this->relation->queryAsControlUser($page_query, false);
 
         if (! $page_rs) {
             return [];

--- a/libraries/classes/Database/Designer/Common.php
+++ b/libraries/classes/Database/Designer/Common.php
@@ -99,9 +99,7 @@ class Common
                 QueryGenerator::getColumnsSql(
                     $designerTable->getDatabaseName(),
                     $designerTable->getTableName()
-                ),
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
+                )
             );
             $j = 0;
             while ($row = $this->dbi->fetchAssoc($fieldsRs)) {
@@ -133,11 +131,7 @@ class Common
         $con = [];
         $con['C_NAME'] = [];
         $i = 0;
-        $alltab_rs = $this->dbi->query(
-            'SHOW TABLES FROM ' . Util::backquote($GLOBALS['db']),
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
-        );
+        $alltab_rs = $this->dbi->query('SHOW TABLES FROM ' . Util::backquote($GLOBALS['db']));
         while ($val = $alltab_rs->fetchRow()) {
             $val = (string) $val[0];
 
@@ -294,8 +288,7 @@ class Common
             $query,
             'name',
             null,
-            DatabaseInterface::CONNECT_CONTROL,
-            DatabaseInterface::QUERY_STORE
+            DatabaseInterface::CONNECT_CONTROL
         );
     }
 
@@ -321,8 +314,7 @@ class Common
             $query,
             null,
             null,
-            DatabaseInterface::CONNECT_CONTROL,
-            DatabaseInterface::QUERY_STORE
+            DatabaseInterface::CONNECT_CONTROL
         );
 
         return $page_name[0] ?? null;
@@ -343,12 +335,12 @@ class Common
         $query = 'DELETE FROM ' . Util::backquote($pdfFeature->database)
             . '.' . Util::backquote($pdfFeature->tableCoords)
             . ' WHERE ' . Util::backquote('pdf_page_number') . ' = ' . intval($pg);
-        $this->relation->queryAsControlUser($query, true, DatabaseInterface::QUERY_STORE);
+        $this->relation->queryAsControlUser($query);
 
         $query = 'DELETE FROM ' . Util::backquote($pdfFeature->database)
             . '.' . Util::backquote($pdfFeature->pdfPages)
             . ' WHERE ' . Util::backquote('page_nr') . ' = ' . intval($pg);
-        $this->relation->queryAsControlUser($query, true, DatabaseInterface::QUERY_STORE);
+        $this->relation->queryAsControlUser($query);
 
         return true;
     }
@@ -378,8 +370,7 @@ class Common
             $query,
             null,
             null,
-            DatabaseInterface::CONNECT_CONTROL,
-            DatabaseInterface::QUERY_STORE
+            DatabaseInterface::CONNECT_CONTROL
         );
 
         if (isset($default_page_no[0])) {
@@ -410,8 +401,7 @@ class Common
             $query,
             null,
             null,
-            DatabaseInterface::CONNECT_CONTROL,
-            DatabaseInterface::QUERY_STORE
+            DatabaseInterface::CONNECT_CONTROL
         );
 
         return count($pageNos) > 0;
@@ -446,8 +436,7 @@ class Common
             $query,
             null,
             null,
-            DatabaseInterface::CONNECT_CONTROL,
-            DatabaseInterface::QUERY_STORE
+            DatabaseInterface::CONNECT_CONTROL
         );
         $page_no = $min_page_no[0] ?? -1;
 
@@ -491,7 +480,7 @@ class Common
             . '.' . Util::backquote($pdfFeature->tableCoords)
             . " WHERE `pdf_page_number` = '" . $pageId . "'";
 
-        $this->relation->queryAsControlUser($query, true, DatabaseInterface::QUERY_STORE);
+        $this->relation->queryAsControlUser($query);
 
         foreach ($_POST['t_h'] as $key => $value) {
             $DB = $_POST['t_db'][$key];
@@ -511,7 +500,7 @@ class Common
                 . "'" . $this->dbi->escapeString($_POST['t_x'][$key]) . "', "
                 . "'" . $this->dbi->escapeString($_POST['t_y'][$key]) . "')";
 
-            $this->relation->queryAsControlUser($query, true, DatabaseInterface::QUERY_STORE);
+            $this->relation->queryAsControlUser($query);
         }
 
         return true;
@@ -677,7 +666,7 @@ class Common
             . "'" . $this->dbi->escapeString($T1) . "', "
             . "'" . $this->dbi->escapeString($F1) . "')";
 
-        if ($this->relation->queryAsControlUser($q, false, DatabaseInterface::QUERY_STORE)) {
+        if ($this->relation->queryAsControlUser($q, false)) {
             return [
                 true,
                 __('Internal relationship has been added.'),
@@ -750,7 +739,7 @@ class Common
             . " AND foreign_table = '" . $this->dbi->escapeString($T1) . "'"
             . " AND foreign_field = '" . $this->dbi->escapeString($F1) . "'";
 
-        $result = $this->relation->queryAsControlUser($delete_query, false, DatabaseInterface::QUERY_STORE);
+        $result = $this->relation->queryAsControlUser($delete_query, false);
 
         if (! $result) {
             $error = $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);

--- a/libraries/classes/Database/Qbe.php
+++ b/libraries/classes/Database/Qbe.php
@@ -316,11 +316,7 @@ class Qbe
             }
         }
 
-        $allTables = $this->dbi->query(
-            'SHOW TABLES FROM ' . Util::backquote($this->db) . ';',
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
-        );
+        $allTables = $this->dbi->query('SHOW TABLES FROM ' . Util::backquote($this->db) . ';');
         $allTablesCount = $allTables->numRows();
         if ($allTablesCount == 0) {
             echo Message::error(__('No tables found in database.'))->getDisplay();

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -1305,14 +1305,13 @@ class DatabaseInterface implements DbalInterface
      * // $users['admin']['John Doe'] = '123'
      * </code>
      *
-     * @param string                $query   query to execute
-     * @param string|int|array|null $key     field-name or offset
-     *                                       used as key for array
-     *                                       or array of those
-     * @param string|int|null       $value   value-name or offset
-     *                                       used as value for array
-     * @param int                   $link    link type
-     * @param int                   $options query options
+     * @param string                $query query to execute
+     * @param string|int|array|null $key   field-name or offset
+     *                                     used as key for array
+     *                                     or array of those
+     * @param string|int|null       $value value-name or offset
+     *                                     used as value for array
+     * @param int                   $link  link type
      *
      * @return array resultrows or values indexed by $key
      */
@@ -1320,12 +1319,11 @@ class DatabaseInterface implements DbalInterface
         string $query,
         $key = null,
         $value = null,
-        $link = self::CONNECT_USER,
-        int $options = self::QUERY_BUFFERED
+        $link = self::CONNECT_USER
     ): array {
         $resultrows = [];
 
-        $result = $this->tryQuery($query, $link, $options, false);
+        $result = $this->tryQuery($query, $link, self::QUERY_BUFFERED, false);
 
         // return empty array if result is empty or false
         if ($result === false) {

--- a/libraries/classes/DbTableExists.php
+++ b/libraries/classes/DbTableExists.php
@@ -84,11 +84,7 @@ final class DbTableExists
                 return;
             }
 
-            $result = $dbi->tryQuery(
-                'SHOW TABLES LIKE \'' . $dbi->escapeString($table) . '\';',
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
-            );
+            $result = $dbi->tryQuery('SHOW TABLES LIKE \'' . $dbi->escapeString($table) . '\';');
             $is_table = $result && $result->numRows();
         }
 
@@ -105,11 +101,7 @@ final class DbTableExists
              * SHOW TABLES doesn't show temporary tables, so try select
              * (as it can happen just in case temporary table, it should be fast):
              */
-            $result = $dbi->tryQuery(
-                'SELECT COUNT(*) FROM ' . Util::backquote($table) . ';',
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
-            );
+            $result = $dbi->tryQuery('SELECT COUNT(*) FROM ' . Util::backquote($table) . ';');
             $is_table = $result && $result->numRows();
         }
 

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -378,16 +378,15 @@ interface DbalInterface
      * // $users['admin']['John Doe'] = '123'
      * </code>
      *
-     * @param string           $query   query to execute
-     * @param string|int|array $key     field-name or offset
-     *                                  used as key for
-     *                                  array or array of
-     *                                  those
-     * @param string|int       $value   value-name or offset
-     *                                  used as value for
-     *                                  array
-     * @param int              $link    link type
-     * @param int              $options query options
+     * @param string           $query query to execute
+     * @param string|int|array $key   field-name or offset
+     *                                used as key for
+     *                                array or array of
+     *                                those
+     * @param string|int       $value value-name or offset
+     *                                used as value for
+     *                                array
+     * @param int              $link  link type
      *
      * @return array resultrows or values indexed by $key
      */
@@ -395,8 +394,7 @@ interface DbalInterface
         string $query,
         $key = null,
         $value = null,
-        $link = DatabaseInterface::CONNECT_USER,
-        int $options = 0
+        $link = DatabaseInterface::CONNECT_USER
     ): array;
 
     /**

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -171,11 +171,7 @@ class InsertEdit
                 . Util::backquote($db) . '.'
                 . Util::backquote($table)
                 . ' WHERE ' . $whereClause . ';';
-            $result[$keyId] = $this->dbi->query(
-                $localQuery,
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
-            );
+            $result[$keyId] = $this->dbi->query($localQuery);
             $rows[$keyId] = $this->dbi->fetchAssoc($result[$keyId]);
 
             $whereClauses[$keyId] = str_replace('\\', '\\\\', $whereClause);
@@ -258,9 +254,7 @@ class InsertEdit
     {
         $result = $this->dbi->query(
             'SELECT * FROM ' . Util::backquote($db)
-            . '.' . Util::backquote($table) . ' LIMIT 1;',
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
+            . '.' . Util::backquote($table) . ' LIMIT 1;'
         );
         // Can be a string on some old configuration storage settings
         $rows = array_fill(0, (int) $GLOBALS['cfg']['InsertRows'], false);
@@ -1424,11 +1418,7 @@ class InsertEdit
                 . '.' . Util::backquote($foreigner['foreign_table'])
                 . ' WHERE ' . Util::backquote($foreigner['foreign_field'])
                 . $whereComparison;
-            $dispresult = $this->dbi->tryQuery(
-                $dispsql,
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
-            );
+            $dispresult = $this->dbi->tryQuery($dispsql);
             if ($dispresult && $dispresult->numRows() > 0) {
                 return (string) $dispresult->fetchValue();
             }

--- a/libraries/classes/Menu.php
+++ b/libraries/classes/Menu.php
@@ -468,10 +468,7 @@ class Menu
         } else {
             $binaryLogs = $this->dbi->fetchResult(
                 'SHOW MASTER LOGS',
-                'Log_name',
-                null,
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
+                'Log_name'
             );
             SessionCache::set('binary_logs', $binaryLogs);
         }

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -1431,9 +1431,7 @@ class ExportSql extends ExportPlugin
 
         $result = $dbi->tryQuery(
             'SHOW TABLE STATUS FROM ' . Util::backquote($db)
-            . ' WHERE Name = \'' . $dbi->escapeString((string) $table) . '\'',
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
+            . ' WHERE Name = \'' . $dbi->escapeString((string) $table) . '\''
         );
         if ($result != false) {
             if ($result->numRows() > 0) {

--- a/libraries/classes/Plugins/Schema/TableStats.php
+++ b/libraries/classes/Plugins/Schema/TableStats.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Schema;
 
 use PhpMyAdmin\ConfigStorage\Relation;
-use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Font;
 use PhpMyAdmin\Index;
 use PhpMyAdmin\Util;
@@ -131,7 +130,7 @@ abstract class TableStats
         global $dbi;
 
         $sql = 'DESCRIBE ' . Util::backquote($this->tableName);
-        $result = $dbi->tryQuery($sql, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
+        $result = $dbi->tryQuery($sql);
         if (! $result || ! $result->numRows()) {
             $this->showMissingTableError();
         }
@@ -196,11 +195,7 @@ abstract class TableStats
     {
         global $dbi;
 
-        $result = $dbi->query(
-            'SHOW INDEX FROM ' . Util::backquote($this->tableName) . ';',
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
-        );
+        $result = $dbi->query('SHOW INDEX FROM ' . Util::backquote($this->tableName) . ';');
         if ($result->numRows() <= 0) {
             return;
         }

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -1952,11 +1952,7 @@ class Privileges
             $data['databases'] = $databases;
             $data['escaped_databases'] = $escapedDatabases;
         } elseif ($type === 'table') {
-            $result = $this->dbi->tryQuery(
-                'SHOW TABLES FROM ' . Util::backquote($dbname),
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
-            );
+            $result = $this->dbi->tryQuery('SHOW TABLES FROM ' . Util::backquote($dbname));
 
             $tables = [];
             if ($result) {
@@ -2087,9 +2083,7 @@ class Privileges
         }
 
         $initials = $this->dbi->tryQuery(
-            'SELECT DISTINCT UPPER(LEFT(`User`,1)) FROM `user` ORDER BY UPPER(LEFT(`User`,1)) ASC',
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
+            'SELECT DISTINCT UPPER(LEFT(`User`,1)) FROM `user` ORDER BY UPPER(LEFT(`User`,1)) ASC'
         );
         if ($initials) {
             while ($tmpInitial = $this->dbi->fetchRow($initials)) {
@@ -2951,8 +2945,8 @@ class Privileges
         $sqlQuery .= ' ORDER BY `User` ASC, `Host` ASC;';
         $sqlQueryAll .= ' ;';
 
-        $res = $this->dbi->tryQuery($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
-        $resAll = $this->dbi->tryQuery($sqlQueryAll, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
+        $res = $this->dbi->tryQuery($sqlQuery);
+        $resAll = $this->dbi->tryQuery($sqlQueryAll);
 
         $errorMessages = '';
         if (! $res) {
@@ -2963,7 +2957,7 @@ class Privileges
 
             unset($resAll);
             $sqlQuery = 'SELECT * FROM `mysql`.`user`';
-            $res = $this->dbi->tryQuery($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
+            $res = $this->dbi->tryQuery($sqlQuery);
 
             if (! $res) {
                 $errorMessages .= $this->getHtmlForViewUsersError();
@@ -3211,9 +3205,7 @@ class Privileges
     ) {
         $res = $this->dbi->query(
             'SELECT `Db`, `Table_name`, `Table_priv` FROM `mysql`.`tables_priv`'
-            . $userHostCondition,
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
+            . $userHostCondition
         );
         while ($row = $this->dbi->fetchAssoc($res)) {
             $res2 = $this->dbi->query(
@@ -3227,9 +3219,7 @@ class Privileges
                 . ' = \'' . $this->dbi->escapeString($row['Db']) . "'"
                 . ' AND `Table_name`'
                 . ' = \'' . $this->dbi->escapeString($row['Table_name']) . "'"
-                . ';',
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
+                . ';'
             );
 
             $tmpPrivs1 = $this->extractPrivInfo($row);

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -331,13 +331,7 @@ class Sql
     {
         $fieldInfoQuery = QueryGenerator::getColumnsSql($db, $table, $this->dbi->escapeString($column));
 
-        $fieldInfoResult = $this->dbi->fetchResult(
-            $fieldInfoQuery,
-            null,
-            null,
-            DatabaseInterface::CONNECT_USER,
-            DatabaseInterface::QUERY_STORE
-        );
+        $fieldInfoResult = $this->dbi->fetchResult($fieldInfoQuery);
 
         if (! isset($fieldInfoResult[0])) {
             return null;
@@ -625,7 +619,7 @@ class Sql
         // Measure query time.
         $queryTimeBefore = array_sum(explode(' ', microtime()));
 
-        $result = @$this->dbi->tryQuery($fullSqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_STORE);
+        $result = $this->dbi->tryQuery($fullSqlQuery);
         $queryTimeAfter = array_sum(explode(' ', microtime()));
 
         if (! defined('TESTSUITE')) {

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -796,9 +796,7 @@ class Table implements Stringable
                 $result = $this->dbi->tryQuery(
                     'SELECT 1 FROM ' . Util::backquote($db) . '.'
                     . Util::backquote($table) . ' LIMIT '
-                    . $GLOBALS['cfg']['MaxExactCountViews'],
-                    DatabaseInterface::CONNECT_USER,
-                    DatabaseInterface::QUERY_STORE
+                    . $GLOBALS['cfg']['MaxExactCountViews']
                 );
                 if ($result) {
                     $rowCount = $result->numRows();
@@ -932,9 +930,9 @@ class Table implements Stringable
               . Util::backquote((string) $relationParams[$table]) . '
              WHERE ' . implode(' AND ', $whereParts);
 
-        // must use DatabaseInterface::QUERY_STORE here, since we execute
+        // must use DatabaseInterface::QUERY_BUFFERED here, since we execute
         // another query inside the loop
-        $tableCopyRs = $relation->queryAsControlUser($tableCopyQuery, true, DatabaseInterface::QUERY_STORE);
+        $tableCopyRs = $relation->queryAsControlUser($tableCopyQuery);
 
         foreach ($tableCopyRs as $tableCopyRow) {
             $valueParts = [];

--- a/libraries/classes/Transformations.php
+++ b/libraries/classes/Transformations.php
@@ -390,7 +390,7 @@ class Transformations
                 AND `table_name`  = \'' . $dbi->escapeString($table) . '\'
                 AND `column_name` = \'' . $dbi->escapeString($key) . '\'';
 
-        $test_rs = $relation->queryAsControlUser($test_qry, true, DatabaseInterface::QUERY_STORE);
+        $test_rs = $relation->queryAsControlUser($test_qry);
 
         if ($test_rs->numRows() > 0) {
             $row = $test_rs->fetchAssoc();

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2366,11 +2366,7 @@ class Util
                 }
             }
 
-            $dbInfoResult = $dbi->query(
-                'SHOW FULL TABLES FROM ' . self::backquote($db) . $tblGroupSql,
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
-            );
+            $dbInfoResult = $dbi->query('SHOW FULL TABLES FROM ' . self::backquote($db) . $tblGroupSql);
             unset($tblGroupSql, $whereAdded);
 
             if ($dbInfoResult->numRows() > 0) {

--- a/test/classes/Controllers/Server/VariablesControllerTest.php
+++ b/test/classes/Controllers/Server/VariablesControllerTest.php
@@ -64,7 +64,6 @@ class VariablesControllerTest extends AbstractTestCase
                 0,
                 1,
                 DatabaseInterface::CONNECT_USER,
-                0,
                 $serverSessionVariables,
             ],
             [
@@ -72,7 +71,6 @@ class VariablesControllerTest extends AbstractTestCase
                 0,
                 1,
                 DatabaseInterface::CONNECT_USER,
-                0,
                 $serverGlobalVariables,
             ],
         ];

--- a/test/classes/Database/Designer/CommonTest.php
+++ b/test/classes/Database/Designer/CommonTest.php
@@ -69,8 +69,7 @@ class CommonTest extends AbstractTestCase
             WHERE pdf_page_number = " . $pg,
                 'name',
                 null,
-                DatabaseInterface::CONNECT_CONTROL,
-                DatabaseInterface::QUERY_STORE
+                DatabaseInterface::CONNECT_CONTROL
             );
         $GLOBALS['dbi'] = $dbi;
 
@@ -100,8 +99,7 @@ class CommonTest extends AbstractTestCase
                 . ' WHERE `page_nr` = ' . $pg,
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL,
-                DatabaseInterface::QUERY_STORE
+                DatabaseInterface::CONNECT_CONTROL
             )
             ->will($this->returnValue([$pageName]));
         $GLOBALS['dbi'] = $dbi;
@@ -160,8 +158,7 @@ class CommonTest extends AbstractTestCase
                 . " AND `page_descr` = '" . $db . "'",
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL,
-                DatabaseInterface::QUERY_STORE
+                DatabaseInterface::CONNECT_CONTROL
             )
             ->will($this->returnValue([$default_pg]));
         $dbi->expects($this->any())->method('escapeString')
@@ -193,8 +190,7 @@ class CommonTest extends AbstractTestCase
                 . " AND `page_descr` = '" . $db . "'",
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL,
-                DatabaseInterface::QUERY_STORE
+                DatabaseInterface::CONNECT_CONTROL
             )
             ->will($this->returnValue([]));
         $dbi->expects($this->any())->method('escapeString')
@@ -227,8 +223,7 @@ class CommonTest extends AbstractTestCase
                 . " AND `page_descr` = '" . $db . "'",
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL,
-                DatabaseInterface::QUERY_STORE
+                DatabaseInterface::CONNECT_CONTROL
             )
             ->will($this->returnValue([$default_pg]));
         $dbi->expects($this->any())->method('escapeString')

--- a/test/classes/Database/DesignerTest.php
+++ b/test/classes/Database/DesignerTest.php
@@ -71,7 +71,6 @@ class DesignerTest extends AbstractTestCase
                 'SELECT `page_nr`, `page_descr` FROM `pmadb`.`pdf_pages`'
                 . " WHERE db_name = '" . $db . "' ORDER BY `page_descr`",
                 DatabaseInterface::CONNECT_CONTROL,
-                DatabaseInterface::QUERY_STORE,
                 false
             )
             ->will($this->returnValue($resultStub));

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -355,9 +355,7 @@ class InsertEditTest extends AbstractTestCase
         $dbi->expects($this->once())
             ->method('query')
             ->with(
-                'SELECT * FROM `db`.`table` LIMIT 1;',
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
+                'SELECT * FROM `db`.`table` LIMIT 1;'
             )
             ->will($this->returnValue($resultStub));
 
@@ -1821,9 +1819,7 @@ class InsertEditTest extends AbstractTestCase
         $dbi->expects($this->once())
             ->method('tryQuery')
             ->with(
-                'SELECT `TABLE_COMMENT` FROM `information_schema`.`TABLES` WHERE `f`=1',
-                DatabaseInterface::CONNECT_USER,
-                DatabaseInterface::QUERY_STORE
+                'SELECT `TABLE_COMMENT` FROM `information_schema`.`TABLES` WHERE `f`=1'
             )
             ->will($this->returnValue($resultStub));
 

--- a/test/classes/TableTest.php
+++ b/test/classes/TableTest.php
@@ -89,7 +89,6 @@ class TableTest extends AbstractTestCase
                 null,
                 null,
                 DatabaseInterface::CONNECT_USER,
-                0,
                 ['PMA_BookMark'],
             ],
             [
@@ -97,7 +96,6 @@ class TableTest extends AbstractTestCase
                 null,
                 null,
                 DatabaseInterface::CONNECT_USER,
-                0,
                 [],
             ],
             [
@@ -105,7 +103,6 @@ class TableTest extends AbstractTestCase
                 null,
                 null,
                 DatabaseInterface::CONNECT_USER,
-                0,
                 [],
             ],
             [
@@ -113,7 +110,6 @@ class TableTest extends AbstractTestCase
                 null,
                 null,
                 DatabaseInterface::CONNECT_USER,
-                0,
                 ['PMA_BookMark'],
             ],
             [
@@ -121,7 +117,6 @@ class TableTest extends AbstractTestCase
                 null,
                 null,
                 DatabaseInterface::CONNECT_USER,
-                0,
                 [],
             ],
             [
@@ -129,7 +124,6 @@ class TableTest extends AbstractTestCase
                 null,
                 null,
                 DatabaseInterface::CONNECT_USER,
-                0,
                 [
                     [
                         'COLUMN_NAME' => 'COLUMN_NAME',
@@ -145,7 +139,6 @@ class TableTest extends AbstractTestCase
                 ],
                 'Column_name',
                 DatabaseInterface::CONNECT_USER,
-                0,
                 [
                     ['index1'],
                     ['index3'],
@@ -157,7 +150,6 @@ class TableTest extends AbstractTestCase
                 'Column_name',
                 'Column_name',
                 DatabaseInterface::CONNECT_USER,
-                0,
                 [
                     'column1',
                     'column3',
@@ -172,7 +164,6 @@ class TableTest extends AbstractTestCase
                 'Field',
                 'Field',
                 DatabaseInterface::CONNECT_USER,
-                0,
                 [
                     'column1',
                     'column3',
@@ -187,7 +178,6 @@ class TableTest extends AbstractTestCase
                 null,
                 null,
                 DatabaseInterface::CONNECT_USER,
-                0,
                 [
                     [
                         'Field' => 'COLUMN_NAME1',


### PR DESCRIPTION
This PR deals with the constant `QUERY_STORE`. The main check was already removed in c9bcda3212b85b197b9a0295995d1e91e30fc81c. I have decided to keep a constant, but rename it and use `0` as its value to match the value used as default in the `$options` parameter. I removed the parameter from all the places where it matched the default. 

The line length warning from linter can be ignored as this is just temporary anyway. Part 3 will fix it. 