### PR TITLE
Fix #17793 - insert record - fix null not selected if nullable UUID & insert error

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1106,7 +1106,14 @@ class InsertEdit
     private function getSpecialCharsAndBackupFieldForInsertingMode(
         array $column
     ) {
-        if (! isset($column['Default'])) {
+        $isNullableUUID = ! empty($column['True_Type'])
+            && ! empty($column['Default'])
+            && ! empty($column['Null'])
+            && $column['True_Type'] === 'uuid'
+            && $column['Default'] === 'uuid()'
+            && $column['Null'] === 'YES';
+
+        if ($isNullableUUID || (! isset($column['Default']))) {
             $column['Default'] = '';
             $realNullValue = true;
             $data = '';

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1106,14 +1106,7 @@ class InsertEdit
     private function getSpecialCharsAndBackupFieldForInsertingMode(
         array $column
     ) {
-        $isNullableUUID = ! empty($column['True_Type'])
-            && ! empty($column['Default'])
-            && ! empty($column['Null'])
-            && $column['True_Type'] === 'uuid'
-            && $column['Default'] === 'uuid()'
-            && $column['Null'] === 'YES';
-
-        if ($isNullableUUID || (! isset($column['Default']))) {
+        if (! isset($column['Default'])) {
             $column['Default'] = '';
             $realNullValue = true;
             $data = '';

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -246,6 +246,8 @@ final class ColumnsDefinition
                     case 'NULL':
                     case 'CURRENT_TIMESTAMP':
                     case 'current_timestamp()':
+                    case 'UUID':
+                    case 'uuid()':
                         $columnMeta['Default'] = $columnMeta['DefaultType'];
                         break;
                 }
@@ -301,6 +303,11 @@ final class ColumnsDefinition
                     case 'CURRENT_TIMESTAMP':
                     case 'current_timestamp()':
                         $columnMeta['DefaultType'] = 'CURRENT_TIMESTAMP';
+                        $columnMeta['DefaultValue'] = '';
+                        break;
+                    case 'UUID':
+                    case 'uuid()':
+                        $columnMeta['DefaultType'] = 'UUID';
                         $columnMeta['DefaultValue'] = '';
                         break;
                     default:

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -84,7 +84,7 @@ final class ColumnsDefinition
                     ]
                 );
                 if (isset($_POST['field_where'])) {
-                    $form_params['after_field'] = $_POST['after_field'];
+                    $form_params['after_field'] = (string) $_POST['after_field'];
                 }
             }
 
@@ -284,16 +284,15 @@ final class ColumnsDefinition
                     $columnMeta['Expression'] = is_array($expressions) ? $expressions[$columnMeta['Field']] : null;
                 }
 
+                $columnMeta['DefaultType'] = 'USER_DEFINED';
+                $columnMeta['DefaultValue'] = '';
+
                 switch ($columnMeta['Default']) {
                     case null:
                         if ($columnMeta['Default'] === null) {
-                            if ($columnMeta['Null'] === 'YES') {
-                                $columnMeta['DefaultType'] = 'NULL';
-                                $columnMeta['DefaultValue'] = '';
-                            } else {
-                                $columnMeta['DefaultType'] = 'NONE';
-                                $columnMeta['DefaultValue'] = '';
-                            }
+                            $columnMeta['DefaultType'] = $columnMeta['Null'] === 'YES'
+                                ? 'NULL'
+                                : 'NONE';
                         } else { // empty
                             $columnMeta['DefaultType'] = 'USER_DEFINED';
                             $columnMeta['DefaultValue'] = $columnMeta['Default'];
@@ -303,15 +302,14 @@ final class ColumnsDefinition
                     case 'CURRENT_TIMESTAMP':
                     case 'current_timestamp()':
                         $columnMeta['DefaultType'] = 'CURRENT_TIMESTAMP';
-                        $columnMeta['DefaultValue'] = '';
+
                         break;
                     case 'UUID':
                     case 'uuid()':
                         $columnMeta['DefaultType'] = 'UUID';
-                        $columnMeta['DefaultValue'] = '';
+
                         break;
                     default:
-                        $columnMeta['DefaultType'] = 'USER_DEFINED';
                         $columnMeta['DefaultValue'] = $columnMeta['Default'];
 
                         if (substr($columnMeta['Type'], -4) === 'text') {

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1732,34 +1732,6 @@ class InsertEditTest extends AbstractTestCase
                     'hello world&lt;br&gt;&lt;b&gt;lorem&lt;/b&gt; ipsem',
                 ],
             ],
-            'uuid with nullable' => [
-                [
-                    'True_Type' => 'uuid',
-                    'Default' => 'uuid()',
-                    'Null' => 'YES',
-                ],
-                [
-                    true,
-                    '',
-                    '',
-                    '',
-                    '',
-                ],
-            ],
-            'uuid with not nullable' => [
-                [
-                    'True_Type' => 'uuid',
-                    'Default' => 'uuid()',
-                    'Null' => 'NO',
-                ],
-                [
-                    false,
-                    'uuid()',
-                    'uuid()',
-                    '',
-                    'uuid()',
-                ],
-            ],
         ];
     }
 

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1590,37 +1590,20 @@ class InsertEditTest extends AbstractTestCase
 
     /**
      * Test for getSpecialCharsAndBackupFieldForInsertingMode
+     *
+     * @param array $column   Column parameters
+     * @param array $expected Expected result
+     * @psalm-param array<string, string|bool|null> $column
+     * @psalm-param array<bool|string> $expected
+     *
+     * @dataProvider providerForTestGetSpecialCharsAndBackupFieldForInsertingMode
      */
