### PR TITLE
fix 'Undefined array key "hide_connection_errors"'

### DIFF
--- a/libraries/classes/Dbal/DbiMysqli.php
+++ b/libraries/classes/Dbal/DbiMysqli.php
@@ -107,7 +107,7 @@ class DbiMysqli implements DbiExtension
             $host = $server['host'];
         }
 
-        if ($server['hide_connection_errors']) {
+        if (array_key_exists('hide_connection_errors',$server) && $server['hide_connection_errors']) {
             $return_value = @$mysqli->real_connect(
                 $host,
                 $user,
@@ -157,7 +157,7 @@ class DbiMysqli implements DbiExtension
                 return self::connect($user, $password, $server);
             }
 
-            if ($error_number === 1045 && $server['hide_connection_errors']) {
+            if ($error_number === 1045 && array_key_exists('hide_connection_errors',$server) && $server['hide_connection_errors']) {
                 trigger_error(
                     sprintf(
                         __(


### PR DESCRIPTION
### on version 5.2.0-rc1 
Mysqli connection for **control user** (only) raise an warning: **Undefined array key "hide_connection_errors"**
array `$server` parameter for `connect` function didn't have `'hide_connection_errors'` key in `/libraries/classes/Dbal/DbiMysqli.php`

```
$server: Array (
    [host] => 127.0.0.1
    [port] => 3306
    [socket] => 
    [compress] => 1
    [ssl] => 
    [ssl_verify] => 1
)

```
Stack
```
#0 \libraries\classes\DatabaseInterface.php(1874): PhpMyAdmin\Dbal\DbiMysqli->connect('...', '...', Array)
#1 \libraries\classes\Common.php(600): PhpMyAdmin\DatabaseInterface->connect(257)
#2 \libraries\classes\Common.php(233): PhpMyAdmin\Common::connectToDatabaseServer(Object(PhpMyAdmin\DatabaseInterface), Object(PhpMyAdmin\Plugins\Auth\AuthenticationCookie))
#3 \index.php(): PhpMyAdmin\Common::run()
```

Signed-off-by @nono303

### Description

Please describe your pull request.

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
