### PR TITLE
Fix #17793 - insert UUID

### DIFF
--- a/libraries/classes/Html/Generator.php
+++ b/libraries/classes/Html/Generator.php
@@ -311,6 +311,11 @@ class Generator
             $defaultFunction = $cfg['DefaultFunctions']['first_timestamp'];
         }
 
+        // For uuid field, no default function
+        if ($field['True_Type'] === 'uuid') {
+            $defaultFunction = '';
+        }
+
         // For primary keys of type char(36) or varchar(36) UUID if the default
         // function
         // Only applies to insert mode, as it would silently trash data on updates.

--- a/libraries/classes/Html/Generator.php
+++ b/libraries/classes/Html/Generator.php
@@ -313,7 +313,7 @@ class Generator
 
         // For uuid field, no default function
         if ($field['True_Type'] === 'uuid') {
-            $defaultFunction = '';
+            return '';
         }
 
         // For primary keys of type char(36) or varchar(36) UUID if the default

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -870,7 +870,7 @@ class InsertEdit
                     . $columnNameAppendix . '" value="' . $type . '">';
             }
 
-            if (in_array($column['True_Type'], ['bit', 'uuid'])) {
+            if (in_array($column['True_Type'], ['bit', 'uuid'], true)) {
                 $htmlOutput .= '<input type="hidden" name="fields_type'
                     . $columnNameAppendix . '" value="' . $column['True_Type'] . '">';
             }

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -870,9 +870,9 @@ class InsertEdit
                     . $columnNameAppendix . '" value="' . $type . '">';
             }
 
-            if ($column['True_Type'] === 'bit') {
+            if (in_array($column['True_Type'], ['bit', 'uuid'])) {
                 $htmlOutput .= '<input type="hidden" name="fields_type'
-                    . $columnNameAppendix . '" value="bit">';
+                    . $columnNameAppendix . '" value="' . $column['True_Type'] . '">';
             }
         }
 
@@ -1806,6 +1806,18 @@ class InsertEdit
             && ! isset($multiEditColumnsNull[$key])
         ) {
             $currentValue = "''";
+        }
+
+        // For uuid type, generate uuid value
+        // if empty value but not set null or value is uuid() function
+        if (
+            $type === 'uuid'
+                && ! isset($multiEditColumnsNull[$key])
+                && ($currentValue == "''"
+                    || $currentValue == ''
+                    || $currentValue === "'uuid()'")
+        ) {
+            $currentValue = 'uuid()';
         }
 
         return $currentValue;

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -485,7 +485,7 @@ class Table implements Stringable
      * @param string      $collation        collation
      * @param bool|string $null             with 'NULL' or 'NOT NULL'
      * @param string      $defaultType      whether default is CURRENT_TIMESTAMP,
-     *                                       NULL, NONE, USER_DEFINED
+     *                                       NULL, NONE, USER_DEFINED, UUID
      * @param string      $defaultValue     default value for USER_DEFINED
      *                                       default type
      * @param string      $extra            'AUTO_INCREMENT'
@@ -636,6 +636,11 @@ class Table implements Stringable
                         ) {
                             $query .= '(' . $length . ')';
                         }
+
+                        break;
+                    case 'UUID':
+                    case 'uuid()':
+                        $query .= ' DEFAULT uuid()';
 
                         break;
                     case 'NONE':

--- a/libraries/classes/Twig/UtilExtension.php
+++ b/libraries/classes/Twig/UtilExtension.php
@@ -83,6 +83,10 @@ class UtilExtension extends AbstractExtension
                 ['is_safe' => ['html']]
             ),
             new TwigFunction(
+                'is_uuid_supported',
+                [Util::class, 'isUUIDSupported'],
+            ),
+            new TwigFunction(
                 'is_foreign_key_supported',
                 [ForeignKey::class, 'isSupported']
             ),

