### PR TITLE
Fix isNumeric

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -2682,16 +2682,7 @@ class Results
 
             $displayParams = $this->properties['display_params'] ?? [];
 
-            // in some situations (issue 11406), numeric returns 1
-            // even for a string type
-            // for decimal numeric is returning 1
-            // have to improve logic
-            // Nullable text fields and text fields have the blob flag (issue 16896)
-            $isNumericAndNotBlob = $meta->isNumeric && ! $meta->isBlob;
-            if (
-                ($isNumericAndNotBlob && $meta->isNotType(FieldMetadata::TYPE_STRING))
-                || $meta->isType(FieldMetadata::TYPE_REAL)
-            ) {
+            if ($meta->isNumeric) {
                 // n u m e r i c
 
                 $displayParams['data'][$rowNumber][$i] = $this->getDataCellForNumericColumns(

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -47,6 +47,8 @@ use function time;
 use function trim;
 use function urlencode;
 
+use const ENT_COMPAT;
+
 /**
  * PhpMyAdmin\Export class
  */
@@ -209,7 +211,7 @@ class Export
             }
         } else {
             // We export as html - replace special chars
-            echo htmlspecialchars((string) $line);
+            echo htmlspecialchars((string) $line, ENT_COMPAT);
         }
 
         return true;

--- a/libraries/classes/FieldMetadata.php
+++ b/libraries/classes/FieldMetadata.php
@@ -12,7 +12,6 @@ use const MYSQLI_BLOB_FLAG;
 use const MYSQLI_ENUM_FLAG;
 use const MYSQLI_MULTIPLE_KEY_FLAG;
 use const MYSQLI_NOT_NULL_FLAG;
-use const MYSQLI_NUM_FLAG;
 use const MYSQLI_PRI_KEY_FLAG;
 use const MYSQLI_SET_FLAG;
 use const MYSQLI_TYPE_BIT;
@@ -235,17 +234,14 @@ final class FieldMetadata
             $this->isNotNull = (bool) ($fieldFlags & MYSQLI_NOT_NULL_FLAG);
             $this->isUnsigned = (bool) ($fieldFlags & MYSQLI_UNSIGNED_FLAG);
             $this->isZerofill = (bool) ($fieldFlags & MYSQLI_ZEROFILL_FLAG);
+            $this->isBlob = (bool) ($fieldFlags & MYSQLI_BLOB_FLAG);
+            $this->isEnum = (bool) ($fieldFlags & MYSQLI_ENUM_FLAG);
+            $this->isSet = (bool) ($fieldFlags & MYSQLI_SET_FLAG);
 
             // as flags 32768 can be NUM_FLAG or GROUP_FLAG
             // reference: https://www.php.net/manual/en/mysqli-result.fetch-fields.php
             // so check field type instead of flags
-            // but if no or unknown field type then check flags
-            $this->isNumeric = $this->isType(self::TYPE_INT)
-                || ($fieldType <= 0 && ($fieldFlags & MYSQLI_NUM_FLAG));
-
-            $this->isBlob = (bool) ($fieldFlags & MYSQLI_BLOB_FLAG);
-            $this->isEnum = (bool) ($fieldFlags & MYSQLI_ENUM_FLAG);
-            $this->isSet = (bool) ($fieldFlags & MYSQLI_SET_FLAG);
+            $this->isNumeric = $this->isType(self::TYPE_INT) || $this->isType(self::TYPE_REAL);
 
             /*
                 MYSQLI_PART_KEY_FLAG => 'part_key',
@@ -375,14 +371,6 @@ final class FieldMetadata
     public function isSet(): bool
     {
         return $this->isSet;
-    }
-
-    /**
-     * Checks that it is type INT or type REAL
-     */
-    public function isNumericType(): bool
-    {
-        return $this->isType(self::TYPE_INT) || $this->isType(self::TYPE_REAL);
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportOds.php
+++ b/libraries/classes/Plugins/Export/ExportOds.php
@@ -283,10 +283,7 @@ class ExportOds extends ExportPlugin
                         . '</text:p>'
                         . '</table:table-cell>';
                 } elseif (
-                    ($fieldsMeta[$j]->isNumeric
-                    && ! $fieldsMeta[$j]->isMappedTypeTimestamp
-                    && ! $fieldsMeta[$j]->isBlob)
-                    || $fieldsMeta[$j]->isType(FieldMetadata::TYPE_REAL)
+                    $fieldsMeta[$j]->isNumeric
                 ) {
                     $GLOBALS['ods_buffer'] .= '<table:table-cell office:value-type="float"'
                         . ' office:value="' . $row[$j] . '" >'

--- a/libraries/classes/Plugins/Export/ExportOdt.php
+++ b/libraries/classes/Plugins/Export/ExportOdt.php
@@ -293,8 +293,6 @@ class ExportOdt extends ExportPlugin
                         . '</table:table-cell>';
                 } elseif (
                     $fieldsMeta[$j]->isNumeric
-                    && ! $fieldsMeta[$j]->isMappedTypeTimestamp
-                    && ! $fieldsMeta[$j]->isBlob
                 ) {
                     $GLOBALS['odt_buffer'] .= '<table:table-cell office:value-type="float"'
                         . ' office:value="' . $row[$j] . '" >'

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -2383,12 +2383,8 @@ class ExportSql extends ExportPlugin
                     $values[] = 'NULL';
                 } elseif (
                     $fieldsMeta[$j]->isNumeric
-                    && ! $fieldsMeta[$j]->isMappedTypeTimestamp
-                    && ! $fieldsMeta[$j]->isBlob
                 ) {
                     // a number
-                    // timestamp is numeric on some MySQL 4.1, BLOBs are
-                    // sometimes numeric
                     $values[] = $row[$j];
                 } elseif ($fieldsMeta[$j]->isBinary && isset($GLOBALS['sql_hex_for_binary'])) {
                     // a true BLOB

--- a/templates/table/chart/tbl_chart.twig
+++ b/templates/table/chart/tbl_chart.twig
@@ -73,7 +73,7 @@
           <label class="form-label" for="chartSeriesSelect">{% trans 'Series:' %}</label>
           <select class="form-select resize-vertical" name="chartSeriesSelect" id="chartSeriesSelect" multiple>
             {% for idx, key in keys %}
-              {% if fields_meta[idx].isNumericType() %}
+              {% if fields_meta[idx].isNumeric %}
                 {% if idx == xaxis and table_has_a_numeric_column %}
                   <option value="{{ idx }}">{{ key }}</option>
                 {% else %}
@@ -92,7 +92,7 @@
           {%- endfor %}">
         <input type="hidden" name="numericCols" value="
           {%- for idx, key in keys -%}
-            {%- if fields_meta[idx].isNumericType() -%}
+            {%- if fields_meta[idx].isNumeric -%}
               {{- idx ~ ' ' -}}
             {%- endif -%}
           {%- endfor %}">
@@ -127,7 +127,7 @@
           <select class="form-select" name="chartValueColumnSelect" id="chartValueColumnSelect" disabled>
             {% set selected = false %}
             {% for idx, key in keys %}
-              {% if fields_meta[idx].isNumericType() %}
+              {% if fields_meta[idx].isNumeric %}
                 {% if not selected and idx != xaxis and idx != series_column %}
                   <option value="{{ idx }}" selected>{{ key }}</option>
                   {% set selected = true %}

--- a/test/classes/Controllers/Export/ExportControllerTest.php
+++ b/test/classes/Controllers/Export/ExportControllerTest.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 
 use function htmlspecialchars;
 
+use const ENT_COMPAT;
 use const MYSQLI_NUM_FLAG;
 use const MYSQLI_PRI_KEY_FLAG;
 use const MYSQLI_TYPE_DATETIME;
@@ -168,6 +169,6 @@ SQL;
         $exportController = new ExportController(new ResponseRenderer(), new Template(), new Export($this->dbi));
         $exportController($request);
         $output = $this->getActualOutputForAssertion();
-        $this->assertStringContainsString(htmlspecialchars($expectedOutput), $output);
+        $this->assertStringContainsString(htmlspecialchars($expectedOutput, ENT_COMPAT), $output);
     }
 }

