### PR TITLE
Refactor JS escaping mechanism

### DIFF
--- a/libraries/classes/Config/FormDisplay.php
+++ b/libraries/classes/Config/FormDisplay.php
@@ -436,22 +436,22 @@ class FormDisplay
         $this->setComments($systemPath, $opts);
 
         // send default value to form's JS
-        $jsLine = '\'' . $translatedPath . '\': ';
+        $jsLine = '';
         switch ($type) {
             case 'text':
             case 'short_text':
             case 'number_text':
             case 'password':
-                $jsLine .= '\'' . Sanitize::escapeJsString($valueDefault) . '\'';
+                $jsLine = (string) $valueDefault;
                 break;
             case 'checkbox':
-                $jsLine .= $valueDefault ? 'true' : 'false';
+                $jsLine = (bool) $valueDefault;
                 break;
             case 'select':
                 $valueDefaultJs = is_bool($valueDefault)
                 ? (int) $valueDefault
                 : $valueDefault;
-                $jsLine .= '[\'' . Sanitize::escapeJsString($valueDefaultJs) . '\']';
+                $jsLine = (array) $valueDefaultJs;
                 break;
             case 'list':
                 $val = $valueDefault;
@@ -459,12 +459,11 @@ class FormDisplay
                     unset($val['wrapper_params']);
                 }
 
-                $jsLine .= '\'' . Sanitize::escapeJsString(implode("\n", $val))
-                . '\'';
+                $jsLine = implode("\n", $val);
                 break;
         }
 
