### PR TITLE
Replace `cfg` global with `Settings` class

### DIFF
--- a/libraries/classes/Common.php
+++ b/libraries/classes/Common.php
@@ -615,11 +615,11 @@ final class Common
          */
         $controlLink = false;
         if ($server->controluser !== '') {
-            $controlLink = $dbi->connect(DatabaseInterface::CONNECT_CONTROL);
+            $controlLink = $dbi->connect($server, DatabaseInterface::CONNECT_CONTROL);
         }
 
         // Connects to the server (validates user's login)
-        $userLink = $dbi->connect(DatabaseInterface::CONNECT_USER);
+        $userLink = $dbi->connect($server, DatabaseInterface::CONNECT_USER);
 
         if ($userLink === false) {
             $auth->showFailure('mysql-denied');
@@ -633,7 +633,7 @@ final class Common
          * Open separate connection for control queries, this is needed to avoid problems with table locking used in
          * main connection and phpMyAdmin issuing queries to configuration storage, which is not locked by that time.
          */
-        $dbi->connect(DatabaseInterface::CONNECT_USER, null, DatabaseInterface::CONNECT_CONTROL);
+        $dbi->connect($server, DatabaseInterface::CONNECT_USER, null, DatabaseInterface::CONNECT_CONTROL);
     }
 
     public static function getRequest(): ServerRequest

--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -103,8 +103,11 @@ class Config
      */
     public $done = false;
 
+    /** @var Settings */
+    public $config;
+
     /**
-     * @param string $source source to read config from
+     * @param string|null $source source to read config from
      */
     public function __construct(?string $source = null)
     {
@@ -118,6 +121,7 @@ class Config
         $this->checkSystem();
 
         $this->baseSettings = $this->settings;
+        $this->config = new Settings($this->settings);
     }
 
     /**
@@ -340,7 +344,7 @@ class Config
      * loads configuration from $source, usually the config file
      * should be called on object creation
      *
-     * @param string $source config file
+     * @param string|null $source config file
      */
     public function load(?string $source = null): bool
     {
@@ -462,6 +466,7 @@ class Config
         // load config array
         $this->settings = array_replace_recursive($this->settings, $config_data);
         $GLOBALS['cfg'] = array_replace_recursive($GLOBALS['cfg'], $config_data);
+        $this->config = new Settings($this->settings);
 
         if (isset($GLOBALS['isMinimumCommon'])) {
             return;
@@ -568,6 +573,7 @@ class Config
 
         Core::arrayWrite($cfg_path, $GLOBALS['cfg'], $new_cfg_value);
         Core::arrayWrite($cfg_path, $this->settings, $new_cfg_value);
+        $this->config = new Settings($this->settings);
 
         return $result;
     }
@@ -729,6 +735,7 @@ class Config
         }
 
         $this->settings[$setting] = $value;
+        $this->config = new Settings($this->settings);
         $this->setMtime = time();
     }
 
@@ -1195,6 +1202,8 @@ class Config
                 $this->settings['Server'] = [];
             }
         }
+
+        $this->config = new Settings($this->settings);
 
         return (int) $server;
     }

