### PR TITLE
Fix #17698 - Can't DROP 'test'; check that column/key exists

### DIFF
--- a/js/src/table/structure.js
+++ b/js/src/table/structure.js
@@ -173,11 +173,10 @@ window.AJAX.registerOnload('table/structure.js', function () {
      */
     $(document).on('click', 'a.drop_column_anchor.ajax', function (event) {
         event.preventDefault();
-
         /**
          * @var callBackCheck boolean will flag to true if the previous deleted column is remembered (i.e in case the already deleted column is attempted to be deleted again)
          */
-         var callBackCheck = false;
+        var callBackCheck = false;
         /**
          * @var currTableName String containing the name of the current table
          */
@@ -201,9 +200,8 @@ window.AJAX.registerOnload('table/structure.js', function () {
         var question = Functions.sprintf(window.Messages.strDoYouReally, 'ALTER TABLE `' + currTableName + '` DROP `' + currColumnName + '`;');
         var $thisAnchor = $(this);
         $thisAnchor.confirm(question, $thisAnchor.attr('href'), function (url) {
-
             // callBackCheck true means the previous deleted column is remembered using callbacks and hence ignore it
-            if(callBackCheck === true) {
+            if (callBackCheck === true) {
                 return;
             }
             var $msg = Functions.ajaxShowMessage(window.Messages.strDroppingColumn, false);

--- a/js/src/table/structure.js
+++ b/js/src/table/structure.js
@@ -173,6 +173,11 @@ window.AJAX.registerOnload('table/structure.js', function () {
      */
     $(document).on('click', 'a.drop_column_anchor.ajax', function (event) {
         event.preventDefault();
+
+        /**
+         * @var callBackCheck boolean will flag to true if the previous deleted column is remembered (i.e in case the already deleted column is attempted to be deleted again)
+         */
+         var callBackCheck = false;
         /**
          * @var currTableName String containing the name of the current table
          */
@@ -196,6 +201,11 @@ window.AJAX.registerOnload('table/structure.js', function () {
         var question = Functions.sprintf(window.Messages.strDoYouReally, 'ALTER TABLE `' + currTableName + '` DROP `' + currColumnName + '`;');
         var $thisAnchor = $(this);
         $thisAnchor.confirm(question, $thisAnchor.attr('href'), function (url) {
+
+            // callBackCheck true means the previous deleted column is remembered using callbacks and hence ignore it
+            if(callBackCheck === true) {
+                return;
+            }
             var $msg = Functions.ajaxShowMessage(window.Messages.strDroppingColumn, false);
             var params = Functions.getJsConfirmCommonParam(this, $thisAnchor.getPostData());
             params += window.CommonParams.get('arg_separator') + 'ajax_page_request=1';
@@ -238,6 +248,7 @@ window.AJAX.registerOnload('table/structure.js', function () {
                 } else {
                     Functions.ajaxShowMessage(window.Messages.strErrorProcessingRequest + ' : ' + data.error, false);
                 }
+                callBackCheck = true;
             }); // end $.post()
         });
     }); // end of Drop Column Anchor action


### PR DESCRIPTION
Signed-off-by: Vimal K <vimalinfo10@gmail.com>

### Description

The error pop up while deleting columns where due to callbacks which was remembering the previous deleted row. This check might handle that use case.

[localhost_81  127.0.0.1  codeanalyzer  vimal_sample _ phpMyAdmin 5.3.0-dev.webm](https://user-images.githubusercontent.com/35750792/199177373-0f83d11f-0c42-48c3-9b5a-564e167bb7a0.webm)


Fixes #17698 

### Before submitting pull request, please review the following checklist:
- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