-        $jsDefault[] = $jsLine;
+        $jsDefault[$translatedPath] = $jsLine;
 
         return $this->formDisplayTemplate->displayInput(
             $translatedPath,

--- a/libraries/classes/Config/FormDisplayTemplate.php
+++ b/libraries/classes/Config/FormDisplayTemplate.php
@@ -8,11 +8,12 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Config;
 
 use PhpMyAdmin\Config;
-use PhpMyAdmin\Sanitize;
 use PhpMyAdmin\Template;
 
 use function array_shift;
-use function implode;
+use function json_encode;
+
+use const JSON_HEX_TAG;
 
 /**
  * PhpMyAdmin\Config\FormDisplayTemplate class
@@ -144,12 +145,7 @@ class FormDisplayTemplate
         foreach ((array) $validators as $validator) {
             $validator = (array) $validator;
             $vName = array_shift($validator);
-            $vArgs = [];
-            foreach ($validator as $arg) {
-                $vArgs[] = Sanitize::escapeJsString($arg);
-            }
-
-            $vArgs = $vArgs ? ", ['" . implode("', '", $vArgs) . "']" : '';
+            $vArgs = $validator !== [] ? ', ' . json_encode($validator, JSON_HEX_TAG) : '';
             $jsArray[] = "window.Config.registerFieldValidator('"
                 . $fieldId . "', '" . $vName . "', true" . $vArgs . ')';
         }

--- a/libraries/classes/Controllers/Table/ChangeController.php
+++ b/libraries/classes/Controllers/Table/ChangeController.php
@@ -63,7 +63,6 @@ class ChangeController extends AbstractController
         $GLOBALS['after_insert'] = $GLOBALS['after_insert'] ?? null;
         $GLOBALS['comments_map'] = $GLOBALS['comments_map'] ?? null;
         $GLOBALS['table_columns'] = $GLOBALS['table_columns'] ?? null;
-        $GLOBALS['chg_evt_handler'] = $GLOBALS['chg_evt_handler'] ?? null;
         $GLOBALS['timestamp_seen'] = $GLOBALS['timestamp_seen'] ?? null;
         $GLOBALS['columns_cnt'] = $GLOBALS['columns_cnt'] ?? null;
         $GLOBALS['tabindex'] = $GLOBALS['tabindex'] ?? null;
@@ -172,9 +171,6 @@ class ChangeController extends AbstractController
         /**
          * Displays the form
          */
-        // autocomplete feature of IE kills the "onchange" event handler and it
-        //        must be replaced by the "onpropertychange" one in this case
-        $GLOBALS['chg_evt_handler'] = 'onchange';
         // Had to put the URI because when hosted on an https server,
         // some browsers send wrongly this form to the http server.
 
@@ -254,7 +250,6 @@ class ChangeController extends AbstractController
                 $GLOBALS['comments_map'],
                 $GLOBALS['timestamp_seen'],
                 $GLOBALS['current_result'],
-                $GLOBALS['chg_evt_handler'],
                 $GLOBALS['jsvkey'],
                 $GLOBALS['vkey'],
                 $GLOBALS['insert_mode'],

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -16,13 +16,14 @@ use function defined;
 use function gmdate;
 use function header;
 use function htmlspecialchars;
-use function implode;
 use function ini_get;
-use function is_bool;
+use function json_encode;
 use function sprintf;
 use function strlen;
 use function strtolower;
 use function urlencode;
+
+use const JSON_HEX_TAG;
 
 /**
  * Class used to output the HTTP and HTML headers
@@ -201,15 +202,8 @@ class Header
     public function getJsParamsCode(): string
     {
         $params = $this->getJsParams();
-        foreach ($params as $key => $value) {
-            if (is_bool($value)) {
-                $params[$key] = $key . ':' . ($value ? 'true' : 'false') . '';
-            } else {
-                $params[$key] = $key . ':"' . Sanitize::escapeJsString($value) . '"';
-            }
-        }
 
-        return 'window.CommonParams.setAll({' . implode(',', $params) . '});';
+        return 'window.CommonParams.setAll(' . json_encode($params, JSON_HEX_TAG) . ');';
     }
 
     /**

--- a/libraries/classes/Html/Generator.php
+++ b/libraries/classes/Html/Generator.php
@@ -39,6 +39,8 @@ use function in_array;
 use function ini_get;
 use function intval;
 use function is_array;
+use function is_string;
+use function json_encode;
 use function mb_strlen;
 use function mb_strstr;
 use function mb_strtolower;
@@ -57,6 +59,7 @@ use function trim;
 use function urlencode;
 
 use const ENT_COMPAT;
+use const JSON_HEX_TAG;
 
 /**
  * HTML Generator
@@ -1055,20 +1058,13 @@ class Generator
             $url = $urlPath . Url::getCommon($urlParams, str_contains($urlPath, '?') ? '&' : '?', false);
         }
 
-        $urlLength = strlen($url);
-
-        if (! is_array($tagParams)) {
-            $tmp = $tagParams;
-            $tagParams = [];
-            if (! empty($tmp)) {
-                $tagParams['onclick'] = 'return Functions.confirmLink(this, \''
-                    . Sanitize::escapeJsString($tmp) . '\')';
-            }
-
-            unset($tmp);
+        if (is_string($tagParams)) {
+            $tagParams = $tagParams !== '' ?
+                ['onclick' => 'return Functions.confirmLink(this, ' . json_encode($tagParams, JSON_HEX_TAG) . ')'] :
+                [];
         }
 
-        if (! empty($target)) {
+        if ($target !== '') {
             $tagParams['target'] = $target;
             if ($target === '_blank' && str_starts_with($url, 'index.php?route=/url&url=')) {
                 $tagParams['rel'] = 'noopener noreferrer';
@@ -1077,7 +1073,7 @@ class Generator
 
         // Suhosin: Check that each query parameter is not above maximum
         $inSuhosinLimits = true;
-        if ($urlLength <= $GLOBALS['cfg']['LinkLengthLimit']) {
+        if (strlen($url) <= $GLOBALS['cfg']['LinkLengthLimit']) {
             $suhosinGetMaxValueLength = ini_get('suhosin.get.max_value_length');
             if ($suhosinGetMaxValueLength) {
                 $queryParts = Util::splitURLQuery($url);
@@ -1096,7 +1092,7 @@ class Generator
         }
 
         $tagParamsStrings = [];
-        $isDataPostFormatSupported = ($urlLength > $GLOBALS['cfg']['LinkLengthLimit'])
+        $isDataPostFormatSupported = (strlen($url) > $GLOBALS['cfg']['LinkLengthLimit'])
             || ! $inSuhosinLimits
             || (
                 // Has as sql_query without a signature, to be accepted it needs to be sent using POST

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -28,6 +28,7 @@ use function in_array;
 use function is_array;
 use function is_file;
 use function is_string;
+use function json_encode;
 use function max;
 use function mb_stripos;
 use function mb_strlen;
@@ -595,7 +596,7 @@ class InsertEdit
             . ' cols="' . $textareaCols . '"'
             . ' dir="' . $textDir . '"'
             . ' id="field_' . $idindex . '_3"'
-            . ($onChangeClause ? ' ' . $onChangeClause : '')
+            . ($onChangeClause ? ' onchange="' . htmlspecialchars($onChangeClause, ENT_COMPAT) . '"' : '')
             . ' tabindex="' . ($tabindex + $tabindexForValue) . '"'
             . ' data-type="' . $dataType . '">'
             . $specialCharsEncoded
@@ -715,7 +716,7 @@ class InsertEdit
             . ($readOnly ? ' readonly="readonly"' : '')
             . ($inputMinMax ? ' ' . $inputMinMax : '')
             . ' data-type="' . $dataType . '"'
-            . ' class="' . $theClass . '" ' . $onChangeClause
+            . ' class="' . $theClass . '" onchange="' . htmlspecialchars($onChangeClause, ENT_COMPAT) . '"'
             . ' tabindex="' . ($tabindex + $tabindexForValue) . '"'
             . ($isInteger ? ' inputmode="numeric"' : '')
             . ' id="field_' . $idindex . '_3">';
@@ -1959,7 +1960,6 @@ class InsertEdit
      * @param array           $commentsMap        comments map
      * @param bool            $timestampSeen      whether timestamp seen
      * @param ResultInterface $currentResult      current result
-     * @param string          $chgEvtHandler      javascript change event handler
      * @param string          $jsvkey             javascript validation key
      * @param string          $vkey               validation key
      * @param bool            $insertMode         whether insert mode
@@ -1988,7 +1988,6 @@ class InsertEdit
         array $commentsMap,
         $timestampSeen,
         ResultInterface $currentResult,
-        $chgEvtHandler,
         $jsvkey,
         $vkey,
         $insertMode,
@@ -2035,10 +2034,9 @@ class InsertEdit
         }
 
         //Call validation when the form submitted...
-        $onChangeClause = $chgEvtHandler
-            . "=\"return verificationsAfterFieldChange('"
-            . Sanitize::escapeJsString($fieldHashMd5) . "', '"
-            . Sanitize::escapeJsString($jsvkey) . "','" . $column['pma_type'] . "')\"";
+        $onChangeClause = 'return verificationsAfterFieldChange('
+            . json_encode($fieldHashMd5) . ', '
+            . json_encode($jsvkey) . ',' . json_encode($column['pma_type']) . ')';
 
         // Use an MD5 as an array index to avoid having special characters
         // in the name attribute (see bug #1746964 )
@@ -2340,7 +2338,6 @@ class InsertEdit
      * @param array           $commentsMap        comments map
      * @param bool            $timestampSeen      whether timestamp seen
      * @param ResultInterface $currentResult      current result
-     * @param string          $chgEvtHandler      javascript change event handler
      * @param string          $jsvkey             javascript validation key
      * @param string          $vkey               validation key
      * @param bool            $insertMode         whether insert mode
@@ -2367,7 +2364,6 @@ class InsertEdit
         array $commentsMap,
         $timestampSeen,
         ResultInterface $currentResult,
-        $chgEvtHandler,
         $jsvkey,
         $vkey,
         $insertMode,
@@ -2420,7 +2416,6 @@ class InsertEdit
                 $commentsMap,
                 $timestampSeen,
                 $currentResult,
-                $chgEvtHandler,
                 $jsvkey,
                 $vkey,
                 $insertMode,

--- a/libraries/classes/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
+++ b/libraries/classes/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
@@ -9,19 +9,21 @@ namespace PhpMyAdmin\Plugins\Transformations\Abs;
 
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\TransformationsPlugin;
-use PhpMyAdmin\Sanitize;
 use PhpMyAdmin\Util;
 
 use function __;
 use function checkdate;
 use function gmdate;
 use function htmlspecialchars;
+use function json_encode;
 use function mb_strlen;
 use function mb_strtolower;
 use function mb_substr;
 use function mktime;
 use function preg_match;
 use function strtotime;
+
+use const ENT_COMPAT;
 
 /**
  * Provides common methods for all of the date format transformations plugins.
@@ -140,7 +142,7 @@ abstract class DateFormatTransformationsPlugin extends TransformationsPlugin
                 $text = 'INVALID DATE TYPE';
             }
 
-            return '<dfn onclick="alert(\'' . Sanitize::jsFormat($source, false) . '\');" title="'
+            return '<dfn onclick="alert(' . htmlspecialchars((string) json_encode($source), ENT_COMPAT) . ');" title="'
                 . htmlspecialchars((string) $source) . '">' . htmlspecialchars((string) $text) . '</dfn>';
         }
 

--- a/libraries/classes/Sanitize.php
+++ b/libraries/classes/Sanitize.php
@@ -20,7 +20,6 @@ use function json_encode;
 use function preg_match;
 use function preg_replace;
 use function preg_replace_callback;
-use function str_replace;
 use function str_starts_with;
 use function strlen;
 use function strtolower;
@@ -258,61 +257,6 @@ class Sanitize
         $filename = preg_replace($pattern, '_', $filename);
 
         return $filename;
-    }
-
-    /**
-     * Format a string so it can be a string inside JavaScript code inside an
-     * eventhandler (onclick, onchange, on..., ).
-     * This function is used to displays a javascript confirmation box for
-     * "DROP/DELETE/ALTER" queries.
-     *
-     * @param string $a_string       the string to format
-     * @param bool   $add_backquotes whether to add backquotes to the string or not
-     *
-     * @return string   the formatted string
-     */
-    public static function jsFormat($a_string = '', $add_backquotes = true)
-    {
-        $a_string = htmlspecialchars((string) $a_string);
-        $a_string = self::escapeJsString($a_string);
-        // Needed for inline javascript to prevent some browsers
-        // treating it as a anchor
-        $a_string = str_replace('#', '\\#', $a_string);
-
-        return $add_backquotes
-            ? Util::backquote($a_string)
-            : $a_string;
-    }
-
-    /**
-     * escapes a string to be inserted as string a JavaScript block
-     * enclosed by <![CDATA[ ... ]]>
-     * this requires only to escape ' with \' and end of script block
-     *
-     * We also remove NUL byte as some browsers (namely MSIE) ignore it and
-     * inserting it anywhere inside </script would allow to bypass this check.
-     *
-     * @param string $string the string to be escaped
-     *
-     * @return string  the escaped string
-     */
-    public static function escapeJsString($string)
-    {
-        return preg_replace(
-            '@</script@i',
-            '</\' + \'script',
-            strtr(
-                (string) $string,
-                [
-                    "\000" => '',
-                    '\\' => '\\\\',
-                    '\'' => '\\\'',
-                    '"' => '\"',
-                    "\n" => '\n',
-                    "\r" => '\r',
-                ]
-            )
-        );
     }
 
     /**

--- a/libraries/classes/Sanitize.php
+++ b/libraries/classes/Sanitize.php
@@ -15,10 +15,8 @@ use function array_merge;
 use function count;
 use function htmlspecialchars;
 use function in_array;
-use function is_array;
-use function is_bool;
-use function is_int;
 use function is_string;
+use function json_encode;
 use function preg_match;
 use function preg_replace;
 use function preg_replace_callback;
@@ -28,6 +26,8 @@ use function strlen;
 use function strtolower;
 use function strtr;
 use function substr;
+
+use const JSON_HEX_TAG;
 
 /**
  * This class includes various sanitization methods that can be called statically
@@ -316,57 +316,17 @@ class Sanitize
     }
 
     /**
-     * Formats a value for javascript code.
-     *
-     * @param string|bool|int $value String to be formatted.
-     *
-     * @return int|string formatted value.
-     */
-    public static function formatJsVal($value)
-    {
-        if (is_bool($value)) {
-            if ($value) {
-                return 'true';
-            }
-
-            return 'false';
-        }
-
-        if (is_int($value)) {
-            return $value;
-        }
-
-        return '"' . self::escapeJsString($value) . '"';
-    }
-
-    /**
      * Formats an javascript assignment with proper escaping of a value
      * and support for assigning array of strings.
      *
-     * @param string $key    Name of value to set
-     * @param mixed  $value  Value to set, can be either string or array of strings
-     * @param bool   $escape Whether to escape value or keep it as it is
-     *                       (for inclusion of js code)
+     * @param string $key   Name of value to set
+     * @param mixed  $value Value to set, can be either string or array of strings
      *
      * @return string Javascript code.
      */
-    public static function getJsValue($key, $value, $escape = true)
+    public static function getJsValue($key, $value)
     {
-        $result = $key . ' = ';
-        if (! $escape) {
-            $result .= $value;
-        } elseif (is_array($value)) {
-            $result .= '[';
-            foreach ($value as $val) {
-                $result .= self::formatJsVal($val) . ',';
-            }
-
-            $result .= "];\n";
-        } else {
-            $result .= self::formatJsVal($value) . ";\n";
-        }
-
-        return $result;
+        return $key . ' = ' . json_encode($value, JSON_HEX_TAG) . ";\n";
     }
 
     /**

--- a/libraries/classes/Tracking.php
+++ b/libraries/classes/Tracking.php
@@ -21,6 +21,7 @@ use function htmlspecialchars;
 use function in_array;
 use function ini_set;
 use function is_array;
+use function json_encode;
 use function mb_strstr;
 use function preg_replace;
 use function rtrim;
@@ -464,11 +465,11 @@ class Tracking
             . '<option value="sqldumpfile">' . __('SQL dump (file download)')
             . '</option>'
             . '<option value="sqldump">' . __('SQL dump') . '</option>'
-            . '<option value="execution" onclick="alert(\''
-            . Sanitize::escapeJsString(
+            . '<option value="execution" onclick="alert('
+            . htmlspecialchars((string) json_encode(
                 __('This option will replace your table and contained data.')
-            )
-            . '\')">' . __('SQL execution') . '</option></select>';
+            ))
+            . ')">' . __('SQL execution') . '</option></select>';
 
         $str_export2 = '<input class="btn btn-primary" type="submit" value="' . __('Go') . '">';
 

--- a/libraries/classes/Twig/SanitizeExtension.php
+++ b/libraries/classes/Twig/SanitizeExtension.php
@@ -20,11 +20,6 @@ class SanitizeExtension extends AbstractExtension
     {
         return [
             new TwigFilter(
-                'js_format',
-                [Sanitize::class, 'jsFormat'],
-                ['is_safe' => ['html']]
-            ),
-            new TwigFilter(
                 'sanitize',
                 [Sanitize::class, 'sanitizeMessage'],
                 ['is_safe' => ['html']]

--- a/libraries/classes/Twig/SanitizeExtension.php
+++ b/libraries/classes/Twig/SanitizeExtension.php
@@ -20,11 +20,6 @@ class SanitizeExtension extends AbstractExtension
     {
         return [
             new TwigFilter(
-                'escape_js_string',
-                [Sanitize::class, 'escapeJsString'],
-                ['is_safe' => ['html']]
-            ),
-            new TwigFilter(
                 'js_format',
                 [Sanitize::class, 'jsFormat'],
                 ['is_safe' => ['html']]

--- a/libraries/classes/UrlRedirector.php
+++ b/libraries/classes/UrlRedirector.php
@@ -47,7 +47,7 @@ final class UrlRedirector
          */
         $template = $container->get('template');
         echo $template->render('javascript/redirect', [
-            'url' => Sanitize::escapeJsString((string) $_GET['url']),
+            'url' => (string) $_GET['url'],
         ]);
         // Display redirecting msg on screen.
         // Do not display the value of $_GET['url'] to avoid showing injected content

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -401,6 +401,11 @@ parameters:
 			path: libraries/classes/Config/FormDisplay.php
 
 		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: libraries/classes/Config/FormDisplay.php
+
+		-
 			message: "#^Call to function function_exists\\(\\) with 'bzcompress'\\|'gzcompress'\\|'gzencode' will always evaluate to true\\.$#"
 			count: 1
 			path: libraries/classes/Config/FormDisplay.php
@@ -453,11 +458,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$path of method PhpMyAdmin\\\\Config\\\\ConfigFile\\:\\:set\\(\\) expects string, int\\|string given\\.$#"
 			count: 1
-			path: libraries/classes/Config/FormDisplay.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of static method PhpMyAdmin\\\\Sanitize\\:\\:escapeJsString\\(\\) expects string, mixed given\\.$#"
-			count: 2
 			path: libraries/classes/Config/FormDisplay.php
 
 		-
@@ -7008,16 +7008,6 @@ parameters:
 		-
 			message: "#^Casting to array\\<string, mixed\\> something that's already array\\<string, mixed\\>\\.$#"
 			count: 4
-			path: libraries/classes/Sanitize.php
-
-		-
-			message: "#^Casting to string something that's already string\\.$#"
-			count: 2
-			path: libraries/classes/Sanitize.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Sanitize\\:\\:escapeJsString\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
 			path: libraries/classes/Sanitize.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7031,11 +7031,6 @@ parameters:
 			path: libraries/classes/Sanitize.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of static method PhpMyAdmin\\\\Sanitize\\:\\:formatJsVal\\(\\) expects bool\\|int\\|string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Sanitize.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\SavedSearches\\:\\:getCriterias\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/SavedSearches.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10871,11 +10871,6 @@ parameters:
 			path: test/classes/SanitizeTest.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\SanitizeTest\\:\\:escapeDataProvider\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/SanitizeTest.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\SanitizeTest\\:\\:variables\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/SanitizeTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -489,7 +489,7 @@
     </UnevaluatedCode>
   </file>
   <file src="libraries/classes/Config/FormDisplay.php">
-    <MixedArgument occurrences="20">
+    <MixedArgument occurrences="18">
       <code>$canonicalPath</code>
       <code>$errorList</code>
       <code>$form-&gt;fields[$field]</code>
@@ -507,8 +507,6 @@
       <code>$val</code>
       <code>$validators[$path]</code>
       <code>$value</code>
-      <code>$valueDefault</code>
-      <code>$valueDefaultJs</code>
       <code>$workPath</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="7">
@@ -593,14 +591,11 @@
     <PossiblyFalseIterator occurrences="1">
       <code>$values[$path]</code>
     </PossiblyFalseIterator>
-    <PossiblyInvalidArgument occurrences="3">
+    <PossiblyInvalidArgument occurrences="1">
       <code>$_POST[$key]</code>
-      <code>$valueDefault</code>
-      <code>$valueDefaultJs</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="2">
+    <PossiblyInvalidCast occurrences="1">
       <code>$valueDefault</code>
-      <code>$valueDefaultJs</code>
     </PossiblyInvalidCast>
     <PossiblyNullOperand occurrences="1"/>
     <PropertyNotSetInConstructor occurrences="1">
@@ -608,11 +603,7 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="libraries/classes/Config/FormDisplayTemplate.php">
-    <MixedArgument occurrences="1">
-      <code>$arg</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="4">
-      <code>$arg</code>
+    <MixedAssignment occurrences="3">
       <code>$isSetupScript</code>
       <code>$vName</code>
       <code>$validator</code>
@@ -3255,11 +3246,10 @@
       <code>$row_id</code>
       <code>$row_id</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="28">
+    <MixedAssignment occurrences="27">
       <code>$GLOBALS['after_insert']</code>
       <code>$GLOBALS['biggest_max_file_size']</code>
       <code>$GLOBALS['checked']</code>
-      <code>$GLOBALS['chg_evt_handler']</code>
       <code>$GLOBALS['columns_cnt']</code>
       <code>$GLOBALS['comments_map']</code>
       <code>$GLOBALS['current_result']</code>
@@ -7773,7 +7763,7 @@
       <code>$GLOBALS['cfg']['CSPAllow']</code>
       <code>$GLOBALS['cfg']['CaptchaCsp']</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="10">
+    <MixedArgument occurrences="9">
       <code>$cspAllow</code>
       <code>$cspAllow</code>
       <code>$cspAllow</code>
@@ -7783,18 +7773,13 @@
       <code>$cspAllow</code>
       <code>$cspAllow</code>
       <code>$cspAllow</code>
-      <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$params</code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['buffer_message']</code>
       <code>$GLOBALS['theme']</code>
       <code>$bufferMessage</code>
       <code>$cspAllow</code>
       <code>$pftext</code>
-      <code>$value</code>
     </MixedAssignment>
     <MixedOperand occurrences="1">
       <code>$GLOBALS['cfg']['CaptchaCsp']</code>
@@ -8282,8 +8267,7 @@
       <code>new $className()</code>
       <code>new $className()</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="3">
-      <code>$column['pma_type']</code>
+    <MixedOperand occurrences="2">
       <code>$file</code>
       <code>$maxlength</code>
     </MixedOperand>
@@ -12383,17 +12367,14 @@
     </RedundantCondition>
   </file>
   <file src="libraries/classes/Sanitize.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="4">
       <code>$found[1]</code>
       <code>$found[1]</code>
       <code>$found[1]</code>
       <code>$found[3]</code>
-      <code>$val</code>
-      <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$url</code>
-      <code>$val</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>string</code>
@@ -12401,10 +12382,9 @@
     <MixedMethodCall occurrences="1">
       <code>get</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="3">
+    <MixedOperand occurrences="2">
       <code>$found[3]</code>
       <code>$url</code>
-      <code>$value</code>
     </MixedOperand>
     <MixedReturnStatement occurrences="2">
       <code>$found[0]</code>
@@ -12416,10 +12396,6 @@
       <code>(array) $_POST</code>
       <code>(array) $_REQUEST</code>
     </RedundantCast>
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(string) $a_string</code>
-      <code>(string) $string</code>
-    </RedundantCastGivenDocblockType>
     <RedundantCondition occurrences="1">
       <code>$GLOBALS['config'] !== null</code>
     </RedundantCondition>
@@ -16045,8 +16021,7 @@
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/classes/SanitizeTest.php">
-    <MixedInferredReturnType occurrences="4">
-      <code>array</code>
+    <MixedInferredReturnType occurrences="3">
       <code>array</code>
       <code>array</code>
       <code>array</code>

--- a/templates/config/form_display/display.twig
+++ b/templates/config/form_display/display.twig
@@ -68,9 +68,9 @@
       'error_value_lte': '{{ 'Value must be less than or equal to %s!'|trans|e('js') }}',
     });
 
