### PR TITLE
Fix table creation

### DIFF
--- a/libraries/classes/Controllers/Table/CreateController.php
+++ b/libraries/classes/Controllers/Table/CreateController.php
@@ -58,14 +58,12 @@ class CreateController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['num_fields'] = $GLOBALS['num_fields'] ?? null;
-        $GLOBALS['result'] = $GLOBALS['result'] ?? null;
         $this->checkParameters(['db']);
 
         $cfg = $this->config->settings;
 
         /* Check if database name is empty */
-        if (strlen($GLOBALS['db']) === 0) {
+        if ($GLOBALS['db'] === '') {
             Generator::mysqlDie(
                 __('The database name is empty!'),
                 '',
@@ -98,7 +96,7 @@ class CreateController extends AbstractController
 
         $createAddField = new CreateAddField($this->dbi);
 
-        $GLOBALS['num_fields'] = $createAddField->getNumberOfFieldsFromRequest();
+        $numFields = $createAddField->getNumberOfFieldsFromRequest();
 
         /**
          * The form used to define the structure of the table has been submitted
@@ -120,9 +118,9 @@ class CreateController extends AbstractController
             }
 
             // Executes the query
-            $GLOBALS['result'] = $this->dbi->tryQuery($GLOBALS['sql_query']);
+            $result = $this->dbi->tryQuery($GLOBALS['sql_query']);
 
-            if ($GLOBALS['result']) {
+            if ($result) {
                 // Update comment table for mime types [MIME]
                 if (isset($_POST['field_mimetype']) && is_array($_POST['field_mimetype']) && $cfg['BrowseMIME']) {
                     foreach ($_POST['field_mimetype'] as $fieldindex => $mimetype) {
@@ -158,9 +156,9 @@ class CreateController extends AbstractController
 
         $this->addScriptFiles(['vendor/jquery/jquery.uitablefilter.js', 'indexes.js']);
 
-        $this->checkParameters(['server', 'db', 'table', 'num_fields']);
+        $this->checkParameters(['server', 'db']);
 
-        $templateData = $this->columnsDefinition->displayForm('/table/create', $GLOBALS['num_fields']);
+        $templateData = $this->columnsDefinition->displayForm('/table/create', $numFields);
 
         $this->render('columns_definitions/column_definitions_form', $templateData);
     }


### PR DESCRIPTION
Fixes #17544 

@MauricioFauth Could you please take a look? I removed 2 globabls which IMHO shouldn't be global and excluded check for table, because that is an optional argument. The page can be opened without providing the table name. 