### PR TITLE
Fix #17656 - Replace/Change/Set table prefix is not working

### DIFF
--- a/templates/database/structure/bulk_action_modal.twig
+++ b/templates/database/structure/bulk_action_modal.twig
@@ -1,0 +1,16 @@
+<div class="modal fade" id="bulkActionModal" data-bs-backdrop="static" data-bs-keyboard="false"
+     tabindex="-1" aria-labelledby="bulkActionLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="bulkActionLabel"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Cancel' %}"></button>
+      </div>
+      <div class="modal-body"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
+        <button type="button" class="btn btn-primary" id="bulkActionContinue">{% trans 'Continue' %}</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/database/structure/check_all_tables.twig
+++ b/templates/database/structure/check_all_tables.twig
@@ -39,23 +39,6 @@
     {{ hidden_fields|join('\n')|raw }}
 </div>
 
-<div class="modal fade" id="bulkActionModal" data-bs-backdrop="static" data-bs-keyboard="false"
-     tabindex="-1" aria-labelledby="bulkActionLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="bulkActionLabel"></h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Cancel' %}"></button>
-      </div>
-      <div class="modal-body"></div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
-        <button type="button" class="btn btn-primary" id="bulkActionContinue">{% trans 'Continue' %}</button>
-      </div>
-    </div>
-  </div>
-</div>
-
 {% if central_columns_work is defined and central_columns_work %}
   <div class="modal fade" id="makeConsistentWithCentralListModal" data-bs-backdrop="static" data-bs-keyboard="false"
        tabindex="-1" aria-labelledby="makeConsistentWithCentralListModalLabel" aria-hidden="true">

--- a/templates/database/structure/table_header.twig
+++ b/templates/database/structure/table_header.twig
@@ -72,7 +72,7 @@
     {% endif %}
 </table>
 </div>
+</form>
 {% if check_all_tables %}
     {% include 'database/structure/check_all_tables.twig' with check_all_tables only %}
 {% endif %}
-</form>

--- a/templates/database/structure/table_header.twig
+++ b/templates/database/structure/table_header.twig
@@ -72,7 +72,10 @@
     {% endif %}
 </table>
 </div>
+{% if check_all_tables %}
+  {% include 'database/structure/check_all_tables.twig' with check_all_tables only %}
+{% endif %}
 </form>
 {% if check_all_tables %}
-    {% include 'database/structure/check_all_tables.twig' with check_all_tables only %}
+  {% include 'database/structure/bulk_action_modal.twig' with check_all_tables only %}
 {% endif %}


### PR DESCRIPTION
### Description

The browser prevents the bulkActionModal loading other forms directly into its modal-body (f.e. the "Replace table prefix" action) because it itself is placed inside a `form` tag.

Fixes #17656

---

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
