### PR TITLE
Add better error handling when IndexedDB is not working

### DIFF
--- a/js/src/designer/database.js
+++ b/js/src/designer/database.js
@@ -46,10 +46,17 @@ var DesignerOfflineDB = (function () {
             }
         };
 
-        request.onerror = designerDB.onerror;
+        request.onerror = function () {
+            Functions.ajaxShowMessage(Messages.strIndexedDBNotWorking, null, 'error');
+        };
     };
 
     designerDB.loadObject = function (table, id, callback) {
+        if (datastore === null) {
+            Functions.ajaxShowMessage(Messages.strIndexedDBNotWorking, null, 'error');
+            return;
+        }
+
         var db = datastore;
         var transaction = db.transaction([table], 'readwrite');
         var objStore = transaction.objectStore(table);
@@ -63,6 +70,11 @@ var DesignerOfflineDB = (function () {
     };
 
     designerDB.loadAllObjects = function (table, callback) {
+        if (datastore === null) {
+            Functions.ajaxShowMessage(Messages.strIndexedDBNotWorking, null, 'error');
+            return;
+        }
+
         var db = datastore;
         var transaction = db.transaction([table], 'readwrite');
         var objStore = transaction.objectStore(table);
@@ -87,6 +99,11 @@ var DesignerOfflineDB = (function () {
     };
 
     designerDB.loadFirstObject = function (table, callback) {
+        if (datastore === null) {
+            Functions.ajaxShowMessage(Messages.strIndexedDBNotWorking, null, 'error');
+            return;
+        }
+
         var db = datastore;
         var transaction = db.transaction([table], 'readwrite');
         var objStore = transaction.objectStore(table);
@@ -110,6 +127,11 @@ var DesignerOfflineDB = (function () {
     };
 
     designerDB.addObject = function (table, obj, callback) {
+        if (datastore === null) {
+            Functions.ajaxShowMessage(Messages.strIndexedDBNotWorking, null, 'error');
+            return;
+        }
+
         var db = datastore;
         var transaction = db.transaction([table], 'readwrite');
         var objStore = transaction.objectStore(table);
@@ -125,6 +147,11 @@ var DesignerOfflineDB = (function () {
     };
 
     designerDB.deleteObject = function (table, id, callback) {
+        if (datastore === null) {
+            Functions.ajaxShowMessage(Messages.strIndexedDBNotWorking, null, 'error');
+            return;
+        }
+
         var db = datastore;
         var transaction = db.transaction([table], 'readwrite');
         var objStore = transaction.objectStore(table);

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -2262,7 +2262,7 @@ Functions.ajaxShowMessage = function (message, timeout, type) {
         selfClosing = false;
     }
     // Figure out whether (or after how long) to remove the notification
-    if (newTimeOut === undefined) {
+    if (newTimeOut === undefined || newTimeOut === null) {
         newTimeOut = 5000;
     } else if (newTimeOut === false) {
         selfClosing = false;

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -726,6 +726,10 @@ final class JavaScriptMessagesController
             'strU2FErrorAuthenticate' => _pgettext('U2F error', 'Invalid security key.'),
 
             /* Designer */
+            'strIndexedDBNotWorking' => __(
+                'You can not open, save or delete your page layout, as IndexedDB is not working'
+                . ' in your browser and your phpMyAdmin configuration storage is not configured for this.'
+            ),
             'strTableAlreadyExists' => _pgettext(
                 'The table already exists in the designer and can not be added once more.',
                 'Table %s already exists!'


### PR DESCRIPTION
When the phpMyAdmin configuration storage does not have `table_coords` and `pdf_pages` properly configured, the Database Designer uses the [IndexedDB API](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) to save the page layout.

But when IndexedDB is not working (Firefox in private window, for example), errors will be thrown when trying to work with pages. So this pull request fixes this issue by handling these errors.

- Fixes #16853

