### PR TITLE
Fix broken single column change page introduced by #17862

### DIFF
--- a/libraries/classes/Controllers/Table/Structure/ChangeController.php
+++ b/libraries/classes/Controllers/Table/Structure/ChangeController.php
@@ -38,7 +38,7 @@ final class ChangeController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        if ($request->getParsedBodyParam('change_column') !== null) {
+        if ($request->getParam('change_column') !== null) {
             $this->displayHtmlForColumnChange([$request->getParam('field')]);
 
             return;


### PR DESCRIPTION
### Description

#17862 changed the check from an URL query to a POST body. On single column changes we request the page via a GET.

Fixes 

When you tried to change a single column the page was just blank. With this change you can see the values again.


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
