### PR TITLE
Revert to old behavior for `ShowServerInfo`

### DIFF
--- a/libraries/classes/Controllers/HomeController.php
+++ b/libraries/classes/Controllers/HomeController.php
@@ -143,20 +143,16 @@ class HomeController extends AbstractController
         }
 
         $databaseServer = [];
-        if ($server > 0) {
+        if ($server > 0 && $cfg['ShowServerInfo']) {
             $hostInfo = '';
             if (! empty($cfg['Server']['verbose'])) {
                 $hostInfo .= $cfg['Server']['verbose'];
-                if ($cfg['ShowServerInfo']) {
-                    $hostInfo .= ' (';
-                }
+                $hostInfo .= ' (';
             }
 
-            if ($cfg['ShowServerInfo'] || empty($cfg['Server']['verbose'])) {
-                $hostInfo .= $this->dbi->getHostInfo();
-            }
+            $hostInfo .= $this->dbi->getHostInfo();
 
-            if (! empty($cfg['Server']['verbose']) && $cfg['ShowServerInfo']) {
+            if (! empty($cfg['Server']['verbose'])) {
                 $hostInfo .= ')';
             }
 


### PR DESCRIPTION
### Description

Seems we changed the flag behavior here: https://github.com/phpmyadmin/phpmyadmin/commit/cd1b8a9b770b9e8e4589e5de808ead4ab781595b#diff-bb8d8aecc2e174245e8b95be9344176aba8971d024f3b2c2311b8e58ddd59b31L149

I'm not sure whether that was intentional, but it causes the `Database server` panel to always show compared to pre 5.2.0.

Truth be told, it doesn't make sense to have that flag and then the additional checks in the block when we know it's `true`, so I updated the code to take care of that.
