### PR TITLE
FIXES #17414 - Adjusting export object in PluginExport to export databases with comp…

### DIFF
--- a/libraries/classes/Plugins/ExportPlugin.php
+++ b/libraries/classes/Plugins/ExportPlugin.php
@@ -43,9 +43,9 @@ abstract class ExportPlugin implements Plugin
     {
         global $dbi;
 
-        $this->relation = new Relation($dbi);
-        $this->export = new Export($dbi);
-        $this->transformations = new Transformations();
+        $this->relation = $GLOBALS['containerBuilder']->get('relation');
+        $this->export = $GLOBALS['containerBuilder']->get('export');
+        $this->transformations = $GLOBALS['containerBuilder']->get('transformations');
         $this->init();
         $this->properties = $this->setProperties();
     }

--- a/libraries/classes/Plugins/ExportPlugin.php
+++ b/libraries/classes/Plugins/ExportPlugin.php
@@ -40,7 +40,7 @@ abstract class ExportPlugin implements Plugin
     protected $transformations;
 
     /**
-     * @psalm-supress InvalidArrayOffset, MixedAssignment, MixedMethodCall
+     * @psalm-suppress InvalidArrayOffset, MixedAssignment, MixedMethodCall
      */
     final public function __construct()
     {

--- a/libraries/classes/Plugins/ExportPlugin.php
+++ b/libraries/classes/Plugins/ExportPlugin.php
@@ -44,7 +44,6 @@ abstract class ExportPlugin implements Plugin
      */
     final public function __construct()
     {
-
         $this->relation = $GLOBALS['containerBuilder']->get('relation');
         $this->export = $GLOBALS['containerBuilder']->get('export');
         $this->transformations = $GLOBALS['containerBuilder']->get('transformations');

--- a/libraries/classes/Plugins/ExportPlugin.php
+++ b/libraries/classes/Plugins/ExportPlugin.php
@@ -39,9 +39,11 @@ abstract class ExportPlugin implements Plugin
     /** @var Transformations */
     protected $transformations;
 
+    /**
+     * @psalm-supress InvalidArrayOffset, MixedAssignment, MixedMethodCall
+     */
     final public function __construct()
     {
-        global $dbi;
 
         $this->relation = $GLOBALS['containerBuilder']->get('relation');
         $this->export = $GLOBALS['containerBuilder']->get('export');

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -89,6 +89,7 @@ abstract class AbstractTestCase extends TestCase
         $this->setGlobalConfig();
         $this->loadContainerBuilder();
         $this->setGlobalDbi();
+        $this->loadDbiIntoContainerBuilder();
         Cache::purge();
     }
 


### PR DESCRIPTION
…ress

Signed-off-by: Rodrigo Pokemaobr <contato@pokemaobr.dev>

### Description

The export object was regenerated in ExportPlugin then causes empty content in buffer and compressed files empty.

Fixes #17414  

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