-    $.extend(window.defaultValues, {
-      {{ js_default|join(",\n      ")|raw }}
-    });
+    $.extend(window.defaultValues,
+      {{ js_default|json_encode(constant('JSON_HEX_TAG'))|raw }}
+    );
   });
   if (typeof window.configScriptLoaded !== 'undefined' && window.configInlineParams) {
     window.Config.loadInlineConfig();

--- a/templates/header_location.twig
+++ b/templates/header_location.twig
@@ -8,14 +8,14 @@
     <meta http-equiv="Refresh" content="0;url={{ uri }}">
     <script type="text/javascript">
         //<![CDATA[
-        setTimeout(function() { window.location = decodeURI('{{ uri|e('js') }}'); }, 2000);
+        setTimeout(function() { window.location = decodeURI('{{ uri|escape('js') }}'); }, 2000);
         //]]>
     </script>
 </head>
 <body>
 <script type="text/javascript">
     //<![CDATA[
-    document.write('<p><a href="{{ uri|e('js') }}">{% trans 'Go' %}</a></p>');
+    document.write('<p><a href="{{ uri|escape('js') }}">{% trans 'Go' %}</a></p>');
     //]]>
 </script>
 </body>

--- a/templates/header_location.twig
+++ b/templates/header_location.twig
@@ -8,14 +8,14 @@
     <meta http-equiv="Refresh" content="0;url={{ uri }}">
     <script type="text/javascript">
         //<![CDATA[
-        setTimeout(function() { window.location = decodeURI('{{ uri|escape_js_string }}'); }, 2000);
+        setTimeout(function() { window.location = decodeURI('{{ uri|e('js') }}'); }, 2000);
         //]]>
     </script>
 </head>
 <body>
 <script type="text/javascript">
     //<![CDATA[
-    document.write('<p><a href="{{ uri|e|escape_js_string }}">{% trans 'Go' %}</a></p>');
+    document.write('<p><a href="{{ uri|e('js') }}">{% trans 'Go' %}</a></p>');
     //]]>
 </script>
 </body>

--- a/templates/import/javascript.twig
+++ b/templates/import/javascript.twig
@@ -26,7 +26,7 @@ $( function() {
                             </div>
                         </div>
                         <div>
-                            <img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock"> {{ 'Uploading your import file…'|trans|e('js') -}}
+                            <img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock"> {{ 'Uploading your import file…'|trans|escape('js') -}}
                         </div>
                         <div id="statustext"></div>
                     </div>
@@ -51,7 +51,7 @@ $( function() {
                     complete = response.complete;
 
                     if (total==0 && complete==0 && percent==0) {
-                        $("#upload_form_status_info").html('<img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock"> {{ promot_str|e('js') }}');
+                        $("#upload_form_status_info").html('<img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock"> {{ promot_str|escape('js') }}');
                         $("#upload_form_status").css("display", "none");
                     } else {
                         var now = new Date();
@@ -64,7 +64,7 @@ $( function() {
                             now.getSeconds())
                             + now.getMilliseconds() - 1000;
                         var statustext = Functions.sprintf(
-                            "{{ statustext_str|e('js') }}",
+                            "{{ statustext_str|escape('js') }}",
                             Functions.formatBytes(
                                 complete, 1, window.Messages.strDecimalSeparator
                             ),
@@ -86,7 +86,7 @@ $( function() {
                             var used_time = now - import_start;
                             var seconds = parseInt(((total - complete) / complete) * used_time / 1000);
                             var speed = Functions.sprintf(
-                                "{{ second_str|e('js') }}",
+                                "{{ second_str|escape('js') }}",
                                 Functions.formatBytes(complete / used_time * 1000, 1, window.Messages.strDecimalSeparator)
                             );
 
@@ -94,12 +94,12 @@ $( function() {
                             seconds %= 60;
                             var estimated_time;
                             if (minutes > 0) {
-                                estimated_time = "{{ remaining_min|e('js') }}"
+                                estimated_time = "{{ remaining_min|escape('js') }}"
                                     .replace("%MIN", minutes)
                                     .replace("%SEC", seconds);
                             }
                             else {
-                                estimated_time = "{{ remaining_second|e('js') }}"
+                                estimated_time = "{{ remaining_second|escape('js') }}"
                                 .replace("%SEC", seconds);
                             }
 
@@ -149,7 +149,7 @@ $( function() {
             {# No plugin available #}
             {% set image_tag -%}
                 <img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock">
-                {{- 'Please be patient, the file is being uploaded. Details about the upload are not available.'|trans|e('js') -}}
+                {{- 'Please be patient, the file is being uploaded. Details about the upload are not available.'|trans|escape('js') -}}
                 {{- show_docu('faq', 'faq2-9') -}}
             {%- endset %}
             $('#upload_form_status_info').html('{{ image_tag|raw }}');

--- a/templates/import/javascript.twig
+++ b/templates/import/javascript.twig
@@ -10,7 +10,7 @@ $( function() {
                 'import_status': 1
             }, '&') %}
             {% set promot_str = 'The file being uploaded is probably larger than the maximum allowed size or this is a known bug in webkit based (Safari, Google Chrome, Arora etc.) browsers.'|trans|js_format(false) %}
-            {% set statustext_str = '%s of %s'|trans|escape_js_string %}
+            {% set statustext_str = '%s of %s'|trans|e('js') %}
             {% set second_str = '%s/sec.'|trans|js_format(false) %}
             {% set remaining_min = 'About %MIN min. %SEC sec. remaining.'|trans|js_format(false) %}
             {% set remaining_second = 'About %SEC sec. remaining.'|trans|js_format(false) %}

--- a/templates/import/javascript.twig
+++ b/templates/import/javascript.twig
@@ -9,12 +9,12 @@ $( function() {
             {% set ajax_url = 'index.php?route=/import-status&id=' ~ upload_id ~ get_common_raw({
                 'import_status': 1
             }, '&') %}
-            {% set promot_str = 'The file being uploaded is probably larger than the maximum allowed size or this is a known bug in webkit based (Safari, Google Chrome, Arora etc.) browsers.'|trans|js_format(false) %}
-            {% set statustext_str = '%s of %s'|trans|e('js') %}
-            {% set second_str = '%s/sec.'|trans|js_format(false) %}
-            {% set remaining_min = 'About %MIN min. %SEC sec. remaining.'|trans|js_format(false) %}
-            {% set remaining_second = 'About %SEC sec. remaining.'|trans|js_format(false) %}
-            {% set processed_str = 'The file is being processed, please be patient.'|trans|js_format(false) %}
+            {% set promot_str = 'The file being uploaded is probably larger than the maximum allowed size or this is a known bug in webkit based (Safari, Google Chrome, Arora etc.) browsers.'|trans %}
+            {% set statustext_str = '%s of %s'|trans %}
+            {% set second_str = '%s/sec.'|trans %}
+            {% set remaining_min = 'About %MIN min. %SEC sec. remaining.'|trans %}
+            {% set remaining_second = 'About %SEC sec. remaining.'|trans %}
+            {% set processed_str = 'The file is being processed, please be patient.'|trans %}
             {% set import_url = get_common_raw({'import_status': 1}, '&') %}
 
             {% set upload_html %}
@@ -26,7 +26,7 @@ $( function() {
                             </div>
                         </div>
                         <div>
-                            <img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock"> {{ 'Uploading your import file…'|trans|js_format(false) -}}
+                            <img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock"> {{ 'Uploading your import file…'|trans|e('js') -}}
                         </div>
                         <div id="statustext"></div>
                     </div>
@@ -51,7 +51,7 @@ $( function() {
                     complete = response.complete;
 
                     if (total==0 && complete==0 && percent==0) {
-                        $("#upload_form_status_info").html('<img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock"> {{ promot_str|raw }}');
+                        $("#upload_form_status_info").html('<img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock"> {{ promot_str|e('js') }}');
                         $("#upload_form_status").css("display", "none");
                     } else {
                         var now = new Date();
@@ -64,7 +64,7 @@ $( function() {
                             now.getSeconds())
                             + now.getMilliseconds() - 1000;
                         var statustext = Functions.sprintf(
-                            "{{ statustext_str|raw }}",
+                            "{{ statustext_str|e('js') }}",
                             Functions.formatBytes(
                                 complete, 1, window.Messages.strDecimalSeparator
                             ),
@@ -86,7 +86,7 @@ $( function() {
                             var used_time = now - import_start;
                             var seconds = parseInt(((total - complete) / complete) * used_time / 1000);
                             var speed = Functions.sprintf(
-                                "{{ second_str|raw }}",
+                                "{{ second_str|e('js') }}",
                                 Functions.formatBytes(complete / used_time * 1000, 1, window.Messages.strDecimalSeparator)
                             );
 
@@ -94,12 +94,12 @@ $( function() {
                             seconds %= 60;
                             var estimated_time;
                             if (minutes > 0) {
-                                estimated_time = "{{ remaining_min|raw }}"
+                                estimated_time = "{{ remaining_min|e('js') }}"
                                     .replace("%MIN", minutes)
                                     .replace("%SEC", seconds);
                             }
                             else {
-                                estimated_time = "{{ remaining_second|raw }}"
+                                estimated_time = "{{ remaining_second|e('js') }}"
                                 .replace("%SEC", seconds);
                             }
 
@@ -149,7 +149,7 @@ $( function() {
             {# No plugin available #}
             {% set image_tag -%}
                 <img src="{{ image('ajax_clock_small.gif') }}" width="16" height="16" alt="ajax clock">
-                {{- 'Please be patient, the file is being uploaded. Details about the upload are not available.'|trans|js_format(false) -}}
+                {{- 'Please be patient, the file is being uploaded. Details about the upload are not available.'|trans|e('js') -}}
                 {{- show_docu('faq', 'faq2-9') -}}
             {%- endset %}
             $('#upload_form_status_info').html('{{ image_tag|raw }}');

--- a/templates/javascript/redirect.twig
+++ b/templates/javascript/redirect.twig
@@ -1,5 +1,5 @@
 <script type='text/javascript'>
     window.onload = function () {
-        window.location = '{{ url }}';
+        window.location = '{{ url|e('js') }}';
     };
 </script>

--- a/templates/javascript/redirect.twig
+++ b/templates/javascript/redirect.twig
@@ -1,5 +1,5 @@
 <script type='text/javascript'>
     window.onload = function () {
-        window.location = '{{ url|e('js') }}';
+        window.location = '{{ url|escape('js') }}';
     };
 </script>

--- a/templates/scripts.twig
+++ b/templates/scripts.twig
@@ -10,13 +10,13 @@
 {% if files is not empty %}
 window.AJAX.scriptHandler
 {% for file in files %}
-  .add('{{ file.filename|escape_js_string }}', {{ file.has_onload ? 1 : 0 }})
+  .add('{{ file.filename|e('js') }}', {{ file.has_onload ? 1 : 0 }})
 {% endfor %}
 ;
 $(function() {
 {% for file in files %}
   {% if file.has_onload %}
-  window.AJAX.fireOnload('{{ file.filename|escape_js_string }}');
+  window.AJAX.fireOnload('{{ file.filename|e('js') }}');
   {% endif %}
 {% endfor %}
 });

--- a/templates/scripts.twig
+++ b/templates/scripts.twig
@@ -10,13 +10,13 @@
 {% if files is not empty %}
 window.AJAX.scriptHandler
 {% for file in files %}
-  .add('{{ file.filename|e('js') }}', {{ file.has_onload ? 1 : 0 }})
+  .add('{{ file.filename|escape('js') }}', {{ file.has_onload ? 1 : 0 }})
 {% endfor %}
 ;
 $(function() {
 {% for file in files %}
   {% if file.has_onload %}
-  window.AJAX.fireOnload('{{ file.filename|e('js') }}');
+  window.AJAX.fireOnload('{{ file.filename|escape('js') }}');
   {% endif %}
 {% endfor %}
 });

--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -17,7 +17,7 @@
       <td class="text-center">--</td>
     {% else %}
       <td>
-        <select name="funcs[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_1">
+        <select name="funcs[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_1">
           {{ function_options|raw }}
         </select>
       </td>
@@ -30,7 +30,7 @@
       <input type="checkbox" class="checkbox_null" name="fields_null[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_2" aria-label="{% trans 'Use the NULL value for this column.' %}"{{ real_null_value ? ' checked' }}>
       <input type="hidden" class="nullify_code" name="nullify_code[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ nullify_code }}">
       <input type="hidden" class="hashed_field" name="hashed_field[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ column.Field_md5 }}">
-      <input type="hidden" class="multi_edit" name="multi_edit[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ ('[multi_edit][' ~ row_id ~ ']')|escape_js_string }}">
+      <input type="hidden" class="multi_edit" name="multi_edit[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ ('[multi_edit][' ~ row_id ~ ']') }}">
     {% endif %}
   </td>
 
@@ -44,18 +44,18 @@
       {% if is_value_foreign_link %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="foreign">
-        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_3" value="{{ data }}">
+        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_3" value="{{ data }}">
         <a class="ajax browse_foreign" href="{{ url('/browse-foreigners') }}" data-post="{{ get_common({'db': db, 'table': table, 'field': column.Field, 'rownumber': row_id, 'data': data}) }}">{{ get_icon('b_browse', 'Browse foreign values'|trans) }}</a>
       {% elseif foreign_dropdown is not empty %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ column.is_binary ? 'hex' : 'foreign' }}">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')">
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
           {{ foreign_dropdown|raw }}
         </select>
       {% elseif (longtext_double_textarea and 'longtext' in column.pma_type) or 'json' in column.pma_type or 'text' in column.pma_type %}
         {{ backup_field|raw }}
         <textarea name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_3" data-type="{{ data_type }}" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}"
-          {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')">
+          {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
           {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
           {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
         </textarea>
@@ -68,7 +68,7 @@
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="enum">
         {% if column.Type|length > 20 %}
-          <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')">
+          <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
             <option value=""></option>
             {% for enum_value in column.values %}
               <option value="{{ enum_value.plain }}"{{ enum_value.plain == enum_selected_value ? ' selected' }}>{{ enum_value.plain }}</option>
@@ -76,14 +76,14 @@
           </select>
         {% else %}
           {% for enum_value in column.values %}
-            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ enum_value.plain }}" class="textfield" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')"{{ enum_value.plain == enum_selected_value ? ' checked' }}>
+            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ enum_value.plain }}" class="textfield" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')"{{ enum_value.plain == enum_selected_value ? ' checked' }}>
             <label for="field_{{ id_index }}_3_{{ loop.index0 }}">{{ enum_value.plain }}</label>
           {% endfor %}
         {% endif %}
       {% elseif column.pma_type == 'set' %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="set">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}][]" class="textfield" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')" multiple>
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}][]" class="textfield" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')" multiple>
           {% for set_value in set_values %}
             <option value="{{ set_value.plain }}"{{ set_value.plain in data|split(',') ? ' selected' }}>{{ set_value.plain }}</option>
           {% endfor %}
@@ -98,7 +98,7 @@
           {{ backup_field|raw }}
           <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="hex">
           <textarea name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_3" data-type="HEX" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}"
-            {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')">
+            {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
             {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
             {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
           </textarea>
@@ -110,7 +110,7 @@
         {% if is_upload and column.is_blob %}
           <br>
           {# We don't want to prevent users from using browser's default drag-drop feature on some page(s), so we add noDragDrop class to the input #}
-          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape_js_string }}', '{{ row_id|escape_js_string }}', '{{ column.pma_type }}')">
+          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
           {{ max_upload_size }}
         {% endif %}
         {{ select_option_for_upload|raw }}

--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -17,7 +17,7 @@
       <td class="text-center">--</td>
     {% else %}
       <td>
-        <select name="funcs[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_1">
+        <select name="funcs[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_1">
           {{ function_options|raw }}
         </select>
       </td>
@@ -44,18 +44,18 @@
       {% if is_value_foreign_link %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="foreign">
-        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_3" value="{{ data }}">
+        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_3" value="{{ data }}">
         <a class="ajax browse_foreign" href="{{ url('/browse-foreigners') }}" data-post="{{ get_common({'db': db, 'table': table, 'field': column.Field, 'rownumber': row_id, 'data': data}) }}">{{ get_icon('b_browse', 'Browse foreign values'|trans) }}</a>
       {% elseif foreign_dropdown is not empty %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ column.is_binary ? 'hex' : 'foreign' }}">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
           {{ foreign_dropdown|raw }}
         </select>
       {% elseif (longtext_double_textarea and 'longtext' in column.pma_type) or 'json' in column.pma_type or 'text' in column.pma_type %}
         {{ backup_field|raw }}
         <textarea name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_3" data-type="{{ data_type }}" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}"
-          {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
+          {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
           {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
           {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
         </textarea>
@@ -68,7 +68,7 @@
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="enum">
         {% if column.Type|length > 20 %}
-          <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
+          <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
             <option value=""></option>
             {% for enum_value in column.values %}
               <option value="{{ enum_value.plain }}"{{ enum_value.plain == enum_selected_value ? ' selected' }}>{{ enum_value.plain }}</option>
@@ -76,14 +76,14 @@
           </select>
         {% else %}
           {% for enum_value in column.values %}
-            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ enum_value.plain }}" class="textfield" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')"{{ enum_value.plain == enum_selected_value ? ' checked' }}>
+            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ enum_value.plain }}" class="textfield" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')"{{ enum_value.plain == enum_selected_value ? ' checked' }}>
             <label for="field_{{ id_index }}_3_{{ loop.index0 }}">{{ enum_value.plain }}</label>
           {% endfor %}
         {% endif %}
       {% elseif column.pma_type == 'set' %}
         {{ backup_field|raw }}
         <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="set">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}][]" class="textfield" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')" multiple>
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}][]" class="textfield" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')" multiple>
           {% for set_value in set_values %}
             <option value="{{ set_value.plain }}"{{ set_value.plain in data|split(',') ? ' selected' }}>{{ set_value.plain }}</option>
           {% endfor %}
@@ -98,7 +98,7 @@
           {{ backup_field|raw }}
           <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="hex">
           <textarea name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_3" data-type="HEX" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}"
-            {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
+            {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
             {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
             {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
           </textarea>
@@ -110,7 +110,7 @@
         {% if is_upload and column.is_blob %}
           <br>
           {# We don't want to prevent users from using browser's default drag-drop feature on some page(s), so we add noDragDrop class to the input #}
-          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|e('js') }}', '{{ row_id|e('js') }}', '{{ column.pma_type }}')">
+          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
           {{ max_upload_size }}
         {% endif %}
         {{ select_option_for_upload|raw }}

--- a/test/classes/Config/FormDisplayTemplateTest.php
+++ b/test/classes/Config/FormDisplayTemplateTest.php
@@ -267,8 +267,8 @@ class FormDisplayTemplateTest extends AbstractTestCase
         $this->assertEquals(
             [
                 'window.Config.registerFieldValidator(\'testID\', \'\\\';\', true, '
-                . '[\'\\\\r\\\\n\\\\\\\''
-                . '<scrIpt></\\\' + \\\'script>\'])',
+                . '["\\\\r\\\\n\\\\\''
+                . '\u003CscrIpt\u003E\u003C\/\' + \'script\u003E"])',
                 'window.Config.registerFieldValidator(\'testID\', \'\', true)',
             ],
             $js

--- a/test/classes/Controllers/Table/ChangeControllerTest.php
+++ b/test/classes/Controllers/Table/ChangeControllerTest.php
@@ -57,7 +57,7 @@ class ChangeControllerTest extends AbstractTestCase
             '<input type="text" name="fields[multi_edit][0][b80bb7740288fda1f201890375a60c8f]" value="NULL"'
             . ' size="4" min="-2147483648" max="2147483647" data-type="INT" class="textfield"'
             . ' onchange="return'
-            . ' verificationsAfterFieldChange(\'b80bb7740288fda1f201890375a60c8f\', \'0\',\'int(11)\')"'
+            . ' verificationsAfterFieldChange(&quot;b80bb7740288fda1f201890375a60c8f&quot;, 0,&quot;int(11)&quot;)"'
             . ' tabindex="1" inputmode="numeric" id="field_1_3"><input type="hidden"'
             . ' name="auto_increment[multi_edit][0][b80bb7740288fda1f201890375a60c8f]" value="1">',
             $actual
@@ -65,14 +65,14 @@ class ChangeControllerTest extends AbstractTestCase
         $this->assertStringContainsString(
             '<input type="text" name="fields[multi_edit][0][b068931cc450442b63f5b3d276ea4297]" value="NULL" size="20"'
             . ' data-maxlength="20" data-type="CHAR" class="textfield" onchange="return'
-            . ' verificationsAfterFieldChange(\'b068931cc450442b63f5b3d276ea4297\', \'0\',\'varchar(20)\')"'
+            . ' verificationsAfterFieldChange(&quot;b068931cc450442b63f5b3d276ea4297&quot;, 0,&quot;varchar(20)&quot;)"'
             . ' tabindex="2" id="field_2_3">',
             $actual
         );
         $this->assertStringContainsString(
             '<input type="text" name="fields[multi_edit][0][a55dbdcc1a45ed90dbee68864d566b99]" value="NULL.000000"'
             . ' size="4" data-type="DATE" class="textfield datetimefield" onchange="return'
-            . ' verificationsAfterFieldChange(\'a55dbdcc1a45ed90dbee68864d566b99\', \'0\',\'datetime\')"'
+            . ' verificationsAfterFieldChange(&quot;a55dbdcc1a45ed90dbee68864d566b99&quot;, 0,&quot;datetime&quot;)"'
             . ' tabindex="3" id="field_3_3"><input type="hidden"'
             . ' name="fields_type[multi_edit][0][a55dbdcc1a45ed90dbee68864d566b99]" value="datetime">',
             $actual

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1002,7 +1002,7 @@ class InsertEditTest extends AbstractTestCase
 
         $this->assertEquals(
             '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
-            . ' class="textfield datefield" c tabindex="25" id="field_0_3">',
+            . ' class="textfield datefield" onchange="c" tabindex="25" id="field_0_3">',
             $result
         );
 
@@ -1028,7 +1028,7 @@ class InsertEditTest extends AbstractTestCase
         );
         $this->assertEquals(
             '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
-            . ' class="textfield datetimefield" c tabindex="25" id="field_0_3">',
+            . ' class="textfield datetimefield" onchange="c" tabindex="25" id="field_0_3">',
             $result
         );
 
@@ -1054,7 +1054,7 @@ class InsertEditTest extends AbstractTestCase
         );
         $this->assertEquals(
             '<input type="text" name="fieldsa" value="b" size="30" data-type="DATE"'
-            . ' class="textfield datetimefield" c tabindex="25" id="field_0_3">',
+            . ' class="textfield datetimefield" onchange="c" tabindex="25" id="field_0_3">',
             $result
         );
 
@@ -1081,7 +1081,7 @@ class InsertEditTest extends AbstractTestCase
         );
         $this->assertEquals(
             '<input type="text" name="fieldsa" value="b" size="11" min="-2147483648" max="2147483647" data-type="INT"'
-            . ' class="textfield" c tabindex="25" inputmode="numeric" id="field_0_3">',
+            . ' class="textfield" onchange="c" tabindex="25" inputmode="numeric" id="field_0_3">',
             $result
         );
     }
@@ -1181,7 +1181,7 @@ class InsertEditTest extends AbstractTestCase
             "a\na\n"
             . '<textarea name="fieldsb" class="char charField" '
             . 'data-maxlength="25" rows="7" cols="1" dir="/" '
-            . 'id="field_1_3" c tabindex="34" data-type="CHAR">'
+            . 'id="field_1_3" onchange="c" tabindex="34" data-type="CHAR">'
             . '&lt;</textarea>',
             $result
         );
@@ -1216,7 +1216,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals(
             "a\n"
             . '<input type="text" name="fieldsb" value="&lt;" size="20" data-type="'
-            . 'DATE" class="textfield datetimefield" c tabindex="34" id="field_1_3"'
+            . 'DATE" class="textfield datetimefield" onchange="c" tabindex="34" id="field_1_3"'
             . '><input type="hidden" name="auto_incrementb" value="1">'
             . '<input type="hidden" name="fields_typeb" value="timestamp">',
             $result
@@ -2867,7 +2867,6 @@ class InsertEditTest extends AbstractTestCase
                 $resultStub,
                 '',
                 '',
-                '',
                 false,
                 [],
                 &$o_rows,
@@ -2924,7 +2923,6 @@ class InsertEditTest extends AbstractTestCase
                 [],
                 false,
                 $resultStub,
-                '',
                 '',
                 '[a][0]',
                 true,
@@ -3032,7 +3030,6 @@ class InsertEditTest extends AbstractTestCase
             $resultStub,
             '',
             '',
-            '',
             false,
             [],
             $o_rows,
@@ -3112,7 +3109,6 @@ class InsertEditTest extends AbstractTestCase
             $resultStub,
             '',
             '',
-            '',
             false,
             [],
             $o_rows,
@@ -3171,7 +3167,6 @@ class InsertEditTest extends AbstractTestCase
             [],
             false,
             $resultStub,
-            '',
             '',
             '',
             true,

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -845,7 +845,7 @@ class TransformationPluginsTest extends AbstractTestCase
                     [0],
                     new FieldMetadata(MYSQLI_TYPE_TINY, 0, (object) []),
                 ],
-                '<dfn onclick="alert(\'12345\');" title="12345">Jan 01, 1970 at 03:25 AM</dfn>',
+                '<dfn onclick="alert(&quot;12345&quot;);" title="12345">Jan 01, 1970 at 03:25 AM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
@@ -854,7 +854,7 @@ class TransformationPluginsTest extends AbstractTestCase
                     [0],
                     new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) []),
                 ],
-                '<dfn onclick="alert(\'12345678\');" title="12345678">May 23, 1970 at 09:21 PM</dfn>',
+                '<dfn onclick="alert(&quot;12345678&quot;);" title="12345678">May 23, 1970 at 09:21 PM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
@@ -863,7 +863,7 @@ class TransformationPluginsTest extends AbstractTestCase
                     [0],
                     new FieldMetadata(-1, 0, (object) []),
                 ],
-                '<dfn onclick="alert(\'123456789\');" title="123456789">Nov 29, 1973 at 09:33 PM</dfn>',
+                '<dfn onclick="alert(&quot;123456789&quot;);" title="123456789">Nov 29, 1973 at 09:33 PM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
@@ -872,7 +872,7 @@ class TransformationPluginsTest extends AbstractTestCase
                     [0],
                     new FieldMetadata(-1, 0, (object) []),
                 ],
-                '<dfn onclick="alert(\'20100201\');" title="20100201">Feb 01, 2010 at 12:00 AM</dfn>',
+                '<dfn onclick="alert(&quot;20100201&quot;);" title="20100201">Feb 01, 2010 at 12:00 AM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
@@ -885,7 +885,7 @@ class TransformationPluginsTest extends AbstractTestCase
                     ],
                     new FieldMetadata(-1, 0, (object) []),
                 ],
-                '<dfn onclick="alert(\'1617153941\');" title="1617153941">Mar 31, 2021 at 01:25 AM</dfn>',
+                '<dfn onclick="alert(&quot;1617153941&quot;);" title="1617153941">Mar 31, 2021 at 01:25 AM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
@@ -898,7 +898,7 @@ class TransformationPluginsTest extends AbstractTestCase
                     ],
                     new FieldMetadata(-1, 0, (object) []),
                 ],
-                '<dfn onclick="alert(\'1617153941\');" title="1617153941">2021-03-31  01:25:41</dfn>',
+                '<dfn onclick="alert(&quot;1617153941&quot;);" title="1617153941">2021-03-31  01:25:41</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
@@ -911,7 +911,7 @@ class TransformationPluginsTest extends AbstractTestCase
                     ],
                     new FieldMetadata(-1, 0, (object) []),
                 ],
-                '<dfn onclick="alert(\'1617153941\');" title="1617153941">Mar 31, 2021 at 01:25 AM</dfn>',
+                '<dfn onclick="alert(&quot;1617153941&quot;);" title="1617153941">Mar 31, 2021 at 01:25 AM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
@@ -924,7 +924,7 @@ class TransformationPluginsTest extends AbstractTestCase
                     ],
                     new FieldMetadata(-1, 0, (object) []),
                 ],
-                '<dfn onclick="alert(\'1617153941\');" title="1617153941">01:25:41 2021-31-03</dfn>',
+                '<dfn onclick="alert(&quot;1617153941&quot;);" title="1617153941">01:25:41 2021-31-03</dfn>',
             ],
             [
                 new Text_Plain_External(),

--- a/test/classes/SanitizeTest.php
+++ b/test/classes/SanitizeTest.php
@@ -188,14 +188,6 @@ class SanitizeTest extends AbstractTestCase
     }
 
     /**
-     * Test for Sanitize::jsFormat
-     */
-    public function testJsFormat(): void
-    {
-        $this->assertEquals('`foo`', Sanitize::jsFormat('foo'));
-    }
-
-    /**
      * Provider for testFormat
      *
      * @return array
@@ -251,54 +243,6 @@ class SanitizeTest extends AbstractTestCase
                 'foo',
                 'bar"baz',
                 "foo = \"bar\\\"baz\";\n",
-            ],
-        ];
-    }
-
-    /**
-     * Sanitize::escapeJsString tests
-     *
-     * @param string $target expected output
-     * @param string $source string to be escaped
-     *
-     * @dataProvider escapeDataProvider
-     */
-    public function testEscapeJsString(string $target, string $source): void
-    {
-        $this->assertEquals($target, Sanitize::escapeJsString($source));
-    }
-
-    /**
-     * Data provider for testEscape
-     *
-     * @return array data for testEscape test case
-     */
-    public function escapeDataProvider(): array
-    {
-        return [
-            [
-                '\\\';',
-                '\';',
-            ],
-            [
-                '\r\n\\\'<scrIpt></\' + \'script>',
-                "\r\n'<scrIpt></sCRIPT>",
-            ],
-            [
-                '\\\';[XSS]',
-                '\';[XSS]',
-            ],
-            [
-                '</\' + \'script></head><body>[HTML]',
-                '</SCRIPT></head><body>[HTML]',
-            ],
-            [
-                '\"\\\'\\\\\\\'\"',
-                '"\'\\\'"',
-            ],
-            [
-                "\\\\\'\'\'\'\'\'\'\'\'\'\'\'\\\\",
-                "\\''''''''''''\\",
             ],
         ];
     }

--- a/test/classes/SanitizeTest.php
+++ b/test/classes/SanitizeTest.php
@@ -185,20 +185,6 @@ class SanitizeTest extends AbstractTestCase
     public function testGetJsValue(string $key, $value, string $expected): void
     {
         $this->assertEquals($expected, Sanitize::getJsValue($key, $value));
-        $this->assertEquals('foo = 100', Sanitize::getJsValue('foo', '100', false));
-        $array = [
-            '1',
-            '2',
-            '3',
-        ];
-        $this->assertEquals(
-            "foo = [\"1\",\"2\",\"3\",];\n",
-            Sanitize::getJsValue('foo', $array)
-        );
-        $this->assertEquals(
-            "foo = \"bar\\\"baz\";\n",
-            Sanitize::getJsValue('foo', 'bar"baz')
-        );
     }
 
     /**
@@ -250,7 +236,21 @@ class SanitizeTest extends AbstractTestCase
             [
                 'foo',
                 'apostroph\'',
-                "foo = \"apostroph\\'\";\n",
+                "foo = \"apostroph'\";\n",
+            ],
+            [
+                'foo',
+                [
+                    '1',
+                    '2',
+                    '3',
+                ],
+                "foo = [\"1\",\"2\",\"3\"];\n",
+            ],
+            [
+                'foo',
+                'bar"baz',
+                "foo = \"bar\\\"baz\";\n",
             ],
         ];
     }


### PR DESCRIPTION
Here's something that bothered me for some time. There is logic for JS escaping that doesn't really need to be there. The usual way to output a variable into JS context is to use `json_encode`. We also have Twig which implements JS string escaping. Why does phpMyAdmin need custom JS escaping logic? 

My solution is to replace all custom JS escaping with either Twig's escaping (for when a string is needed only) or `json_encode` for when an unknown type is being formatted in JS context. 

I admit this was a little risky because the custom escaping wasn't the same. I also don't know if everything is covered by tests. I can't find any regressions though. 

Overall, I think this is an improvement, but some areas should be looked at more in detail at some later point in time. Perhaps, some code could be moved into templates. 