### PR TITLE
Query as control user

### DIFF
--- a/libraries/classes/ConfigStorage/RelationCleanup.php
+++ b/libraries/classes/ConfigStorage/RelationCleanup.php
@@ -48,7 +48,7 @@ class RelationCleanup
                 . '\''
                 . ' AND column_name = \'' . $this->dbi->escapeString($column)
                 . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->displayFeature !== null) {
@@ -60,7 +60,7 @@ class RelationCleanup
                 . '\''
                 . ' AND display_field = \'' . $this->dbi->escapeString($column)
                 . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->relationFeature === null) {
@@ -76,7 +76,7 @@ class RelationCleanup
             . '\''
             . ' AND master_field = \'' . $this->dbi->escapeString($column)
             . '\'';
-        $this->relation->queryAsControlUser($remove_query);
+        $this->dbi->queryAsControlUser($remove_query);
 
         $remove_query = 'DELETE FROM '
             . Util::backquote($relationParameters->relationFeature->database)
@@ -87,7 +87,7 @@ class RelationCleanup
             . '\''
             . ' AND foreign_field = \'' . $this->dbi->escapeString($column)
             . '\'';
-        $this->relation->queryAsControlUser($remove_query);
+        $this->dbi->queryAsControlUser($remove_query);
     }
 
     /**
@@ -107,7 +107,7 @@ class RelationCleanup
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\''
                 . ' AND table_name = \'' . $this->dbi->escapeString($table)
                 . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->displayFeature !== null) {
@@ -117,7 +117,7 @@ class RelationCleanup
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\''
                 . ' AND table_name = \'' . $this->dbi->escapeString($table)
                 . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->pdfFeature !== null) {
@@ -127,7 +127,7 @@ class RelationCleanup
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\''
                 . ' AND table_name = \'' . $this->dbi->escapeString($table)
                 . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->relationFeature !== null) {
@@ -138,7 +138,7 @@ class RelationCleanup
                 . '\''
                 . ' AND master_table = \'' . $this->dbi->escapeString($table)
                 . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
 
             $remove_query = 'DELETE FROM '
                 . Util::backquote($relationParameters->relationFeature->database)
@@ -147,7 +147,7 @@ class RelationCleanup
                 . '\''
                 . ' AND foreign_table = \'' . $this->dbi->escapeString($table)
                 . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->uiPreferencesFeature !== null) {
@@ -157,7 +157,7 @@ class RelationCleanup
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\''
                 . ' AND table_name = \'' . $this->dbi->escapeString($table)
                 . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->navigationItemsHidingFeature === null) {
@@ -173,7 +173,7 @@ class RelationCleanup
             . ' OR (item_name = \'' . $this->dbi->escapeString($table)
             . '\''
             . ' AND item_type = \'table\'))';
-        $this->relation->queryAsControlUser($remove_query);
+        $this->dbi->queryAsControlUser($remove_query);
     }
 
     /**
@@ -193,7 +193,7 @@ class RelationCleanup
                 . Util::backquote($relationParameters->columnCommentsFeature->database)
                 . '.' . Util::backquote($relationParameters->columnCommentsFeature->columnInfo)
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->bookmarkFeature !== null) {
@@ -201,7 +201,7 @@ class RelationCleanup
                 . Util::backquote($relationParameters->bookmarkFeature->database)
                 . '.' . Util::backquote($relationParameters->bookmarkFeature->bookmark)
                 . ' WHERE dbase  = \'' . $this->dbi->escapeString($db) . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->displayFeature !== null) {
@@ -209,7 +209,7 @@ class RelationCleanup
                 . Util::backquote($relationParameters->displayFeature->database)
                 . '.' . Util::backquote($relationParameters->displayFeature->tableInfo)
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->pdfFeature !== null) {
@@ -217,13 +217,13 @@ class RelationCleanup
                 . Util::backquote($relationParameters->pdfFeature->database)
                 . '.' . Util::backquote($relationParameters->pdfFeature->pdfPages)
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
 
             $remove_query = 'DELETE FROM '
                 . Util::backquote($relationParameters->pdfFeature->database)
                 . '.' . Util::backquote($relationParameters->pdfFeature->tableCoords)
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->relationFeature !== null) {
@@ -232,14 +232,14 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->relationFeature->relation)
                 . ' WHERE master_db  = \''
                 . $this->dbi->escapeString($db) . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
 
             $remove_query = 'DELETE FROM '
                 . Util::backquote($relationParameters->relationFeature->database)
                 . '.' . Util::backquote($relationParameters->relationFeature->relation)
                 . ' WHERE foreign_db  = \'' . $this->dbi->escapeString($db)
                 . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->uiPreferencesFeature !== null) {
@@ -247,7 +247,7 @@ class RelationCleanup
                 . Util::backquote($relationParameters->uiPreferencesFeature->database)
                 . '.' . Util::backquote($relationParameters->uiPreferencesFeature->tableUiPrefs)
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->navigationItemsHidingFeature !== null) {
@@ -255,7 +255,7 @@ class RelationCleanup
                 . Util::backquote($relationParameters->navigationItemsHidingFeature->database)
                 . '.' . Util::backquote($relationParameters->navigationItemsHidingFeature->navigationHiding)
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->savedQueryByExampleSearchesFeature !== null) {
@@ -263,7 +263,7 @@ class RelationCleanup
                 . Util::backquote($relationParameters->savedQueryByExampleSearchesFeature->database)
                 . '.' . Util::backquote($relationParameters->savedQueryByExampleSearchesFeature->savedSearches)
                 . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\'';
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->centralColumnsFeature === null) {
@@ -274,7 +274,7 @@ class RelationCleanup
             . Util::backquote($relationParameters->centralColumnsFeature->database)
             . '.' . Util::backquote($relationParameters->centralColumnsFeature->centralColumns)
             . ' WHERE db_name  = \'' . $this->dbi->escapeString($db) . '\'';
-        $this->relation->queryAsControlUser($remove_query);
+        $this->dbi->queryAsControlUser($remove_query);
     }
 
     /**
@@ -295,7 +295,7 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->bookmarkFeature->bookmark)
                 . " WHERE `user`  = '" . $this->dbi->escapeString($username)
                 . "'";
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->sqlHistoryFeature !== null) {
@@ -304,7 +304,7 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->sqlHistoryFeature->history)
                 . " WHERE `username`  = '" . $this->dbi->escapeString($username)
                 . "'";
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->recentlyUsedTablesFeature !== null) {
@@ -313,7 +313,7 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->recentlyUsedTablesFeature->recent)
                 . " WHERE `username`  = '" . $this->dbi->escapeString($username)
                 . "'";
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->favoriteTablesFeature !== null) {
@@ -322,7 +322,7 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->favoriteTablesFeature->favorite)
                 . " WHERE `username`  = '" . $this->dbi->escapeString($username)
                 . "'";
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->uiPreferencesFeature !== null) {
@@ -331,7 +331,7 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->uiPreferencesFeature->tableUiPrefs)
                 . " WHERE `username`  = '" . $this->dbi->escapeString($username)
                 . "'";
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->userPreferencesFeature !== null) {
@@ -340,7 +340,7 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->userPreferencesFeature->userConfig)
                 . " WHERE `username`  = '" . $this->dbi->escapeString($username)
                 . "'";
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->configurableMenusFeature !== null) {
@@ -349,7 +349,7 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->configurableMenusFeature->users)
                 . " WHERE `username`  = '" . $this->dbi->escapeString($username)
                 . "'";
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->navigationItemsHidingFeature !== null) {
@@ -358,7 +358,7 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->navigationItemsHidingFeature->navigationHiding)
                 . " WHERE `username`  = '" . $this->dbi->escapeString($username)
                 . "'";
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->savedQueryByExampleSearchesFeature !== null) {
@@ -367,7 +367,7 @@ class RelationCleanup
                 . '.' . Util::backquote($relationParameters->savedQueryByExampleSearchesFeature->savedSearches)
                 . " WHERE `username`  = '" . $this->dbi->escapeString($username)
                 . "'";
-            $this->relation->queryAsControlUser($remove_query);
+            $this->dbi->queryAsControlUser($remove_query);
         }
 
         if ($relationParameters->databaseDesignerSettingsFeature === null) {
@@ -379,6 +379,6 @@ class RelationCleanup
             . '.' . Util::backquote($relationParameters->databaseDesignerSettingsFeature->designerSettings)
             . " WHERE `username`  = '" . $this->dbi->escapeString($username)
             . "'";
-        $this->relation->queryAsControlUser($remove_query);
+        $this->dbi->queryAsControlUser($remove_query);
     }
 }

--- a/libraries/classes/ConfigStorage/UserGroups.php
+++ b/libraries/classes/ConfigStorage/UserGroups.php
@@ -41,7 +41,6 @@ class UserGroups
 
         $users = [];
         $numRows = 0;
-        $relation = new Relation($dbi);
 
         $userGroupSpecialChars = htmlspecialchars($userGroup);
         $usersTable = Util::backquote($configurableMenusFeature->database)
@@ -49,7 +48,7 @@ class UserGroups
         $sql_query = 'SELECT `username` FROM ' . $usersTable
             . " WHERE `usergroup`='" . $dbi->escapeString($userGroup)
             . "'";
-        $result = $relation->queryAsControlUser($sql_query, false);
+        $result = $dbi->tryQueryAsControlUser($sql_query);
         if ($result) {
             $i = 0;
             while ($row = $result->fetchRow()) {
@@ -78,11 +77,10 @@ class UserGroups
     {
         global $dbi;
 
-        $relation = new Relation($dbi);
         $groupTable = Util::backquote($configurableMenusFeature->database)
             . '.' . Util::backquote($configurableMenusFeature->userGroups);
         $sql_query = 'SELECT * FROM ' . $groupTable . ' ORDER BY `usergroup` ASC';
-        $result = $relation->queryAsControlUser($sql_query, false);
+        $result = $dbi->tryQueryAsControlUser($sql_query);
         $userGroups = [];
         $userGroupsValues = [];
         $action = Url::getFromRoute('/server/privileges');
@@ -173,7 +171,6 @@ class UserGroups
     {
         global $dbi;
 
-        $relation = new Relation($dbi);
         $userTable = Util::backquote($configurableMenusFeature->database)
             . '.' . Util::backquote($configurableMenusFeature->users);
         $groupTable = Util::backquote($configurableMenusFeature->database)
@@ -181,11 +178,11 @@ class UserGroups
         $sql_query = 'DELETE FROM ' . $userTable
             . " WHERE `usergroup`='" . $dbi->escapeString($userGroup)
             . "'";
-        $relation->queryAsControlUser($sql_query, true);
+        $dbi->queryAsControlUser($sql_query);
         $sql_query = 'DELETE FROM ' . $groupTable
             . " WHERE `usergroup`='" . $dbi->escapeString($userGroup)
             . "'";
-        $relation->queryAsControlUser($sql_query, true);
+        $dbi->queryAsControlUser($sql_query);
     }
 
     /**
@@ -201,7 +198,6 @@ class UserGroups
     ): string {
         global $dbi;
 
-        $relation = new Relation($dbi);
         $urlParams = [];
 
         $editUserGroupSpecialChars = '';
@@ -227,7 +223,7 @@ class UserGroups
             $sql_query = 'SELECT * FROM ' . $groupTable
                 . " WHERE `usergroup`='" . $dbi->escapeString($userGroup)
                 . "'";
-            $result = $relation->queryAsControlUser($sql_query, false);
+            $result = $dbi->tryQueryAsControlUser($sql_query);
             if ($result) {
                 foreach ($result as $row) {
                     $key = $row['tab'];
@@ -316,7 +312,6 @@ class UserGroups
     ): void {
         global $dbi;
 
-        $relation = new Relation($dbi);
         $tabs = Util::getMenuTabList();
         $groupTable = Util::backquote($configurableMenusFeature->database)
             . '.' . Util::backquote($configurableMenusFeature->userGroups);
@@ -325,7 +320,7 @@ class UserGroups
             $sql_query = 'DELETE FROM ' . $groupTable
                 . " WHERE `usergroup`='" . $dbi->escapeString($userGroup)
                 . "';";
-            $relation->queryAsControlUser($sql_query, true);
+            $dbi->queryAsControlUser($sql_query);
         }
 
         $sql_query = 'INSERT INTO ' . $groupTable
@@ -348,6 +343,6 @@ class UserGroups
         }
 
         $sql_query .= ';';
-        $relation->queryAsControlUser($sql_query, true);
+        $dbi->queryAsControlUser($sql_query);
     }
 }

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -53,7 +53,7 @@ class QueryByExampleController extends AbstractController
         $this->addScriptFiles(['database/qbe.js']);
         if ($savedQbeSearchesFeature !== null) {
             //Get saved search list.
-            $savedSearch = new SavedSearches($this->relation);
+            $savedSearch = new SavedSearches();
             $savedSearch->setUsername($GLOBALS['cfg']['Server']['user'])
                 ->setDbname($db);
 
@@ -74,14 +74,14 @@ class QueryByExampleController extends AbstractController
                 } elseif ($_POST['action'] === 'delete') {
                     $savedSearch->delete($savedQbeSearchesFeature);
                     //After deletion, reset search.
-                    $savedSearch = new SavedSearches($this->relation);
+                    $savedSearch = new SavedSearches();
                     $savedSearch->setUsername($GLOBALS['cfg']['Server']['user'])
                         ->setDbname($db);
                     $_POST = [];
                 } elseif ($_POST['action'] === 'load') {
                     if (empty($_POST['searchId'])) {
                         //when not loading a search, reset the object.
-                        $savedSearch = new SavedSearches($this->relation);
+                        $savedSearch = new SavedSearches();
                         $savedSearch->setUsername($GLOBALS['cfg']['Server']['user'])
                             ->setDbname($db);
                         $_POST = [];

--- a/libraries/classes/Controllers/Server/UserGroupsFormController.php
+++ b/libraries/classes/Controllers/Server/UserGroupsFormController.php
@@ -88,7 +88,7 @@ final class UserGroupsFormController extends AbstractController
 
         $allUserGroups = [];
         $sqlQuery = 'SELECT DISTINCT `usergroup` FROM ' . $groupTable;
-        $result = $this->relation->queryAsControlUser($sqlQuery, false);
+        $result = $this->dbi->tryQueryAsControlUser($sqlQuery);
         if ($result) {
             while ($row = $result->fetchRow()) {
                 $allUserGroups[$row[0]] = $row[0];

--- a/libraries/classes/Database/Designer.php
+++ b/libraries/classes/Database/Designer.php
@@ -104,7 +104,7 @@ class Designer
             . Util::backquote($pdfFeature->pdfPages)
             . " WHERE db_name = '" . $this->dbi->escapeString($db) . "'"
             . ' ORDER BY `page_descr`';
-        $page_rs = $this->relation->queryAsControlUser($page_query, false);
+        $page_rs = $this->dbi->tryQueryAsControlUser($page_query);
 
         if (! $page_rs) {
             return [];

--- a/libraries/classes/Database/Designer/Common.php
+++ b/libraries/classes/Database/Designer/Common.php
@@ -335,12 +335,12 @@ class Common
         $query = 'DELETE FROM ' . Util::backquote($pdfFeature->database)
             . '.' . Util::backquote($pdfFeature->tableCoords)
             . ' WHERE ' . Util::backquote('pdf_page_number') . ' = ' . intval($pg);
-        $this->relation->queryAsControlUser($query);
+        $this->dbi->queryAsControlUser($query);
 
         $query = 'DELETE FROM ' . Util::backquote($pdfFeature->database)
             . '.' . Util::backquote($pdfFeature->pdfPages)
             . ' WHERE ' . Util::backquote('page_nr') . ' = ' . intval($pg);
-        $this->relation->queryAsControlUser($query);
+        $this->dbi->queryAsControlUser($query);
 
         return true;
     }
@@ -480,7 +480,7 @@ class Common
             . '.' . Util::backquote($pdfFeature->tableCoords)
             . " WHERE `pdf_page_number` = '" . $pageId . "'";
 
-        $this->relation->queryAsControlUser($query);
+        $this->dbi->queryAsControlUser($query);
 
         foreach ($_POST['t_h'] as $key => $value) {
             $DB = $_POST['t_db'][$key];
@@ -500,7 +500,7 @@ class Common
                 . "'" . $this->dbi->escapeString($_POST['t_x'][$key]) . "', "
                 . "'" . $this->dbi->escapeString($_POST['t_y'][$key]) . "')";
 
-            $this->relation->queryAsControlUser($query);
+            $this->dbi->queryAsControlUser($query);
         }
 
         return true;
@@ -666,7 +666,7 @@ class Common
             . "'" . $this->dbi->escapeString($T1) . "', "
             . "'" . $this->dbi->escapeString($F1) . "')";
 
-        if ($this->relation->queryAsControlUser($q, false)) {
+        if ($this->dbi->tryQueryAsControlUser($q)) {
             return [
                 true,
                 __('Internal relationship has been added.'),
@@ -739,7 +739,7 @@ class Common
             . " AND foreign_table = '" . $this->dbi->escapeString($T1) . "'"
             . " AND foreign_field = '" . $this->dbi->escapeString($F1) . "'";
 
-        $result = $this->relation->queryAsControlUser($delete_query, false);
+        $result = $this->dbi->tryQueryAsControlUser($delete_query);
 
         if (! $result) {
             $error = $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
@@ -765,7 +765,6 @@ class Common
     public function saveSetting($index, $value): bool
     {
         $databaseDesignerSettingsFeature = $this->relation->getRelationParameters()->databaseDesignerSettingsFeature;
-        $success = true;
         if ($databaseDesignerSettingsFeature !== null) {
             $cfgDesigner = [
                 'user' => $GLOBALS['cfg']['Server']['user'],
@@ -797,7 +796,7 @@ class Common
                     . " WHERE username = '"
                     . $this->dbi->escapeString($cfgDesigner['user']) . "';";
 
-                $success = $this->relation->queryAsControlUser($save_query);
+                $this->dbi->queryAsControlUser($save_query);
             } else {
                 $save_data = [$index => $value];
 
@@ -808,10 +807,10 @@ class Common
                     . " VALUES('" . $this->dbi->escapeString($cfgDesigner['user'])
                     . "', '" . json_encode($save_data) . "');";
 
-                $success = $this->relation->queryAsControlUser($query);
+                $this->dbi->queryAsControlUser($query);
             }
         }
 
-        return (bool) $success;
+        return true;
     }
 }

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -280,6 +280,40 @@ class DatabaseInterface implements DbalInterface
     }
 
     /**
+     * Executes a query as controluser.
+     * The result is always buffered and never cached
+     *
+     * @param string $sql the query to execute
+     *
+     * @return ResultInterface the result set
+     */
+    public function queryAsControlUser(string $sql): ResultInterface
+    {
+        // Avoid caching of the number of rows affected; for example, this function
+        // is called for tracking purposes but we want to display the correct number
+        // of rows affected by the original query, not by the query generated for
+        // tracking.
+        return $this->query($sql, self::CONNECT_CONTROL, self::QUERY_BUFFERED, false);
+    }
+
+    /**
+     * Executes a query as controluser.
+     * The result is always buffered and never cached
+     *
+     * @param string $sql the query to execute
+     *
+     * @return ResultInterface|false the result set, or false if the query failed
+     */
+    public function tryQueryAsControlUser(string $sql)
+    {
+        // Avoid caching of the number of rows affected; for example, this function
+        // is called for tracking purposes but we want to display the correct number
+        // of rows affected by the original query, not by the query generated for
+        // tracking.
+        return $this->tryQuery($sql, self::CONNECT_CONTROL, self::QUERY_BUFFERED, false);
+    }
+
+    /**
      * returns array with table names for given db
      *
      * @param string $database name of database

--- a/libraries/classes/Export/TemplateModel.php
+++ b/libraries/classes/Export/TemplateModel.php
@@ -33,7 +33,7 @@ final class TemplateModel
             $this->dbi->escapeString($template->getName()),
             $this->dbi->escapeString($template->getData())
         );
-        $result = $this->dbi->tryQuery($query, DatabaseInterface::CONNECT_CONTROL, 0, false);
+        $result = $this->dbi->tryQueryAsControlUser($query);
         if ($result !== false) {
             return '';
         }
@@ -50,7 +50,7 @@ final class TemplateModel
             $id,
             $this->dbi->escapeString($user)
         );
-        $result = $this->dbi->tryQuery($query, DatabaseInterface::CONNECT_CONTROL, 0, false);
+        $result = $this->dbi->tryQueryAsControlUser($query);
         if ($result !== false) {
             return '';
         }
@@ -70,7 +70,7 @@ final class TemplateModel
             $id,
             $this->dbi->escapeString($user)
         );
-        $result = $this->dbi->tryQuery($query, DatabaseInterface::CONNECT_CONTROL, 0, false);
+        $result = $this->dbi->tryQueryAsControlUser($query);
         if ($result === false) {
             return $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
         }
@@ -99,7 +99,7 @@ final class TemplateModel
             $template->getId(),
             $this->dbi->escapeString($template->getUsername())
         );
-        $result = $this->dbi->tryQuery($query, DatabaseInterface::CONNECT_CONTROL, 0, false);
+        $result = $this->dbi->tryQueryAsControlUser($query);
         if ($result !== false) {
             return '';
         }
@@ -119,7 +119,7 @@ final class TemplateModel
             $this->dbi->escapeString($user),
             $this->dbi->escapeString($exportType)
         );
-        $result = $this->dbi->tryQuery($query, DatabaseInterface::CONNECT_CONTROL, 0, false);
+        $result = $this->dbi->tryQueryAsControlUser($query);
         if ($result === false) {
             return $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
         }

--- a/libraries/classes/Menu.php
+++ b/libraries/classes/Menu.php
@@ -137,7 +137,7 @@ class Menu
                 . $userTable . " WHERE `username` = '"
                 . $this->dbi->escapeString($GLOBALS['cfg']['Server']['user']) . "')";
 
-            $result = $this->relation->queryAsControlUser($sqlQuery, false);
+            $result = $this->dbi->tryQueryAsControlUser($sqlQuery);
             if ($result) {
                 while ($row = $this->dbi->fetchAssoc($result)) {
                     $tab = (string) $row['tab'];

--- a/libraries/classes/Navigation/Navigation.php
+++ b/libraries/classes/Navigation/Navigation.php
@@ -175,7 +175,7 @@ class Navigation
             . "'" . $this->dbi->escapeString($dbName) . "',"
             . "'" . (! empty($tableName) ? $this->dbi->escapeString($tableName) : '' )
             . "')";
-        $this->relation->queryAsControlUser($sqlQuery, false);
+        $this->dbi->tryQueryAsControlUser($sqlQuery);
     }
 
     /**
@@ -211,7 +211,7 @@ class Navigation
                 ? " AND `table_name`='" . $this->dbi->escapeString($tableName) . "'"
                 : ''
             );
-        $this->relation->queryAsControlUser($sqlQuery, false);
+        $this->dbi->tryQueryAsControlUser($sqlQuery);
     }
 
     /**
@@ -266,7 +266,7 @@ class Navigation
             . " AND `db_name`='" . $this->dbi->escapeString($database) . "'"
             . " AND `table_name`='"
             . (! empty($table) ? $this->dbi->escapeString($table) : '') . "'";
-        $result = $this->relation->queryAsControlUser($sqlQuery, false);
+        $result = $this->dbi->tryQueryAsControlUser($sqlQuery);
 
         $hidden = [];
         if ($result) {

--- a/libraries/classes/Navigation/Nodes/NodeDatabase.php
+++ b/libraries/classes/Navigation/Nodes/NodeDatabase.php
@@ -396,7 +396,7 @@ class NodeDatabase extends Node
             . " AND `item_type`='" . $type
             . "' AND `db_name`='" . $dbi->escapeString($db)
             . "'";
-        $result = $this->relation->queryAsControlUser($sqlQuery, false);
+        $result = $dbi->tryQueryAsControlUser($sqlQuery);
         if ($result) {
             return $result->fetchAllColumn();
         }

--- a/libraries/classes/Plugins/Schema/ExportRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/ExportRelationSchema.php
@@ -258,7 +258,7 @@ class ExportRelationSchema
                 . Util::backquote($pdfFeature->database) . '.'
                 . Util::backquote($pdfFeature->pdfPages)
                 . ' WHERE page_nr = ' . $this->pageNumber;
-            $_name_rs = $this->relation->queryAsControlUser($_name_sql);
+            $_name_rs = $dbi->queryAsControlUser($_name_sql);
             $_name_row = $dbi->fetchRow($_name_rs);
             $filename = $_name_row[0] . $extension;
         }

--- a/libraries/classes/Plugins/Schema/Pdf/Pdf.php
+++ b/libraries/classes/Plugins/Schema/Pdf/Pdf.php
@@ -276,7 +276,7 @@ class Pdf extends PdfLib
                 . Util::backquote($pdfFeature->pdfPages)
                 . ' WHERE db_name = \'' . $dbi->escapeString($this->db)
                 . '\' AND page_nr = \'' . $this->pageNumber . '\'';
-            $test_rs = $this->relation->queryAsControlUser($test_query);
+            $test_rs = $dbi->queryAsControlUser($test_query);
             $pageDesc = '';
             $pages = $dbi->fetchAssoc($test_rs);
             if ($pages !== []) {

--- a/libraries/classes/RecentFavoriteTable.php
+++ b/libraries/classes/RecentFavoriteTable.php
@@ -123,7 +123,7 @@ class RecentFavoriteTable
         $sql_query = ' SELECT `tables` FROM ' . $this->getPmaTable() .
             " WHERE `username` = '" . $dbi->escapeString($GLOBALS['cfg']['Server']['user']) . "'";
 
-        $result = $this->relation->queryAsControlUser($sql_query, false);
+        $result = $dbi->tryQueryAsControlUser($sql_query);
         if ($result) {
             $value = $result->fetchValue();
             if (is_string($value)) {

--- a/libraries/classes/SavedSearches.php
+++ b/libraries/classes/SavedSearches.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin;
 
 use PhpMyAdmin\ConfigStorage\Features\SavedQueryByExampleSearchesFeature;
-use PhpMyAdmin\ConfigStorage\Relation;
 
 use function __;
 use function count;
@@ -58,14 +57,6 @@ class SavedSearches
      * @var array
      */
     private $criterias = null;
