### PR TITLE
Make search input field types match columns types (integer and float)

### DIFF
--- a/js/src/table/change.js
+++ b/js/src/table/change.js
@@ -194,6 +194,19 @@ function verifyAfterSearchFieldChange (index, searchFormId) {
         }
         // Update error on dropdown change
         $thisInput.valid();
+    } else if ($thisInput.data('type') === 'FLOAT') {
+        // Trim spaces
+        $thisInput.val($thisInput.val().trim());
+
+        $(searchFormId).validate({
+            // update errors as we write
+            onkeyup: function (element) {
+                $(element).valid();
+            }
+        });
+        validateFloatField($thisInput, true);
+        // Update error on dropdown change
+        $thisInput.valid();
     }
 }
 window.verifyAfterSearchFieldChange = verifyAfterSearchFieldChange;
@@ -257,6 +270,26 @@ function validateIntField (jqueryInput, returnValueIfIsNumber) {
                 }
             }
         }
+    });
+}
+
+/**
+ * Validate the an input contains an float value
+ * @param {jQuery} jqueryInput the Jquery object
+ * @param {boolean} returnValueIfIsNumber the value to return if the validator passes
+ * @return {void}
+ */
+function validateFloatField (jqueryInput, returnValueIfIsNumber) {
+    // removing previous rules
+    jqueryInput.rules('remove');
+
+    jqueryInput.rules('add', {
+        number: {
+            param: true,
+            depends: function () {
+                return returnValueIfIsNumber;
+            }
+        },
     });
 }
 

--- a/libraries/classes/Controllers/Table/SearchController.php
+++ b/libraries/classes/Controllers/Table/SearchController.php
@@ -362,12 +362,17 @@ class SearchController extends AbstractController
             ''
         );
         $htmlAttributes = '';
+        $is_integer = false;
+        $is_float = false;
         if (in_array($cleanType, $this->dbi->types->getIntegerTypes())) {
+            $is_integer = true;
             $extractedColumnspec = Util::extractColumnSpec($this->originalColumnTypes[$column_index]);
             $is_unsigned = $extractedColumnspec['unsigned'];
             $minMaxValues = $this->dbi->types->getIntegerRange($cleanType, ! $is_unsigned);
             $htmlAttributes = 'data-min="' . $minMaxValues[0] . '" '
                             . 'data-max="' . $minMaxValues[1] . '"';
+        } else if (in_array($cleanType, $this->dbi->types->getFloatTypes())) {
+            $is_float = true;
         }
 
         $htmlAttributes .= ' onfocus="return '
@@ -412,6 +417,8 @@ class SearchController extends AbstractController
             'in_fbs' => true,
             'foreign_dropdown' => $foreignDropdown,
             'search_column_in_foreigners' => $searchColumnInForeigners,
+            'is_integer' => $is_integer,
+            'is_float' => $is_float,
         ]);
 
         return [

--- a/libraries/classes/Controllers/Table/SearchController.php
+++ b/libraries/classes/Controllers/Table/SearchController.php
@@ -362,17 +362,14 @@ class SearchController extends AbstractController
             ''
         );
         $htmlAttributes = '';
