### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/daily-snapshots.yml
+++ b/.github/workflows/daily-snapshots.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   generate-snapshots:
     name: Generate ${{ matrix.version }} snapshots

--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -8,6 +8,9 @@ on:
       - master
       - QA_**
 
+permissions:
+  contents: read
+
 jobs:
   lint-node:
     runs-on: ubuntu-latest

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,8 +4,13 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   lock:
+    permissions:
+      issues: write  # for dessant/lock-threads to lock issues
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v2

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Mutation tests with PHP ${{ matrix.php-version }}

--- a/.github/workflows/other-tools.yml
+++ b/.github/workflows/other-tools.yml
@@ -8,6 +8,9 @@ on:
       - master
       - QA_**
 
+permissions:
+  contents: read
+
 jobs:
   build-documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-selenium.yml
+++ b/.github/workflows/test-selenium.yml
@@ -11,6 +11,9 @@ on:
 env:
   php-version: "8.1"
 
+permissions:
+  contents: read
+
 jobs:
   selenium:
     name: "Selenium"

--- a/.github/workflows/update-po.yml
+++ b/.github/workflows/update-po.yml
@@ -5,8 +5,13 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   update-po:
+    permissions:
+      contents: write  # for Git to git push
     name: Update po files
     runs-on: ubuntu-latest
     # Source: https://github.community/t/do-not-run-cron-workflows-in-forks/17636/2?u=williamdes


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
