### PR TITLE
Fix #17777 - Uncaught TypeError: Cannot read properties of null (reading 'inline')

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -757,7 +757,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
             if ($dp.length > 0) {
                 // eslint-disable-next-line no-underscore-dangle
                 $(document).on('mousedown', $.datepicker._checkExternalClick);
-                $dp.datepicker('destroy');
+                $dp.datepicker('refresh');
+
                 // change the cursor in edit box back to normal
                 // (the cursor become a hand pointer when we add datepicker)
                 $(g.cEdit).find('.edit_box').css('cursor', 'inherit');


### PR DESCRIPTION
Signed-off-by: Vimal K <vimalinfo10@gmail.com>

### Description

Resolving - Uncaught TypeError: Cannot read properties of null (reading 'inline')

Replacing the early destroy of datepicker with refresh function to maintain the sanity.

[localhost_81  127.0.0.1 _ phpMyAdmin 5.3.0-dev.webm](https://user-images.githubusercontent.com/35750792/199039571-dd14acf8-0389-4ff0-8d78-dc57f2d61471.webm)

Ref: https://api.jqueryui.com/datepicker/#method-destroy

Fixes #17777 

### Client configuration
Browser: Chrome
Chrome Version: 107.0.5304.88 (Official Build) (64-bit)
Operating system: Windows 10

### Before submitting pull request, please review the following checklist:
- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