--- a/libraries/classes/Twig/UtilExtension.php
+++ b/libraries/classes/Twig/UtilExtension.php
@@ -84,7 +84,7 @@ class UtilExtension extends AbstractExtension
             ),
             new TwigFunction(
                 'is_uuid_supported',
-                [Util::class, 'isUUIDSupported'],
+                [Util::class, 'isUUIDSupported']
             ),
             new TwigFunction(
                 'is_foreign_key_supported',

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1764,9 +1764,7 @@ class Util
      */
     public static function isUUIDSupported()
     {
-        global $dbi;
-
-        return Compatibility::isUUIDSupported($dbi);
+        return Compatibility::isUUIDSupported($GLOBALS['dbi']);
     }
 
     /**

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin;
 use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Html\MySQLDocumentation;
+use PhpMyAdmin\Query\Compatibility;
 use PhpMyAdmin\Query\Utilities;
 use PhpMyAdmin\SqlParser\Components\Expression;
 use PhpMyAdmin\SqlParser\Context;
@@ -1754,6 +1755,18 @@ class Util
     public static function unsupportedDatatypes(): array
     {
         return [];
+    }
+
+    /**
+     * This function is to check whether database support UUID
+     *
+     * @return bool
+     */
+    public static function isUUIDSupported()
+    {
+        global $dbi;
+
+        return Compatibility::isUUIDSupported($dbi);
     }
 
     /**

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -1759,10 +1759,8 @@ class Util
 
     /**
      * This function is to check whether database support UUID
-     *
-     * @return bool
      */
-    public static function isUUIDSupported()
+    public static function isUUIDSupported(): bool
     {
         return Compatibility::isUUIDSupported($GLOBALS['dbi']);
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10526,11 +10526,6 @@ parameters:
 			path: test/classes/InsertEditTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, mixed given\\.$#"
-			count: 26
-			path: test/classes/InsertEditTest.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\IpAllowDenyTest\\:\\:proxyIPs\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/IpAllowDenyTest.php

--- a/templates/columns_definitions/column_attributes.twig
+++ b/templates/columns_definitions/column_attributes.twig
@@ -46,9 +46,11 @@
     <option value="CURRENT_TIMESTAMP"{{ column_meta['DefaultType'] is defined and column_meta['DefaultType'] == 'CURRENT_TIMESTAMP' ? ' selected' }}>
       CURRENT_TIMESTAMP
     </option>
+    {% if is_uuid_supported() %}
     <option value="UUID"{{ column_meta['DefaultType'] is defined and column_meta['DefaultType'] == 'UUID' ? ' selected' }}>
       UUID
     </option>
+    {% endif %}
   </select>
   {% if char_editing == 'textarea' %}
     <textarea name="field_default_value[{{ column_number }}]" cols="15" class="textfield default_value">{{ default_value }}</textarea>

--- a/templates/columns_definitions/column_attributes.twig
+++ b/templates/columns_definitions/column_attributes.twig
@@ -46,6 +46,9 @@
     <option value="CURRENT_TIMESTAMP"{{ column_meta['DefaultType'] is defined and column_meta['DefaultType'] == 'CURRENT_TIMESTAMP' ? ' selected' }}>
       CURRENT_TIMESTAMP
     </option>
+    <option value="UUID"{{ column_meta['DefaultType'] is defined and column_meta['DefaultType'] == 'UUID' ? ' selected' }}>
+      UUID
+    </option>
   </select>
   {% if char_editing == 'textarea' %}
     <textarea name="field_default_value[{{ column_number }}]" cols="15" class="textfield default_value">{{ default_value }}</textarea>

--- a/test/classes/Html/GeneratorTest.php
+++ b/test/classes/Html/GeneratorTest.php
@@ -452,4 +452,80 @@ class GeneratorTest extends AbstractTestCase
             Generator::getServerSSL()
         );
     }