-        $is_integer = false;
-        $is_float = false;
-        if (in_array($cleanType, $this->dbi->types->getIntegerTypes())) {
-            $is_integer = true;
+        $isInteger = in_array($cleanType, $this->dbi->types->getIntegerTypes());
+        $isFloat = in_array($cleanType, $this->dbi->types->getFloatTypes());
+        if ($isInteger) {
             $extractedColumnspec = Util::extractColumnSpec($this->originalColumnTypes[$column_index]);
             $is_unsigned = $extractedColumnspec['unsigned'];
             $minMaxValues = $this->dbi->types->getIntegerRange($cleanType, ! $is_unsigned);
             $htmlAttributes = 'data-min="' . $minMaxValues[0] . '" '
                             . 'data-max="' . $minMaxValues[1] . '"';
-        } else if (in_array($cleanType, $this->dbi->types->getFloatTypes())) {
-            $is_float = true;
         }
 
         $htmlAttributes .= ' onfocus="return '
@@ -402,7 +399,7 @@ class SearchController extends AbstractController
         $value = $this->template->render('table/search/input_box', [
             'str' => '',
             'column_type' => (string) $type,
-            'column_data_type' => $is_integer ? "INT" : ($is_float ? "FLOAT" : strtoupper($cleanType)),
+            'column_data_type' => $isInteger ? 'INT' : ($isFloat ? 'FLOAT' : strtoupper($cleanType)),
             'html_attributes' => $htmlAttributes,
             'column_id' => 'fieldID_',
             'in_zoom_search_edit' => false,
@@ -417,8 +414,8 @@ class SearchController extends AbstractController
             'in_fbs' => true,
             'foreign_dropdown' => $foreignDropdown,
             'search_column_in_foreigners' => $searchColumnInForeigners,
-            'is_integer' => $is_integer,
-            'is_float' => $is_float,
+            'is_integer' => $isInteger,
+            'is_float' => $isFloat,
         ]);
 
         return [

--- a/libraries/classes/Controllers/Table/SearchController.php
+++ b/libraries/classes/Controllers/Table/SearchController.php
@@ -402,7 +402,7 @@ class SearchController extends AbstractController
         $value = $this->template->render('table/search/input_box', [
             'str' => '',
             'column_type' => (string) $type,
-            'column_data_type' => strtoupper($cleanType),
+            'column_data_type' => $is_integer ? "INT" : ($is_float ? "FLOAT" : strtoupper($cleanType)),
             'html_attributes' => $htmlAttributes,
             'column_id' => 'fieldID_',
             'in_zoom_search_edit' => false,

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -455,7 +455,6 @@ class ZoomSearchController extends AbstractController
         $isInteger = in_array($cleanType, $this->dbi->types->getIntegerTypes());
         $isFloat = in_array($cleanType, $this->dbi->types->getFloatTypes());
         if ($isInteger) {
-            $is_integer = true;
             $extractedColumnspec = Util::extractColumnSpec($this->originalColumnTypes[$column_index]);
             $is_unsigned = $extractedColumnspec['unsigned'];
             $minMaxValues = $this->dbi->types->getIntegerRange($cleanType, ! $is_unsigned);

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -487,7 +487,7 @@ class ZoomSearchController extends AbstractController
         $value = $this->template->render('table/search/input_box', [
             'str' => '',
             'column_type' => (string) $type,
-            'column_data_type' => strtoupper($cleanType),
+            'column_data_type' => $is_integer ? "INT" : ($is_float ? "FLOAT" : strtoupper($cleanType)),
             'html_attributes' => $htmlAttributes,
             'column_id' => 'fieldID_',
             'in_zoom_search_edit' => false,

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -452,17 +452,15 @@ class ZoomSearchController extends AbstractController
             ''
         );
         $htmlAttributes = '';
-        $is_integer = false;
-        $is_float = false;
-        if (in_array($cleanType, $this->dbi->types->getIntegerTypes())) {
+        $isInteger = in_array($cleanType, $this->dbi->types->getIntegerTypes());
+        $isFloat = in_array($cleanType, $this->dbi->types->getFloatTypes());
+        if ($isInteger) {
             $is_integer = true;
             $extractedColumnspec = Util::extractColumnSpec($this->originalColumnTypes[$column_index]);
             $is_unsigned = $extractedColumnspec['unsigned'];
             $minMaxValues = $this->dbi->types->getIntegerRange($cleanType, ! $is_unsigned);
             $htmlAttributes = 'data-min="' . $minMaxValues[0] . '" '
                             . 'data-max="' . $minMaxValues[1] . '"';
-        } else if (in_array($cleanType, $this->dbi->types->getFloatTypes())) {
-            $is_float = true;
         }
 
         $htmlAttributes .= ' onfocus="return '
@@ -487,7 +485,7 @@ class ZoomSearchController extends AbstractController
         $value = $this->template->render('table/search/input_box', [
             'str' => '',
             'column_type' => (string) $type,
-            'column_data_type' => $is_integer ? "INT" : ($is_float ? "FLOAT" : strtoupper($cleanType)),
+            'column_data_type' => $isInteger ? 'INT' : ($isFloat ? 'FLOAT' : strtoupper($cleanType)),
             'html_attributes' => $htmlAttributes,
             'column_id' => 'fieldID_',
             'in_zoom_search_edit' => false,
@@ -501,8 +499,8 @@ class ZoomSearchController extends AbstractController
             'db' => $GLOBALS['db'],
             'in_fbs' => true,
             'foreign_dropdown' => $foreignDropdown,
-            'is_integer' => $is_integer,
-            'is_float' => $is_float,
+            'is_integer' => $isInteger,
+            'is_float' => $isFloat,
         ]);
 
         return [

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -452,12 +452,17 @@ class ZoomSearchController extends AbstractController
             ''
         );
         $htmlAttributes = '';
+        $is_integer = false;
+        $is_float = false;
         if (in_array($cleanType, $this->dbi->types->getIntegerTypes())) {
+            $is_integer = true;
             $extractedColumnspec = Util::extractColumnSpec($this->originalColumnTypes[$column_index]);
             $is_unsigned = $extractedColumnspec['unsigned'];
             $minMaxValues = $this->dbi->types->getIntegerRange($cleanType, ! $is_unsigned);
             $htmlAttributes = 'data-min="' . $minMaxValues[0] . '" '
                             . 'data-max="' . $minMaxValues[1] . '"';
+        } else if (in_array($cleanType, $this->dbi->types->getFloatTypes())) {
+            $is_float = true;
         }
 
         $htmlAttributes .= ' onfocus="return '
@@ -496,6 +501,8 @@ class ZoomSearchController extends AbstractController
             'db' => $GLOBALS['db'],
             'in_fbs' => true,
             'foreign_dropdown' => $foreignDropdown,
+            'is_integer' => $is_integer,
+            'is_float' => $is_float,
         ]);
 
         return [

--- a/libraries/classes/Types.php
+++ b/libraries/classes/Types.php
@@ -846,7 +846,7 @@ class Types
      *
      * @return string[] float types
      */
-    public function getFloatTypes()
+    public function getFloatTypes(): array
     {
         return [
             'decimal',

--- a/libraries/classes/Types.php
+++ b/libraries/classes/Types.php
@@ -842,6 +842,21 @@ class Types
     }
 
     /**
+     * Returns an array of float types
+     *
+     * @return string[] float types
+     */
+    public function getFloatTypes()
+    {
+        return [
+            'decimal',
+            'float',
+            'double',
+            'real',
+        ];
+    }
+
+    /**
      * Returns the min and max values of a given integer type
      *
      * @param string $type   integer type

--- a/templates/table/search/input_box.twig
+++ b/templates/table/search/input_box.twig
@@ -83,10 +83,8 @@
         {% if is_integer or is_float %}
             type="number"
             {% if is_integer %}
-                data-type="INT"
                 inputmode="numeric"
             {% else %}
-                data-type="FLOAT"
                 inputmode="decimal"
             {% endif %}
         {% else %}

--- a/templates/table/search/input_box.twig
+++ b/templates/table/search/input_box.twig
@@ -79,7 +79,18 @@
     {% elseif column_type starts with 'bit' %}
         {% set the_class = the_class ~ ' bit' %}
     {% endif %}
-    <input type="text"
+    <input
+        {% if is_integer or is_float %}
+            type="number"
+            {% if is_integer %}
+                data-type="INT"
+            {% else %}
+                data-type="FLOAT"
+            {% endif %}
+        {% else %}
+            type="text"
+        {% endif %}
+
         name="criteriaValues[{{ column_index }}]"
         data-type="{{ column_data_type }}"
         {{ html_attributes|raw }}

--- a/templates/table/search/input_box.twig
+++ b/templates/table/search/input_box.twig
@@ -84,8 +84,10 @@
             type="number"
             {% if is_integer %}
                 data-type="INT"
+                inputmode="numeric"
             {% else %}
                 data-type="FLOAT"
+                inputmode="decimal"
             {% endif %}
         {% else %}
             type="text"


### PR DESCRIPTION
Signed-off-by: Bhuvi100 <gbhuvanesh100@gmail.com>

### Description

This PR adds type attribute as well as inputmode attribute to search value input fields which makes it easier for validation as well as for using phpMyAdmin on touch devices with virtual keyboards.

Fixes #17745 Input types should match the column type (reopened)
