### PR TITLE
Fix #17366 - refresh rate popup on Monitor page (Firefox)

### DIFF
--- a/js/src/server/status/monitor.js
+++ b/js/src/server/status/monitor.js
@@ -101,9 +101,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
             var $cnt = $(this);
             var pos = $cnt.offset();
             // Hide if the mouseclick is outside the popupcontent
-            if (event.pageX < pos.left ||
-                event.pageY < pos.top ||
-                event.pageX > pos.left + $cnt.outerWidth() ||
+            if (event.pageX > pos.left + $cnt.outerWidth() ||
                 event.pageY > pos.top + $cnt.outerHeight()
             ) {
                 $cnt.hide().removeClass('openedPopup');


### PR DESCRIPTION
Signed-off-by: Liviu-Mihail Concioiu <liviu.concioiu@gmail.com>

### Description

This PR fixes the refresh rate popup auto-closing on Firefox when selecting a refresh rate.

Fixes #17366

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