+
+    /**
+     * Test for Generator::getDefaultFunctionForField
+     *
+     * @param array  $field      field settings
+     * @param bool   $insertMode true if insert mode
+     * @param string $expected   expected result
+     * @psalm-param array<string, string|bool|null> $row
+     *
+     * @dataProvider providerForTestGetDefaultFunctionForField
+     */
+    public function testGetDefaultFunctionForField(
+        array $field,
+        bool $insertMode,
+        string $expected
+    ): void {
+        $result = Generator::getDefaultFunctionForField($field, $insertMode);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for Generator::getDefaultFunctionForField test
+     *
+     * @return array
+     * @psalm-return array<int, array{array<string, string|bool|null>, bool, string}>
+     */
+    public function providerForTestGetDefaultFunctionForField(): array
+    {
+        return [
+            [
+                [
+                    'True_Type' => 'GEOMETRY',
+                    'first_timestamp' => false,
+                    'Extra' => null,
+                    'Key' => '',
+                    'Type' => '',
+                    'Null' => 'NO',
+                ],
+                true,
+                'ST_GeomFromText',
+            ],
+            [
+                [
+                    'True_Type' => 'timestamp',
+                    'first_timestamp' => true,
+                    'Extra' => null,
+                    'Key' => '',
+                    'Type' => '',
+                    'Null' => 'NO',
+                ],
+                true,
+                'NOW',
+            ],
+            [
+                [
+                    'True_Type' => 'uuid',
+                    'first_timestamp' => false,
+                    'Key' => '',
+                    'Type' => '',
+                ],
+                true,
+                '',
+            ],
+            [
+                [
+                    'True_Type' => '',
+                    'first_timestamp' => false,
+                    'Key' => 'PRI',
+                    'Type' => 'char(36)',
+                ],
+                true,
+                'UUID',
+            ],
+        ];
+    }
 }

--- a/test/classes/Html/GeneratorTest.php
+++ b/test/classes/Html/GeneratorTest.php
@@ -459,7 +459,7 @@ class GeneratorTest extends AbstractTestCase
      * @param array  $field      field settings
      * @param bool   $insertMode true if insert mode
      * @param string $expected   expected result
