### PR TITLE
Adding inputmode numeric to integer fields

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -693,6 +693,7 @@ class InsertEdit
             }
         }
 
+        $inputMode = '';
         $inputMinMax = '';
         if (in_array($column['True_Type'], $this->dbi->types->getIntegerTypes())) {
             $extractedColumnspec = Util::extractColumnSpec($column['Type']);
@@ -701,6 +702,7 @@ class InsertEdit
             $inputMinMax = 'min="' . $minMaxValues[0] . '" '
                 . 'max="' . $minMaxValues[1] . '"';
             $dataType = 'INT';
+            $inputMode = 'inputmode="numeric"';
         }
 
         // do not use the 'date' or 'time' types here; they have no effect on some
@@ -716,6 +718,7 @@ class InsertEdit
             . ' data-type="' . $dataType . '"'
             . ' class="' . $theClass . '" ' . $onChangeClause
             . ' tabindex="' . ($tabindex + $tabindexForValue) . '"'
+            . ($inputMode ? ' ' . $inputMode : '')
             . ' id="field_' . $idindex . '_3">';
     }
 

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -693,16 +693,15 @@ class InsertEdit
             }
         }
 
-        $inputMode = '';
         $inputMinMax = '';
-        if (in_array($column['True_Type'], $this->dbi->types->getIntegerTypes())) {
+        $isInteger = in_array($column['True_Type'], $this->dbi->types->getIntegerTypes());
+        if ($isInteger) {
             $extractedColumnspec = Util::extractColumnSpec($column['Type']);
             $isUnsigned = $extractedColumnspec['unsigned'];
             $minMaxValues = $this->dbi->types->getIntegerRange($column['True_Type'], ! $isUnsigned);
             $inputMinMax = 'min="' . $minMaxValues[0] . '" '
                 . 'max="' . $minMaxValues[1] . '"';
             $dataType = 'INT';
-            $inputMode = 'inputmode="numeric"';
         }
 
         // do not use the 'date' or 'time' types here; they have no effect on some
@@ -718,7 +717,7 @@ class InsertEdit
             . ' data-type="' . $dataType . '"'
             . ' class="' . $theClass . '" ' . $onChangeClause
             . ' tabindex="' . ($tabindex + $tabindexForValue) . '"'
-            . ($inputMode ? ' ' . $inputMode : '')
+            . ($isInteger ? ' inputmode="numeric"' : '')
             . ' id="field_' . $idindex . '_3">';
     }
 

--- a/test/classes/Controllers/Table/ChangeControllerTest.php
+++ b/test/classes/Controllers/Table/ChangeControllerTest.php
@@ -58,7 +58,7 @@ class ChangeControllerTest extends AbstractTestCase
             . ' size="4" min="-2147483648" max="2147483647" data-type="INT" class="textfield"'
             . ' onchange="return'
             . ' verificationsAfterFieldChange(\'b80bb7740288fda1f201890375a60c8f\', \'0\',\'int(11)\')"'
-            . ' tabindex="1" id="field_1_3"><input type="hidden"'
+            . ' tabindex="1" inputmode="numeric" id="field_1_3"><input type="hidden"'
             . ' name="auto_increment[multi_edit][0][b80bb7740288fda1f201890375a60c8f]" value="1">',
             $actual
         );

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1052,6 +1052,32 @@ class InsertEditTest extends AbstractTestCase
             . ' class="textfield datetimefield" c tabindex="25" id="field_0_3">',
             $result
         );
+
+        // case 4 int
+        $column['pma_type'] = 'int';
+        $column['True_Type'] = 'int';
+        $result = $this->callFunction(
+            $this->insertEdit,
+            InsertEdit::class,
+            'getHtmlInput',
+            [
+                $column,
+                'a',
+                'b',
+                30,
+                'c',
+                23,
+                2,
+                0,
+                'DATE',
+                false,
+            ]
+        );
+        $this->assertEquals(
+            '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
+            . ' class="textfield datetimefield" c tabindex="25" inputmode="numeric" id="field_0_3">',
+            $result
+        );
     }
 
     /**

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1056,6 +1056,7 @@ class InsertEditTest extends AbstractTestCase
         // case 4 int
         $column['pma_type'] = 'int';
         $column['True_Type'] = 'int';
+        $column['Type'] = 'int(11)';
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
@@ -1064,18 +1065,18 @@ class InsertEditTest extends AbstractTestCase
                 $column,
                 'a',
                 'b',
-                30,
+                11,
                 'c',
                 23,
                 2,
                 0,
-                'DATE',
+                'INT',
                 false,
             ]
         );
         $this->assertEquals(
-            '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
-            . ' class="textfield datetimefield" c tabindex="25" inputmode="numeric" id="field_0_3">',
+            '<input type="text" name="fieldsa" value="b" size="11" min="-2147483648" max="2147483647" data-type="INT"'
+            . ' class="textfield" c tabindex="25" inputmode="numeric" id="field_0_3">',
             $result
         );
     }


### PR DESCRIPTION
### Description

To easier use phpMyAdmin on touch devices with virtual keyboards, adding the inputmode ensures that the correct virtual keyboard is shown per default when focusing the field.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode for more information.

Ref:  #17745 

Signed-off-by: Jesper Skytte <jesper@skytte.it>