### PR TITLE
Refactor import sql

### DIFF
--- a/libraries/classes/Controllers/Sql/SqlController.php
+++ b/libraries/classes/Controllers/Sql/SqlController.php
@@ -61,7 +61,6 @@ class SqlController extends AbstractController
         $GLOBALS['disp_query'] = $GLOBALS['disp_query'] ?? null;
         $GLOBALS['extra_data'] = $GLOBALS['extra_data'] ?? null;
         $GLOBALS['message_to_show'] = $GLOBALS['message_to_show'] ?? null;
-        $GLOBALS['sql_data'] = $GLOBALS['sql_data'] ?? null;
         $GLOBALS['disp_message'] = $GLOBALS['disp_message'] ?? null;
         $GLOBALS['complete_query'] = $GLOBALS['complete_query'] ?? null;
         $GLOBALS['is_gotofile'] = $GLOBALS['is_gotofile'] ?? null;
@@ -216,7 +215,7 @@ class SqlController extends AbstractController
             $GLOBALS['import_text'] ?? null,
             $GLOBALS['extra_data'] ?? null,
             $GLOBALS['message_to_show'] ?? null,
-            $GLOBALS['sql_data'] ?? null,
+            null,
             $GLOBALS['goto'],
             isset($GLOBALS['disp_query']) ? $GLOBALS['display_query'] : null,
             $GLOBALS['disp_message'] ?? null,

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -329,9 +329,9 @@ class Import
     /**
      * Looks for the presence of USE to possibly change current db
      *
-     * @param string $buffer buffer to examine
-     * @param string $db     current db
-     * @param bool   $reload reload
+     * @param string|null $buffer buffer to examine
+     * @param string|null $db     current db
+     * @param bool|null   $reload reload
      *
      * @return array (current or new db, whether to reload)
      */
@@ -843,7 +843,7 @@ class Import
     /**
      * Determines what MySQL type a cell is
      *
-     * @param int         $lastCumulativeType Last cumulative column type
+     * @param int|null    $lastCumulativeType Last cumulative column type
      *                                        (VARCHAR or INT or BIGINT or DECIMAL or NONE)
      * @param string|null $cell               String representation of the cell for which
      *                                        a best-fit type is to be determined

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -901,7 +901,7 @@ class Import
      *
      * @todo    Handle the error case more elegantly
      */
