### PR TITLE
Ignore invalid routes cache file

### DIFF
--- a/test/classes/RoutingTest.php
+++ b/test/classes/RoutingTest.php
@@ -8,6 +8,11 @@ use FastRoute\Dispatcher;
 use PhpMyAdmin\Controllers\HomeController;
 use PhpMyAdmin\Routing;
 
+use function copy;
+
+use const CACHE_DIR;
+use const ROOT_PATH;
+
 /**
  * @covers \PhpMyAdmin\Routing
  */
@@ -23,6 +28,52 @@ class RoutingTest extends AbstractTestCase
         $this->assertSame(
             [Dispatcher::FOUND, HomeController::class, []],
             $dispatcher->dispatch('GET', '/')
+        );
+    }
+
+    public function testGetDispatcherWithValidCacheFile(): void
+    {
+        $GLOBALS['cfg']['environment'] = null;
+
+        $this->assertDirectoryIsWritable(CACHE_DIR);
+        $this->assertTrue(copy(
+            ROOT_PATH . 'test/test_data/routes/routes-valid.cache.txt',
+            CACHE_DIR . 'routes.cache.php'
+        ));
+
+        $dispatcher = Routing::getDispatcher();
+        $this->assertInstanceOf(Dispatcher::class, $dispatcher);
+        $this->assertSame(
+            [Dispatcher::FOUND, HomeController::class, []],
+            $dispatcher->dispatch('GET', '/')
+        );
+
+        $this->assertFileEquals(
+            CACHE_DIR . 'routes.cache.php',
+            ROOT_PATH . 'test/test_data/routes/routes-valid.cache.txt'
+        );
+    }
+
+    public function testGetDispatcherWithInvalidCacheFile(): void
+    {
+        $GLOBALS['cfg']['environment'] = null;
+
+        $this->assertDirectoryIsWritable(CACHE_DIR);
+        $this->assertTrue(copy(
+            ROOT_PATH . 'test/test_data/routes/routes-invalid.cache.txt',
+            CACHE_DIR . 'routes.cache.php'
+        ));
+
+        $dispatcher = Routing::getDispatcher();
+        $this->assertInstanceOf(Dispatcher::class, $dispatcher);
+        $this->assertSame(
+            [Dispatcher::FOUND, HomeController::class, []],
+            $dispatcher->dispatch('GET', '/')
+        );
+
+        $this->assertFileNotEquals(
+            CACHE_DIR . 'routes.cache.php',
+            ROOT_PATH . 'test/test_data/routes/routes-invalid.cache.txt'
         );
     }
 

--- a/test/test_data/routes/routes-invalid.cache.txt
+++ b/test/test_data/routes/routes-invalid.cache.txt
@@ -1,0 +1,34 @@
+<?php return array (
+  0 => 
+  array (
+    'GET' => 
+    array (
+      '' => 
+      array (
+        0 => 'PhpMyAdmin\\Controllers\\HomeController',
+        1 => 'index',
+      ),
+      '/' => 
+      array (
+        0 => 'PhpMyAdmin\\Controllers\\HomeController',
+        1 => 'index',
+      ),
+    ),
+    'POST' => 
+    array (
+      '' => 
+      array (
+        0 => 'PhpMyAdmin\\Controllers\\HomeController',
+        1 => 'index',
+      ),
+      '/' => 
+      array (
+        0 => 'PhpMyAdmin\\Controllers\\HomeController',
+        1 => 'index',
+      ),
+    ),
+  ),
+  1 => 
+  array (
+  ),
+);

--- a/test/test_data/routes/routes-valid.cache.txt
+++ b/test/test_data/routes/routes-valid.cache.txt
@@ -1,0 +1,18 @@
+<?php return array (
+  0 => 
+  array (
+    'GET' => 
+    array (
+      '' => 'PhpMyAdmin\\Controllers\\HomeController',
+      '/' => 'PhpMyAdmin\\Controllers\\HomeController',
+    ),
+    'POST' => 
+    array (
+      '' => 'PhpMyAdmin\\Controllers\\HomeController',
+      '/' => 'PhpMyAdmin\\Controllers\\HomeController',
+    ),
+  ),
+  1 => 
+  array (
+  ),
+);


### PR DESCRIPTION
If the `libraries/cache/routes.cache.php` file is invalid (usually from 5.1), ignores it and try to write a new one instead of failing.

- Fixes https://github.com/phpmyadmin/phpmyadmin/issues/17522.
