### PR TITLE
Fix #17271 - database names dissapearing from Processes tab

### DIFF
--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -133,14 +133,18 @@ final class Processes
                 'column_name' => __('Status'),
                 'order_by_field' => 'State',
             ],
-            [
+        ];
+
+        if ($this->dbi->isMariaDB()) {
+            $sortableColumns[] = [
                 'column_name' => __('Progress'),
                 'order_by_field' => 'Progress',
-            ],
-            [
-                'column_name' => __('SQL query'),
-                'order_by_field' => 'Info',
-            ],
+            ];
+        }
+
+        $sortableColumns[] = [
+            'column_name' => __('SQL query'),
+            'order_by_field' => 'Info',
         ];
 
         $sortableColCount = count($sortableColumns);

--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -70,21 +70,26 @@ final class Processes
         while ($process = $result->fetchAssoc()) {
             // Array keys need to modify due to the way it has used
             // to display column values
-            foreach (array_keys($process) as $key) {
-                $newKey = ucfirst(mb_strtolower($key));
-                if ($newKey === $key) {
-                    continue;
-                }
+            if (
+                (! empty($params['order_by_field']) && ! empty($params['sort_order']))
+                || ! empty($params['showExecuting'])
+            ) {
+                foreach (array_keys($process) as $key) {
+                    $newKey = ucfirst(mb_strtolower($key));
+                    if ($newKey === $key) {
+                        continue;
+                    }
 
-                $process[$newKey] = $process[$key];
-                unset($process[$key]);
+                    $process[$newKey] = $process[$key];
+                    unset($process[$key]);
+                }
             }
 
             $rows[] = [
                 'id' => $process['Id'],
                 'user' => $process['User'],
                 'host' => $process['Host'],
-                'db' => ! isset($process['Db']) || strlen($process['Db']) === 0 ? '' : $process['Db'],
+                'db' => ! isset($process['db']) || strlen($process['db']) === 0 ? '' : $process['db'],
                 'command' => $process['Command'],
                 'time' => $process['Time'],
                 'state' => ! empty($process['State']) ? $process['State'] : '---',
@@ -119,7 +124,7 @@ final class Processes
             ],
             [
                 'column_name' => __('Database'),
-                'order_by_field' => 'Db',
+                'order_by_field' => 'db',
             ],
             [
                 'column_name' => __('Command'),

--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -70,26 +70,21 @@ final class Processes
         while ($process = $result->fetchAssoc()) {
             // Array keys need to modify due to the way it has used
             // to display column values
-            if (
-                (! empty($params['order_by_field']) && ! empty($params['sort_order']))
-                || ! empty($params['showExecuting'])
-            ) {
-                foreach (array_keys($process) as $key) {
-                    $newKey = ucfirst(mb_strtolower($key));
-                    if ($newKey === $key) {
-                        continue;
-                    }
-
-                    $process[$newKey] = $process[$key];
-                    unset($process[$key]);
+            foreach (array_keys($process) as $key) {
+                $newKey = ucfirst(mb_strtolower($key));
+                if ($newKey === $key) {
+                    continue;
                 }
+
+                $process[$newKey] = $process[$key];
+                unset($process[$key]);
             }
 
             $rows[] = [
                 'id' => $process['Id'],
                 'user' => $process['User'],
                 'host' => $process['Host'],
-                'db' => ! isset($process['db']) || strlen($process['db']) === 0 ? '' : $process['db'],
+                'db' => ! isset($process['Db']) || strlen($process['Db']) === 0 ? '' : $process['Db'],
                 'command' => $process['Command'],
                 'time' => $process['Time'],
                 'state' => ! empty($process['State']) ? $process['State'] : '---',
@@ -124,7 +119,7 @@ final class Processes
             ],
             [
                 'column_name' => __('Database'),
-                'order_by_field' => 'db',
+                'order_by_field' => 'Db',
             ],
             [
                 'column_name' => __('Command'),

--- a/templates/server/status/processes/list.twig
+++ b/templates/server/status/processes/list.twig
@@ -45,25 +45,11 @@
             </a>
           </td>
           <td class="font-monospace text-end">{{ row.id }}</td>
-          <td>
-            <a href="{{ url('/server/privileges', {
-                'username': row.user,
-                'hostname': row.host,
-                'dbname': row.db,
-                'tablename': '',
-                'routinename': '',
-              }) }}">
-              {{ row.user }}
-            </a>
-          </td>
+          <td>{{ row.user }}</td>
           <td>{{ row.host }}</td>
           <td>
             {% if row.db != '' %}
-              <a href="{{ url('/database/structure', {
-                  'db': row.db,
-                }) }}">
-                {{ row.db }}
-              </a>
+              {{ row.db }}
             {% else %}
               <em>{% trans 'None' %}</em>
             {% endif %}