-    public function analyzeTable(array &$table)
+    public function analyzeTable(array $table)
     {
         /* Get number of rows in table */
         $numRows = count($table[self::ROWS]);
@@ -1003,7 +1003,7 @@ class Import
     public function buildSql(
         string $dbName,
         array &$tables,
-        ?array &$analyses = null,
+        ?array $analyses = null,
         ?array &$additionalSql = null,
         ?array $options = null,
         array &$sqlData = []

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -157,10 +157,7 @@ class Import
 
             if (($aNumRows > 0) || $isUseQuery) {
                 $sqlData['valid_sql'][] = $sql;
-                if (! isset($sqlData['valid_queries'])) {
-                    $sqlData['valid_queries'] = 0;
-                }
-
+                $sqlData['valid_queries'] = $sqlData['valid_queries'] ?? 0;
                 $sqlData['valid_queries']++;
             }
         }
@@ -246,10 +243,7 @@ class Import
                 $GLOBALS['sql_query'] = $this->importRunBuffer;
                 $sqlData['valid_sql'][] = $this->importRunBuffer;
                 $sqlData['valid_full'][] = $this->importRunBuffer;
-                if (! isset($sqlData['valid_queries'])) {
-                    $sqlData['valid_queries'] = 0;
-                }
-
+                $sqlData['valid_queries'] = $sqlData['valid_queries'] ?? 0;
                 $sqlData['valid_queries']++;
             } elseif ($GLOBALS['run_query']) {
                 /* Handle rollback from go_sql */

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -34,7 +34,6 @@ use function preg_replace;
 use function sprintf;
 use function str_contains;
 use function str_starts_with;
-use function strcmp;
 use function strlen;
 use function strpos;
 use function substr;
@@ -638,7 +637,7 @@ class Import
         /**
          * If the cell is NULL, don't treat it as a varchar
          */
-        if (! strcmp('NULL', $cell)) {
+        if ($cell === 'NULL') {
             return $lastCumulativeSize;
         }
 
@@ -859,7 +858,7 @@ class Import
          * Else, we call it varchar for simplicity
          */
 
-        if (! strcmp('NULL', (string) $cell)) {
+        if ($cell === 'NULL') {
             if ($lastCumulativeType === null || $lastCumulativeType == self::NONE) {
                 return self::NONE;
             }
@@ -873,8 +872,8 @@ class Import
 
         if (
             $cell == (string) (float) $cell
-            && str_contains((string) $cell, '.')
-            && mb_substr_count((string) $cell, '.') === 1
+            && str_contains($cell, '.')
+            && mb_substr_count($cell, '.') === 1
         ) {
             return self::DECIMAL;
         }
@@ -973,7 +972,7 @@ class Import
         /* Check to ensure that all types are valid */
         $len = count($types);
         for ($n = 0; $n < $len; ++$n) {
-            if (strcmp((string) self::NONE, (string) $types[$n])) {
+            if ((string) $types[$n] !== (string) self::NONE) {
                 continue;
             }
 
@@ -1176,7 +1175,7 @@ class Import
                         }
 
                         /* Don't put quotes around NULL fields */
-                        if (! strcmp((string) $tables[$i][self::ROWS][$j][$k], 'NULL')) {
+                        if ((string) $tables[$i][self::ROWS][$j][$k] === 'NULL') {
                             $isVarchar = false;
                         }
 
@@ -1249,7 +1248,7 @@ class Import
 
             if (count($regs)) {
                 for ($n = 0; $n < $numTables; ++$n) {
-                    if (! strcmp($regs[1], $tables[$n][self::TBL_NAME])) {
+                    if ($regs[1] === $tables[$n][self::TBL_NAME]) {
                         $inTables = true;
                         break;
                     }

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -185,12 +185,10 @@ class Import
      * of last SELECT, SHOW or HANDLER results and similar nice stuff.
      *
      * @param string $sql     query to run
-     * @param string $full    query to display, this might be commented
      * @param array  $sqlData SQL parse data storage
      */
     public function runQuery(
         string $sql = '',
-        string $full = '',
         array &$sqlData = []
     ): void {
         $GLOBALS['go_sql'] = $GLOBALS['go_sql'] ?? null;
@@ -206,7 +204,7 @@ class Import
         $GLOBALS['read_multiply'] = 1;
         if (! isset($GLOBALS['import_run_buffer'])) {
             // Do we have something to push into buffer?
-            $GLOBALS['import_run_buffer'] = $this->runQueryPost($sql, $full);
+            $GLOBALS['import_run_buffer'] = $this->runQueryPost($sql);
 
             return;
         }
@@ -215,7 +213,7 @@ class Import
         if ($GLOBALS['skip_queries'] > 0) {
             $GLOBALS['skip_queries']--;
             // Do we have something to push into buffer?
-            $GLOBALS['import_run_buffer'] = $this->runQueryPost($sql, $full);
+            $GLOBALS['import_run_buffer'] = $this->runQueryPost($sql);
 
             return;
         }
@@ -296,7 +294,7 @@ class Import
         }
 
         // Do we have something to push into buffer?
-        $GLOBALS['import_run_buffer'] = $this->runQueryPost($sql, $full);
+        $GLOBALS['import_run_buffer'] = $this->runQueryPost($sql);
 
         // In case of ROLLBACK, notify the user.
         if (! isset($_POST['rollback_query'])) {
@@ -310,20 +308,15 @@ class Import
      * Return import run buffer
      *
      * @param string $sql  SQL query
-     * @param string $full Query to display
      *
      * @return array|null Buffer of queries for import
      */
-    public function runQueryPost(string $sql, string $full): ?array
+    public function runQueryPost(string $sql): ?array
     {
-        if (! empty($sql) || ! empty($full)) {
-            return [
-                'sql' => $sql . ';',
-                'full' => $full . ';',
-            ];
-        }
-
-        return null;
+        return $sql !== '' ? [
+            'sql' => $sql . ';',
+            'full' => $sql . ';',
+        ] : null;
     }
 
     /**
@@ -1040,7 +1033,7 @@ class Import
         /* Execute the SQL statements create above */
         $sqlLength = count($sql);
         for ($i = 0; $i < $sqlLength; ++$i) {
-            $this->runQuery($sql[$i], $sql[$i], $sqlData);
+            $this->runQuery($sql[$i], $sqlData);
         }
 
         /* No longer needed */
@@ -1071,7 +1064,7 @@ class Import
             for ($i = 0; $i < $additionalSqlLength; ++$i) {
                 $additionalSql[$i] = preg_replace($pattern, $replacement, $additionalSql[$i]);
                 /* Execute the resulting statements */
-                $this->runQuery($additionalSql[$i], $additionalSql[$i], $sqlData);
+                $this->runQuery($additionalSql[$i], $sqlData);
             }
         }
 
@@ -1124,7 +1117,7 @@ class Import
                  * after it is formed so that we don't have
                  * to store them in a (possibly large) buffer
                  */
-                $this->runQuery($tempSQLStr, $tempSQLStr, $sqlData);
+                $this->runQuery($tempSQLStr, $sqlData);
             }
         }
 
@@ -1216,7 +1209,7 @@ class Import
              * after it is formed so that we don't have
              * to store them in a (possibly large) buffer
              */
-            $this->runQuery($tempSQLStr, $tempSQLStr, $sqlData);
+            $this->runQuery($tempSQLStr, $sqlData);
         }
 
         /* No longer needed */

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -728,8 +728,8 @@ class Import
                 /* New val if M or D is greater than current largest */
                 if ($size[self::M] > $oldM || $size[self::D] > $oldD) {
                     /* Take the largest of both types */
-                    return (string) (($size[self::M] > $oldM ? $size[self::M] : $oldM)
-                        . ',' . ($size[self::D] > $oldD ? $size[self::D] : $oldD));
+                    return ($size[self::M] > $oldM ? $size[self::M] : $oldM)
+                        . ',' . ($size[self::D] > $oldD ? $size[self::D] : $oldD);
                 }
 
                 return $lastCumulativeSize;
@@ -791,7 +791,7 @@ class Import
                 $oldM = $this->getDecimalPrecision($lastCumulativeSize);
                 $oldD = $this->getDecimalScale($lastCumulativeSize);
                 $oldInt = $oldM - $oldD;
-                $newInt = mb_strlen((string) $cell);
+                $newInt = mb_strlen($cell);
 
                 /* See which has the larger integer length */
                 if ($oldInt >= $newInt) {

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -1234,34 +1234,26 @@ class Import
         $tablePattern = '@CREATE TABLE IF NOT EXISTS `([^`]+)`@';
         /* Check a third pattern to make sure its not a "USE `db_name`;" statement */
 
-        $regs = [];
-
-        $inTables = false;
-
-        $additionalSqlLength = $additionalSql === null ? 0 : count($additionalSql);
-        for ($i = 0; $i < $additionalSqlLength; ++$i) {
-            preg_match($viewPattern, $additionalSql[$i], $regs);
-
-            if (count($regs) === 0) {
-                preg_match($tablePattern, $additionalSql[$i], $regs);
-            }
-
-            if (count($regs)) {
-                for ($n = 0; $n < $numTables; ++$n) {
-                    if ($regs[1] === $tables[$n][self::TBL_NAME]) {
-                        $inTables = true;
-                        break;
-                    }
-                }
-
-                if (! $inTables) {
-                    $tables[] = [self::TBL_NAME => $regs[1]];
-                }
-            }
-
-            /* Reset the array */
+        /** @var string $sql */
+        foreach ($additionalSql ?? [] as $sql) {
             $regs = [];
-            $inTables = false;
+            preg_match($viewPattern, $sql, $regs);
+
+            if ($regs === []) {
+                preg_match($tablePattern, $sql, $regs);
+            }
+
+            if ($regs === []) {
+                continue;
+            }
+
+            for ($n = 0; $n < $numTables; ++$n) {
+                if ($regs[1] === $tables[$n][self::TBL_NAME]) {
+                    continue 2;
+                }
+            }
+
+            $tables[] = [self::TBL_NAME => $regs[1]];
         }
 
         $params = ['db' => $dbName];

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -153,6 +153,8 @@ class ImportCsv extends AbstractImportCsv
 
     /**
      * Handles the whole import logic
+     *
+     * @return string[]
      */
     public function doImport(?File $importHandle = null): array
     {

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -544,7 +544,7 @@ class ImportCsv extends AbstractImportCsv
                      * @todo maybe we could add original line to verbose
                      * SQL in comment
                      */
-                    $this->import->runQuery($sql, $sql, $sql_data);
+                    $this->import->runQuery($sql, $sql_data);
                 }
 
                 $line++;
@@ -633,7 +633,7 @@ class ImportCsv extends AbstractImportCsv
         }
 
         // Commit any possible data in buffers
-        $this->import->runQuery('', '', $sql_data);
+        $this->import->runQuery('', $sql_data);
 
         if (count($values) == 0 || $GLOBALS['error'] !== false) {
             return;

--- a/libraries/classes/Plugins/Import/ImportLdi.php
+++ b/libraries/classes/Plugins/Import/ImportLdi.php
@@ -86,10 +86,8 @@ class ImportLdi extends AbstractImportCsv
 
     /**
      * Handles the whole import logic
-     *
-     * @param array $sql_data 2-element array with sql data
      */
-    public function doImport(?File $importHandle = null, array &$sql_data = []): void
+    public function doImport(?File $importHandle = null): array
     {
         $GLOBALS['finished'] = $GLOBALS['finished'] ?? null;
         $GLOBALS['import_file'] = $GLOBALS['import_file'] ?? null;
@@ -104,6 +102,7 @@ class ImportLdi extends AbstractImportCsv
         $GLOBALS['skip_queries'] = $GLOBALS['skip_queries'] ?? null;
         $GLOBALS['ldi_columns'] = $GLOBALS['ldi_columns'] ?? null;
 
+        $sqlStatements = [];
         $compression = '';
         if ($importHandle !== null) {
             $compression = $importHandle->getCompression();
@@ -116,7 +115,7 @@ class ImportLdi extends AbstractImportCsv
             );
             $GLOBALS['error'] = true;
 
-            return;
+            return [];
         }
 
         $sql = 'LOAD DATA';
@@ -186,9 +185,11 @@ class ImportLdi extends AbstractImportCsv
             $sql .= ')';
         }
 
-        $this->import->runQuery($sql, $sql_data);
-        $this->import->runQuery('', $sql_data);
+        $this->import->runQuery($sql, $sqlStatements);
+        $this->import->runQuery('', $sqlStatements);
         $GLOBALS['finished'] = true;
+
+        return $sqlStatements;
     }
 
     public function isAvailable(): bool

--- a/libraries/classes/Plugins/Import/ImportLdi.php
+++ b/libraries/classes/Plugins/Import/ImportLdi.php
@@ -86,6 +86,8 @@ class ImportLdi extends AbstractImportCsv
 
     /**
      * Handles the whole import logic
+     *
+     * @return string[]
      */
     public function doImport(?File $importHandle = null): array
     {

--- a/libraries/classes/Plugins/Import/ImportLdi.php
+++ b/libraries/classes/Plugins/Import/ImportLdi.php
@@ -186,8 +186,8 @@ class ImportLdi extends AbstractImportCsv
             $sql .= ')';
         }
 
-        $this->import->runQuery($sql, $sql, $sql_data);
-        $this->import->runQuery('', '', $sql_data);
+        $this->import->runQuery($sql, $sql_data);
+        $this->import->runQuery('', $sql_data);
         $GLOBALS['finished'] = true;
     }
 

--- a/libraries/classes/Plugins/Import/ImportMediawiki.php
+++ b/libraries/classes/Plugins/Import/ImportMediawiki.php
@@ -323,7 +323,7 @@ class ImportMediawiki extends ImportPlugin
         }
 
         // Commit any possible data in buffers
-        $this->import->runQuery('', '', $sql_data);
+        $this->import->runQuery('', $sql_data);
     }
 
     /**

--- a/libraries/classes/Plugins/Import/ImportMediawiki.php
+++ b/libraries/classes/Plugins/Import/ImportMediawiki.php
@@ -63,6 +63,8 @@ class ImportMediawiki extends ImportPlugin
 
     /**
      * Handles the whole import logic
+     *
+     * @return string[]
      */
     public function doImport(?File $importHandle = null): array
     {

--- a/libraries/classes/Plugins/Import/ImportOds.php
+++ b/libraries/classes/Plugins/Import/ImportOds.php
@@ -98,15 +98,14 @@ class ImportOds extends ImportPlugin
 
     /**
      * Handles the whole import logic
-     *
-     * @param array $sql_data 2-element array with sql data
      */
-    public function doImport(?File $importHandle = null, array &$sql_data = []): void
+    public function doImport(?File $importHandle = null): array
     {
         $GLOBALS['error'] = $GLOBALS['error'] ?? null;
         $GLOBALS['timeout_passed'] = $GLOBALS['timeout_passed'] ?? null;
         $GLOBALS['finished'] = $GLOBALS['finished'] ?? null;
 
+        $sqlStatements = [];
         $buffer = '';
 
         /**
@@ -223,12 +222,14 @@ class ImportOds extends ImportPlugin
         $create = null;
 
         /* Created and execute necessary SQL statements from data */
-        $this->import->buildSql($db_name, $tables, $analyses, $create, $options, $sql_data);
+        $this->import->buildSql($db_name, $tables, $analyses, $create, $options, $sqlStatements);
 
         unset($tables, $analyses);
 
         /* Commit any possible data in buffers */
-        $this->import->runQuery('', $sql_data);
+        $this->import->runQuery('', $sqlStatements);
+
+        return $sqlStatements;
     }
 
     /**

--- a/libraries/classes/Plugins/Import/ImportOds.php
+++ b/libraries/classes/Plugins/Import/ImportOds.php
@@ -228,7 +228,7 @@ class ImportOds extends ImportPlugin
         unset($tables, $analyses);
 
         /* Commit any possible data in buffers */
-        $this->import->runQuery('', '', $sql_data);
+        $this->import->runQuery('', $sql_data);
     }
 
     /**

--- a/libraries/classes/Plugins/Import/ImportOds.php
+++ b/libraries/classes/Plugins/Import/ImportOds.php
@@ -98,6 +98,8 @@ class ImportOds extends ImportPlugin
 
     /**
      * Handles the whole import logic
+     *
+     * @return string[]
      */
     public function doImport(?File $importHandle = null): array
     {

--- a/libraries/classes/Plugins/Import/ImportShp.php
+++ b/libraries/classes/Plugins/Import/ImportShp.php
@@ -74,10 +74,8 @@ class ImportShp extends ImportPlugin
 
     /**
      * Handles the whole import logic
-     *
-     * @param array $sql_data 2-element array with sql data
      */
-    public function doImport(?File $importHandle = null, array &$sql_data = []): void
+    public function doImport(?File $importHandle = null): array
     {
         $GLOBALS['error'] = $GLOBALS['error'] ?? null;
         $GLOBALS['import_file'] = $GLOBALS['import_file'] ?? null;
@@ -86,7 +84,7 @@ class ImportShp extends ImportPlugin
         $GLOBALS['finished'] = false;
 
         if ($importHandle === null || $this->zipExtension === null) {
-            return;
+            return [];
         }
 
         /** @see ImportShp::readFromBuffer() */
@@ -104,7 +102,7 @@ class ImportShp extends ImportPlugin
                 );
                 $GLOBALS['message']->addParam($importHandle->getError());
 
-                return;
+                return [];
             }
         }
 
@@ -170,7 +168,7 @@ class ImportShp extends ImportPlugin
             );
             $GLOBALS['message']->addParam($shp->lastError);
 
-            return;
+            return [];
         }
 
         switch ($shp->shapeType) {
@@ -200,7 +198,7 @@ class ImportShp extends ImportPlugin
                 );
                 $GLOBALS['message']->addParam($shp->getShapeName());
 
