### PR TITLE
Fix #17617 - replace isset to empty

### DIFF
--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -1869,7 +1869,7 @@ class Table implements Stringable
      */
     public function getUiProp($property)
     {
-        if (! isset($this->uiprefs)) {
+        if (empty($this->uiprefs)) {
             $this->loadUiPrefs();
         }
 
@@ -1939,7 +1939,7 @@ class Table implements Stringable
      */
     public function setUiProp($property, $value, $tableCreateTime = null)
     {
-        if (! isset($this->uiprefs)) {
+        if (empty($this->uiprefs)) {
             $this->loadUiPrefs();
         }
 
@@ -1986,7 +1986,7 @@ class Table implements Stringable
      */
     public function removeUiProp($property)
     {
-        if (! isset($this->uiprefs)) {
+        if (empty($this->uiprefs)) {
             $this->loadUiPrefs();
         }
 


### PR DESCRIPTION
Signed-off-by: Atomu Oku [atomu.work@gmail.com](mailto:atomu.work@gmail.com)

### Description

This PR will fix the issue: #17617

IF statement `! isset($this->uiprefs)` was causing issue.

Private property 'uiprefs' is initialized to empty array, so `! isset($this->uiprefs)` is always FALSE;
It's not hopefull, so I replace `! isset($this->uiprefs)` to `empty($this->uiprefs)` to fix #17617 bug;

Fixes #17617

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
