### PR TITLE
Add method to AbstractController to send error messages

### DIFF
--- a/js/src/ajax.js
+++ b/js/src/ajax.js
@@ -895,6 +895,23 @@ $(document).on('ajaxError', function (event, request) {
         var details = '';
         var state = request.state();
 
+        if (
+            'responseJSON' in request &&
+            'isErrorResponse' in request.responseJSON &&
+            request.responseJSON.isErrorResponse
+        ) {
+            Functions.ajaxShowMessage(
+                '<div class="alert alert-danger" role="alert">' +
+                Functions.escapeHtml(request.responseJSON.error) +
+                '</div>',
+                false
+            );
+            AJAX.active = false;
+            AJAX.xhr = null;
+
+            return;
+        }
+
         if (request.status !== 0) {
             details += '<div>' + Functions.escapeHtml(Functions.sprintf(Messages.strErrorCode, request.status)) + '</div>';
         }

--- a/libraries/classes/Controllers/AbstractController.php
+++ b/libraries/classes/Controllers/AbstractController.php
@@ -146,4 +146,22 @@ abstract class AbstractController
         $this->response->setHttpResponseCode(400);
         Core::fatalError($errorMessage);
     }
+
+    /**
+     * @psalm-param int<400,599> $statusCode
+     */
+    protected function sendErrorResponse(string $message, int $statusCode = 400): void
+    {
+        $this->response->setHttpResponseCode($statusCode);
+        $this->response->setRequestStatus(false);
+
+        if ($this->response->isAjax()) {
+            $this->response->addJSON('isErrorResponse', true);
+            $this->response->addJSON('message', $message);
+
+            return;
+        }
+
+        $this->response->addHTML(Message::error($message)->getDisplay());
+    }
 }

--- a/libraries/classes/Controllers/Table/DropColumnConfirmationController.php
+++ b/libraries/classes/Controllers/Table/DropColumnConfirmationController.php
@@ -25,15 +25,11 @@ final class DropColumnConfirmationController extends AbstractController
             $table = TableName::fromValue($request->getParsedBodyParam('table'));
             Assert::allStringNotEmpty($fields);
         } catch (InvalidIdentifierName $exception) {
-            $this->response->setHttpResponseCode(400);
-            $this->response->setRequestStatus(false);
-            $this->response->addJSON('message', $exception->getMessage());
+            $this->sendErrorResponse($exception->getMessage());
 
             return;
         } catch (InvalidArgumentException $exception) {
-            $this->response->setHttpResponseCode(400);
-            $this->response->setRequestStatus(false);
-            $this->response->addJSON('message', __('No column selected.'));
+            $this->sendErrorResponse(__('No column selected.'));
 
             return;
         }

--- a/test/classes/Controllers/AbstractControllerTest.php
+++ b/test/classes/Controllers/AbstractControllerTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests\Controllers;
 
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Html\MySQLDocumentation;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\Sanitize;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -58,8 +59,7 @@ class AbstractControllerTest extends AbstractTestCase
         $_REQUEST = [];
 
         $response = new ResponseRenderer();
-        $template = new Template();
-        $controller = new class ($response, $template) extends AbstractController {
+        $controller = new class ($response, new Template()) extends AbstractController {
             /**
              * @psalm-param non-empty-list<non-empty-string> $params
              */
@@ -79,5 +79,57 @@ class AbstractControllerTest extends AbstractTestCase
         $controller->testCheckParameters(['param1', 'param2']);
 
         $this->assertSame(200, $response->getHttpResponseCode());
+    }
+
+    public function testSendErrorResponseWithJson(): void
+    {
+        $response = new ResponseRenderer();
+        $response->setAjax(true);
+
+        $controller = new class ($response, new Template()) extends AbstractController {
+            /**
+             * @psalm-param int<400,599> $statusCode
+             */
+            public function testSendErrorResponse(string $message, int $statusCode = 400): void
+            {
+                parent::sendErrorResponse($message, $statusCode);
+            }
+        };
+
+        $controller->testSendErrorResponse('Error message.', 404);
+
+        $this->assertSame(404, $response->getHttpResponseCode());
+        $this->assertFalse($response->hasSuccessState());
+        $this->assertSame('', $response->getHTMLResult());
+        $this->assertSame([
+            'isErrorResponse' => true,
+            'message' => 'Error message.',
+        ], $response->getJSONResult());
+    }
+
+    public function testSendErrorResponseWithHtml(): void
+    {
+        $response = new ResponseRenderer();
+        $response->setAjax(false);
+
+        $controller = new class ($response, new Template()) extends AbstractController {
+            /**
+             * @psalm-param int<400,599> $statusCode
+             */
+            public function testSendErrorResponse(string $message, int $statusCode = 400): void
+            {
+                parent::sendErrorResponse($message, $statusCode);
+            }
+        };
+
+        $controller->testSendErrorResponse('Error message.', 404);
+
+        $this->assertSame(404, $response->getHttpResponseCode());
+        $this->assertFalse($response->hasSuccessState());
+        $this->assertSame(
+            Message::error('Error message.')->getDisplay(),
+            $response->getHTMLResult()
+        );
+        $this->assertSame([], $response->getJSONResult());
     }
 }

--- a/test/classes/Controllers/Table/DropColumnConfirmationControllerTest.php
+++ b/test/classes/Controllers/Table/DropColumnConfirmationControllerTest.php
@@ -28,6 +28,8 @@ class DropColumnConfirmationControllerTest extends AbstractTestCase
         $this->dummyDbi->addResult('SHOW TABLES LIKE \'test_table\';', [['test_table']]);
 
         $response = new ResponseRenderer();
+        $response->setAjax(true);
+
         $template = new Template();
         $expected = $template->render('table/structure/drop_confirm', [
             'db' => 'test_db',
@@ -53,11 +55,16 @@ class DropColumnConfirmationControllerTest extends AbstractTestCase
         ]);
 
         $response = new ResponseRenderer();
+        $response->setAjax(true);
+
         (new DropColumnConfirmationController($response, new Template()))($request);
 
         $this->assertSame(400, $response->getHttpResponseCode());
         $this->assertFalse($response->hasSuccessState());
-        $this->assertSame(['message' => 'No column selected.'], $response->getJSONResult());
+        $this->assertSame([
+            'isErrorResponse' => true,
+            'message' => 'No column selected.'
+        ], $response->getJSONResult());
         $this->assertSame('', $response->getHTMLResult());
     }
 
@@ -71,11 +78,16 @@ class DropColumnConfirmationControllerTest extends AbstractTestCase
         ]);
 
         $response = new ResponseRenderer();
+        $response->setAjax(true);
+
         (new DropColumnConfirmationController($response, new Template()))($request);
 
         $this->assertSame(400, $response->getHttpResponseCode());
         $this->assertFalse($response->hasSuccessState());
-        $this->assertSame(['message' => 'The database name must be a non-empty string.'], $response->getJSONResult());
+        $this->assertSame([
+            'isErrorResponse' => true,
+            'message' => 'The database name must be a non-empty string.'
+        ], $response->getJSONResult());
         $this->assertSame('', $response->getHTMLResult());
     }
 }


### PR DESCRIPTION
- Related to #17098.

This doesn't fix the issue, but adds better error handling for expected error messages.