### PR TITLE
Fix #17703 - Multiple Datepicker issues resolved

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -595,6 +595,12 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
          * @param cell <td> element to be edited
          */
         showEditCell: function (cell) {
+            // destroy the date picker instance left if any, see: #17703
+            var $datePickerInstance = $(g.cEdit).find('.hasDatepicker');
+            if ($datePickerInstance.length > 0) {
+                $datePickerInstance.datepicker('destroy');
+            }
+
             if ($(cell).is('.grid_edit') &&
                 !g.colRsz && !g.colReorder) {
                 if (!g.isCellEditActive) {


### PR DESCRIPTION
Signed-off-by: Vimal K <vimalinfo10@gmail.com>


### Description

1. Datepicker appears on all column types, not just date - Fixed
2. If you copy a row, on the bottom left appears the date picker - Fixed
3.  If the column type is only date, the date picker doesn't appear - Fixed
4. ~~Tooltip appearing in a wrong place - Fixed (Styling)~~ Reverted by @williamdes 

Fixes: #17703

### Screenshots in order:
### 1
[Datepicker appears on all column types, not just date.webm](https://user-images.githubusercontent.com/35750792/199934574-ecfe6138-04df-4996-9c47-ade82d2e50e1.webm)


### 2
[If you copy a row, on the bottom left appears the date picker.webm](https://user-images.githubusercontent.com/35750792/199934797-06dd0660-8db4-4490-8b50-2e79c6e0add5.webm)


### 3
[If the column type is only date, the date picker doesn't appear.webm](https://user-images.githubusercontent.com/35750792/199934821-a9b03905-5569-4efc-a85e-dfbb2716c5f5.webm)

### 4
[Tooltip appearing in a wrong place.webm](https://user-images.githubusercontent.com/35750792/199934861-4e096a39-fe2d-4a3a-b83a-75060a77e532.webm)

Fixes #17703 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
