### PR TITLE
Clear config storage params from session after failed access

### DIFF
--- a/test/classes/UserPreferencesTest.php
+++ b/test/classes/UserPreferencesTest.php
@@ -140,6 +140,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
      */
     public function testSave(): void
     {
+        $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['server'] = 2;
         $_SESSION['relation'][2]['PMA_VERSION'] = PMA_VERSION;
         $_SESSION['relation'][2]['userconfigwork'] = null;
@@ -251,7 +252,8 @@ class UserPreferencesTest extends AbstractNetworkTestCase
 
         $this->assertInstanceOf(Message::class, $result);
         $this->assertEquals(
-            'Could not save configuration<br><br>err1',
+            'Could not save configuration<br><br>err1'
+            . '<br><br>The phpMyAdmin configuration storage database could not be accessed.',
             $result->getMessage()
         );
     }


### PR DESCRIPTION
The issue happens when the config storage is deleted after a session is started. The error message will still appears, but only a single time, because the the config storage will be cleared from session, forcing phpMyAdmin to check it again.

- Fixes #17368