### PR TITLE
Fix broken filtering 17593

### DIFF
--- a/js/src/sql.js
+++ b/js/src/sql.js
@@ -675,7 +675,7 @@ AJAX.registerOnload('sql.js', function () {
         var $headerCells = $targetTable.find('th[data-column]');
         var targetColumns = [];
 
-        // To handle colspan=4, in case of edit, copy, etc options (Table row links). Add 3 dummy <TH> elements - only when the Table row links are on the "Right"
+        // To handle colspan=4, in case of edit, copy, etc options (Table row links). Add 3 dummy <TH> elements - only when the Table row links are NOT on the "Right"
         var rowLinksLocation = ($targetTable.find('thead > tr > th')).first();
         var dummyTh = (rowLinksLocation[0].getAttribute("colspan") !== null) ? '<th class="hide dummy_th"></th><th class="hide dummy_th"></th><th class="hide dummy_th"></th>' : ''; // Selecting columns that will be considered for filtering and searching.
     

--- a/js/src/sql.js
+++ b/js/src/sql.js
@@ -674,10 +674,11 @@ AJAX.registerOnload('sql.js', function () {
         var $targetTable = $('.table_results[data-uniqueId=\'' + uniqueId + '\']');
         var $headerCells = $targetTable.find('th[data-column]');
         var targetColumns = [];
-        // To handle colspan=4, in case of edit,copy etc options.
-        var dummyTh = ($('.edit_row_anchor').length !== 0 ?
-            '<th class="hide dummy_th"></th><th class="hide dummy_th"></th><th class="hide dummy_th"></th>'
-            : '');
+
+        // To handle colspan=4, in case of edit, copy, etc options (Table row links). Add 3 dummy <TH> elements - only when the Table row links are on the "Right"
+        var rowLinksLocation = ($targetTable.find('thead > tr > th')).first();
+        var dummyTh = (rowLinksLocation[0].getAttribute("colspan") !== null) ? '<th class="hide dummy_th"></th><th class="hide dummy_th"></th><th class="hide dummy_th"></th>' : ''; // Selecting columns that will be considered for filtering and searching.
+    
         // Selecting columns that will be considered for filtering and searching.
         $headerCells.each(function () {
             targetColumns.push($(this).text().trim());


### PR DESCRIPTION
### Description
Issue: Table filtering is broken when action buttons are on the right side of the row
Fixes #17593

In (Page-related settings) -> (Where to show the table row links) there are 4 options: Left, Right, Both, and Nowhere.
The 3 dummy <TH> elements (mentioned in this ticket) are only needed for Left, Both, and Nowhere... and they are NOT needed for "Right".
Since the main thing that distinguishes the "Right" position from the other 3 is - "colspan", my code checks for the presence of "colspan" on the first existing (non-dummy) <TH> element, and then decides whether or not to add the 3 additional dummy-<TH> elements.

Signed-off-by: Angelo Grebenarov

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
