### PR TITLE
Fix table navigation layout if row count is unknown

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -933,6 +933,11 @@ class Results
             false
         );
 
+        // If the number of rows is unknown, stop here (don't add the End button)
+        if ($this->properties['unlim_num_rows'] === false) {
+            return $buttonsHtml;
+        }
+
         $inputForRealEnd = '';
         // prepare some options for the End button
         if ($isInnodb && $this->properties['unlim_num_rows'] > $GLOBALS['cfg']['MaxExactCount']) {

--- a/templates/display/results/table.twig
+++ b/templates/display/results/table.twig
@@ -8,7 +8,7 @@
         {{ navigation.page_selector|raw }}
         {{ navigation.move_forward_buttons|raw }}
 
-        {% if navigation.number_total_page > 1 %}
+        {% if navigation.number_total_page != 1 %}
           <td><div class="navigation_separator">|</div></td>
         {% endif %}
 


### PR DESCRIPTION
### Description

Now that #17055 has been fixed, there are a pair of issues with the navigation buttons for system tables (and any table that has an unknown number of rows) that I have fixed. The End button was nonfunctional, so it is no longer shown, and the separator between the navigation buttons and the adjacent "Show all" checkbox was missing.

The following GIFs show the fix in action:

- Expected behavior (table with known row count):
![NavLayoutKnownRowCountCurrent](https://user-images.githubusercontent.com/59065888/152911163-94be922b-3045-4e22-8a30-b6ad14fa3532.gif)

- Current behavior (table with unknown row count):
![NavLayoutUnknownRowCountCurrent](https://user-images.githubusercontent.com/59065888/152911203-700e01f6-2335-4a7c-8c18-c956c5b94264.gif)

- Fixed behavior (table with unknown row count):
![NavLayoutUnknownRowCountFixed](https://user-images.githubusercontent.com/59065888/152911232-f9fa780e-fd87-41cb-b804-48fccc8057aa.gif)