### PR TITLE
Fix issue - Edit/Copy/Delete row doesn't work when using GROUP BY

### DIFF
--- a/libraries/classes/FieldMetadata.php
+++ b/libraries/classes/FieldMetadata.php
@@ -240,8 +240,8 @@ final class FieldMetadata
             // reference: https://www.php.net/manual/en/mysqli-result.fetch-fields.php
             // so check field type instead of flags
             // but if no or unknown field type then check flags
-            $this->isNumeric = $this->isType(self::TYPE_INT)
-                ||  ($fieldType <= 0 && ($fieldFlags & MYSQLI_NUM_FLAG));
+            $this->isNumeric = (bool) $this->isType(self::TYPE_INT)
+                || ($fieldType <= 0 && ($fieldFlags & MYSQLI_NUM_FLAG));
 
             $this->isBlob = (bool) ($fieldFlags & MYSQLI_BLOB_FLAG);
             $this->isEnum = (bool) ($fieldFlags & MYSQLI_ENUM_FLAG);

--- a/libraries/classes/FieldMetadata.php
+++ b/libraries/classes/FieldMetadata.php
@@ -227,6 +227,8 @@ final class FieldMetadata
 
     public function __construct(int $fieldType, int $fieldFlags, object $field)
     {
+            $this->mappedType = $this->getTypeMap()[$fieldType] ?? null;
+
             $this->isMultipleKey = (bool) ($fieldFlags & MYSQLI_MULTIPLE_KEY_FLAG);
             $this->isPrimaryKey = (bool) ($fieldFlags & MYSQLI_PRI_KEY_FLAG);
             $this->isUniqueKey = (bool) ($fieldFlags & MYSQLI_UNIQUE_KEY_FLAG);
@@ -236,9 +238,8 @@ final class FieldMetadata
 
             // as flags 32768 can be NUM_FLAG or GROUP_FLAG
             // reference: https://www.php.net/manual/en/mysqli-result.fetch-fields.php
-            // so also check field type that not 253 (VARCHAR)
-            $this->isNumeric = (bool) (($fieldFlags & MYSQLI_NUM_FLAG)
-                && $this->isType(self::TYPE_INT));
+            // so also check field type instead of flags
+            $this->isNumeric = $this->isType(self::TYPE_INT);
 
             $this->isBlob = (bool) ($fieldFlags & MYSQLI_BLOB_FLAG);
             $this->isEnum = (bool) ($fieldFlags & MYSQLI_ENUM_FLAG);
@@ -249,8 +250,6 @@ final class FieldMetadata
                 MYSQLI_TIMESTAMP_FLAG => 'timestamp',
                 MYSQLI_AUTO_INCREMENT_FLAG => 'auto_increment',
             */
-
-            $this->mappedType = $this->getTypeMap()[$fieldType] ?? null;
 
             $this->isMappedTypeBit = $this->isType(self::TYPE_BIT);
             $this->isMappedTypeGeometry = $this->isType(self::TYPE_GEOMETRY);

--- a/libraries/classes/FieldMetadata.php
+++ b/libraries/classes/FieldMetadata.php
@@ -67,7 +67,6 @@ final class FieldMetadata
     public const TYPE_TIMESTAMP = 11;
     public const TYPE_DATETIME = 12;
     public const TYPE_YEAR = 13;
-    public const TYPE_VARCHAR = 253;
 
     /**
      * @var bool
@@ -234,8 +233,13 @@ final class FieldMetadata
             $this->isNotNull = (bool) ($fieldFlags & MYSQLI_NOT_NULL_FLAG);
             $this->isUnsigned = (bool) ($fieldFlags & MYSQLI_UNSIGNED_FLAG);
             $this->isZerofill = (bool) ($fieldFlags & MYSQLI_ZEROFILL_FLAG);
+
+            // as flags 32768 can be NUM_FLAG or GROUP_FLAG
+            // reference: https://www.php.net/manual/en/mysqli-result.fetch-fields.php
+            // so also check field type that not 253 (VARCHAR)
             $this->isNumeric = (bool) (($fieldFlags & MYSQLI_NUM_FLAG)
-                && $fieldType !== self::TYPE_VARCHAR);
+                && $this->isType(self::TYPE_INT));
+
             $this->isBlob = (bool) ($fieldFlags & MYSQLI_BLOB_FLAG);
             $this->isEnum = (bool) ($fieldFlags & MYSQLI_ENUM_FLAG);
             $this->isSet = (bool) ($fieldFlags & MYSQLI_SET_FLAG);

--- a/libraries/classes/FieldMetadata.php
+++ b/libraries/classes/FieldMetadata.php
@@ -239,9 +239,9 @@ final class FieldMetadata
             // as flags 32768 can be NUM_FLAG or GROUP_FLAG
             // reference: https://www.php.net/manual/en/mysqli-result.fetch-fields.php
             // so check field type instead of flags
-            // but if no field type then check flags
+            // but if no or unknown field type then check flags
             $this->isNumeric = $this->isType(self::TYPE_INT)
-                ||  (!$fieldType && ($fieldFlags & MYSQLI_NUM_FLAG));
+                ||  ($fieldType <= 0 && ($fieldFlags & MYSQLI_NUM_FLAG));
 
             $this->isBlob = (bool) ($fieldFlags & MYSQLI_BLOB_FLAG);
             $this->isEnum = (bool) ($fieldFlags & MYSQLI_ENUM_FLAG);

--- a/libraries/classes/FieldMetadata.php
+++ b/libraries/classes/FieldMetadata.php
@@ -238,8 +238,10 @@ final class FieldMetadata
 
             // as flags 32768 can be NUM_FLAG or GROUP_FLAG
             // reference: https://www.php.net/manual/en/mysqli-result.fetch-fields.php
-            // so also check field type instead of flags
-            $this->isNumeric = $this->isType(self::TYPE_INT);
+            // so check field type instead of flags
+            // but if no field type then check flags
+            $this->isNumeric = $this->isType(self::TYPE_INT)
+                ||  (!$fieldType && ($fieldFlags & MYSQLI_NUM_FLAG));
 
             $this->isBlob = (bool) ($fieldFlags & MYSQLI_BLOB_FLAG);
             $this->isEnum = (bool) ($fieldFlags & MYSQLI_ENUM_FLAG);

--- a/libraries/classes/FieldMetadata.php
+++ b/libraries/classes/FieldMetadata.php
@@ -67,6 +67,7 @@ final class FieldMetadata
     public const TYPE_TIMESTAMP = 11;
     public const TYPE_DATETIME = 12;
     public const TYPE_YEAR = 13;
+    public const TYPE_VARCHAR = 253;
 
     /**
      * @var bool
@@ -233,7 +234,8 @@ final class FieldMetadata
             $this->isNotNull = (bool) ($fieldFlags & MYSQLI_NOT_NULL_FLAG);
             $this->isUnsigned = (bool) ($fieldFlags & MYSQLI_UNSIGNED_FLAG);
             $this->isZerofill = (bool) ($fieldFlags & MYSQLI_ZEROFILL_FLAG);
-            $this->isNumeric = (bool) ($fieldFlags & MYSQLI_NUM_FLAG);
+            $this->isNumeric = (bool) (($fieldFlags & MYSQLI_NUM_FLAG)
+                && $fieldType !== self::TYPE_VARCHAR);
             $this->isBlob = (bool) ($fieldFlags & MYSQLI_BLOB_FLAG);
             $this->isEnum = (bool) ($fieldFlags & MYSQLI_ENUM_FLAG);
             $this->isSet = (bool) ($fieldFlags & MYSQLI_SET_FLAG);

--- a/libraries/classes/FieldMetadata.php
+++ b/libraries/classes/FieldMetadata.php
@@ -240,7 +240,7 @@ final class FieldMetadata
             // reference: https://www.php.net/manual/en/mysqli-result.fetch-fields.php
             // so check field type instead of flags
             // but if no or unknown field type then check flags
-            $this->isNumeric = (bool) $this->isType(self::TYPE_INT)
+            $this->isNumeric = $this->isType(self::TYPE_INT)
                 || ($fieldType <= 0 && ($fieldFlags & MYSQLI_NUM_FLAG));
 
             $this->isBlob = (bool) ($fieldFlags & MYSQLI_BLOB_FLAG);

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -880,7 +880,7 @@ class Util
         // See commit: 049fc7fef7548c2ba603196937c6dcaf9ff9bf00
         // See bug: https://sourceforge.net/p/phpmyadmin/bugs/3064/
         if ($meta->isNumeric && ! $meta->isMappedTypeTimestamp && $meta->isNotType(FieldMetadata::TYPE_REAL)) {
-            $conditionValue = '= ' . $row;
+            $conditionValue = '= "' . $dbi->escapeString((string) $row) . '"';
         } elseif ($isBlobAndIsBinaryCharset || (! empty($row) && $isBinaryString)) {
             // hexify only if this is a true not empty BLOB or a BINARY
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -880,7 +880,7 @@ class Util
         // See commit: 049fc7fef7548c2ba603196937c6dcaf9ff9bf00
         // See bug: https://sourceforge.net/p/phpmyadmin/bugs/3064/
         if ($meta->isNumeric && ! $meta->isMappedTypeTimestamp && $meta->isNotType(FieldMetadata::TYPE_REAL)) {
-            $conditionValue = '= "' . $dbi->escapeString((string) $row) . '"';
+            $conditionValue = '= ' . $row;
         } elseif ($isBlobAndIsBinaryCharset || (! empty($row) && $isBinaryString)) {
             // hexify only if this is a true not empty BLOB or a BINARY
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -911,7 +911,7 @@ class Util
                 . self::printableBitValue((int) $row, (int) $meta->length) . "'";
         } else {
             $conditionValue = '= \''
-                . $dbi->escapeString($row) . '\'';
+                . $dbi->escapeString((string) $row) . '\'';
         }
 
         return [$conditionValue, $condition];

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -875,11 +875,7 @@ class Util
         $isBinaryString = $meta->isType(FieldMetadata::TYPE_STRING) && $meta->isBinary();
         // 63 is the binary charset, see: https://dev.mysql.com/doc/internals/en/charsets.html
         $isBlobAndIsBinaryCharset = $meta->isType(FieldMetadata::TYPE_BLOB) && $meta->charsetnr === 63;
-        // timestamp is numeric on some MySQL 4.1
-        // for real we use CONCAT above and it should compare to string
-        // See commit: 049fc7fef7548c2ba603196937c6dcaf9ff9bf00
-        // See bug: https://sourceforge.net/p/phpmyadmin/bugs/3064/
-        if ($meta->isNumeric && ! $meta->isMappedTypeTimestamp && $meta->isNotType(FieldMetadata::TYPE_REAL)) {
+        if ($meta->isNumeric) {
             $conditionValue = '= ' . $row;
         } elseif ($isBlobAndIsBinaryCharset || (! empty($row) && $isBinaryString)) {
             // hexify only if this is a true not empty BLOB or a BINARY

--- a/test/classes/FieldMetadataTest.php
+++ b/test/classes/FieldMetadataTest.php
@@ -100,7 +100,7 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isNotNull());
         $this->assertFalse($fm->isPrimaryKey());
         $this->assertFalse($fm->isMultipleKey());
-        $this->assertTrue($fm->isNumeric());
+        $this->assertFalse($fm->isNumeric());
         $this->assertFalse($fm->isBlob());
     }
 
@@ -134,7 +134,7 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isNotNull());
         $this->assertFalse($fm->isPrimaryKey());
         $this->assertFalse($fm->isMultipleKey());
-        $this->assertTrue($fm->isNumeric());
+        $this->assertFalse($fm->isNumeric());
         $this->assertFalse($fm->isBlob());
     }
 }

--- a/test/classes/FieldMetadataTest.php
+++ b/test/classes/FieldMetadataTest.php
@@ -10,8 +10,8 @@ use stdClass;
 use const MYSQLI_BLOB_FLAG;
 use const MYSQLI_NUM_FLAG;
 use const MYSQLI_TYPE_FLOAT;
-use const MYSQLI_TYPE_STRING;
 use const MYSQLI_TYPE_INT24;
+use const MYSQLI_TYPE_STRING;
 
 /**
  * @covers \PhpMyAdmin\FieldMetadata

--- a/test/classes/FieldMetadataTest.php
+++ b/test/classes/FieldMetadataTest.php
@@ -105,6 +105,23 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isBlob());
     }
 
+    public function testIsNumericForUnknownFieldType(): void
+    {
+        $fm = new FieldMetadata(-1, MYSQLI_NUM_FLAG, (object) []);
+        $this->assertSame('', $fm->getMappedType());
+        $this->assertFalse($fm->isBinary());
+        $this->assertFalse($fm->isEnum());
+        $this->assertFalse($fm->isUniqueKey());
+        $this->assertFalse($fm->isUnsigned());
+        $this->assertFalse($fm->isZerofill());
+        $this->assertFalse($fm->isSet());
+        $this->assertFalse($fm->isNotNull());
+        $this->assertFalse($fm->isPrimaryKey());
+        $this->assertFalse($fm->isMultipleKey());
+        $this->assertTrue($fm->isNumeric());
+        $this->assertFalse($fm->isBlob());
+    }
+
     public function testIsBlob(): void
     {
         $fm = new FieldMetadata(-1, MYSQLI_BLOB_FLAG, (object) []);

--- a/test/classes/FieldMetadataTest.php
+++ b/test/classes/FieldMetadataTest.php
@@ -11,6 +11,7 @@ use const MYSQLI_BLOB_FLAG;
 use const MYSQLI_NUM_FLAG;
 use const MYSQLI_TYPE_FLOAT;
 use const MYSQLI_TYPE_STRING;
+use const MYSQLI_TYPE_INT24;
 
 /**
  * @covers \PhpMyAdmin\FieldMetadata
@@ -89,8 +90,8 @@ class FieldMetadataTest extends AbstractTestCase
 
     public function testIsNumeric(): void
     {
-        $fm = new FieldMetadata(-1, MYSQLI_NUM_FLAG, (object) []);
-        $this->assertSame('', $fm->getMappedType());
+        $fm = new FieldMetadata(MYSQLI_TYPE_INT24, MYSQLI_NUM_FLAG, (object) []);
+        $this->assertSame('int', $fm->getMappedType());
         $this->assertFalse($fm->isBinary());
         $this->assertFalse($fm->isEnum());
         $this->assertFalse($fm->isUniqueKey());
@@ -100,7 +101,7 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isNotNull());
         $this->assertFalse($fm->isPrimaryKey());
         $this->assertFalse($fm->isMultipleKey());
-        $this->assertFalse($fm->isNumeric());
+        $this->assertTrue($fm->isNumeric());
         $this->assertFalse($fm->isBlob());
     }
 

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -1243,7 +1243,7 @@ class ExportSqlTest extends AbstractTestCase
             $result
         );
 
-        $this->assertStringContainsString('(NULL, test, 0x3130, 0x36, 0x000a0d1a);', $result);
+        $this->assertStringContainsString('(NULL, &#039;test&#039;, 0x3130, 0x36, 0x000a0d1a);', $result);
 
         $this->assertStringContainsString('SET IDENTITY_INSERT &quot;table&quot; OFF;', $result);
     }

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -1243,7 +1243,7 @@ class ExportSqlTest extends AbstractTestCase
             $result
         );
 
-        $this->assertStringContainsString('(NULL, &#039;test&#039;, 0x3130, 0x36, 0x000a0d1a);', $result);
+        $this->assertStringContainsString('(NULL, test, 0x3130, 0x36, 0x000a0d1a);', $result);
 
         $this->assertStringContainsString('SET IDENTITY_INSERT &quot;table&quot; OFF;', $result);
     }

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -286,8 +286,7 @@ class UtilTest extends AbstractTestCase
     /**
      * Provider for testGetUniqueConditionForGroupFlag
      *
-     * @return array
-     * @psalm-return array<string, array{FieldMetadata[], array<int, mixed>, array{string, bool, array<string, string>}}>
+     * @return array<string, array{FieldMetadata[], array<int, mixed>, array{string, bool, array<string, string>}}>
      */
     public function providerGetUniqueConditionForGroupFlag(): array
     {

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -179,8 +179,8 @@ class UtilTest extends AbstractTestCase
         ], false, 'table');
         $this->assertEquals(
             [
-                '`table`.`field1` IS NULL AND `table`.`field2` = \'value\\\'s\' AND `table`.`field3` = "123456"'
-                . ' AND `table`.`field4` = "123.456" AND `table`.`field5` = CAST(0x76616c7565 AS BINARY)'
+                '`table`.`field1` IS NULL AND `table`.`field2` = \'value\\\'s\' AND `table`.`field3` = 123456'
+                . ' AND `table`.`field4` = 123.456 AND `table`.`field5` = CAST(0x76616c7565 AS BINARY)'
                 . ' AND `table`.`field7` = \'value\' AND `table`.`field8` = \'value\''
                 . ' AND `table`.`field9` = CAST(0x76616c7565 AS BINARY)'
                 . ' AND `table`.`field10` = CAST(0x76616c7565 AS BINARY)'
@@ -189,8 +189,8 @@ class UtilTest extends AbstractTestCase
                 [
                     '`table`.`field1`' => 'IS NULL',
                     '`table`.`field2`' => '= \'value\\\'s\'',
-                    '`table`.`field3`' => '= "123456"',
-                    '`table`.`field4`' => '= "123.456"',
+                    '`table`.`field3`' => '= 123456',
+                    '`table`.`field4`' => '= 123.456',
                     '`table`.`field5`' => '= CAST(0x76616c7565 AS BINARY)',
                     '`table`.`field7`' => '= \'value\'',
                     '`table`.`field8`' => '= \'value\'',
@@ -237,7 +237,7 @@ class UtilTest extends AbstractTestCase
         ];
 
         $actual = Util::getUniqueCondition(count($meta), $meta, [1, 'value']);
-        $this->assertEquals(['`table`.`id` = "1"', true, ['`table`.`id`' => '= "1"']], $actual);
+        $this->assertEquals(['`table`.`id` = 1', true, ['`table`.`id`' => '= 1']], $actual);
     }
 
     public function testGetUniqueConditionWithUniqueKey(): void

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -264,14 +264,21 @@ class UtilTest extends AbstractTestCase
     /**
      * Test for Util::getUniqueCondition
      *
-     * @param array $meta     Meta
      * @param array $row      Data Row
-     * @param array $expected Expected value
+     * @param array $expected Expected Result
      *
      * @dataProvider providerGetUniqueConditionAfterGroupByQuery
      */
-    public function testGetUniqueConditionAfterGroupByQuery($meta, $row, $expected): void
+    public function testGetUniqueConditionAfterGroupByQuery($row, $expected): void
     {
+        $meta = [
+            new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                'name' => 'col',
+                'table' => 'table',
+                'orgtable' => 'table',
+            ]),
+        ];
+
         $actual = Util::getUniqueCondition(1, $meta, $row);
 
         $this->assertEquals($expected, $actual);
