### PR TITLE
Replace `PhpMyAdmin\Core::fatalError()` method calls

### DIFF
--- a/libraries/classes/Common.php
+++ b/libraries/classes/Common.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use Exception;
 use PhpMyAdmin\Config\ConfigFile;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Dbal\DatabaseName;
@@ -13,6 +14,7 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
 use PhpMyAdmin\SqlParser\Lexer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Throwable;
 
 use function __;
 use function array_pop;
@@ -40,6 +42,7 @@ use function ob_start;
 use function register_shutdown_function;
 use function restore_error_handler;
 use function session_id;
+use function sprintf;
 use function strlen;
 use function trigger_error;
 use function urldecode;
@@ -157,8 +160,19 @@ final class Common
         $config->checkPermissions();
         $config->checkErrors();
 
-        self::checkServerConfiguration();
-        self::checkRequest();
+        try {
+            self::checkServerConfiguration();
+            self::checkRequest();
+        } catch (Throwable $exception) {
+            echo (new Template())->render('error/generic', [
+                'lang' => $GLOBALS['lang'] ?? 'en',
+                'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                'error_message' => $exception->getMessage(),
+            ]);
+
+            return;
+        }
+
         self::setCurrentServerGlobal($config);
 
         $GLOBALS['cfg'] = $config->settings;
@@ -225,13 +239,17 @@ final class Common
             Logging::logUser($GLOBALS['cfg']['Server']['user']);
 
             if ($GLOBALS['dbi']->getVersion() < $GLOBALS['cfg']['MysqlMinVersion']['internal']) {
-                Core::fatalError(
-                    __('You should upgrade to %s %s or later.'),
-                    [
+                echo (new Template())->render('error/generic', [
+                    'lang' => $GLOBALS['lang'] ?? 'en',
+                    'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                    'error_message' => sprintf(
+                        __('You should upgrade to %s %s or later.'),
                         'MySQL',
-                        $GLOBALS['cfg']['MysqlMinVersion']['human'],
-                    ]
-                );
+                        (string) $GLOBALS['cfg']['MysqlMinVersion']['human']
+                    ),
+                ]);
+
+                return;
             }
 
             // Sets the default delimiter (if specified).
