### PR TITLE
Bump Node version to from 12 to 14

### DIFF
--- a/.github/workflows/daily-snapshots.yml
+++ b/.github/workflows/daily-snapshots.yml
@@ -21,9 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { version: '5.1', branch: 'QA_5_1', php-version: '7.1', node-version: '12', python-version: '3.6' }
           - { version: '5.2', branch: 'QA_5_2', php-version: '7.2', node-version: '12', python-version: '3.6' }
-          - { version: '5.3', branch: 'master', php-version: '7.2', node-version: '12', python-version: '3.6' }
+          - { version: '5.3', branch: 'master', php-version: '7.2', node-version: '14', python-version: '3.6' }
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/other-tools.yml
+++ b/.github/workflows/other-tools.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/test-selenium.yml
+++ b/.github/workflows/test-selenium.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -23,7 +23,7 @@ build:
     analysis:
       environment:
         php: 7.2
-        node: 12
+        node: 14
       dependencies:
         before:
           - composer config --unset repositories.0

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "GPL-2.0",
   "private": true,
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
- Removes the phpMyAdmin 5.1 snapshot build

See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
