### PR TITLE
Fix #17793 UUID - Fix insert error for 5.3

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1746,7 +1746,7 @@ class InsertEdit
         if (
             $editField->type === 'uuid'
                 && ! $editField->isNull
-                && in_array($editField->value, ["''", '', "'uuid()'"], true)
+                && in_array($editField->value, ["''", '', "'uuid()'", 'uuid()'], true)
         ) {
             return 'uuid()';
         }

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1109,7 +1109,14 @@ class InsertEdit
     private function getSpecialCharsAndBackupFieldForInsertingMode(
         array $column
     ) {
-        if (! isset($column['Default'])) {
+        $isNullableUUID = ! empty($column['True_Type'])
+            && ! empty($column['Default'])
+            && ! empty($column['Null'])
+            && $column['True_Type'] === 'uuid'
+            && $column['Default'] === 'uuid()'
+            && $column['Null'] === 'YES';
+
+        if ($isNullableUUID || (! isset($column['Default']))) {
             $column['Default'] = '';
             $realNullValue = true;
             $data = '';

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1109,14 +1109,7 @@ class InsertEdit
     private function getSpecialCharsAndBackupFieldForInsertingMode(
         array $column
     ) {
-        $isNullableUUID = ! empty($column['True_Type'])
-            && ! empty($column['Default'])
-            && ! empty($column['Null'])
-            && $column['True_Type'] === 'uuid'
-            && $column['Default'] === 'uuid()'
-            && $column['Null'] === 'YES';
-
-        if ($isNullableUUID || (! isset($column['Default']))) {
+        if (! isset($column['Default'])) {
             $column['Default'] = '';
             $realNullValue = true;
             $data = '';

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -243,6 +243,8 @@ final class ColumnsDefinition
                     case 'NULL':
                     case 'CURRENT_TIMESTAMP':
                     case 'current_timestamp()':
+                    case 'UUID':
+                    case 'uuid()':
                         $columnMeta['Default'] = $columnMeta['DefaultType'];
                         break;
                 }
@@ -298,6 +300,11 @@ final class ColumnsDefinition
                     case 'CURRENT_TIMESTAMP':
                     case 'current_timestamp()':
                         $columnMeta['DefaultType'] = 'CURRENT_TIMESTAMP';
+                        $columnMeta['DefaultValue'] = '';
+                        break;
+                    case 'UUID':
+                    case 'uuid()':
+                        $columnMeta['DefaultType'] = 'UUID';
                         $columnMeta['DefaultValue'] = '';
                         break;
                     default:

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -82,7 +82,7 @@ final class ColumnsDefinition
             if ($action === '/table/add-field') {
                 $form_params = array_merge($form_params, ['field_where' => $_POST['field_where'] ?? null]);
                 if (isset($_POST['field_where'])) {
-                    $form_params['after_field'] = $_POST['after_field'];
+                    $form_params['after_field'] = (string) $_POST['after_field'];
                 }
             }
 
@@ -281,16 +281,15 @@ final class ColumnsDefinition
                     $columnMeta['Expression'] = is_array($expressions) ? $expressions[$columnMeta['Field']] : null;
                 }
 
+                $columnMeta['DefaultType'] = 'USER_DEFINED';
+                $columnMeta['DefaultValue'] = '';
+
                 switch ($columnMeta['Default']) {
                     case null:
                         if ($columnMeta['Default'] === null) {
-                            if ($columnMeta['Null'] === 'YES') {
-                                $columnMeta['DefaultType'] = 'NULL';
-                                $columnMeta['DefaultValue'] = '';
-                            } else {
-                                $columnMeta['DefaultType'] = 'NONE';
-                                $columnMeta['DefaultValue'] = '';
-                            }
+                            $columnMeta['DefaultType'] = $columnMeta['Null'] === 'YES'
+                                ? 'NULL'
+                                : 'NONE';
                         } else { // empty
                             $columnMeta['DefaultType'] = 'USER_DEFINED';
                             $columnMeta['DefaultValue'] = $columnMeta['Default'];
@@ -300,15 +299,14 @@ final class ColumnsDefinition
                     case 'CURRENT_TIMESTAMP':
                     case 'current_timestamp()':
                         $columnMeta['DefaultType'] = 'CURRENT_TIMESTAMP';
-                        $columnMeta['DefaultValue'] = '';
+
                         break;
                     case 'UUID':
                     case 'uuid()':
                         $columnMeta['DefaultType'] = 'UUID';
-                        $columnMeta['DefaultValue'] = '';
+
                         break;
                     default:
-                        $columnMeta['DefaultType'] = 'USER_DEFINED';
                         $columnMeta['DefaultValue'] = $columnMeta['Default'];
 
                         if (substr($columnMeta['Type'], -4) === 'text') {

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -2768,6 +2768,24 @@ class InsertEditTest extends AbstractTestCase
 
         $this->assertEquals('`fld` = uuid()', $result);
 
+        // Test that the uuid function as a value uses the uuid function to generate a value
+        $result = $this->insertEdit->getQueryValueForUpdate(
+            new EditField(
+                'fld',
+                "uuid()",
+                'uuid',
+                false,
+                false,
+                false,
+                '',
+                null,
+                '',
+                false
+            )
+        );
+
+        $this->assertEquals('`fld` = uuid()', $result);
+
         // Test that the uuid type does not have a default value other than null when it is nullable
         $result = $this->insertEdit->getQueryValueForUpdate(
             new EditField(

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1801,34 +1801,6 @@ class InsertEditTest extends AbstractTestCase
                     'hello world&lt;br&gt;&lt;b&gt;lorem&lt;/b&gt; ipsem',
                 ],
             ],
-            'uuid with nullable' => [
-                [
-                    'True_Type' => 'uuid',
-                    'Default' => 'uuid()',
-                    'Null' => 'YES',
-                ],
-                [
-                    true,
-                    '',
-                    '',
-                    '',
-                    '',
-                ],
-            ],
-            'uuid with not nullable' => [
-                [
-                    'True_Type' => 'uuid',
-                    'Default' => 'uuid()',
-                    'Null' => 'NO',
-                ],
-                [
-                    false,
-                    'uuid()',
-                    'uuid()',
-                    '',
-                    'uuid()',
-                ],
-            ],
         ];
     }
 

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -2772,7 +2772,7 @@ class InsertEditTest extends AbstractTestCase
         $result = $this->insertEdit->getQueryValueForUpdate(
             new EditField(
                 'fld',
-                "uuid()",
+                'uuid()',
                 'uuid',
                 false,
                 false,

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1659,37 +1659,20 @@ class InsertEditTest extends AbstractTestCase
 
     /**
      * Test for getSpecialCharsAndBackupFieldForInsertingMode
+     *
+     * @param array $column   Column parameters
+     * @param array $expected Expected result
+     * @psalm-param array<string, string|bool|null> $column
+     * @psalm-param array<bool|string> $expected
+     *
+     * @dataProvider providerForTestGetSpecialCharsAndBackupFieldForInsertingMode
      */
-    public function testGetSpecialCharsAndBackupFieldForInsertingMode(): void
-    {
-        $column = [];
-        $column['True_Type'] = 'bit';
-        $column['Default'] = 'b\'101\'';
-        $column['is_binary'] = true;
+    public function testGetSpecialCharsAndBackupFieldForInsertingMode(
+        array $column,
+        array $expected
+    ): void {
         $GLOBALS['cfg']['ProtectBinary'] = false;
         $GLOBALS['cfg']['ShowFunctionFields'] = true;
-
-        $result = $this->callFunction(
-            $this->insertEdit,
-            InsertEdit::class,
-            'getSpecialCharsAndBackupFieldForInsertingMode',
-            [$column]
-        );
-
-        $this->assertEquals(
-            [
-                false,
-                'b\'101\'',
-                '101',
-                '',
-                '101',
-            ],
-            $result
-        );
-
-        // case 2
-        unset($column['Default']);
-        $column['True_Type'] = 'char';
 
         $result = (array) $this->callFunction(
             $this->insertEdit,
@@ -1699,15 +1682,154 @@ class InsertEditTest extends AbstractTestCase
         );
 
         $this->assertEquals(
-            [
-                true,
-                '',
-                '',
-                '',
-                '',
-            ],
+            $expected,
             $result
         );
+    }
+
+    /**
+     * Data provider for test getSpecialCharsAndBackupFieldForInsertingMode()
+     *
+     * @return array
+     * @psalm-return array<string, array{array<string, string|bool|null>, array<bool|string>}>
+     */
+    public function providerForTestGetSpecialCharsAndBackupFieldForInsertingMode(): array
+    {
+        return [
+            'bit' => [
+                [
+                    'True_Type' => 'bit',
+                    'Default' => 'b\'101\'',
+                    'is_binary' => true,
+                ],
+                [
+                    false,
+                    'b\'101\'',
+                    '101',
+                    '',
+                    '101',
+                ],
+            ],
+            'char' => [
+                [
+                    'True_Type' => 'char',
+                    'is_binary' => true,
+                ],
+                [
+                    true,
+                    '',
+                    '',
+                    '',
+                    '',
+                ],
+            ],
+            'time with CURRENT_TIMESTAMP value' => [
+                [
+                    'True_Type' => 'time',
+                    'Default' => 'CURRENT_TIMESTAMP',
+                ],
+                [
+                    false,
+                    'CURRENT_TIMESTAMP',
+                    'CURRENT_TIMESTAMP',
+                    '',
+                    'CURRENT_TIMESTAMP',
+                ],
+            ],
+            'time with current_timestamp() value' => [
+                [
+                    'True_Type' => 'time',
+                    'Default' => 'current_timestamp()',
+                ],
+                [
+                    false,
+                    'current_timestamp()',
+                    'current_timestamp()',
+                    '',
+                    'current_timestamp()',
+                ],
+            ],
+            'time with no dot value' => [
+                [
+                    'True_Type' => 'time',
+                    'Default' => '10',
+                ],
+                [
+                    false,
+                    '10',
+                    '10.000000',
+                    '',
+                    '10.000000',
+                ],
+            ],
+            'time with dot value' => [
+                [
+                    'True_Type' => 'time',
+                    'Default' => '10.08',
+                ],
+                [
+                    false,
+                    '10.08',
+                    '10.080000',
+                    '',
+                    '10.080000',
+                ],
+            ],
+            'any text with escape text default' => [
+                [
+                    'True_Type' => 'text',
+                    'Default' => '"lorem\"ipsem"',
+                ],
+                [
+                    false,
+                    '"lorem\"ipsem"',
+                    'lorem"ipsem',
+                    '',
+                    'lorem"ipsem',
+                ],
+            ],
+            'varchar with html special chars' => [
+                [
+                    'True_Type' => 'varchar',
+                    'Default' => 'hello world<br><b>lorem</b> ipsem',
+                ],
+                [
+                    false,
+                    'hello world<br><b>lorem</b> ipsem',
+                    'hello world&lt;br&gt;&lt;b&gt;lorem&lt;/b&gt; ipsem',
+                    '',
+                    'hello world&lt;br&gt;&lt;b&gt;lorem&lt;/b&gt; ipsem',
+                ],
+            ],
+            'uuid with nullable' => [
+                [
+                    'True_Type' => 'uuid',
+                    'Default' => 'uuid()',
+                    'Null' => 'YES',
+                ],
+                [
+                    true,
+                    '',
+                    '',
+                    '',
+                    '',
+                ],
+            ],
+            'uuid with not nullable' => [
+                [
+                    'True_Type' => 'uuid',
+                    'Default' => 'uuid()',
+                    'Null' => 'NO',
+                ],
+                [
+                    false,
+                    'uuid()',
+                    'uuid()',
+                    '',
+                    'uuid()',
+                ],
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
### Description

Same fix as commits based on `QA_5_2` branch
- Fix issue - null is not selected for uuid field with nullable setting
- Fix issue - default select option not select `UUID` when alter column 

But add new commit (required change on `master` because effected code not existed in `QA_5_2`)
- Fix issue - insert error

Related PR: https://github.com/phpmyadmin/phpmyadmin/pull/17860
Reference issue: https://github.com/phpmyadmin/phpmyadmin/issues/17793

Signed-off-by: Mo Sureerat <sureemo@gmail.com>