@@ -518,13 +536,11 @@ final class Common
          * empty value or 0.
          */
         if (extension_loaded('mbstring') && ! empty(ini_get('mbstring.func_overload'))) {
-            Core::fatalError(
-                __(
-                    'You have enabled mbstring.func_overload in your PHP '
-                    . 'configuration. This option is incompatible with phpMyAdmin '
-                    . 'and might cause some data to be corrupted!'
-                )
-            );
+            throw new Exception(__(
+                'You have enabled mbstring.func_overload in your PHP '
+                . 'configuration. This option is incompatible with phpMyAdmin '
+                . 'and might cause some data to be corrupted!'
+            ));
         }
 
         /**
@@ -535,11 +551,9 @@ final class Common
             return;
         }
 
-        Core::fatalError(
-            __(
-                'The ini_get and/or ini_set functions are disabled in php.ini. phpMyAdmin requires these functions!'
-            )
-        );
+        throw new Exception(__(
+            'The ini_get and/or ini_set functions are disabled in php.ini. phpMyAdmin requires these functions!'
+        ));
     }
 
     /**
@@ -548,7 +562,7 @@ final class Common
     private static function checkRequest(): void
     {
         if (isset($_REQUEST['GLOBALS']) || isset($_FILES['GLOBALS'])) {
-            Core::fatalError(__('GLOBALS overwrite attempt'));
+            throw new Exception(__('GLOBALS overwrite attempt'));
         }
 
         /**
@@ -558,7 +572,7 @@ final class Common
             return;
         }
 
-        Core::fatalError(__('possible exploit'));
+        throw new Exception(__('possible exploit'));
     }
 
     private static function connectToDatabaseServer(DatabaseInterface $dbi, AuthenticationPlugin $auth): void

--- a/libraries/classes/Common.php
+++ b/libraries/classes/Common.php
@@ -102,7 +102,18 @@ final class Common
         $errorHandler = $GLOBALS['containerBuilder']->get('error_handler');
         $GLOBALS['errorHandler'] = $errorHandler;
 
-        self::checkRequiredPhpExtensions();
+        try {
+            self::checkRequiredPhpExtensions();
+        } catch (Throwable $exception) {
+            echo (new Template())->render('error/generic', [
+                'lang' => $GLOBALS['lang'] ?? 'en',
+                'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                'error_message' => $exception->getMessage(),
+            ]);
+
+            return;
+        }
+
         self::configurePhpSettings();
         self::cleanupPathInfo();
 
@@ -334,6 +345,15 @@ final class Common
          */
         if (! function_exists('ctype_alpha')) {
             Core::warnMissingExtension('ctype', true);
+        }
+
+        if (! function_exists('mysqli_connect')) {
+            $moreInfo = sprintf(__('See %sour documentation%s for more information.'), '[doc@faqmysql]', '[/doc]');
+            Core::warnMissingExtension('mysqli', true, $moreInfo);
+        }
+
+        if (! function_exists('session_name')) {
+            Core::warnMissingExtension('session', true);
         }
 
         /**

--- a/libraries/classes/Common.php
+++ b/libraries/classes/Common.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
-use Exception;
 use PhpMyAdmin\Config\ConfigFile;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Dbal\DatabaseName;
 use PhpMyAdmin\Dbal\TableName;
+use PhpMyAdmin\Exceptions\MissingExtensionException;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Plugins\AuthenticationPlugin;
 use PhpMyAdmin\SqlParser\Lexer;
+use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Throwable;
 
 use function __;
 use function array_pop;
@@ -104,7 +104,7 @@ final class Common
 
         try {
             self::checkRequiredPhpExtensions();
-        } catch (Throwable $exception) {
+        } catch (MissingExtensionException $exception) {
             echo (new Template())->render('error/generic', [
                 'lang' => $GLOBALS['lang'] ?? 'en',
                 'dir' => $GLOBALS['text_dir'] ?? 'ltr',
@@ -174,7 +174,7 @@ final class Common
         try {
             self::checkServerConfiguration();
             self::checkRequest();
-        } catch (Throwable $exception) {
+        } catch (RuntimeException $exception) {
             echo (new Template())->render('error/generic', [
                 'lang' => $GLOBALS['lang'] ?? 'en',
                 'dir' => $GLOBALS['text_dir'] ?? 'ltr',
@@ -556,7 +556,7 @@ final class Common
          * empty value or 0.
          */
         if (extension_loaded('mbstring') && ! empty(ini_get('mbstring.func_overload'))) {
-            throw new Exception(__(
+            throw new RuntimeException(__(
                 'You have enabled mbstring.func_overload in your PHP '
                 . 'configuration. This option is incompatible with phpMyAdmin '
                 . 'and might cause some data to be corrupted!'
@@ -571,7 +571,7 @@ final class Common
             return;
         }
 
-        throw new Exception(__(
+        throw new RuntimeException(__(
             'The ini_get and/or ini_set functions are disabled in php.ini. phpMyAdmin requires these functions!'
         ));
     }
@@ -582,7 +582,7 @@ final class Common
     private static function checkRequest(): void
     {
         if (isset($_REQUEST['GLOBALS']) || isset($_FILES['GLOBALS'])) {
-            throw new Exception(__('GLOBALS overwrite attempt'));
+            throw new RuntimeException(__('GLOBALS overwrite attempt'));
         }
 
         /**
@@ -592,7 +592,7 @@ final class Common
             return;
         }
 
-        throw new Exception(__('possible exploit'));
+        throw new RuntimeException(__('possible exploit'));
     }
 
     private static function connectToDatabaseServer(DatabaseInterface $dbi, AuthenticationPlugin $auth): void

--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -636,16 +636,20 @@ class Config
 
             if ($contents === false) {
                 $this->sourceMtime = 0;
-                Core::fatalError(
-                    sprintf(
+                echo (new Template())->render('error/generic', [
+                    'lang' => $GLOBALS['lang'] ?? 'en',
+                    'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                    'error_message' => sprintf(
                         function_exists('__')
-                        ? __('Existing configuration file (%s) is not readable.')
-                        : 'Existing configuration file (%s) is not readable.',
+                            ? __('Existing configuration file (%s) is not readable.')
+                            : 'Existing configuration file (%s) is not readable.',
                         $this->getSource()
-                    )
-                );
+                    ),
+                ]);
 
-                return false;
+                if (! defined('TESTSUITE')) {
+                    exit;
+                }
             }
         }
 
@@ -675,11 +679,13 @@ class Config
         }
 
         $this->sourceMtime = 0;
-        Core::fatalError(
-            __(
-                'Wrong permissions on configuration file, should not be world writable!'
-            )
-        );
+        echo (new Template())->render('error/generic', [
+            'lang' => $GLOBALS['lang'] ?? 'en',
+            'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+            'error_message' => __('Wrong permissions on configuration file, should not be world writable!'),
+        ]);
+
+        exit;
     }
 
     /**
@@ -1041,14 +1047,18 @@ class Config
             return;
         }
 
-        Core::fatalError(
-            sprintf(
+        echo (new Template())->render('error/generic', [
+            'lang' => $GLOBALS['lang'] ?? 'en',
+            'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+            'error_message' => sprintf(
                 'Failed to load phpMyAdmin configuration (%s:%s): %s',
                 Error::relPath($error['file']),
                 $error['line'],
                 $error['message']
-            )
-        );
+            ),
+        ]);
+
+        exit;
     }
 
     /**

--- a/libraries/classes/Controllers/AbstractController.php
+++ b/libraries/classes/Controllers/AbstractController.php
@@ -146,7 +146,12 @@ abstract class AbstractController
         }
 
         $this->response->setHttpResponseCode(400);
-        Core::fatalError($errorMessage);
+        $this->response->setRequestStatus(false);
+        $this->response->addHTML(Message::error($errorMessage)->getDisplay());
+
+        if (! defined('TESTSUITE')) {
+            exit;
+        }
     }
 
     /**

--- a/libraries/classes/Controllers/Export/ExportController.php
+++ b/libraries/classes/Controllers/Export/ExportController.php
@@ -129,7 +129,10 @@ final class ExportController extends AbstractController
 
         // Check export type
         if (empty($GLOBALS['export_plugin'])) {
-            Core::fatalError(__('Bad type!'));
+            $this->response->setRequestStatus(false);
+            $this->response->addHTML(Message::error(__('Bad type!'))->getDisplay());
+
+            return;
         }
 
         /**
@@ -221,7 +224,10 @@ final class ExportController extends AbstractController
         } elseif ($GLOBALS['export_type'] === 'raw') {
             $GLOBALS['errorUrl'] = Url::getFromRoute('/server/export', ['sql_query' => $GLOBALS['sql_query']]);
         } else {
-            Core::fatalError(__('Bad parameters!'));
+            $this->response->setRequestStatus(false);
+            $this->response->addHTML(Message::error(__('Bad parameters!'))->getDisplay());
+
+            return;
         }
 
         // Merge SQL Query aliases with Export aliases from

--- a/libraries/classes/Controllers/Import/ImportController.php
+++ b/libraries/classes/Controllers/Import/ImportController.php
@@ -245,7 +245,10 @@ final class ImportController extends AbstractController
         if (! in_array($GLOBALS['format'], ['csv', 'ldi', 'mediawiki', 'ods', 'shp', 'sql', 'xml'])) {
             // this should not happen for a normal user
             // but only during an attack
-            Core::fatalError('Incorrect format parameter');
+            $this->response->setRequestStatus(false);
+            $this->response->addHTML(Message::error(__('Incorrect format parameter'))->getDisplay());
+
+            return;
         }
 
         $post_patterns = [

--- a/libraries/classes/Controllers/SchemaExportController.php
+++ b/libraries/classes/Controllers/SchemaExportController.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers;
 
-use PhpMyAdmin\Core;
 use PhpMyAdmin\Export;
 use PhpMyAdmin\Html\MySQLDocumentation;
 use PhpMyAdmin\Http\ServerRequest;
+use PhpMyAdmin\Message;
+use PhpMyAdmin\ResponseRenderer;
 
 use function __;
 
@@ -19,9 +20,13 @@ class SchemaExportController
     /** @var Export */
     private $export;
 
-    public function __construct(Export $export)
+    /** @var ResponseRenderer */
+    private $response;
+
+    public function __construct(Export $export, ResponseRenderer $response)
     {
         $this->export = $export;
+        $this->response = $response;
     }
 
     public function __invoke(ServerRequest $request): void
@@ -30,7 +35,8 @@ class SchemaExportController
             $errorMessage = __('Missing parameter:') . ' export_type'
                 . MySQLDocumentation::showDocumentation('faq', 'faqmissingparameters', true)
                 . '[br]';
-            Core::fatalError($errorMessage);
+            $this->response->setRequestStatus(false);
+            $this->response->addHTML(Message::error($errorMessage)->getDisplay());
 
             return;
         }

--- a/libraries/classes/Controllers/SchemaExportController.php
+++ b/libraries/classes/Controllers/SchemaExportController.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Html\MySQLDocumentation;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
+use Throwable;
 
 use function __;
 
@@ -45,6 +46,11 @@ class SchemaExportController
          * Include the appropriate Schema Class depending on $export_type
          * default is PDF
          */
-        $this->export->processExportSchema($request->getParsedBodyParam('export_type'));
+        try {
+            $this->export->processExportSchema($request->getParsedBodyParam('export_type'));
+        } catch (Throwable $exception) {
+            $this->response->setRequestStatus(false);
+            $this->response->addHTML(Message::error($exception->getMessage())->getDisplay());
+        }
     }
 }

--- a/libraries/classes/Controllers/SchemaExportController.php
+++ b/libraries/classes/Controllers/SchemaExportController.php
@@ -9,7 +9,7 @@ use PhpMyAdmin\Html\MySQLDocumentation;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
-use Throwable;
+use RuntimeException;
 
 use function __;
 
@@ -48,7 +48,7 @@ class SchemaExportController
          */
         try {
             $this->export->processExportSchema($request->getParsedBodyParam('export_type'));
-        } catch (Throwable $exception) {
+        } catch (RuntimeException $exception) {
             $this->response->setRequestStatus(false);
             $this->response->addHTML(Message::error($exception->getMessage())->getDisplay());
         }

--- a/libraries/classes/Controllers/Setup/FormController.php
+++ b/libraries/classes/Controllers/Setup/FormController.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Controllers\Setup;
 
-use PhpMyAdmin\Config\Forms\BaseForm;
 use PhpMyAdmin\Config\Forms\Setup\SetupFormList;
-use PhpMyAdmin\Core;
 use PhpMyAdmin\Setup\FormProcessing;
 
 use function __;
@@ -29,11 +27,14 @@ class FormController extends AbstractController
 
         $formClass = SetupFormList::get($formset);
         if ($formClass === null) {
-            Core::fatalError(__('Incorrect form specified!'));
+            return $this->template->render('error/generic', [
+                'lang' => $GLOBALS['lang'] ?? 'en',
+                'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                'error_message' => __('Incorrect form specified!'),
+            ]);
         }
 
         ob_start();
-        /** @var BaseForm $form */
         $form = new $formClass($this->config);
         FormProcessing::process($form);
         $page = ob_get_clean();

--- a/libraries/classes/Controllers/Setup/MainController.php
+++ b/libraries/classes/Controllers/Setup/MainController.php
@@ -21,7 +21,13 @@ final class MainController
     public function __invoke(ServerRequest $request): void
     {
         if (@file_exists(CONFIG_FILE) && ! $GLOBALS['cfg']['DBG']['demo']) {
-            Core::fatalError(__('Configuration already exists, setup is disabled!'));
+            echo (new Template())->render('error/generic', [
+                'lang' => $GLOBALS['lang'] ?? 'en',
+                'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                'error_message' => __('Configuration already exists, setup is disabled!'),
+            ]);
+
+            return;
         }
 
         /** @var mixed $pageParam */

--- a/libraries/classes/Controllers/Setup/ValidateController.php
+++ b/libraries/classes/Controllers/Setup/ValidateController.php
@@ -34,7 +34,9 @@ final class ValidateController
         $valuesParam = $request->getParsedBodyParam('values');
         $values = json_decode(is_string($valuesParam) ? $valuesParam : '');
         if (! ($values instanceof stdClass)) {
-            Core::fatalError(__('Wrong data'));
+            echo json_encode(['success' => false, 'message' => __('Wrong data')]);
+
+            return;
         }
 
         $values = (array) $values;

--- a/libraries/classes/Controllers/Table/GetFieldController.php
+++ b/libraries/classes/Controllers/Table/GetFieldController.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Http\ServerRequest;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\Mime;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
@@ -62,8 +63,9 @@ class GetFieldController extends AbstractController
             || ! isset($_GET['where_clause_sign'])
             || ! Core::checkSqlQuerySignature($_GET['where_clause'], $_GET['where_clause_sign'])
         ) {
+            $this->response->setRequestStatus(false);
             /* l10n: In case a SQL query did not pass a security check  */
-            Core::fatalError(__('There is an issue with your request.'));
+            $this->response->addHTML(Message::error(__('There is an issue with your request.'))->getDisplay());
 
             return;
         }

--- a/libraries/classes/Controllers/Transformation/WrapperController.php
+++ b/libraries/classes/Controllers/Transformation/WrapperController.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Dbal\TableName;
 use PhpMyAdmin\DbTableExists;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Image\ImageWrapper;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Transformations;
@@ -74,8 +75,9 @@ class WrapperController extends AbstractController
 
         $query = $this->getQuery($table, $request->getParam('where_clause'), $request->getParam('where_clause_sign'));
         if ($query === null) {
+            $this->response->setRequestStatus(false);
             /* l10n: In case a SQL query did not pass a security check  */
-            Core::fatalError(__('There is an issue with your request.'));
+            $this->response->addHTML(Message::error(__('There is an issue with your request.'))->getDisplay());
 
             return;
         }

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use Exception;
 use PhpMyAdmin\Http\ServerRequest;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -211,9 +212,7 @@ class Core
         }
 
         if ($fatal) {
-            self::fatalError($message);
-
-            return;
+            throw new Exception(Sanitize::sanitizeMessage($message));
         }
 
         $GLOBALS['errorHandler']->addError($message, E_USER_WARNING, '', 0, false);

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -52,7 +52,6 @@ use function substr;
 use function trigger_error;
 use function unserialize;
 use function urldecode;
-use function vsprintf;
 
 use const DATE_RFC1123;
 use const E_USER_ERROR;
@@ -83,20 +82,10 @@ class Core
      *
      * loads language file if not loaded already
      *
-     * @param string       $error_message the error message or named error message
-     * @param string|array $message_args  arguments applied to $error_message
+     * @param string $error_message the error message or named error message
      */
-    public static function fatalError(
-        string $error_message,
-        $message_args = null
-    ): void {
-        /* Use format string if applicable */
-        if (is_string($message_args)) {
-            $error_message = sprintf($error_message, $message_args);
-        } elseif (is_array($message_args)) {
-            $error_message = vsprintf($error_message, $message_args);
-        }
-
+    public static function fatalError(string $error_message): void
+    {
         /**
          * Avoid using Response class as config does not have to be loaded yet
          * (this can happen on early fatal error)

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
-use Exception;
+use PhpMyAdmin\Exceptions\MissingExtensionException;
 use PhpMyAdmin\Http\ServerRequest;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -134,7 +134,7 @@ class Core
         }
 
         if ($fatal) {
-            throw new Exception(Sanitize::sanitizeMessage($message));
+            throw new MissingExtensionException(Sanitize::sanitizeMessage($message));
         }
 
         $GLOBALS['errorHandler']->addError($message, E_USER_WARNING, '', 0, false);

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -2083,15 +2083,6 @@ class DatabaseInterface implements DbalInterface
             return new self($extension);
         }
 
-        if (! Util::checkDbExtension('mysqli')) {
-            $docLink = sprintf(
-                __('See %sour documentation%s for more information.'),
-                '[doc@faqmysql]',
-                '[/doc]'
-            );
-            Core::warnMissingExtension('mysqli', true, $docLink);
-        }
-
         return new self(new DbiMysqli());
     }
 

--- a/libraries/classes/Exceptions/MissingExtensionException.php
+++ b/libraries/classes/Exceptions/MissingExtensionException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Exceptions;
+
+use RuntimeException;
+
+class MissingExtensionException extends RuntimeException
+{
+}

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -7,13 +7,13 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
-use Exception;
 use PhpMyAdmin\Controllers\Database\ExportController as DatabaseExportController;
 use PhpMyAdmin\Controllers\Server\ExportController as ServerExportController;
 use PhpMyAdmin\Controllers\Table\ExportController as TableExportController;
 use PhpMyAdmin\Dbal\DatabaseName;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Plugins\SchemaPlugin;
+use RuntimeException;
 
 use function __;
 use function array_filter;
@@ -1260,7 +1260,7 @@ class Export
 
         // Check schema export type
         if ($exportPlugin === null) {
-            throw new Exception(__('Bad type!'));
+            throw new RuntimeException(__('Bad type!'));
         }
 
         $this->dbi->selectDb($_POST['db']);

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use Exception;
 use PhpMyAdmin\Controllers\Database\ExportController as DatabaseExportController;
 use PhpMyAdmin\Controllers\Server\ExportController as ServerExportController;
 use PhpMyAdmin\Controllers\Table\ExportController as TableExportController;
@@ -1259,7 +1260,7 @@ class Export
 
         // Check schema export type
         if ($exportPlugin === null) {
-            Core::fatalError(__('Bad type!'));
+            throw new Exception(__('Bad type!'));
         }
 
         $this->dbi->selectDb($_POST['db']);

--- a/libraries/classes/Plugins.php
+++ b/libraries/classes/Plugins.php
@@ -27,6 +27,7 @@ use Throwable;
 use function __;
 use function class_exists;
 use function count;
+use function defined;
 use function get_class;
 use function htmlspecialchars;
 use function is_subclass_of;
@@ -628,10 +629,16 @@ class Plugins
             . ucfirst(strtolower($GLOBALS['cfg']['Server']['auth_type']));
 
         if (! class_exists($class)) {
-            Core::fatalError(
-                __('Invalid authentication method set in configuration:')
-                . ' ' . $GLOBALS['cfg']['Server']['auth_type']
-            );
+            echo (new Template())->render('error/generic', [
+                'lang' => $GLOBALS['lang'] ?? 'en',
+                'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                'error_message' => __('Invalid authentication method set in configuration:')
+                    . ' ' . $GLOBALS['cfg']['Server']['auth_type'],
+            ]);
+
+            if (! defined('TESTSUITE')) {
+                exit;
+            }
         }
 
         /** @var AuthenticationPlugin $plugin */

--- a/libraries/classes/Plugins/Auth/AuthenticationHttp.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationHttp.php
@@ -198,10 +198,18 @@ class AuthenticationHttp extends AuthenticationPlugin
         parent::showFailure($failure);
         $error = $GLOBALS['dbi']->getError();
         if ($error && $GLOBALS['errno'] != 1045) {
-            Core::fatalError($error);
-        } else {
-            $this->authForm();
+            echo $this->template->render('error/generic', [
+                'lang' => $GLOBALS['lang'] ?? 'en',
+                'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                'error_message' => $error,
+            ]);
+
+            if (! defined('TESTSUITE')) {
+                exit;
+            }
         }
+
+        $this->authForm();
     }
 
     /**

--- a/libraries/classes/Plugins/Auth/AuthenticationSignon.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationSignon.php
@@ -42,7 +42,15 @@ class AuthenticationSignon extends AuthenticationPlugin
         ResponseRenderer::getInstance()->disable();
         unset($_SESSION['LAST_SIGNON_URL']);
         if (empty($GLOBALS['cfg']['Server']['SignonURL'])) {
-            Core::fatalError('You must set SignonURL!');
+            echo $this->template->render('error/generic', [
+                'lang' => $GLOBALS['lang'] ?? 'en',
+                'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                'error_message' => 'You must set SignonURL!',
+            ]);
+
+            if (! defined('TESTSUITE')) {
+                exit;
+            }
         } else {
             Core::sendHeaderLocation($GLOBALS['cfg']['Server']['SignonURL']);
         }
@@ -145,10 +153,13 @@ class AuthenticationSignon extends AuthenticationPlugin
         /* Handle script based auth */
         if ($script_name !== '') {
             if (! @file_exists($script_name)) {
-                Core::fatalError(
-                    __('Can not find signon authentication script:')
-                    . ' ' . $script_name
-                );
+                echo $this->template->render('error/generic', [
+                    'lang' => $GLOBALS['lang'] ?? 'en',
+                    'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+                    'error_message' => __('Can not find signon authentication script:') . ' ' . $script_name,
+                ]);
+
+                exit;
             }
 
             include $script_name;

--- a/libraries/classes/Routing.php
+++ b/libraries/classes/Routing.php
@@ -203,9 +203,13 @@ class Routing
             return;
         }
 
-        Core::fatalError(sprintf(
-            __('Error 404! The page %s was not found.'),
-            '[code]' . htmlspecialchars($route) . '[/code]'
-        ));
+        echo (new Template())->render('error/generic', [
+            'lang' => $GLOBALS['lang'] ?? 'en',
+            'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+            'error_message' => Sanitize::sanitizeMessage(sprintf(
+                __('Error 404! The page %s was not found.'),
+                '[code]' . htmlspecialchars($route) . '[/code]'
+            )),
+        ]);
     }
 }