-                return;
+                return [];
         }
 
         if (isset($gis_type)) {
@@ -248,7 +246,7 @@ class ImportShp extends ImportPlugin
                 __('The imported file does not contain any data!')
             );
 
-            return;
+            return [];
         }
 
         // Column names for spatial column and the rest of the columns,
@@ -299,7 +297,8 @@ class ImportShp extends ImportPlugin
 
         // Created and execute necessary SQL statements from data
         $null_param = null;
-        $this->import->buildSql($db_name, $tables, $analyses, $null_param, $options, $sql_data);
+        $sqlStatements = [];
+        $this->import->buildSql($db_name, $tables, $analyses, $null_param, $options, $sqlStatements);
 
         unset($tables, $analyses);
 
@@ -307,7 +306,9 @@ class ImportShp extends ImportPlugin
         $GLOBALS['error'] = false;
 
         // Commit any possible data in buffers
-        $this->import->runQuery('', $sql_data);
+        $this->import->runQuery('', $sqlStatements);
+
+        return $sqlStatements;
     }
 
     /**

--- a/libraries/classes/Plugins/Import/ImportShp.php
+++ b/libraries/classes/Plugins/Import/ImportShp.php
@@ -74,6 +74,8 @@ class ImportShp extends ImportPlugin
 
     /**
      * Handles the whole import logic
+     *
+     * @return string[]
      */
     public function doImport(?File $importHandle = null): array
     {

--- a/libraries/classes/Plugins/Import/ImportShp.php
+++ b/libraries/classes/Plugins/Import/ImportShp.php
@@ -307,7 +307,7 @@ class ImportShp extends ImportPlugin
         $GLOBALS['error'] = false;
 
         // Commit any possible data in buffers
-        $this->import->runQuery('', '', $sql_data);
+        $this->import->runQuery('', $sql_data);
     }
 
     /**

--- a/libraries/classes/Plugins/Import/ImportSql.php
+++ b/libraries/classes/Plugins/Import/ImportSql.php
@@ -93,6 +93,8 @@ class ImportSql extends ImportPlugin
 
     /**
      * Handles the whole import logic
+     *
+     * @return string[]
      */
     public function doImport(?File $importHandle = null): array
     {

--- a/libraries/classes/Plugins/Import/ImportSql.php
+++ b/libraries/classes/Plugins/Import/ImportSql.php
@@ -146,7 +146,7 @@ class ImportSql extends ImportPlugin
             }
 
             // Executing the query.
