### PR TITLE
Fix tables spacing and colors

### DIFF
--- a/js/src/server/status/monitor.js
+++ b/js/src/server/status/monitor.js
@@ -1934,7 +1934,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
     function buildLogTable (data, groupInserts) {
         var rows = data.rows;
         var cols = [];
-        var $table = $('<table class="table table-light table-striped table-hover align-middle sortable"></table>');
+        var $table = $('<table class="table table-striped table-hover align-middle sortable"></table>');
         var $tBody;
         var $tRow;
         var $tCell;
@@ -2132,7 +2132,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
 
             if (data.profiling) {
                 var chartData = [];
-                var numberTable = '<table class="table table-sm table-light table-striped table-hover w-auto queryNums"><thead><tr><th>' + Messages.strStatus + '</th><th>' + Messages.strTime + '</th></tr></thead><tbody>';
+                var numberTable = '<table class="table table-sm table-striped table-hover w-auto queryNums"><thead><tr><th>' + Messages.strStatus + '</th><th>' + Messages.strTime + '</th></tr></thead><tbody>';
                 var duration;
                 var otherTime = 0;
 

--- a/libraries/classes/BrowseForeigners.php
+++ b/libraries/classes/BrowseForeigners.php
@@ -210,7 +210,7 @@ class BrowseForeigners
             . '</fieldset>'
             . '</form>';
 
-        $output .= '<table class="table table-light table-striped table-hover" id="browse_foreign_table">';
+        $output .= '<table class="table table-striped table-hover" id="browse_foreign_table">';
 
         if (! is_array($foreignData['disp_row'])) {
             return $output . '</tbody>'

--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -1190,7 +1190,7 @@ class Routines
                 $result = $this->dbi->storeResult();
 
                 if ($result !== false && $result->numRows() > 0) {
-                    $output .= '<table class="table table-light table-striped w-auto"><tr>';
+                    $output .= '<table class="table table-striped w-auto"><tr>';
                     foreach ($result->getFieldNames() as $field) {
                         $output .= '<th>';
                         $output .= htmlspecialchars($field);

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -1290,7 +1290,7 @@ class Results
         $displayParams = $this->properties['display_params'];
 
         // 1. Displays the full/partial text button (part 1)...
-        $buttonHtml = '<thead class="table-light"><tr>' . "\n";
+        $buttonHtml = '<thead><tr>' . "\n";
 
         $emptyPreCondition = $displayParts['edit_lnk'] != self::NO_EDIT_OR_DELETE
                            && $displayParts['del_lnk'] != self::NO_EDIT_OR_DELETE;

--- a/libraries/classes/Engines/Innodb.php
+++ b/libraries/classes/Engines/Innodb.php
@@ -130,11 +130,11 @@ class Innodb extends StorageEngine
         /** @var string[] $bytes */
         $bytes = Util::formatByteDown($status['Innodb_buffer_pool_pages_total'] * $status['Innodb_page_size']);
 
-        $output = '<table class="table table-light table-striped table-hover w-auto float-start caption-top">' . "\n"
+        $output = '<table class="table table-striped table-hover w-auto float-start caption-top">' . "\n"
             . '    <caption>' . "\n"
             . '        ' . __('Buffer Pool Usage') . "\n"
             . '    </caption>' . "\n"
-            . '    <tfoot class="table-light">' . "\n"
+            . '    <tfoot>' . "\n"
             . '        <tr>' . "\n"
             . '            <th colspan="2">' . "\n"
             . '                ' . __('Total:') . ' '
@@ -189,7 +189,7 @@ class Innodb extends StorageEngine
 
         $output .= '    </tbody>' . "\n"
             . '</table>' . "\n\n"
-            . '<table class="table table-light table-striped table-hover w-auto ms-4 float-start caption-top">' . "\n"
+            . '<table class="table table-striped table-hover w-auto ms-4 float-start caption-top">' . "\n"
             . '    <caption>' . "\n"
             . '        ' . __('Buffer Pool Activity') . "\n"
             . '    </caption>' . "\n"

--- a/libraries/classes/StorageEngine.php
+++ b/libraries/classes/StorageEngine.php
@@ -369,7 +369,7 @@ class StorageEngine
                 . "\n"
                 . '</p>' . "\n";
         } else {
-            $ret = '<table class="table table-light table-striped table-hover w-auto">'
+            $ret = '<table class="table table-striped table-hover w-auto">'
                 . "\n" . $ret . '</table>' . "\n";
         }
 

--- a/templates/columns_definitions/partitions.twig
+++ b/templates/columns_definitions/partitions.twig
@@ -71,7 +71,7 @@
     {% endif %}
 </table>
 {% if partition_details['partition_count'] > 1 %}
-    <table class="table table-light align-middle" id="partition_definition_table">
+    <table class="table align-middle" id="partition_definition_table">
         <thead><tr>
             <th>{% trans 'Partition' %}</th>
             {% if partition_details['value_enabled'] %}

--- a/templates/database/central_columns/main.twig
+++ b/templates/database/central_columns/main.twig
@@ -8,8 +8,8 @@
         {{ get_hidden_inputs(db) }}
         <input type="hidden" name="add_new_column" value="add_new_column">
         <div class="table-responsive">
-            <table class="table table-light w-auto">
-                <thead class="table-light">
+            <table class="table w-auto">
+                <thead>
                     <tr>
                         <th></th>
                         <th class="" title="" data-column="name">
@@ -208,10 +208,10 @@
     </form>
     <div id="tableslistcontainer">
         <form name="tableslistcontainer">
-            <table id="table_columns" class="table table-light table-striped table-hover tablesorter w-auto">
+            <table id="table_columns" class="table table-striped table-hover tablesorter w-auto">
                 {% set class = 'column_heading' %}
                 {% set title = 'Click to sort.' | trans %}
-                <thead class="table-light">
+                <thead>
                     <tr>
                         <th class="{{ class }}"></th>
                         <th class="hide"></th>

--- a/templates/database/events/index.twig
+++ b/templates/database/events/index.twig
@@ -36,8 +36,8 @@
       {% trans 'There are no events to display.' %}
     </div>
 
-    <table id="eventsTable" class="table table-light table-striped table-hover{{ items is empty ? ' hide' }} w-auto data">
-      <thead class="table-light">
+    <table id="eventsTable" class="table table-striped table-hover{{ items is empty ? ' hide' }} w-auto data">
+      <thead>
       <tr>
         <th></th>
         <th>{% trans 'Name' %}</th>

--- a/templates/database/privileges/index.twig
+++ b/templates/database/privileges/index.twig
@@ -10,8 +10,8 @@
         </legend>
 
         <div class="table-responsive jsresponsive">
-          <table class="table table-light table-striped table-hover w-auto">
-            <thead class="table-light">
+          <table class="table table-striped table-hover w-auto">
+            <thead>
               <tr>
                 <th></th>
                 <th scope="col">{% trans 'User name' %}</th>

--- a/templates/database/routines/index.twig
+++ b/templates/database/routines/index.twig
@@ -42,8 +42,8 @@
       {% trans 'There are no routines to display.' %}
     </div>
 
-    <table id="routinesTable" class="table table-light table-striped table-hover{{ items is empty ? ' hide' }} data w-auto">
-      <thead class="table-light">
+    <table id="routinesTable" class="table table-striped table-hover{{ items is empty ? ' hide' }} data w-auto">
+      <thead>
       <tr>
         <th></th>
         <th>{% trans 'Name' %}</th>

--- a/templates/database/structure/body_for_table_summary.twig
+++ b/templates/database/structure/body_for_table_summary.twig
@@ -1,4 +1,4 @@
-<tfoot id="tbl_summary_row" class="table-light">
+<tfoot id="tbl_summary_row">
 <tr>
     <th class="d-print-none"></th>
     <th class="tbl_num text-nowrap">

--- a/templates/database/structure/show_create.twig
+++ b/templates/database/structure/show_create.twig
@@ -4,7 +4,7 @@
   {% if tables.tables is not empty %}
     <fieldset class="pma-fieldset">
       <legend>{% trans 'Tables' %}</legend>
-      <table class="table table-light table-striped show_create">
+      <table class="table table-striped show_create">
         <thead>
           <tr>
             <th>{% trans 'Table' %}</th>
@@ -26,7 +26,7 @@
   {% if tables.views is not empty %}
     <fieldset class="pma-fieldset">
       <legend>{% trans 'Views' %}</legend>
-      <table class="table table-light table-striped show_create">
+      <table class="table table-striped show_create">
         <thead>
           <tr>
             <th>{% trans 'View' %}</th>

--- a/templates/database/structure/table_header.twig
+++ b/templates/database/structure/table_header.twig
@@ -1,8 +1,8 @@
 <form method="post" action="{{ url('/database/structure') }}" name="tablesForm" id="tablesForm">
 {{ get_hidden_inputs(db) }}
 <div class="table-responsive">
-<table class="table table-light table-striped table-hover table-sm w-auto data">
-    <thead class="table-light">
+<table class="table table-striped table-hover table-sm w-auto data">
+    <thead>
         <tr>
             <th class="d-print-none"></th>
             <th>{{ sortable_table_header('Table'|trans, 'table') }}</th>

--- a/templates/database/tracking/tables.twig
+++ b/templates/database/tracking/tables.twig
@@ -6,8 +6,8 @@
         <form method="post" action="{{ url('/database/tracking') }}" name="trackedForm"
             id="trackedForm" class="ajax">
             {{ get_hidden_inputs(db) }}
-            <table id="versions" class="table table-light table-striped table-hover w-auto">
-                <thead class="table-light">
+            <table id="versions" class="table table-striped table-hover w-auto">
+                <thead>
                     <tr>
                         <th></th>
                         <th>{% trans 'Table' %}</th>
@@ -146,8 +146,8 @@
     <form method="post" action="{{ url('/database/tracking') }}" name="untrackedForm"
         id="untrackedForm" class="ajax">
         {{ get_hidden_inputs(db) }}
-        <table id="noversions" class="table table-light table-striped table-hover w-auto">
-            <thead class="table-light">
+        <table id="noversions" class="table table-striped table-hover w-auto">
+            <thead>
                 <tr>
                     <th></th>
                     <th>{% trans 'Table' %}</th>

--- a/templates/database/triggers/list.twig
+++ b/templates/database/triggers/list.twig
@@ -36,8 +36,8 @@
       {% trans 'There are no triggers to display.' %}
     </div>
 
-    <table id="triggersTable" class="table table-light table-striped table-hover{{ items is empty ? ' hide' }} w-auto data">
-      <thead class="table-light">
+    <table id="triggersTable" class="table table-striped table-hover{{ items is empty ? ' hide' }} w-auto data">
+      <thead>
         <tr>
           <th></th>
           <th>{% trans 'Name' %}</th>

--- a/templates/display/results/table.twig
+++ b/templates/display/results/table.twig
@@ -202,7 +202,7 @@
 {% endif %}
 
   <div class="table-responsive-md">
-    <table class="table table-light table-striped table-hover table-sm table_results data ajax w-auto" data-uniqueId="{{ unique_id }}">
+    <table class="table table-striped table-hover table-sm table_results data ajax w-auto" data-uniqueId="{{ unique_id }}">
 
       {{ headers.button|raw }}
       {{ headers.table_headers_for_columns|raw }}

--- a/templates/indexes.twig
+++ b/templates/indexes.twig
@@ -9,8 +9,8 @@
 
     {{ include('modals/preview_sql_confirmation.twig') }}
     <div class="table-responsive jsresponsive">
-      <table class="table table-light table-striped table-hover table-sm w-auto align-middle" id="table_index">
-        <thead class="table-light">
+      <table class="table table-striped table-hover table-sm w-auto align-middle" id="table_index">
+        <thead>
         <tr>
             <th colspan="3" class="d-print-none">{% trans 'Action' %}</th>
             <th>{% trans 'Keyname' %}</th>

--- a/templates/relation/check_relations.twig
+++ b/templates/relation/check_relations.twig
@@ -32,7 +32,7 @@
       {% endapply %}
     {% endif %}
 
-    <table class="table table-light table-striped">
+    <table class="table table-striped">
       <tr>
         <th class="text-start" scope="row">
           <code>$cfg['Servers'][$i]['pmadb']</code>

--- a/templates/server/binlog/index.twig
+++ b/templates/server/binlog/index.twig
@@ -37,7 +37,7 @@
 
 {{ sql_message|raw }}
 
-<table class="table table-light table-striped table-hover align-middle" id="binlogTable">
+<table class="table table-striped table-hover align-middle" id="binlogTable">
   <thead>
     <tr>
       <td colspan="6" class="text-center">

--- a/templates/server/databases/index.twig
+++ b/templates/server/databases/index.twig
@@ -92,7 +92,7 @@
       {{ get_hidden_inputs(url_params) }}
       <div class="table-responsive">
         <table class="table table-striped table-hover w-auto">
-          <thead class="table-light">
+          <thead>
             <tr>
               {% if is_drop_allowed %}
                 <th></th>
@@ -247,7 +247,7 @@
             {% endfor %}
           </tbody>
 
-          <tfoot class="table-light">
+          <tfoot>
             <tr>
               <th colspan="{{ is_drop_allowed ? '3' : '2' }}">
                 {% trans 'Total:' %}

--- a/templates/server/engines/index.twig
+++ b/templates/server/engines/index.twig
@@ -7,8 +7,8 @@
   </div>
 
   <div class="table-responsive">
-    <table class="table table-light table-striped table-hover w-auto">
-      <thead class="table-light">
+    <table class="table table-striped table-hover w-auto">
+      <thead>
         <tr>
           <th scope="col">{% trans 'Storage Engine' %}</th>
           <th scope="col">{% trans 'Description' %}</th>

--- a/templates/server/plugins/index.twig
+++ b/templates/server/plugins/index.twig
@@ -17,11 +17,11 @@
   {% for type, list in plugins %}
     <div class="row">
       <div class="table-responsive col-12">
-        <table class="table table-light table-striped table-hover caption-top w-auto" id="plugins-{{ clean_types[type] }}">
+        <table class="table table-striped table-hover caption-top w-auto" id="plugins-{{ clean_types[type] }}">
           <caption>
             {{ type }}
           </caption>
-          <thead class="table-light">
+          <thead>
             <tr>
               <th scope="col">{% trans 'Plugin' %}</th>
               <th scope="col">{% trans 'Description' %}</th>

--- a/templates/server/privileges/privileges_summary.twig
+++ b/templates/server/privileges/privileges_summary.twig
@@ -8,8 +8,8 @@
             {{ legend }}
         </legend>
 
-        <table class="table table-light table-striped table-hover w-auto">
-            <thead class="table-light">
+        <table class="table table-striped table-hover w-auto">
+            <thead>
                 <tr>
                     <th scope="col">{{ type_label }}</th>
                     <th scope="col">{% trans 'Privileges' %}</th>

--- a/templates/server/privileges/users_overview.twig
+++ b/templates/server/privileges/users_overview.twig
@@ -1,8 +1,8 @@
 <form name="usersForm" id="usersForm" action="{{ url('/server/privileges') }}" method="post">
   {{ get_hidden_inputs() }}
   <div class="table-responsive">
-    <table id="userRightsTable" class="table table-light table-striped table-hover w-auto">
-      <thead class="table-light">
+    <table id="userRightsTable" class="table table-striped table-hover w-auto">
+      <thead>
         <tr>
           <th></th>
           <th scope="col">{% trans 'User name' %}</th>

--- a/templates/server/status/processes/list.twig
+++ b/templates/server/status/processes/list.twig
@@ -1,6 +1,6 @@
 <div class="responsivetable row">
-  <table id="tableprocesslist" class="table table-light table-striped table-hover sortable w-auto">
-    <thead class="table-light">
+  <table id="tableprocesslist" class="table table-striped table-hover sortable w-auto">
+    <thead>
       <tr>
         <th>{% trans 'Processes' %}</th>
         {% for column in columns %}

--- a/templates/server/status/queries/index.twig
+++ b/templates/server/status/queries/index.twig
@@ -26,13 +26,13 @@
 </div>
 
 <div class="row">
-  <table id="serverStatusQueriesDetails" class="table table-light table-striped table-hover sortable col-md-4 col-12 w-auto">
+  <table id="serverStatusQueriesDetails" class="table table-striped table-hover sortable col-md-4 col-12 w-auto">
     <colgroup>
       <col class="namecol">
       <col class="valuecol" span="3">
     </colgroup>
 
-    <thead class="table-light">
+    <thead>
       <tr>
         <th scope="col">{% trans 'Statements' %}</th>
         <th class="text-end" scope="col">{% trans %}#{% notes %}# = Amount of queries{% endtrans %}</th>

--- a/templates/server/status/status/index.twig
+++ b/templates/server/status/status/index.twig
@@ -7,8 +7,8 @@
   <div class="row"><p>{{ 'This MySQL server has been running for %1$s. It started up on %2$s.'|trans|format(uptime, start_time) }}</p></div>
 
 <div class="row align-items-start">
-  <table class="table table-light table-striped table-hover col-12 col-md-5 w-auto">
-    <thead class="table-light">
+  <table class="table table-striped table-hover col-12 col-md-5 w-auto">
+    <thead>
       <tr>
         <th scope="col">
           {% trans 'Traffic' %}
@@ -30,8 +30,8 @@
     </tbody>
   </table>
 
-  <table class="table table-light table-striped table-hover col-12 col-md-6 w-auto">
-    <thead class="table-light">
+  <table class="table table-striped table-hover col-12 col-md-6 w-auto">
+    <thead>
       <tr>
         <th scope="col">{% trans 'Connections' %}</th>
         <th class="text-end" scope="col">#</th>

--- a/templates/server/status/variables/index.twig
+++ b/templates/server/status/variables/index.twig
@@ -64,13 +64,13 @@
   </div>
 
   <div class="responsivetable row">
-    <table class="table table-light table-striped table-hover table-sm" id="serverStatusVariables">
+    <table class="table table-striped table-hover table-sm" id="serverStatusVariables">
       <colgroup>
         <col class="namecol">
         <col class="valuecol">
         <col class="descrcol">
       </colgroup>
-      <thead class="table-light">
+      <thead>
         <tr>
           <th scope="col">{% trans 'Variable' %}</th>
           <th scope="col">{% trans 'Value' %}</th>

--- a/templates/server/user_groups/user_groups.twig
+++ b/templates/server/user_groups/user_groups.twig
@@ -2,8 +2,8 @@
 {% if  has_rows %}
     <form name="userGroupsForm" id="userGroupsForm" action="{{ action|raw }}" method="post">
         {{ hidden_inputs|raw  }}
-        <table class="table table-light table-striped table-hover">
-            <thead class="table-light">
+        <table class="table table-striped table-hover">
+            <thead>
                 <tr class="text-nowrap">
                     <th scope="col">
                         {% trans 'User groups' %}

--- a/templates/server/variables/index.twig
+++ b/templates/server/variables/index.twig
@@ -24,8 +24,8 @@
   } only %}
 
   <div class="table-responsive">
-    <table id="serverVariables" class="table table-light table-striped table-hover table-sm">
-      <thead class="table-light">
+    <table id="serverVariables" class="table table-striped table-hover table-sm">
+      <thead>
         <tr>
           <th scope="col">{% trans 'Action' %}</th>
           <th scope="col">{% trans 'Variable' %}</th>

--- a/templates/table/insert/get_head_and_foot_of_insert_row_table.twig
+++ b/templates/table/insert/get_head_and_foot_of_insert_row_table.twig
@@ -1,5 +1,5 @@
 <div class="table-responsive-lg">
-  <table class="table table-light table-striped align-middle my-3 insertRowTable w-auto">
+  <table class="table table-striped align-middle my-3 insertRowTable w-auto">
     <thead>
     <tr>
       <th>{% trans 'Column' %}</th>

--- a/templates/table/privileges/index.twig
+++ b/templates/table/privileges/index.twig
@@ -12,8 +12,8 @@
       </legend>
 
       <div class="table-responsive-md jsresponsive">
-        <table class="table table-light table-striped table-hover w-auto">
-          <thead class="table-light">
+        <table class="table table-striped table-hover w-auto">
+          <thead>
             <tr>
               <th></th>
               <th>{% trans 'User name' %}</th>

--- a/templates/table/relation/common_form.twig
+++ b/templates/table/relation/common_form.twig
@@ -8,8 +8,8 @@
         <fieldset class="pma-fieldset mb-3">
             <legend>{% trans 'Foreign key constraints' %}</legend>
             <div class="table-responsive-md jsresponsive">
-            <table class="relationalTable table table-light table-striped w-auto">
-                <thead class="table-light">
+            <table class="relationalTable table table-striped w-auto">
+                <thead>
                 <tr>
                     <th>{% trans 'Actions' %}</th>
                     <th>{% trans 'Constraint properties' %}</th>
@@ -114,8 +114,8 @@
                 {% trans 'Internal relationships' %}
                 {{ show_docu('config', 'cfg_Servers_relation') }}
             </legend>
-            <table class="relationalTable table table-light table-striped table-hover table-sm w-auto">
-                <thead class="table-light">
+            <table class="relationalTable table table-striped table-hover table-sm w-auto">
+                <thead>
                   <tr>
                     <th>{% trans 'Column' %}</th>
                     <th>

--- a/templates/table/search/index.twig
+++ b/templates/table/search/index.twig
@@ -29,8 +29,8 @@
     <div class="card-body">
       <div id="fieldset_table_qbe">
         <div class="table-responsive-md jsresponsive">
-          <table class="table table-light table-striped table-hover table-sm w-auto">
-            <thead class="table-light">
+          <table class="table table-striped table-hover table-sm w-auto">
+            <thead>
               <tr>
                 {% if geom_column_flag %}
                   <th>{% trans 'Function' %}</th>

--- a/templates/table/structure/display_partitions.twig
+++ b/templates/table/structure/display_partitions.twig
@@ -17,8 +17,8 @@
                     <code>{{ sub_partition_method }}({{ sub_partition_expression }})</code>
                 <p>
             {% endif %}
-            <table class="table table-light table-striped table-hover table-sm">
-                <thead class="table-light">
+            <table class="table table-striped table-hover table-sm">
+                <thead>
                     <tr>
                         <th colspan="2">#</th>
                         <th>{% trans 'Partition' %}</th>

--- a/templates/table/structure/display_structure.twig
+++ b/templates/table/structure/display_structure.twig
@@ -12,7 +12,7 @@
             "table"
         {%- endif %}>
     <div class="table-responsive-md">
-    <table id="tablestructure" class="table table-light table-striped table-hover w-auto align-middle">
+    <table id="tablestructure" class="table table-striped table-hover w-auto align-middle">
         {# Table header #}
         <thead>
             <tr>
@@ -451,8 +451,8 @@
 
         {{ include('modals/preview_sql_confirmation.twig') }}
         <div class="table-responsive jsresponsive">
-          <table class="table table-light table-striped table-hover table-sm w-auto align-middle" id="table_index">
-            <thead class="table-light">
+          <table class="table table-striped table-hover table-sm w-auto align-middle" id="table_index">
+            <thead>
               <tr>
                 <th colspan="3" class="d-print-none">{% trans 'Action' %}</th>
                 <th>{% trans 'Keyname' %}</th>

--- a/templates/table/structure/display_table_stats.twig
+++ b/templates/table/structure/display_table_stats.twig
@@ -10,7 +10,7 @@
         <a id="showusage"></a>
 
         {% if not tbl_is_view and not db_is_system_schema %}
-            <table class="table table-light table-striped table-hover table-sm w-auto caption-top">
+            <table class="table table-striped table-hover table-sm w-auto caption-top">
                 <caption>{% trans 'Space usage' %}</caption>
                 <tbody>
                     <tr>
@@ -56,7 +56,7 @@
                     or tbl_storage_engine == 'MARIA'
                     or tbl_storage_engine == 'BDB')
                     or (tbl_storage_engine == 'INNODB' and innodb_file_per_table == true) %}
-                <tfoot class="table-light">
+                <tfoot>
                     <tr class="d-print-none">
                         <th colspan="3" class="center">
                             <a href="{{ url('/sql') }}" data-post="{{ get_common({
@@ -76,7 +76,7 @@
 
         {% set avg_size = avg_size is defined ? avg_size : null %}
         {% set avg_unit = avg_unit is defined ? avg_unit : null %}
-        <table class="table table-light table-striped table-hover table-sm w-auto caption-top">
+        <table class="table table-striped table-hover table-sm w-auto caption-top">
             <caption>{% trans 'Row statistics' %}</caption>
             <tbody>
                 {% if showtable['Row_format'] is defined %}

--- a/templates/table/tracking/main.twig
+++ b/templates/table/tracking/main.twig
@@ -21,8 +21,8 @@
 {% if last_version > 0 %}
     <form method="post" action="{{ url('/table/tracking') }}" name="versionsForm" id="versionsForm" class="ajax">
         {{ get_hidden_inputs(db, table) }}
-        <table id="versions" class="table table-light table-striped table-hover table-sm w-auto">
-            <thead class="table-light">
+        <table id="versions" class="table table-striped table-hover table-sm w-auto">
+            <thead>
                 <tr>
                     <th></th>
                     <th>{% trans 'Version' %}</th>

--- a/templates/table/tracking/report_table.twig
+++ b/templates/table/tracking/report_table.twig
@@ -1,5 +1,5 @@
-<table id="{{ table_id }}" class="table table-light table-striped table-hover">
-    <thead class="table-light">
+<table id="{{ table_id }}" class="table table-striped table-hover">
+    <thead>
         <tr>
             <th>{% trans %}#{% context %}Number{% endtrans %}</th>
             <th>{% trans 'Date' %}</th>

--- a/templates/table/tracking/structure_snapshot_columns.twig
+++ b/templates/table/tracking/structure_snapshot_columns.twig
@@ -1,6 +1,6 @@
 <h3>{% trans 'Structure' %}</h3>
-<table id="tablestructure" class="table table-light table-striped table-hover w-auto">
-    <thead class="table-light">
+<table id="tablestructure" class="table table-striped table-hover w-auto">
+    <thead>
         <tr>
             <th>{% trans %}#{% context %}Number{% endtrans %}</th>
             <th>{% trans 'Column' %}</th>

--- a/templates/table/tracking/structure_snapshot_indexes.twig
+++ b/templates/table/tracking/structure_snapshot_indexes.twig
@@ -1,6 +1,6 @@
 <h3>{% trans 'Indexes' %}</h3>
-<table id="tablestructure_indexes" class="table table-light table-striped table-hover">
-    <thead class="table-light">
+<table id="tablestructure_indexes" class="table table-striped table-hover">
+    <thead>
         <tr>
             <th>{% trans 'Keyname' %}</th>
             <th>{% trans 'Type' %}</th>

--- a/templates/table/zoom_search/index.twig
+++ b/templates/table/zoom_search/index.twig
@@ -27,8 +27,8 @@
     <div class="card-header">{% trans 'Do a "query by example" (wildcard: "%") for two different columns' %}</div>
 
     <div class="card-body" id="inputSection">
-      <table class="table table-light table-striped table-hover table-sm w-auto" id="tableFieldsId">
-        <thead class="table-light">
+      <table class="table table-striped table-hover table-sm w-auto" id="tableFieldsId">
+        <thead>
           <tr>
             {% if geom_column_flag %}
               <th>{% trans 'Function' %}</th>

--- a/templates/transformation_overview.twig
+++ b/templates/transformation_overview.twig
@@ -12,7 +12,7 @@
 
 <h2 id="transformation">{% trans 'Available browser display transformations' %}</h2>
 
-<table class="table table-light table-striped align-middle">
+<table class="table table-striped align-middle">
   <thead>
     <tr>
       <th>{% trans 'Browser display transformation' %}</th>
@@ -31,7 +31,7 @@
 
 <h2 id="input_transformation">{% trans 'Available input transformations' %}</h2>
 
-<table class="table table-light table-striped align-middle">
+<table class="table table-striped align-middle">
   <thead>
     <tr>
       <th>{% trans 'Input transformation' %}</th>

--- a/test/classes/BrowseForeignersTest.php
+++ b/test/classes/BrowseForeignersTest.php
@@ -203,7 +203,7 @@ class BrowseForeignersTest extends AbstractTestCase
         );
 
         $this->assertStringContainsString(
-            '<table class="table table-light table-striped table-hover" id="browse_foreign_table">',
+            '<table class="table table-striped table-hover" id="browse_foreign_table">',
             $result
         );
 
