### PR TITLE
Fix broken escaping on Insert page

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -363,7 +363,6 @@ class InsertEdit
         array $commentsMap,
         $timestampSeen
     ) {
-        $column['Field_html'] = htmlspecialchars($column['Field']);
         $column['Field_md5'] = md5($column['Field']);
         // True_Type contains only the type (stops at first bracket)
         $column['True_Type'] = preg_replace('@\(.*@s', '', $column['Type']);
@@ -415,10 +414,10 @@ class InsertEdit
         if (isset($commentsMap[$column['Field']])) {
             return '<span style="border-bottom: 1px dashed black;" title="'
                 . htmlspecialchars($commentsMap[$column['Field']]) . '">'
-                . $column['Field_html'] . '</span>';
+                . htmlspecialchars($column['Field']) . '</span>';
         }
 
-        return $column['Field_html'];
+        return htmlspecialchars($column['Field']);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10411,11 +10411,6 @@ parameters:
 			path: test/classes/InsertEditTest.php
 
 		-
-			message: "#^Cannot access offset 'Field_html' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
 			message: "#^Cannot access offset 'Field_md5' on mixed\\.$#"
 			count: 1
 			path: test/classes/InsertEditTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7688,7 +7688,7 @@
     </MixedAssignment>
   </file>
   <file src="libraries/classes/InsertEdit.php">
-    <MixedArgument occurrences="85">
+    <MixedArgument occurrences="86">
       <code>$_POST['fields']['multi_edit']</code>
       <code>$_POST['fields']['multi_edit'][$rownumber][$key]</code>
       <code>$backupField</code>
@@ -7702,6 +7702,7 @@
       <code>$column['Extra']</code>
       <code>$column['Extra']</code>
       <code>$column['Extra']</code>
+      <code>$column['Field']</code>
       <code>$column['Field']</code>
       <code>$column['Field']</code>
       <code>$column['Field']</code>
@@ -7869,18 +7870,16 @@
       <code>$whereClause</code>
       <code>$whereClause</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
+    <MixedInferredReturnType occurrences="2">
       <code>int</code>
-      <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="2">
       <code>new $className()</code>
       <code>new $className()</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="10">
+    <MixedOperand occurrences="9">
       <code>$_POST['where_clause'][0]</code>
-      <code>$column['Field_html']</code>
       <code>$column['pma_type']</code>
       <code>$file</code>
       <code>$maxlength</code>
@@ -7890,9 +7889,8 @@
       <code>$multiEditFuncs[$key]</code>
       <code>$whereClause</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="3">
+    <MixedReturnStatement occurrences="2">
       <code>$_POST['err_url']</code>
-      <code>$column['Field_html']</code>
     </MixedReturnStatement>
     <PossiblyNullArgument occurrences="2">
       <code>$newValue</code>
@@ -15109,9 +15107,8 @@
       <code>$result</code>
       <code>$result</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="11">
+    <MixedArrayAccess occurrences="10">
       <code>$result['Field']</code>
-      <code>$result['Field_html']</code>
       <code>$result['Field_md5']</code>
       <code>$result['Field_title']</code>
       <code>$result['True_Type']</code>

--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -1,7 +1,7 @@
 <tr class="noclick">
   <td class="text-center">
-    {{ column.Field_title }}
-    <input type="hidden" name="fields_name[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ column.Field_html }}">
+    {{ column.Field_title|raw }}
+    <input type="hidden" name="fields_name[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ column.Field }}">
   </td>
 
   {% if show_field_types_in_data_edit_view %}

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -473,8 +473,6 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $this->assertEquals($result['Field_html'], '1&lt;2');
-
         $this->assertEquals($result['Field_md5'], '4342210df36bf2ff2c4e2a997a6d4089');
 
         $this->assertEquals($result['True_Type'], 'float');
@@ -503,7 +501,6 @@ class InsertEditTest extends AbstractTestCase
     {
         $column = [];
         $column['Field'] = 'f1<';
-        $column['Field_html'] = 'f1&lt;';
 
         $this->assertEquals(
             $this->callFunction(


### PR DESCRIPTION
I have started working on fixing all escaping issues some time ago but then I got busy with other stuff and I never finished it. Here's another small fix. This time it is the Insert page that mangled up the HTML for fields with `"'<>&`.

I'll slowly chip away at the rest of the issues as I can still see plenty. 