### PR TITLE
Allow removing DEFINER clause from exported SQL

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -2729,6 +2729,15 @@ Export and import settings
 
     .. seealso:: :ref:`faq6_27`
 
+.. config:option:: $cfg['Export']['remove_definer_from_definitions']
+
+    :type: boolean
+    :default: false
+
+    Remove DEFINER clause from the event, view and routine definitions.
+
+    .. versionadded:: 5.2.0
+
 .. config:option:: $cfg['Import']
 
     :type: array

--- a/libraries/classes/Config/Descriptions.php
+++ b/libraries/classes/Config/Descriptions.php
@@ -703,6 +703,7 @@ class Descriptions
             'Export_quick_export_onserver_name' => __('Save on server'),
             'Export_quick_export_onserver_overwrite_name' => __('Overwrite existing file(s)'),
             'Export_remember_file_template_name' => __('Remember filename template'),
+            'Export_remove_definer_from_definitions_name' => __('Remove DEFINER clause from definitions'),
             'Export_sql_auto_increment_name' => __('Add AUTO_INCREMENT value'),
             'Export_sql_backquotes_name' => __('Enclose table and column names with backquotes'),
             'Export_sql_compatibility_name' => __('SQL compatibility mode'),

--- a/libraries/classes/Config/Settings/Export.php
+++ b/libraries/classes/Config/Settings/Export.php
@@ -469,6 +469,9 @@ final class Export
      */
     public $yaml_structure_or_data;
 
+    /** @var bool */
+    public $remove_definer_from_definitions;
+
     /**
      * @param array<int|string, mixed> $export
      */
@@ -582,6 +585,7 @@ final class Export
         $this->xml_export_views = $this->setXmlExportViews($export);
         $this->xml_export_contents = $this->setXmlExportContents($export);
         $this->yaml_structure_or_data = $this->setYamlStructureOrData($export);
+        $this->remove_definer_from_definitions = $this->setRemoveDefinerClause($export);
     }
 
     /**
@@ -2007,5 +2011,17 @@ final class Export
         }
 
         return $export['yaml_structure_or_data'];
+    }
+
+    /**
+     * @param array<int|string, mixed> $export
+     */
+    private function setRemoveDefinerClause(array $export): bool
+    {
+        if (! isset($export['remove_definer_from_definitions'])) {
+            return false;
+        }
+
+        return (bool) $export['remove_definer_from_definitions'];
     }
 }

--- a/libraries/config.default.php
+++ b/libraries/config.default.php
@@ -1857,6 +1857,11 @@ $cfg['Export']['json_pretty_print'] = false;
 $cfg['Export']['json_unicode'] = true;
 
 /**
+ * @global string $cfg['Export']['remove_definer_from_definitions']
+ */
+$cfg['Export']['remove_definer_from_definitions'] = false;
+
+/**
  * @global string $cfg['Export']['sql_structure_or_data']
  */
 $cfg['Export']['sql_structure_or_data'] = 'structure_and_data';


### PR DESCRIPTION
### Description

Allow removing the DEFINER clause from the exported event, view and routine definitions.

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