--- a/libraries/classes/Session.php
+++ b/libraries/classes/Session.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use function defined;
 use function htmlspecialchars;
 use function implode;
 use function ini_get;
@@ -52,7 +53,13 @@ class Session
             return;
         }
 
-        Core::fatalError('Failed to generate random CSRF token!');
+        echo (new Template())->render('error/generic', [
+            'lang' => $GLOBALS['lang'] ?? 'en',
+            'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+            'error_message' => 'Failed to generate random CSRF token!',
+        ]);
+
+        exit;
     }
 
     /**
@@ -101,14 +108,19 @@ class Session
         }
 
         // Session initialization is done before selecting language, so we can not use translations here.
-        Core::fatalError(
-            'Error during session start; please check your PHP and/or '
+        $errorMessage = 'Error during session start; please check your PHP and/or '
             . 'webserver log file and configure your PHP '
             . 'installation properly. Also ensure that cookies are enabled '
             . 'in your browser.'
             . '<br><br>'
-            . implode('<br><br>', $messages)
-        );
+            . implode('<br><br>', $messages);
+        echo (new Template())->render('error/generic', [
+            'lang' => $GLOBALS['lang'] ?? 'en',
+            'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+            'error_message' => $errorMessage,
+        ]);
+
+        exit;
     }
 
     /**
@@ -239,6 +251,14 @@ class Session
             return;
         }
 
-        Core::fatalError('Failed to store CSRF token in session! Probably sessions are not working properly.');
+        echo (new Template())->render('error/generic', [
+            'lang' => $GLOBALS['lang'] ?? 'en',
+            'dir' => $GLOBALS['text_dir'] ?? 'ltr',
+            'error_message' => 'Failed to store CSRF token in session! Probably sessions are not working properly.',
+        ]);
+
+        if (! defined('TESTSUITE')) {
+            exit;
+        }
     }
 }

--- a/libraries/classes/Session.php
+++ b/libraries/classes/Session.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
-use function function_exists;
 use function htmlspecialchars;
 use function implode;
 use function ini_get;
@@ -120,10 +119,7 @@ class Session
      */
     public static function setUp(Config $config, ErrorHandler $errorHandler): void
     {
-        // verify if PHP supports session, die if it does not
-        if (! function_exists('session_name')) {
-            Core::warnMissingExtension('session', true);
-        } elseif (! empty(ini_get('session.auto_start')) && session_name() !== 'phpMyAdmin' && ! empty(session_id())) {
+        if (! empty(ini_get('session.auto_start')) && session_name() !== 'phpMyAdmin' && ! empty(session_id())) {
             // Do not delete the existing non empty session, it might be used by
             // other applications; instead just close it.
             if (empty($_SESSION)) {

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2326,16 +2326,6 @@ class Util
     }
 
     /**
-     * Checks whether database extension is loaded
-     *
-     * @param string $extension mysql extension to check
-     */
-    public static function checkDbExtension(string $extension = 'mysqli'): bool
-    {
-        return function_exists($extension . '_connect');
-    }
-
-    /**
      * Returns list of used PHP extensions.
      *
      * @return string[]
@@ -2343,7 +2333,7 @@ class Util
     public static function listPHPExtensions(): array
     {
         $result = [];
-        if (self::checkDbExtension('mysqli')) {
+        if (function_exists('mysqli_connect')) {
             $result[] = 'mysqli';
         }
 

--- a/libraries/services_controllers.php
+++ b/libraries/services_controllers.php
@@ -813,7 +813,7 @@ return [
         ],
         SchemaExportController::class => [
             'class' => SchemaExportController::class,
-            'arguments' => ['$export' => '@export'],
+            'arguments' => ['$export' => '@export', '$response' => '@response'],
         ],
         Server\BinlogController::class => [
             'class' => Server\BinlogController::class,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1996,11 +1996,6 @@ parameters:
 			path: libraries/classes/Core.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Core\\:\\:fatalError\\(\\) has parameter \\$message_args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Core.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Core\\:\\:previewSQL\\(\\) has parameter \\$query_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Core.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2088,16 +2088,8 @@
       <code>$GLOBALS['whatStrucOrData']</code>
     </PossiblyInvalidCast>
     <PossiblyInvalidPropertyAssignmentValue occurrences="2"/>
-    <PossiblyNullArgument occurrences="18">
+    <PossiblyNullArgument occurrences="10">
       <code>$GLOBALS['charset']</code>
-      <code>$GLOBALS['export_plugin']</code>
-      <code>$GLOBALS['export_plugin']</code>
-      <code>$GLOBALS['export_plugin']</code>
-      <code>$GLOBALS['export_plugin']</code>
-      <code>$GLOBALS['export_plugin']</code>
-      <code>$GLOBALS['export_plugin']</code>
-      <code>$GLOBALS['export_plugin']</code>
-      <code>$GLOBALS['export_plugin']</code>
       <code>$GLOBALS['export_type']</code>
       <code>$GLOBALS['export_type']</code>
       <code>$GLOBALS['export_type']</code>
@@ -2108,10 +2100,6 @@
       <code>$GLOBALS['export_type']</code>
       <code>$GLOBALS['filename_template']</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="2">
-      <code>exportFooter</code>
-      <code>exportHeader</code>
-    </PossiblyNullReference>
     <RedundantCondition occurrences="2">
       <code>! $GLOBALS['save_on_server']</code>
       <code>$outputFormat === 'sendit' &amp;&amp; ! $GLOBALS['save_on_server']</code>
@@ -3059,21 +3047,11 @@
       <code>$value</code>
     </MixedAssignment>
   </file>
-  <file src="libraries/classes/Controllers/Setup/FormController.php">
-    <UndefinedClass occurrences="1">
-      <code>new $formClass($this-&gt;config)</code>
-    </UndefinedClass>
-  </file>
   <file src="libraries/classes/Controllers/Setup/HomeController.php">
     <MixedArgumentTypeCoercion occurrences="2">
       <code>$id</code>
       <code>$id</code>
     </MixedArgumentTypeCoercion>
-  </file>
-  <file src="libraries/classes/Controllers/Setup/ValidateController.php">
-    <MixedAssignment occurrences="1">
-      <code>$values</code>
-    </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Sql/ColumnPreferencesController.php">
     <MixedAssignment occurrences="2">

--- a/test/classes/Controllers/AbstractControllerTest.php
+++ b/test/classes/Controllers/AbstractControllerTest.php
@@ -7,7 +7,6 @@ namespace PhpMyAdmin\Tests\Controllers;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Html\MySQLDocumentation;
 use PhpMyAdmin\Message;
-use PhpMyAdmin\Sanitize;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
@@ -47,16 +46,10 @@ class AbstractControllerTest extends AbstractTestCase
         $message = 'index.php: Missing parameter: param2';
         $message .= MySQLDocumentation::showDocumentation('faq', 'faqmissingparameters', true);
         $message .= '[br]';
-        $expected = $template->render('error/generic', [
-            'lang' => 'en',
-            'dir' => 'ltr',
-            'error_message' => Sanitize::sanitizeMessage($message),
-        ]);
-
-        $this->expectOutputString($expected);
+        $expected = Message::error($message)->getDisplay();
 
         $controller->testCheckParameters(['param1', 'param2']);
-
+        $this->assertSame($expected, $response->getHTMLResult());
         $this->assertSame(400, $response->getHttpResponseCode());
     }
 
@@ -79,8 +72,6 @@ class AbstractControllerTest extends AbstractTestCase
 
         $GLOBALS['param1'] = 'param1';
         $GLOBALS['param2'] = 'param2';
-
-        $this->expectOutputString('');
 
         $controller->testCheckParameters(['param1', 'param2']);
 

--- a/test/classes/CoreTest.php
+++ b/test/classes/CoreTest.php
@@ -376,30 +376,6 @@ class CoreTest extends AbstractNetworkTestCase
     }
 
     /**
-     * Test for Core::fatalError
-     */
-    public function testFatalErrorMessageWithArgs(): void
-    {
-        $_REQUEST = [];
-        ResponseRenderer::getInstance()->setAjax(false);
-
-        $message = 'Fatal error #%d in file %s.';
-        $params = [
-            1,
-            'error_file.php',
-        ];
-
-        $this->expectOutputRegex('/Fatal error #1 in file error_file.php./');
-        Core::fatalError($message, $params);
-
-        $message = 'Fatal error in file %s.';
-        $params = 'error_file.php';
-
-        $this->expectOutputRegex('/Fatal error in file error_file.php./');
-        Core::fatalError($message, $params);
-    }
-
-    /**
      * Test for Core::getRealSize
      *
      * @param string $size     Size

--- a/test/classes/CoreTest.php
+++ b/test/classes/CoreTest.php
@@ -364,18 +364,6 @@ class CoreTest extends AbstractNetworkTestCase
     }
 
     /**
-     * Test for Core::fatalError
-     */
-    public function testFatalErrorMessage(): void
-    {
-        $_REQUEST = [];
-        ResponseRenderer::getInstance()->setAjax(false);
-
-        $this->expectOutputRegex('/FatalError!/');
-        Core::fatalError('FatalError!');
-    }
-
-    /**
      * Test for Core::getRealSize
      *
      * @param string $size     Size

--- a/test/classes/CoreTest.php
+++ b/test/classes/CoreTest.php
@@ -15,11 +15,6 @@ use function _pgettext;
 use function hash;
 use function header;
 use function htmlspecialchars;
-use function mb_strpos;
-use function ob_end_clean;
-use function ob_get_contents;
-use function ob_start;
-use function preg_quote;
 use function serialize;
 use function str_repeat;
 use function strtr;
@@ -804,7 +799,7 @@ class CoreTest extends AbstractNetworkTestCase
             . '" target="Documentation"><em>' . $ext
             . '</em></a> extension is missing. Please check your PHP configuration.';
 
-        $this->expectOutputRegex('@' . preg_quote($warn, '@') . '@');
+        $this->expectExceptionMessage($warn);
 
         Core::warnMissingExtension($ext, true);
     }
@@ -825,12 +820,9 @@ class CoreTest extends AbstractNetworkTestCase
             . '</em></a> extension is missing. Please check your PHP configuration.'
             . ' ' . $extra;
 
-        ob_start();
-        Core::warnMissingExtension($ext, true, $extra);
-        $printed = ob_get_contents();
-        ob_end_clean();
+        $this->expectExceptionMessage($warn);
 
-        $this->assertGreaterThan(0, mb_strpos((string) $printed, $warn));
+        Core::warnMissingExtension($ext, true, $extra);
     }
 
     /**

--- a/test/classes/Plugins/Auth/AuthenticationHttpTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationHttpTest.php
@@ -339,9 +339,11 @@ class AuthenticationHttpTest extends AbstractNetworkTestCase
 
     /**
      * @group medium
+     * @runInSeparateProcess
      */
     public function testAuthFails(): void
     {
+        $GLOBALS['cfg']['Server']['host'] = '';
         $_REQUEST = [];
         ResponseRenderer::getInstance()->setAjax(false);
 


### PR DESCRIPTION
The `PhpMyAdmin\Core::fatalError()` method terminates the execution with `exit` when called.
This PR replaces the calls to `fatalError` with other options, like throwing an exception for example.