### PR TITLE
Fix #17428 - search UUID data type error

### DIFF
--- a/libraries/classes/Table/Search.php
+++ b/libraries/classes/Table/Search.php
@@ -164,7 +164,7 @@ final class Search
             // strings to numbers and numbers to strings as necessary
             // during the comparison
             if (
-                preg_match('@char|binary|blob|text|set|date|time|year@i', $types)
+                preg_match('@char|binary|blob|text|set|date|time|year|uuid@i', $types)
                 || mb_strpos(' ' . $func_type, 'LIKE')
             ) {
                 $quot = '\'';

--- a/libraries/classes/Types.php
+++ b/libraries/classes/Types.php
@@ -140,6 +140,25 @@ class Types
     }
 
     /**
+     * UUID search operators
+     *
+     * @return string[]
+     */
+    public function getUUIDOperators()
+    {
+        return [
+            '=',
+            '!=',
+            'LIKE',
+            'LIKE %...%',
+            'NOT LIKE',
+            'NOT LIKE %...%',
+            'IN (...)',
+            'NOT IN (...)',
+        ];
+    }
+
+    /**
      * Returns operators for given type
      *
      * @param string $type Type of field
@@ -156,6 +175,8 @@ class Types
             $ret = array_merge($ret, $this->getEnumOperators());
         } elseif ($class === 'CHAR') {
             $ret = array_merge($ret, $this->getTextOperators());
+        } elseif ($class === 'UUID') {
+            $ret = array_merge($ret, $this->getUUIDOperators());
         } else {
             $ret = array_merge($ret, $this->getNumberOperators());
         }

--- a/test/classes/Table/SearchTest.php
+++ b/test/classes/Table/SearchTest.php
@@ -208,4 +208,34 @@ class SearchTest extends AbstractTestCase
             $this->search->buildSqlQuery()
         );
     }
+
+    public function testBuildSqlQueryWithWhereClauseUUID(): void
+    {
+        $_POST['zoom_submit'] = true;
+        $_POST['table'] = 'PMA';
+
+        $this->assertEquals(
+            'SELECT *  FROM `PMA`',
+            $this->search->buildSqlQuery()
+        );
+
+        $_POST['customWhereClause'] = '';
+
+        $this->assertEquals(
+            'SELECT *  FROM `PMA`',
+            $this->search->buildSqlQuery()
+        );
+
+        unset($_POST['customWhereClause']);
+        $_POST['criteriaColumnNames'] = ['id'];
+        $_POST['criteriaColumnOperators'] = ['='];
+
+        $_POST['criteriaValues'] = ['07ca1fdd-4805-11ed-a4dc-0242ac110002'];
+        $_POST['criteriaColumnTypes'] = ['uuid'];
+
+        $this->assertEquals(
+            "SELECT *  FROM `PMA` WHERE `id` = '07ca1fdd-4805-11ed-a4dc-0242ac110002'",
+            $this->search->buildSqlQuery()
+        );
+    }
 }

--- a/test/classes/TypesTest.php
+++ b/test/classes/TypesTest.php
@@ -131,6 +131,26 @@ class TypesTest extends AbstractTestCase
     }
 
     /**
+     * Test for getUUIDOperators
+     */
+    public function testGetUUIDOperators(): void
+    {
+        $this->assertEquals(
+            [
+                '=',
+                '!=',
+                'LIKE',
+                'LIKE %...%',
+                'NOT LIKE',
+                'NOT LIKE %...%',
+                'IN (...)',
+                'NOT IN (...)',
+            ],
+            $this->object->getUUIDOperators()
+        );
+    }
+
+    /**
      * Test for getting type operators
      *
      * @param string       $type   Type of field
@@ -192,6 +212,36 @@ class TypesTest extends AbstractTestCase
                         '=',
                         '!=',
                     ],
+                ],
+            ],
+            [
+                'UUID',
+                false,
+                [
+                    '=',
+                    '!=',
+                    'LIKE',
+                    'LIKE %...%',
+                    'NOT LIKE',
+                    'NOT LIKE %...%',
+                    'IN (...)',
+                    'NOT IN (...)',
+                ],
+            ],
+            [
+                'UUID',
+                true,
+                [
+                    '=',
+                    '!=',
+                    'LIKE',
+                    'LIKE %...%',
+                    'NOT LIKE',
+                    'NOT LIKE %...%',
+                    'IN (...)',
+                    'NOT IN (...)',
+                    'IS NULL',
+                    'IS NOT NULL',
                 ],
             ],
         ];


### PR DESCRIPTION
Reference issue: https://github.com/phpmyadmin/phpmyadmin/issues/17248#issuecomment-1276642763

What's changed:
- Fix error after search uuid field with `=`
- Update the operator options for uuid according to the screenshot
  <img width="156" alt="Screen Shot 2565-10-13 at 04 56 51" src="https://user-images.githubusercontent.com/1849256/195455676-8a6c4c05-c833-4de9-ad9d-84c39758da0a.png">

Signed-off-by: Mo Sureerat <sureemo@gmail.com>