### PR TITLE
Simpler PHPUnit 8 compatibility

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8941,6 +8941,16 @@ parameters:
 			path: libraries/classes/ZipExtension.php
 
 		-
+			message: "#^Call to an undefined static method PHPUnit\\\\Framework\\\\TestCase\\:\\:assertFileDoesNotExist\\(\\)\\.$#"
+			count: 1
+			path: test/classes/AbstractTestCase.php
+
+		-
+			message: "#^Call to an undefined static method PHPUnit\\\\Framework\\\\TestCase\\:\\:assertMatchesRegularExpression\\(\\)\\.$#"
+			count: 1
+			path: test/classes/AbstractTestCase.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\AbstractTestCase\\:\\:callFunction\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/AbstractTestCase.php

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -21,6 +21,7 @@ use ReflectionClass;
 
 use function array_keys;
 use function in_array;
+use function method_exists;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -43,6 +44,32 @@ abstract class AbstractTestCase extends TestCase
         '__PHPUNIT_CONFIGURATION_FILE',
         '__PHPUNIT_BOOTSTRAP',
     ];
+
+    /**
+     * For PHPUnit < 9.1 compatibility
+     */
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        if (method_exists(parent::class, 'assertMatchesRegularExpression')) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            /** @psalm-suppress DeprecatedMethod */
+            parent::assertRegExp($pattern, $string, $message);
+        }
+    }
+
+    /**
+     * For PHPUnit < 9.1 compatibility
+     */
+    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+    {
+        if (method_exists(parent::class, 'assertFileDoesNotExist')) {
+            parent::assertFileDoesNotExist($filename, $message);
+        } else {
+            /** @psalm-suppress DeprecatedMethod */
+            parent::assertFileNotExists($filename, $message);
+        }
+    }
 
     /**
      * Prepares environment for the test.

--- a/test/classes/Config/FormTest.php
+++ b/test/classes/Config/FormTest.php
@@ -11,7 +11,6 @@ use ReflectionClass;
 use ReflectionProperty;
 
 use function array_keys;
-use function method_exists;
 use function preg_match;
 
 /**
@@ -151,13 +150,7 @@ class FormTest extends AbstractTestCase
         $this->assertIsString($result[1]);
 
         // needs regexp because the counter is static
-
-        if (method_exists($this, 'assertMatchesRegularExpression')) {
-            $this->assertMatchesRegularExpression('/^preffoo\/foo\/bar\/\:group\:end\:\d+$/', $result[1]);
-        } else {
-            /** @psalm-suppress DeprecatedMethod */
-            $this->assertRegExp('/^preffoo\/foo\/bar\/\:group\:end\:\d+$/', $result[1]);
-        }
+        $this->assertMatchesRegularExpression('/^preffoo\/foo\/bar\/\:group\:end\:\d+$/', $result[1]);
     }
 
     /**
@@ -189,17 +182,10 @@ class FormTest extends AbstractTestCase
         unset($result['test']);
 
         // needs regexp because the counter is static
-
-        $keys = array_keys($result);
-        $key = $keys[0];
+        $key = array_keys($result)[0];
         $this->assertIsString($key);
 
-        if (method_exists($this, 'assertMatchesRegularExpression')) {
-            $this->assertMatchesRegularExpression('/^\:group\:end\:(\d+)$/', $key);
-        } else {
-            /** @psalm-suppress DeprecatedMethod */
-            $this->assertRegExp('/^\:group\:end\:(\d+)$/', $key);
-        }
+        $this->assertMatchesRegularExpression('/^\:group\:end\:(\d+)$/', $key);
 
         preg_match('/^\:group\:end\:(\d+)$/', $key, $matches);
         $digit = $matches[1];

--- a/test/classes/Gis/GisGeometryCollectionTest.php
+++ b/test/classes/Gis/GisGeometryCollectionTest.php
@@ -9,9 +9,6 @@ use PhpMyAdmin\Image\ImageWrapper;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use TCPDF;
 
