### PR TITLE
Handle connection errors with Exception instead of warnings

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5612,10 +5612,8 @@
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Dbal/DbiMysqli.php">
-    <MixedArgument occurrences="9">
+    <MixedArgument occurrences="7">
       <code>$host</code>
-      <code>$host</code>
-      <code>$server['port']</code>
       <code>$server['port']</code>
       <code>$server['ssl_ca'] ?? ''</code>
       <code>$server['ssl_ca_path'] ?? ''</code>


### PR DESCRIPTION
Sets the [MySQLi error reporting mode](https://www.php.net/manual/en/mysqli-driver.report-mode.php) to exception for connections and disables it afterwards.

If an error occurs, catches it and then use `trigger_error` to simulate the previous behavior.

Since this is the new PHP default, the idea is to enable exceptions incrementally, also to ensure that all exceptions are being caught.