### PR TITLE
Remove redundant tests

### DIFF
--- a/test/classes/FieldMetadataTest.php
+++ b/test/classes/FieldMetadataTest.php
@@ -34,46 +34,11 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isBlob());
     }
 
-    public function testIsBinaryStdClassAsObject(): void
+    public function testIsBinary(): void
     {
         $obj = new stdClass();
         $obj->charsetnr = 63;
         $fm = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $obj);
-        $this->assertTrue($fm->isBinary());
-        $this->assertFalse($fm->isEnum());
-        $this->assertFalse($fm->isUniqueKey());
-        $this->assertFalse($fm->isUnsigned());
-        $this->assertFalse($fm->isZerofill());
-        $this->assertFalse($fm->isSet());
-        $this->assertFalse($fm->isNotNull());
-        $this->assertFalse($fm->isPrimaryKey());
-        $this->assertFalse($fm->isMultipleKey());
-        $this->assertFalse($fm->isNumeric());
-        $this->assertFalse($fm->isBlob());
-    }
-
-    public function testIsBinaryCustomClassAsObject(): void
-    {
-        $obj = new stdClass();
-        $obj->charsetnr = 63;
-        $objmd = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $obj);
-        $fm = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $objmd);
-        $this->assertTrue($fm->isBinary());
-        $this->assertFalse($fm->isEnum());
-        $this->assertFalse($fm->isUniqueKey());
-        $this->assertFalse($fm->isUnsigned());
-        $this->assertFalse($fm->isZerofill());
-        $this->assertFalse($fm->isSet());
-        $this->assertFalse($fm->isNotNull());
-        $this->assertFalse($fm->isPrimaryKey());
-        $this->assertFalse($fm->isMultipleKey());
-        $this->assertFalse($fm->isNumeric());
-        $this->assertFalse($fm->isBlob());
-    }
-
-    public function testIsBinary(): void
-    {
-        $fm = new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) ['charsetnr' => 63]);
         $this->assertTrue($fm->isBinary());
         $this->assertFalse($fm->isEnum());
         $this->assertFalse($fm->isUniqueKey());


### PR DESCRIPTION
Typecasting to object is the same as creating the object with `new`. The test just repeats the previous test. 

In the whole codebase, we never create `FieldMetadata` recursively, so that test is also unnecessary. I assume the test was just to verify that `FieldMetadata` exposes the raw properties, but IMHO this isn't needed. 

Unrelated, but what should we do about the signature of `FieldMetadata::__construct()`? `type` and `flags` are their own properties while the rest is accepted in the form of an object. 