### PR TITLE
Fix broken tests

### DIFF
--- a/templates/error/get_display.twig
+++ b/templates/error/get_display.twig
@@ -1,8 +1,8 @@
 <div class="alert alert-{{ context }}" role="alert">
 
-  {% if isUserError == false %}
+  {%- if isUserError == false %}
     <strong>{{ type }}</strong> in {{ file ~'#'~ line }} <br>
-  {% endif %}
+  {% endif -%}
 
   {{ message }}
 

--- a/test/classes/Config/PageSettingsTest.php
+++ b/test/classes/Config/PageSettingsTest.php
@@ -53,7 +53,7 @@ class PageSettingsTest extends AbstractTestCase
             '<div id="page_settings_modal">'
             . '<div class="page_settings">'
             . '<form method="post" '
-            . 'action="index.php&#x3F;db&#x3D;db&amp;server&#x3D;1&amp;lang&#x3D;en" '
+            . 'action="index.php&#x3F;route&#x3D;&#x25;2F&amp;db&#x3D;db&amp;server&#x3D;1&amp;lang&#x3D;en" '
             . 'class="config-form disableAjax">',
             $html
         );

--- a/test/classes/ErrorTest.php
+++ b/test/classes/ErrorTest.php
@@ -131,7 +131,7 @@ class ErrorTest extends AbstractTestCase
     public function testGetDisplay(): void
     {
         $this->assertStringContainsString(
-            '<div class="alert alert-danger" role="alert"><strong>Warning</strong>',
+            '<div class="alert alert-danger" role="alert">    <strong>Warning</strong>',
             $this->object->getDisplay()
         );
     }


### PR DESCRIPTION
The first one fixes `$route` parameter. In real execution the value should have never been null, which means that it should always be present in the `action=` and the default value is `/`.

The second one is basically whitespace in the generated HTML. We can ask Twig to trim it around the `{%` but I don't think there's anyway to trim it around `<strong>`