### PR TITLE
Fix #17812 - Add missing styles to buttons on "Page-related settings" modal

### DIFF
--- a/js/src/page_settings.js
+++ b/js/src/page_settings.js
@@ -8,12 +8,22 @@
  */
 
 function showSettings (selector) {
-    var buttons = {};
-    buttons[Messages.strApply] = function () {
+    var buttons = {
+        [Messages.strApply]: {
+            text: Messages.strApply,
+            class: 'btn btn-primary',
+        },
+        [Messages.strCancel]: {
+            text: Messages.strCancel,
+            class: 'btn btn-secondary',
+        },
+    };
+
+    buttons[Messages.strApply].click = function () {
         $('.config-form').trigger('submit');
     };
 
-    buttons[Messages.strCancel] = function () {
+    buttons[Messages.strCancel].click = function () {
         $(this).dialog('close');
     };
 


### PR DESCRIPTION
Signed-off-by: Liviu-Mihail Concioiu <liviu.concioiu@gmail.com>

### Description

Add missing styles to buttons on "Page-related settings" modal.

Before:

![before](https://user-images.githubusercontent.com/25424343/198365924-d44823de-eedb-4c0a-b89b-492512c262d9.png)

After:

![after](https://user-images.githubusercontent.com/25424343/198365947-5dcf68cb-e2d0-4cb1-85fc-ecb7bf521e75.png)

Fixes #17812

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
