### PR TITLE
Fix Replica bugs

### DIFF
--- a/libraries/classes/Controllers/Server/ReplicationController.php
+++ b/libraries/classes/Controllers/Server/ReplicationController.php
@@ -87,12 +87,10 @@ class ReplicationController extends AbstractController
                 $request->getParsedBodyParam('sr_replica_skip_error') !== null,
                 (int) $srSkipErrorsCount,
                 $srReplicaControlParam,
-                [
-                    'username' => $GLOBALS['dbi']->escapeString($request->getParsedBodyParam('username')),
-                    'pma_pw' => $GLOBALS['dbi']->escapeString($request->getParsedBodyParam('pma_pw')),
-                    'hostname' => $GLOBALS['dbi']->escapeString($request->getParsedBodyParam('hostname')),
-                    'port' => (int) $GLOBALS['dbi']->escapeString($request->getParsedBodyParam('text_port')),
-                ]
+                $request->getParsedBodyParam('username', ''),
+                $request->getParsedBodyParam('pma_pw', ''),
+                $request->getParsedBodyParam('hostname', ''),
+                (int) $request->getParsedBodyParam('text_port')
             );
         }
 

--- a/libraries/classes/Replication.php
+++ b/libraries/classes/Replication.php
@@ -78,10 +78,10 @@ class Replication
      * @return ResultInterface|false output of CHANGE MASTER mysql command
      */
     public function replicaChangePrimary(
-        $user,
-        $password,
-        $host,
-        $port,
+        string $user,
+        string $password,
+        string $host,
+        int $port,
         array $pos,
         bool $stop,
         bool $start,
@@ -93,10 +93,10 @@ class Replication
 
         $out = $GLOBALS['dbi']->tryQuery(
             'CHANGE MASTER TO ' .
-            'MASTER_HOST=\'' . $host . '\',' .
-            'MASTER_PORT=' . ($port * 1) . ',' .
-            'MASTER_USER=\'' . $user . '\',' .
-            'MASTER_PASSWORD=\'' . $password . '\',' .
+            'MASTER_HOST=\'' . $GLOBALS['dbi']->escapeString($host) . '\',' .
+            'MASTER_PORT=' . $port . ',' .
+            'MASTER_USER=\'' . $GLOBALS['dbi']->escapeString($user) . '\',' .
+            'MASTER_PASSWORD=\'' . $GLOBALS['dbi']->escapeString($password) . '\',' .
             'MASTER_LOG_FILE=\'' . $pos['File'] . '\',' .
             'MASTER_LOG_POS=' . $pos['Position'] . ';',
             $link

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1456,6 +1456,26 @@ parameters:
 			path: libraries/classes/Controllers/Server/DatabasesController.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Server/ReplicationController.php
+
+		-
+			message: "#^Parameter \\#10 \\$hostname of method PhpMyAdmin\\\\ReplicationGui\\:\\:handleControlRequest\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Server/ReplicationController.php
+
+		-
+			message: "#^Parameter \\#8 \\$username of method PhpMyAdmin\\\\ReplicationGui\\:\\:handleControlRequest\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Server/ReplicationController.php
+
+		-
+			message: "#^Parameter \\#9 \\$pmaPassword of method PhpMyAdmin\\\\ReplicationGui\\:\\:handleControlRequest\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Server/ReplicationController.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Server\\\\Status\\\\Processes\\\\KillController\\:\\:__invoke\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Server/Status/Processes/KillController.php
@@ -7037,16 +7057,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\ReplicationGui\\:\\:getHtmlForReplicaConfiguration\\(\\) has parameter \\$serverReplicaReplication with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/ReplicationGui.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\ReplicationGui\\:\\:handleControlRequest\\(\\) has parameter \\$sr with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/ReplicationGui.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\ReplicationGui\\:\\:handleRequestForReplicaChangePrimary\\(\\) has parameter \\$sr with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/ReplicationGui.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2802,12 +2802,11 @@
     </UnusedVariable>
   </file>
   <file src="libraries/classes/Controllers/Server/ReplicationController.php">
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="4">
       <code>$replicaInfo['status']</code>
-      <code>$request-&gt;getParsedBodyParam('hostname')</code>
-      <code>$request-&gt;getParsedBodyParam('pma_pw')</code>
-      <code>$request-&gt;getParsedBodyParam('text_port')</code>
-      <code>$request-&gt;getParsedBodyParam('username')</code>
+      <code>$request-&gt;getParsedBodyParam('hostname', '')</code>
+      <code>$request-&gt;getParsedBodyParam('pma_pw', '')</code>
+      <code>$request-&gt;getParsedBodyParam('username', '')</code>
     </MixedArgument>
     <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
@@ -12099,20 +12098,10 @@
     </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/ReplicationGui.php">
-    <MixedArgument occurrences="16">
+    <MixedArgument occurrences="6">
       <code>$database</code>
       <code>$errorMessage</code>
       <code>$serverReplicationVariable</code>
-      <code>$sr['hostname']</code>
-      <code>$sr['hostname']</code>
-      <code>$sr['hostname']</code>
-      <code>$sr['hostname']</code>
-      <code>$sr['pma_pw']</code>
-      <code>$sr['pma_pw']</code>
-      <code>$sr['port']</code>
-      <code>$sr['port']</code>
-      <code>$sr['username']</code>
-      <code>$sr['username']</code>
       <code>$successMessage</code>
       <code>$val['Type']</code>
       <code>$val['Type']</code>
@@ -12151,11 +12140,7 @@
       <code>$_SESSION['replication']['sr_action_status']</code>
       <code>$_SESSION['replication']['sr_action_status']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="10">
-      <code>$_SESSION['replication']['m_hostname']</code>
-      <code>$_SESSION['replication']['m_password']</code>
-      <code>$_SESSION['replication']['m_port']</code>
-      <code>$_SESSION['replication']['m_username']</code>
+    <MixedAssignment occurrences="6">
       <code>$database</code>
       <code>$errorMessage</code>
       <code>$linkToPrimary</code>


### PR DESCRIPTION
This PR fixes recently refactored code. The escaping for SQL should ALWAYS be done right when it's concatenated into SQL. Otherwise, we introduce random escaping bugs. The values also don't need to be passed as an array, only to be split and merged into an array again. I opted for splitting them in controller and passing them individually to other methods. The values also cannot be null, so I provided empty string as default. 