-
-    /** @var Relation */
-    private $relation;
-
-    public function __construct(Relation $relation)
-    {
-        $this->relation = $relation;
-    }
 
     /**
      * Setter of id
@@ -300,10 +291,7 @@ class SavedSearches
                 . "'" . $dbi->escapeString(json_encode($this->getCriterias()))
                 . "')";
 
-            $result = (bool) $this->relation->queryAsControlUser($sqlQuery);
-            if (! $result) {
-                return false;
-            }
+            $dbi->queryAsControlUser($sqlQuery);
 
             $this->setId($dbi->insertId());
 
@@ -335,7 +323,7 @@ class SavedSearches
             . $dbi->escapeString(json_encode($this->getCriterias())) . "' "
             . 'WHERE id = ' . $this->getId();
 
-        return (bool) $this->relation->queryAsControlUser($sqlQuery);
+        return (bool) $dbi->queryAsControlUser($sqlQuery);
     }
 
     /**
@@ -362,7 +350,7 @@ class SavedSearches
         $sqlQuery = 'DELETE FROM ' . $savedSearchesTbl
             . "WHERE id = '" . $dbi->escapeString((string) $this->getId()) . "'";
 
-        return (bool) $this->relation->queryAsControlUser($sqlQuery);
+        return (bool) $dbi->queryAsControlUser($sqlQuery);
     }
 
     /**
@@ -390,7 +378,7 @@ class SavedSearches
             . 'FROM ' . $savedSearchesTbl . ' '
             . "WHERE id = '" . $dbi->escapeString((string) $this->getId()) . "' ";
 
-        $resList = $this->relation->queryAsControlUser($sqlQuery);
+        $resList = $dbi->queryAsControlUser($sqlQuery);
         $oneResult = $resList->fetchAssoc();
 
         if ($oneResult === []) {
@@ -438,7 +426,7 @@ class SavedSearches
 
         $sqlQuery .= 'order by search_name ASC ';
 
-        $resList = $this->relation->queryAsControlUser($sqlQuery);
+        $resList = $dbi->queryAsControlUser($sqlQuery);
 
         return $resList->fetchAllKeyPair();
     }

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -581,7 +581,7 @@ class Privileges
             return;
         }
 
-        $this->relation->queryAsControlUser($updQuery);
+        $this->dbi->queryAsControlUser($updQuery);
     }
 
     /**
@@ -2009,7 +2009,7 @@ class Privileges
         if ($configurableMenusFeature !== null) {
             $sqlQuery = 'SELECT * FROM ' . Util::backquote($configurableMenusFeature->database)
                 . '.' . Util::backquote($configurableMenusFeature->users);
-            $result = $this->relation->queryAsControlUser($sqlQuery, false);
+            $result = $this->dbi->tryQueryAsControlUser($sqlQuery);
             $groupAssignment = [];
             if ($result) {
                 while ($row = $result->fetchAssoc()) {

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -932,7 +932,7 @@ class Table implements Stringable
 
         // must use DatabaseInterface::QUERY_BUFFERED here, since we execute
         // another query inside the loop
-        $tableCopyRs = $relation->queryAsControlUser($tableCopyQuery);
+        $tableCopyRs = $dbi->queryAsControlUser($tableCopyQuery);
 
         foreach ($tableCopyRs as $tableCopyRow) {
             $valueParts = [];
@@ -952,7 +952,7 @@ class Table implements Stringable
                 . implode('\', \'', $valueParts) . '\', \''
                 . implode('\', \'', $newValueParts) . '\')';
 
-            $relation->queryAsControlUser($newTableQuery);
+            $dbi->queryAsControlUser($newTableQuery);
             $lastId = $dbi->insertId();
         }
 
@@ -1320,7 +1320,7 @@ class Table implements Stringable
 
         if ($relationParameters->columnCommentsFeature !== null) {
             // Get all comments and MIME-Types for current table
-            $commentsCopyRs = $relation->queryAsControlUser(
+            $commentsCopyRs = $dbi->queryAsControlUser(
                 'SELECT column_name, comment'
                 . ($relationParameters->browserTransformationFeature !== null
                 ? ', mimetype, transformation, transformation_options'
@@ -1359,7 +1359,7 @@ class Table implements Stringable
                         . '\''
                         : '')
                     . ')';
-                $relation->queryAsControlUser($newCommentQuery);
+                $dbi->queryAsControlUser($newCommentQuery);
             }
 
             unset($commentsCopyRs);
@@ -1759,7 +1759,7 @@ class Table implements Stringable
             $this->dbi->escapeString($this->name)
         );
 
-        $value = $this->relation->queryAsControlUser($sqlQuery)->fetchValue();
+        $value = $this->dbi->queryAsControlUser($sqlQuery)->fetchValue();
         if (is_string($value)) {
             return json_decode($value, true);
         }

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -2205,7 +2205,7 @@ class Table implements Stringable
                 . '\'' . $this->dbi->escapeString($displayField) . '\')';
         }
 
-        $this->dbi->query($updQuery, DatabaseInterface::CONNECT_CONTROL, 0, false);
+        $this->dbi->queryAsControlUser($updQuery);
     }
 
     /**
@@ -2283,7 +2283,7 @@ class Table implements Stringable
                 continue;
             }
 
-            $this->dbi->query($updQuery, DatabaseInterface::CONNECT_CONTROL, 0, false);
+            $this->dbi->queryAsControlUser($updQuery);
             $updated = true;
         }
 

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -275,7 +275,7 @@ class Tracker
             $dbi->escapeString($trackingSet)
         );
 
-        $relation->queryAsControlUser($sqlQuery);
+        $dbi->queryAsControlUser($sqlQuery);
 
         // Deactivate previous version
         return self::deactivateTracking($dbName, $tableName, (int) $version - 1);
@@ -309,7 +309,7 @@ class Tracker
             $sqlQuery .= " AND `version` = '" . $dbi->escapeString($version) . "'";
         }
 
-        return (bool) $relation->queryAsControlUser($sqlQuery);
+        return (bool) $dbi->queryAsControlUser($sqlQuery);
     }
 
     /**
@@ -368,7 +368,7 @@ class Tracker
             $dbi->escapeString($trackingSet)
         );
 
-        return (bool) $relation->queryAsControlUser($sqlQuery);
+        return (bool) $dbi->queryAsControlUser($sqlQuery);
     }
 
     /**
@@ -404,7 +404,7 @@ class Tracker
             $dbi->escapeString((string) $version)
         );
 
-        return (bool) $relation->queryAsControlUser($sqlQuery);
+        return (bool) $dbi->queryAsControlUser($sqlQuery);
     }
 
     /**
@@ -465,7 +465,7 @@ class Tracker
             $dbi->escapeString($version)
         );
 
-        $result = $relation->queryAsControlUser($sqlQuery);
+        $result = $dbi->queryAsControlUser($sqlQuery);
 
         return (bool) $result;
     }
@@ -528,7 +528,7 @@ class Tracker
             $sqlQuery .= " AND FIND_IN_SET('" . $statement . "',tracking) > 0";
         }
 
-        $result = $relation->queryAsControlUser($sqlQuery, false);
+        $result = $dbi->tryQueryAsControlUser($sqlQuery);
 
         if ($result === false) {
             return -1;
@@ -575,7 +575,7 @@ class Tracker
         $sqlQuery .= " AND `version` = '" . $dbi->escapeString($version)
             . "' ORDER BY `version` DESC LIMIT 1";
 
-        $mixed = $dbi->fetchAssoc($relation->queryAsControlUser($sqlQuery));
+        $mixed = $dbi->fetchAssoc($dbi->queryAsControlUser($sqlQuery));
 
         // PHP 7.4 fix for accessing array offset on null
         if ($mixed === []) {
@@ -952,6 +952,6 @@ class Tracker
         . $dbi->escapeString($result['tablename']) . "' " .
         " AND `version` = '" . $dbi->escapeString($version ?? '') . "' ";
 
-        $relation->queryAsControlUser($sqlQuery);
+        $dbi->queryAsControlUser($sqlQuery);
     }
 }

--- a/libraries/classes/Tracking.php
+++ b/libraries/classes/Tracking.php
@@ -206,7 +206,7 @@ class Tracking
             "' " .
             ' ORDER BY db_name, table_name';
 
-        return $this->relation->queryAsControlUser($sql_query);
+        return $this->dbi->queryAsControlUser($sql_query);
     }
 
     /**
@@ -1105,7 +1105,6 @@ class Tracking
         array $urlParams,
         string $textDir
     ) {
-        $relation = $this->relation;
         $trackingFeature = $this->relation->getRelationParameters()->trackingFeature;
         if ($trackingFeature === null) {
             return '';
@@ -1120,7 +1119,7 @@ class Tracking
             ' GROUP BY table_name' .
             ' ORDER BY table_name ASC';
 
-        $allTablesResult = $relation->queryAsControlUser($allTablesQuery);
+        $allTablesResult = $this->dbi->queryAsControlUser($allTablesQuery);
         $untrackedTables = $this->getUntrackedTables($db);
 
         // If a HEAD version exists
@@ -1136,7 +1135,7 @@ class Tracking
                 . $this->dbi->escapeString($tableName)
                 . '\' AND `version` = \'' . $versionNumber . '\'';
 
-            $versions[] = $relation->queryAsControlUser($tableQuery)->fetchAssoc();
+            $versions[] = $this->dbi->queryAsControlUser($tableQuery)->fetchAssoc();
         }
 
         return $this->template->render('database/tracking/tables', [

--- a/libraries/classes/Tracking.php
+++ b/libraries/classes/Tracking.php
@@ -119,7 +119,7 @@ class Tracking
             $this->dbi->escapeString($table)
         );
 
-        return $this->dbi->query($query, DatabaseInterface::CONNECT_CONTROL, 0, false);
+        return $this->dbi->queryAsControlUser($query);
     }
 
     /**

--- a/libraries/classes/Transformations.php
+++ b/libraries/classes/Transformations.php
@@ -390,7 +390,7 @@ class Transformations
                 AND `table_name`  = \'' . $dbi->escapeString($table) . '\'
                 AND `column_name` = \'' . $dbi->escapeString($key) . '\'';
 
-        $test_rs = $relation->queryAsControlUser($test_qry);
+        $test_rs = $dbi->queryAsControlUser($test_qry);
 
         if ($test_rs->numRows() > 0) {
             $row = $test_rs->fetchAssoc();
@@ -441,7 +441,7 @@ class Transformations
         }
 
         if (isset($upd_query)) {
-            return (bool) $relation->queryAsControlUser($upd_query);
+            return (bool) $dbi->queryAsControlUser($upd_query);
         }
 
         return false;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -386,11 +386,6 @@ parameters:
 			path: libraries/classes/Config/Form.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 2
-			path: libraries/classes/Config/Form.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: libraries/classes/Config/FormDisplay.php
@@ -953,16 +948,6 @@ parameters:
 		-
 			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\UserGroups\\:\\:getTabList\\(\\) has parameter \\$selected with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: libraries/classes/ConfigStorage/UserGroups.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|null given\\.$#"
-			count: 3
-			path: libraries/classes/ConfigStorage/UserGroups.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|null given\\.$#"
-			count: 3
 			path: libraries/classes/ConfigStorage/UserGroups.php
 
 		-
@@ -7156,16 +7141,6 @@ parameters:
 			path: libraries/classes/SavedSearches.php
 
 		-
-			message: "#^Cannot call method fetchAllKeyPair\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
-			count: 1
-			path: libraries/classes/SavedSearches.php
-
-		-
-			message: "#^Cannot call method fetchAssoc\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
-			count: 1
-			path: libraries/classes/SavedSearches.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SavedSearches\\:\\:getCriterias\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/SavedSearches.php
@@ -7187,16 +7162,6 @@ parameters:
 
 		-
 			message: "#^Offset non\\-empty\\-string does not exist on array\\|string\\.$#"
-			count: 1
-			path: libraries/classes/SavedSearches.php
-
-		-
-			message: "#^Parameter \\#1 \\$criterias of method PhpMyAdmin\\\\SavedSearches\\:\\:setCriterias\\(\\) expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/SavedSearches.php
-
-		-
-			message: "#^Parameter \\#1 \\$searchName of method PhpMyAdmin\\\\SavedSearches\\:\\:setSearchName\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/SavedSearches.php
 
@@ -8136,16 +8101,6 @@ parameters:
 			path: libraries/classes/SystemDatabase.php
 
 		-
-			message: "#^Argument of an invalid type PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 2
-			path: libraries/classes/Table.php
-
-		-
-			message: "#^Cannot call method fetchValue\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
-			count: 1
-			path: libraries/classes/Table.php
-
-		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: libraries/classes/Table.php
@@ -8461,16 +8416,6 @@ parameters:
 			path: libraries/classes/Theme.php
 
 		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: libraries/classes/Theme.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: libraries/classes/ThemeManager.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\ThemeManager\\:\\:getThemesArray\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/ThemeManager.php
@@ -8483,11 +8428,6 @@ parameters:
 		-
 			message: "#^Static property PhpMyAdmin\\\\ThemeManager\\:\\:\\$instance \\(PhpMyAdmin\\\\ThemeManager\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
-			path: libraries/classes/ThemeManager.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 2
 			path: libraries/classes/ThemeManager.php
 
 		-
@@ -8567,16 +8507,6 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Tracking.php
-
-		-
-			message: "#^Cannot call method fetchAssoc\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
-			count: 1
-			path: libraries/classes/Tracking.php
-
-		-
-			message: "#^Cannot call method fetchRow\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
 			count: 1
 			path: libraries/classes/Tracking.php
 
@@ -8821,16 +8751,6 @@ parameters:
 			path: libraries/classes/Tracking.php
 
 		-
-			message: "#^Cannot call method fetchAssoc\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
-			count: 1
-			path: libraries/classes/Transformations.php
-
-		-
-			message: "#^Cannot call method numRows\\(\\) on PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false\\.$#"
-			count: 1
-			path: libraries/classes/Transformations.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Transformations\\:\\:getAvailableMimeTypes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Transformations.php
@@ -8842,11 +8762,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Transformations\\:\\:getOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Transformations.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Transformations.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14433,30 +14433,9 @@
     </MixedAssignment>
   </file>
   <file src="test/classes/ConfigStorage/RelationCleanupTest.php">
-    <MixedMethodCall occurrences="12">
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>withConsecutive</code>
-      <code>withConsecutive</code>
-      <code>withConsecutive</code>
-      <code>withConsecutive</code>
-    </MixedMethodCall>
-    <PossiblyUndefinedMethod occurrences="8">
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-    </PossiblyUndefinedMethod>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$dbi</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="test/classes/ConfigStorage/RelationTest.php">
     <DocblockTypeContradiction occurrences="1">

--- a/test/classes/ConfigStorage/RelationCleanupTest.php
+++ b/test/classes/ConfigStorage/RelationCleanupTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests\ConfigStorage;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
+use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -21,6 +22,9 @@ class RelationCleanupTest extends AbstractTestCase
     /** @var RelationCleanup */
     private $relationCleanup;
 
