### PR TITLE
Fix #17586 Statistics not showing for empty databases

### DIFF
--- a/libraries/classes/Controllers/Server/DatabasesController.php
+++ b/libraries/classes/Controllers/Server/DatabasesController.php
@@ -255,7 +255,7 @@ class DatabasesController extends AbstractController
             $statistics = $this->getStatisticsColumns();
             if ($this->hasStatistics) {
                 foreach (array_keys($statistics) as $key) {
-                    $statistics[$key]['raw'] = $database[$key] ?? null;
+                    $statistics[$key]['raw'] = (int) $database[$key] ?? 0;
                     $totalStatistics[$key]['raw'] += (int) $database[$key] ?? 0;
                 }
             }


### PR DESCRIPTION
### Description

Fix statistics for not showing empty databases.

Before:

![before](https://user-images.githubusercontent.com/25424343/172230928-ad6113b5-be12-4bbc-8d91-b55a2eaecc69.png)

After:

![after](https://user-images.githubusercontent.com/25424343/172230951-cf73863e-aa73-49db-8f84-28db679b8feb.png)

Fixes #17586

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
