### PR TITLE
Enable tabindex recompute on preview button while insert new rows

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1974,7 +1974,7 @@ class InsertEdit
             )
             . '</td>'
             . '<td colspan="3" class="right vmiddle">'
-            . '<input type="button" class="btn btn-secondary preview_sql" value="' . __('Preview SQL') . '"'
+            . '<input type="button" class="btn btn-secondary preview_sql control_at_footer" value="' . __('Preview SQL') . '"'
             . ' tabindex="' . ($tabindex + $tabindex_for_value + 6) . '">'
             . '<input type="reset" class="btn btn-secondary control_at_footer" value="' . __('Reset') . '"'
             . ' tabindex="' . ($tabindex + $tabindex_for_value + 7) . '">'

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1974,7 +1974,8 @@ class InsertEdit
             )
             . '</td>'
             . '<td colspan="3" class="right vmiddle">'
-            . '<input type="button" class="btn btn-secondary preview_sql control_at_footer" value="' . __('Preview SQL') . '"'
+            . '<input type="button" class="btn btn-secondary preview_sql control_at_footer"'
+            . ' value="' . __('Preview SQL') . '"'
             . ' tabindex="' . ($tabindex + $tabindex_for_value + 6) . '">'
             . '<input type="reset" class="btn btn-secondary control_at_footer" value="' . __('Reset') . '"'
             . ' tabindex="' . ($tabindex + $tabindex_for_value + 7) . '">'

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -2484,7 +2484,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         $this->assertStringContainsString(
-            '<input type="button" class="btn btn-secondary preview_sql" value="Preview SQL" '
+            '<input type="button" class="btn btn-secondary preview_sql control_at_footer" value="Preview SQL" '
             . 'tabindex="7">',
             $result
         );


### PR DESCRIPTION
### Description

Allow to recompute the tabindex on the preview SQL button on the insert page. 

Fixes #17111 

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
