### PR TITLE
Fix for handle large number of tables in a single database (more than 10k)

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -387,6 +387,10 @@ class DatabaseInterface implements DbalInterface
         }
 
         $tables = [];
+		
+		if ($limitCount && is_array($table)) {
+			$table = array_slice($table, $limitOffset, $limitCount);
+		}
 
         if (! $GLOBALS['cfg']['Server']['DisableIS']) {
             $sqlWhereTable = QueryGenerator::getTableCondition(
@@ -503,8 +507,7 @@ class DatabaseInterface implements DbalInterface
                                         $this,
                                         'escapeString',
                                     ],
-                                    $table,
-                                    $link
+                                    $table
                                 )
                             ) . '\')';
                     } else {

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2191,7 +2191,7 @@ class Util
             // We must use union operator here instead of array_merge to preserve numerical keys
             $tables = $groupTable + $GLOBALS['dbi']->getTablesFull(
                 $db,
-                $groupWithSeparator !== false ? $groupWithSeparator : '',
+                $groupWithSeparator !== false ? $groupWithSeparator : $tables,
                 $groupWithSeparator !== false,
                 $limitOffset,
                 $limitCount,


### PR DESCRIPTION
Hi, this is a patch to handle large number of table in a single database. I test it with more than 300 000 tables.
It works with or without `DisableIS`.
To be able to use phpMyAdmin with this amount of table, $cfg['EnableAutocompleteForTablesAndColumns'] must be set to false.
I hesitated to automatically disable `EnableAutocompleteForTablesAndColumns` when there was more than 10 000 tables, I can add it if you think it can be helpful.