@@ -219,7 +219,7 @@ class BrowseForeignersTest extends AbstractTestCase
         );
 
         $this->assertStringContainsString(
-            '<table class="table table-light table-striped table-hover" id="browse_foreign_table">',
+            '<table class="table table-striped table-hover" id="browse_foreign_table">',
             $result
         );
 

--- a/test/classes/Controllers/Server/BinlogControllerTest.php
+++ b/test/classes/Controllers/Server/BinlogControllerTest.php
@@ -60,7 +60,7 @@ class BinlogControllerTest extends AbstractTestCase
         $this->assertStringContainsString("SHOW BINLOG EVENTS IN 'index1' LIMIT 3, 10", $actual);
 
         $this->assertStringContainsString(
-            '<table class="table table-light table-striped table-hover align-middle" id="binlogTable">',
+            '<table class="table table-striped table-hover align-middle" id="binlogTable">',
             $actual
         );
 

--- a/test/classes/Controllers/Server/Status/ProcessesControllerTest.php
+++ b/test/classes/Controllers/Server/Status/ProcessesControllerTest.php
@@ -68,7 +68,7 @@ class ProcessesControllerTest extends AbstractTestCase
         $this->assertStringContainsString('5 seconds', $html);
 
         $this->assertStringContainsString(
-            '<table id="tableprocesslist" class="table table-light table-striped table-hover sortable w-auto">',
+            '<table id="tableprocesslist" class="table table-striped table-hover sortable w-auto">',
             $html
         );
         $this->assertStringContainsString('<th>Processes</th>', $html);

