### PR TITLE
Fix #17348 - Resolve formatting of <code> in Preferences > Export

### DIFF
--- a/libraries/classes/Config/Descriptions.php
+++ b/libraries/classes/Config/Descriptions.php
@@ -10,7 +10,6 @@ namespace PhpMyAdmin\Config;
 use PhpMyAdmin\Sanitize;
 
 use function __;
-use function htmlspecialchars;
 use function sprintf;
 use function str_replace;
 
@@ -653,10 +652,7 @@ class Descriptions
             'DisplayServersList_name' => __('Display servers as a list'),
             'DisableMultiTableMaintenance_name' => __('Disable multi table maintenance'),
             'ExecTimeLimit_name' => __('Maximum execution time'),
-            'Export_lock_tables_name' => sprintf(
-                __('Use %s statement'),
-                htmlspecialchars('<code>LOCK TABLES</code>')
-            ),
+            'Export_lock_tables_name' => __('Use [code]LOCK TABLES[/code] statement'),
             'Export_asfile_name' => __('Save as file'),
             'Export_charset_name' => __('Character set of the file'),
             'Export_codegen_format_name' => __('Format'),


### PR DESCRIPTION
Signed-off-by: Jonah Tan <47470981+jonahtanjz@users.noreply.github.com>

### Description
Replace usage of `<code></code>` with BBCode, `[code][/code]`, so that the `sanitizeMessage` method will return the description with the correct html output.

Before:
![image](https://user-images.githubusercontent.com/47470981/152828606-ca095355-dc6b-41fb-9880-4a9510aaf8ec.png)

After:
![image](https://user-images.githubusercontent.com/47470981/152828673-0e4c6590-c4bf-43ed-94f7-0763d7abbd6b.png)


Fixes #17348 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