--- a/test/classes/FieldMetadataTest.php
+++ b/test/classes/FieldMetadataTest.php
@@ -31,7 +31,6 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isNotNull());
         $this->assertFalse($fm->isPrimaryKey());
         $this->assertFalse($fm->isMultipleKey());
-        $this->assertFalse($fm->isNumeric());
         $this->assertFalse($fm->isBlob());
     }
 
@@ -49,7 +48,6 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isNotNull());
         $this->assertFalse($fm->isPrimaryKey());
         $this->assertFalse($fm->isMultipleKey());
-        $this->assertFalse($fm->isNumeric());
         $this->assertFalse($fm->isBlob());
     }
 
@@ -68,7 +66,6 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isNotNull());
         $this->assertFalse($fm->isPrimaryKey());
         $this->assertFalse($fm->isMultipleKey());
-        $this->assertFalse($fm->isNumeric());
         $this->assertFalse($fm->isBlob());
     }
 
@@ -84,7 +81,6 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isNotNull());
         $this->assertFalse($fm->isPrimaryKey());
         $this->assertFalse($fm->isMultipleKey());
-        $this->assertFalse($fm->isNumeric());
         $this->assertFalse($fm->isBlob());
     }
 
@@ -92,23 +88,6 @@ class FieldMetadataTest extends AbstractTestCase
     {
         $fm = new FieldMetadata(MYSQLI_TYPE_INT24, MYSQLI_NUM_FLAG, (object) []);
         $this->assertSame('int', $fm->getMappedType());
-        $this->assertFalse($fm->isBinary());
-        $this->assertFalse($fm->isEnum());
-        $this->assertFalse($fm->isUniqueKey());
-        $this->assertFalse($fm->isUnsigned());
-        $this->assertFalse($fm->isZerofill());
-        $this->assertFalse($fm->isSet());
-        $this->assertFalse($fm->isNotNull());
-        $this->assertFalse($fm->isPrimaryKey());
-        $this->assertFalse($fm->isMultipleKey());
-        $this->assertTrue($fm->isNumeric());
-        $this->assertFalse($fm->isBlob());
-    }
-
-    public function testIsNumericForUnknownFieldType(): void
-    {
-        $fm = new FieldMetadata(-1, MYSQLI_NUM_FLAG, (object) []);
-        $this->assertSame('', $fm->getMappedType());
         $this->assertFalse($fm->isBinary());
         $this->assertFalse($fm->isEnum());
         $this->assertFalse($fm->isUniqueKey());
@@ -135,7 +114,6 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isNotNull());
         $this->assertFalse($fm->isPrimaryKey());
         $this->assertFalse($fm->isMultipleKey());
