### PR TITLE
Remove `OutputBuffering::getInstance()` method

### DIFF
--- a/libraries/classes/OutputBuffering.php
+++ b/libraries/classes/OutputBuffering.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * Output buffering wrapper
- */
 
 declare(strict_types=1);
 
@@ -19,7 +16,6 @@ use function ob_get_length;
 use function ob_get_level;
 use function ob_get_status;
 use function ob_start;
-use function register_shutdown_function;
 use function sprintf;
 
 /**
@@ -27,25 +23,18 @@ use function sprintf;
  */
 class OutputBuffering
 {
-    /** @var self */
-    private static $instance;
-
     /** @var int */
     private $mode;
 
     /** @var string */
-    private $content;
+    private $content = '';
 
     /** @var bool */
-    private $on;
+    private $on = false;
 
-    /**
-     * Initializes class
-     */
-    private function __construct()
+    public function __construct()
     {
         $this->mode = $this->getMode();
-        $this->on = false;
     }
 
     /**
@@ -56,7 +45,7 @@ class OutputBuffering
     private function getMode()
     {
         $mode = 0;
-        if ($GLOBALS['cfg']['OBGzip'] && function_exists('ob_start')) {
+        if (! defined('TESTSUITE') && $GLOBALS['cfg']['OBGzip'] && function_exists('ob_start')) {
             if (ini_get('output_handler') === 'ob_gzhandler') {
                 // If a user sets the output_handler in php.ini to ob_gzhandler, then
                 // any right frame file in phpMyAdmin will not be handled properly by
@@ -80,27 +69,13 @@ class OutputBuffering
     }
 
     /**
-     * Returns the singleton OutputBuffering object
-     *
-     * @return OutputBuffering object
-     */
-    public static function getInstance()
-    {
-        if (empty(self::$instance)) {
-            self::$instance = new OutputBuffering();
-        }
-
-        return self::$instance;
-    }
-
-    /**
      * This function will need to run at the top of all pages if output
      * output buffering is turned on.  It also needs to be passed $mode from
      * the PMA_outBufferModeGet() function or it will be useless.
      */
     public function start(): void
     {
-        if ($this->on) {
+        if (defined('TESTSUITE') || $this->on) {
             return;
         }
 
@@ -111,12 +86,6 @@ class OutputBuffering
         ob_start();
         $this->sendHeader('X-ob_mode', (string) $this->mode);
 
-        register_shutdown_function(
-            [
-                self::class,
-                'stop',
-            ]
-        );
         $this->on = true;
     }
 
@@ -134,15 +103,14 @@ class OutputBuffering
      * buffering is turned on.  It also needs to be passed $mode from the
      * PMA_outBufferModeGet() function or it will be useless.
      */
-    public static function stop(): void
+    public function stop(): void
     {
-        $buffer = self::getInstance();
-        if (! $buffer->on) {
+        if (! $this->on) {
             return;
         }
 
-        $buffer->on = false;
-        $buffer->content = ob_get_contents();
+        $this->on = false;
+        $this->content = (string) ob_get_contents();
         if (ob_get_length() <= 0) {
             return;
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5451,16 +5451,6 @@ parameters:
 			path: libraries/classes/Operations.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\OutputBuffering\\:\\:\\$content \\(string\\) does not accept string\\|false\\.$#"
-			count: 1
-			path: libraries/classes/OutputBuffering.php
-
-		-
-			message: "#^Static property PhpMyAdmin\\\\OutputBuffering\\:\\:\\$instance \\(PhpMyAdmin\\\\OutputBuffering\\) in empty\\(\\) is not falsy\\.$#"
-			count: 1
-			path: libraries/classes/OutputBuffering.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Partitioning\\\\Maintenance\\:\\:analyze\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Partitioning/Maintenance.php
@@ -7042,11 +7032,6 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\ResponseRenderer\\:\\:\\$JSON type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/ResponseRenderer.php
-
-		-
-			message: "#^Static property PhpMyAdmin\\\\ResponseRenderer\\:\\:\\$instance \\(PhpMyAdmin\\\\ResponseRenderer\\) in empty\\(\\) is not falsy\\.$#"
 			count: 1
 			path: libraries/classes/ResponseRenderer.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9114,14 +9114,6 @@
       <code>'data'</code>
     </TypeDoesNotContainNull>
   </file>
-  <file src="libraries/classes/OutputBuffering.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>empty(self::$instance)</code>
-    </DocblockTypeContradiction>
-    <PropertyNotSetInConstructor occurrences="1">
-      <code>$content</code>
-    </PropertyNotSetInConstructor>
-  </file>
   <file src="libraries/classes/Partitioning/Maintenance.php">
     <MixedArrayAccess occurrences="4">
       <code>$row['Table']</code>
@@ -12262,9 +12254,6 @@
     </MixedArgument>
   </file>
   <file src="libraries/classes/ResponseRenderer.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>empty(self::$instance)</code>
-    </DocblockTypeContradiction>
     <MixedAssignment occurrences="1">
       <code>$value</code>
     </MixedAssignment>


### PR DESCRIPTION
The `OutputBuffering` class is only used inside the `ResponseRendering` class and since it's already a singleton, there is no reason to use the `OutputBuffering` class as a singleton as well.
Also removes the need for the `register_shutdown_function()` call for `OutputBuffering::stop()`.