### PR TITLE
Fix #16042 - gzip encoding in Firefox for 5.2.x

### DIFF
--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -42,7 +42,6 @@ use function preg_match;
 use function preg_replace;
 use function session_write_close;
 use function sprintf;
-use function str_contains;
 use function str_replace;
 use function strlen;
 use function strpos;
@@ -488,24 +487,10 @@ class Core
 
         $headers['Content-Type'] = $mimetype;
 
-        /** @var string $browserAgent */
-        $browserAgent = $GLOBALS['config']->get('PMA_USR_BROWSER_AGENT');
-
-        // inform the server that compression has been done,
-        // to avoid a double compression (for example with Apache + mod_deflate)
-        if (str_contains($mimetype, 'gzip')) {
-            /**
-             * @see https://github.com/phpmyadmin/phpmyadmin/issues/11283
-             */
-            if ($browserAgent !== 'CHROME') {
-                $headers['Content-Encoding'] = 'gzip';
-            }
-        } else {
-            // The default output in PMA uses gzip,
-            // so if we want to output uncompressed file, we should reset the encoding.
-            // See PHP bug https://github.com/php/php-src/issues/8218
-            header_remove('Content-Encoding');
-        }
+        // The default output in PMA uses gzip,
+        // so if we want to output uncompressed file, we should reset the encoding.
+        // See PHP bug https://github.com/php/php-src/issues/8218
+        header_remove('Content-Encoding');
 
         $headers['Content-Transfer-Encoding'] = 'binary';
 

--- a/test/classes/CoreTest.php
+++ b/test/classes/CoreTest.php
@@ -1046,7 +1046,7 @@ class CoreTest extends AbstractNetworkTestCase
         $this->assertContains('Content-Description: File Transfer', $headersList);
         $this->assertContains('Content-Disposition: attachment; filename="test.sql.gz"', $headersList);
         $this->assertContains('Content-Type: application/x-gzip', $headersList);
-        $this->assertContains('Content-Encoding: gzip', $headersList);
+        $this->assertNotContains('Content-Encoding: gzip', $headersList);
         $this->assertContains('Content-Transfer-Encoding: binary', $headersList);
         $this->assertNotContains('Content-Length: 0', $headersList);
     }


### PR DESCRIPTION
Fixes: #16042