### PR TITLE
Allow removing DEFINER clause from exported SQL

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -2729,6 +2729,15 @@ Export and import settings
 
     .. seealso:: :ref:`faq6_27`
 
+.. config:option:: $cfg['Export']['removeDefinerFromDefinitions']
+
+    :type: boolean
+    :default: false
+
+    Remove DEFINER clause from the event, view and routine definitions.
+
+    .. versionadded:: 5.1.4
+
 .. config:option:: $cfg['Import']
 
     :type: array

--- a/libraries/classes/Config/Descriptions.php
+++ b/libraries/classes/Config/Descriptions.php
@@ -707,6 +707,7 @@ class Descriptions
             'Export_quick_export_onserver_name' => __('Save on server'),
             'Export_quick_export_onserver_overwrite_name' => __('Overwrite existing file(s)'),
             'Export_remember_file_template_name' => __('Remember filename template'),
+            'Export_removeDefinerFromDefinitions_name' => __('Remove Definer clause from definitions'),
             'Export_sql_auto_increment_name' => __('Add AUTO_INCREMENT value'),
             'Export_sql_backquotes_name' => __('Enclose table and column names with backquotes'),
             'Export_sql_compatibility_name' => __('SQL compatibility mode'),

--- a/libraries/classes/Config/Settings/Export.php
+++ b/libraries/classes/Config/Settings/Export.php
@@ -469,6 +469,9 @@ final class Export
      */
     public $yaml_structure_or_data;
 
+    /** @var bool */
+    public $remove_definer_clause;
+
     /**
      * @param array<int|string, mixed> $export
      */
@@ -582,6 +585,7 @@ final class Export
         $this->xml_export_views = $this->setXmlExportViews($export);
         $this->xml_export_contents = $this->setXmlExportContents($export);
         $this->yaml_structure_or_data = $this->setYamlStructureOrData($export);
+        $this->remove_definer_clause = $this->setRemoveDefinerClause($export);
     }
 
     /**
@@ -2007,5 +2011,17 @@ final class Export
         }
 
         return $export['yaml_structure_or_data'];
+    }
+
+    /**
+     * @param array<int|string, mixed> $export
+     */
+    private function setRemoveDefinerClause(array $export): string
+    {
+        if (! isset($export['removeDefinerFromDefinitions'])) {
+            return false;
+        }
+
+        return (bool) $export['removeDefinerFromDefinitions'];
     }
 }

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -557,6 +557,10 @@ class ExportSql extends ExportPlugin
                 '',
                 $flag
             );
+            if ($GLOBALS['cfg']['Export']['removeDefinerFromDefinitions']) {
+                // Remove definer clause from routine definitions
+                $createQuery = preg_replace('/ DEFINER=`[a-zA-Z0-9_\.]*`@`.*?` /', ' ', $createQuery);
+            }
             // One warning per database
             if ($flag) {
                 $usedAlias = true;
@@ -995,8 +999,12 @@ class ExportSql extends ExportPlugin
                         . $delimiter . $GLOBALS['crlf'];
                 }
 
-                $text .= $GLOBALS['dbi']->getDefinition($db, 'EVENT', $eventName)
-                    . $delimiter . $GLOBALS['crlf'] . $GLOBALS['crlf'];
+                $eventDef = $GLOBALS['dbi']->getDefinition($db, 'EVENT', $eventName);
+                if ($GLOBALS['cfg']['Export']['removeDefinerFromDefinitions']) {
+                    // remove definer clause from the event definition
+                    $eventDef = preg_replace('/ DEFINER=`[a-zA-Z0-9\.]*`@`.*?` /', ' ', $eventDef);
+                }
+                $text .= $eventDef . $delimiter . $GLOBALS['crlf'] . $GLOBALS['crlf'];
             }
 
             $text .= 'DELIMITER ;' . $GLOBALS['crlf'];
@@ -1523,6 +1531,10 @@ class ExportSql extends ExportPlugin
              * statement.
              */
             if ($view) {
+                if ($GLOBALS['cfg']['Export']['removeDefinerFromDefinitions']) {
+                    // Remove definer clause from view definition
+                    $createQuery = preg_replace('/ DEFINER=`[a-zA-Z0-9_\.]*`@`.*?` /', ' ', $createQuery);
+                }
                 //TODO: use parser
                 $createQuery = preg_replace(
                     '/' . preg_quote(Util::backquote($db), '/') . '\./',

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -1857,6 +1857,11 @@ $cfg['Export']['json_pretty_print'] = false;
 $cfg['Export']['json_unicode'] = true;
 
 /**
+ * @global string $cfg['Export']['removeDefinerFromDefinitions']
+ */
+$cfg['Export']['removeDefinerFromDefinitions'] = false;
+
+/**
  * @global string $cfg['Export']['sql_structure_or_data']
  */
 $cfg['Export']['sql_structure_or_data'] = 'structure_and_data';


### PR DESCRIPTION
### Description

Allow removing the DEFINER clause from the exported event, view and routine definitions.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
