### PR TITLE
Fix for handle large number of tables in a single database (based on QA_5_2)

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -385,6 +385,15 @@ class DatabaseInterface implements DbalInterface
         }
 
         $tables = [];
+        $paging_applied = false;
+
+        if ($limit_count && is_array($table) && $sort_by === 'Name') {
+            if ($sort_order === 'DESC') {
+                $table = array_reverse($table);
+            }
+            $table = array_slice($table, $limit_offset, $limit_count);
+            $paging_applied = true;
+        }
 
         if (! $GLOBALS['cfg']['Server']['DisableIS']) {
             $sql_where_table = QueryGenerator::getTableCondition(
@@ -412,7 +421,7 @@ class DatabaseInterface implements DbalInterface
             // Sort the tables
             $sql .= ' ORDER BY ' . $sort_by . ' ' . $sort_order;
 
-            if ($limit_count) {
+            if ($limit_count && ! $paging_applied) {
                 $sql .= ' LIMIT ' . $limit_count . ' OFFSET ' . $limit_offset;
             }
 
@@ -593,7 +602,7 @@ class DatabaseInterface implements DbalInterface
                 unset($sortValues);
             }
 
-            if ($limit_count) {
+            if ($limit_count && ! $paging_applied) {
                 $each_tables = array_slice($each_tables, $limit_offset, $limit_count, true);
             }
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2292,7 +2292,7 @@ class Util
 
             $tables = $groupTable + $dbi->getTablesFull(
                 $db,
-                $groupWithSeparator !== false ? $groupWithSeparator : '',
+                $groupWithSeparator !== false ? $groupWithSeparator : $tables,
                 $groupWithSeparator !== false,
                 $limitOffset,
                 $limitCount,


### PR DESCRIPTION
Hi, this is a patch to handle large number of table in a single database. I test it with more than 300 000 tables.
It works with or without DisableIS.
To be able to use phpMyAdmin with this amount of table, [$cfg['EnableAutocompleteForTablesAndColumns']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_EnableAutocompleteForTablesAndColumns) must be set to false.
I hesitated to automatically disable EnableAutocompleteForTablesAndColumns when there was more than 10 000 tables, I can add it if you think it can be helpful.

Fixes:  #17702 