### PR TITLE
Refactor ServerConfigChecks::performConfigChecks

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -621,26 +621,6 @@ parameters:
 			path: libraries/classes/Config/Forms/User/SqlForm.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Config\\\\ServerConfigChecks\\:\\:performConfigChecksServers\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Config/ServerConfigChecks.php
-
-		-
-			message: "#^Parameter \\#1 \\$blowfishSecret of method PhpMyAdmin\\\\Config\\\\ServerConfigChecks\\:\\:performConfigChecksServersSetBlowfishSecret\\(\\) expects string\\|null, bool\\|string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Config/ServerConfigChecks.php
-
-		-
-			message: "#^Parameter \\#2 \\$blowfishSecret of method PhpMyAdmin\\\\Config\\\\ServerConfigChecks\\:\\:performConfigChecksServers\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Config/ServerConfigChecks.php
-
-		-
-			message: "#^Parameter \\#3 \\$blowfishSecretSet of method PhpMyAdmin\\\\Config\\\\ServerConfigChecks\\:\\:performConfigChecksServersSetBlowfishSecret\\(\\) expects bool, bool\\|string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Config/ServerConfigChecks.php
-
-		-
 			message: "#^Cannot access offset int\\|string on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Config/Settings.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -688,18 +688,7 @@
     </ReferenceConstraintViolation>
   </file>
   <file src="libraries/classes/Config/ServerConfigChecks.php">
-    <InvalidScalarArgument occurrences="2">
-      <code>$blowfishSecret</code>
-      <code>$blowfishSecretSet</code>
-    </InvalidScalarArgument>
-    <MixedArgument occurrences="4">
-      <code>$blowfishSecret</code>
-      <code>$blowfishSecret</code>
-      <code>$blowfishSecretSet</code>
-      <code>$cookieAuthUsed</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$blowfishSecret</code>
+    <MixedAssignment occurrences="1">
       <code>$loginCookieValidity</code>
     </MixedAssignment>
   </file>


### PR DESCRIPTION
I think this code might have been generated by software because it was a little bit nonsensical. Just passing variables back and forth. 