### PR TITLE
Remove spaces around table name

### DIFF
--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -8,7 +8,7 @@
     </td>
     <th>
         <a href="{{ url('/sql', table_url_params|merge({'pos': 0})) }}" title="{{ browse_table_label_title }}">
-            {{ browse_table_label_truename }}
+            {{- browse_table_label_truename -}}
         </a>
         {{ tracking_icon|raw }}
     </th>


### PR DESCRIPTION
Signed-off-by: Liviu-Mihail Concioiu <liviu.concioiu@gmail.com>

### Description

This PR removes the white space around table names, when a table is dropped.

Before:

![before](https://user-images.githubusercontent.com/25424343/197173078-50802e7e-b474-4b65-bcba-5ab0c718156d.png)

After:

![after](https://user-images.githubusercontent.com/25424343/197173107-afdd10e3-e5c8-40b8-a24d-855d6065ad7e.png)

Fixes #

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