--- a/test/classes/Controllers/Server/Status/StatusControllerTest.php
+++ b/test/classes/Controllers/Server/Status/StatusControllerTest.php
@@ -79,7 +79,7 @@ class StatusControllerTest extends AbstractTestCase
         $this->assertStringContainsString($primaryHtml, $html);
 
         //validate 2: Status::getHtmlForServerStateTraffic
-        $trafficHtml = '<table class="table table-light table-striped table-hover col-12 col-md-5 w-auto">';
+        $trafficHtml = '<table class="table table-striped table-hover col-12 col-md-5 w-auto">';
         $this->assertStringContainsString($trafficHtml, $html);
         //traffic hint
         $trafficHtml = 'On a busy server, the byte counters may overrun';
@@ -93,7 +93,7 @@ class StatusControllerTest extends AbstractTestCase
         $this->assertStringContainsString('<th scope="col">Connections</th>', $html);
         $this->assertStringContainsString('<th class="text-end" scope="col">ø per hour</th>', $html);
         $this->assertStringContainsString(
-            '<table class="table table-light table-striped table-hover col-12 col-md-6 w-auto">',
+            '<table class="table table-striped table-hover col-12 col-md-6 w-auto">',
             $html
         );
         $this->assertStringContainsString('<th>Max. concurrent connections</th>', $html);