--- a/templates/server/status/processes/list.twig
+++ b/templates/server/status/processes/list.twig
@@ -45,11 +45,25 @@
             </a>
           </td>
           <td class="font-monospace text-end">{{ row.id }}</td>
-          <td>{{ row.user }}</td>
+          <td>
+            <a href="{{ url('/server/privileges', {
+                'username': row.user,
+                'hostname': row.host,
+                'dbname': row.db,
+                'tablename': '',
+                'routinename': '',
+              }) }}">
+              {{ row.user }}
+            </a>
+          </td>
           <td>{{ row.host }}</td>
           <td>
             {% if row.db != '' %}
-              {{ row.db }}
+              <a href="{{ url('/database/structure', {
+                  'db': row.db,
+                }) }}">
+                {{ row.db }}
+              </a>
             {% else %}
               <em>{% trans 'None' %}</em>
             {% endif %}

--- a/templates/server/status/processes/list.twig
+++ b/templates/server/status/processes/list.twig
@@ -75,7 +75,9 @@
           <td>{{ row.command }}</td>
           <td class="font-monospace text-end">{{ row.time }}</td>
           <td>{{ row.state }}</td>
-          <td>{{ row.progress }}</td>
+          {% if is_mariadb %}
+            <td>{{ row.progress }}</td>
+          {% endif %}
           <td>{{ row.info|raw }}</td>
       {% endfor %}
     </tbody>

--- a/templates/server/status/processes/list.twig
+++ b/templates/server/status/processes/list.twig
@@ -45,11 +45,29 @@
             </a>
           </td>
           <td class="font-monospace text-end">{{ row.id }}</td>
-          <td>{{ row.user }}</td>
+          <td>
+            {% if row.user != 'system user' %}
+              <a href="{{ url('/server/privileges', {
+                  'username': row.user,
+                  'hostname': row.host,
+                  'dbname': row.db,
+                  'tablename': '',
+                  'routinename': '',
+                }) }}">
+                {{ row.user }}
+              </a>
+            {% else %}
+              {{ row.user }}
+            {% endif %}
+          </td>
           <td>{{ row.host }}</td>
           <td>
             {% if row.db != '' %}
-              {{ row.db }}
+              <a href="{{ url('/database/structure', {
+                  'db': row.db,
+                }) }}">
+                {{ row.db }}
+              </a>
             {% else %}
               <em>{% trans 'None' %}</em>
             {% endif %}

--- a/test/classes/Controllers/Server/Status/ProcessesControllerTest.php
+++ b/test/classes/Controllers/Server/Status/ProcessesControllerTest.php
@@ -77,7 +77,7 @@ class ProcessesControllerTest extends AbstractTestCase
 
         $_POST['full'] = '1';
         $_POST['column_name'] = 'Database';
-        $_POST['order_by_field'] = 'db';
+        $_POST['order_by_field'] = 'Db';
         $_POST['sort_order'] = 'ASC';
 
         $this->dummyDbi->addSelectDb('mysql');

--- a/test/classes/Controllers/Server/Status/ProcessesControllerTest.php
+++ b/test/classes/Controllers/Server/Status/ProcessesControllerTest.php
@@ -77,7 +77,7 @@ class ProcessesControllerTest extends AbstractTestCase
 
         $_POST['full'] = '1';
         $_POST['column_name'] = 'Database';
-        $_POST['order_by_field'] = 'Db';
+        $_POST['order_by_field'] = 'db';
         $_POST['sort_order'] = 'ASC';
 
         $this->dummyDbi->addSelectDb('mysql');


### PR DESCRIPTION
Signed-off-by: Liviu-Mihail Concioiu <liviu.concioiu@gmail.com>

### Description

I have fixed the database names disappearing from the Processes tab. This happened because `SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST` has a `DB` column, while `SHOW PROCESSLIST` has a `db` column.

I have also added links to users and databases.

Before:

https://user-images.githubusercontent.com/25424343/170884829-d87b1809-7588-4d9d-8dc2-8b0c1a46bfd3.mp4

After:

https://user-images.githubusercontent.com/25424343/170884835-2132adc6-6699-40fa-9c61-a08b81393f3c.mp4

Fixes #17271

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
