### PR TITLE
Bump `js-cookie` version from 2.2.1 to 3.0.1

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -1205,8 +1205,8 @@ Functions.insertQuery = function (queryType) {
         if (isStorageSupported('localStorage') &&
             typeof window.localStorage.getItem(key) === 'string') {
             Functions.setQuery(window.localStorage.getItem(key));
-        } else if (Cookies.get(key)) {
-            Functions.setQuery(Cookies.get(key));
+        } else if (Cookies.get(key, { path: CommonParams.get('rootPath') })) {
+            Functions.setQuery(Cookies.get(key, { path: CommonParams.get('rootPath') }));
         } else {
             Functions.ajaxShowMessage(Messages.strNoAutoSavedQuery);
         }
@@ -4364,8 +4364,6 @@ AJAX.registerOnload('functions.js', function () {
             $('#ssl_reqd_warning_cp').hide();
         }
     });
-
-    Cookies.defaults.path = CommonParams.get('rootPath');
 
     // Bind event handlers for toggling sort icons
     $(document).on('mouseover', '.sortlink', function () {

--- a/js/src/sql.js
+++ b/js/src/sql.js
@@ -50,7 +50,7 @@ Sql.autoSave = function (query) {
         if (isStorageSupported('localStorage')) {
             window.localStorage.setItem(key, query);
         } else {
-            Cookies.set(key, query);
+            Cookies.set(key, query, { path: CommonParams.get('rootPath') });
         }
     }
 };
@@ -73,8 +73,8 @@ Sql.showThisQuery = function (db, table, query) {
         window.localStorage.showThisQuery = 1;
         window.localStorage.showThisQueryObject = JSON.stringify(showThisQueryObject);
     } else {
-        Cookies.set('showThisQuery', 1);
-        Cookies.set('showThisQueryObject', JSON.stringify(showThisQueryObject));
+        Cookies.set('showThisQuery', 1, { path: CommonParams.get('rootPath') });
+        Cookies.set('showThisQueryObject', JSON.stringify(showThisQueryObject), { path: CommonParams.get('rootPath') });
     }
 };
 
@@ -118,7 +118,7 @@ Sql.autoSaveWithSort = function (query) {
         if (isStorageSupported('localStorage')) {
             window.localStorage.setItem('autoSavedSqlSort', query);
         } else {
-            Cookies.set('autoSavedSqlSort', query);
+            Cookies.set('autoSavedSqlSort', query, { path: CommonParams.get('rootPath') });
         }
     }
 };
@@ -132,7 +132,7 @@ Sql.clearAutoSavedSort = function () {
     if (isStorageSupported('localStorage')) {
         window.localStorage.removeItem('autoSavedSqlSort');
     } else {
-        Cookies.set('autoSavedSqlSort', '');
+        Cookies.set('autoSavedSqlSort', '', { path: CommonParams.get('rootPath') });
     }
 };
 
@@ -259,7 +259,7 @@ AJAX.registerOnload('sql.js', function () {
                 Sql.clearAutoSavedSort();
             }
             // If sql query with sort for current table is stored, change sort by key select value
-            var sortStoredQuery = useLocalStorageValue ? window.localStorage.autoSavedSqlSort : Cookies.get('autoSavedSqlSort');
+            var sortStoredQuery = useLocalStorageValue ? window.localStorage.autoSavedSqlSort : Cookies.get('autoSavedSqlSort', { path: CommonParams.get('rootPath') });
             if (typeof sortStoredQuery !== 'undefined' && sortStoredQuery !== $('select[name="sql_query"]').val() && $('select[name="sql_query"] option[value="' + sortStoredQuery + '"]').length !== 0) {
                 $('select[name="sql_query"]').val(sortStoredQuery).trigger('change');
             }
@@ -979,7 +979,7 @@ Sql.checkSavedQuery = function () {
     if (isStorageSupported('localStorage') &&
         typeof window.localStorage.getItem(key) === 'string') {
         Functions.ajaxShowMessage(Messages.strPreviousSaveQuery);
-    } else if (Cookies.get(key)) {
+    } else if (Cookies.get(key, { path: CommonParams.get('rootPath') })) {
         Functions.ajaxShowMessage(Messages.strPreviousSaveQuery);
     }
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jquery-ui-timepicker-addon": "1.6.3",
     "jquery-uitablefilter": "^1.0.0",
     "jquery-validation": "1.19.3",
-    "js-cookie": "2.2.1",
+    "js-cookie": "3.0.1",
     "locutus.sprintf": "^2.0.14-code-lts.2",
     "mini-css-extract-plugin": "^2.5.3",
     "ol": "6.14.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -135,7 +135,7 @@ module.exports = [
                     { from: path.resolve(__dirname, 'node_modules/jquery-ui-dist/jquery-ui.min.js'), to: path.resolve(__dirname, 'js/vendor/jquery/jquery-ui.min.js') },
                     { from: path.resolve(__dirname, 'node_modules/jquery-validation/dist/jquery.validate.js'), to: path.resolve(__dirname, 'js/vendor/jquery/jquery.validate.js') },
                     { from: path.resolve(__dirname, 'node_modules/jquery-validation/dist/additional-methods.js'), to: path.resolve(__dirname, 'js/vendor/jquery/additional-methods.js') },
-                    { from: path.resolve(__dirname, 'node_modules/js-cookie/src/js.cookie.js'), to: path.resolve(__dirname, 'js/vendor/js.cookie.js') },
+                    { from: path.resolve(__dirname, 'node_modules/js-cookie/dist/js.cookie.js'), to: path.resolve(__dirname, 'js/vendor/js.cookie.js') },
                     { from: path.resolve(__dirname, 'node_modules/bootstrap/dist/js/bootstrap.bundle.min.js'), to: path.resolve(__dirname, 'js/vendor/bootstrap/bootstrap.bundle.min.js') },
                     { from: path.resolve(__dirname, 'node_modules/bootstrap/dist/js/bootstrap.bundle.min.js.map'), to: path.resolve(__dirname, 'js/vendor/bootstrap/bootstrap.bundle.min.js.map') },
                     { from: path.resolve(__dirname, 'node_modules/@zxcvbn-ts/core/dist/zxcvbn-ts.js'), to: path.resolve(__dirname, 'js/vendor/zxcvbn-ts.js') },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3787,10 +3787,10 @@ jquery@3.6.0, jquery@>=1.2.6, jquery@>=1.7, "jquery@>=1.8.0 <4.0.0":
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
-js-cookie@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+js-cookie@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Removes the `Cookies.defaults` and sets the `path` attribute for each call.

- https://github.com/js-cookie/js-cookie/releases/tag/v3.0.0
