### PR TITLE
Refactor insert edit

### DIFF
--- a/libraries/classes/Controllers/Table/ReplaceController.php
+++ b/libraries/classes/Controllers/Table/ReplaceController.php
@@ -260,7 +260,7 @@ final class ReplaceController extends AbstractController
 
                 if (! isset($multi_edit_virtual[$key])) {
                     if ($isInsert) {
-                        $queryPart = $this->insertEdit->getQueryValuesForInsert(
+                        $queryPart = $this->insertEdit->getQueryValueForInsert(
                             $editField,
                             $usingKey,
                             $where_clause
@@ -270,7 +270,7 @@ final class ReplaceController extends AbstractController
                             $queryFields[] = Util::backquote($editField->columnName);
                         }
                     } else {
-                        $queryPart = $this->insertEdit->getQueryValuesForUpdate($editField);
+                        $queryPart = $this->insertEdit->getQueryValueForUpdate($editField);
                     }
 
                     if ($queryPart !== '') {

--- a/libraries/classes/Controllers/Table/ReplaceController.php
+++ b/libraries/classes/Controllers/Table/ReplaceController.php
@@ -244,20 +244,23 @@ final class ReplaceController extends AbstractController
                 $file_to_insert->cleanUp();
 
                 if (empty($multi_edit_funcs[$key])) {
-                    $current_value_as_an_array = $this->insertEdit->getCurrentValueForDifferentTypes(
-                        $possibly_uploaded_val,
-                        $key,
-                        $multi_edit_columns_type,
-                        $current_value,
-                        $multi_edit_auto_increment,
-                        $multi_edit_columns_name,
-                        $multi_edit_columns_null,
-                        $multi_edit_columns_null_prev,
-                        $isInsert,
-                        $usingKey,
-                        $where_clause,
-                        $GLOBALS['table']
-                    );
+                    if ($possibly_uploaded_val !== false) {
+                        $current_value_as_an_array = $current_value;
+                    } else {
+                        $current_value_as_an_array = $this->insertEdit->getCurrentValueForDifferentTypes(
+                            $key,
+                            $multi_edit_columns_type,
+                            $current_value,
+                            $multi_edit_auto_increment,
+                            $column_name,
+                            $multi_edit_columns_null,
+                            $multi_edit_columns_null_prev,
+                            $isInsert,
+                            $usingKey,
+                            $where_clause,
+                            $GLOBALS['table']
+                        );
+                    }
                 } else {
                     $current_value_as_an_array = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(
                         $multi_edit_funcs[$key],
@@ -271,7 +274,7 @@ final class ReplaceController extends AbstractController
                         $queryValues,
                         $queryFields,
                     ] = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-                        $multi_edit_columns_name,
+                        $column_name,
                         $multi_edit_columns_null,
                         $current_value,
                         $multi_edit_columns_prev,
@@ -286,11 +289,9 @@ final class ReplaceController extends AbstractController
                     );
                 }
 
-                if (! isset($multi_edit_columns_null[$key])) {
-                    continue;
+                if (isset($multi_edit_columns_null[$key])) {
+                    $multi_edit_columns[$key] = null;
                 }
-
-                $multi_edit_columns[$key] = null;
             }
 
             // temporarily store rows not inserted
@@ -299,7 +300,7 @@ final class ReplaceController extends AbstractController
                 $GLOBALS['unsaved_values'][$rownumber] = $multi_edit_columns;
             }
 
-            if ($insert_fail || count($queryValues) <= 0) {
+            if ($insert_fail || $queryValues === []) {
                 continue;
             }
 

--- a/libraries/classes/EditField.php
+++ b/libraries/classes/EditField.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin;
+
+/**
+ * @psalm-immutable
+ */
+final class EditField
+{
+    /** @var string $columnName */
+    public $columnName;
+    /** @var string $value */
+    public $value;
+    /** @var string $type */
+    public $type;
+    /** @var bool $autoIncrement */
+    public $autoIncrement;
+    /** @var bool $isNull */
+    public $isNull;
+    /** @var bool $wasPreviouslyNull */
+    public $wasPreviouslyNull;
+    /** @var string $function */
+    public $function;
+    /** @var string|null $salt */
+    public $salt;
+    /** @var string|null $previousValue */
+    public $previousValue;
+    /** @var bool $isUploaded */
+    public $isUploaded;
+
+    public function __construct(
+        string $columnName,
+        string $value,
+        string $type,
+        bool $autoIncrement,
+        bool $isNull,
+        bool $wasPreviouslyNull,
+        string $function,
+        ?string $salt,
+        ?string $previousValue,
+        bool $isUploaded
+    ) {
+        $this->columnName = $columnName;
+        $this->value = $value;
+        $this->type = $type;
+        $this->autoIncrement = $autoIncrement;
+        $this->isNull = $isNull;
+        $this->wasPreviouslyNull = $wasPreviouslyNull;
+        $this->function = $function;
+        $this->salt = $salt;
+        $this->previousValue = $previousValue;
+        $this->isUploaded = $isUploaded;
+    }
+}

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1630,7 +1630,7 @@ class InsertEdit
      *
      * @param string|int $whereClause Either a positional index or string representing selected row
      */
-    public function getQueryValuesForInsert(
+    public function getQueryValueForInsert(
         EditField $editField,
         bool $usingKey,
         $whereClause
@@ -1652,7 +1652,7 @@ class InsertEdit
      * Get field-value pairs for update SQL.
      * During update, we build the SQL only with the fields that should be updated.
      */
-    public function getQueryValuesForUpdate(EditField $editField): string
+    public function getQueryValueForUpdate(EditField $editField): string
     {
         $currentValueFormattedAsSql = $this->getValueFormattedAsSql($editField);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4351,31 +4351,6 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getCurrentValueForDifferentTypes\\(\\) has parameter \\$multiEditAutoIncrement with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getCurrentValueForDifferentTypes\\(\\) has parameter \\$multiEditColumnsName with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getCurrentValueForDifferentTypes\\(\\) has parameter \\$multiEditColumnsNull with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getCurrentValueForDifferentTypes\\(\\) has parameter \\$multiEditColumnsNullPrev with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getCurrentValueForDifferentTypes\\(\\) has parameter \\$multiEditColumnsType with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getDisplayValueForForeignTableColumn\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
@@ -4497,51 +4472,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getParamsForUpdateOrInsert\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getQueryValuesForInsertAndUpdateInMultipleEdit\\(\\) has parameter \\$multiEditColumnsName with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getQueryValuesForInsertAndUpdateInMultipleEdit\\(\\) has parameter \\$multiEditColumnsNull with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getQueryValuesForInsertAndUpdateInMultipleEdit\\(\\) has parameter \\$multiEditColumnsNullPrev with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getQueryValuesForInsertAndUpdateInMultipleEdit\\(\\) has parameter \\$multiEditColumnsPrev with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getQueryValuesForInsertAndUpdateInMultipleEdit\\(\\) has parameter \\$multiEditFuncs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getQueryValuesForInsertAndUpdateInMultipleEdit\\(\\) has parameter \\$queryFields with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getQueryValuesForInsertAndUpdateInMultipleEdit\\(\\) has parameter \\$queryValues with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getQueryValuesForInsertAndUpdateInMultipleEdit\\(\\) has parameter \\$valueSets with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:getQueryValuesForInsertAndUpdateInMultipleEdit\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3656,29 +3656,20 @@
     <InvalidArgument occurrences="1">
       <code>$insertErrors</code>
     </InvalidArgument>
-    <MixedArgument occurrences="31">
+    <MixedArgument occurrences="21">
       <code>$_POST['db']</code>
       <code>$_POST['rel_fields_list']</code>
       <code>$_POST['table']</code>
       <code>$_POST['transform_fields_list']</code>
       <code>$column_name</code>
       <code>$column_name</code>
-      <code>$current_value</code>
-      <code>$current_value</code>
-      <code>$current_value</code>
+      <code>$column_name</code>
       <code>$errorMessages</code>
       <code>$extra_data</code>
       <code>$lastMessages</code>
-      <code>$multi_edit_auto_increment</code>
-      <code>$multi_edit_columns_name</code>
-      <code>$multi_edit_columns_null</code>
-      <code>$multi_edit_columns_null</code>
-      <code>$multi_edit_columns_null_prev</code>
-      <code>$multi_edit_columns_null_prev</code>
-      <code>$multi_edit_columns_prev</code>
-      <code>$multi_edit_columns_type</code>
-      <code>$multi_edit_funcs</code>
-      <code>$multi_edit_funcs[$key]</code>
+      <code>$multi_edit_columns_prev[$key] ?? null</code>
+      <code>$multi_edit_columns_type[$key] ?? ''</code>
+      <code>$multi_edit_funcs[$key] ?? ''</code>
       <code>$multi_edit_salt[$key] ?? null</code>
       <code>$one_where_clause</code>
       <code>$relation_field</code>
@@ -3687,19 +3678,14 @@
       <code>$totalAffectedRows</code>
       <code>$totalAffectedRows</code>
       <code>$warningMessages</code>
-      <code>$where_clause</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="5">
-      <code>$current_value</code>
-      <code>$key</code>
-      <code>$key</code>
-      <code>$queryValues</code>
-      <code>$queryValues</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="4">
+    <MixedArrayAccess occurrences="7">
       <code>$_POST['fields_name']['multi_edit']</code>
       <code>$extra_data['relations']</code>
       <code>$multi_edit_columns[$key]</code>
+      <code>$multi_edit_columns_prev[$key]</code>
+      <code>$multi_edit_columns_type[$key]</code>
+      <code>$multi_edit_funcs[$key]</code>
       <code>$multi_edit_salt[$key]</code>
     </MixedArrayAccess>
     <MixedArrayAssignment occurrences="4">
@@ -3711,7 +3697,7 @@
     <MixedArrayOffset occurrences="1">
       <code>$mimeMap[$column_name]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="32">
+    <MixedAssignment occurrences="31">
       <code>$GLOBALS['active_page']</code>
       <code>$GLOBALS['cfg']['InsertRows']</code>
       <code>$GLOBALS['disp_message']</code>
@@ -3727,11 +3713,11 @@
       <code>$column_name</code>
       <code>$column_name</code>
       <code>$curr_rel_field</code>
-      <code>$current_value</code>
       <code>$extra_data['row_count']</code>
       <code>$insertRows</code>
       <code>$multi_edit_auto_increment</code>
       <code>$multi_edit_columns</code>
+      <code>$multi_edit_columns[$key]</code>
       <code>$multi_edit_columns_name</code>
       <code>$multi_edit_columns_null</code>
       <code>$multi_edit_columns_null_prev</code>
@@ -3743,32 +3729,17 @@
       <code>$one_where_clause</code>
       <code>$relation_field</code>
       <code>$relation_field_value</code>
-      <code>$where_clause</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
       <code>new $classname()</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="3">
+    <MixedOperand occurrences="1">
       <code>$relation_field_value</code>
-      <code>$where_clause</code>
-      <code>$where_clause</code>
     </MixedOperand>
-    <PossiblyNullArgument occurrences="11">
+    <PossiblyNullArgument occurrences="2">
       <code>$GLOBALS['urlParams']</code>
       <code>$GLOBALS['urlParams']</code>
-      <code>$current_value</code>
-      <code>$current_value</code>
-      <code>$current_value</code>
-      <code>$multi_edit_columns_null</code>
-      <code>$multi_edit_columns_null</code>
-      <code>$multi_edit_columns_null_prev</code>
-      <code>$multi_edit_columns_null_prev</code>
-      <code>$multi_edit_columns_prev</code>
-      <code>$multi_edit_funcs</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$multi_edit_salt[$key]</code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullReference occurrences="1">
       <code>get</code>
     </PossiblyNullReference>
@@ -7900,7 +7871,7 @@
   </file>
   <file src="libraries/classes/InsertEdit.php">
     <LessSpecificReturnStatement occurrences="1"/>
-    <MixedArgument occurrences="76">
+    <MixedArgument occurrences="72">
       <code>$_POST['fields']['multi_edit']</code>
       <code>$backupField</code>
       <code>$columnMime['input_transformation_options']</code>
@@ -7957,10 +7928,6 @@
       <code>$foreigner['foreign_table']</code>
       <code>$foreigner['foreign_table']</code>
       <code>$foreigner['foreign_table']</code>
-      <code>$multiEditColumnsName[$key]</code>
-      <code>$multiEditColumnsName[$key]</code>
-      <code>$multiEditColumnsName[$key]</code>
-      <code>$protectedRow[$multiEditColumnsName[$key]]</code>
       <code>$rows[$keyId]</code>
       <code>$singleQuery</code>
       <code>$singleQuery</code>
@@ -7988,7 +7955,7 @@
       <code>$urlParams</code>
       <code>$valueSets</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="8">
+    <MixedArrayAccess occurrences="7">
       <code>$_POST['fields']['multi_edit']</code>
       <code>$_POST['where_clause'][0]</code>
       <code>$_SESSION['tmpval']['relational_display']</code>
@@ -7996,13 +7963,12 @@
       <code>$enumValue['plain']</code>
       <code>$enumValue['plain']</code>
       <code>$enumValue['plain']</code>
-      <code>$protectedRow[$multiEditColumnsName[$key]]</code>
     </MixedArrayAccess>
     <MixedArrayAssignment occurrences="2">
       <code>$editedValues[$cellIndex][$columnName]</code>
       <code>$extraData['transformations'][$cellIndex]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="28">
+    <MixedArrayOffset occurrences="27">
       <code>$commentsMap[$column['Field']]</code>
       <code>$commentsMap[$column['Field']]</code>
       <code>$currentRow[$column['Field']]</code>
@@ -8030,9 +7996,8 @@
       <code>$currentRow[$column['Field']]</code>
       <code>$mimeMap[$tableColumn['Field']]</code>
       <code>$mimeMap[$tableColumn['Field']]</code>
-      <code>$protectedRow[$multiEditColumnsName[$key]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="36">
+    <MixedAssignment occurrences="35">
       <code>$GLOBALS['cfg']['ShowFieldTypesInDataEditView']</code>
       <code>$GLOBALS['cfg']['ShowFunctionFields']</code>
       <code>$_SESSION['edit_next']</code>
@@ -8061,7 +8026,6 @@
       <code>$tmp['Default']</code>
       <code>$transformedHtml</code>
       <code>$trueType</code>
-      <code>$type</code>
       <code>$urlParams['sql_query']</code>
       <code>$whereClause</code>
       <code>$whereClause</code>
@@ -8093,13 +8057,10 @@
     </MixedReturnTypeCoercion>
     <MoreSpecificReturnType occurrences="1"/>
     <PossiblyNullArgument occurrences="3">
-      <code>$multiEditSalt</code>
+      <code>$editField-&gt;salt</code>
       <code>$newValue</code>
       <code>$newValue</code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedVariable occurrences="1">
-      <code>$protectedRow</code>
-    </PossiblyUndefinedVariable>
     <RedundantCast occurrences="1">
       <code>(int) $GLOBALS['cfg']['InsertRows']</code>
     </RedundantCast>
@@ -15238,9 +15199,7 @@
       <code>$result['pma_type']</code>
       <code>$result['wrap']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="5">
-      <code>$_POST['fields']['multi_edit']</code>
-      <code>$_POST['fields']['multi_edit']</code>
+    <MixedArrayAssignment occurrences="3">
       <code>$_POST['fields']['multi_edit']</code>
       <code>$_SESSION['tmpval']['relational_display']</code>
       <code>$_SESSION['tmpval']['relational_display']</code>

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -2266,7 +2266,7 @@ class InsertEditTest extends AbstractTestCase
             new Template()
         );
 
-        $result = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(
+        $result = $this->insertEdit->formatAsSqlFunction(
             $multi_edit_function,
             null,
             'currVal'
@@ -2277,7 +2277,7 @@ class InsertEditTest extends AbstractTestCase
         // case 3
         $multi_edit_function = 'AES_ENCRYPT';
         $multi_edit_salt = '';
-        $result = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(
+        $result = $this->insertEdit->formatAsSqlFunction(
             $multi_edit_function,
             $multi_edit_salt,
             "'"
@@ -2286,7 +2286,7 @@ class InsertEditTest extends AbstractTestCase
 
         // case 4
         $multi_edit_function = 'ABS';
-        $result = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(
+        $result = $this->insertEdit->formatAsSqlFunction(
             $multi_edit_function,
             null,
             "'"
@@ -2295,7 +2295,7 @@ class InsertEditTest extends AbstractTestCase
 
         // case 5
         $multi_edit_function = 'RAND';
-        $result = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(
+        $result = $this->insertEdit->formatAsSqlFunction(
             $multi_edit_function,
             null,
             ''
@@ -2304,7 +2304,7 @@ class InsertEditTest extends AbstractTestCase
 
         // case 6
         $multi_edit_function = 'PHP_PASSWORD_HASH';
-        $result = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(
+        $result = $this->insertEdit->formatAsSqlFunction(
             $multi_edit_function,
             null,
             "a'c"
@@ -2325,7 +2325,7 @@ class InsertEditTest extends AbstractTestCase
             new Template()
         );
 
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             '123',
             '0',
             [],
@@ -2343,7 +2343,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('123', $result);
 
         // case 2
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             false,
             '0',
             ['test'],
@@ -2361,7 +2361,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('NULL', $result);
 
         // case 3
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             false,
             '0',
             ['test'],
@@ -2380,7 +2380,7 @@ class InsertEditTest extends AbstractTestCase
 
         // case 4
         $_POST['fields']['multi_edit'][0][0] = [];
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             false,
             '0',
             ['set'],
@@ -2398,7 +2398,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals("''", $result);
 
         // case 5
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             false,
             '0',
             ['protected'],
@@ -2416,7 +2416,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('0x313031', $result);
 
         // case 6
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             false,
             '0',
             ['protected'],
@@ -2434,7 +2434,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('', $result);
 
         // case 7
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             false,
             '0',
             ['bit'],
@@ -2452,7 +2452,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals("b'00010'", $result);
 
         // case 7
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             false,
             '0',
             ['date'],
@@ -2471,7 +2471,7 @@ class InsertEditTest extends AbstractTestCase
 
         // case 8
         $_POST['fields']['multi_edit'][0][0] = [];
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             false,
             '0',
             ['set'],
@@ -2489,7 +2489,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('NULL', $result);
 
         // case 9
-        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
             false,
             '0',
             ['protected'],

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1994,7 +1994,7 @@ class InsertEditTest extends AbstractTestCase
     public function testGetQueryValuesForInsert(): void
     {
         // Simple insert
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 'fld',
                 'foo',
@@ -2016,7 +2016,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // Test for file upload
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '0x123',
@@ -2044,7 +2044,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // case 1
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '',
@@ -2064,7 +2064,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals("'uuid1234'", $result);
 
         // case 2
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 "'",
@@ -2083,7 +2083,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals("AES_ENCRYPT('\\'','')", $result);
 
         // case 3
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 "'",
@@ -2102,7 +2102,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals("ABS('\\'')", $result);
 
         // case 4
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '',
@@ -2121,7 +2121,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('RAND()', $result);
 
         // case 5
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 "a'c",
@@ -2143,7 +2143,7 @@ class InsertEditTest extends AbstractTestCase
 
         // Datatype: protected copied from the databse
         $GLOBALS['table'] = 'test_table';
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 'name',
                 '',
@@ -2162,7 +2162,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('0x313031', $result);
 
         // An empty value for auto increment column should be converted to NULL
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '', // empty for null
@@ -2181,7 +2181,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('NULL', $result);
 
         // Simple empty value
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '',
@@ -2200,7 +2200,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals("''", $result);
 
         // Datatype: set
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '', // doesn't matter what the value is
@@ -2219,7 +2219,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals("''", $result);
 
         // Datatype: protected with no value should produce an empty string
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '',
@@ -2238,7 +2238,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('', $result);
 
         // Datatype: protected with null flag set
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '',
@@ -2257,7 +2257,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('NULL', $result);
 
         // Datatype: bit
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '20\'12',
@@ -2276,7 +2276,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals("b'00010'", $result);
 
         // Datatype: date
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '20\'12',
@@ -2295,7 +2295,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals("'20\\'12'", $result);
 
         // A NULL checkbox
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '',
@@ -2314,7 +2314,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('NULL', $result);
 
         // Datatype: protected but NULL checkbox was unchecked without uploading a file
-        $result = $this->insertEdit->getQueryValuesForInsert(
+        $result = $this->insertEdit->getQueryValueForInsert(
             new EditField(
                 '',
                 '',
@@ -2339,7 +2339,7 @@ class InsertEditTest extends AbstractTestCase
     public function testGetQueryValuesForUpdate(): void
     {
         // Simple update
-        $result = $this->insertEdit->getQueryValuesForUpdate(
+        $result = $this->insertEdit->getQueryValueForUpdate(
             new EditField(
                 'fld',
                 'foo',
@@ -2359,7 +2359,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // Update of null when it was null previously
-        $result = $this->insertEdit->getQueryValuesForUpdate(
+        $result = $this->insertEdit->getQueryValueForUpdate(
             new EditField(
                 'fld',
                 '', // null fields will have no value
@@ -2379,7 +2379,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // Update of null when it was NOT null previously
-        $result = $this->insertEdit->getQueryValuesForUpdate(
+        $result = $this->insertEdit->getQueryValueForUpdate(
             new EditField(
                 'fld',
                 '', // null fields will have no value
@@ -2399,7 +2399,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // Update to NOT null when it was null previously
-        $result = $this->insertEdit->getQueryValuesForUpdate(
+        $result = $this->insertEdit->getQueryValueForUpdate(
             new EditField(
                 'fld',
                 "ab'c",
@@ -2419,7 +2419,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // Test to see if a zero-string is not ignored
-        $result = $this->insertEdit->getQueryValuesForUpdate(
+        $result = $this->insertEdit->getQueryValueForUpdate(
             new EditField(
                 'fld',
                 '0', // zero-string provided as value
@@ -2439,7 +2439,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // Test to check if blob field that was left unchanged during edit will be ignored
-        $result = $this->insertEdit->getQueryValuesForUpdate(
+        $result = $this->insertEdit->getQueryValueForUpdate(
             new EditField(
                 'fld',
                 '', // no value
@@ -2459,7 +2459,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // Test to see if a field will be ignored if it the value is unchanged
-        $result = $this->insertEdit->getQueryValuesForUpdate(
+        $result = $this->insertEdit->getQueryValueForUpdate(
             new EditField(
                 'fld',
                 "a'b",

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -2331,6 +2331,63 @@ class InsertEditTest extends AbstractTestCase
             ''
         );
         $this->assertEquals("''", $result);
+
+        // Datatype: date with default value
+        $result = $this->insertEdit->getQueryValueForInsert(
+            new EditField(
+                '',
+                'current_timestamp()',
+                'date',
+                false,
+                false,
+                true, // NULL should be ignored
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals('current_timestamp()', $result);
+
+        // Datatype: hex without 0x
+        $result = $this->insertEdit->getQueryValueForInsert(
+            new EditField(
+                '',
+                '222aaafff',
+                'hex',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals('0x222aaafff', $result);
+
+        // Datatype: hex with 0x
+        $result = $this->insertEdit->getQueryValueForInsert(
+            new EditField(
+                '',
+                '0x222aaafff',
+                'hex',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals('0x222aaafff', $result);
     }
 
     /**

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Warning;
+use PhpMyAdmin\EditField;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\FileListing;
 use PhpMyAdmin\InsertEdit;
@@ -1988,269 +1989,53 @@ class InsertEditTest extends AbstractTestCase
     }
 
     /**
-     * Test for getQueryValuesForInsertAndUpdateInMultipleEdit
+     * Test for getQueryValuesForInsert
      */
-    public function testGetQueryValuesForInsertAndUpdateInMultipleEdit(): void
+    public function testGetQueryValuesForInsert(): void
     {
-        $multi_edit_columns_name = ['0' => 'fld'];
-
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            [],
-            '',
-            [],
-            [],
-            true,
-            [1],
-            [2],
-            'foo',
-            [],
-            '0',
-            []
-        );
-
-        $this->assertEquals(
-            [
-                [
-                    1,
-                    'foo',
-                ],
-                [
-                    2,
-                    '`fld`',
-                ],
-            ],
-            $result
-        );
-
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            [],
-            '',
-            [],
-            [],
+        // Simple insert
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                'fld',
+                'foo',
+                '',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
             false,
-            [1],
-            [2],
-            'foo',
-            [],
-            '0',
-            ['a']
+            ''
         );
-
         $this->assertEquals(
-            [
-                [
-                    1,
-                    '`fld` = foo',
-                ],
-                [2],
-            ],
+            "'foo'",
             $result
         );
 
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            ['b'],
-            "'`c`'",
-            ['c'],
-            [],
+        // Test for file upload
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '0x123',
+                '',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                true
+            ),
             false,
-            [1],
-            [2],
-            'foo',
-            [],
-            '0',
-            ['a']
+            ''
         );
 
-        $this->assertEquals(
-            [
-                [1],
-                [2],
-            ],
-            $result
-        );
+        $this->assertEquals('0x123', $result);
 
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            ['b'],
-            "'`c`'",
-            ['c'],
-            [3],
-            false,
-            [1],
-            [2],
-            'foo',
-            [],
-            '0',
-            []
-        );
-
-        $this->assertEquals(
-            [
-                [
-                    1,
-                    '`fld` = foo',
-                ],
-                [2],
-            ],
-            $result
-        );
-
-        // Test to see if a zero-string is not ignored
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            [],
-            '0',
-            [],
-            [],
-            false,
-            [],
-            [],
-            "'0'",
-            [],
-            '0',
-            []
-        );
-
-        $this->assertEquals(
-            [
-                ["`fld` = '0'"],
-                [],
-            ],
-            $result
-        );
-
-        // Can only happen when table contains blob field that was left unchanged during edit
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            [],
-            '',
-            [],
-            [],
-            false,
-            [],
-            [],
-            '',
-            [],
-            '0',
-            []
-        );
-
-        $this->assertEquals(
-            [
-                [],
-                [],
-            ],
-            $result
-        );
-
-        // Test to see if a field will be set to null when it wasn't null previously
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            ['on'],
-            '',
-            [],
-            [],
-            false,
-            [],
-            [],
-            'NULL',
-            [],
-            '0',
-            []
-        );
-
-        $this->assertEquals(
-            [
-                ['`fld` = NULL'],
-                [],
-            ],
-            $result
-        );
-
-        // Test to see if a field will be ignored if it was null previously
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            ['on'],
-            '',
-            [],
-            [],
-            false,
-            [],
-            [],
-            'NULL',
-            [],
-            '0',
-            ['on']
-        );
-
-        $this->assertEquals(
-            [
-                [],
-                [],
-            ],
-            $result
-        );
-
-        // Test to see if a field will be ignored if it the value is unchanged
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            [],
-            "a'b",
-            ["a'b"],
-            [],
-            false,
-            [],
-            [],
-            "'a\'b'",
-            [],
-            '0',
-            []
-        );
-
-        $this->assertEquals(
-            [
-                [],
-                [],
-            ],
-            $result
-        );
-
-        // Test to see if a field can be set to NULL
-        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
-            $multi_edit_columns_name,
-            ['on'],
-            '',
-            [''],
-            [],
-            false,
-            [],
-            [],
-            'NULL',
-            [],
-            '0',
-            []
-        );
-
-        $this->assertEquals(
-            [
-                ['`fld` = NULL'],
-                [],
-            ],
-            $result
-        );
-    }
-
-    /**
-     * Test for getCurrentValueAsAnArrayForMultipleEdit
-     */
-    public function testGetCurrentValueAsAnArrayForMultipleEdit(): void
-    {
-        // case 2
-        $multi_edit_function = 'UUID';
-
+        // Test functions
         $this->dummyDbi->addResult(
             'SELECT UUID()',
             [
@@ -2258,253 +2043,441 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $this->insertEdit = new InsertEdit(
-            $GLOBALS['dbi'],
-            new Relation($GLOBALS['dbi']),
-            new Transformations(),
-            new FileListing(),
-            new Template()
-        );
-
-        $result = $this->insertEdit->formatAsSqlFunction(
-            $multi_edit_function,
-            null,
-            'currVal'
+        // case 1
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '',
+                '',
+                false,
+                false,
+                false,
+                'UUID',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
         );
 
         $this->assertEquals("'uuid1234'", $result);
 
-        // case 3
-        $multi_edit_function = 'AES_ENCRYPT';
-        $multi_edit_salt = '';
-        $result = $this->insertEdit->formatAsSqlFunction(
-            $multi_edit_function,
-            $multi_edit_salt,
-            "'"
+        // case 2
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                "'",
+                '',
+                false,
+                false,
+                false,
+                'AES_ENCRYPT',
+                '',
+                null,
+                false
+            ),
+            false,
+            ''
         );
         $this->assertEquals("AES_ENCRYPT('\\'','')", $result);
 
-        // case 4
-        $multi_edit_function = 'ABS';
-        $result = $this->insertEdit->formatAsSqlFunction(
-            $multi_edit_function,
-            null,
-            "'"
+        // case 3
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                "'",
+                '',
+                false,
+                false,
+                false,
+                'ABS',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
         );
         $this->assertEquals("ABS('\\'')", $result);
 
-        // case 5
-        $multi_edit_function = 'RAND';
-        $result = $this->insertEdit->formatAsSqlFunction(
-            $multi_edit_function,
-            null,
+        // case 4
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '',
+                '',
+                false,
+                false,
+                false,
+                'RAND',
+                null,
+                null,
+                false
+            ),
+            false,
             ''
         );
         $this->assertEquals('RAND()', $result);
 
-        // case 6
-        $multi_edit_function = 'PHP_PASSWORD_HASH';
-        $result = $this->insertEdit->formatAsSqlFunction(
-            $multi_edit_function,
-            null,
-            "a'c"
+        // case 5
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                "a'c",
+                '',
+                false,
+                false,
+                false,
+                'PHP_PASSWORD_HASH',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
         );
         $this->assertTrue(password_verify("a'c", mb_substr($result, 1, -1)));
+
+        // Test different data types
+
+        // Datatype: protected copied from the databse
+        $GLOBALS['table'] = 'test_table';
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                'name',
+                '',
+                'protected',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            true,
+            '`id` = 4'
+        );
+        $this->assertEquals('0x313031', $result);
+
+        // An empty value for auto increment column should be converted to NULL
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '', // empty for null
+                '',
+                true,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals('NULL', $result);
+
+        // Simple empty value
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '',
+                '',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals("''", $result);
+
+        // Datatype: set
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '', // doesn't matter what the value is
+                'set',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals("''", $result);
+
+        // Datatype: protected with no value should produce an empty string
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '',
+                'protected',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals('', $result);
+
+        // Datatype: protected with null flag set
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '',
+                'protected',
+                false,
+                true,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals('NULL', $result);
+
+        // Datatype: bit
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '20\'12',
+                'bit',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals("b'00010'", $result);
+
+        // Datatype: date
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '20\'12',
+                'date',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals("'20\\'12'", $result);
+
+        // A NULL checkbox
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '',
+                'set',
+                false,
+                true,
+                false,
+                '',
+                null,
+                null,
+                false
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals('NULL', $result);
+
+        // Datatype: protected but NULL checkbox was unchecked without uploading a file
+        $result = $this->insertEdit->getQueryValuesForInsert(
+            new EditField(
+                '',
+                '',
+                'protected',
+                false,
+                false,
+                true, // was previously NULL
+                '',
+                null,
+                null,
+                false // no upload
+            ),
+            false,
+            ''
+        );
+        $this->assertEquals("''", $result);
     }
 
     /**
-     * Test for getCurrentValueForDifferentTypes
+     * Test for getQueryValuesForUpdate
      */
-    public function testGetCurrentValueForDifferentTypes(): void
+    public function testGetQueryValuesForUpdate(): void
     {
-        $this->insertEdit = new InsertEdit(
-            $GLOBALS['dbi'],
-            new Relation($GLOBALS['dbi']),
-            new Transformations(),
-            new FileListing(),
-            new Template()
+        // Simple update
+        $result = $this->insertEdit->getQueryValuesForUpdate(
+            new EditField(
+                'fld',
+                'foo',
+                '',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            )
+        );
+        $this->assertEquals(
+            "`fld` = 'foo'",
+            $result
         );
 
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            '123',
-            '0',
-            [],
+        // Update of null when it was null previously
+        $result = $this->insertEdit->getQueryValuesForUpdate(
+            new EditField(
+                'fld',
+                '', // null fields will have no value
+                '',
+                false,
+                true,
+                true,
+                '',
+                null,
+                null,
+                false
+            )
+        );
+        $this->assertEquals(
             '',
-            [],
-            [],
-            [],
-            [],
-            true,
-            true,
-            '',
-            'test_table'
+            $result
         );
 
-        $this->assertEquals('123', $result);
-
-        // case 2
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            false,
-            '0',
-            ['test'],
-            '',
-            [1],
-            [],
-            [],
-            [],
-            true,
-            true,
-            '',
-            'test_table'
+        // Update of null when it was NOT null previously
+        $result = $this->insertEdit->getQueryValuesForUpdate(
+            new EditField(
+                'fld',
+                '', // null fields will have no value
+                '',
+                false,
+                true,
+                false,
+                '',
+                null,
+                '', // in edit mode the previous value will be empty string
+                false
+            )
+        );
+        $this->assertEquals(
+            '`fld` = NULL',
+            $result
         );
 
-        $this->assertEquals('NULL', $result);
-
-        // case 3
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            false,
-            '0',
-            ['test'],
-            '',
-            [],
-            [],
-            [],
-            [],
-            true,
-            true,
-            '',
-            'test_table'
+        // Update to NOT null when it was null previously
+        $result = $this->insertEdit->getQueryValuesForUpdate(
+            new EditField(
+                'fld',
+                "ab'c",
+                '',
+                false,
+                false,
+                true,
+                '',
+                null,
+                null,
+                false
+            )
+        );
+        $this->assertEquals(
+            "`fld` = 'ab\'c'",
+            $result
         );
 
-        $this->assertEquals("''", $result);
-
-        // case 4
-        $_POST['fields']['multi_edit'][0][0] = [];
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            false,
-            '0',
-            ['set'],
-            '',
-            [],
-            [],
-            [],
-            [],
-            true,
-            true,
-            '',
-            'test_table'
+        // Test to see if a zero-string is not ignored
+        $result = $this->insertEdit->getQueryValuesForUpdate(
+            new EditField(
+                'fld',
+                '0', // zero-string provided as value
+                '',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            )
+        );
+        $this->assertEquals(
+            "`fld` = '0'",
+            $result
         );
 
-        $this->assertEquals("''", $result);
-
-        // case 5
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            false,
-            '0',
-            ['protected'],
+        // Test to check if blob field that was left unchanged during edit will be ignored
+        $result = $this->insertEdit->getQueryValuesForUpdate(
+            new EditField(
+                'fld',
+                '', // no value
+                'protected',
+                false,
+                false,
+                false,
+                '',
+                null,
+                null,
+                false
+            )
+        );
+        $this->assertEquals(
             '',
-            [],
-            ['name'],
-            [],
-            [],
-            true,
-            true,
-            '`id` = 4',
-            'test_table'
+            $result
         );
 
-        $this->assertEquals('0x313031', $result);
-
-        // case 6
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            false,
-            '0',
-            ['protected'],
-            '',
-            [],
-            ['a'],
-            [],
-            [],
-            true,
-            true,
-            '',
-            'test_table'
+        // Test to see if a field will be ignored if it the value is unchanged
+        $result = $this->insertEdit->getQueryValuesForUpdate(
+            new EditField(
+                'fld',
+                "a'b",
+                '',
+                false,
+                false,
+                false,
+                '',
+                null,
+                "a'b",
+                false
+            )
         );
 
-        $this->assertEquals('', $result);
-
-        // case 7
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            false,
-            '0',
-            ['bit'],
-            '20\'12',
-            [],
-            ['a'],
-            [],
-            [],
-            true,
-            true,
+        $this->assertEquals(
             '',
-            'test_table'
+            $result
         );
-
-        $this->assertEquals("b'00010'", $result);
-
-        // case 7
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            false,
-            '0',
-            ['date'],
-            '20\'12',
-            [],
-            ['a'],
-            [],
-            [],
-            true,
-            true,
-            '',
-            'test_table'
-        );
-
-        $this->assertEquals("'20\\'12'", $result);
-
-        // case 8
-        $_POST['fields']['multi_edit'][0][0] = [];
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            false,
-            '0',
-            ['set'],
-            '',
-            [],
-            [],
-            [1],
-            [],
-            true,
-            true,
-            '',
-            'test_table'
-        );
-
-        $this->assertEquals('NULL', $result);
-
-        // case 9
-        $result = $this->insertEdit->formatAsSqlValueBasedOnType(
-            false,
-            '0',
-            ['protected'],
-            '',
-            [],
-            ['a'],
-            [],
-            [1],
-            true,
-            true,
-            '',
-            'test_table'
-        );
-
-        $this->assertEquals("''", $result);
     }
 
     /**

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -2762,9 +2762,9 @@ class DbiDummy implements DbiExtension
                 ],
             ],
             [
-                'query' => 'SELECT * FROM `test_table` WHERE `id` = 4;',
-                'columns' => ['id', 'name', 'datetimefield'],
-                'result' => [['4', '101', '2013-01-20 02:00:02']],
+                'query' => 'SELECT `name` FROM `test_table` WHERE `id` = 4',
+                'columns' => ['name'],
+                'result' => [['101']],
             ],
             [
                 'query' => 'SELECT * FROM `mysql`.`user` WHERE `User` = \'username\' AND `Host` = \'hostname\';',


### PR DESCRIPTION
This is a major redesign of the code that handles these four actions: in-place edit(AJAX), edit of multiple rows, copying of rows, and insertion of new rows. The goal is to make the code easier to read and more understandable. 

- I introduced a new DTO for better readability. 
- Some of the methods were made private to the model
- The controller has access to two methods for getting the value for INSERT and for UPDATE
- Unfortunately, I have introduced method envy on EditField, but I do not want to move the functionality away from InsertEdit.php
- Unit tests have not improved in readability but I added helpful comments explaining what we are testing. There's probably a way to improve it too. 

I will probably merge all commits once I decide it's ready for review. 