--- a/test/classes/Controllers/Server/Status/VariablesControllerTest.php
+++ b/test/classes/Controllers/Server/Status/VariablesControllerTest.php
@@ -66,7 +66,7 @@ class VariablesControllerTest extends AbstractTestCase
         $this->assertStringContainsString('<span class="status_binlog_cache">', $html);
 
         $this->assertStringContainsString(
-            '<table class="table table-light table-striped table-hover table-sm" id="serverStatusVariables">',
+            '<table class="table table-striped table-hover table-sm" id="serverStatusVariables">',
             $html
         );
         $this->assertStringContainsString('<th scope="col">Variable</th>', $html);

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -1584,7 +1584,7 @@ class ResultsTest extends AbstractTestCase
                 ],
                 'options' => '$optionsBlock',
                 'has_bulk_actions_form' => false,
-                'button' => '<thead class="table-light"><tr>' . "\n",
+                'button' => '<thead><tr>' . "\n",
                 'table_headers_for_columns' => $tableHeadersForColumns,
                 'column_at_right_side' => "\n" . '<td class="d-print-none"></td>',
             ],

--- a/test/classes/Engines/InnodbTest.php
+++ b/test/classes/Engines/InnodbTest.php
@@ -137,11 +137,11 @@ class InnodbTest extends AbstractTestCase
     public function testGetPageBufferpool(): void
     {
         $this->assertEquals(
-            '<table class="table table-light table-striped table-hover w-auto float-start caption-top">' . "\n" .
+            '<table class="table table-striped table-hover w-auto float-start caption-top">' . "\n" .
             '    <caption>' . "\n" .
             '        Buffer Pool Usage' . "\n" .
             '    </caption>' . "\n" .
-            '    <tfoot class="table-light">' . "\n" .
+            '    <tfoot>' . "\n" .
             '        <tr>' . "\n" .
             '            <th colspan="2">' . "\n" .
             '                Total: 4,096&nbsp;pages / 65,536&nbsp;KiB' . "\n" .
@@ -173,7 +173,7 @@ class InnodbTest extends AbstractTestCase
             '</td>' . "\n" .
             '        </tr>    </tbody>' . "\n" .
             '</table>' . "\n\n" .
-            '<table class="table table-light table-striped table-hover w-auto ms-4 float-start caption-top">' . "\n" .
+            '<table class="table table-striped table-hover w-auto ms-4 float-start caption-top">' . "\n" .
             '    <caption>' . "\n" .
             '        Buffer Pool Activity' . "\n" .
             '    </caption>' . "\n" .

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -1011,10 +1011,6 @@ select.invalid_value,
   overflow: hidden;
 }
 
-#tablestructure tbody label {
-  margin: 0.3rem 0;
-}
-
 #structure-action-links a {
   margin-right: 1em;
 }

