### PR TITLE
Fix #17404 - Handling and Redirecting to the database list page after dropping the current Database

### DIFF
--- a/libraries/classes/Controllers/AbstractController.php
+++ b/libraries/classes/Controllers/AbstractController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Controllers;
 
 use PhpMyAdmin\Core;
-use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Url;
@@ -67,11 +66,9 @@ abstract class AbstractController
 
         if (strlen($db) === 0 || ! $is_db) {
             if ($this->response->isAjax()) {
-                $this->response->setRequestStatus(false);
-                $this->response->addJSON(
-                    'message',
-                    Message::error(__('No databases selected.'))
-                );
+                //Redirecting to the server page and exiting the AJAX control
+                $param = ['ajax_request' => 'false', 'message' => __('No databases selected.')];
+                $this->redirect('/server/databases', $param);
 
                 return false;
             }


### PR DESCRIPTION
Signed-off-by: Vimal K <vimalinfo10@gmail.com>

### Description

Handling and Redirecting to the database list page after dropping the current database.

After dropping the DB and redirecting, a gentle message is shown saying 'No database selected'. No error message pop up.

![image](https://user-images.githubusercontent.com/35750792/200754875-a0cf48fd-b436-4d32-9331-eb57dc7d7ae0.png)

[drop_db_pma.webm](https://user-images.githubusercontent.com/35750792/200754647-7ac93f12-ac13-4a1a-9490-abb32e346944.webm)


Fixes #17404 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