-    public function testGetSpecialCharsAndBackupFieldForInsertingMode(): void
-    {
-        $column = [];
-        $column['True_Type'] = 'bit';
-        $column['Default'] = 'b\'101\'';
-        $column['is_binary'] = true;
+    public function testGetSpecialCharsAndBackupFieldForInsertingMode(
+        array $column,
+        array $expected
+    ): void {
         $GLOBALS['cfg']['ProtectBinary'] = false;
         $GLOBALS['cfg']['ShowFunctionFields'] = true;
-
-        $result = $this->callFunction(
-            $this->insertEdit,
-            InsertEdit::class,
-            'getSpecialCharsAndBackupFieldForInsertingMode',
-            [$column]
-        );
-
-        $this->assertEquals(
-            [
-                false,
-                'b\'101\'',
-                '101',
-                '',
-                '101',
-            ],
-            $result
-        );
-
-        // case 2
-        unset($column['Default']);
-        $column['True_Type'] = 'char';
 
         $result = (array) $this->callFunction(
             $this->insertEdit,
@@ -1630,15 +1613,154 @@ class InsertEditTest extends AbstractTestCase
         );
 
         $this->assertEquals(
-            [
-                true,
-                '',
-                '',
-                '',
-                '',
-            ],
+            $expected,
             $result
         );
+    }
+
+    /**
+     * Data provider for test getSpecialCharsAndBackupFieldForInsertingMode()
+     *
+     * @return array
+     * @psalm-return array<string, array{array<string, string|bool|null>, array<bool|string>}>
+     */
+    public function providerForTestGetSpecialCharsAndBackupFieldForInsertingMode(): array
+    {
+        return [
+            'bit' => [
+                [
+                    'True_Type' => 'bit',
+                    'Default' => 'b\'101\'',
+                    'is_binary' => true,
+                ],
+                [
+                    false,
+                    'b\'101\'',
+                    '101',
+                    '',
+                    '101',
+                ],
+            ],
+            'char' => [
+                [
+                    'True_Type' => 'char',
+                    'is_binary' => true,
+                ],
+                [
+                    true,
+                    '',
+                    '',
+                    '',
+                    '',
+                ],
+            ],
+            'time with CURRENT_TIMESTAMP value' => [
+                [
+                    'True_Type' => 'time',
+                    'Default' => 'CURRENT_TIMESTAMP',
+                ],
+                [
+                    false,
+                    'CURRENT_TIMESTAMP',
+                    'CURRENT_TIMESTAMP',
+                    '',
+                    'CURRENT_TIMESTAMP',
+                ],
+            ],
+            'time with current_timestamp() value' => [
+                [
+                    'True_Type' => 'time',
+                    'Default' => 'current_timestamp()',
+                ],
+                [
+                    false,
+                    'current_timestamp()',
+                    'current_timestamp()',
+                    '',
+                    'current_timestamp()',
+                ],
+            ],
+            'time with no dot value' => [
+                [
+                    'True_Type' => 'time',
+                    'Default' => '10',
+                ],
+                [
+                    false,
+                    '10',
+                    '10.000000',
+                    '',
+                    '10.000000',
+                ],
+            ],
+            'time with dot value' => [
+                [
+                    'True_Type' => 'time',
+                    'Default' => '10.08',
+                ],
+                [
+                    false,
+                    '10.08',
+                    '10.080000',
+                    '',
+                    '10.080000',
+                ],
+            ],
+            'any text with escape text default' => [
+                [
+                    'True_Type' => 'text',
+                    'Default' => '"lorem\"ipsem"',
+                ],
+                [
+                    false,
+                    '"lorem\"ipsem"',
+                    'lorem"ipsem',
+                    '',
+                    'lorem"ipsem',
+                ],
+            ],
+            'varchar with html special chars' => [
+                [
+                    'True_Type' => 'varchar',
+                    'Default' => 'hello world<br><b>lorem</b> ipsem',
+                ],
+                [
+                    false,
+                    'hello world<br><b>lorem</b> ipsem',
+                    'hello world&lt;br&gt;&lt;b&gt;lorem&lt;/b&gt; ipsem',
+                    '',
+                    'hello world&lt;br&gt;&lt;b&gt;lorem&lt;/b&gt; ipsem',
+                ],
+            ],
+            'uuid with nullable' => [
+                [
+                    'True_Type' => 'uuid',
+                    'Default' => 'uuid()',
+                    'Null' => 'YES',
+                ],
+                [
+                    true,
+                    '',
+                    '',
+                    '',
+                    '',
+                ],
+            ],
+            'uuid with not nullable' => [
+                [
+                    'True_Type' => 'uuid',
+                    'Default' => 'uuid()',
+                    'Null' => 'NO',
+                ],
+                [
+                    false,
+                    'uuid()',
+                    'uuid()',
+                    '',
+                    'uuid()',
+                ],
+            ],
+        ];
     }
 
     /**

--- a/test/classes/Table/ColumnsDefinitionTest.php
+++ b/test/classes/Table/ColumnsDefinitionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests\Table;
+
+use PhpMyAdmin\Table\ColumnsDefinition;
+use PhpMyAdmin\Tests\AbstractTestCase;
+
+/**
+ * @covers \PhpMyAdmin\Table\ColumnsDefinition
+ */
+class ColumnsDefinitionTest extends AbstractTestCase
+{
+    /**
+     * test for ColumnsDefinition::decorateColumnMetaDefault
+     *
+     * @param array $columnMeta column metadata
+     * @param array $expected   expected result
+     * @phpstan-param array<string, string|null> $columnMeta
+     * @phpstan-param array<string, string> $expected
+     *
+     * @dataProvider providerColumnMetaDefault
+     */
+    public function testDecorateColumnMetaDefault(array $columnMeta, array $expected): void
+    {
+        $result = ColumnsDefinition::decorateColumnMetaDefault($columnMeta);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for testDecorateColumnMetaDefault
+     *
+     * @return array
+     * @psalm-return array<string, array{array<string, string|null>, array<string, string>}>
+     */
+    public function providerColumnMetaDefault(): array
+    {
+        return [
+            'when Default is null and Null is YES' => [
+                [
+                    'Default' => null,
+                    'Null' => 'YES',
+                ],
+                [
+                    'DefaultType' => 'NULL',
+                    'DefaultValue' => '',
+                ],
+            ],
+            'when Default is null and Null is NO' => [
+                [
+                    'Default' => null,
+                    'Null' => 'NO',
+                ],
+                [
+                    'DefaultType' => 'NONE',
+                    'DefaultValue' => '',
+                ],
+            ],
+            'when Default is CURRENT_TIMESTAMP' => [
+                ['Default' => 'CURRENT_TIMESTAMP'],
+                [
+                    'DefaultType' => 'CURRENT_TIMESTAMP',
+                    'DefaultValue' => '',
+                ],
+            ],
+            'when Default is current_timestamp' => [
+                ['Default' => 'current_timestamp()'],
+                [
+                    'DefaultType' => 'CURRENT_TIMESTAMP',
+                    'DefaultValue' => '',
+                ],
+            ],
+            'when Default is UUID' => [
+                ['Default' => 'UUID'],
+                [
+                    'DefaultType' => 'UUID',
+                    'DefaultValue' => '',
+                ],
+            ],
+            'when Default is uuid()' => [
+                ['Default' => 'uuid()'],
+                [
+                    'DefaultType' => 'UUID',
+                    'DefaultValue' => '',
+                ],
+            ],
+            'when Default is anything else and Type is text' => [
+                [
+                    'Default' => '"some\/thing"',
+                    'Type' => 'text',
+                ],
+                [
+                    'Default' => 'some/thing',
+                    'DefaultType' => 'USER_DEFINED',
+                    'DefaultValue' => '"some\/thing"',
+                ],
+            ],
+            'when Default is anything else and Type is not text' => [
+                [
+                    'Default' => '"some\/thing"',
+                    'Type' => 'something',
+                ],
+                [
+                    'DefaultType' => 'USER_DEFINED',
+                    'DefaultValue' => '"some\/thing"',
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### Description

- Fix issue - null is not selected for uuid field with nullable setting
- Fix issue - default select option not select `UUID` when alter column 

Related PR: https://github.com/phpmyadmin/phpmyadmin/pull/17797
Reference issue: https://github.com/phpmyadmin/phpmyadmin/issues/17793

Signed-off-by: Mo Sureerat <sureemo@gmail.com>
