### PR TITLE
Fix #17388 - find and replace using regex makes an invalid query if no matching result set found

### DIFF
--- a/libraries/classes/Controllers/Table/FindReplaceController.php
+++ b/libraries/classes/Controllers/Table/FindReplaceController.php
@@ -324,17 +324,24 @@ class FindReplaceController extends AbstractController
         if ($useRegex) {
             $toReplace = $this->getRegexReplaceRows($columnIndex, $find, $replaceWith, $charSet);
             $sql_query = 'UPDATE ' . Util::backquote($this->table)
-                . ' SET ' . Util::backquote($column) . ' = CASE';
+                . ' SET ' . Util::backquote($column);
+
             if (is_array($toReplace)) {
-                foreach ($toReplace as $row) {
-                    $sql_query .= "\n WHEN " . Util::backquote($column)
-                        . " = '" . $this->dbi->escapeString($row[0])
-                        . "' THEN '" . $this->dbi->escapeString($row[1]) . "'";
+                if (count($toReplace) > 0) {
+                    $sql_query .= ' = CASE';
+                    foreach ($toReplace as $row) {
+                        $sql_query .= "\n WHEN " . Util::backquote($column)
+                            . " = '" . $this->dbi->escapeString($row[0])
+                            . "' THEN '" . $this->dbi->escapeString($row[1]) . "'";
+                    }
+                    $sql_query .= ' END';
+                }
+                else {
+                    $sql_query .= ' = ' . Util::backquote($column);
                 }
             }
 
-            $sql_query .= ' END'
-                . ' WHERE ' . Util::backquote($column)
+            $sql_query .= ' WHERE ' . Util::backquote($column)
                 . " RLIKE '" . $this->dbi->escapeString($find) . "' COLLATE "
                 . $charSet . '_bin'; // here we
             // change the collation of the 2nd operand to a case sensitive

--- a/test/classes/Controllers/Table/FindReplaceControllerTest.php
+++ b/test/classes/Controllers/Table/FindReplaceControllerTest.php
@@ -92,4 +92,30 @@ class FindReplaceControllerTest extends AbstractTestCase
             . "WHERE `Field1` LIKE '%Field%' COLLATE UTF-8_bin";
         $this->assertEquals($result, $sql_query);
     }
+
+    public function testReplaceWithRegex(): void
+    {
+        $tableSearch = new FindReplaceController(
+            ResponseRenderer::getInstance(),
+            new Template(),
+            $GLOBALS['db'],
+            $GLOBALS['table'],
+            $GLOBALS['dbi']
+        );
+
+        $columnIndex = 0;
+        $find = 'Field';
+        $replaceWith = 'Column';
+        $useRegex = true;
+        $charSet = 'UTF-8';
+
+        $tableSearch->replace($columnIndex, $find, $replaceWith, $useRegex, $charSet);
+
+        $sql_query = $GLOBALS['sql_query'];
+
+        $result = 'UPDATE `table` SET `Field1` = `Field1`'
+            . " WHERE `Field1` RLIKE 'Field' COLLATE UTF-8_bin";
+
+        $this->assertEquals($result, $sql_query);
+    }
 }


### PR DESCRIPTION
Signed-off-by: Ankush Patil <aspraz2658@gmail.com>

### Description
When find and replace searching used with regex, at the time of replace empty CASE END condition was causing issue.

Fixes #17388 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
