### PR TITLE
Fix blob column downloads

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -1,3 +1,1 @@
-{{ header|raw }}
-{{ content|raw }}
-{{ footer|raw }}
+{{- header|raw -}}{{- content|raw -}}{{- footer|raw -}}


### PR DESCRIPTION
### Description

Since the change in 0843ba0 new lines were added to the start and end of the output even if the header or footer were empty. This broke (at least) blob column downloads as the resulting downloaded file didn't represent the data stored in the database. It also caused nginx error log entries as the "Content-Length" header didn't match the return content length due to the added new lines.

```
2022/06/12 12:09:08 [warn] 721502#721502: *114638337 upstream sent more data than specified in "Content-Length" header while reading upstream, client: 127.0.0.1, server: xxx, request: "GET /index.php?route=/table/get-field&... HTTP/2.0", upstream: "fastcgi://unix:/run/php/php8.1-fpm.sock:", host: "xxx"
```

With "blob colum downloads" I mean these kind of links:
![grafik](https://user-images.githubusercontent.com/4395417/173229440-dda5f842-ccc3-420d-bb48-c428a8a3d74c.png)


Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
