### PR TITLE
Mark test as incomplete for not supported queries

### DIFF
--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Dbal\DatabaseName;
 use PhpMyAdmin\Dbal\DbiExtension;
 use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\FieldMetadata;
+use PHPUnit\Framework\Assert;
 
 use function addslashes;
 use function count;
@@ -239,9 +240,7 @@ class DbiDummy implements DbiExtension
             return new DummyResult($this, $i + self::OFFSET_GLOBAL);
         }
 
-        echo 'Not supported query: ' . $query . "\n";
-
-        return false;
+        Assert::markTestIncomplete('Not supported query: ' . $query);
     }
 
     /**


### PR DESCRIPTION
Instead of printing the query, it marks the test as incomplete, this way we have a stack trace that help finding why it happened.

Example:
https://github.com/phpmyadmin/phpmyadmin/runs/4857851124?check_suite_focus=true#step:8:62