### PR TITLE
Remove `jquery-debounce-throttle` JavaScript dependency

### DIFF
--- a/js/src/navigation.js
+++ b/js/src/navigation.js
@@ -1201,10 +1201,8 @@ Navigation.ResizeHandler = function () {
     this.mousedown = function (event) {
         event.preventDefault();
         $(document)
-            .on('mousemove', { 'resize_handler': event.data.resize_handler },
-                $.throttle(event.data.resize_handler.mousemove, 4))
-            .on('mouseup', { 'resize_handler': event.data.resize_handler },
-                event.data.resize_handler.mouseup);
+            .on('mousemove', { 'resize_handler': event.data.resize_handler }, event.data.resize_handler.mousemove)
+            .on('mouseup', { 'resize_handler': event.data.resize_handler }, event.data.resize_handler.mouseup);
         $('body').css('cursor', 'col-resize');
     };
     /**

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -139,7 +139,6 @@ class Header
         $this->scripts->addFile('vendor/js.cookie.js');
         $this->scripts->addFile('vendor/jquery/jquery.validate.js');
         $this->scripts->addFile('vendor/jquery/jquery-ui-timepicker-addon.js');
-        $this->scripts->addFile('vendor/jquery/jquery.debounce-1.0.6.js');
         $this->scripts->addFile('menu_resizer.js');
 
         // Cross-framing protection

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "^6.6.0",
     "jquery": "3.6.0",
-    "jquery-debounce-throttle": "^1.0.6-rc.0",
     "jquery-migrate": "3.4.0",
     "jquery-ui-dist": "1.13.1",
     "jquery-ui-timepicker-addon": "1.6.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -144,7 +144,6 @@ module.exports = [
                     { from: path.resolve(__dirname, 'node_modules/u2f-api-polyfill/u2f-api-polyfill.js'), to: path.resolve(__dirname, 'js/vendor/u2f-api-polyfill.js') },
                     { from: path.resolve(__dirname, 'node_modules/jquery-uitablefilter/jquery.uitablefilter.js'), to: path.resolve(__dirname, 'js/vendor/jquery/jquery.uitablefilter.js') },
                     { from: path.resolve(__dirname, 'node_modules/tablesorter/dist/js/jquery.tablesorter.js'), to: path.resolve(__dirname, 'js/vendor/jquery/jquery.tablesorter.js') },
-                    { from: path.resolve(__dirname, 'node_modules/jquery-debounce-throttle/index.js'), to: path.resolve(__dirname, 'js/vendor/jquery/jquery.debounce-1.0.6.js') },
                     { from: path.resolve(__dirname, 'node_modules/jquery-ui-timepicker-addon/dist/jquery-ui-timepicker-addon.js'), to: path.resolve(__dirname, 'js/vendor/jquery/jquery-ui-timepicker-addon.js') },
                     { from: path.resolve(__dirname, 'node_modules/ol/ol.css'), to: path.resolve(__dirname, 'js/vendor/openlayers/theme/ol.css') },
                     { from: path.resolve(__dirname, 'node_modules/locutus.sprintf/src/php/strings/sprintf.browser.js'), to: path.resolve(__dirname, 'js/vendor/sprintf.js') },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3748,13 +3748,6 @@ jest@^27.3.1:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
-jquery-debounce-throttle@^1.0.6-rc.0:
-  version "1.0.6-rc.0"
-  resolved "https://registry.yarnpkg.com/jquery-debounce-throttle/-/jquery-debounce-throttle-1.0.6-rc.0.tgz#59a7737e46d8b435d01bc94b224e98fa126aba46"
-  integrity sha512-GhdvfeD+sMiYdK4BT6WZOpxFbaS9o+87OaqdmH0K1hXyvZd0uzZukXSSy9lt9kQ6FoVY06GGphFmrpyJUrGyNQ==
-  dependencies:
-    jquery ">=1.7"
-
 jquery-migrate@3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/jquery-migrate/-/jquery-migrate-3.4.0.tgz#915d6e914c76bd7410a58c86d20fec0052784af9"
@@ -3782,7 +3775,7 @@ jquery-validation@1.19.3:
   resolved "https://registry.yarnpkg.com/jquery-validation/-/jquery-validation-1.19.3.tgz#50b350eba8b02bcfd119ba15f199487b7eb64086"
   integrity sha512-iXxCS5W7STthSTMFX/NDZfWHBLbJ1behVK3eAgHXAV8/0vRa9M4tiqHvJMr39VGWHMGdlkhrtrkBuaL2UlE8yw==
 
-jquery@3.6.0, jquery@>=1.2.6, jquery@>=1.7, "jquery@>=1.8.0 <4.0.0":
+jquery@3.6.0, jquery@>=1.2.6, "jquery@>=1.8.0 <4.0.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==


### PR DESCRIPTION
This package is not supported anymore.

Removes the call to `.throttle()` when resizing the navigation sidebar.

- https://github.com/dfilatov/jquery-plugins