### PR TITLE
Fix import/export escaping

### DIFF
--- a/libraries/classes/Controllers/Import/ImportController.php
+++ b/libraries/classes/Controllers/Import/ImportController.php
@@ -150,10 +150,9 @@ final class ImportController extends AbstractController
             // apply values for parameters
             if (! empty($_POST['parameterized']) && ! empty($_POST['parameters']) && is_array($_POST['parameters'])) {
                 $parameters = $_POST['parameters'];
-                foreach ($parameters as $parameter => $replacement) {
-                    $replacementValue = $this->dbi->escapeString($replacement);
+                foreach ($parameters as $parameter => $replacementValue) {
                     if (! is_numeric($replacementValue)) {
-                        $replacementValue = '\'' . $replacementValue . '\'';
+                        $replacementValue = '\'' . $this->dbi->escapeString($replacementValue) . '\'';
                     }
 
                     $quoted = preg_quote($parameter, '/');

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -2403,23 +2403,20 @@ class ExportSql extends ExportPlugin
                     }
                 } elseif ($fieldsMeta[$j]->isMappedTypeBit) {
                     // detection of 'bit' works only on mysqli extension
-                    $values[] = "b'" . $dbi->escapeString(
-                        Util::printableBitValue(
-                            (int) $row[$j],
-                            (int) $fieldsMeta[$j]->length
-                        )
-                    )
-                    . "'";
+                    $values[] = "b'" . Util::printableBitValue(
+                        (int) $row[$j],
+                        (int) $fieldsMeta[$j]->length
+                    ) . "'";
                 } elseif ($fieldsMeta[$j]->isMappedTypeGeometry) {
                     // export GIS types as hex
                     $values[] = '0x' . bin2hex($row[$j]);
                 } elseif (! empty($GLOBALS['exporting_metadata']) && $row[$j] === '@LAST_PAGE') {
                     $values[] = '@LAST_PAGE';
+                } elseif ($row[$j] === '') {
+                    $values[] = "''";
                 } else {
                     // something else -> treat as a string
-                    $values[] = '\''
-                        . $dbi->escapeString($row[$j])
-                        . '\'';
+                    $values[] = '\'' . $dbi->escapeString($row[$j]) . '\'';
                 }
             }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1321,6 +1321,11 @@ parameters:
 			path: libraries/classes/Controllers/Import/ImportController.php
 
 		-
+			message: "#^Parameter \\#2 \\$replace of function preg_replace expects array\\|string, float\\|int\\|string\\|string given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Import/ImportController.php
+
+		-
 			message: "#^Parameter \\#2 \\$size of method PhpMyAdmin\\\\Import\\:\\:getNextChunk\\(\\) expects int, float\\|int given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Import/ImportController.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2206,7 +2206,7 @@
       <code>$import_type</code>
       <code>$local_import_file</code>
       <code>$parameter</code>
-      <code>$replacement</code>
+      <code>$replacementValue</code>
       <code>$skip &lt; $read_limit ? $skip : $read_limit</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast occurrences="7">
@@ -2216,7 +2216,7 @@
       <code>$_POST['sql_query']</code>
       <code>$format</code>
       <code>$local_import_file</code>
-      <code>$replacement</code>
+      <code>$replacementValue</code>
     </PossiblyInvalidCast>
     <PossiblyInvalidOperand occurrences="3">
       <code>$charset_of_file</code>


### PR DESCRIPTION
- A bit string consists of only 1s and 0s so there's no need to escape it. 
- Escaping is not needed for numeric strings because they are treated as a number and not a string
- We can optimize export for tables with a lot of empty columns by not escaping them at all. 