### PR TITLE
Remove usage of deprecated String.prototype.substr()

### DIFF
--- a/js/src/common.js
+++ b/js/src/common.js
@@ -91,7 +91,7 @@ var CommonParams = (function () {
             if (typeof common === 'string' && common.length > 0) {
                 // If the last char is the separator, do not add it
                 // Else add it
-                common = common.substr(common.length - 1, common.length) === argsep ? common : common + argsep;
+                common = common.endsWith(argsep) ? common : common + argsep;
             }
 
             return Functions.sprintf(

--- a/js/src/config.js
+++ b/js/src/config.js
@@ -667,7 +667,7 @@ function setupRestoreField () {
             var fieldSel;
             if ($(this).hasClass('restore-default')) {
                 fieldSel = href;
-                restoreField(fieldSel.substr(1));
+                restoreField(fieldSel.substring(1));
             } else {
                 fieldSel = href.match(/^[^=]+/)[0];
                 var value = href.match(/=(.+)$/)[1];

--- a/js/src/console.js
+++ b/js/src/console.js
@@ -599,7 +599,7 @@ var ConsoleInput = {
             } else {
                 // Get cursor position from textarea
                 var text = ConsoleInput.getText();
-                cursorLine = text.substr(0, editor.prop('selectionStart')).split('\n').length - 1;
+                cursorLine = text.substring(0, editor.prop('selectionStart')).split('\n').length - 1;
                 totalLine = text.split(/\r*\n/).length;
             }
             if (cursorLine === 0) {

--- a/js/src/database/routines.js
+++ b/js/src/database/routines.js
@@ -554,19 +554,19 @@ const DatabaseRoutines = {
                  *                the input field being reindexed
                  */
                 var inputname = $(this).attr('name');
-                if (inputname.substr(0, 14) === 'item_param_dir') {
-                    $(this).attr('name', inputname.substr(0, 14) + '[' + index + ']');
-                } else if (inputname.substr(0, 15) === 'item_param_name') {
-                    $(this).attr('name', inputname.substr(0, 15) + '[' + index + ']');
-                } else if (inputname.substr(0, 15) === 'item_param_type') {
-                    $(this).attr('name', inputname.substr(0, 15) + '[' + index + ']');
-                } else if (inputname.substr(0, 17) === 'item_param_length') {
-                    $(this).attr('name', inputname.substr(0, 17) + '[' + index + ']');
+                if (inputname.startsWith('item_param_dir')) {
+                    $(this).attr('name', inputname.substring(0, 14) + '[' + index + ']');
+                } else if (inputname.startsWith('item_param_name')) {
+                    $(this).attr('name', inputname.substring(0, 15) + '[' + index + ']');
+                } else if (inputname.startsWith('item_param_type')) {
+                    $(this).attr('name', inputname.substring(0, 15) + '[' + index + ']');
+                } else if (inputname.startsWith('item_param_length')) {
+                    $(this).attr('name', inputname.substring(0, 17) + '[' + index + ']');
                     $(this).attr('id', 'item_param_length_' + index);
-                } else if (inputname.substr(0, 20) === 'item_param_opts_text') {
-                    $(this).attr('name', inputname.substr(0, 20) + '[' + index + ']');
-                } else if (inputname.substr(0, 19) === 'item_param_opts_num') {
-                    $(this).attr('name', inputname.substr(0, 19) + '[' + index + ']');
+                } else if (inputname.startsWith('item_param_opts_text')) {
+                    $(this).attr('name', inputname.substring(0, 20) + '[' + index + ']');
+                } else if (inputname.startsWith('item_param_opts_num')) {
+                    $(this).attr('name', inputname.substring(0, 19) + '[' + index + ']');
                 }
             });
             index++;
@@ -593,9 +593,9 @@ const DatabaseRoutines = {
             if (isSuccess) {
                 $(this).find(':input').each(function () {
                     inputname = $(this).attr('name');
-                    if (inputname.substr(0, 14) === 'item_param_dir' ||
-                        inputname.substr(0, 15) === 'item_param_name' ||
-                        inputname.substr(0, 15) === 'item_param_type') {
+                    if (inputname.startsWith('item_param_dir') ||
+                        inputname.startsWith('item_param_name') ||
+                        inputname.startsWith('item_param_type')) {
                         if ($(this).val() === '') {
                             $(this).trigger('focus');
                             isSuccess = false;
@@ -616,7 +616,7 @@ const DatabaseRoutines = {
             var $inputtyp = $(this).find('select[name^=item_param_type]');
             var $inputlen = $(this).find('input[name^=item_param_length]');
             if ($inputtyp.length && $inputlen.length) {
-                if (($inputtyp.val() === 'ENUM' || $inputtyp.val() === 'SET' || $inputtyp.val().substr(0, 3) === 'VAR') &&
+                if (($inputtyp.val() === 'ENUM' || $inputtyp.val() === 'SET' || $inputtyp.val().startsWith('VAR')) &&
                     $inputlen.val() === ''
                 ) {
                     $inputlen.trigger('focus');
@@ -634,7 +634,7 @@ const DatabaseRoutines = {
             // be set, if the type is SET, ENUM, VARCHAR or VARBINARY.
             var $returntyp = this.$ajaxDialog.find('select[name=item_returntype]');
             var $returnlen = this.$ajaxDialog.find('input[name=item_returnlength]');
-            if (($returntyp.val() === 'ENUM' || $returntyp.val() === 'SET' || $returntyp.val().substr(0, 3) === 'VAR') &&
+            if (($returntyp.val() === 'ENUM' || $returntyp.val() === 'SET' || $returntyp.val().startsWith('VAR')) &&
                 $returnlen.val() === ''
             ) {
                 $returnlen.trigger('focus');

--- a/js/src/designer/history.js
+++ b/js/src/designer/history.js
@@ -504,7 +504,7 @@ DesignerHistory.queryGroupBy = function () {
             str += '`' + historyArray[i].getColumnName() + '`, ';
         }
     }
-    str = str.substr(0, str.length - 2);
+    str = str.substring(0, str.length - 2);
     return str;
 };
 
@@ -529,7 +529,7 @@ DesignerHistory.queryHaving = function () {
     if (and === '(') {
         and = '';
     } else {
-        and = and.substr(0, and.length - 2) + ')';
+        and = and.substring(0, and.length - 2) + ')';
     }
     return and;
 };
@@ -549,7 +549,7 @@ DesignerHistory.queryOrderBy = function () {
                 historyArray[i].getObj().getOrder() + ', ';
         }
     }
-    str = str.substr(0, str.length - 2);
+    str = str.substring(0, str.length - 2);
     return str;
 };
 

--- a/js/src/designer/move.js
+++ b/js/src/designer/move.js
@@ -1569,7 +1569,7 @@ DesignerMove.hideTabAll = function (idThis) {
     var E = document.getElementById('container-form');
     var EelementsLength = E.elements.length;
     for (var i = 0; i < EelementsLength; i++) {
-        if (E.elements[i].type === 'checkbox' && E.elements[i].id.substring(0, 10) === 'check_vis_') {
+        if (E.elements[i].type === 'checkbox' && E.elements[i].id.startsWith('check_vis_')) {
             if (idThis.alt === 'v') {
                 E.elements[i].checked = true;
                 document.getElementById(E.elements[i].value).style.display = '';
@@ -1622,7 +1622,7 @@ DesignerMove.noHaveConstr = function (idThis) {
     var E = document.getElementById('container-form');
     var EelementsLength = E.elements.length;
     for (var i = 0; i < EelementsLength; i++) {
-        if (E.elements[i].type === 'checkbox' && E.elements[i].id.substring(0, 10) === 'check_vis_') {
+        if (E.elements[i].type === 'checkbox' && E.elements[i].id.startsWith('check_vis_')) {
             if (!DesignerMove.inArrayK(E.elements[i].value, a)) {
                 if (idThis.alt === 'v') {
                     E.elements[i].checked = true;

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -710,7 +710,7 @@ Functions.confirmQuery = function (theForm1, sqlQuery1) {
         doConfirmRegExp4.test(sqlQuery1)) {
         var message;
         if (sqlQuery1.length > 100) {
-            message = sqlQuery1.substr(0, 100) + '\n    ...';
+            message = sqlQuery1.substring(0, 100) + '\n    ...';
         } else {
             message = sqlQuery1;
         }
@@ -1374,8 +1374,8 @@ Functions.getJsConfirmCommonParam = function (elem, parameters) {
     var sep = CommonParams.get('arg_separator');
     if (params) {
         // Strip possible leading ?
-        if (params.substring(0,1) === '?') {
-            params = params.substr(1);
+        if (params.startsWith('?')) {
+            params = params.substring(1);
         }
         params += sep;
     } else {
@@ -4551,8 +4551,8 @@ Functions.configGet = function (key, cached, successCallback) {
 Functions.getPostData = function () {
     var dataPost = this.attr('data-post');
     // Strip possible leading ?
-    if (dataPost !== undefined && dataPost.substring(0,1) === '?') {
-        dataPost = dataPost.substr(1);
+    if (dataPost !== undefined && dataPost.startsWith('?')) {
+        dataPost = dataPost.substring(1);
     }
     return dataPost;
 };

--- a/js/src/gis_data_editor.js
+++ b/js/src/gis_data_editor.js
@@ -296,7 +296,7 @@ AJAX.registerOnload('gis_data_editor.js', function () {
         var $a = $(this);
         var name = $a.attr('name');
         // Eg. name = gis_data[0][MULTIPOINT][add_point] => prefix = gis_data[0][MULTIPOINT]
-        var prefix = name.substr(0, name.length - 11);
+        var prefix = name.substring(0, name.length - 11);
         // Find the number of points
         var $noOfPointsInput = $('input[name=\'' + prefix + '[no_of_points]' + '\']');
         var noOfPoints = parseInt($noOfPointsInput.val(), 10);
@@ -314,7 +314,7 @@ AJAX.registerOnload('gis_data_editor.js', function () {
         var name = $a.attr('name');
 
         // Eg. name = gis_data[0][MULTILINESTRING][add_line] => prefix = gis_data[0][MULTILINESTRING]
-        var prefix = name.substr(0, name.length - 10);
+        var prefix = name.substring(0, name.length - 10);
         var type = prefix.slice(prefix.lastIndexOf('[') + 1, prefix.lastIndexOf(']'));
 
         // Find the number of lines
@@ -349,7 +349,7 @@ AJAX.registerOnload('gis_data_editor.js', function () {
         var $a = $(this);
         var name = $a.attr('name');
         // Eg. name = gis_data[0][MULTIPOLYGON][add_polygon] => prefix = gis_data[0][MULTIPOLYGON]
-        var prefix = name.substr(0, name.length - 13);
+        var prefix = name.substring(0, name.length - 13);
         // Find the number of polygons
         var $noOfPolygonsInput = $('input[name=\'' + prefix + '[no_of_polygons]' + '\']');
         var noOfPolygons = parseInt($noOfPolygonsInput.val(), 10);

--- a/js/src/home.js
+++ b/js/src/home.js
@@ -12,13 +12,13 @@ const GitInfo = {
         // Parse possible alpha/beta/rc/
         const state = str.split('-');
         if (state.length >= 2) {
-            if (state[1].substr(0, 2) === 'rc') {
-                add = - 20 - parseInt(state[1].substr(2), 10);
-            } else if (state[1].substr(0, 4) === 'beta') {
-                add =  - 40 - parseInt(state[1].substr(4), 10);
-            } else if (state[1].substr(0, 5) === 'alpha') {
-                add =  - 60 - parseInt(state[1].substr(5), 10);
-            } else if (state[1].substr(0, 3) === 'dev') {
+            if (state[1].startsWith('rc')) {
+                add = - 20 - parseInt(state[1].substring(2), 10);
+            } else if (state[1].startsWith('beta')) {
+                add =  - 40 - parseInt(state[1].substring(4), 10);
+            } else if (state[1].startsWith('alpha')) {
+                add =  - 60 - parseInt(state[1].substring(5), 10);
+            } else if (state[1].startsWith('dev')) {
                 /* We don't handle dev, it's git snapshot */
                 add = 0;
             }

--- a/js/src/navigation.js
+++ b/js/src/navigation.js
@@ -447,7 +447,7 @@ $(function () {
     /** New index */
     $(document).on('click', '#pma_navigation_tree li.new_index a.ajax', function (event) {
         event.preventDefault();
-        var url = $(this).attr('href').substr(
+        var url = $(this).attr('href').substring(
             $(this).attr('href').indexOf('?') + 1
         ) + CommonParams.get('arg_separator') + 'ajax_request=true';
         var title = Messages.strAddIndex;
@@ -457,7 +457,7 @@ $(function () {
     /** Edit index */
     $(document).on('click', 'li.index a.ajax', function (event) {
         event.preventDefault();
-        var url = $(this).attr('href').substr(
+        var url = $(this).attr('href').substring(
             $(this).attr('href').indexOf('?') + 1
         ) + CommonParams.get('arg_separator') + 'ajax_request=true';
         var title = Messages.strEditIndex;

--- a/js/src/server/status/monitor.js
+++ b/js/src/server/status/monitor.js
@@ -89,7 +89,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
 
     $('a.popupLink').on('click', function () {
         var $link = $(this);
-        $('div.' + $link.attr('href').substr(1))
+        $('div.' + $link.attr('href').substring(1))
             .show()
             .offset({ top: $link.offset().top + $link.height() + 5, left: $link.offset().left })
             .addClass('openedPopup');
@@ -862,7 +862,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                     $dialog.find('img.ajaxIcon').hide();
                     $dialog.find('a.set').on('click', function () {
                         var nameValue = $(this).attr('href').split('-');
-                        loadLogVars({ varName: nameValue[0].substr(1), varValue: nameValue[1] });
+                        loadLogVars({ varName: nameValue[0].substring(1), varValue: nameValue[1] });
                         $dialog.find('img.ajaxIcon').show();
                     });
                 }

--- a/js/src/table/change.js
+++ b/js/src/table/change.js
@@ -319,7 +319,7 @@ function verificationsAfterFieldChange (urlField, multiEdit, theType) {
         });
     }
 
-    if (target.value === 'HEX' && theType.substring(0,3) === 'int') {
+    if (target.value === 'HEX' && theType.startsWith('int')) {
         // Add note when HEX function is selected on a int
         var newHexInfo = '<br><p id="note' +  target.id + '">' + Messages.HexConversionInfo + '</p>';
         if (!$('#note' + target.id).length) {
@@ -338,10 +338,10 @@ function verificationsAfterFieldChange (urlField, multiEdit, theType) {
     $('input[name=\'insert_ignore_' + multiEdit + '\']').prop('checked', false);
 
     var charExceptionHandling;
-    if (theType.substring(0,4) === 'char') {
-        charExceptionHandling = theType.substring(5,6);
-    } else if (theType.substring(0,7) === 'varchar') {
-        charExceptionHandling = theType.substring(8,9);
+    if (theType.startsWith('char')) {
+        charExceptionHandling = theType.substring(5, 6);
+    } else if (theType.startsWith('varchar')) {
+        charExceptionHandling = theType.substring(8, 9);
     }
     if (functionSelected) {
         $thisInput.removeAttr('min');
@@ -436,7 +436,7 @@ AJAX.registerOnload('table/change.js', function () {
         });
 
         jQuery.validator.addMethod('validationFunctionForMd5', function (value, element, options) {
-            return !(value.substring(0, 3) === 'MD5' &&
+            return !(value.startsWith('MD5') &&
                 typeof options.data('maxlength') !== 'undefined' &&
                 options.data('maxlength') < 32);
         });

--- a/js/src/table/chart.js
+++ b/js/src/table/chart.js
@@ -20,12 +20,12 @@ function extractDate (dateString) {
     matches = dateTimeRegExp.exec(dateString);
     if (matches !== null && matches.length > 0) {
         match = matches[0];
-        return new Date(match.substr(0, 4), parseInt(match.substr(5, 2), 10) - 1, match.substr(8, 2), match.substr(11, 2), match.substr(14, 2), match.substr(17, 2));
+        return new Date(match.substring(0, 4), parseInt(match.substring(5, 7), 10) - 1, match.substring(8, 10), match.substring(11, 13), match.substring(14, 16), match.substring(17, 19));
     } else {
         matches = dateRegExp.exec(dateString);
         if (matches !== null && matches.length > 0) {
             match = matches[0];
-            return new Date(match.substr(0, 4), parseInt(match.substr(5, 2), 10) - 1, match.substr(8, 2));
+            return new Date(match.substring(0, 4), parseInt(match.substring(5, 7), 10) - 1, match.substring(8, 10));
         }
     }
     return null;


### PR DESCRIPTION
String.prototype.substr() is deprecated (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) so we either switch to String.prototype.substring() or something else appropriate for the use case
Signed-off-by: Tobias Speicher <rootcommander@gmail.com>

### Description
This commit remove all usage of .substr() in the codebase (except in the vendored js files). The calls to substr() are either replaced with substring() which is a near replacement in most cases or other functions which are designed to be used in these use cases.


Fixes #
Removes deprecation warnings due to usage of .substr()

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