--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -1187,10 +1187,6 @@ input {
   overflow: hidden;
 }
 
-#tablestructure tbody label {
-  margin: 0.3rem 0;
-}
-
 #structure-action-links a {
   margin-right: 1em;
 }

--- a/themes/metro/scss/_tables.scss
+++ b/themes/metro/scss/_tables.scss
@@ -4,15 +4,14 @@
     vertical-align: middle;
   }
 
-  .table-light {
-    th {
-      font-family: $font-family-bold;
-      font-weight: normal;
-      border-bottom: 1px solid $border-color;
+  th {
+    background-color: $th-background;
+    font-family: $font-family-bold;
+    font-weight: normal;
+    border-bottom: 1px solid $border-color;
 
-      a {
-        color: $th-color;
-      }
+    a {
+      color: $th-color;
     }
   }
 }

--- a/themes/metro/scss/_tables.scss
+++ b/themes/metro/scss/_tables.scss
@@ -1,4 +1,6 @@
 .table {
+  caption-side: top;
+
   td {
     touch-action: manipulation;
     vertical-align: middle;
@@ -13,6 +15,13 @@
     a {
       color: $th-color;
     }
+  }
+
+  caption {
+    font-family: $font-family-bold;
+    background-color: $th-background;
+    font-weight: normal;
+    text-align: center;
   }
 }
 

--- a/themes/metro/scss/_variables.scss
+++ b/themes/metro/scss/_variables.scss
@@ -185,6 +185,7 @@ $headings-font-weight: normal;
 
 $table-cell-padding: 0.6em;
 $table-cell-padding-sm: $table-cell-padding;
+$table-bg: $bg-two;
 $table-head-bg: #fff;
 $table-head-color: $th-color;
 $table-striped-order: even;

--- a/themes/metro/scss/_variables.scss
+++ b/themes/metro/scss/_variables.scss
@@ -194,6 +194,7 @@ $table-striped-order: even;
 $table-hover-color: $th-pointer-color;
 $table-hover-bg: $browse-marker-background;
 $table-border-width: 0;
+$table-caption-color: $table-head-color;
 
 // Buttons
 

--- a/themes/metro/scss/_variables.scss
+++ b/themes/metro/scss/_variables.scss
@@ -183,8 +183,10 @@ $headings-font-weight: normal;
 
 // Tables
 
-$table-cell-padding: 0.6em;
-$table-cell-padding-sm: $table-cell-padding;
+$table-cell-padding-y: 0.6em;
+$table-cell-padding-x: 0.6em;
+$table-cell-padding-y-sm: $table-cell-padding-y;
+$table-cell-padding-x-sm: $table-cell-padding-x;
 $table-bg: $bg-two;
 $table-head-bg: #fff;
 $table-head-color: $th-color;

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -1011,10 +1011,6 @@ select.invalid_value,
   vertical-align: middle;
 }
 
