### PR TITLE
Improve `ErrorHandler::handleException` to show errors

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ phpMyAdmin - ChangeLog
 5.2.1 (not yet released)
 - issue #17522 Fix case where the routes cache file is invalid
 - issue #17506 Fix error when configuring 2FA without XMLWriter or Imagick
+- issue        Fix blank page when some error occurs
 
 5.2.0 (2022-05-10)
 - issue #16521 Upgrade Bootstrap to version 5

--- a/js/src/ajax.js
+++ b/js/src/ajax.js
@@ -466,6 +466,14 @@ var AJAX = {
         if (typeof data === 'undefined' || data === null) {
             return;
         }
+        // Can be a string when an error occurred and only HTML was returned.
+        if (typeof data === 'string') {
+            Functions.ajaxRemoveMessage(AJAX.$msgbox);
+            Functions.ajaxShowMessage($(data).text(), false, 'error');
+            AJAX.active = false;
+            AJAX.xhr = null;
+            return;
+        }
         if (typeof data.success !== 'undefined' && data.success) {
             $('html, body').animate({ scrollTop: 0 }, 'fast');
             Functions.ajaxRemoveMessage(AJAX.$msgbox);

--- a/libraries/classes/ErrorHandler.php
+++ b/libraries/classes/ErrorHandler.php
@@ -12,6 +12,7 @@ use function array_splice;
 use function count;
 use function defined;
 use function error_reporting;
+use function get_class;
 use function headers_sent;
 use function htmlspecialchars;
 use function set_error_handler;
@@ -229,18 +230,17 @@ class ErrorHandler
 
     /**
      * Hides exception if it's not in the development environment.
-     *
-     * @throws Throwable
      */
     public function handleException(Throwable $exception): void
     {
         $config = $GLOBALS['config'] ?? null;
-        $environment = $config instanceof Config ? $config->get('environment') : 'production';
-        if ($environment !== 'development') {
-            return;
-        }
-
-        throw $exception;
+        $this->hideLocation = ! $config instanceof Config || $config->get('environment') !== 'development';
+        $this->addError(
+            get_class($exception) . ': ' . $exception->getMessage(),
+            (int) $exception->getCode(),
+            $exception->getFile(),
+            $exception->getLine()
+        );
     }
 
     /**
@@ -303,7 +303,9 @@ class ErrorHandler
             default:
                 // FATAL error, display it and exit
                 $this->dispFatalError($error);
-                exit;
+                if (! defined('TESTSUITE')) {
+                    exit;
+                }
         }
     }
 
@@ -334,7 +336,9 @@ class ErrorHandler
 
         echo $error->getDisplay();
         $this->dispPageEnd();
-        exit;
+        if (! defined('TESTSUITE')) {
+            exit;
+        }
     }
 
     /**


### PR DESCRIPTION
It doesn't shows a blank page when not in `development` environment anymore. Now it shows a simple page with the error, and when it's an AJAX request, it shows the error instead of doing nothing.

Related to #17519.