### PR TITLE
Refactor ExportSql::exportData()

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -2122,13 +2122,13 @@ class DatabaseInterface implements DbalInterface
      *
      * @return string a MySQL escaped string
      */
-    public function escapeString(string $str, $link = self::CONNECT_USER)
+    public function escapeString(string $str, $link = self::CONNECT_USER): string
     {
-        if ($this->extension === null || ! isset($this->links[$link])) {
-            return $str;
+        if (isset($this->links[$link])) {
+            return $this->extension->escapeString($this->links[$link], $str);
         }
 
-        return $this->extension->escapeString($this->links[$link], $str);
+        return $str;
     }
 
     /**

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -632,7 +632,7 @@ interface DbalInterface
      *
      * @return string a MySQL escaped string
      */
-    public function escapeString(string $str, $link = DatabaseInterface::CONNECT_USER);
+    public function escapeString(string $str, $link = DatabaseInterface::CONNECT_USER): string;
 
     /**
      * returns properly escaped string for use in MySQL LIKE clauses

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -2415,7 +2415,7 @@ class ExportSql extends ExportPlugin
                     $insertLine = '(' . implode(', ', $values) . ')';
                     $insertLineSize = mb_strlen($insertLine);
                     $sqlMaxSize = $GLOBALS['sql_max_query_size'];
-                    if (isset($sqlMaxSize) && $sqlMaxSize > 0 && $querySize + $insertLineSize > $sqlMaxSize) {
+                    if ($sqlMaxSize > 0 && $querySize + $insertLineSize > $sqlMaxSize) {
                         if (! $this->export->outputHandler(';' . $crlf)) {
                             return false;
                         }

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -1285,12 +1285,10 @@ class ExportSql extends ExportPlugin
     /**
      * Returns CREATE definition that matches $view's structure
      *
-     * @param string $db           the database name
-     * @param string $view         the view name
-     * @param string $crlf         the end of line sequence
-     * @param bool   $addSemicolon whether to add semicolon and end-of-line at
-     *                              the end
-     * @param array  $aliases      Aliases of db/table/columns
+     * @param string $db      the database name
+     * @param string $view    the view name
+     * @param string $crlf    the end of line sequence
+     * @param array  $aliases Aliases of db/table/columns
      *
      * @return string resulting schema
      */
@@ -1298,7 +1296,6 @@ class ExportSql extends ExportPlugin
         $db,
         $view,
         $crlf,
-        $addSemicolon = true,
         array $aliases = []
     ) {
         $dbAlias = $db;
@@ -1353,7 +1350,7 @@ class ExportSql extends ExportPlugin
             $firstCol = false;
         }
 
-        $createQuery .= $crlf . ')' . ($addSemicolon ? ';' : '') . $crlf;
+        $createQuery .= $crlf . ');' . $crlf;
 
         $compat = $GLOBALS['sql_compatibility'] ?? 'NONE';
 
@@ -2118,7 +2115,7 @@ class ExportSql extends ExportPlugin
                         . Util::backquote($tableAlias) . ';' . $crlf;
                     }
 
-                    $dump .= $this->getTableDefForView($db, $table, $crlf, true, $aliases);
+                    $dump .= $this->getTableDefForView($db, $table, $crlf, $aliases);
                 }
 
                 break;

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -840,11 +840,7 @@ class ExportSql extends ExportPlugin
             $dbAlias = $db;
         }
 
