### PR TITLE
Fix incomplete Privileges test

### DIFF
--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -1698,10 +1698,9 @@ class Privileges
                 continue;
             }
 
-            $dbRightsSqls[] = '
-                SELECT DISTINCT `' . $dbOrTableName . '`
-                FROM `mysql`.' . Util::backquote($tableSearchIn)
-               . $userHostCondition;
+            $dbRightsSqls[] = 'SELECT DISTINCT `' . $dbOrTableName
+                . '` FROM `mysql`.' . Util::backquote($tableSearchIn)
+                . $userHostCondition;
         }
 
         $userDefaults = [

--- a/test/classes/Server/PrivilegesTest.php
+++ b/test/classes/Server/PrivilegesTest.php
@@ -1636,7 +1636,7 @@ class PrivilegesTest extends AbstractTestCase
         );
         // phpcs:disable Generic.Files.LineLength.TooLong
         $dummyDbi->addResult(
-            '( SELECT DISTINCT `Table_name` FROM `mysql`.`columns_priv` WHERE `User` = \'pma\' AND `Host` = \'host\' AND `Db` LIKE \'pmadb\') ORDER BY `Table_name` ASC',
+            '(SELECT DISTINCT `Table_name` FROM `mysql`.`columns_priv` WHERE `User` = \'pma\' AND `Host` = \'host\' AND `Db` LIKE \'pmadb\') ORDER BY `Table_name` ASC',
             [],
             ['Table_name']
         );
@@ -1646,7 +1646,7 @@ class PrivilegesTest extends AbstractTestCase
             ['Table_name', 'Table_priv', 'Column_priv']
         );
         $dummyDbi->addResult(
-            '( SELECT DISTINCT `Db` FROM `mysql`.`tables_priv` WHERE `User` = \'pma2\' AND `Host` = \'host2\') UNION ( SELECT DISTINCT `Db` FROM `mysql`.`columns_priv` WHERE `User` = \'pma2\' AND `Host` = \'host2\') ORDER BY `Db` ASC',
+            '(SELECT DISTINCT `Db` FROM `mysql`.`tables_priv` WHERE `User` = \'pma2\' AND `Host` = \'host2\') UNION (SELECT DISTINCT `Db` FROM `mysql`.`columns_priv` WHERE `User` = \'pma2\' AND `Host` = \'host2\') ORDER BY `Db` ASC',
             [],
             ['Db']
         );


### PR DESCRIPTION
The test PhpMyAdmin\Tests\Server\PrivilegesTest::testGetHtmlForAllTableSpecificRights was marked as incomplete. I don't think the spaces were intentional. 