### PR TITLE
getDbInfo mangles table with numerical names

### DIFF
--- a/libraries/classes/Controllers/Database/Operations/CollationController.php
+++ b/libraries/classes/Controllers/Database/Operations/CollationController.php
@@ -68,7 +68,7 @@ final class CollationController extends AbstractController
          */
         if (isset($_POST['change_all_tables_collations']) && $_POST['change_all_tables_collations'] === 'on') {
             [$tables] = Util::getDbInfo($db, '');
-            foreach ($tables as $tableName => $data) {
+            foreach ($tables as ['Name' => $tableName]) {
                 if ($this->dbi->getTable($db, $tableName)->isView()) {
                     // Skip views, we can not change the collation of a view.
                     // issue #15283

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2271,18 +2271,16 @@ class Util
                 }
             }
 
-            $tables = array_merge(
-                $groupTable,
-                $dbi->getTablesFull(
-                    $db,
-                    $groupWithSeparator !== false ? $groupWithSeparator : '',
-                    $groupWithSeparator !== false,
-                    $limitOffset,
-                    $limitCount,
-                    $sort,
-                    $sortOrder,
-                    $tableType
-                )
+            // We must use union operator here instead of array_merge to preserve numerical keys
+            $tables = $groupTable + $dbi->getTablesFull(
+                $db,
+                $groupWithSeparator !== false ? $groupWithSeparator : '',
+                $groupWithSeparator !== false,
+                $limitOffset,
+                $limitCount,
+                $sort,
+                $sortOrder,
+                $tableType
             );
         }
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1262,16 +1262,15 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>['db' =&gt; $db]</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="2">
-      <code>$data</code>
+    <MixedArrayAccess occurrences="1">
       <code>$tableName</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>['Name' =&gt; $tableName]</code>
     </MixedAssignment>
     <PossiblyNullArgument occurrences="1">
       <code>$_POST['db_collation']</code>
     </PossiblyNullArgument>
-    <UnusedForeachValue occurrences="1">
-      <code>$data</code>
-    </UnusedForeachValue>
   </file>
   <file src="libraries/classes/Controllers/Database/OperationsController.php">
     <MixedArgument occurrences="10">


### PR DESCRIPTION
When tables have numerical keys `array_merge` will reindex the array keys and then we can't process them for example when changing table collations in bulk. Additionally, PHP arrays are ... strange, and when working with mixed numerical and string keys, they will cast numerical keys to int, so to avoid fatal error due to invalid parameter type, we simply don't use keys. The table names are available in the array structure anyway. 