-            $this->import->runQuery($statement, $statement, $sql_data);
+            $this->import->runQuery($statement, $sql_data);
         }
 
         // Extracting remaining statements.
@@ -156,11 +156,11 @@ class ImportSql extends ImportPlugin
                 continue;
             }
 
-            $this->import->runQuery($statement, $statement, $sql_data);
+            $this->import->runQuery($statement, $sql_data);
         }
 
         // Finishing.
-        $this->import->runQuery('', '', $sql_data);
+        $this->import->runQuery('', $sql_data);
     }
 
     /**

--- a/libraries/classes/Plugins/Import/ImportSql.php
+++ b/libraries/classes/Plugins/Import/ImportSql.php
@@ -116,13 +116,13 @@ class ImportSql extends ImportPlugin
          */
         $GLOBALS['finished'] = false;
 
-        while (! $GLOBALS['error'] && (! $GLOBALS['timeout_passed'])) {
+        while (! $GLOBALS['error'] && ! $GLOBALS['timeout_passed']) {
             // Getting the first statement, the remaining data and the last
             // delimiter.
             $statement = $bq->extract();
 
             // If there is no full statement, we are looking for more data.
-            if (empty($statement)) {
+            if ($statement === false || $statement === '') {
                 // Importing new data.
                 $newData = $this->import->getNextChunk($importHandle);
 
@@ -152,7 +152,7 @@ class ImportSql extends ImportPlugin
         // Extracting remaining statements.
         while (! $GLOBALS['error'] && ! $GLOBALS['timeout_passed'] && ! empty($bq->query)) {
             $statement = $bq->extract(true);
-            if (empty($statement)) {
+            if ($statement === false || $statement === '') {
                 continue;
             }
 

--- a/libraries/classes/Plugins/Import/ImportSql.php
+++ b/libraries/classes/Plugins/Import/ImportSql.php
@@ -18,7 +18,6 @@ use PhpMyAdmin\Properties\Plugins\ImportPluginProperties;
 use PhpMyAdmin\SqlParser\Utils\BufferedQuery;
 
 use function __;
-use function count;
 use function implode;
 use function mb_strlen;
 use function preg_replace;
@@ -44,7 +43,7 @@ class ImportSql extends ImportPlugin
         $importPluginProperties->setOptionsText(__('Options'));
 
         $compats = $GLOBALS['dbi']->getCompatibilities();
-        if (count($compats) > 0) {
+        if ($compats !== []) {
             $values = [];
             foreach ($compats as $val) {
                 $values[$val] = $val;
@@ -181,7 +180,7 @@ class ImportSql extends ImportPlugin
             $sql_modes[] = 'NO_AUTO_VALUE_ON_ZERO';
         }
 
-        if (count($sql_modes) <= 0) {
+        if ($sql_modes === []) {
             return;
         }
 

--- a/libraries/classes/Plugins/Import/ImportSql.php
+++ b/libraries/classes/Plugins/Import/ImportSql.php
@@ -169,7 +169,7 @@ class ImportSql extends ImportPlugin
      * @param DatabaseInterface $dbi     Database interface
      * @param array             $request Request array
      */
-    private function setSQLMode($dbi, array $request): void
+    private function setSQLMode(DatabaseInterface $dbi, array $request): void
     {
         $sql_modes = [];
         if (isset($request['sql_compatibility']) && $request['sql_compatibility'] !== 'NONE') {
@@ -184,8 +184,6 @@ class ImportSql extends ImportPlugin
             return;
         }
 
-        $dbi->tryQuery(
-            'SET SQL_MODE="' . implode(',', $sql_modes) . '"'
-        );
+        $dbi->tryQuery('SET SQL_MODE="' . implode(',', $sql_modes) . '"');
     }
 }

--- a/libraries/classes/Plugins/Import/ImportSql.php
+++ b/libraries/classes/Plugins/Import/ImportSql.php
@@ -93,10 +93,8 @@ class ImportSql extends ImportPlugin
 
     /**
      * Handles the whole import logic
-     *
-     * @param array $sql_data 2-element array with sql data
      */
-    public function doImport(?File $importHandle = null, array &$sql_data = []): void
+    public function doImport(?File $importHandle = null): array
     {
         $GLOBALS['error'] = $GLOBALS['error'] ?? null;
         $GLOBALS['timeout_passed'] = $GLOBALS['timeout_passed'] ?? null;
@@ -115,6 +113,8 @@ class ImportSql extends ImportPlugin
          * @global bool $GLOBALS ['finished']
          */
         $GLOBALS['finished'] = false;
+
+        $sqlStatements = [];
 
         while (! $GLOBALS['error'] && ! $GLOBALS['timeout_passed']) {
             // Getting the first statement, the remaining data and the last
@@ -146,7 +146,7 @@ class ImportSql extends ImportPlugin
             }
 
             // Executing the query.
-            $this->import->runQuery($statement, $sql_data);
+            $this->import->runQuery($statement, $sqlStatements);
         }
 
         // Extracting remaining statements.
@@ -156,11 +156,13 @@ class ImportSql extends ImportPlugin
                 continue;
             }
 
-            $this->import->runQuery($statement, $sql_data);
+            $this->import->runQuery($statement, $sqlStatements);
         }
 
         // Finishing.
-        $this->import->runQuery('', $sql_data);
+        $this->import->runQuery('', $sqlStatements);
+
+        return $sqlStatements;
     }
 
     /**

--- a/libraries/classes/Plugins/Import/ImportXml.php
+++ b/libraries/classes/Plugins/Import/ImportXml.php
@@ -55,6 +55,8 @@ class ImportXml extends ImportPlugin
 
     /**
      * Handles the whole import logic
+     *
+     * @return string[]
      */
     public function doImport(?File $importHandle = null): array
     {

--- a/libraries/classes/Plugins/Import/ImportXml.php
+++ b/libraries/classes/Plugins/Import/ImportXml.php
@@ -227,6 +227,7 @@ class ImportXml extends ImportPlugin
             ->children();
 
         $data_present = false;
+        $analyses = null;
 
         /**
          * Only attempt to analyze/collect data if there is data present

--- a/libraries/classes/Plugins/Import/ImportXml.php
+++ b/libraries/classes/Plugins/Import/ImportXml.php
@@ -55,10 +55,8 @@ class ImportXml extends ImportPlugin
 
     /**
      * Handles the whole import logic
-     *
-     * @param array $sql_data 2-element array with sql data
      */
-    public function doImport(?File $importHandle = null, array &$sql_data = []): void
+    public function doImport(?File $importHandle = null): array
     {
         $GLOBALS['error'] = $GLOBALS['error'] ?? null;
         $GLOBALS['timeout_passed'] = $GLOBALS['timeout_passed'] ?? null;
@@ -117,7 +115,7 @@ class ImportXml extends ImportPlugin
             unset($xml);
             $GLOBALS['finished'] = false;
 
-            return;
+            return [];
         }
 
         /**
@@ -180,7 +178,7 @@ class ImportXml extends ImportPlugin
             unset($xml);
             $GLOBALS['finished'] = false;
 
-            return;
+            return [];
         }
 
         /**
@@ -354,11 +352,14 @@ class ImportXml extends ImportPlugin
         }
 
         /* Created and execute necessary SQL statements from data */
-        $this->import->buildSql($db_name, $tables, $analyses, $create, $options, $sql_data);
+        $sqlStatements = [];
+        $this->import->buildSql($db_name, $tables, $analyses, $create, $options, $sqlStatements);
 
         unset($analyses, $tables, $create);
 
         /* Commit any possible data in buffers */
-        $this->import->runQuery('', $sql_data);
+        $this->import->runQuery('', $sqlStatements);
+
+        return $sqlStatements;
     }
 }

--- a/libraries/classes/Plugins/Import/ImportXml.php
+++ b/libraries/classes/Plugins/Import/ImportXml.php
@@ -359,6 +359,6 @@ class ImportXml extends ImportPlugin
         unset($analyses, $tables, $create);
 
         /* Commit any possible data in buffers */
-        $this->import->runQuery('', '', $sql_data);
+        $this->import->runQuery('', $sql_data);
     }
 }

--- a/libraries/classes/Plugins/Import/README.md
+++ b/libraries/classes/Plugins/Import/README.md
@@ -94,18 +94,17 @@ class Import[Name] extends ImportPlugin
     /**
      * Handles the whole import logic
      *
-     * @param array &$sql_data 2-element array with sql data
-     *
-     * @return void
+     * @return array A list of SQL statements to be executed
      */
-    public function doImport(&$sql_data = [])
+    public function doImport(?File $importHandle = null): array
     {
         // get globals (others are optional)
         global $error, $timeout_passed, $finished;
 
+        $sqlStatements = [];
         $buffer = '';
         while (! ($finished && $i >= $len) && ! $error && ! $timeout_passed) {
-            $data = $this->import->getNextChunk();
+            $data = $this->import->getNextChunk($importHandle);
             if ($data === false) {
                 // subtract data we didn't handle yet and stop processing
                 $GLOBALS['offset'] -= strlen($buffer);
@@ -119,10 +118,12 @@ class Import[Name] extends ImportPlugin
                 $buffer .= $data;
             }
             // PARSE $buffer here, post sql queries using:
-            $this->import->runQuery($sql, $verbose_sql_with_comments, $sql_data);
+            $this->import->runQuery($sql, $sqlStatements);
         } // End of import loop
         // Commit any possible data in buffers
-        $this->import->runQuery('', '', $sql_data);
+        $this->import->runQuery('', $sqlStatements);
+
+        return $sqlStatements;
     }
 
     /* optional:                                                     */

--- a/libraries/classes/Plugins/ImportPlugin.php
+++ b/libraries/classes/Plugins/ImportPlugin.php
@@ -46,6 +46,8 @@ abstract class ImportPlugin implements Plugin
 
     /**
      * Handles the whole import logic
+     *
+     * @return string[]
      */
     abstract public function doImport(?File $importHandle = null): array;
 

--- a/libraries/classes/Plugins/ImportPlugin.php
+++ b/libraries/classes/Plugins/ImportPlugin.php
@@ -46,10 +46,8 @@ abstract class ImportPlugin implements Plugin
 
     /**
      * Handles the whole import logic
-     *
-     * @param array $sql_data 2-element array with sql data
      */
-    abstract public function doImport(?File $importHandle = null, array &$sql_data = []): void;
+    abstract public function doImport(?File $importHandle = null): array;
 
     /**
      * Gets the import specific format plugin properties

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4256,17 +4256,7 @@ parameters:
 			path: libraries/classes/Import.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Import\\:\\:buildSql\\(\\) has parameter \\$sqlData with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Import.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Import\\:\\:buildSql\\(\\) has parameter \\$tables with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Import.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Import\\:\\:executeQuery\\(\\) has parameter \\$sqlData with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Import.php
 
@@ -4286,21 +4276,6 @@ parameters:
 			path: libraries/classes/Import.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Import\\:\\:runQuery\\(\\) has parameter \\$sqlData with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Import.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Import\\:\\:runQueryPost\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Import.php
-
-		-
-			message: "#^Offset int\\<0, max\\> does not exist on array\\|null\\.$#"
-			count: 2
-			path: libraries/classes/Import.php
-
-		-
 			message: "#^Parameter \\#1 \\$lastCumulativeSize of method PhpMyAdmin\\\\Import\\:\\:getDecimalPrecision\\(\\) expects string, int\\|string given\\.$#"
 			count: 3
 			path: libraries/classes/Import.php
@@ -4308,6 +4283,11 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$lastCumulativeSize of method PhpMyAdmin\\\\Import\\:\\:getDecimalScale\\(\\) expects string, int\\|string given\\.$#"
 			count: 2
+			path: libraries/classes/Import.php
+
+		-
+			message: "#^Parameter \\#1 \\$sql of method PhpMyAdmin\\\\Import\\:\\:executeQuery\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
 			path: libraries/classes/Import.php
 
 		-
@@ -5981,11 +5961,6 @@ parameters:
 			path: libraries/classes/Plugins/Import/ImportCsv.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportCsv\\:\\:doImport\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportCsv.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportCsv\\:\\:getColumnNames\\(\\) has parameter \\$columnNames with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportCsv.php
@@ -6006,22 +5981,7 @@ parameters:
 			path: libraries/classes/Plugins/Import/ImportCsv.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportLdi\\:\\:doImport\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportLdi.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportMediawiki\\:\\:doImport\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportMediawiki.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportMediawiki\\:\\:executeImportTables\\(\\) has parameter \\$analyses with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportMediawiki.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportMediawiki\\:\\:executeImportTables\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportMediawiki.php
 
@@ -6032,11 +5992,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportMediawiki\\:\\:explodeMarkup\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportMediawiki.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportMediawiki\\:\\:importDataOneTable\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportMediawiki.php
 
@@ -6064,11 +6019,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$str of function trim expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportMediawiki.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportOds\\:\\:doImport\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportOds.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportOds\\:\\:iterateOverColumns\\(\\) has parameter \\$col_names with no value type specified in iterable type array\\.$#"
@@ -6136,24 +6086,9 @@ parameters:
 			path: libraries/classes/Plugins/Import/ImportOds.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportShp\\:\\:doImport\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportShp.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportSql\\:\\:doImport\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportSql.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportSql\\:\\:setSQLMode\\(\\) has parameter \\$request with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportSql.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportXml\\:\\:doImport\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportXml.php
 
 		-
 			message: "#^Offset 'charset' does not exist on SimpleXMLElement\\|null\\.$#"
@@ -6184,11 +6119,6 @@ parameters:
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\Upload\\\\UploadSession\\:\\:getUploadStatus\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/Upload/UploadSession.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\ImportPlugin\\:\\:doImport\\(\\) has parameter \\$sql_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/ImportPlugin.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\ImportPlugin\\:\\:getDbnameAndOptions\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2324,7 +2324,7 @@
       <code>$_SESSION['Import_message']['message']</code>
       <code>$_SESSION['Import_message']['message']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="43">
+    <MixedAssignment occurrences="42">
       <code>$GLOBALS['MAX_FILE_SIZE']</code>
       <code>$GLOBALS['active_page']</code>
       <code>$GLOBALS['ajax_reload']</code>
@@ -2358,7 +2358,6 @@
       <code>$GLOBALS['run_query']</code>
       <code>$GLOBALS['show_as_php']</code>
       <code>$GLOBALS['skip_queries']</code>
-      <code>$GLOBALS['sql_data']</code>
       <code>$GLOBALS['sql_file']</code>
       <code>$GLOBALS['sql_query_disabled']</code>
       <code>$GLOBALS['table']</code>
@@ -2398,8 +2397,7 @@
       <code>$GLOBALS['offset'] == 0</code>
       <code>$GLOBALS['result'] === false</code>
     </RedundantCondition>
-    <TypeDoesNotContainType occurrences="4">
-      <code>! empty($GLOBALS['sql_data']) &amp;&amp; ($GLOBALS['sql_data']['valid_queries'] &gt; 1)</code>
+    <TypeDoesNotContainType occurrences="3">
       <code>$GLOBALS['finished']</code>
       <code>$GLOBALS['result']</code>
       <code>$GLOBALS['timeout_passed']</code>
@@ -3127,7 +3125,7 @@
     <InvalidArrayOffset occurrences="1">
       <code>$GLOBALS['cfg']['AllowUserDropDatabase']</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="21">
+    <MixedArgument occurrences="20">
       <code>$GLOBALS['cfg']['AllowUserDropDatabase']</code>
       <code>$GLOBALS['db']</code>
       <code>$GLOBALS['db']</code>
@@ -3140,7 +3138,6 @@
       <code>$GLOBALS['extra_data'] ?? null</code>
       <code>$GLOBALS['find_real_end'] ?? null</code>
       <code>$GLOBALS['message_to_show'] ?? null</code>
-      <code>$GLOBALS['sql_data'] ?? null</code>
       <code>$GLOBALS['sql_query']</code>
       <code>$GLOBALS['sql_query']</code>
       <code>$GLOBALS['table']</code>
@@ -3155,7 +3152,7 @@
       <code>$_POST['bkm_fields']['bkm_label']</code>
       <code>$_POST['bkm_fields']['bkm_label']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="19">
+    <MixedAssignment occurrences="18">
       <code>$GLOBALS['ajax_reload']</code>
       <code>$GLOBALS['back']</code>
       <code>$GLOBALS['db']</code>
@@ -3167,7 +3164,6 @@
       <code>$GLOBALS['find_real_end']</code>
       <code>$GLOBALS['is_gotofile']</code>
       <code>$GLOBALS['message_to_show']</code>
-      <code>$GLOBALS['sql_data']</code>
       <code>$GLOBALS['sql_query']</code>
       <code>$GLOBALS['sql_query']</code>
       <code>$GLOBALS['sql_query']</code>
@@ -7813,20 +7809,11 @@
     </TooFewArguments>
   </file>
   <file src="libraries/classes/Import.php">
-    <MixedArgument occurrences="37">
+    <MixedArgument occurrences="27">
       <code>$GLOBALS['charset_of_file']</code>
-      <code>$GLOBALS['import_run_buffer']['full']</code>
-      <code>$GLOBALS['import_run_buffer']['sql']</code>
-      <code>$GLOBALS['import_run_buffer']['sql']</code>
-      <code>$GLOBALS['import_run_buffer']['sql']</code>
       <code>$GLOBALS['reload']</code>
-      <code>$GLOBALS['sql_query']</code>
       <code>$active</code>
       <code>$additionalSql[$i]</code>
-      <code>$additionalSql[$i]</code>
-      <code>$additionalSql[$i]</code>
-      <code>$fulls[$i]</code>
-      <code>$queries[$i]</code>
       <code>$size</code>
       <code>$size</code>
       <code>$size</code>
@@ -7850,16 +7837,13 @@
       <code>$tables[$i][self::ROWS]</code>
       <code>$tables[$i][self::TBL_NAME]</code>
       <code>$tables[$i][self::TBL_NAME]</code>
-      <code>$tables[$n][self::TBL_NAME]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="24">
+    <MixedArrayAccess occurrences="22">
       <code>$analyses[$i][self::FORMATTEDSQL][$colCount]</code>
       <code>$analyses[$i][self::SIZES]</code>
       <code>$analyses[$i][self::TYPES]</code>
       <code>$analyses[$i][self::TYPES]</code>
       <code>$analyses[$i][self::TYPES]</code>
-      <code>$fulls[$i]</code>
-      <code>$queries[$i]</code>
       <code>$table[self::ROWS][$j][$i]</code>
       <code>$table[self::TBL_NAME]</code>
       <code>$tables[$i][self::COL_NAMES]</code>
@@ -7878,16 +7862,13 @@
       <code>$tables[$i][self::TBL_NAME]</code>
       <code>$tables[$n][self::TBL_NAME]</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="4">
+    <MixedArrayAssignment occurrences="1">
       <code>$GLOBALS['my_die'][]</code>
-      <code>$sqlData['valid_full'][]</code>
-      <code>$sqlData['valid_sql'][]</code>
-      <code>$sqlData['valid_sql'][]</code>
     </MixedArrayAssignment>
     <MixedArrayOffset occurrences="1">
       <code>$typeArray[$analyses[$i][self::TYPES][$j]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="44">
+    <MixedAssignment occurrences="36">
       <code>$GLOBALS['charset_conversion']</code>
       <code>$GLOBALS['charset_of_file']</code>
       <code>$GLOBALS['executed_queries']</code>
@@ -7907,7 +7888,6 @@
       <code>$GLOBALS['run_query']</code>
       <code>$GLOBALS['skip_queries']</code>
       <code>$GLOBALS['skip_queries']</code>
-      <code>$GLOBALS['sql_query']</code>
       <code>$GLOBALS['sql_query_disabled']</code>
       <code>$GLOBALS['sql_query_disabled']</code>
       <code>$GLOBALS['timeout_passed']</code>
@@ -7916,18 +7896,11 @@
       <code>$cellValue</code>
       <code>$charset</code>
       <code>$collation</code>
-      <code>$count</code>
       <code>$createDb</code>
-      <code>$fulls</code>
       <code>$importPlugin</code>
       <code>$queries</code>
-      <code>$queries</code>
       <code>$size</code>
       <code>$size</code>
-      <code>$sqlData['valid_full'][]</code>
-      <code>$sqlData['valid_queries']</code>
-      <code>$sqlData['valid_queries']</code>
-      <code>$sqlData['valid_sql'][]</code>
       <code>$sqlDelimiter</code>
       <code>$sqlQuery</code>
       <code>$table</code>
@@ -7940,12 +7913,8 @@
       <code>getExtension</code>
       <code>getProperties</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="23">
+    <MixedOperand occurrences="17">
       <code>$GLOBALS['executed_queries']</code>
-      <code>$GLOBALS['import_run_buffer']['full']</code>
-      <code>$GLOBALS['import_run_buffer']['full']</code>
-      <code>$GLOBALS['import_run_buffer']['full']</code>
-      <code>$GLOBALS['import_run_buffer']['full']</code>
       <code>$GLOBALS['maximum_time']</code>
       <code>$GLOBALS['msg']</code>
       <code>$GLOBALS['read_multiply']</code>
@@ -7962,8 +7931,6 @@
       <code>$size[self::D]</code>
       <code>$size[self::D] &gt; $oldD ? $size[self::D] : $oldD</code>
       <code>$size[self::M] &gt; $oldM ? $size[self::M] : $oldM</code>
-      <code>$sqlData['valid_queries']</code>
-      <code>$sqlData['valid_queries']</code>
     </MixedOperand>
     <MixedReturnStatement occurrences="3">
       <code>$size[self::FULL]</code>
@@ -7985,9 +7952,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$GLOBALS['charset_of_file']</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$additionalSql[$i]</code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullOperand occurrences="5">
       <code>$GLOBALS['executed_queries']</code>
       <code>$GLOBALS['maximum_time']</code>
@@ -7995,11 +7959,6 @@
       <code>$GLOBALS['read_multiply']</code>
       <code>$GLOBALS['timestamp']</code>
     </PossiblyNullOperand>
-    <RedundantCast occurrences="4">
-      <code>(string) $cell</code>
-      <code>(string) $cell</code>
-      <code>(string) $cell</code>
-    </RedundantCast>
   </file>
   <file src="libraries/classes/Import/Ajax.php">
     <MixedArrayAccess occurrences="1">
@@ -10814,9 +10773,6 @@
       <code>! $GLOBALS['finished']</code>
       <code>$GLOBALS['finished']</code>
     </RedundantCondition>
-    <ReferenceConstraintViolation occurrences="1">
-      <code>$analyses</code>
-    </ReferenceConstraintViolation>
   </file>
   <file src="libraries/classes/Plugins/Import/ImportOds.php">
     <MixedArgument occurrences="17">
@@ -10926,6 +10882,10 @@
       <code>$record-&gt;dbfData</code>
       <code>$record-&gt;shpData</code>
     </MixedPropertyFetch>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>$sqlStatements</code>
+      <code>string[]</code>
+    </MixedReturnTypeCoercion>
     <PossiblyNullArgument occurrences="4">
       <code>$GLOBALS['buffer']</code>
       <code>$GLOBALS['buffer']</code>
@@ -15723,9 +15683,7 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/classes/ImportTest.php">
-    <DocblockTypeContradiction occurrences="8">
-      <code>assertNull</code>
-      <code>assertSame</code>
+    <DocblockTypeContradiction occurrences="6">
       <code>assertSame</code>
       <code>assertSame</code>
       <code>assertSame</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -253,7 +253,6 @@
             hostname: string,
             import_file: string,
             import_file_name: string,
-            import_run_buffer: array,
             import_text: string,
             is_create_db_priv: bool,
             is_reload_priv: bool,

--- a/test/classes/Controllers/Import/ImportControllerTest.php
+++ b/test/classes/Controllers/Import/ImportControllerTest.php
@@ -22,7 +22,6 @@ class ImportControllerTest extends AbstractTestCase
         $GLOBALS['server'] = 1;
         $GLOBALS['cfg']['Server']['user'] = 'user';
         $GLOBALS['PMA_PHP_SELF'] = 'index.php';
-        $GLOBALS['import_run_buffer'] = null;
 
         parent::loadResponseIntoContainerBuilder();
 

--- a/test/classes/ImportTest.php
+++ b/test/classes/ImportTest.php
@@ -557,10 +557,7 @@ class ImportTest extends AbstractTestCase
         $GLOBALS['run_query'] = true;
         $sqlData = [];
 
-        $query = 'SELECT 1';
-        $full = 'SELECT 1';
-
-        $this->import->runQuery($query, $full, $sqlData);
+        $this->import->runQuery('SELECT 1', $sqlData);
 
         $this->assertSame([], $sqlData);
         $this->assertSame([
@@ -571,10 +568,7 @@ class ImportTest extends AbstractTestCase
         $this->assertNull($GLOBALS['complete_query']);
         $this->assertNull($GLOBALS['display_query']);
 
-        $query = 'SELECT 2';
-        $full = 'SELECT 2';
-
-        $this->import->runQuery($query, $full, $sqlData);
+        $this->import->runQuery('SELECT 2', $sqlData);
 
         $this->assertSame([
             'valid_sql' => ['SELECT 1;'],
@@ -589,10 +583,7 @@ class ImportTest extends AbstractTestCase
         $this->assertSame('SELECT 1;', $GLOBALS['complete_query']);
         $this->assertSame('SELECT 1;', $GLOBALS['display_query']);
 
-        $query = '';
-        $full = '';
-
-        $this->import->runQuery($query, $full, $sqlData);
+        $this->import->runQuery('', $sqlData);
 
         $this->assertSame([
             'valid_sql' => [

--- a/test/classes/ImportTest.php
+++ b/test/classes/ImportTest.php
@@ -26,7 +26,6 @@ class ImportTest extends AbstractTestCase
         parent::setUp();
         $GLOBALS['server'] = 0;
         $GLOBALS['cfg']['ServerDefault'] = '';
-        $GLOBALS['import_run_buffer'] = null;
         $GLOBALS['complete_query'] = null;
         $GLOBALS['display_query'] = null;
         $GLOBALS['skip_queries'] = null;
@@ -560,10 +559,6 @@ class ImportTest extends AbstractTestCase
         $this->import->runQuery('SELECT 1', $sqlData);
 
         $this->assertSame([], $sqlData);
-        $this->assertSame([
-            'sql' => 'SELECT 1;',
-            'full' => 'SELECT 1;',
-        ], $GLOBALS['import_run_buffer']);
         $this->assertSame('', $GLOBALS['sql_query']);
         $this->assertNull($GLOBALS['complete_query']);
         $this->assertNull($GLOBALS['display_query']);
@@ -575,10 +570,6 @@ class ImportTest extends AbstractTestCase
             'valid_full' => ['SELECT 1;'],
             'valid_queries' => 1,
         ], $sqlData);
-        $this->assertSame([
-            'sql' => 'SELECT 2;',
-            'full' => 'SELECT 2;',
-        ], $GLOBALS['import_run_buffer']);
         $this->assertSame('SELECT 1;', $GLOBALS['sql_query']);
         $this->assertSame('SELECT 1;', $GLOBALS['complete_query']);
         $this->assertSame('SELECT 1;', $GLOBALS['display_query']);
@@ -597,7 +588,6 @@ class ImportTest extends AbstractTestCase
             'valid_queries' => 2,
         ], $sqlData);
 
-        $this->assertNull($GLOBALS['import_run_buffer']);
         $this->assertSame('SELECT 2;', $GLOBALS['sql_query']);
         $this->assertSame('SELECT 1;SELECT 2;', $GLOBALS['complete_query']);
         $this->assertSame('SELECT 1;SELECT 2;', $GLOBALS['display_query']);

--- a/test/classes/ImportTest.php
+++ b/test/classes/ImportTest.php
@@ -565,11 +565,7 @@ class ImportTest extends AbstractTestCase
 
         $this->import->runQuery('SELECT 2', $sqlData);
 
-        $this->assertSame([
-            'valid_sql' => ['SELECT 1;'],
-            'valid_full' => ['SELECT 1;'],
-            'valid_queries' => 1,
-        ], $sqlData);
+        $this->assertSame(['SELECT 1;'], $sqlData);
         $this->assertSame('SELECT 1;', $GLOBALS['sql_query']);
         $this->assertSame('SELECT 1;', $GLOBALS['complete_query']);
         $this->assertSame('SELECT 1;', $GLOBALS['display_query']);
@@ -577,15 +573,8 @@ class ImportTest extends AbstractTestCase
         $this->import->runQuery('', $sqlData);
 
         $this->assertSame([
-            'valid_sql' => [
-                'SELECT 1;',
-                'SELECT 2;',
-            ],
-            'valid_full' => [
-                'SELECT 1;',
-                'SELECT 2;',
-            ],
-            'valid_queries' => 2,
+            'SELECT 1;',
+            'SELECT 2;',
         ], $sqlData);
 
         $this->assertSame('SELECT 2;', $GLOBALS['sql_query']);

--- a/test/classes/Plugins/Import/ImportCsvTest.php
+++ b/test/classes/Plugins/Import/ImportCsvTest.php
@@ -39,7 +39,6 @@ class ImportCsvTest extends AbstractTestCase
         $GLOBALS['timeout_passed'] = null;
         $GLOBALS['maximum_time'] = null;
         $GLOBALS['charset_conversion'] = null;
-        $GLOBALS['import_run_buffer'] = null;
         $GLOBALS['skip_queries'] = null;
         $GLOBALS['max_sql_len'] = null;
         $GLOBALS['executed_queries'] = null;

--- a/test/classes/Plugins/Import/ImportLdiTest.php
+++ b/test/classes/Plugins/Import/ImportLdiTest.php
@@ -37,7 +37,6 @@ class ImportLdiTest extends AbstractTestCase
         $GLOBALS['ldi_columns'] = null;
         $GLOBALS['ldi_enclosed'] = null;
         $GLOBALS['ldi_new_line'] = null;
-        $GLOBALS['import_run_buffer'] = null;
         $GLOBALS['max_sql_len'] = null;
         $GLOBALS['sql_query'] = '';
         $GLOBALS['executed_queries'] = null;

--- a/test/classes/Plugins/Import/ImportMediawikiTest.php
+++ b/test/classes/Plugins/Import/ImportMediawikiTest.php
@@ -32,7 +32,6 @@ class ImportMediawikiTest extends AbstractTestCase
         $GLOBALS['maximum_time'] = null;
         $GLOBALS['charset_conversion'] = null;
         $GLOBALS['db'] = '';
-        $GLOBALS['import_run_buffer'] = null;
         $GLOBALS['skip_queries'] = null;
         $GLOBALS['max_sql_len'] = null;
         $GLOBALS['sql_query_disabled'] = null;

--- a/test/classes/Plugins/Import/ImportOdsTest.php
+++ b/test/classes/Plugins/Import/ImportOdsTest.php
@@ -34,7 +34,6 @@ class ImportOdsTest extends AbstractTestCase
         $GLOBALS['maximum_time'] = null;
         $GLOBALS['charset_conversion'] = null;
         $GLOBALS['db'] = '';
-        $GLOBALS['import_run_buffer'] = null;
         $GLOBALS['skip_queries'] = null;
         $GLOBALS['max_sql_len'] = null;
         $GLOBALS['executed_queries'] = null;

--- a/test/classes/Plugins/Import/ImportShpTest.php
+++ b/test/classes/Plugins/Import/ImportShpTest.php
@@ -32,7 +32,6 @@ class ImportShpTest extends AbstractTestCase
         $GLOBALS['buffer'] = null;
         $GLOBALS['maximum_time'] = null;
         $GLOBALS['charset_conversion'] = null;
-        $GLOBALS['import_run_buffer'] = null;
         $GLOBALS['eof'] = null;
         $GLOBALS['db'] = '';
         $GLOBALS['skip_queries'] = null;

--- a/test/classes/Plugins/Import/ImportSqlTest.php
+++ b/test/classes/Plugins/Import/ImportSqlTest.php
@@ -29,7 +29,6 @@ class ImportSqlTest extends AbstractTestCase
         $GLOBALS['timeout_passed'] = null;
         $GLOBALS['maximum_time'] = null;
         $GLOBALS['charset_conversion'] = null;
-        $GLOBALS['import_run_buffer'] = null;
         $GLOBALS['skip_queries'] = null;
         $GLOBALS['max_sql_len'] = null;
         $GLOBALS['sql_query'] = '';

--- a/test/classes/Plugins/Import/ImportXmlTest.php
+++ b/test/classes/Plugins/Import/ImportXmlTest.php
@@ -34,7 +34,6 @@ class ImportXmlTest extends AbstractTestCase
         $GLOBALS['maximum_time'] = null;
         $GLOBALS['charset_conversion'] = null;
         $GLOBALS['db'] = '';
-        $GLOBALS['import_run_buffer'] = null;
         $GLOBALS['skip_queries'] = null;
         $GLOBALS['max_sql_len'] = null;
         $GLOBALS['sql_query_disabled'] = null;


### PR DESCRIPTION
This is a simplification of the existing Import functionality. It removes certain globals and reduces code complexity in other places.

The biggest change is the removal of SQL with comments aka `$full` query. All parameters and array storage for this was removed which allowed for significant simplification.  