### PR TITLE
Fix PHP documentation links for Chinese (Simplified)

### DIFF
--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -162,7 +162,7 @@ class Core
         /* List of PHP documentation translations */
         $php_doc_languages = [
             'pt_BR',
-            'zh',
+            'zh_CN',
             'fr',
             'de',
             'ja',
@@ -173,7 +173,11 @@ class Core
 
         $lang = 'en';
         if (isset($GLOBALS['lang']) && in_array($GLOBALS['lang'], $php_doc_languages)) {
-            $lang = $GLOBALS['lang'];
+            if ($GLOBALS['lang'] === 'zh_CN') {
+                $lang = 'zh';
+            } else {
+                $lang = $GLOBALS['lang'];
+            }
         }
 
         return self::linkURL('https://www.php.net/manual/' . $lang . '/' . $target);


### PR DESCRIPTION
### Description

This PR fixes PHP documentation links for Chinese (Simplified).

Before:

![before](https://user-images.githubusercontent.com/25424343/171729905-c38a847f-0635-40fd-bdd8-8ef52db5d4d7.png)

After:

![after](https://user-images.githubusercontent.com/25424343/171729920-9e9e0add-3a09-4af8-afad-6dc3a62136ce.png)

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
