### PR TITLE
Set data type should be an array in column_row.twig template

### DIFF
--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -83,7 +83,7 @@
       {% elseif column.pma_type == 'set' %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="set">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')" multiple>
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}][]" class="textfield" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')" multiple>
           {% for set_value in set_values %}
             <option value="{{ set_value.plain }}"{{ set_value.plain in data|split(',') ? ' selected' }}>{{ set_value.plain }}</option>
           {% endfor %}


### PR DESCRIPTION
### Description

The `column_row.twig` template that was introduced with version 5.2.0 seems to define set fields as single values rather than as array values. This causes any inserts to `set` fields to fail and result in a blank page.

The previous version had sets properly defined as arrays: https://github.com/phpmyadmin/phpmyadmin/blob/RELEASE_5_1_4/libraries/classes/InsertEdit.php#L1307

Fixes: #17557

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