+    /** @var DatabaseInterface&MockObject */
+    protected $dbi;
+
     /**
      * Prepares environment for the test.
      */
@@ -31,9 +35,13 @@ class RelationCleanupTest extends AbstractTestCase
 
         $this->relation = $this->getMockBuilder(Relation::class)
             ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+        $this->dbi = $this->getMockBuilder(DatabaseInterface::class)
+            ->disableOriginalConstructor()
             ->onlyMethods(['queryAsControlUser'])
             ->getMock();
-        $this->relationCleanup = new RelationCleanup($GLOBALS['dbi'], $this->relation);
+        $this->relationCleanup = new RelationCleanup($this->dbi, $this->relation);
     }
 
     /**
@@ -41,7 +49,7 @@ class RelationCleanupTest extends AbstractTestCase
      */
     public function testColumnWithoutRelations(): void
     {
-        $this->relation->expects($this->never())
+        $this->dbi->expects($this->never())
             ->method('queryAsControlUser');
 
         $this->relationCleanup->column('database', 'table', 'column');
@@ -64,7 +72,7 @@ class RelationCleanupTest extends AbstractTestCase
             'column_info' => 'column_info',
         ])->toArray();
 
-        $this->relation->expects($this->exactly(4))
+        $this->dbi->expects($this->exactly(4))
             ->method('queryAsControlUser')
             ->withConsecutive(
                 [
@@ -101,7 +109,7 @@ class RelationCleanupTest extends AbstractTestCase
      */
     public function testTableWithoutRelations(): void
     {
-        $this->relation->expects($this->never())
+        $this->dbi->expects($this->never())
             ->method('queryAsControlUser');
 
         $this->relationCleanup->table('database', 'table');
@@ -131,7 +139,7 @@ class RelationCleanupTest extends AbstractTestCase
             'navigationhiding' => 'navigationhiding',
         ])->toArray();
 
-        $this->relation->expects($this->exactly(7))
+        $this->dbi->expects($this->exactly(7))
             ->method('queryAsControlUser')
             ->withConsecutive(
                 [
@@ -180,7 +188,7 @@ class RelationCleanupTest extends AbstractTestCase
      */
     public function testDatabaseWithoutRelations(): void
     {
-        $this->relation->expects($this->never())
+        $this->dbi->expects($this->never())
             ->method('queryAsControlUser');
 
         $this->relationCleanup->database('database');
@@ -216,7 +224,7 @@ class RelationCleanupTest extends AbstractTestCase
             'central_columns' => 'central_columns',
         ])->toArray();
 
-        $this->relation->expects($this->exactly(11))
+        $this->dbi->expects($this->exactly(11))
             ->method('queryAsControlUser')
             ->withConsecutive(
                 [$this->equalTo("DELETE FROM `pmadb`.`column_info` WHERE db_name  = 'database'")],
@@ -240,7 +248,7 @@ class RelationCleanupTest extends AbstractTestCase
      */
     public function testUserWithoutRelations(): void
     {
-        $this->relation->expects($this->never())
+        $this->dbi->expects($this->never())
             ->method('queryAsControlUser');
 
         $this->relationCleanup->user('user');
@@ -278,7 +286,7 @@ class RelationCleanupTest extends AbstractTestCase
             'designer_settings' => 'designer_settings',
         ])->toArray();
 
-        $this->relation->expects($this->exactly(10))
+        $this->dbi->expects($this->exactly(10))
             ->method('queryAsControlUser')
             ->withConsecutive(
                 [$this->equalTo("DELETE FROM `pmadb`.`bookmark` WHERE `user`  = 'user'")],

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -42,40 +42,6 @@ class RelationTest extends AbstractTestCase
     }
 
     /**
-     * Test for queryAsControlUser
-     */
-    public function testPMAQueryAsControlUser(): void
-    {
-        $resultStub1 = $this->createMock(DummyResult::class);
-        $resultStub2 = $this->createMock(DummyResult::class);
-
-        $dbi = $this->getMockBuilder(DatabaseInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $dbi->expects($this->once())
-            ->method('query')
-            ->will($this->returnValue($resultStub1));
-
-        $dbi->expects($this->once())
-            ->method('tryQuery')
-            ->will($this->returnValue($resultStub2));
-
-        $GLOBALS['dbi'] = $dbi;
-        $this->relation->dbi = $GLOBALS['dbi'];
-
-        $sql = 'insert into PMA_bookmark A,B values(1, 2)';
-        $this->assertSame(
-            $resultStub1,
-            $this->relation->queryAsControlUser($sql)
-        );
-        $this->assertSame(
-            $resultStub2,
-            $this->relation->queryAsControlUser($sql, false)
-        );
-    }
-
-    /**
      * Test for getDisplayField
      */
     public function testPMAGetDisplayField(): void
@@ -160,7 +126,7 @@ class RelationTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->any())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->will($this->returnValue($resultStub));
         $resultStub->expects($this->any())
             ->method('numRows')

--- a/test/classes/ConfigStorage/UserGroupsTest.php
+++ b/test/classes/ConfigStorage/UserGroupsTest.php
@@ -55,7 +55,7 @@ class UserGroupsTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->with($expectedQuery)
             ->will($this->returnValue($resultStub));
         $resultStub->expects($this->once())
@@ -101,7 +101,7 @@ class UserGroupsTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->exactly(2))
-            ->method('query')
+            ->method('queryAsControlUser')
             ->withConsecutive([$this->equalTo($userDelQuery)], [$this->equalTo($userGrpDelQuery)]);
         $dbi->expects($this->any())
             ->method('escapeString')
@@ -129,7 +129,7 @@ class UserGroupsTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->with($expectedQuery)
             ->will($this->returnValue($resultStub));
         $resultStub->expects($this->exactly(1))

--- a/test/classes/Database/Designer/CommonTest.php
+++ b/test/classes/Database/Designer/CommonTest.php
@@ -125,7 +125,7 @@ class CommonTest extends AbstractTestCase
             ->getMock();
 
         $dbi->expects($this->exactly(2))
-            ->method('query')
+            ->method('queryAsControlUser')
             ->willReturnOnConsecutiveCalls($resultStub, $resultStub);
         $dbi->expects($this->any())->method('escapeString')
             ->will($this->returnArgument(0));

--- a/test/classes/Database/DesignerTest.php
+++ b/test/classes/Database/DesignerTest.php
@@ -66,12 +66,10 @@ class DesignerTest extends AbstractTestCase
             ->getMock();
 
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->with(
                 'SELECT `page_nr`, `page_descr` FROM `pmadb`.`pdf_pages`'
-                . " WHERE db_name = '" . $db . "' ORDER BY `page_descr`",
-                DatabaseInterface::CONNECT_CONTROL,
-                false
+                . " WHERE db_name = '" . $db . "' ORDER BY `page_descr`"
             )
             ->will($this->returnValue($resultStub));
 

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Database\DatabaseList;
+use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\Query\Utilities;
 use PhpMyAdmin\SystemDatabase;
 use PhpMyAdmin\Utils\SessionCache;
@@ -478,5 +479,25 @@ class DatabaseInterfaceTest extends AbstractTestCase
 
         $actual = $this->dbi->getTablesFull('test_db');
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test for queryAsControlUser
+     */
+    public function testQueryAsControlUser(): void
+    {
+        $sql = 'insert into PMA_bookmark A,B values(1, 2)';
+        $this->dummyDbi->addResult($sql, [true]);
+        $this->dummyDbi->addResult($sql, [true]);
+
+        $this->assertInstanceOf(
+            ResultInterface::class,
+            $this->dbi->queryAsControlUser($sql)
+        );
+        $this->assertInstanceOf(
+            ResultInterface::class,
+            $this->dbi->tryQueryAsControlUser($sql)
+        );
+        $this->assertFalse($this->dbi->tryQueryAsControlUser('Invalid query'));
     }
 }