@@ -286,13 +293,6 @@ class UtilTest extends AbstractTestCase
     {
         return [
             'value is string' => [
-                [
-                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
-                        'name' => 'col',
-                        'table' => 'table',
-                        'orgtable' => 'table',
-                    ]),
-                ],
                 ['test'],
                 [
                     "`table`.`col` = 'test'",
@@ -301,13 +301,6 @@ class UtilTest extends AbstractTestCase
                 ],
             ],
             'value is string with double quote' => [
-                [
-                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
-                        'name' => 'col',
-                        'table' => 'table',
-                        'orgtable' => 'table',
-                    ]),
-                ],
                 ['"test"'],
                 [
                     "`table`.`col` = '\\\"test\\\"'",
@@ -316,13 +309,6 @@ class UtilTest extends AbstractTestCase
                 ],
             ],
             'value is string with single quote' => [
-                [
-                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
-                        'name' => 'col',
-                        'table' => 'table',
-                        'orgtable' => 'table',
-                    ]),
-                ],
                 ["'test'"],
                 [
                     "`table`.`col` = '\'test\''",

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -265,7 +265,7 @@ class UtilTest extends AbstractTestCase
 
     /**
      * Test for Util::getUniqueCondition
-     * note: GROUP_FLAG = MYSQLI_NUM_FLAG
+     * note: GROUP_FLAG = MYSQLI_NUM_FLAG = 32769
      *
      * @param FieldMetadata[] $meta     Meta Information for Field
      * @param array           $row      Current Ddata Row
@@ -386,7 +386,7 @@ class UtilTest extends AbstractTestCase
                     false,
                     [
                         '`table`.`col`' => "= 'test'",
-                        '`table`.`status_id`' => "= 2",
+                        '`table`.`status_id`' => '= 2',
                     ],
                 ],
             ],

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -263,13 +263,14 @@ class UtilTest extends AbstractTestCase
 
     /**
      * Test for Util::getUniqueCondition
+     * note: GROUP_FLAG = MYSQLI_NUM_FLAG
      *
      * @param array $row      Data Row
      * @param array $expected Expected Result
      *
-     * @dataProvider providerGetUniqueConditionAfterGroupByQuery
+     * @dataProvider providerGetUniqueConditionForGroupFlag
      */
-    public function testGetUniqueConditionAfterGroupByQuery($row, $expected): void
+    public function testGetUniqueConditionForGroupFlag(array $row, array $expected): void
     {
         $meta = [
             new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
@@ -285,11 +286,11 @@ class UtilTest extends AbstractTestCase
     }
 
     /**
-     * Provider for testGetUniqueConditionAfterGroupByQuery
+     * Provider for testGetUniqueConditionForGroupFlag
      *
      * @return array
      */
-    public function providerGetUniqueConditionAfterGroupByQuery(): array
+    public function providerGetUniqueConditionForGroupFlag(): array
     {
         return [
             'value is string' => [

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -179,8 +179,8 @@ class UtilTest extends AbstractTestCase
         ], false, 'table');
         $this->assertEquals(
             [
-                '`table`.`field1` IS NULL AND `table`.`field2` = \'value\\\'s\' AND `table`.`field3` = \'123456\''
-                . ' AND `table`.`field4` = \'123.456\' AND `table`.`field5` = CAST(0x76616c7565 AS BINARY)'
+                '`table`.`field1` IS NULL AND `table`.`field2` = \'value\\\'s\' AND `table`.`field3` = 123456'
+                . ' AND `table`.`field4` = 123.456 AND `table`.`field5` = CAST(0x76616c7565 AS BINARY)'
                 . ' AND `table`.`field7` = \'value\' AND `table`.`field8` = \'value\''
                 . ' AND `table`.`field9` = CAST(0x76616c7565 AS BINARY)'
                 . ' AND `table`.`field10` = CAST(0x76616c7565 AS BINARY)'
@@ -189,8 +189,8 @@ class UtilTest extends AbstractTestCase
                 [
                     '`table`.`field1`' => 'IS NULL',
                     '`table`.`field2`' => '= \'value\\\'s\'',
-                    '`table`.`field3`' => '= \'123456\'',
-                    '`table`.`field4`' => '= \'123.456\'',
+                    '`table`.`field3`' => '= 123456',
+                    '`table`.`field4`' => '= 123.456',
                     '`table`.`field5`' => '= CAST(0x76616c7565 AS BINARY)',
                     '`table`.`field7`' => '= \'value\'',
                     '`table`.`field8`' => '= \'value\'',

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -40,6 +40,8 @@ use const MYSQLI_TYPE_SHORT;
 use const MYSQLI_TYPE_STRING;
 use const MYSQLI_UNIQUE_KEY_FLAG;
 
+const FIELD_TYPE_VARCHAR = 253;
+
 /**
  * @covers \PhpMyAdmin\Util
  */
@@ -257,6 +259,78 @@ class UtilTest extends AbstractTestCase
 
         $actual = Util::getUniqueCondition(count($meta), $meta, ['unique', 'value']);
         $this->assertEquals(['`table`.`id` = \'unique\'', true, ['`table`.`id`' => '= \'unique\'']], $actual);
+    }
+
+    /**
+     * Test for Util::getUniqueCondition
+     *
+     * @param array $meta     Meta
+     * @param array $row      Data Row
+     * @param array $expected Expected value
+     *
+     * @dataProvider providerGetUniqueConditionAfterGroupByQuery
+     */
+    public function testGetUniqueConditionAfterGroupByQuery($meta, $row, $expected): void
+    {
+        $actual = Util::getUniqueCondition(1, $meta, $row);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Provider for testGetUniqueConditionAfterGroupByQuery
+     *
+     * @return array
+     */
+    public function providerGetUniqueConditionAfterGroupByQuery(): array
+    {
+        return [
+            'value is string' => [
+                [
+                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'col',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                ],
+                ['test'],
+                [
+                    "`table`.`col` = 'test'",
+                    false,
+                    ['`table`.`col`' => "= 'test'"],
+                ],
+            ],
+            'value is string with double quote' => [
+                [
+                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'col',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                ],
+                ['"test"'],
+                [
+                    "`table`.`col` = '\\\"test\\\"'",
+                    false,
+                    ['`table`.`col`' => "= '\\\"test\\\"'"],
+                ],
+            ],
+            'value is string with single quote' => [
+                [
+                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'col',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                ],
+                ["'test'"],
+                [
+                    "`table`.`col` = '\'test\''",
+                    false,
+                    ['`table`.`col`' => "= '\'test\''"],
+                ],
+            ],
+        ];
     }
 
     /**

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -179,8 +179,8 @@ class UtilTest extends AbstractTestCase
         ], false, 'table');
         $this->assertEquals(
             [
-                '`table`.`field1` IS NULL AND `table`.`field2` = \'value\\\'s\' AND `table`.`field3` = 123456'
-                . ' AND `table`.`field4` = 123.456 AND `table`.`field5` = CAST(0x76616c7565 AS BINARY)'
+                '`table`.`field1` IS NULL AND `table`.`field2` = \'value\\\'s\' AND `table`.`field3` = \'123456\''
+                . ' AND `table`.`field4` = \'123.456\' AND `table`.`field5` = CAST(0x76616c7565 AS BINARY)'
                 . ' AND `table`.`field7` = \'value\' AND `table`.`field8` = \'value\''
                 . ' AND `table`.`field9` = CAST(0x76616c7565 AS BINARY)'
                 . ' AND `table`.`field10` = CAST(0x76616c7565 AS BINARY)'
@@ -189,8 +189,8 @@ class UtilTest extends AbstractTestCase
                 [
                     '`table`.`field1`' => 'IS NULL',
                     '`table`.`field2`' => '= \'value\\\'s\'',
-                    '`table`.`field3`' => '= 123456',
-                    '`table`.`field4`' => '= 123.456',
+                    '`table`.`field3`' => '= \'123456\'',
+                    '`table`.`field4`' => '= \'123.456\'',
                     '`table`.`field5`' => '= CAST(0x76616c7565 AS BINARY)',
                     '`table`.`field7`' => '= \'value\'',
                     '`table`.`field8`' => '= \'value\'',

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -288,11 +288,19 @@ class UtilTest extends AbstractTestCase
     /**
      * Provider for testGetUniqueConditionForGroupFlag
      *
-     * @return array<string, array<mixed>>
+     * @return array<string, array<int, array<int, array<string, string>|bool|int|string>>>
      */
     public function providerGetUniqueConditionForGroupFlag(): array
     {
         return [
+            'value is number' => [
+                [123],
+                [
+                    "`table`.`col` = '123'",
+                    false,
+                    ['`table`.`col`' => "= '123'"],
+                ],
+            ],
             'value is string' => [
                 ['test'],
                 [

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -40,7 +40,9 @@ use const MYSQLI_TYPE_SHORT;
 use const MYSQLI_TYPE_STRING;
 use const MYSQLI_UNIQUE_KEY_FLAG;
 
+const FIELD_TYPE_INTEGER = 1;
 const FIELD_TYPE_VARCHAR = 253;
+const FIELD_TYPE_UNKNOWN = -1;
 
 /**
  * @covers \PhpMyAdmin\Util
@@ -265,22 +267,18 @@ class UtilTest extends AbstractTestCase
      * Test for Util::getUniqueCondition
      * note: GROUP_FLAG = MYSQLI_NUM_FLAG
      *
-     * @param array<int, string>                           $row      Data Row
-     * @param array<int, array<string,string>|bool|string> $expected Expected Result
+     * @param FieldMetadata[] $meta     Meta Information for Field
+     * @param array           $row      Current Ddata Row
+     * @param array           $expected Expected Result
+     * @psalm-param array<int, mixed> $row
+     * @psalm-param array{string, bool, array<string, string>} $expected
      *
      * @dataProvider providerGetUniqueConditionForGroupFlag
      */
-    public function testGetUniqueConditionForGroupFlag(array $row, array $expected): void
+    public function testGetUniqueConditionForGroupFlag(array $meta, array $row, array $expected): void
     {
-        $meta = [
-            new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
-                'name' => 'col',
-                'table' => 'table',
-                'orgtable' => 'table',
-            ]),
-        ];
-
-        $actual = Util::getUniqueCondition(1, $meta, $row);
+        $fieldsCount = count($meta);
+        $actual = Util::getUniqueCondition($fieldsCount, $meta, $row);
 
         $this->assertEquals($expected, $actual);
     }
@@ -288,20 +286,50 @@ class UtilTest extends AbstractTestCase
     /**
      * Provider for testGetUniqueConditionForGroupFlag
      *
-     * @return array<string, array<int, array<int, array<string, string>|bool|int|string>>>
+     * @return array
+     * @psalm-return array<string, array{FieldMetadata[], array<int, mixed>, array{string, bool, array<string, string>}}>
      */
     public function providerGetUniqueConditionForGroupFlag(): array
     {
         return [
-            'value is number' => [
+            'field type is integer, value is number - not escape string' => [
+                [
+                    new FieldMetadata(FIELD_TYPE_INTEGER, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'col',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                ],
                 [123],
                 [
-                    "`table`.`col` = '123'",
+                    '`table`.`col` = 123',
                     false,
-                    ['`table`.`col`' => "= '123'"],
+                    ['`table`.`col`' => '= 123'],
                 ],
             ],
-            'value is string' => [
+            'field type is unknown, value is string - not escape string' => [
+                [
+                    new FieldMetadata(FIELD_TYPE_UNKNOWN, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'col',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                ],
+                ['test'],
+                [
+                    '`table`.`col` = test',
+                    false,
+                    ['`table`.`col`' => '= test'],
+                ],
+            ],
+            'field type is varchar, value is string - escape string' => [
+                [
+                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'col',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                ],
                 ['test'],
                 [
                     "`table`.`col` = 'test'",
@@ -309,7 +337,14 @@ class UtilTest extends AbstractTestCase
                     ['`table`.`col`' => "= 'test'"],
                 ],
             ],
-            'value is string with double quote' => [
+            'field type is varchar, value is string with double quote - escape string' => [
+                [
+                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'col',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                ],
                 ['"test"'],
                 [
                     "`table`.`col` = '\\\"test\\\"'",
@@ -317,12 +352,42 @@ class UtilTest extends AbstractTestCase
                     ['`table`.`col`' => "= '\\\"test\\\"'"],
                 ],
             ],
-            'value is string with single quote' => [
+            'field type is varchar, value is string with single quote - escape string' => [
+                [
+                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'col',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                ],
                 ["'test'"],
                 [
                     "`table`.`col` = '\'test\''",
                     false,
                     ['`table`.`col`' => "= '\'test\''"],
+                ],
+            ],
+            'group by multiple columns and field type is mixed' => [
+                [
+                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'col',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                    new FieldMetadata(FIELD_TYPE_INTEGER, MYSQLI_NUM_FLAG, (object) [
+                        'name' => 'status_id',
+                        'table' => 'table',
+                        'orgtable' => 'table',
+                    ]),
+                ],
+                ['test', 2],
+                [
+                    "`table`.`col` = 'test' AND `table`.`status_id` = 2",
+                    false,
+                    [
+                        '`table`.`col`' => "= 'test'",
+                        '`table`.`status_id`' => "= 2",
+                    ],
                 ],
             ],
         ];

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -179,8 +179,8 @@ class UtilTest extends AbstractTestCase
         ], false, 'table');
         $this->assertEquals(
             [
-                '`table`.`field1` IS NULL AND `table`.`field2` = \'value\\\'s\' AND `table`.`field3` = 123456'
-                . ' AND `table`.`field4` = 123.456 AND `table`.`field5` = CAST(0x76616c7565 AS BINARY)'
+                '`table`.`field1` IS NULL AND `table`.`field2` = \'value\\\'s\' AND `table`.`field3` = "123456"'
+                . ' AND `table`.`field4` = "123.456" AND `table`.`field5` = CAST(0x76616c7565 AS BINARY)'
                 . ' AND `table`.`field7` = \'value\' AND `table`.`field8` = \'value\''
                 . ' AND `table`.`field9` = CAST(0x76616c7565 AS BINARY)'
                 . ' AND `table`.`field10` = CAST(0x76616c7565 AS BINARY)'
@@ -189,8 +189,8 @@ class UtilTest extends AbstractTestCase
                 [
                     '`table`.`field1`' => 'IS NULL',
                     '`table`.`field2`' => '= \'value\\\'s\'',
-                    '`table`.`field3`' => '= 123456',
-                    '`table`.`field4`' => '= 123.456',
+                    '`table`.`field3`' => '= "123456"',
+                    '`table`.`field4`' => '= "123.456"',
                     '`table`.`field5`' => '= CAST(0x76616c7565 AS BINARY)',
                     '`table`.`field7`' => '= \'value\'',
                     '`table`.`field8`' => '= \'value\'',
@@ -237,7 +237,7 @@ class UtilTest extends AbstractTestCase
         ];
 
         $actual = Util::getUniqueCondition(count($meta), $meta, [1, 'value']);
-        $this->assertEquals(['`table`.`id` = 1', true, ['`table`.`id`' => '= 1']], $actual);
+        $this->assertEquals(['`table`.`id` = "1"', true, ['`table`.`id`' => '= "1"']], $actual);
     }
 
     public function testGetUniqueConditionWithUniqueKey(): void

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -265,8 +265,8 @@ class UtilTest extends AbstractTestCase
      * Test for Util::getUniqueCondition
      * note: GROUP_FLAG = MYSQLI_NUM_FLAG
      *
-     * @param array $row      Data Row
-     * @param array $expected Expected Result
+     * @param array<int, string>                           $row      Data Row
+     * @param array<int, array<string,string>|bool|string> $expected Expected Result
      *
      * @dataProvider providerGetUniqueConditionForGroupFlag
      */
@@ -288,7 +288,7 @@ class UtilTest extends AbstractTestCase
     /**
      * Provider for testGetUniqueConditionForGroupFlag
      *
-     * @return array
+     * @return array<string, array<mixed>>
      */
     public function providerGetUniqueConditionForGroupFlag(): array
     {


### PR DESCRIPTION
### Description

Reference issue: https://github.com/phpmyadmin/phpmyadmin/issues/17756

### Issue Detail

Step to reproduce are explained in the [issue detail](https://github.com/phpmyadmin/phpmyadmin/issues/17756).

When query with group by and try to edit/copy/delete, following are the sample issues:

**copy row with all string value, error message occurs**

<img width="306" alt="Screen Shot 2565-10-09 at 00 57 39" src="https://user-images.githubusercontent.com/1849256/194721214-f232ce41-7196-43e8-a883-c91267ce5a74.png">

<img width="585" alt="Screen Shot 2565-10-09 at 00 58 11" src="https://user-images.githubusercontent.com/1849256/194721216-591aaeb9-3d3a-4ab3-8ded-5171bba333fe.png">

**copy row with double quote, value is not available in form**

<img width="274" alt="Screen Shot 2565-10-09 at 00 59 03" src="https://user-images.githubusercontent.com/1849256/194721243-0172b6b6-1e4a-4846-a1fa-f58d83fbec61.png">

<img width="831" alt="Screen Shot 2565-10-09 at 00 58 40" src="https://user-images.githubusercontent.com/1849256/194721247-7915788c-017e-4329-a1c0-ebedd53fe34d.png">

**copy row with single quote, value is not available in form**

<img width="278" alt="Screen Shot 2565-10-09 at 00 59 08" src="https://user-images.githubusercontent.com/1849256/194721287-32e8bccc-42d4-4a60-86ad-844a9d0ae449.png">

<img width="821" alt="Screen Shot 2565-10-09 at 00 59 17" src="https://user-images.githubusercontent.com/1849256/194721299-c7c47c2e-0899-4af4-8a07-e5891da6a8fe.png">

Signed-off-by: Mo Sureerat <sureemo@gmail.com>