### PR TITLE
Move side effects from JS files into the `main.js` file

### DIFF
--- a/js/src/ajax.js
+++ b/js/src/ajax.js
@@ -936,18 +936,3 @@ window.AJAX = {
         };
     }
 };
-
-window.AJAX.registerOnload('functions.js', function () {
-    window.AJAX.removeSubmitEvents();
-});
-
-$(window.AJAX.loadEventHandler());
-
-/**
- * Attach a generic event handler to clicks
- * on pages and submissions of forms
- */
-$(document).on('click', 'a', window.AJAX.requestHandler);
-$(document).on('submit', 'form', window.AJAX.requestHandler);
-
-$(document).on('ajaxError', window.AJAX.getFatalErrorHandler());

--- a/js/src/config.js
+++ b/js/src/config.js
@@ -824,6 +824,3 @@ window.Config = {
         };
     }
 };
-
-window.AJAX.registerTeardown('config.js', window.Config.off());
-window.AJAX.registerOnload('config.js', window.Config.on());

--- a/js/src/cross_framing_protection.js
+++ b/js/src/cross_framing_protection.js
@@ -2,7 +2,7 @@
  * Conditionally included if framing is not allowed.
  * @return {void}
  */
-const crossFramingProtection = () => {
+window.crossFramingProtection = () => {
     if (window.allowThirdPartyFraming) {
         return;
     }
@@ -20,5 +20,3 @@ const crossFramingProtection = () => {
 
     styleElement.parentNode.removeChild(styleElement);
 };
-
-crossFramingProtection();

--- a/js/src/keyhandler.js
+++ b/js/src/keyhandler.js
@@ -151,6 +151,3 @@ const KeyHandlerEvents = {
 };
 
 window.KeyHandlerEvents = KeyHandlerEvents;
-
-window.AJAX.registerTeardown('keyhandler.js', window.KeyHandlerEvents.off());
-window.AJAX.registerOnload('keyhandler.js', window.KeyHandlerEvents.on());

--- a/js/src/main.js
+++ b/js/src/main.js
@@ -8,3 +8,6 @@ $(document).on('click', 'a', window.AJAX.requestHandler);
 $(document).on('submit', 'form', window.AJAX.requestHandler);
 
 $(document).on('ajaxError', window.AJAX.getFatalErrorHandler());
+
+window.AJAX.registerTeardown('keyhandler.js', window.KeyHandlerEvents.off());
+window.AJAX.registerOnload('keyhandler.js', window.KeyHandlerEvents.on());

--- a/js/src/main.js
+++ b/js/src/main.js
@@ -11,3 +11,5 @@ $(document).on('ajaxError', window.AJAX.getFatalErrorHandler());
 
 window.AJAX.registerTeardown('keyhandler.js', window.KeyHandlerEvents.off());
 window.AJAX.registerOnload('keyhandler.js', window.KeyHandlerEvents.on());
+
+window.crossFramingProtection();

--- a/js/src/main.js
+++ b/js/src/main.js
@@ -13,3 +13,6 @@ window.AJAX.registerTeardown('keyhandler.js', window.KeyHandlerEvents.off());
 window.AJAX.registerOnload('keyhandler.js', window.KeyHandlerEvents.on());
 
 window.crossFramingProtection();
+
+window.AJAX.registerTeardown('config.js', window.Config.off());
+window.AJAX.registerOnload('config.js', window.Config.on());

--- a/js/src/main.js
+++ b/js/src/main.js
@@ -1,0 +1,10 @@
+window.AJAX.registerOnload('functions.js', () => window.AJAX.removeSubmitEvents());
+$(window.AJAX.loadEventHandler());
+
+/**
+ * Attach a generic event handler to clicks on pages and submissions of forms.
+ */
+$(document).on('click', 'a', window.AJAX.requestHandler);
+$(document).on('submit', 'form', window.AJAX.requestHandler);
+
+$(document).on('ajaxError', window.AJAX.getFatalErrorHandler());

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -132,6 +132,7 @@ class Header
         $this->scripts->addFile('vendor/jquery/jquery-migrate.js');
         $this->scripts->addFile('vendor/sprintf.js');
         $this->scripts->addFile('ajax.js');
+        $this->scripts->addFile('main.js');
         $this->scripts->addFile('keyhandler.js');
         $this->scripts->addFile('vendor/jquery/jquery-ui.min.js');
         $this->scripts->addFile('name-conflict-fixes.js');

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -133,7 +133,6 @@ class Header
         $this->scripts->addFile('vendor/sprintf.js');
         $this->scripts->addFile('ajax.js');
         $this->scripts->addFile('keyhandler.js');
-        $this->scripts->addFile('main.js');
         $this->scripts->addFile('vendor/jquery/jquery-ui.min.js');
         $this->scripts->addFile('name-conflict-fixes.js');
         $this->scripts->addFile('vendor/bootstrap/bootstrap.bundle.min.js');
@@ -142,6 +141,7 @@ class Header
         $this->scripts->addFile('vendor/jquery/jquery-ui-timepicker-addon.js');
         $this->scripts->addFile('menu_resizer.js');
         $this->scripts->addFile('cross_framing_protection.js');
+        $this->scripts->addFile('main.js');
         $this->scripts->addFile('messages.php', ['l' => $GLOBALS['lang']]);
         $this->scripts->addFile('config.js');
         $this->scripts->addFile('doclinks.js');

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -132,8 +132,8 @@ class Header
         $this->scripts->addFile('vendor/jquery/jquery-migrate.js');
         $this->scripts->addFile('vendor/sprintf.js');
         $this->scripts->addFile('ajax.js');
-        $this->scripts->addFile('main.js');
         $this->scripts->addFile('keyhandler.js');
+        $this->scripts->addFile('main.js');
         $this->scripts->addFile('vendor/jquery/jquery-ui.min.js');
         $this->scripts->addFile('name-conflict-fixes.js');
         $this->scripts->addFile('vendor/bootstrap/bootstrap.bundle.min.js');

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -141,9 +141,9 @@ class Header
         $this->scripts->addFile('vendor/jquery/jquery-ui-timepicker-addon.js');
         $this->scripts->addFile('menu_resizer.js');
         $this->scripts->addFile('cross_framing_protection.js');
-        $this->scripts->addFile('main.js');
         $this->scripts->addFile('messages.php', ['l' => $GLOBALS['lang']]);
         $this->scripts->addFile('config.js');
+        $this->scripts->addFile('main.js');
         $this->scripts->addFile('doclinks.js');
         $this->scripts->addFile('functions.js');
         $this->scripts->addFile('navigation.js');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,6 +49,7 @@ module.exports = [
             'jqplot/plugins/jqplot.byteFormatter': './js/src/jqplot/plugins/jqplot.byteFormatter.js',
             'jquery.sortable-table': './js/src/jquery.sortable-table.js',
             'keyhandler': './js/src/keyhandler.js',
+            'main': './js/src/main.js',
             'makegrid': './js/src/makegrid.js',
             'menu_resizer': './js/src/menu_resizer.js',
             'multi_column_sort': './js/src/multi_column_sort.js',


### PR DESCRIPTION
The idea is move all side effects to this `main.js` file so the other files only have function declarations.

The intent is to help migrating to [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).