--- a/test/classes/Navigation/NavigationTest.php
+++ b/test/classes/Navigation/NavigationTest.php
@@ -69,7 +69,7 @@ class NavigationTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->with($expectedQuery);
         $dbi->expects($this->any())->method('escapeString')
             ->will($this->returnArgument(0));
@@ -91,7 +91,7 @@ class NavigationTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->with($expectedQuery);
 
         $dbi->expects($this->any())->method('escapeString')

--- a/test/classes/Plugins/Export/ExportHtmlwordTest.php
+++ b/test/classes/Plugins/Export/ExportHtmlwordTest.php
@@ -413,7 +413,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             ->will($this->returnValue([$columns]));
 
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())
@@ -498,7 +498,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             ->will($this->returnValue([$columns]));
 
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())

--- a/test/classes/Plugins/Export/ExportLatexTest.php
+++ b/test/classes/Plugins/Export/ExportLatexTest.php
@@ -588,7 +588,7 @@ class ExportLatexTest extends AbstractTestCase
             ->will($this->returnValue($columns));
 
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())
@@ -693,7 +693,7 @@ class ExportLatexTest extends AbstractTestCase
             ->will($this->returnValue($columns));
 
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -599,7 +599,7 @@ class ExportOdtTest extends AbstractTestCase
             ->will($this->returnValue([$columns]));
 
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())
@@ -697,7 +697,7 @@ class ExportOdtTest extends AbstractTestCase
             ->will($this->returnValue([$columns]));
 
         $dbi->expects($this->once())
