### PR TITLE
Allow fields to be set to NULL

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1673,6 +1673,7 @@ class InsertEdit
                 . ' = ' . $currentValueAsAnArray;
         } elseif (
             ! (empty($multiEditFuncs[$key])
+                && empty($multiEditColumnsNull[$key])
                 && isset($multiEditColumnsPrev[$key])
                 && $currentValue === $multiEditColumnsPrev[$key])
             && $currentValueAsAnArray !== ''

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -2143,6 +2143,30 @@ class InsertEditTest extends AbstractTestCase
             ],
             $result
         );
+
+        // Test to see if a field can be set to NULL
+        $result = $this->insertEdit->getQueryValuesForInsertAndUpdateInMultipleEdit(
+            $multi_edit_columns_name,
+            ['on'],
+            '',
+            [''],
+            [],
+            false,
+            [],
+            [],
+            'NULL',
+            [],
+            '0',
+            []
+        );
+
+        $this->assertEquals(
+            [
+                ['`fld` = NULL'],
+                [],
+            ],
+            $result
+        );
     }
 
     /**


### PR DESCRIPTION
While writing new tests I noticed that this functionality is still broken. 

When a field is marked as NULL in the form, the value is unchanged and only the NULL flag is set. We need to exclude this when checking whether the field was changed or not. 