-use function method_exists;
-use function preg_match;
-
 /**
  * @covers \PhpMyAdmin\Gis\GisGeometryCollection
  * @runTestsInSeparateProcesses
@@ -253,21 +250,8 @@ class GisGeometryCollectionTest extends AbstractTestCase
         array $scaleData,
         string $output
     ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
-
-        if (method_exists($this, 'assertMatchesRegularExpression')) {
-            $this->assertMatchesRegularExpression(
-                $output,
-                $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData)
-            );
-        } else {
-            /** @psalm-suppress DeprecatedMethod */
-            $this->assertRegExp(
-                $output,
-                $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData)
-            );
-        }
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
+        $this->assertMatchesRegularExpression($output, $svg);
     }
 
     /**

--- a/test/classes/Gis/GisLineStringTest.php
+++ b/test/classes/Gis/GisLineStringTest.php
@@ -8,8 +8,6 @@ use PhpMyAdmin\Gis\GisLineString;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
-use function preg_match;
-
 /**
  * @covers \PhpMyAdmin\Gis\GisLineString
  * @runTestsInSeparateProcesses
@@ -246,8 +244,8 @@ class GisLineStringTest extends GisGeomTestCase
         array $scaleData,
         string $output
     ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
+        $this->assertMatchesRegularExpression($output, $svg);
     }
 
     /**

--- a/test/classes/Gis/GisMultiLineStringTest.php
+++ b/test/classes/Gis/GisMultiLineStringTest.php
@@ -8,8 +8,6 @@ use PhpMyAdmin\Gis\GisMultiLineString;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
-use function preg_match;
-
 /**
  * @covers \PhpMyAdmin\Gis\GisMultiLineString
  * @runTestsInSeparateProcesses
@@ -328,8 +326,8 @@ class GisMultiLineStringTest extends GisGeomTestCase
         array $scaleData,
         string $output
     ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
+        $this->assertMatchesRegularExpression($output, $svg);
     }
 
     /**

--- a/test/classes/Gis/GisMultiPointTest.php
+++ b/test/classes/Gis/GisMultiPointTest.php
@@ -8,8 +8,6 @@ use PhpMyAdmin\Gis\GisMultiPoint;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
-use function preg_match;
-
 /**
  * @covers \PhpMyAdmin\Gis\GisMultiPoint
  * @runTestsInSeparateProcesses
@@ -248,8 +246,8 @@ class GisMultiPointTest extends GisGeomTestCase
         array $scaleData,
         string $output
     ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $pointColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $pointColor, $scaleData);
+        $this->assertMatchesRegularExpression($output, $svg);
     }
 
     /**

--- a/test/classes/Gis/GisMultiPolygonTest.php
+++ b/test/classes/Gis/GisMultiPolygonTest.php
@@ -8,8 +8,6 @@ use PhpMyAdmin\Gis\GisMultiPolygon;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
-use function preg_match;
-
 /**
  * @covers \PhpMyAdmin\Gis\GisMultiPolygon
  * @runTestsInSeparateProcesses
@@ -413,8 +411,8 @@ class GisMultiPolygonTest extends GisGeomTestCase
         array $scaleData,
         string $output
     ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $fillColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $fillColor, $scaleData);
+        $this->assertMatchesRegularExpression($output, $svg);
     }
 
     /**

--- a/test/classes/Gis/GisPointTest.php
+++ b/test/classes/Gis/GisPointTest.php
@@ -262,15 +262,8 @@ class GisPointTest extends GisGeomTestCase
         array $scaleData,
         string $output
     ): void {
-        $this->assertEquals(
-            $output,
-            $this->object->prepareRowAsSvg(
-                $spatial,
-                $label,
-                $pointColor,
-                $scaleData
-            )
-        );
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $pointColor, $scaleData);
+        $this->assertMatchesRegularExpression($output, $svg);
     }
 
     /**
@@ -291,7 +284,7 @@ class GisPointTest extends GisGeomTestCase
                     'scale' => 2,
                     'height' => 150,
                 ],
-                '',
+                '/^$/',
             ],
         ];
     }

--- a/test/classes/Gis/GisPolygonTest.php
+++ b/test/classes/Gis/GisPolygonTest.php
@@ -8,8 +8,6 @@ use PhpMyAdmin\Gis\GisPolygon;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
-use function preg_match;
-
 /**
  * @covers \PhpMyAdmin\Gis\GisPolygon
  * @runTestsInSeparateProcesses
@@ -499,8 +497,8 @@ class GisPolygonTest extends GisGeomTestCase
         array $scaleData,
         string $output
     ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $fillColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $fillColor, $scaleData);
+        $this->assertMatchesRegularExpression($output, $svg);
     }
 
     /**

--- a/test/classes/RoutingTest.php
+++ b/test/classes/RoutingTest.php
@@ -9,7 +9,6 @@ use PhpMyAdmin\Controllers\HomeController;
 use PhpMyAdmin\Routing;
 
 use function copy;
-use function method_exists;
 use function unlink;
 
 use const CACHE_DIR;
@@ -50,12 +49,7 @@ class RoutingTest extends AbstractTestCase
         // Create new cache file.
         $this->assertTrue(unlink($cacheFilename));
 
-        if (method_exists($this, 'assertFileDoesNotExist')) {
-            $this->assertFileDoesNotExist($cacheFilename);
-        } else {
-            /** @psalm-suppress DeprecatedMethod */
-            $this->assertFileNotExists($cacheFilename);
-        }
+        $this->assertFileDoesNotExist($cacheFilename);
 
         $dispatcher = Routing::getDispatcher();
         $this->assertInstanceOf(Dispatcher::class, $dispatcher);