-            ->method('tryQuery')
+            ->method('tryQueryAsControlUser')
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())

--- a/test/classes/TrackerTest.php
+++ b/test/classes/TrackerTest.php
@@ -410,22 +410,16 @@ class TrackerTest extends AbstractTestCase
         $resultStub1 = $this->createMock(DummyResult::class);
         $resultStub2 = $this->createMock(DummyResult::class);
 
-        $dbi->method('query')
+        $dbi->method('queryAsControlUser')
             ->will(
                 $this->returnValueMap(
                     [
                         [
                             $sql_query_1,
-                            DatabaseInterface::CONNECT_CONTROL,
-                            0,
-                            false,
                             $resultStub1,
                         ],
                         [
                             $sql_query_2,
-                            DatabaseInterface::CONNECT_CONTROL,
-                            0,
-                            false,
                             $resultStub2,
                         ],
                     ]

--- a/test/classes/TrackerTest.php
+++ b/test/classes/TrackerTest.php
@@ -273,7 +273,7 @@ class TrackerTest extends AbstractTestCase
             . " AND `table_name` = 'testtable'";
 
         $dbi->expects($this->exactly(1))
-            ->method('query')
+            ->method('queryAsControlUser')
             ->with($sql_query)
             ->will($this->returnValue($resultStub));
         $dbi->expects($this->any())->method('escapeString')
@@ -305,8 +305,8 @@ class TrackerTest extends AbstractTestCase
             . '\', \'CREATE DATABASE,ALTER DATABASE,DROP DATABASE\')';
 
         $dbi->expects($this->exactly(1))
-            ->method('query')
-            ->with($this->matches($expectedMainQuery), DatabaseInterface::CONNECT_CONTROL, 0, false)
+            ->method('queryAsControlUser')
+            ->with($this->matches($expectedMainQuery))
             ->will($this->returnValue($resultStub));
 
         $dbi->expects($this->any())->method('escapeString')
@@ -346,8 +346,8 @@ class TrackerTest extends AbstractTestCase
         " AND `version` = '" . $version . "'";
 
         $dbi->expects($this->exactly(1))
-            ->method('query')
-            ->with($sql_query, DatabaseInterface::CONNECT_CONTROL, 0, false)
+            ->method('queryAsControlUser')
+            ->with($sql_query)
             ->will($this->returnValue($resultStub));
 
         $dbi->expects($this->any())->method('escapeString')
@@ -491,7 +491,7 @@ class TrackerTest extends AbstractTestCase
             ->getMock();
 
         $dbi->expects($this->once())
-            ->method('query')
+            ->method('queryAsControlUser')
             ->will($this->returnValue($resultStub));
 
         $dbi->expects($this->once())


### PR DESCRIPTION
Split the method into two methods, where one returns false instead of displaying an error message. Move the methods to DatabaseInterface. 

The new methods will always return buffered results and they will never cache the rows. 

In theory, these methods are not very useful as they are just syntactic sugar for `query()` and `tryQuery()`. I think it at least helps with static analysis and visual comprehension. Code with multiple arguments would be less understandable than a dedicated method. 