-     * @psalm-param array<string, string|bool|null> $row
+     * @psalm-param array<string, string|bool|null> $field
      *
      * @dataProvider providerForTestGetDefaultFunctionForField
      */

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1210,6 +1210,58 @@ class InsertEditTest extends AbstractTestCase
         );
 
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="date">', $result);
+
+        // case 5: (else -> bit)
+        $column['True_Type'] = 'bit';
+        $result = $this->callFunction(
+            $this->insertEdit,
+            InsertEdit::class,
+            'getValueColumnForOtherDatatypes',
+            [
+                $column,
+                'defchar',
+                'a',
+                'b',
+                'c',
+                22,
+                '&lt;',
+                12,
+                1,
+                '/',
+                '&lt;',
+                "foo\nbar",
+                $extracted_columnspec,
+                false,
+            ]
+        );
+
+        $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="bit">', $result);
+
+        // case 6: (else -> uuid)
+        $column['True_Type'] = 'uuid';
+        $result = $this->callFunction(
+            $this->insertEdit,
+            InsertEdit::class,
+            'getValueColumnForOtherDatatypes',
+            [
+                $column,
+                'defchar',
+                'a',
+                'b',
+                'c',
+                22,
+                '&lt;',
+                12,
+                1,
+                '/',
+                '&lt;',
+                "foo\nbar",
+                $extracted_columnspec,
+                false,
+            ]
+        );
+
+        $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="uuid">', $result);
     }
 
     /**
@@ -2472,6 +2524,46 @@ class InsertEditTest extends AbstractTestCase
         );
 
         $this->assertEquals("''", $result);
+
+        // case 10
+        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+            false,
+            '0',
+            ['uuid'],
+            '',
+            [],
+            0,
+            ['a'],
+            [],
+            [1],
+            true,
+            true,
+            '',
+            'test_table',
+            []
+        );
+
+        $this->assertEquals('uuid()', $result);
+
+        // case 11
+        $result = $this->insertEdit->getCurrentValueForDifferentTypes(
+            false,
+            '0',
+            ['uuid'],
+            'uuid()',
+            [],
+            0,
+            ['a'],
+            [],
+            [1],
+            true,
+            true,
+            '',
+            'test_table',
+            []
+        );
+
+        $this->assertEquals('uuid()', $result);
     }
 
     /**

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -21,6 +21,7 @@ use function mb_substr;
 use function md5;
 use function password_verify;
 use function sprintf;
+use function strval;
 
 use const MYSQLI_PRI_KEY_FLAG;
 use const MYSQLI_TYPE_DECIMAL;
@@ -423,6 +424,8 @@ class InsertEditTest extends AbstractTestCase
 
         $result = $this->insertEdit->showTypeOrFunction('function', $url_params, false);
 
+        $result = strval($result);
+
         $this->assertStringContainsString('index.php?route=/table/change', $result);
         $this->assertStringContainsString(
             'ShowFunctionFields=1&ShowFieldTypesInDataEditView=1&goto=index.php%3Froute%3D%2Fsql',
@@ -432,6 +435,8 @@ class InsertEditTest extends AbstractTestCase
 
         // case 2
         $result = $this->insertEdit->showTypeOrFunction('function', $url_params, true);
+
+        $result = strval($result);
 
         $this->assertStringContainsString('index.php?route=/table/change', $result);
         $this->assertStringContainsString(
@@ -443,6 +448,8 @@ class InsertEditTest extends AbstractTestCase
         // case 3
         $result = $this->insertEdit->showTypeOrFunction('type', $url_params, false);
 
+        $result = strval($result);
+
         $this->assertStringContainsString('index.php?route=/table/change', $result);
         $this->assertStringContainsString(
             'ShowFunctionFields=1&ShowFieldTypesInDataEditView=1&goto=index.php%3Froute%3D%2Fsql',
@@ -452,6 +459,8 @@ class InsertEditTest extends AbstractTestCase
 
         // case 4
         $result = $this->insertEdit->showTypeOrFunction('type', $url_params, true);
+
+        $result = strval($result);
 
         $this->assertStringContainsString('index.php?route=/table/change', $result);
         $this->assertStringContainsString(
@@ -537,6 +546,8 @@ class InsertEditTest extends AbstractTestCase
                 $comments,
             ]
         );
+
+        $result = strval($result);
 
         $this->assertStringContainsString('title="comment&gt;"', $result);
 
@@ -833,6 +844,8 @@ class InsertEditTest extends AbstractTestCase
                 false,
             ]
         );
+
+        $result = strval($result);
 
         $this->assertStringContainsString(
             '<textarea name="fieldsb" class="char charField" '
@@ -1183,6 +1196,8 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
+        $result = strval($result);
+
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="datetime">', $result);
 
         // case 4: (else -> date)
@@ -1208,6 +1223,8 @@ class InsertEditTest extends AbstractTestCase
                 false,
             ]
         );
+
+        $result = strval($result);
 
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="date">', $result);
 
@@ -1235,6 +1252,8 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
+        $result = strval($result);
+
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="bit">', $result);
 
         // case 6: (else -> uuid)
@@ -1260,6 +1279,8 @@ class InsertEditTest extends AbstractTestCase
                 false,
             ]
         );
+
+        $result = strval($result);
 
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="uuid">', $result);
     }
@@ -1321,6 +1342,8 @@ class InsertEditTest extends AbstractTestCase
 
         $result = $this->insertEdit->getContinueInsertionForm('tbl', 'db', $where_clause_array, 'localhost');
 
+        $result = strval($result);
+
         $this->assertStringContainsString(
             '<form id="continueForm" method="post" action="' . Url::getFromRoute('/table/replace')
             . '" name="continueForm">',
@@ -1367,6 +1390,8 @@ class InsertEditTest extends AbstractTestCase
             'getHeadAndFootOfInsertRowTable',
             [$url_params]
         );
+
+        $result = strval($result);
 
         $this->assertStringContainsString('index.php?route=/table/change', $result);
 
@@ -2861,6 +2886,8 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
+        $actual = strval($actual);
+
         $this->assertStringContainsString('col', $actual);
         $this->assertStringContainsString('<option>AES_ENCRYPT</option>', $actual);
         $this->assertStringContainsString('<span class="column_type" dir="ltr">varchar(20)</span>', $actual);
@@ -2919,6 +2946,9 @@ class InsertEditTest extends AbstractTestCase
                 '',
             ]
         );
+
+        $actual = strval($actual);
+
         $this->assertStringContainsString('qwerty', $actual);
         $this->assertStringContainsString('<option>UUID</option>', $actual);
         $this->assertStringContainsString('<span class="column_type" dir="ltr">datetime</span>', $actual);
@@ -3022,6 +3052,9 @@ class InsertEditTest extends AbstractTestCase
             [],
             ['wc']
         );
+
+        $actual = strval($actual);
+
         $this->assertStringContainsString('test', $actual);
         $this->assertStringContainsString('<th>Column</th>', $actual);
         $this->assertStringContainsString('<a', $actual);
@@ -3102,6 +3135,9 @@ class InsertEditTest extends AbstractTestCase
             [],
             ['wc']
         );
+
+        $actual = strval($actual);
+
         $this->assertStringContainsString('foo', $actual);
         $this->assertStringNotContainsString('bar', $actual);
 
@@ -3163,6 +3199,9 @@ class InsertEditTest extends AbstractTestCase
             [],
             ['wc']
         );
+
+        $actual = strval($actual);
+
         $this->assertStringContainsString('foo', $actual);
         $this->assertStringContainsString(
             '<textarea name="fields[multi_edit][0][37b51d194a7513e45b56f6524f2d51f2]"',

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -3042,7 +3042,6 @@ class InsertEditTest extends AbstractTestCase
             [],
             ['wc']
         );
-
         $this->assertStringContainsString('test', $actual);
         $this->assertStringContainsString('<th>Column</th>', $actual);
         $this->assertStringContainsString('<a', $actual);
@@ -3123,7 +3122,6 @@ class InsertEditTest extends AbstractTestCase
             [],
             ['wc']
         );
-
         $this->assertStringContainsString('foo', $actual);
         $this->assertStringNotContainsString('bar', $actual);
 
@@ -3185,7 +3183,6 @@ class InsertEditTest extends AbstractTestCase
             [],
             ['wc']
         );
-
         $this->assertStringContainsString('foo', $actual);
         $this->assertStringContainsString(
             '<textarea name="fields[multi_edit][0][37b51d194a7513e45b56f6524f2d51f2]"',

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -424,8 +424,6 @@ class InsertEditTest extends AbstractTestCase
 
         $result = $this->insertEdit->showTypeOrFunction('function', $url_params, false);
 
-        $result = strval($result);
-
         $this->assertStringContainsString('index.php?route=/table/change', $result);
         $this->assertStringContainsString(
             'ShowFunctionFields=1&ShowFieldTypesInDataEditView=1&goto=index.php%3Froute%3D%2Fsql',
@@ -435,8 +433,6 @@ class InsertEditTest extends AbstractTestCase
 
         // case 2
         $result = $this->insertEdit->showTypeOrFunction('function', $url_params, true);
-
-        $result = strval($result);
 
         $this->assertStringContainsString('index.php?route=/table/change', $result);
         $this->assertStringContainsString(
@@ -448,8 +444,6 @@ class InsertEditTest extends AbstractTestCase
         // case 3
         $result = $this->insertEdit->showTypeOrFunction('type', $url_params, false);
 
-        $result = strval($result);
-
         $this->assertStringContainsString('index.php?route=/table/change', $result);
         $this->assertStringContainsString(
             'ShowFunctionFields=1&ShowFieldTypesInDataEditView=1&goto=index.php%3Froute%3D%2Fsql',
@@ -459,8 +453,6 @@ class InsertEditTest extends AbstractTestCase
 
         // case 4
         $result = $this->insertEdit->showTypeOrFunction('type', $url_params, true);
-
-        $result = strval($result);
 
         $this->assertStringContainsString('index.php?route=/table/change', $result);
         $this->assertStringContainsString(
@@ -1341,8 +1333,6 @@ class InsertEditTest extends AbstractTestCase
         $_POST['sql_query'] = 'SELECT 1';
 
         $result = $this->insertEdit->getContinueInsertionForm('tbl', 'db', $where_clause_array, 'localhost');
-
-        $result = strval($result);
 
         $this->assertStringContainsString(
             '<form id="continueForm" method="post" action="' . Url::getFromRoute('/table/replace')
@@ -3053,8 +3043,6 @@ class InsertEditTest extends AbstractTestCase
             ['wc']
         );
 
-        $actual = strval($actual);
-
         $this->assertStringContainsString('test', $actual);
         $this->assertStringContainsString('<th>Column</th>', $actual);
         $this->assertStringContainsString('<a', $actual);
@@ -3136,8 +3124,6 @@ class InsertEditTest extends AbstractTestCase
             ['wc']
         );
 
-        $actual = strval($actual);
-
         $this->assertStringContainsString('foo', $actual);
         $this->assertStringNotContainsString('bar', $actual);
 
@@ -3199,8 +3185,6 @@ class InsertEditTest extends AbstractTestCase
             [],
             ['wc']
         );
-
-        $actual = strval($actual);
 
         $this->assertStringContainsString('foo', $actual);
         $this->assertStringContainsString(

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -17,6 +17,9 @@ use ReflectionProperty;
 use stdClass;
 
 use function hash;
+use function is_object;
+use function is_scalar;
+use function is_string;
 use function mb_substr;
 use function md5;
 use function password_verify;
@@ -539,7 +542,7 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $result = strval($result);
+        $result = $this->parseString($result);
 
         $this->assertStringContainsString('title="comment&gt;"', $result);
 
@@ -837,7 +840,7 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $result = strval($result);
+        $result = $this->parseString($result);
 
         $this->assertStringContainsString(
             '<textarea name="fieldsb" class="char charField" '
@@ -1188,7 +1191,7 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $result = strval($result);
+        $result = $this->parseString($result);
 
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="datetime">', $result);
 
@@ -1216,7 +1219,7 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $result = strval($result);
+        $result = $this->parseString($result);
 
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="date">', $result);
 
@@ -1244,7 +1247,7 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $result = strval($result);
+        $result = $this->parseString($result);
 
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="bit">', $result);
 
@@ -1272,7 +1275,7 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $result = strval($result);
+        $result = $this->parseString($result);
 
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="uuid">', $result);
     }
@@ -1381,7 +1384,7 @@ class InsertEditTest extends AbstractTestCase
             [$url_params]
         );
 
-        $result = strval($result);
+        $result = $this->parseString($result);
 
         $this->assertStringContainsString('index.php?route=/table/change', $result);
 
@@ -1619,7 +1622,7 @@ class InsertEditTest extends AbstractTestCase
         unset($column['Default']);
         $column['True_Type'] = 'char';
 
-        $result = $this->callFunction(
+        $result = (array) $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
             'getSpecialCharsAndBackupFieldForInsertingMode',
@@ -1865,7 +1868,7 @@ class InsertEditTest extends AbstractTestCase
         $GLOBALS['dbi'] = $dbi;
         $this->insertEdit = new InsertEdit($GLOBALS['dbi']);
 
-        $result = $this->callFunction(
+        $result = (array) $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
             'getWarningMessages',
@@ -2876,7 +2879,7 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $actual = strval($actual);
+        $actual = $this->parseString($actual);
 
         $this->assertStringContainsString('col', $actual);
         $this->assertStringContainsString('<option>AES_ENCRYPT</option>', $actual);
@@ -2937,7 +2940,7 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $actual = strval($actual);
+        $actual = $this->parseString($actual);
 
         $this->assertStringContainsString('qwerty', $actual);
         $this->assertStringContainsString('<option>UUID</option>', $actual);
@@ -3194,5 +3197,25 @@ class InsertEditTest extends AbstractTestCase
             . '</span></a>',
             $actual
         );
+    }
+
+    /**
+     * Convert mixed type value to string
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    private function parseString($value)
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        if (is_object($value) || is_scalar($value)) {
+            return strval($value);
+        }
+
+        return '';
     }
 }

--- a/test/classes/TableTest.php
+++ b/test/classes/TableTest.php
@@ -706,6 +706,54 @@ class TableTest extends AbstractTestCase
             $query
         );
 
+        //$default_type is UUID
+        $type = 'UUID';
+        $default_type = 'UUID';
+        $move_to = '';
+        $query = Table::generateFieldSpec(
+            $name,
+            $type,
+            $length,
+            $attribute,
+            $collation,
+            $null,
+            $default_type,
+            $default_value,
+            $extra,
+            '',
+            $virtuality,
+            $expression,
+            $move_to
+        );
+        $this->assertEquals(
+            '`PMA_name` UUID PMA_attribute NULL DEFAULT uuid()',
+            $query
+        );
+
+        //$default_type is uuid()
+        $type = 'UUID';
+        $default_type = 'uuid()';
+        $move_to = '';
+        $query = Table::generateFieldSpec(
+            $name,
+            $type,
+            $length,
+            $attribute,
+            $collation,
+            $null,
+            $default_type,
+            $default_value,
+            $extra,
+            '',
+            $virtuality,
+            $expression,
+            $move_to
+        );
+        $this->assertEquals(
+            '`PMA_name` UUID PMA_attribute NULL DEFAULT uuid()',
+            $query
+        );
+
         //$default_type is NONE
         $type = 'BOOLEAN';
         $default_type = 'NONE';

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -2446,4 +2446,65 @@ class UtilTest extends AbstractTestCase
             Util::getScriptNameForOption($target, $location)
         );
     }
+
+    /**
+     * Tests for Util::testIsUUIDSupported() method.
+     *
+     * @param bool $isMariaDB True if mariadb
+     * @param int  $version   Database version as integer
+     * @param bool $expected  Expected Result
+     *
+     * @dataProvider provideForTestIsUUIDSupported
+     */
+    public function testIsUUIDSupported(bool $isMariaDB, int $version, bool $expected): void
+    {
+        $dbi = $this->getMockBuilder(DatabaseInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $dbi->expects($this->any())
+            ->method('isMariaDB')
+            ->will($this->returnValue($isMariaDB));
+
+        $dbi->expects($this->any())
+            ->method('getVersion')
+            ->will($this->returnValue($version));
+
+        $oldDbi = $GLOBALS['dbi'];
+        $GLOBALS['dbi'] = $dbi;
+        $this->assertEquals(Util::isUUIDSupported(), $expected);
+        $GLOBALS['dbi'] = $oldDbi;
+    }
+
+    /**
+     * Data provider for isUUIDSupported() tests.
+     *
+     * @return array
+     * @psalm-return array<int, array{bool, int, bool}>
+     */
+    public function provideForTestIsUUIDSupported(): array
+    {
+        return [
+            [
+                false,
+                60100,
+                false,
+            ],
+            [
+                false,
+                100700,
+                false,
+            ],
+            [
+                true,
+                60100,
+                false,
+            ],
+            [
+                true,
+                100700,
+                true,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
### Description

- Add/Change table schema - Add UUID in default options
  <img width="198" alt="Screen Shot 2565-10-15 at 04 13 22" src="https://user-images.githubusercontent.com/1849256/195960935-aa7ac164-bffb-48a3-b49e-e146f6915b29.png">
- Insert/Edit - Generate uuid only when not defined value and not check null option

Reference issue: https://github.com/phpmyadmin/phpmyadmin/issues/17793

Signed-off-by: Mo Sureerat <sureemo@gmail.com>
