### PR TITLE
Improve mutation tests workflow

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -1,34 +1,38 @@
+# https://docs.github.com/en/actions
+
 name: Mutation tests
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+    paths:
+      - '*/classes/**.php'
   pull_request:
-    branches: [master]
+    branches:
+      - master
+    paths:
+      - '*/classes/**.php'
 
 permissions:
   contents: read
 
 jobs:
-  tests:
-    name: Mutation tests with PHP ${{ matrix.php-version }}
+  infection:
+    name: Infection
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        php-version: ["8.0"]
-        operating-system: [ubuntu-latest]
+        php-version:
+          - "8.1"
+        operating-system:
+          - ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Fetch github.base_ref (for diffing)
-        if: ${{ github.base_ref != '' }}
-        run: |
-          git fetch --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-
       - name: Install Gettext
-        run: |
-          sudo apt-get install -y gettext
+        run: sudo apt-get install -y gettext
 
       - name: Generate mo files
         run: ./scripts/generate-mo --quiet
@@ -43,31 +47,26 @@ jobs:
 
       - name: Install Infection
         # The GPG key can be found at https://infection.github.io/guide/installation.html
-        run: |
-          phive --no-progress install --target ./build/tools --trust-gpg-keys C5095986493B4AA0 infection
+        run: phive --no-progress install --target ./build/tools --trust-gpg-keys C5095986493B4AA0 infection
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           dependency-versions: highest
 
       - name: Collect coverage report
-        run: |
-          composer run phpunit -- --testsuite unit --stop-on-failure
+        run: composer run phpunit -- --testsuite unit --stop-on-failure
 
-      - name: Infection
-        if: ${{ github.base_ref != '' }}
+      - name: Run Infection for changed files only
+        if: github.event_name == 'pull_request'
         run: |
-          CHANGED_FILES=$(git diff origin/$GITHUB_BASE_REF --diff-filter=AM --name-only | grep libraries/classes/ | paste -sd "," -);
-          ./build/tools/infection -j$(nproc) --skip-initial-tests --no-interaction --no-progress --coverage=build/logs \
-            --ignore-msi-with-no-mutations \
-            --filter=$CHANGED_FILES
+          git fetch --depth=1 origin $GITHUB_BASE_REF
+          ./build/tools/infection -j$(nproc) --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF \
+            --logger-github --ignore-msi-with-no-mutations --only-covered \
+            --skip-initial-tests --coverage=build/logs --no-interaction --no-progress
+
+      - name: Run Infection
+        if: github.event_name == 'push'
         env:
           INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
-
-      - name: Infection
-        if: ${{ github.base_ref == '' }}
-        run: |
-          ./build/tools/infection -j$(nproc) --skip-initial-tests --no-interaction --no-progress --coverage=build/logs
-        env:
-          INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
+        run: ./build/tools/infection -j$(nproc) --skip-initial-tests --coverage=build/logs --no-interaction --no-progress

--- a/libraries/classes/Controllers/Table/RecentFavoriteController.php
+++ b/libraries/classes/Controllers/Table/RecentFavoriteController.php
@@ -8,6 +8,8 @@ use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Controllers\Sql\SqlController;
 use PhpMyAdmin\RecentFavoriteTable;
 
+use function is_string;
+
 /**
  * Browse recent and favorite tables chosen from navigation.
  */
@@ -17,9 +19,11 @@ class RecentFavoriteController extends AbstractController
     {
         $GLOBALS['containerBuilder'] = $GLOBALS['containerBuilder'] ?? null;
 
-        RecentFavoriteTable::getInstance('recent')->removeIfInvalid($_REQUEST['db'], $_REQUEST['table']);
+        $db = isset($_REQUEST['db']) && is_string($_REQUEST['db']) ? $_REQUEST['db'] : '';
+        $table = isset($_REQUEST['table']) && is_string($_REQUEST['table']) ? $_REQUEST['table'] : '';
 
-        RecentFavoriteTable::getInstance('favorite')->removeIfInvalid($_REQUEST['db'], $_REQUEST['table']);
+        RecentFavoriteTable::getInstance('recent')->removeIfInvalid($db, $table);
+        RecentFavoriteTable::getInstance('favorite')->removeIfInvalid($db, $table);
 
         /** @var SqlController $controller */
         $controller = $GLOBALS['containerBuilder']->get(SqlController::class);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3556,12 +3556,6 @@
     </MixedArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/RecentFavoriteController.php">
-    <MixedArgument occurrences="4">
-      <code>$_REQUEST['db']</code>
-      <code>$_REQUEST['db']</code>
-      <code>$_REQUEST['table']</code>
-      <code>$_REQUEST['table']</code>
-    </MixedArgument>
     <PossiblyNullReference occurrences="1">
       <code>get</code>
     </PossiblyNullReference>


### PR DESCRIPTION
- Runs only if has changes in `'*/classes/**.php'` files.
- Runs full test for `push`.
- Runs only for changed files for `pull_request`.
- Adds GitHub Annotations for pull requests
- Removes the [unnecessary checks for `[ci skip]`](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/).
- Adds a commit that changes a PHP file to test the workflow.
