### PR TITLE
Incorrect usage of escapeMysqlWildcards

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -55,6 +55,7 @@ use function strncmp;
 use function strpos;
 use function strtolower;
 use function strtoupper;
+use function strtr;
 use function substr;
 use function syslog;
 use function trigger_error;
@@ -490,9 +491,7 @@ class DatabaseInterface implements DbalInterface
                                 ) . '\')';
                         } else {
                             $sql .= " `Name` LIKE '"
-                                . Util::escapeMysqlWildcards(
-                                    $this->escapeString($table, $link)
-                                )
+                                . $this->escapeMysqlLikeString($table, $link)
                                 . "%'";
                         }
                         $needAnd = true;
@@ -904,7 +903,7 @@ class DatabaseInterface implements DbalInterface
         $sql = QueryGenerator::getColumnsSql(
             $database,
             $table,
-            $column === null ? null : Util::escapeMysqlWildcards($this->escapeString($column)),
+            $column === null ? null : $this->escapeMysqlLikeString($column),
             $full
         );
         $fields = $this->fetchResult($sql, 'Field', null, $link);
@@ -2320,6 +2319,19 @@ class DatabaseInterface implements DbalInterface
         }
 
         return $this->extension->escapeString($this->links[$link], $str);
+    }
+
+    /**
+     * returns properly escaped string for use in MySQL LIKE clauses
+     *
+     * @param string $str  string to be escaped
+     * @param int    $link optional database link to use
+     *
+     * @return string a MySQL escaped LIKE string
+     */
+    public function escapeMysqlLikeString(string $str, int $link = self::CONNECT_USER)
+    {
+        return $this->escapeString(strtr($str, ['\\' => '\\\\', '_' => '\\_', '%' => '\\%']), $link);
     }
 
     /**

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -722,6 +722,16 @@ interface DbalInterface
     public function escapeString(string $str, $link = DatabaseInterface::CONNECT_USER);
 
     /**
+     * returns properly escaped string for use in MySQL LIKE clauses
+     *
+     * @param string $str  string to be escaped
+     * @param int    $link optional database link to use
+     *
+     * @return string a MySQL escaped LIKE string
+     */
+    public function escapeMysqlLikeString(string $str, int $link = DatabaseInterface::CONNECT_USER);
+
+    /**
      * Checks if this database server is running on Amazon RDS.
      */
     public function isAmazonRds(): bool;

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -3530,9 +3530,7 @@ class Privileges
         if (isset($_POST['createdb-1'])) {
             // Create database with same name and grant all privileges
             $q = 'CREATE DATABASE IF NOT EXISTS '
-                . Util::backquote(
-                    $this->dbi->escapeString($username)
-                ) . ';';
+                . Util::backquote($username) . ';';
             $sql_query .= $q;
             if (! $this->dbi->tryQuery($q)) {
                 $message = Message::rawError((string) $this->dbi->getError());
@@ -3546,9 +3544,7 @@ class Privileges
 
             $q = 'GRANT ALL PRIVILEGES ON '
                 . Util::backquote(
-                    Util::escapeMysqlWildcards(
-                        $this->dbi->escapeString($username)
-                    )
+                    Util::escapeMysqlWildcards($username)
                 ) . '.* TO \''
                 . $this->dbi->escapeString($username)
                 . '\'@\'' . $this->dbi->escapeString($hostname) . '\';';
@@ -3562,9 +3558,7 @@ class Privileges
             // Grant all privileges on wildcard name (username\_%)
             $q = 'GRANT ALL PRIVILEGES ON '
                 . Util::backquote(
-                    Util::escapeMysqlWildcards(
-                        $this->dbi->escapeString($username)
-                    ) . '\_%'
+                    Util::escapeMysqlWildcards($username) . '\_%'
                 ) . '.* TO \''
                 . $this->dbi->escapeString($username)
                 . '\'@\'' . $this->dbi->escapeString($hostname) . '\';';

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2885,8 +2885,8 @@ class Util
             $tblGroupSql = '';
             $whereAdded = false;
             if (Core::isValid($_REQUEST['tbl_group'])) {
-                $group = self::escapeMysqlWildcards($_REQUEST['tbl_group']);
-                $groupWithSeparator = self::escapeMysqlWildcards(
+                $group = $dbi->escapeMysqlLikeString($_REQUEST['tbl_group']);
+                $groupWithSeparator = $dbi->escapeMysqlLikeString(
                     $_REQUEST['tbl_group']
                     . $GLOBALS['cfg']['NavigationTreeTableSeparator']
                 );

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -1714,7 +1714,7 @@ class DbiDummy implements DbiExtension
                 'result' => [],
             ],
             [
-                'query'  => "SHOW TABLE STATUS FROM `my_dataset` WHERE `Name` LIKE 'company\_users%'",
+                'query'  => "SHOW TABLE STATUS FROM `my_dataset` WHERE `Name` LIKE 'company\\\\_users%'",
                 'result' => [],
             ],
             [
@@ -2328,7 +2328,7 @@ class DbiDummy implements DbiExtension
                 'result' => [['1']],
             ],
             [
-                'query' => 'SHOW TABLE STATUS FROM `PMA_db` WHERE `Name` LIKE \'PMA\_table%\'',
+                'query' => 'SHOW TABLE STATUS FROM `PMA_db` WHERE `Name` LIKE \'PMA\\\\_table%\'',
                 'columns' => ['Name'],
                 'result' => [['PMA_table']],
             ],
@@ -2382,7 +2382,7 @@ class DbiDummy implements DbiExtension
                 ],
             ],
             [
-                'query' => 'SHOW FULL COLUMNS FROM `testdb`.`mytable` LIKE \'\_id\'',
+                'query' => 'SHOW FULL COLUMNS FROM `testdb`.`mytable` LIKE \'\\\\_id\'',
                 'columns' => ['Field', 'Type', 'Collation', 'Null', 'Key', 'Default', 'Extra', 'Privileges', 'Comment'],
                 'result' => [
                     [
@@ -2514,7 +2514,7 @@ class DbiDummy implements DbiExtension
                 'result' => [],
             ],
             [
-                'query' => 'SHOW TABLE STATUS FROM `my_db` WHERE `Name` LIKE \'test\_tbl%\'',
+                'query' => 'SHOW TABLE STATUS FROM `my_db` WHERE `Name` LIKE \'test\\\\_tbl%\'',
                 'result' => [],
             ],
             [


### PR DESCRIPTION
I observed a bug when a column name is named `\'column` and you would like to change it, the application can't find a column with that name. 

The phpdoc clearly states that `escapeMysqlWildcards()` does not escape backslashes. However, backslashes are the default escaping mechanism in `LIKE` queries which means that this function is unsuitable to be used in `LIKE` escaping. `escapeMysqlWildcards` can only be used in statements like `GRANT` where the escaping mechanism seems to not care about a backslash. 

When I observed this bug in phpMyAdmin at first I was confused and [asked on Stack Overflow](https://stackoverflow.com/questions/71024061/show-column-escaping-mechanism). The proper escaping for LIKE should be:
1. Escape the following three characters `_%\` with a backslash `\`. 
2. Perform the usual string escaping if the value is interpolated into SQL or use parameter binding with prepared statements.

This means that in certain places, the escaping was not performed correctly and in fact, the bug I observed was fixed by introducing a proper escaping mechanism.  

This led me to investigate why `escapeMysqlWildcards` belongs to `Util` class and not `Privilege` class. I then noticed that there's another issue with incorrect escaping when creating a user with a database. In the end, I couldn't move the method to the `Privilege` class as there's one more incorrect usage in `Generator`. 