-#tablestructure tbody label {
-  margin: 0.3rem 0;
-}
-
 #structure-action-links a {
   margin-right: 1em;
 }

--- a/themes/original/scss/_tables.scss
+++ b/themes/original/scss/_tables.scss
@@ -6,31 +6,19 @@
     vertical-align: middle;
   }
 
+  th {
+    background-color: $th-background;
+  }
+
   thead th {
     border-bottom: 0;
-    background: $th-background;
   }
 }
 
 .table-striped {
-  tbody tr:nth-of-type(odd) {
-    background-color: $bg-one;
+  > tbody > tr:nth-of-type(#{$table-striped-order}) > th {
+    --#{$variable-prefix}table-accent-bg: #d3dce3;
   }
-
-  tbody tr:nth-of-type(even) {
-    background-color: $bg-two;
-  }
-}
-
-.table-light {
-  --#{$variable-prefix}table-bg: #{$table-bg};
-  --#{$variable-prefix}table-accent-bg: #{$table-accent-bg};
-  --#{$variable-prefix}table-striped-color: #{$table-striped-color};
-  --#{$variable-prefix}table-striped-bg: #{$table-striped-bg};
-  --#{$variable-prefix}table-active-color: #{$table-active-color};
-  --#{$variable-prefix}table-active-bg: #{$table-active-bg};
-  --#{$variable-prefix}table-hover-color: #{$table-hover-color};
-  --#{$variable-prefix}table-hover-bg: #{$table-hover-bg};
 }
 
 @media only screen and (min-width: 768px) {

--- a/themes/original/scss/_tables.scss
+++ b/themes/original/scss/_tables.scss
@@ -1,5 +1,6 @@
 .table {
   border-collapse: separate;
+  caption-side: top;
 
   td {
     touch-action: manipulation;
@@ -12,6 +13,12 @@
 
   thead th {
     border-bottom: 0;
+  }
+
+  caption {
+    background-color: $table-head-bg;
+    font-weight: bold;
+    text-align: center;
   }
 }
 

--- a/themes/original/scss/_variables.scss
+++ b/themes/original/scss/_variables.scss
@@ -82,8 +82,10 @@ $headings-font-weight: bold;
 
 // Tables
 
-$table-cell-padding: 0.1em 0.5em;
-$table-cell-padding-sm: $table-cell-padding;
+$table-cell-padding-y: 0.1em;
+$table-cell-padding-x: 0.5em;
+$table-cell-padding-y-sm: $table-cell-padding-y;
+$table-cell-padding-x-sm: $table-cell-padding-x;
 $table-bg: $bg-one;
 $table-striped-order: even;
 $table-striped-bg: $bg-two;

--- a/themes/original/scss/_variables.scss
+++ b/themes/original/scss/_variables.scss
@@ -93,6 +93,7 @@ $table-hover-bg: $browse-pointer-background;
 $table-hover-color: $browse-pointer-color;
 $table-head-color: $th-color;
 $table-head-bg: $th-background;
+$table-caption-color: $table-head-color;
 
 // Dropdowns
 

--- a/themes/original/scss/_variables.scss
+++ b/themes/original/scss/_variables.scss
@@ -84,8 +84,9 @@ $headings-font-weight: bold;
 
 $table-cell-padding: 0.1em 0.5em;
 $table-cell-padding-sm: $table-cell-padding;
+$table-bg: $bg-one;
 $table-striped-order: even;
-$table-bg: transparent;
+$table-striped-bg: $bg-two;
 $table-hover-bg: $browse-pointer-background;
 $table-hover-color: $browse-pointer-color;
 $table-head-color: $th-color;

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -1197,10 +1197,6 @@ input#import_merge {
   overflow: hidden;
 }
 
-#tablestructure tbody label {
-  margin: 0.3rem 0;
-}
-
 #structure-action-links a {
   margin-right: 1em;
 }

