### PR TITLE
Fix #17534 - Move tbody tag out of for loop in DBtable's index-table

### DIFF
--- a/templates/table/structure/display_structure.twig
+++ b/templates/table/structure/display_structure.twig
@@ -467,8 +467,8 @@
               </tr>
             </thead>
 
+          <tbody class="row_span">
             {% for index in indexes %}
-              <tbody class="row_span">
                 {% set columns_count = index.getColumnCount() %}
                 <tr class="noclick">
                 <td rowspan="{{ columns_count }}" class="edit_index d-print-none ajax">
@@ -534,8 +534,8 @@
                   {% endif %}
                   </tr>
                 {% endfor %}
-              </tbody>
-            {% endfor %}
+              {% endfor %}
+            </tbody>
           </table>
         </div>
       {% else %}


### PR DESCRIPTION
Signed-off-by: Sebastian Walther <swalther@complex-it.de>

### Description

Move tbody-tag out of for loop when rendering table's index-table.

Fixes [#17534](https://github.com/phpmyadmin/phpmyadmin/issues/17534)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
