### PR TITLE
Introduce ServerRequest::hasBodyParam()

### DIFF
--- a/libraries/classes/Controllers/CheckRelationsController.php
+++ b/libraries/classes/Controllers/CheckRelationsController.php
@@ -28,29 +28,22 @@ class CheckRelationsController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        /** @var string|null $createPmaDb */
-        $createPmaDb = $request->getParsedBodyParam('create_pmadb');
-        /** @var string|null $fixAllPmaDb */
-        $fixAllPmaDb = $request->getParsedBodyParam('fixall_pmadb');
-        /** @var string|null $fixPmaDb */
-        $fixPmaDb = $request->getParsedBodyParam('fix_pmadb');
-
         $cfgStorageDbName = $this->relation->getConfigurationStorageDbName();
 
         $db = DatabaseName::tryFromValue($GLOBALS['db']);
 
         // If request for creating the pmadb
-        if (isset($createPmaDb) && $this->relation->createPmaDatabase($cfgStorageDbName)) {
+        if ($request->hasBodyParam('create_pmadb') && $this->relation->createPmaDatabase($cfgStorageDbName)) {
             $this->relation->fixPmaTables($cfgStorageDbName);
         }
 
         // If request for creating all PMA tables.
-        if (isset($fixAllPmaDb) && $db !== null) {
+        if ($request->hasBodyParam('fixall_pmadb') && $db !== null) {
             $this->relation->fixPmaTables($db->getName());
         }
 
         // If request for creating missing PMA tables.
-        if (isset($fixPmaDb)) {
+        if ($request->hasBodyParam('fix_pmadb')) {
             $relationParameters = $this->relation->getRelationParameters();
             $this->relation->fixPmaTables((string) $relationParameters->db);
         }

--- a/libraries/classes/Controllers/Database/SearchController.php
+++ b/libraries/classes/Controllers/Database/SearchController.php
@@ -79,7 +79,7 @@ class SearchController extends AbstractController
         }
 
         // Main search form has been submitted, get results
-        if ($request->getParsedBodyParam('submit_search') !== null) {
+        if ($request->hasBodyParam('submit_search')) {
             $this->response->addHTML($databaseSearch->getSearchResults());
         }
 

--- a/libraries/classes/Controllers/Database/SqlController.php
+++ b/libraries/classes/Controllers/Database/SqlController.php
@@ -56,16 +56,14 @@ class SqlController extends AbstractController
          */
         $GLOBALS['goto'] = Url::getFromRoute('/database/sql');
         $GLOBALS['back'] = $GLOBALS['goto'];
-        $delimiter = $request->getParsedBodyParam('delimiter');
+        $delimiter = $request->getParsedBodyParam('delimiter', ';');
 
         $this->response->addHTML($this->sqlQueryForm->getHtml(
             $GLOBALS['db'],
             '',
             true,
             false,
-            $delimiter !== null
-                ? htmlspecialchars($delimiter)
-                : ';'
+            htmlspecialchars($delimiter)
         ));
     }
 }

--- a/libraries/classes/Controllers/ErrorReportController.php
+++ b/libraries/classes/Controllers/ErrorReportController.php
@@ -48,20 +48,16 @@ class ErrorReportController extends AbstractController
     {
         /** @var string $exceptionType */
         $exceptionType = $request->getParsedBodyParam('exception_type', '');
-        /** @var string|null $sendErrorReport */
-        $sendErrorReport = $request->getParsedBodyParam('send_error_report');
         /** @var string|null $automatic */
         $automatic = $request->getParsedBodyParam('automatic');
         /** @var string|null $alwaysSend */
         $alwaysSend = $request->getParsedBodyParam('always_send');
-        /** @var string|null $getSettings */
-        $getSettings = $request->getParsedBodyParam('get_settings');
 
         if (! in_array($exceptionType, ['js', 'php'])) {
             return;
         }
 
-        if ($sendErrorReport) {
+        if ($request->hasBodyParam('send_error_report')) {
             if ($exceptionType === 'php') {
                 /**
                  * Prevent infinite error submission.
@@ -148,7 +144,7 @@ class ErrorReportController extends AbstractController
                     $userPreferences->persistOption('SendErrorReports', 'always', 'ask');
                 }
             }
-        } elseif ($getSettings) {
+        } elseif ($request->hasBodyParam('get_settings')) {
             $this->response->addJSON('report_setting', $GLOBALS['cfg']['SendErrorReports']);
         } elseif ($exceptionType === 'js') {
             $this->response->addJSON('report_modal', $this->errorReport->getEmptyModal());

--- a/libraries/classes/Controllers/Export/ExportController.php
+++ b/libraries/classes/Controllers/Export/ExportController.php
@@ -109,8 +109,7 @@ final class ExportController extends AbstractController
         $onServerParam = $request->getParsedBodyParam('onserver');
         /** @var array|null $aliasesParam */
         $aliasesParam = $request->getParsedBodyParam('aliases');
-        /** @var string|null $structureOrDataForced */
-        $structureOrDataForced = $request->getParsedBodyParam('structure_or_data_forced');
+        $structureOrDataForced = $request->hasBodyParam('structure_or_data_forced');
 
         $this->addScriptFiles(['export_output.js']);
 

--- a/libraries/classes/Controllers/GisDataEditorController.php
+++ b/libraries/classes/Controllers/GisDataEditorController.php
@@ -51,8 +51,6 @@ class GisDataEditorController extends AbstractController
         $type = $request->getParsedBodyParam('type', '');
         /** @var string|null $value */
         $value = $request->getParsedBodyParam('value');
-        /** @var string|null $generate */
-        $generate = $request->getParsedBodyParam('generate');
         /** @var string|null $inputName */
         $inputName = $request->getParsedBodyParam('input_name');
 
@@ -143,7 +141,7 @@ class GisDataEditorController extends AbstractController
             ->asOl();
 
         // If the call is to update the WKT and visualization make an AJAX response
-        if ($generate) {
+        if ($request->hasBodyParam('generate')) {
             $this->response->addJSON([
                 'result' => $GLOBALS['result'],
                 'visualization' => $GLOBALS['visualization'],

--- a/libraries/classes/Controllers/SchemaExportController.php
+++ b/libraries/classes/Controllers/SchemaExportController.php
@@ -32,7 +32,7 @@ class SchemaExportController
 
     public function __invoke(ServerRequest $request): void
     {
-        if ($request->getParsedBodyParam('export_type') === null) {
+        if (! $request->hasBodyParam('export_type')) {
             $errorMessage = __('Missing parameter:') . ' export_type'
                 . MySQLDocumentation::showDocumentation('faq', 'faqmissingparameters', true)
                 . '[br]';

--- a/libraries/classes/Controllers/Sql/ColumnPreferencesController.php
+++ b/libraries/classes/Controllers/Sql/ColumnPreferencesController.php
@@ -11,13 +11,15 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sql;
+use PhpMyAdmin\Table;
 use PhpMyAdmin\Template;
+
+use function array_map;
+use function explode;
+use function is_string;
 
 final class ColumnPreferencesController extends AbstractController
 {
-    /** @var Sql */
-    private $sql;
-
     /** @var CheckUserPrivileges */
     private $checkUserPrivileges;
 
@@ -32,7 +34,6 @@ final class ColumnPreferencesController extends AbstractController
         DatabaseInterface $dbi
     ) {
         parent::__construct($response, $template);
-        $this->sql = $sql;
         $this->checkUserPrivileges = $checkUserPrivileges;
         $this->dbi = $dbi;
     }
@@ -44,16 +45,21 @@ final class ColumnPreferencesController extends AbstractController
         $tableObject = $this->dbi->getTable($GLOBALS['db'], $GLOBALS['table']);
         $status = false;
 
+        /** @var string|null $tableCreateTime */
+        $tableCreateTime = $request->getParsedBodyParam('table_create_time');
+
         // set column order
         $colorder = $request->getParsedBodyParam('col_order');
-        if ($colorder !== null) {
-            $status = $this->sql->setColumnProperty($tableObject, 'col_order');
+        if (is_string($colorder)) {
+            $propertyValue = array_map('intval', explode(',', $colorder));
+            $status = $tableObject->setUiProp(Table::PROP_COLUMN_ORDER, $propertyValue, $tableCreateTime);
         }
 
         // set column visibility
         $colvisib = $request->getParsedBodyParam('col_visib');
-        if ($status === true && $colvisib !== null) {
-            $status = $this->sql->setColumnProperty($tableObject, 'col_visib');
+        if ($status === true && is_string($colvisib)) {
+            $propertyValue = array_map('intval', explode(',', $colvisib));
+            $status = $tableObject->setUiProp(Table::PROP_COLUMN_ORDER, $propertyValue, $tableCreateTime);
         }
 
         if ($status instanceof Message) {

--- a/libraries/classes/Controllers/Sql/SetValuesController.php
+++ b/libraries/classes/Controllers/Sql/SetValuesController.php
@@ -44,7 +44,6 @@ final class SetValuesController extends AbstractController
 
         $column = $request->getParsedBodyParam('column');
         $currentValue = $request->getParsedBodyParam('curr_value');
-        $fullValues = $request->getParsedBodyParam('get_full_values', false);
         $whereClause = $request->getParsedBodyParam('where_clause');
 
         $values = $this->sql->getValuesForColumn($GLOBALS['db'], $GLOBALS['table'], $column);
@@ -57,7 +56,7 @@ final class SetValuesController extends AbstractController
         }
 
         // If the $currentValue was truncated, we should fetch the correct full values from the table.
-        if ($fullValues && ! empty($whereClause)) {
+        if ($request->hasBodyParam('get_full_values') && ! empty($whereClause)) {
             $currentValue = $this->sql->getFullValuesForSetColumn(
                 $GLOBALS['db'],
                 $GLOBALS['table'],

--- a/libraries/classes/Controllers/Sql/SqlController.php
+++ b/libraries/classes/Controllers/Sql/SqlController.php
@@ -191,9 +191,9 @@ class SqlController extends AbstractController
         /**
          * Bookmark add
          */
-        $store_bkm = $request->getParsedBodyParam('store_bkm');
-        $bkm_all_users = $request->getParsedBodyParam('bkm_all_users');
-        if ($store_bkm !== null && $bkm_fields !== null) {
+        $store_bkm = $request->hasBodyParam('store_bkm');
+        $bkm_all_users = $request->getParsedBodyParam('bkm_all_users'); // Should this be hasBodyParam?
+        if ($store_bkm && $bkm_fields !== null) {
             $this->addBookmark($GLOBALS['goto'], $bkm_fields, (bool) $bkm_all_users);
 
             return;

--- a/libraries/classes/Controllers/Table/Structure/AddIndexController.php
+++ b/libraries/classes/Controllers/Table/Structure/AddIndexController.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function count;
+use function is_array;
 
 final class AddIndexController extends AbstractController
 {
@@ -41,7 +42,7 @@ final class AddIndexController extends AbstractController
 
         $selected = $request->getParsedBodyParam('selected_fld', []);
 
-        if (empty($selected)) {
+        if (! is_array($selected) || $selected === []) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 

--- a/libraries/classes/Controllers/Table/Structure/CentralColumnsAddController.php
+++ b/libraries/classes/Controllers/Table/Structure/CentralColumnsAddController.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 
 use function __;
+use function is_array;
 
 final class CentralColumnsAddController extends AbstractController
 {
@@ -39,7 +40,7 @@ final class CentralColumnsAddController extends AbstractController
 
         $selected = $request->getParsedBodyParam('selected_fld', []);
 
-        if (empty($selected)) {
+        if (! is_array($selected) || $selected === []) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 

--- a/libraries/classes/Controllers/Table/Structure/CentralColumnsRemoveController.php
+++ b/libraries/classes/Controllers/Table/Structure/CentralColumnsRemoveController.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 
 use function __;
+use function is_array;
 
 final class CentralColumnsRemoveController extends AbstractController
 {
@@ -39,7 +40,7 @@ final class CentralColumnsRemoveController extends AbstractController
 
         $selected = $request->getParsedBodyParam('selected_fld', []);
 
-        if (empty($selected)) {
+        if (! is_array($selected) || $selected === []) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 

--- a/libraries/classes/Controllers/Table/Structure/FulltextController.php
+++ b/libraries/classes/Controllers/Table/Structure/FulltextController.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function count;
+use function is_array;
 
 final class FulltextController extends AbstractController
 {
@@ -41,7 +42,7 @@ final class FulltextController extends AbstractController
 
         $selected = $request->getParsedBodyParam('selected_fld', []);
 
-        if (empty($selected)) {
+        if (! is_array($selected) || $selected === []) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 

--- a/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
+++ b/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
@@ -45,7 +45,7 @@ final class MoveColumnsController extends AbstractController
     public function __invoke(ServerRequest $request): void
     {
         $move_columns = $request->getParsedBodyParam('move_columns');
-        if (! isset($move_columns) || ! is_array($move_columns) || ! $this->response->isAjax()) {
+        if (! is_array($move_columns) || ! $this->response->isAjax()) {
             return;
         }
 

--- a/libraries/classes/Controllers/Table/Structure/SpatialController.php
+++ b/libraries/classes/Controllers/Table/Structure/SpatialController.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function count;
+use function is_array;
 
 final class SpatialController extends AbstractController
 {
@@ -41,7 +42,7 @@ final class SpatialController extends AbstractController
 
         $selected = $request->getParsedBodyParam('selected_fld', []);
 
-        if (empty($selected)) {
+        if (! is_array($selected) || $selected === []) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 

--- a/libraries/classes/Controllers/Table/Structure/UniqueController.php
+++ b/libraries/classes/Controllers/Table/Structure/UniqueController.php
@@ -15,6 +15,7 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function count;
+use function is_array;
 
 final class UniqueController extends AbstractController
 {
@@ -41,7 +42,7 @@ final class UniqueController extends AbstractController
 
         $selected = $request->getParsedBodyParam('selected_fld', []);
 
-        if (empty($selected)) {
+        if (! is_array($selected) || $selected === []) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', __('No column selected.'));
 

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -96,14 +96,14 @@ final class TrackingController extends AbstractController
         $GLOBALS['selection_data'] = false;
         $GLOBALS['selection_both'] = false;
 
-        $report = $request->getParsedBodyParam('report');
+        $report = $request->hasBodyParam('report');
         /** @var string $versionParam */
         $versionParam = $request->getParsedBodyParam('version');
         /** @var string $tableParam */
         $tableParam = $request->getParsedBodyParam('table');
 
         // Init vars for tracking report
-        if ($report !== null || $reportExport !== null) {
+        if ($report || $reportExport !== null) {
             $GLOBALS['data'] = Tracker::getTrackedData(
                 $GLOBALS['db'],
                 $GLOBALS['table'],
@@ -170,7 +170,7 @@ final class TrackingController extends AbstractController
         }
 
         $deleteVersion = '';
-        if ($request->getParsedBodyParam('submit_delete_version') !== null) {
+        if ($request->hasBodyParam('submit_delete_version')) {
             $deleteVersion = $this->tracking->deleteTrackingVersion(
                 $GLOBALS['db'],
                 $GLOBALS['table'],
@@ -179,7 +179,7 @@ final class TrackingController extends AbstractController
         }
 
         $createVersion = '';
-        if ($request->getParsedBodyParam('submit_create_version') !== null) {
+        if ($request->hasBodyParam('submit_create_version')) {
             $createVersion = $this->tracking->createTrackingVersion(
                 $GLOBALS['db'],
                 $GLOBALS['table'],
@@ -220,7 +220,7 @@ final class TrackingController extends AbstractController
         }
 
         $schemaSnapshot = '';
-        if ($request->getParsedBodyParam('snapshot') !== null) {
+        if ($request->hasBodyParam('snapshot')) {
             /** @var string $db */
             $db = $request->getParsedBodyParam('db');
             $schemaSnapshot = $this->tracking->getHtmlForSchemaSnapshot(
@@ -232,11 +232,7 @@ final class TrackingController extends AbstractController
         }
 
         $trackingReportRows = '';
-        if (
-            $report !== null
-            && ($request->getParsedBodyParam('delete_ddlog') !== null
-                || $request->getParsedBodyParam('delete_dmlog') !== null)
-        ) {
+        if ($report && ($request->hasBodyParam('delete_ddlog') || $request->hasBodyParam('delete_dmlog'))) {
             $trackingReportRows = $this->tracking->deleteTrackingReportRows(
                 $GLOBALS['db'],
                 $GLOBALS['table'],
@@ -248,7 +244,7 @@ final class TrackingController extends AbstractController
         }
 
         $trackingReport = '';
-        if ($report !== null || $reportExport !== null) {
+        if ($report || $reportExport !== null) {
             $trackingReport = $this->tracking->getHtmlForTrackingReport(
                 $GLOBALS['data'],
                 $GLOBALS['urlParams'],

--- a/libraries/classes/Controllers/TableController.php
+++ b/libraries/classes/Controllers/TableController.php
@@ -23,7 +23,7 @@ final class TableController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        if ($request->getParsedBodyParam('db') === null) {
+        if (! $request->hasBodyParam('db')) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON(['message' => Message::error()]);
 

--- a/libraries/classes/Controllers/View/CreateController.php
+++ b/libraries/classes/Controllers/View/CreateController.php
@@ -103,22 +103,17 @@ class CreateController extends AbstractController
             return;
         }
 
-        /** @var string|null $createview */
-        $createview = $request->getParsedBodyParam('createview');
+        $createview = $request->hasBodyParam('createview');
+        $alterview = $request->hasBodyParam('alterview');
+        $ajaxdialog = $request->hasBodyParam('ajax_dialog');
 
-        /** @var string|null $alterview */
-        $alterview = $request->getParsedBodyParam('alterview');
-
-        /** @var string|null $ajaxdialog */
-        $ajaxdialog = $request->getParsedBodyParam('ajax_dialog');
-
-        if ($createview !== null || $alterview !== null) {
+        if ($createview || $alterview) {
             /**
              * Creates the view
              */
             $GLOBALS['sep'] = "\r\n";
 
-            if ($createview !== null) {
+            if ($createview) {
                 $GLOBALS['sql_query'] = 'CREATE';
                 if (isset($view['or_replace'])) {
                     $GLOBALS['sql_query'] .= ' OR REPLACE';
@@ -167,7 +162,7 @@ class CreateController extends AbstractController
             }
 
             if (! $this->dbi->tryQuery($GLOBALS['sql_query'])) {
-                if ($ajaxdialog === null) {
+                if (! $ajaxdialog) {
                     $GLOBALS['message'] = Message::rawError($this->dbi->getError());
 
                     return;
@@ -213,7 +208,7 @@ class CreateController extends AbstractController
 
             unset($GLOBALS['pma_transformation_data']);
 
-            if ($ajaxdialog !== null) {
+            if ($ajaxdialog) {
                 $GLOBALS['message'] = Message::success();
                 /** @var StructureController $controller */
                 $controller = Core::getContainerBuilder()->get(StructureController::class);
@@ -296,7 +291,7 @@ class CreateController extends AbstractController
         $this->addScriptFiles(['sql.js']);
 
         echo $this->template->render('view_create', [
-            'ajax_dialog' => $ajaxdialog !== null,
+            'ajax_dialog' => $ajaxdialog,
             'text_dir' => $GLOBALS['text_dir'],
             'url_params' => $GLOBALS['urlParams'],
             'view' => $GLOBALS['view'],

--- a/libraries/classes/Controllers/View/OperationsController.php
+++ b/libraries/classes/Controllers/View/OperationsController.php
@@ -17,7 +17,7 @@ use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
 use function __;
-use function strval;
+use function is_string;
 
 /**
  * View manipulations
@@ -64,11 +64,10 @@ class OperationsController extends AbstractController
 
         $message = new Message();
         $type = 'success';
-        $submitoptions = $request->getParsedBodyParam('submitoptions');
         $newname = $request->getParsedBodyParam('new_name');
 
-        if ($submitoptions !== null) {
-            if ($newname !== null && $tableObject->rename(strval($newname))) {
+        if ($request->hasBodyParam('submitoptions')) {
+            if (is_string($newname) && $tableObject->rename($newname)) {
                 $message->addText($tableObject->getLastMessage());
                 $GLOBALS['result'] = true;
                 $GLOBALS['table'] = $tableObject->getName();

--- a/libraries/classes/Http/ServerRequest.php
+++ b/libraries/classes/Http/ServerRequest.php
@@ -382,6 +382,18 @@ class ServerRequest implements ServerRequestInterface
         return $route;
     }
 
+    public function has(string $param): bool
+    {
+        return $this->hasBodyParam($param) || $this->hasQueryParam($param);
+    }
+
+    public function hasQueryParam(string $param): bool
+    {
+        $getParams = $this->getQueryParams();
+
+        return isset($getParams[$param]);
+    }
+
     public function hasBodyParam(string $param): bool
     {
         $postParams = $this->getParsedBody();

--- a/libraries/classes/Http/ServerRequest.php
+++ b/libraries/classes/Http/ServerRequest.php
@@ -381,4 +381,12 @@ class ServerRequest implements ServerRequestInterface
 
         return $route;
     }
+
+    public function hasBodyParam(string $param): bool
+    {
+        $postParams = $this->getParsedBody();
+
+        return is_array($postParams) && isset($postParams[$param])
+            || is_object($postParams) && property_exists($postParams, $param);
+    }
 }

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -23,12 +23,10 @@ use PhpMyAdmin\Utils\ForeignKey;
 
 use function __;
 use function array_keys;
-use function array_map;
 use function bin2hex;
 use function ceil;
 use function count;
 use function defined;
-use function explode;
 use function htmlspecialchars;
 use function in_array;
 use function is_array;
@@ -429,31 +427,6 @@ class Sql
         $isSuperUser
     ): bool {
         return ! $allowUserDropDatabase && $statementInfo->dropDatabase && ! $isSuperUser;
-    }
-
-    /**
-     * Function to set a column property
-     *
-     * @param Table  $table        Table instance
-     * @param string $requestIndex col_order|col_visib
-     *
-     * @return bool|Message
-     */
-    public function setColumnProperty(Table $table, string $requestIndex)
-    {
-        $propertyValue = array_map('intval', explode(',', $_POST[$requestIndex]));
-        switch ($requestIndex) {
-            case 'col_order':
-                $propertyToSet = Table::PROP_COLUMN_ORDER;
-                break;
-            case 'col_visib':
-                $propertyToSet = Table::PROP_COLUMN_VISIB;
-                break;
-            default:
-                $propertyToSet = '';
-        }
-
-        return $table->setUiProp($propertyToSet, $propertyValue, $_POST['table_create_time'] ?? null);
     }
 
     /**

--- a/libraries/services_controllers.php
+++ b/libraries/services_controllers.php
@@ -1115,7 +1115,6 @@ return [
             'arguments' => [
                 '$response' => '@response',
                 '$template' => '@template',
-                '$sql' => '@sql',
                 '$checkUserPrivileges' => '@check_user_privileges',
                 '$dbi' => '@dbi',
             ],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1716,31 +1716,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/SearchController.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/AddIndexController.php
-
-		-
-			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/AddIndexController.php
-
-		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/AddIndexController.php
-
-		-
-			message: "#^Parameter \\#1 \\$field_select of method PhpMyAdmin\\\\Database\\\\CentralColumns\\:\\:syncUniqueColumns\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/CentralColumnsAddController.php
-
-		-
-			message: "#^Parameter \\#2 \\$field_select of method PhpMyAdmin\\\\Database\\\\CentralColumns\\:\\:deleteColumnsFromList\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/CentralColumnsRemoveController.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Table\\\\Structure\\\\ChangeController\\:\\:displayHtmlForColumnChange\\(\\) has parameter \\$selected with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/Structure/ChangeController.php
@@ -1749,21 +1724,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$selected of method PhpMyAdmin\\\\Controllers\\\\Table\\\\Structure\\\\ChangeController\\:\\:displayHtmlForColumnChange\\(\\) expects array\\|null, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/Structure/ChangeController.php
-
-		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/FulltextController.php
-
-		-
-			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/FulltextController.php
-
-		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/FulltextController.php
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
@@ -1864,36 +1824,6 @@ parameters:
 			message: "#^Parameter \\#7 \\$null of static method PhpMyAdmin\\\\Table\\:\\:generateAlter\\(\\) expects bool\\|string, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Controllers/Table/Structure/SaveController.php
-
-		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/SpatialController.php
-
-		-
-			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/SpatialController.php
-
-		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/SpatialController.php
-
-		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/UniqueController.php
-
-		-
-			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/UniqueController.php
-
-		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/UniqueController.php
 
 		-
 			message: "#^Cannot use array destructuring on array\\|null\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13018,21 +13018,15 @@
     <NullableReturnStatement occurrences="1">
       <code>$unlimNumRows</code>
     </NullableReturnStatement>
-    <PossiblyInvalidArgument occurrences="8">
-      <code>$_POST[$requestIndex]</code>
+    <PossiblyInvalidArgument occurrences="6">
       <code>$_POST['bkm_label']</code>
       <code>$_POST['dropped_column'] ?? null</code>
-      <code>$_POST['table_create_time'] ?? null</code>
       <code>$numRows</code>
       <code>$numRows</code>
       <code>$numRows</code>
       <code>$numRows</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidArrayOffset occurrences="1">
-      <code>$_POST[$requestIndex]</code>
-    </PossiblyInvalidArrayOffset>
-    <PossiblyInvalidCast occurrences="2">
-      <code>$_POST[$requestIndex]</code>
+    <PossiblyInvalidCast occurrences="1">
       <code>$_POST['bkm_label']</code>
     </PossiblyInvalidCast>
     <PossiblyInvalidOperand occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3871,13 +3871,11 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/AddIndexController.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$field</code>
-      <code>$selected</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$field</code>
-      <code>$selected</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/AddKeyController.php">
@@ -3899,22 +3897,6 @@
       <code>$_POST['selected_fld']</code>
     </PossiblyInvalidIterator>
   </file>
-  <file src="libraries/classes/Controllers/Table/Structure/CentralColumnsAddController.php">
-    <MixedArgument occurrences="1">
-      <code>$selected</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$selected</code>
-    </MixedAssignment>
-  </file>
-  <file src="libraries/classes/Controllers/Table/Structure/CentralColumnsRemoveController.php">
-    <MixedArgument occurrences="1">
-      <code>$selected</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$selected</code>
-    </MixedAssignment>
-  </file>
   <file src="libraries/classes/Controllers/Table/Structure/ChangeController.php">
     <MixedArgument occurrences="2">
       <code>$selected</code>
@@ -3932,13 +3914,11 @@
     </PossiblyInvalidCast>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/FulltextController.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$field</code>
-      <code>$selected</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$field</code>
-      <code>$selected</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/MoveColumnsController.php">
@@ -4116,23 +4096,19 @@
     </PossiblyInvalidOperand>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/SpatialController.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$field</code>
-      <code>$selected</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$field</code>
-      <code>$selected</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/UniqueController.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$field</code>
-      <code>$selected</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$field</code>
-      <code>$selected</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/StructureController.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3090,10 +3090,9 @@
       <code>$currentValue</code>
       <code>$whereClause</code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$column</code>
       <code>$currentValue</code>
-      <code>$fullValues</code>
       <code>$whereClause</code>
     </MixedAssignment>
   </file>
@@ -3115,7 +3114,7 @@
     <MixedArrayAccess occurrences="1">
       <code>$GLOBALS['ajax_reload']['reload']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="17">
+    <MixedAssignment occurrences="16">
       <code>$GLOBALS['ajax_reload']</code>
       <code>$GLOBALS['back']</code>
       <code>$GLOBALS['disp_message']</code>
@@ -3132,7 +3131,6 @@
       <code>$GLOBALS['unlim_num_rows']</code>
       <code>$bkm_all_users</code>
       <code>$sql_query</code>
-      <code>$store_bkm</code>
     </MixedAssignment>
     <MixedOperand occurrences="1">
       <code>$GLOBALS['errorUrl']</code>
@@ -4203,7 +4201,7 @@
       <code>$GLOBALS['data']['date_from']</code>
       <code>$GLOBALS['data']['date_to']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="18">
+    <MixedAssignment occurrences="17">
       <code>$GLOBALS['data']</code>
       <code>$GLOBALS['data']</code>
       <code>$GLOBALS['entries']</code>
@@ -4216,7 +4214,6 @@
       <code>$GLOBALS['selection_data']</code>
       <code>$GLOBALS['selection_schema']</code>
       <code>$logType</code>
-      <code>$report</code>
       <code>$reportExport</code>
       <code>$selectedVersions</code>
       <code>$submitMult</code>
@@ -4437,17 +4434,15 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/Controllers/View/OperationsController.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$GLOBALS['warning_messages']</code>
-      <code>$newname</code>
     </MixedArgument>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['reload']</code>
       <code>$GLOBALS['result']</code>
       <code>$GLOBALS['warning_messages']</code>
       <code>$newname</code>
-      <code>$submitoptions</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Core.php">

--- a/test/classes/Http/ServerRequestTest.php
+++ b/test/classes/Http/ServerRequestTest.php
@@ -75,4 +75,20 @@ class ServerRequestTest extends TestCase
         $this->assertFalse($request->hasBodyParam('key3'));
         $this->assertTrue($request->hasBodyParam('key4'));
     }
+
+    public function testHasQueryParam(): void
+    {
+        $queryParams = ['key1' => 'value1', 'key2' => ['value2'], 'key4' => ''];
+        $requestStub = $this->createStub(ServerRequestInterface::class);
+        $requestStub->method('getQueryParams')->willReturn($queryParams);
+        $request = new ServerRequest($requestStub);
+        $this->assertTrue($request->hasQueryParam('key1'));
+        $this->assertTrue($request->has('key1'));
+        $this->assertTrue($request->hasQueryParam('key2'));
+        $this->assertTrue($request->has('key2'));
+        $this->assertFalse($request->hasQueryParam('key3'));
+        $this->assertFalse($request->has('key3'));
+        $this->assertTrue($request->hasQueryParam('key4'));
+        $this->assertTrue($request->has('key4'));
+    }
 }

--- a/test/classes/Http/ServerRequestTest.php
+++ b/test/classes/Http/ServerRequestTest.php
@@ -63,4 +63,16 @@ class ServerRequestTest extends TestCase
         $this->assertSame('', $request->getQueryParam('key4'));
         $this->assertSame('', $request->getQueryParam('key4', 'default'));
     }
+
+    public function testHasBodyParam(): void
+    {
+        $queryParams = ['key1' => 'value1', 'key2' => ['value2'], 'key4' => ''];
+        $requestStub = $this->createStub(ServerRequestInterface::class);
+        $requestStub->method('getParsedBody')->willReturn($queryParams);
+        $request = new ServerRequest($requestStub);
+        $this->assertTrue($request->hasBodyParam('key1'));
+        $this->assertTrue($request->hasBodyParam('key2'));
+        $this->assertFalse($request->hasBodyParam('key3'));
+        $this->assertTrue($request->hasBodyParam('key4'));
+    }
 }


### PR DESCRIPTION
This is done in an effort to reduce usage of the infamous `isset`. The `isset` is moved to `ServerRequest`. The idea for this is [borrowed from Laravel](https://github.com/illuminate/http/blob/50ded11e21531c3e00a88928819bb511c4d45398/Concerns/InteractsWithInput.php#L85). 
While implementing this method I accidentally made some other refactorings. 