--- a/themes/pmahomme/scss/_tables.scss
+++ b/themes/pmahomme/scss/_tables.scss
@@ -1,4 +1,6 @@
 .table {
+  caption-side: top;
+
   th,
   td {
     text-shadow: 0 1px 0 #fff;
@@ -17,6 +19,12 @@
   thead th {
     border-right: 1px solid #fff;
     background-image: linear-gradient(#fff, #ccc);
+  }
+
+  caption {
+    background-color: $th-background;
+    font-weight: bold;
+    text-align: center;
   }
 }
 

--- a/themes/pmahomme/scss/_tables.scss
+++ b/themes/pmahomme/scss/_tables.scss
@@ -6,6 +6,7 @@
   }
 
   th {
+    color: $th-color;
     text-align: left;
   }
 
@@ -24,6 +25,12 @@
     &:hover {
       background: linear-gradient(#ced6df, #b6c6d7);
     }
+  }
+}
+
+.table-striped {
+  > tbody > tr:nth-of-type(#{$table-striped-order}) > th {
+    color: $th-color;
   }
 }
 

--- a/themes/pmahomme/scss/_variables.scss
+++ b/themes/pmahomme/scss/_variables.scss
@@ -76,8 +76,10 @@ $h3-font-size: 1rem;
 
 // Tables
 