-        $this->assertFalse($fm->isNumeric());
         $this->assertTrue($fm->isBlob());
     }
 
@@ -152,7 +130,7 @@ class FieldMetadataTest extends AbstractTestCase
         $this->assertFalse($fm->isNotNull());
         $this->assertFalse($fm->isPrimaryKey());
         $this->assertFalse($fm->isMultipleKey());
-        $this->assertFalse($fm->isNumeric());
+        $this->assertTrue($fm->isNumeric());
         $this->assertFalse($fm->isBlob());
     }
 }

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -1243,7 +1243,7 @@ class ExportSqlTest extends AbstractTestCase
             $result
         );
 
-        $this->assertStringContainsString('(NULL, test, 0x3130, 0x36, 0x000a0d1a);', $result);
+        $this->assertStringContainsString('(NULL, \'test\', 0x3130, 0x36, 0x000a0d1a);', $result);
 
         $this->assertStringContainsString('SET IDENTITY_INSERT &quot;table&quot; OFF;', $result);
     }

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -306,7 +306,7 @@ class UtilTest extends AbstractTestCase
                     ['`table`.`col`' => '= 123'],
                 ],
             ],
-            'field type is unknown, value is string - not escape string' => [
+            'field type is unknown, value is string - escape string' => [
                 [
                     new FieldMetadata(FIELD_TYPE_UNKNOWN, MYSQLI_NUM_FLAG, (object) [
                         'name' => 'col',
@@ -316,9 +316,9 @@ class UtilTest extends AbstractTestCase
                 ],
                 ['test'],
                 [
-                    '`table`.`col` = test',
+                    "`table`.`col` = 'test'",
                     false,
-                    ['`table`.`col`' => '= test'],
+                    ['`table`.`col`' => "= 'test'"],
                 ],
             ],
             'field type is varchar, value is string - escape string' => [


### PR DESCRIPTION
Follow-up from #17758

I looked into it more. MySQL doesn't require quotes for integers, floats or decimals. phpMyAdmin already abstracts the MySQL types with two: TYPE_INT and TYPE_REAL. There's already a method called `isNumericType()` so why not simplify it all and get rid of `isNumeric` completely?