-        if (isset($GLOBALS['sql_compatibility'])) {
-            $compat = $GLOBALS['sql_compatibility'];
-        } else {
-            $compat = 'NONE';
-        }
+        $compat = $GLOBALS['sql_compatibility'] ?? 'NONE';
 
         if (isset($GLOBALS['sql_drop_database'])) {
             if (
@@ -928,11 +924,7 @@ class ExportSql extends ExportPlugin
             $dbAlias = $db;
         }
 
-        if (isset($GLOBALS['sql_compatibility'])) {
-            $compat = $GLOBALS['sql_compatibility'];
-        } else {
-            $compat = 'NONE';
-        }
+        $compat = $GLOBALS['sql_compatibility'] ?? 'NONE';
 
         $head = $this->exportComment()
             . $this->exportComment(
@@ -1363,11 +1355,7 @@ class ExportSql extends ExportPlugin
 
         $createQuery .= $crlf . ')' . ($addSemicolon ? ';' : '') . $crlf;
 
-        if (isset($GLOBALS['sql_compatibility'])) {
-            $compat = $GLOBALS['sql_compatibility'];
-        } else {
-            $compat = 'NONE';
-        }
+        $compat = $GLOBALS['sql_compatibility'] ?? 'NONE';
 
         if ($compat === 'MSSQL') {
             $createQuery = $this->makeCreateTableMSSQLCompatible($createQuery);
@@ -1422,11 +1410,7 @@ class ExportSql extends ExportPlugin
         $schemaCreate = '';
         $newCrlf = $crlf;
 
-        if (isset($GLOBALS['sql_compatibility'])) {
-            $compat = $GLOBALS['sql_compatibility'];
-        } else {
-            $compat = 'NONE';
-        }
+        $compat = $GLOBALS['sql_compatibility'] ?? 'NONE';
 
         $result = $GLOBALS['dbi']->tryQuery(
             'SHOW TABLE STATUS FROM ' . Util::backquote($db)
@@ -2046,11 +2030,7 @@ class ExportSql extends ExportPlugin
         $dbAlias = $db;
         $tableAlias = $table;
         $this->initAlias($aliases, $dbAlias, $tableAlias);
-        if (isset($GLOBALS['sql_compatibility'])) {
-            $compat = $GLOBALS['sql_compatibility'];
-        } else {
-            $compat = 'NONE';
-        }
+        $compat = $GLOBALS['sql_compatibility'] ?? 'NONE';
 
         $formattedTableName = Util::backquoteCompat($tableAlias, $compat, isset($GLOBALS['sql_backquotes']));
         $dump = $this->possibleCRLF()

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -947,8 +947,6 @@ class ExportSql extends ExportPlugin
      */
     public function exportDBFooter($db): bool
     {
-        $GLOBALS['crlf'] = $GLOBALS['crlf'] ?? null;
-
         $result = true;
 
         //add indexes to the sql dump file

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5743,9 +5743,6 @@
     </PossiblyNullReference>
   </file>
   <file src="libraries/classes/DatabaseInterface.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>$this-&gt;extension === null</code>
-    </DocblockTypeContradiction>
     <EmptyArrayAccess occurrences="1">
       <code>$resultTarget[]</code>
     </EmptyArrayAccess>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10024,8 +10024,10 @@
       <code>$oneKey['ref_index_list'][$index]</code>
       <code>$values[$val]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="37">
-      <code>$GLOBALS['current_row']</code>
+    <MixedArrayTypeCoercion occurrences="1">
+      <code>$row[$j]</code>
+    </MixedArrayTypeCoercion>
+    <MixedAssignment occurrences="36">
       <code>$GLOBALS['sql_auto_increments']</code>
       <code>$GLOBALS['sql_backquotes']</code>
       <code>$GLOBALS['sql_backquotes']</code>
@@ -10132,9 +10134,7 @@
     <PropertyTypeCoercion occurrences="1">
       <code>$field-&gt;key-&gt;columns</code>
     </PropertyTypeCoercion>
-    <RedundantCastGivenDocblockType occurrences="3">
-      <code>(int) $fieldsMeta[$j]-&gt;length</code>
-      <code>(string) $createQuery</code>
+    <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $table</code>
     </RedundantCastGivenDocblockType>
     <RedundantCondition occurrences="1">

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -740,12 +740,12 @@ class ExportSqlTest extends AbstractTestCase
             );
         $GLOBALS['dbi'] = $dbi;
 
-        $result = $method->invoke($this->object, 'db', 'view', "\n", false);
+        $result = $method->invoke($this->object, 'db', 'view', "\n");
 
         $this->assertEquals(
             "CREATE TABLE IF NOT EXISTS `view`(\n" .
             "    `fname` char COLLATE utf-8 DEFAULT NULL COMMENT 'cmt'\n" .
-            ")\n",
+            ");\n",
             $result
         );
     }

--- a/test/classes/TrackerTest.php
+++ b/test/classes/TrackerTest.php
@@ -500,14 +500,17 @@ class TrackerTest extends AbstractTestCase
                     [
                         [
                             "pma'db",
+                            DatabaseInterface::CONNECT_USER,
                             "pma\'db",
                         ],
                         [
                             "pma'table",
+                            DatabaseInterface::CONNECT_USER,
                             "pma\'table",
                         ],
                         [
                             '1.0',
+                            DatabaseInterface::CONNECT_USER,
                             '1.0',
                         ],
                     ]


### PR DESCRIPTION
This refactoring has started as a search for optimizations in that method, but I was not able to find any. The few opcodes less won't make any difference even with large exports. 

@williamdes I was not able to get results similar to yours. The method `escapeString` takes only about 5% execution time with 40k rows exported with a single varchar column. With more text columns this ratio will grow of course, but that is expected. I see nothing wrong with this method. Perhaps, you have executed a different scenario than me? To be honest, I don't think the profilers are showing accurate results... I don't know if it's just for me though. 

Ref: #16005 