### PR TITLE
Remove `Search` link from tables that have no rows

### DIFF
--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -49,9 +49,13 @@
         </a>
     </td>
     <td class="text-center d-print-none">
-        <a href="{{ url('/table/search', table_url_params) }}">
+        {% if may_have_rows %}
+            <a href="{{ url('/table/search', table_url_params) }}">
+        {% endif %}
           {{ may_have_rows ? get_icon('b_select', 'Search'|trans) : get_icon('bd_select', 'Search'|trans) }}
-        </a>
+        {% if may_have_rows %}
+            </a>
+        {% endif %}
     </td>
 
     {% if not db_is_system_schema %}


### PR DESCRIPTION
Hello 👋🏻
I think there is no need for a `Search` link in empty tables, so in this PR I've removed the `a` tag from `Search` in tables that have no rows.

![Screenshot 2022-02-03 005531](https://user-images.githubusercontent.com/60013703/152257945-b92c029f-20c0-42f6-b682-bf3ec7b95e71.png)

Signed-off-by: Faissal Wahabali <fwahabali@gmail.com>


