### PR TITLE
Allow empty values to be inserted into columns

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1674,9 +1674,8 @@ class InsertEdit
         } elseif (
             ! (empty($multiEditFuncs[$key])
                 && isset($multiEditColumnsPrev[$key])
-                && (($currentValue === "'" . $this->dbi->escapeString($multiEditColumnsPrev[$key]) . "'")
-                    || ($currentValue === '0x' . $multiEditColumnsPrev[$key])))
-            && $currentValue
+                && $currentValue === $multiEditColumnsPrev[$key])
+            && $currentValueAsAnArray !== ''
         ) {
             // avoid setting a field to NULL when it's already NULL
             // (field had the null checkbox before the update

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1448,7 +1448,7 @@ class Sql
             }
         }
 
-        $hasUnique = $table && $this->resultSetContainsUniqueKey($db, $table, $fieldsMeta);
+        $hasUnique = $table !== null && $this->resultSetContainsUniqueKey($db, $table, $fieldsMeta);
 
         $editable = ($hasUnique
             || $GLOBALS['cfg']['RowActionLinksWithoutUnique']

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -2023,6 +2023,126 @@ class InsertEditTest extends AbstractTestCase
             ],
             $result
         );
+
+        // Test to see if a zero-string is not ignored
+        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
+            $multi_edit_columns_name,
+            [],
+            '0',
+            [],
+            [],
+            false,
+            [],
+            [],
+            "'0'",
+            [],
+            '0',
+            []
+        );
+
+        $this->assertEquals(
+            [
+                ["`fld` = '0'"],
+                [],
+            ],
+            $result
+        );
+
+        // Can only happen when table contains blob field that was left unchanged during edit
+        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
+            $multi_edit_columns_name,
+            [],
+            '',
+            [],
+            [],
+            false,
+            [],
+            [],
+            '',
+            [],
+            '0',
+            []
+        );
+
+        $this->assertEquals(
+            [
+                [],
+                [],
+            ],
+            $result
+        );
+
+        // Test to see if a field will be set to null when it wasn't null previously
+        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
+            $multi_edit_columns_name,
+            ['on'],
+            '',
+            [],
+            [],
+            false,
+            [],
+            [],
+            'NULL',
+            [],
+            '0',
+            []
+        );
+
+        $this->assertEquals(
+            [
+                ['`fld` = NULL'],
+                [],
+            ],
+            $result
+        );
+
+        // Test to see if a field will be ignored if it was null previously
+        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
+            $multi_edit_columns_name,
+            ['on'],
+            '',
+            [],
+            [],
+            false,
+            [],
+            [],
+            'NULL',
+            [],
+            '0',
+            ['on']
+        );
+
+        $this->assertEquals(
+            [
+                [],
+                [],
+            ],
+            $result
+        );
+
+        // Test to see if a field will be ignored if it the value is unchanged
+        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
+            $multi_edit_columns_name,
+            [],
+            "a'b",
+            ["a'b"],
+            [],
+            false,
+            [],
+            [],
+            "'a\'b'",
+            [],
+            '0',
+            []
+        );
+
+        $this->assertEquals(
+            [
+                [],
+                [],
+            ],
+            $result
+        );
     }
 
     /**


### PR DESCRIPTION
The first commit is unrelated; it's just something that was annoying me and I had to fix. 

The main commit fixes bug that was uncovered by my previous PR. I don't know why the code didn't allow empty values previously, but I assume it was just bad design that I didn't notice while refactoring. Anyway, this code still looks like a mess, so I might create another PR to refactor it more. 

Fixes: #17658 #17663