### PR TITLE
Drop stripslashes

### DIFF
--- a/libraries/classes/Plugins/Export/ExportCsv.php
+++ b/libraries/classes/Plugins/Export/ExportCsv.php
@@ -21,7 +21,6 @@ use function mb_strtolower;
 use function mb_substr;
 use function preg_replace;
 use function str_replace;
-use function stripslashes;
 use function trim;
 
 /**
@@ -233,7 +232,6 @@ class ExportCsv extends ExportPlugin
                     $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
                 }
 
-                $col_as = stripslashes($col_as);
                 if ($csv_enclosed == '') {
                     $schema_insert .= $col_as;
                 } else {

--- a/libraries/classes/Plugins/Export/ExportHtmlword.php
+++ b/libraries/classes/Plugins/Export/ExportHtmlword.php
@@ -21,7 +21,6 @@ use function __;
 use function htmlspecialchars;
 use function in_array;
 use function str_replace;
-use function stripslashes;
 
 /**
  * Handles the export for the HTML-Word format
@@ -214,7 +213,6 @@ class ExportHtmlword extends ExportPlugin
                     $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
                 }
 
-                $col_as = stripslashes($col_as);
                 $schema_insert .= '<td class="print"><strong>'
                     . htmlspecialchars($col_as)
                     . '</strong></td>';

--- a/libraries/classes/Plugins/Export/ExportJson.php
+++ b/libraries/classes/Plugins/Export/ExportJson.php
@@ -21,7 +21,6 @@ use function __;
 use function bin2hex;
 use function explode;
 use function json_encode;
-use function stripslashes;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_UNICODE;
@@ -263,7 +262,7 @@ class ExportJson extends ExportPlugin
                 $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
             }
 
-            $columns[$i] = stripslashes($col_as);
+            $columns[$i] = $col_as;
         }
 
         $record_cnt = 0;

--- a/libraries/classes/Plugins/Export/ExportLatex.php
+++ b/libraries/classes/Plugins/Export/ExportLatex.php
@@ -24,7 +24,6 @@ use function in_array;
 use function mb_strpos;
 use function mb_substr;
 use function str_replace;
-use function stripslashes;
 
 use const PHP_VERSION;
 
@@ -353,7 +352,7 @@ class ExportLatex extends ExportPlugin
             $buffer = '\\hline ';
             for ($i = 0; $i < $columns_cnt; $i++) {
                 $buffer .= '\\multicolumn{1}{|c|}{\\textbf{'
-                    . self::texEscape(stripslashes($columns_alias[$i])) . '}} & ';
+                    . self::texEscape($columns_alias[$i]) . '}} & ';
             }
 
             $buffer = mb_substr($buffer, 0, -2) . '\\\\ \\hline \hline ';
@@ -398,9 +397,7 @@ class ExportLatex extends ExportPlugin
             // print each row
             for ($i = 0; $i < $columns_cnt; $i++) {
                 if ($record[$columns[$i]] !== null && isset($record[$columns[$i]])) {
-                    $column_value = self::texEscape(
-                        stripslashes($record[$columns[$i]])
-                    );
+                    $column_value = self::texEscape($record[$columns[$i]]);
                 } else {
                     $column_value = $GLOBALS['latex_null'];
                 }

--- a/libraries/classes/Plugins/Export/ExportOds.php
+++ b/libraries/classes/Plugins/Export/ExportOds.php
@@ -22,7 +22,6 @@ use function __;
 use function bin2hex;
 use function date;
 use function htmlspecialchars;
-use function stripslashes;
 use function strtotime;
 
 /**
@@ -225,9 +224,7 @@ class ExportOds extends ExportPlugin
 
                 $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="string">'
                     . '<text:p>'
-                    . htmlspecialchars(
-                        stripslashes($col_as)
-                    )
+                    . htmlspecialchars($col_as)
                     . '</text:p>'
                     . '</table:table-cell>';
             }

--- a/libraries/classes/Plugins/Export/ExportOdt.php
+++ b/libraries/classes/Plugins/Export/ExportOdt.php
@@ -23,7 +23,6 @@ use function __;
 use function bin2hex;
 use function htmlspecialchars;
 use function str_replace;
-use function stripslashes;
 
 /**
  * Handles the export for the ODT class
@@ -261,9 +260,7 @@ class ExportOdt extends ExportPlugin
 
                 $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="string">'
                     . '<text:p>'
-                    . htmlspecialchars(
-                        stripslashes($col_as)
-                    )
+                    . htmlspecialchars($col_as)
                     . '</text:p>'
                     . '</table:table-cell>';
             }

--- a/libraries/classes/Plugins/Export/ExportPhparray.php
+++ b/libraries/classes/Plugins/Export/ExportPhparray.php
@@ -19,7 +19,6 @@ use PhpMyAdmin\Version;
 use function __;
 use function preg_match;
 use function preg_replace;
-use function stripslashes;
 use function strtr;
 use function var_export;
 
@@ -175,7 +174,7 @@ class ExportPhparray extends ExportPlugin
                 $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
             }
 
-            $columns[$i] = stripslashes($col_as);
+            $columns[$i] = $col_as;
         }
 
         $tablefixed = $table;

--- a/libraries/classes/Plugins/Export/ExportTexytext.php
+++ b/libraries/classes/Plugins/Export/ExportTexytext.php
@@ -21,7 +21,6 @@ use function __;
 use function htmlspecialchars;
 use function in_array;
 use function str_replace;
-use function stripslashes;
 
 /**
  * Handles the export for the Texy! text class
@@ -194,8 +193,7 @@ class ExportTexytext extends ExportPlugin
                     $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
                 }
 
-                $text_output .= '|'
-                    . htmlspecialchars(stripslashes($col_as));
+                $text_output .= '|' . htmlspecialchars($col_as);
             }
 
             $text_output .= "\n|------\n";

--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -21,7 +21,6 @@ use function is_array;
 use function mb_substr;
 use function rtrim;
 use function str_replace;
-use function stripslashes;
 use function strlen;
 
 use const PHP_VERSION;
@@ -458,10 +457,7 @@ class ExportXml extends ExportPlugin
             $result = $dbi->query($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
 
             $columns_cnt = $result->numFields();
-            $columns = [];
-            foreach ($result->getFieldNames() as $column) {
-                $columns[] = stripslashes($column);
-            }
+            $columns = $result->getFieldNames();
 
             $buffer = '        <!-- ' . __('Table') . ' '
                 . htmlspecialchars($table_alias) . ' -->' . $crlf;

--- a/libraries/classes/Plugins/Export/ExportYaml.php
+++ b/libraries/classes/Plugins/Export/ExportYaml.php
@@ -19,7 +19,6 @@ use function __;
 use function array_key_exists;
 use function is_numeric;
 use function str_replace;
-use function stripslashes;
 
 /**
  * Handles the export for the YAML format
@@ -150,7 +149,7 @@ class ExportYaml extends ExportPlugin
                 $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
             }
 
-            $columns[$i] = stripslashes($col_as);
+            $columns[$i] = $col_as;
         }
 
         $record_cnt = 0;

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9166,7 +9166,8 @@
     <MixedAssignment occurrences="1">
       <code>$col_as</code>
     </MixedAssignment>
-    <MixedOperand occurrences="17">
+    <MixedOperand occurrences="18">
+      <code>$col_as</code>
       <code>$csv_enclosed</code>
       <code>$csv_enclosed</code>
       <code>$csv_enclosed</code>
@@ -9264,11 +9265,12 @@
     </PossiblyUndefinedVariable>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportJson.php">
-    <MixedArgument occurrences="1">
+    <MixedArrayOffset occurrences="1">
+      <code>$data[$columns[$i]]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="2">
       <code>$col_as</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$col_as</code>
+      <code>$columns[$i]</code>
     </MixedAssignment>
     <MixedOperand occurrences="4">
       <code>$crlf</code>
@@ -9480,11 +9482,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportPhparray.php">
-    <MixedArgument occurrences="1">
+    <MixedAssignment occurrences="2">
       <code>$col_as</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$col_as</code>
+      <code>$columns[$i]</code>
     </MixedAssignment>
     <PossiblyNullArgument occurrences="1">
       <code>$table_alias</code>
@@ -9852,12 +9852,15 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportYaml.php">
-    <MixedArgument occurrences="1">
+    <MixedAssignment occurrences="2">
       <code>$col_as</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$col_as</code>
+      <code>$columns[$i]</code>
     </MixedAssignment>
+    <MixedOperand occurrences="3">
+      <code>$columns[$i]</code>
+      <code>$columns[$i]</code>
+      <code>$columns[$i]</code>
+    </MixedOperand>
     <PossiblyNullOperand occurrences="1">
       <code>$table_alias</code>
     </PossiblyNullOperand>

--- a/test/classes/Plugins/Export/ExportOdsTest.php
+++ b/test/classes/Plugins/Export/ExportOdsTest.php
@@ -357,7 +357,7 @@ class ExportOdsTest extends AbstractTestCase
 
         $this->assertEquals(
             '<table:table table:name="table"><table:table-row><table:table-cell ' .
-            'office:value-type="string"><text:p>fna&quot;me</text:p></table:table' .
+            'office:value-type="string"><text:p>fna\&quot;me</text:p></table:table' .
             '-cell><table:table-cell office:value-type="string"><text:p>' .
             'fnam/&lt;e2</text:p></table:table-cell></table:table-row>' .
             '</table:table>',

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -469,7 +469,7 @@ class ExportOdtTest extends AbstractTestCase
             'is-list-header="true">Dumping data for table table</text:h><table:' .
             'table table:name="table_structure"><table:table-column table:number-' .
             'columns-repeated="2"/><table:table-row><table:table-cell office:' .
-            'value-type="string"><text:p>fna&quot;me</text:p></table:table-cell>' .
+            'value-type="string"><text:p>fna\&quot;me</text:p></table:table-cell>' .
             '<table:table-cell office:value-type="string"><text:p>fnam/&lt;e2' .
             '</text:p></table:table-cell></table:table-row></table:table>',
             $GLOBALS['odt_buffer']


### PR DESCRIPTION
Was there any reason to strip slashes? What slashes are we stripping and why? It seems to me like some bad copy-pasta. 

I tested it with the following table and it definitely garbles up the result.
```sql
CREATE TABLE IF NOT EXISTS `slashes` (
  `\'table` int(11) NOT NULL,
  `\\Some table` int(11) NOT NULL,
  PRIMARY KEY (`\'table`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1;
```