-$table-cell-padding: 0.1em 0.3em;
-$table-cell-padding-sm: $table-cell-padding;
+$table-cell-padding-y: 0.1em;
+$table-cell-padding-x: 0.3em;
+$table-cell-padding-y-sm: $table-cell-padding-y;
+$table-cell-padding-x-sm: $table-cell-padding-x;
 $table-bg: #fff;
 $table-head-bg: #fff;
 $table-head-color: $th-color;

--- a/themes/pmahomme/scss/_variables.scss
+++ b/themes/pmahomme/scss/_variables.scss
@@ -78,9 +78,11 @@ $h3-font-size: 1rem;
 
 $table-cell-padding: 0.1em 0.3em;
 $table-cell-padding-sm: $table-cell-padding;
+$table-bg: #fff;
 $table-head-bg: #fff;
 $table-head-color: $th-color;
 $table-striped-order: even;
+$table-striped-bg: #dfdfdf;
 $table-hover-color: $browse-pointer-color;
 $table-border-color: #fff;
 $table-border-width: 0;

--- a/themes/pmahomme/scss/_variables.scss
+++ b/themes/pmahomme/scss/_variables.scss
@@ -88,6 +88,7 @@ $table-striped-bg: #dfdfdf;
 $table-hover-color: $browse-pointer-color;
 $table-border-color: #fff;
 $table-border-width: 0;
+$table-caption-color: $table-head-color;
 
 // Buttons
 


### PR DESCRIPTION
1. Removes the `table-light` CSS classes. These classes were added by https://github.com/phpmyadmin/phpmyadmin/commit/6408b7179abd139125f44980d016699f8e9f62f5. However they aren't exactly the same as `thead-light` classes that exists in Bootstrap 4.
2. Fixes the table cell padding Sass variables.

- Fixes #17521
- Related to #17455
- Related to #16521