### PR TITLE
Improve column visibility toggle ui

### DIFF
--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -252,6 +252,10 @@ td .icon {
   padding: 0 0.5em;
 }
 
+#pma_demo {
+  z-index: -1;
+}
+
 .confirmation {
   color: $black;
   background-color: pink;
@@ -1588,6 +1592,7 @@ input#auto_increment_opt {
   .lDiv div {
     padding: 0.2em 0.5em 0.2em;
     padding-left: 0.2em;
+    white-space: nowrap;
 
     &:hover {
       background: #ddd;

--- a/themes/metro/scss/_common.scss
+++ b/themes/metro/scss/_common.scss
@@ -490,6 +490,10 @@ img.lightbulb {
   padding: 20px;
 }
 
+#pma_demo {
+  z-index: -1;
+}
+
 #pma_errors #pma_errors {
   padding: 0;
 }
@@ -1791,6 +1795,7 @@ form.append_fields_form .tblFooters {
   .lDiv div {
     padding: 0.2em 0.5em 0.2em;
     padding-left: 0.2em;
+    white-space: nowrap;
 
     &:hover {
       background: $navi-background;

--- a/themes/original/scss/_common.scss
+++ b/themes/original/scss/_common.scss
@@ -234,6 +234,10 @@ img.lightbulb {
   padding: 0 0.5em;
 }
 
+#pma_demo {
+  z-index: -1;
+}
+
 .confirmation {
   background-color: #ffc;
 }
@@ -1592,6 +1596,7 @@ input#auto_increment_opt {
 
   .lDiv div {
     padding: 0.2em 0.5em 0.2em 0.2em;
+    white-space: nowrap;
 
     &:hover {
       background: #ddd;

--- a/themes/pmahomme/scss/_common.scss
+++ b/themes/pmahomme/scss/_common.scss
@@ -432,6 +432,10 @@ img.lightbulb {
   padding: 0 0.5em;
 }
 
+#pma_demo {
+  z-index: -1;
+}
+
 .confirmation {
   color: #000;
   background-color: pink;
@@ -1777,6 +1781,7 @@ input#auto_increment_opt {
   .lDiv div {
     padding: 0.2em 0.5em 0.2em;
     padding-left: 0.2em;
+    white-space: nowrap;
 
     &:hover {
       background: #ddd;


### PR DESCRIPTION
### Description

Reference issue: https://github.com/phpmyadmin/phpmyadmin/issues/17747

Column visibility toggle function has the UI issue. Some columns cannot be selected because of the dropdown is behind other element layer.

### To Reproduce

Steps to reproduce the behavior:
1. Go to table browse data page (note: easy notice bug if select table with many columns but less data)
2. Click on the arrow in front of `id` column
3. See issue on the dropdown column(s) selector

### Expected behavior

1. The dropdown layer should be in front of `Query results operations` element.
2. Checkbox and label should be in same line for better view.

### Screenshots

<table>
  <tr><th>before fix</th><th>after fix</th></tr>
  <tr>
    <td valign="top"><img width="187" alt="Screen Shot 2565-10-03 at 04 12 42" src="https://user-images.githubusercontent.com/1849256/193477023-82b4074b-d25f-4812-92d5-7257b3656684.png">
</td>
    <td valign="top"><img width="165" alt="Screen Shot 2565-10-03 at 04 13 46" src="https://user-images.githubusercontent.com/1849256/193477032-5008e447-d9b0-44c8-a22a-11552a31a157.png">
</td>
  </tr>
</table>

Signed-off-by: Mo Sureerat [sureemo@gmail.com](sureemo@gmail.com)