### PR TITLE
Fix create index form accepting too many columns

### DIFF
--- a/templates/table/structure/display_structure.twig
+++ b/templates/table/structure/display_structure.twig
@@ -505,7 +505,7 @@
         {{ get_hidden_inputs(db, table) }}
         <input type="hidden" name="create_index" value="1">
 
-        {% apply format('<input class="mx-2" type="number" name="added_fields" value="1" min="1" required>')|raw %}
+        {% apply format('<input class="mx-2" type="number" name="added_fields" value="1" min="1" max="16" required>')|raw %}
           {% trans %}Create an index on %s columns{% endtrans %}
         {% endapply %}
 


### PR DESCRIPTION
From [Multiple-Column Indexes (MySQL 5.6 Reference Manual)](https://dev.mysql.com/doc/refman/5.6/en/multiple-column-indexes.html):
> An index may consist of up to 16 columns.

- Fixes #16769