--- a/test/classes/UrlTest.php
+++ b/test/classes/UrlTest.php
@@ -7,7 +7,6 @@ namespace PhpMyAdmin\Tests;
 use PhpMyAdmin\Url;
 
 use function is_string;
-use function method_exists;
 use function parse_str;
 use function str_repeat;
 use function urldecode;
@@ -210,12 +209,7 @@ class UrlTest extends AbstractTestCase
         $this->assertSame('0', $queryParams['pos']);
         $this->assertTrue(is_string($queryParams['eq']));
         $this->assertNotSame('', $queryParams['eq']);
-        if (method_exists($this, 'assertMatchesRegularExpression')) {
-            $this->assertMatchesRegularExpression('/^[a-zA-Z0-9-_=]+$/', $queryParams['eq']);
-        } else {
-            /** @psalm-suppress DeprecatedMethod */
-            $this->assertRegExp('/^[a-zA-Z0-9-_=]+$/', $queryParams['eq']);
-        }
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9-_=]+$/', $queryParams['eq']);
 
         $decrypted = Url::decryptQuery($queryParams['eq']);
         $this->assertNotNull($decrypted);
@@ -236,12 +230,7 @@ class UrlTest extends AbstractTestCase
         $encrypted = Url::encryptQuery($query);
         $this->assertNotSame($query, $encrypted);
         $this->assertNotSame('', $encrypted);
-        if (method_exists($this, 'assertMatchesRegularExpression')) {
-            $this->assertMatchesRegularExpression('/^[a-zA-Z0-9-_=]+$/', $encrypted);
-        } else {
-            /** @psalm-suppress DeprecatedMethod */
-            $this->assertRegExp('/^[a-zA-Z0-9-_=]+$/', $encrypted);
-        }
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9-_=]+$/', $encrypted);
 
         $decrypted = Url::decryptQuery($encrypted);
         $this->assertSame($query, $decrypted);


### PR DESCRIPTION
Signed-off-by: Maximilian Krög <maxi_kroeg@web.de>

Instead of checking in each test individually if the new methods in PHPUnit 9 exist this adds them to the AbstractTest class and calls the correct one accordingly.
