### PR TITLE
restrict request body parameter parsing to post requests on /server/replication page

### DIFF
--- a/libraries/classes/Controllers/Server/ReplicationController.php
+++ b/libraries/classes/Controllers/Server/ReplicationController.php
@@ -71,7 +71,7 @@ class ReplicationController extends AbstractController
             $GLOBALS['urlParams'] = $urlParams;
         }
 
-        if ($this->dbi->isSuperUser()) {
+        if ($this->dbi->isSuperUser() && $request->isPost()) {
             /** @var string|null $srReplicaAction */
             $srReplicaAction = $request->getParsedBodyParam('sr_replica_action');
             /** @var string|int $srSkipErrorsCount */


### PR DESCRIPTION
### Description

the `/server/replication` page was not loading because the same controller function is used on `GET` and `POST` requests.

This change now only checks if the `POST` parameters are provided only when a POST request is received, which alleviates the type mismatch in the function signature.

Fixes #17849

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