--- a/libraries/classes/Config/Settings.php
+++ b/libraries/classes/Config/Settings.php
@@ -142,6 +142,13 @@ final class Settings
     public $Servers;
 
     /**
+     * Selected server configuration.
+     *
+     * @var Server|null
+     */
+    public $Server;
+
+    /**
      * Default server (0 = no default server)
      *
      * If you have more than one server configured, you can set $cfg['ServerDefault']
@@ -1588,6 +1595,7 @@ final class Settings
         $this->AllowThirdPartyFraming = $this->setAllowThirdPartyFraming($settings);
         $this->blowfish_secret = $this->setBlowfishSecret($settings);
         $this->Servers = $this->setServers($settings);
+        $this->Server = $this->setServer($settings);
         $this->ServerDefault = $this->setServerDefault($settings);
         $this->VersionCheck = $this->setVersionCheck($settings);
         $this->ProxyUrl = $this->setProxyUrl($settings);
@@ -1953,6 +1961,18 @@ final class Settings
         }
 
         return $servers;
+    }
+
+    /**
+     * @param array<int|string, mixed> $settings
+     */
+    private function setServer(array $settings): ?Server
+    {
+        if (! isset($settings['Server']) || ! is_array($settings['Server'])) {
+            return null;
+        }
+
+        return new Server($settings['Server']);
     }
 
     /**

--- a/libraries/classes/Config/Settings.php
+++ b/libraries/classes/Config/Settings.php
@@ -1791,6 +1791,7 @@ final class Settings
         $settings['Import'] = get_object_vars($this->Import);
         $settings['Schema'] = get_object_vars($this->Schema);
         $settings['DefaultTransformations'] = get_object_vars($this->DefaultTransformations);
+        $settings['Server'] = $this->Server !== null ? get_object_vars($this->Server) : null;
 
         foreach (array_keys($settings['Servers']) as $key) {
             $settings['Servers'][$key] = get_object_vars($this->Servers[$key]);

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Database\DatabaseList;
 use PhpMyAdmin\Dbal\DatabaseName;
@@ -1852,9 +1853,9 @@ class DatabaseInterface implements DbalInterface
      *
      * @return mixed false on error or a connection object on success
      */
-    public function connect(int $mode, ?array $server = null, ?int $target = null)
+    public function connect(Server $selectedServer, int $mode, ?array $server = null, ?int $target = null)
     {
-        [$user, $password, $server] = Config::getConnectionParams($mode, $server);
+        [$user, $password, $server] = Config::getConnectionParams($selectedServer, $mode, $server);
 
         if ($target === null) {
             $target = $mode;

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Dbal;
 
+use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\FieldMetadata;
@@ -518,7 +519,7 @@ interface DbalInterface
      *
      * @return mixed false on error or a connection object on success
      */
-    public function connect(int $mode, ?array $server = null, ?int $target = null);
+    public function connect(Server $selectedServer, int $mode, ?array $server = null, ?int $target = null);
 
     /**
      * selects given database

--- a/libraries/classes/Replication.php
+++ b/libraries/classes/Replication.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\Dbal\ResultInterface;
 
 use function explode;
@@ -136,7 +137,11 @@ class Replication
 
         // 5th parameter set to true means that it's an auxiliary connection
         // and we must not go back to login page if it fails
-        return $GLOBALS['dbi']->connect(DatabaseInterface::CONNECT_AUXILIARY, $server);
+        return $GLOBALS['dbi']->connect(
+            $GLOBALS['config']->config->Server ?? new Server(),
+            DatabaseInterface::CONNECT_AUXILIARY,
+            $server
+        );
     }
 
     /**

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -17,6 +17,7 @@ use function file_put_contents;
 use function fileperms;
 use function function_exists;
 use function gd_info;
+use function get_object_vars;
 use function mb_strstr;
 use function ob_end_clean;
 use function ob_get_contents;
@@ -1201,8 +1202,8 @@ class ConfigTest extends AbstractTestCase
      */
     public function testGetConnectionParams(array $server_cfg, int $mode, ?array $server, array $expected): void
     {
-        $GLOBALS['cfg']['Server'] = $server_cfg;
-        $result = Config::getConnectionParams($mode, $server);
+        $expected[2] = get_object_vars(new Settings\Server($expected[2]));
+        $result = Config::getConnectionParams(new Settings\Server($server_cfg), $mode, $server);
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
The idea is to replace usages of the `$GLOBALS['cfg']` with the `PhpMyAdmin\Config\Settings` class to improve type checking and reduce global variable usage.

As the `settings` property of `Config` class is changing in a few places, the instance hold by the `config` property is recreated in a few places. It should be refactored in the future to avoid or reduce that.