### PR TITLE
Prevent GET requests to add/remove favorite tables

### DIFF
--- a/libraries/routes.php
+++ b/libraries/routes.php
@@ -164,10 +164,7 @@ return static function (RouteCollector $routes): void {
             $routes->post('/drop-table', [StructureController::class, 'dropTable']);
             $routes->post('/empty-form', [StructureController::class, 'emptyForm']);
             $routes->post('/empty-table', [StructureController::class, 'emptyTable']);
-            $routes->addRoute(['GET', 'POST'], '/favorite-table', [
-                StructureController::class,
-                'addRemoveFavoriteTablesAction',
-            ]);
+            $routes->post('/favorite-table', [StructureController::class, 'addRemoveFavoriteTablesAction']);
             $routes->addRoute(['GET', 'POST'], '/real-row-count', [
                 StructureController::class,
                 'handleRealRowCountRequestAction',


### PR DESCRIPTION
### Description

By changing add or remove POST request to GET request and ignore CSRF token, an attacker can force users to add or remove favorites table.

It means POST request with CSRF token is not required.

By changing add or remove POST request to GET request and ignore CSRF token, it was allowed by server as a valid request.

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
