### PR TITLE
Refactor gis color

### DIFF
--- a/libraries/classes/Gis/GisGeometry.php
+++ b/libraries/classes/Gis/GisGeometry.php
@@ -32,25 +32,25 @@ abstract class GisGeometry
      *
      * @param string $spatial    GIS data object
      * @param string $label      label for the GIS data object
-     * @param string $color      color for the GIS data object
+     * @param int[]  $color      color for the GIS data object
      * @param array  $scale_data data related to scaling
      *
      * @return string the code related to a row in the GIS dataset
      */
-    abstract public function prepareRowAsSvg($spatial, $label, $color, array $scale_data);
+    abstract public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data);
 
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
      * @param string      $spatial    GIS POLYGON object
      * @param string|null $label      Label for the GIS POLYGON object
-     * @param string      $color      Color for the GIS POLYGON object
+     * @param int[]       $color      Color for the GIS POLYGON object
      * @param array       $scale_data Array containing data related to scaling
      */
     abstract public function prepareRowAsPng(
         $spatial,
         ?string $label,
-        $color,
+        array $color,
         array $scale_data,
         ImageWrapper $image
     ): ImageWrapper;
@@ -60,7 +60,7 @@ abstract class GisGeometry
      *
      * @param string      $spatial    GIS data object
      * @param string|null $label      label for the GIS data object
-     * @param string      $color      color for the GIS data object
+     * @param int[]       $color      color for the GIS data object
      * @param array       $scale_data array containing data related to scaling
      * @param TCPDF       $pdf        TCPDF instance
      *
@@ -69,7 +69,7 @@ abstract class GisGeometry
     abstract public function prepareRowAsPdf(
         $spatial,
         ?string $label,
-        $color,
+        array $color,
         array $scale_data,
         $pdf
     );
@@ -81,7 +81,7 @@ abstract class GisGeometry
      * @param string $spatial    GIS data object
      * @param int    $srid       spatial reference ID
      * @param string $label      label for the GIS data object
-     * @param array  $color      color for the GIS data object
+     * @param int[]  $color      color for the GIS data object
      * @param array  $scale_data array containing data related to scaling
      *
      * @return string the JavaScript related to a row in the GIS dataset
@@ -90,7 +90,7 @@ abstract class GisGeometry
         $spatial,
         int $srid,
         $label,
-        $color,
+        array $color,
         array $scale_data
     );
 

--- a/libraries/classes/Gis/GisGeometryCollection.php
+++ b/libraries/classes/Gis/GisGeometryCollection.php
@@ -109,13 +109,13 @@ class GisGeometryCollection extends GisGeometry
      *
      * @param string      $spatial    GIS POLYGON object
      * @param string|null $label      Label for the GIS POLYGON object
-     * @param string      $color      Color for the GIS POLYGON object
+     * @param int[]       $color      Color for the GIS POLYGON object
      * @param array       $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
         ?string $label,
-        $color,
+        array $color,
         array $scale_data,
         ImageWrapper $image
     ): ImageWrapper {
@@ -148,13 +148,13 @@ class GisGeometryCollection extends GisGeometry
      *
      * @param string      $spatial    GIS GEOMETRYCOLLECTION object
      * @param string|null $label      label for the GIS GEOMETRYCOLLECTION object
-     * @param string      $color      color for the GIS GEOMETRYCOLLECTION object
+     * @param int[]       $color      color for the GIS GEOMETRYCOLLECTION object
      * @param array       $scale_data array containing data related to scaling
      * @param TCPDF       $pdf        TCPDF instance
      *
      * @return TCPDF the modified TCPDF instance
      */
-    public function prepareRowAsPdf($spatial, ?string $label, $color, array $scale_data, $pdf)
+    public function prepareRowAsPdf($spatial, ?string $label, array $color, array $scale_data, $pdf)
     {
         // Trim to remove leading 'GEOMETRYCOLLECTION(' and trailing ')'
         $goem_col = mb_substr($spatial, 19, -1);
@@ -185,12 +185,12 @@ class GisGeometryCollection extends GisGeometry
      *
      * @param string $spatial    GIS GEOMETRYCOLLECTION object
      * @param string $label      label for the GIS GEOMETRYCOLLECTION object
-     * @param string $color      color for the GIS GEOMETRYCOLLECTION object
+     * @param int[]  $color      color for the GIS GEOMETRYCOLLECTION object
      * @param array  $scale_data array containing data related to scaling
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, $color, array $scale_data)
+    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
     {
         $row = '';
 
@@ -225,12 +225,12 @@ class GisGeometryCollection extends GisGeometry
      * @param string $spatial    GIS GEOMETRYCOLLECTION object
      * @param int    $srid       spatial reference ID
      * @param string $label      label for the GIS GEOMETRYCOLLECTION object
-     * @param array  $color      color for the GIS GEOMETRYCOLLECTION object
+     * @param int[]  $color      color for the GIS GEOMETRYCOLLECTION object
      * @param array  $scale_data array containing data related to scaling
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
-    public function prepareRowAsOl($spatial, int $srid, $label, $color, array $scale_data)
+    public function prepareRowAsOl($spatial, int $srid, $label, array $color, array $scale_data)
     {
         $row = '';
 

--- a/libraries/classes/Gis/GisLineString.php
+++ b/libraries/classes/Gis/GisLineString.php
@@ -11,10 +11,10 @@ use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
 use function count;
-use function hexdec;
 use function json_encode;
 use function mb_substr;
 use function round;
+use function sprintf;
 use function trim;
 
 /**
@@ -66,22 +66,19 @@ class GisLineString extends GisGeometry
      *
      * @param string      $spatial    GIS POLYGON object
      * @param string|null $label      Label for the GIS POLYGON object
-     * @param string      $line_color Color for the GIS POLYGON object
+     * @param int[]       $color      Color for the GIS POLYGON object
      * @param array       $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
         ?string $label,
-        $line_color,
+        array $color,
         array $scale_data,
         ImageWrapper $image
     ): ImageWrapper {
         // allocate colors
         $black = $image->colorAllocate(0, 0, 0);
-        $red = (int) hexdec(mb_substr($line_color, 1, 2));
-        $green = (int) hexdec(mb_substr($line_color, 3, 2));
-        $blue = (int) hexdec(mb_substr($line_color, 4, 2));
-        $color = $image->colorAllocate($red, $green, $blue);
+        $line_color = $image->colorAllocate(...$color);
 
         $label = trim($label ?? '');
 
@@ -97,7 +94,7 @@ class GisLineString extends GisGeometry
                     (int) round($temp_point[1]),
                     (int) round($point[0]),
                     (int) round($point[1]),
-                    $color
+                    $line_color
                 );
             }
 
@@ -123,25 +120,17 @@ class GisLineString extends GisGeometry
      *
      * @param string      $spatial    GIS LINESTRING object
      * @param string|null $label      Label for the GIS LINESTRING object
-     * @param string      $line_color Color for the GIS LINESTRING object
+     * @param int[]       $color      Color for the GIS LINESTRING object
      * @param array       $scale_data Array containing data related to scaling
      * @param TCPDF       $pdf        TCPDF instance
      *
      * @return TCPDF the modified TCPDF instance
      */
-    public function prepareRowAsPdf($spatial, ?string $label, $line_color, array $scale_data, $pdf)
+    public function prepareRowAsPdf($spatial, ?string $label, array $color, array $scale_data, $pdf)
     {
-        // allocate colors
-        $red = hexdec(mb_substr($line_color, 1, 2));
-        $green = hexdec(mb_substr($line_color, 3, 2));
-        $blue = hexdec(mb_substr($line_color, 4, 2));
         $line = [
             'width' => 1.5,
-            'color' => [
-                $red,
-                $green,
-                $blue,
-            ],
+            'color' => $color,
         ];
 
         $label = trim($label ?? '');
@@ -174,19 +163,19 @@ class GisLineString extends GisGeometry
      *
      * @param string $spatial    GIS LINESTRING object
      * @param string $label      Label for the GIS LINESTRING object
-     * @param string $line_color Color for the GIS LINESTRING object
+     * @param int[]  $color      Color for the GIS LINESTRING object
      * @param array  $scale_data Array containing data related to scaling
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, $line_color, array $scale_data)
+    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
     {
         $line_options = [
             'name' => $label,
             'id' => $label . $this->getRandomId(),
             'class' => 'linestring vector',
             'fill' => 'none',
-            'stroke' => $line_color,
+            'stroke' => sprintf('#%02x%02x%02x', ...$color),
             'stroke-width' => 2,
         ];
 
@@ -216,15 +205,15 @@ class GisLineString extends GisGeometry
      * @param string $spatial    GIS LINESTRING object
      * @param int    $srid       Spatial reference ID
      * @param string $label      Label for the GIS LINESTRING object
-     * @param array  $line_color Color for the GIS LINESTRING object
+     * @param int[]  $color      Color for the GIS LINESTRING object
      * @param array  $scale_data Array containing data related to scaling
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
-    public function prepareRowAsOl($spatial, int $srid, $label, $line_color, array $scale_data)
+    public function prepareRowAsOl($spatial, int $srid, $label, array $color, array $scale_data)
     {
         $stroke_style = [
-            'color' => $line_color,
+            'color' => $color,
             'width' => 2,
         ];
 

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -12,10 +12,10 @@ use TCPDF;
 
 use function count;
 use function explode;
-use function hexdec;
 use function json_encode;
 use function mb_substr;
 use function round;
+use function sprintf;
 use function trim;
 
 /**
@@ -75,22 +75,19 @@ class GisMultiLineString extends GisGeometry
      *
      * @param string      $spatial    GIS POLYGON object
      * @param string|null $label      Label for the GIS POLYGON object
-     * @param string      $line_color Color for the GIS POLYGON object
+     * @param int[]       $color      Color for the GIS POLYGON object
      * @param array       $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
         ?string $label,
-        $line_color,
+        array $color,
         array $scale_data,
         ImageWrapper $image
     ): ImageWrapper {
         // allocate colors
         $black = $image->colorAllocate(0, 0, 0);
-        $red = (int) hexdec(mb_substr($line_color, 1, 2));
-        $green = (int) hexdec(mb_substr($line_color, 3, 2));
-        $blue = (int) hexdec(mb_substr($line_color, 4, 2));
-        $color = $image->colorAllocate($red, $green, $blue);
+        $line_color = $image->colorAllocate(...$color);
 
         $label = trim($label ?? '');
 
@@ -110,7 +107,7 @@ class GisMultiLineString extends GisGeometry
                         (int) round($temp_point[1]),
                         (int) round($point[0]),
                         (int) round($point[1]),
-                        $color
+                        $line_color
                     );
                 }
 
@@ -140,25 +137,17 @@ class GisMultiLineString extends GisGeometry
      *
      * @param string      $spatial    GIS MULTILINESTRING object
      * @param string|null $label      Label for the GIS MULTILINESTRING object
-     * @param string      $line_color Color for the GIS MULTILINESTRING object
+     * @param int[]       $color      Color for the GIS MULTILINESTRING object
      * @param array       $scale_data Array containing data related to scaling
      * @param TCPDF       $pdf        TCPDF instance
      *
      * @return TCPDF the modified TCPDF instance
      */
-    public function prepareRowAsPdf($spatial, ?string $label, $line_color, array $scale_data, $pdf)
+    public function prepareRowAsPdf($spatial, ?string $label, array $color, array $scale_data, $pdf)
     {
-        // allocate colors
-        $red = hexdec(mb_substr($line_color, 1, 2));
-        $green = hexdec(mb_substr($line_color, 3, 2));
-        $blue = hexdec(mb_substr($line_color, 4, 2));
         $line = [
             'width' => 1.5,
-            'color' => [
-                $red,
-                $green,
-                $blue,
-            ],
+            'color' => $color,
         ];
 
         $label = trim($label ?? '');
@@ -199,18 +188,18 @@ class GisMultiLineString extends GisGeometry
      *
      * @param string $spatial    GIS MULTILINESTRING object
      * @param string $label      Label for the GIS MULTILINESTRING object
-     * @param string $line_color Color for the GIS MULTILINESTRING object
+     * @param int[]  $color      Color for the GIS MULTILINESTRING object
      * @param array  $scale_data Array containing data related to scaling
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, $line_color, array $scale_data)
+    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
     {
         $line_options = [
             'name' => $label,
             'class' => 'linestring vector',
             'fill' => 'none',
-            'stroke' => $line_color,
+            'stroke' => sprintf('#%02x%02x%02x', ...$color),
             'stroke-width' => 2,
         ];
 
@@ -247,15 +236,15 @@ class GisMultiLineString extends GisGeometry
      * @param string $spatial    GIS MULTILINESTRING object
      * @param int    $srid       Spatial reference ID
      * @param string $label      Label for the GIS MULTILINESTRING object
-     * @param array  $line_color Color for the GIS MULTILINESTRING object
+     * @param int[]  $color      Color for the GIS MULTILINESTRING object
      * @param array  $scale_data Array containing data related to scaling
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
-    public function prepareRowAsOl($spatial, int $srid, $label, $line_color, array $scale_data)
+    public function prepareRowAsOl($spatial, int $srid, $label, array $color, array $scale_data)
     {
         $stroke_style = [
-            'color' => $line_color,
+            'color' => $color,
             'width' => 2,
         ];
 

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -14,10 +14,10 @@ use function array_merge;
 use function array_slice;
 use function count;
 use function explode;
-use function hexdec;
 use function json_encode;
 use function mb_substr;
 use function round;
+use function sprintf;
 use function str_contains;
 use function trim;
 
@@ -87,22 +87,19 @@ class GisMultiPolygon extends GisGeometry
      *
      * @param string      $spatial    GIS POLYGON object
      * @param string|null $label      Label for the GIS POLYGON object
-     * @param string      $fill_color Color for the GIS POLYGON object
+     * @param int[]       $color      Color for the GIS POLYGON object
      * @param array       $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
         ?string $label,
-        $fill_color,
+        array $color,
         array $scale_data,
         ImageWrapper $image
     ): ImageWrapper {
         // allocate colors
         $black = $image->colorAllocate(0, 0, 0);
-        $red = (int) hexdec(mb_substr($fill_color, 1, 2));
-        $green = (int) hexdec(mb_substr($fill_color, 3, 2));
-        $blue = (int) hexdec(mb_substr($fill_color, 4, 2));
-        $color = $image->colorAllocate($red, $green, $blue);
+        $fill_color = $image->colorAllocate(...$color);
 
         $label = trim($label ?? '');
 
@@ -133,7 +130,7 @@ class GisMultiPolygon extends GisGeometry
             }
 
             // draw polygon
-            $image->filledPolygon($points_arr, $color);
+            $image->filledPolygon($points_arr, $fill_color);
             // mark label point if applicable
             if ($label !== '' && $first_poly) {
                 $label_point = [
@@ -164,24 +161,14 @@ class GisMultiPolygon extends GisGeometry
      *
      * @param string      $spatial    GIS MULTIPOLYGON object
      * @param string|null $label      Label for the GIS MULTIPOLYGON object
-     * @param string      $fill_color Color for the GIS MULTIPOLYGON object
+     * @param int[]       $color      Color for the GIS MULTIPOLYGON object
      * @param array       $scale_data Array containing data related to scaling
      * @param TCPDF       $pdf        TCPDF instance
      *
      * @return TCPDF the modified TCPDF instance
      */
-    public function prepareRowAsPdf($spatial, ?string $label, $fill_color, array $scale_data, $pdf)
+    public function prepareRowAsPdf($spatial, ?string $label, array $color, array $scale_data, $pdf)
     {
-        // allocate colors
-        $red = hexdec(mb_substr($fill_color, 1, 2));
-        $green = hexdec(mb_substr($fill_color, 3, 2));
-        $blue = hexdec(mb_substr($fill_color, 4, 2));
-        $color = [
-            $red,
-            $green,
-            $blue,
-        ];
-
         $label = trim($label ?? '');
 
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
@@ -238,19 +225,19 @@ class GisMultiPolygon extends GisGeometry
      *
      * @param string $spatial    GIS MULTIPOLYGON object
      * @param string $label      Label for the GIS MULTIPOLYGON object
-     * @param string $fill_color Color for the GIS MULTIPOLYGON object
+     * @param int[]  $color      Color for the GIS MULTIPOLYGON object
      * @param array  $scale_data Array containing data related to scaling
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, $fill_color, array $scale_data)
+    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
     {
         $polygon_options = [
             'name' => $label,
             'class' => 'multipolygon vector',
             'stroke' => 'black',
             'stroke-width' => 0.5,
-            'fill' => $fill_color,
+            'fill' => sprintf('#%02x%02x%02x', ...$color),
             'fill-rule' => 'evenodd',
             'fill-opacity' => 0.8,
         ];
@@ -300,17 +287,17 @@ class GisMultiPolygon extends GisGeometry
      * @param string $spatial    GIS MULTIPOLYGON object
      * @param int    $srid       Spatial reference ID
      * @param string $label      Label for the GIS MULTIPOLYGON object
-     * @param array  $fill_color Color for the GIS MULTIPOLYGON object
+     * @param int[]  $color      Color for the GIS MULTIPOLYGON object
      * @param array  $scale_data Array containing data related to scaling
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
-    public function prepareRowAsOl($spatial, int $srid, $label, $fill_color, array $scale_data)
+    public function prepareRowAsOl($spatial, int $srid, $label, array $color, array $scale_data)
     {
-        $fill_color[] = 0.8;
-        $fill_style = ['color' => $fill_color];
+        $color[] = 0.8;
+        $fill_style = ['color' => $color];
         $stroke_style = [
-            'color' => [0,0,0],
+            'color' => [0, 0, 0],
             'width' => 0.5,
         ];
         $row = 'var style = new ol.style.Style({'

--- a/libraries/classes/Gis/GisPoint.php
+++ b/libraries/classes/Gis/GisPoint.php
@@ -10,10 +10,10 @@ namespace PhpMyAdmin\Gis;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
-use function hexdec;
 use function json_encode;
 use function mb_substr;
 use function round;
+use function sprintf;
 use function trim;
 
 /**
@@ -63,24 +63,21 @@ class GisPoint extends GisGeometry
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial     GIS POLYGON object
-     * @param string|null $label       Label for the GIS POLYGON object
-     * @param string      $point_color Color for the GIS POLYGON object
-     * @param array       $scale_data  Array containing data related to scaling
+     * @param string      $spatial    GIS POLYGON object
+     * @param string|null $label      Label for the GIS POLYGON object
+     * @param int[]       $color      Color for the GIS POLYGON object
+     * @param array       $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
         ?string $label,
-        $point_color,
+        array $color,
         array $scale_data,
         ImageWrapper $image
     ): ImageWrapper {
         // allocate colors
         $black = $image->colorAllocate(0, 0, 0);
-        $red = (int) hexdec(mb_substr($point_color, 1, 2));
-        $green = (int) hexdec(mb_substr($point_color, 3, 2));
-        $blue = (int) hexdec(mb_substr($point_color, 4, 2));
-        $color = $image->colorAllocate($red, $green, $blue);
+        $point_color = $image->colorAllocate(...$color);
 
         $label = trim($label ?? '');
 
@@ -97,7 +94,7 @@ class GisPoint extends GisGeometry
                 7,
                 0,
                 360,
-                $color
+                $point_color
             );
             // print label if applicable
             if ($label !== '') {
@@ -117,32 +114,24 @@ class GisPoint extends GisGeometry
     /**
      * Adds to the TCPDF instance, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial     GIS POINT object
-     * @param string|null $label       Label for the GIS POINT object
-     * @param string      $point_color Color for the GIS POINT object
-     * @param array       $scale_data  Array containing data related to scaling
-     * @param TCPDF       $pdf         TCPDF instance
+     * @param string      $spatial    GIS POINT object
+     * @param string|null $label      Label for the GIS POINT object
+     * @param int[]       $color      Color for the GIS POINT object
+     * @param array       $scale_data Array containing data related to scaling
+     * @param TCPDF       $pdf        TCPDF instance
      *
      * @return TCPDF the modified TCPDF instance
      */
     public function prepareRowAsPdf(
         $spatial,
         ?string $label,
-        $point_color,
+        array $color,
         array $scale_data,
         $pdf
     ) {
-        // allocate colors
-        $red = hexdec(mb_substr($point_color, 1, 2));
-        $green = hexdec(mb_substr($point_color, 3, 2));
-        $blue = hexdec(mb_substr($point_color, 4, 2));
         $line = [
             'width' => 1.25,
-            'color' => [
-                $red,
-                $green,
-                $blue,
-            ],
+            'color' => $color,
         ];
 
         $label = trim($label ?? '');
@@ -168,21 +157,21 @@ class GisPoint extends GisGeometry
     /**
      * Prepares and returns the code related to a row in the GIS dataset as SVG.
      *
-     * @param string $spatial     GIS POINT object
-     * @param string $label       Label for the GIS POINT object
-     * @param string $point_color Color for the GIS POINT object
-     * @param array  $scale_data  Array containing data related to scaling
+     * @param string $spatial    GIS POINT object
+     * @param string $label      Label for the GIS POINT object
+     * @param int[]  $color      Color for the GIS POINT object
+     * @param array  $scale_data Array containing data related to scaling
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, $point_color, array $scale_data)
+    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
     {
         $point_options = [
             'name' => $label,
             'id' => $label . $this->getRandomId(),
             'class' => 'point vector',
             'fill' => 'white',
-            'stroke' => $point_color,
+            'stroke' => sprintf('#%02x%02x%02x', ...$color),
             'stroke-width' => 2,
         ];
 
@@ -208,11 +197,11 @@ class GisPoint extends GisGeometry
      * Prepares JavaScript related to a row in the GIS dataset
      * to visualize it with OpenLayers.
      *
-     * @param string $spatial     GIS POINT object
-     * @param int    $srid        Spatial reference ID
-     * @param string $label       Label for the GIS POINT object
-     * @param array  $point_color Color for the GIS POINT object
-     * @param array  $scale_data  Array containing data related to scaling
+     * @param string $spatial    GIS POINT object
+     * @param int    $srid       Spatial reference ID
+     * @param string $label      Label for the GIS POINT object
+     * @param int[]  $color      Color for the GIS POINT object
+     * @param array  $scale_data Array containing data related to scaling
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
@@ -220,12 +209,12 @@ class GisPoint extends GisGeometry
         $spatial,
         int $srid,
         $label,
-        $point_color,
+        array $color,
         array $scale_data
     ) {
         $fill_style = ['color' => 'white'];
         $stroke_style = [
-            'color' => $point_color,
+            'color' => $color,
             'width' => 2,
         ];
         $result = 'var fill = new ol.style.Fill(' . json_encode($fill_style) . ');'

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -44,28 +44,6 @@ class GisVisualization
     private $settings = [
         // Array of colors to be used for GIS visualizations.
         'colors' => [
-            '#B02EE0',
-            '#E0642E',
-            '#E0D62E',
-            '#2E97E0',
-            '#BCE02E',
-            '#E02E75',
-            '#5CE02E',
-            '#E0B02E',
-            '#0022E0',
-            '#726CB1',
-            '#481A36',
-            '#BAC658',
-            '#127224',
-            '#825119',
-            '#238C74',
-            '#4C489B',
-            '#87C9BF',
-        ],
-
-
-        // Hex values for abovementioned colours
-        'colors_hex' => [
             [176, 46, 224],
             [224, 100, 46],
             [224, 214, 46],
@@ -641,12 +619,12 @@ class GisVisualization
      */
     private function prepareDataSet(array $data, array $scale_data, $format, $results)
     {
-        $color_number = 0;
+        /** @var int[][] $colors */
+        $colors = $this->settings['colors'];
+        $color_index = 0;
 
         // loop through the rows
         foreach ($data as $row) {
-            $index = $color_number % count($this->settings['colors']);
-
             // Figure out the data type
             $ref_data = $row[$this->settings['spatialColumn']];
             if (! is_string($ref_data)) {
@@ -665,6 +643,7 @@ class GisVisualization
                 continue;
             }
 
+            $color = $colors[$color_index];
             $label = '';
             if (isset($this->settings['labelColumn'], $row[$this->settings['labelColumn']])) {
                 $label = $row[$this->settings['labelColumn']];
@@ -674,14 +653,14 @@ class GisVisualization
                 $results .= $gis_obj->prepareRowAsSvg(
                     $row[$this->settings['spatialColumn']],
                     $label,
-                    $this->settings['colors'][$index],
+                    $color,
                     $scale_data
                 );
             } elseif ($format === 'png') {
                 $results = $gis_obj->prepareRowAsPng(
                     $row[$this->settings['spatialColumn']],
                     $label,
-                    $this->settings['colors'][$index],
+                    $color,
                     $scale_data,
                     $results
                 );
@@ -689,7 +668,7 @@ class GisVisualization
                 $results = $gis_obj->prepareRowAsPdf(
                     $row[$this->settings['spatialColumn']],
                     $label,
-                    $this->settings['colors'][$index],
+                    $color,
                     $scale_data,
                     $results
                 );
@@ -698,12 +677,12 @@ class GisVisualization
                     $row[$this->settings['spatialColumn']],
                     (int) $row['srid'],
                     $label,
-                    $this->settings['colors_hex'][$index],
+                    $color,
                     $scale_data
                 );
             }
 
-            $color_number++;
+            $color_index = ($color_index + 1) % count($colors);
         }
 
         return $results;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3676,11 +3676,6 @@ parameters:
 			path: libraries/classes/Gis/GisGeometry.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometry\\:\\:prepareRowAsOl\\(\\) has parameter \\$color with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisGeometry.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometry\\:\\:prepareRowAsOl\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisGeometry.php
@@ -3741,11 +3736,6 @@ parameters:
 			path: libraries/classes/Gis/GisGeometryCollection.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometryCollection\\:\\:prepareRowAsOl\\(\\) has parameter \\$color with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisGeometryCollection.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometryCollection\\:\\:prepareRowAsOl\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisGeometryCollection.php
@@ -3787,11 +3777,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisLineString\\:\\:generateWkt\\(\\) has parameter \\$gis_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisLineString\\:\\:prepareRowAsOl\\(\\) has parameter \\$line_color with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisLineString.php
 
@@ -3847,11 +3832,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiLineString\\:\\:getShape\\(\\) has parameter \\$row_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiLineString\\:\\:prepareRowAsOl\\(\\) has parameter \\$line_color with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiLineString.php
 
@@ -3916,11 +3896,6 @@ parameters:
 			path: libraries/classes/Gis/GisMultiPoint.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiPoint\\:\\:prepareRowAsOl\\(\\) has parameter \\$point_color with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPoint.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiPoint\\:\\:prepareRowAsOl\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiPoint.php
@@ -3981,11 +3956,6 @@ parameters:
 			path: libraries/classes/Gis/GisMultiPolygon.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiPolygon\\:\\:prepareRowAsOl\\(\\) has parameter \\$fill_color with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPolygon.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiPolygon\\:\\:prepareRowAsOl\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiPolygon.php
@@ -4037,11 +4007,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisPoint\\:\\:getShape\\(\\) has parameter \\$row_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisPoint\\:\\:prepareRowAsOl\\(\\) has parameter \\$point_color with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisPoint.php
 
@@ -4127,11 +4092,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisPolygon\\:\\:isPointInsidePolygon\\(\\) has parameter \\$polygon with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPolygon.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisPolygon\\:\\:prepareRowAsOl\\(\\) has parameter \\$fill_color with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisPolygon.php
 
@@ -9891,11 +9851,6 @@ parameters:
 			path: test/classes/Gis/GisGeometryCollectionTest.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisGeometryCollectionTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$line_color with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisGeometryCollectionTest.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisGeometryCollectionTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Gis/GisGeometryCollectionTest.php
@@ -10011,11 +9966,6 @@ parameters:
 			path: test/classes/Gis/GisLineStringTest.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisLineStringTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$line_color with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisLineStringTest.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisLineStringTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Gis/GisLineStringTest.php
@@ -10071,11 +10021,6 @@ parameters:
 			path: test/classes/Gis/GisMultiLineStringTest.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisMultiLineStringTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$line_color with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisMultiLineStringTest.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisMultiLineStringTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Gis/GisMultiLineStringTest.php
@@ -10127,11 +10072,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisMultiPointTest\\:\\:providerForTestScaleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisMultiPointTest.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisMultiPointTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$point_color with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Gis/GisMultiPointTest.php
 
@@ -10206,11 +10146,6 @@ parameters:
 			path: test/classes/Gis/GisMultiPolygonTest.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisMultiPolygonTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$fill_color with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisMultiPolygonTest.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisMultiPolygonTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Gis/GisMultiPolygonTest.php
@@ -10272,11 +10207,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisPointTest\\:\\:testGetShape\\(\\) has parameter \\$row_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisPointTest.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisPointTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$point_color with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Gis/GisPointTest.php
 
@@ -10382,11 +10312,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisPolygonTest\\:\\:testIsPointInsidePolygon\\(\\) has parameter \\$polygon with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisPolygonTest.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisPolygonTest\\:\\:testPrepareRowAsOl\\(\\) has parameter \\$fill_color with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Gis/GisPolygonTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6910,15 +6910,9 @@
       <code>$point[0]</code>
       <code>$point[1]</code>
     </MixedOperand>
-    <ParamNameMismatch occurrences="4">
-      <code>$line_color</code>
-      <code>$line_color</code>
-      <code>$line_color</code>
-      <code>$line_color</code>
-    </ParamNameMismatch>
     <PossiblyFalseArgument occurrences="2">
       <code>$black</code>
-      <code>$color</code>
+      <code>$line_color</code>
     </PossiblyFalseArgument>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset(self::$instance)</code>
@@ -6991,15 +6985,9 @@
       <code>$point[0]</code>
       <code>$point[1]</code>
     </MixedOperand>
-    <ParamNameMismatch occurrences="4">
-      <code>$line_color</code>
-      <code>$line_color</code>
-      <code>$line_color</code>
-      <code>$line_color</code>
-    </ParamNameMismatch>
     <PossiblyFalseArgument occurrences="2">
       <code>$black</code>
-      <code>$color</code>
+      <code>$line_color</code>
     </PossiblyFalseArgument>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset(self::$instance)</code>
@@ -7065,15 +7053,9 @@
       <code>$row_data['points'][$i]['x']</code>
       <code>$row_data['points'][$i]['y']</code>
     </MixedOperand>
-    <ParamNameMismatch occurrences="4">
-      <code>$point_color</code>
-      <code>$point_color</code>
-      <code>$point_color</code>
-      <code>$point_color</code>
-    </ParamNameMismatch>
     <PossiblyFalseArgument occurrences="2">
       <code>$black</code>
-      <code>$color</code>
+      <code>$point_color</code>
     </PossiblyFalseArgument>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset(self::$instance)</code>
@@ -7190,15 +7172,9 @@
       <code>$points_arr[0][0]</code>
       <code>$points_arr[0][1]</code>
     </MixedOperand>
-    <ParamNameMismatch occurrences="4">
-      <code>$fill_color</code>
-      <code>$fill_color</code>
-      <code>$fill_color</code>
-      <code>$fill_color</code>
-    </ParamNameMismatch>
     <PossiblyFalseArgument occurrences="2">
       <code>$black</code>
-      <code>$color</code>
+      <code>$fill_color</code>
     </PossiblyFalseArgument>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset(self::$instance)</code>
@@ -7251,15 +7227,9 @@
       <code>$row_data['x'] ?? ''</code>
       <code>$row_data['y'] ?? ''</code>
     </MixedOperand>
-    <ParamNameMismatch occurrences="4">
-      <code>$point_color</code>
-      <code>$point_color</code>
-      <code>$point_color</code>
-      <code>$point_color</code>
-    </ParamNameMismatch>
     <PossiblyFalseArgument occurrences="2">
       <code>$black</code>
-      <code>$color</code>
+      <code>$point_color</code>
     </PossiblyFalseArgument>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset(self::$instance)</code>
@@ -7393,15 +7363,9 @@
     <MixedReturnStatement occurrences="1">
       <code>$area</code>
     </MixedReturnStatement>
-    <ParamNameMismatch occurrences="4">
-      <code>$fill_color</code>
-      <code>$fill_color</code>
-      <code>$fill_color</code>
-      <code>$fill_color</code>
-    </ParamNameMismatch>
     <PossiblyFalseArgument occurrences="2">
       <code>$black</code>
-      <code>$color</code>
+      <code>$fill_color</code>
     </PossiblyFalseArgument>
     <PossiblyNullOperand occurrences="16">
       <code>$x1</code>
@@ -7429,7 +7393,7 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;userSpecifiedSettings === null</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="20">
+    <MixedArgument occurrences="15">
       <code>$label</code>
       <code>$label</code>
       <code>$label</code>
@@ -7439,11 +7403,6 @@
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
-      <code>$this-&gt;settings['colors']</code>
-      <code>$this-&gt;settings['colors'][$index]</code>
-      <code>$this-&gt;settings['colors'][$index]</code>
-      <code>$this-&gt;settings['colors'][$index]</code>
-      <code>$this-&gt;settings['colors_hex'][$index]</code>
       <code>$this-&gt;settings['height']</code>
       <code>$this-&gt;settings['width']</code>
       <code>$this-&gt;userSpecifiedSettings['labelColumn']</code>
@@ -7451,7 +7410,7 @@
       <code>$this-&gt;userSpecifiedSettings['spatialColumn']</code>
       <code>$this-&gt;userSpecifiedSettings['spatialColumn']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="14">
+    <MixedArrayAccess occurrences="10">
       <code>$row[$this-&gt;settings['labelColumn']]</code>
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
@@ -7462,10 +7421,6 @@
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
       <code>$row['srid']</code>
       <code>$row['srid']</code>
-      <code>$this-&gt;settings['colors'][$index]</code>
-      <code>$this-&gt;settings['colors'][$index]</code>
-      <code>$this-&gt;settings['colors'][$index]</code>
-      <code>$this-&gt;settings['colors_hex'][$index]</code>
     </MixedArrayAccess>
     <MixedArrayOffset occurrences="9">
       <code>$row[$this-&gt;settings['labelColumn']]</code>

--- a/test/classes/Controllers/Table/GisVisualizationControllerTest.php
+++ b/test/classes/Controllers/Table/GisVisualizationControllerTest.php
@@ -92,7 +92,7 @@ class GisVisualizationControllerTest extends AbstractTestCase
             'visualization' => '<?xml version="1.0" encoding="UTF-8" standalone="no"?>' . "\n"
                 . '<svg version="1.1" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg"'
                 . ' width="600" height="450"><g id="groupPanel"><circle cx="15" cy="240" r="3" name=""'
-                . ' id="1234567890" class="point vector" fill="white" stroke="#B02EE0" stroke-width="2"/></g></svg>',
+                . ' id="1234567890" class="point vector" fill="white" stroke="#b02ee0" stroke-width="2"/></g></svg>',
             'draw_ol' => 'function drawOpenLayers() {if (typeof ol !== "undefined") {var olCss ='
                 . ' "js/vendor/openlayers/theme/ol.css";$(\'head\').append(\'<link rel="stylesheet" type="text/css"'
                 . ' href=\'+olCss+\'>\');var vectorLayer = new ol.source.Vector({});var map = new ol.Map({target:'

--- a/test/classes/Gis/GisGeometryCollectionTest.php
+++ b/test/classes/Gis/GisGeometryCollectionTest.php
@@ -179,7 +179,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
         $return = $this->object->prepareRowAsPng(
             'GEOMETRYCOLLECTION(POLYGON((35 10,10 20,15 40,45 45,35 10),(20 30,35 32,30 20,20 30)))',
             'image',
-            '#B02EE0',
+            [176, 46, 224],
             ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
             $image
         );
@@ -192,7 +192,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
      *
      * @param string $spatial    string to parse
      * @param string $label      field label
-     * @param string $line_color line color
+     * @param int[]  $color      line color
      * @param array  $scale_data scaling parameters
      * @param TCPDF  $pdf        expected output
      *
@@ -201,11 +201,11 @@ class GisGeometryCollectionTest extends AbstractTestCase
     public function testPrepareRowAsPdf(
         string $spatial,
         string $label,
-        string $line_color,
+        array $color,
         array $scale_data,
         TCPDF $pdf
     ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $line_color, $scale_data, $pdf);
+        $return = $this->object->prepareRowAsPdf($spatial, $label, $color, $scale_data, $pdf);
         $this->assertInstanceOf(TCPDF::class, $return);
     }
 
@@ -220,7 +220,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
             [
                 'GEOMETRYCOLLECTION(POLYGON((35 10,10 20,15 40,45 45,35 10),(20 30,35 32,30 20,20 30)))',
                 'pdf',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -237,7 +237,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
      *
      * @param string $spatial   string to parse
      * @param string $label     field label
-     * @param string $lineColor line color
+     * @param int[]  $color     line color
      * @param array  $scaleData scaling parameters
      * @param string $output    expected output
      *
@@ -246,11 +246,11 @@ class GisGeometryCollectionTest extends AbstractTestCase
     public function testPrepareRowAsSvg(
         string $spatial,
         string $label,
-        string $lineColor,
+        array $color,
         array $scaleData,
         string $output
     ): void {
-        $svg = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
         $this->assertMatchesRegularExpression($output, $svg);
     }
 
@@ -265,7 +265,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
             [
                 'GEOMETRYCOLLECTION(POLYGON((35 10,10 20,15 40,45 45,35 10),(20 30,35 32,30 20,20 30)))',
                 'svg',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -275,7 +275,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
                 '/^(<path d=" M 46, 268 L -4, 248 L 6, 208 L 66, 198 Z  M 16,'
                     . ' 228 L 46, 224 L 36, 248 Z " name="svg" id="svg)(\d+)'
                     . '(" class="polygon vector" stroke="black" stroke-width="0.5"'
-                    . ' fill="#B02EE0" fill-rule="evenodd" fill-opacity="0.8"\/>)$/',
+                    . ' fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8"\/>)$/',
             ],
         ];
     }
@@ -286,7 +286,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
      * @param string $spatial    string to parse
      * @param int    $srid       SRID
      * @param string $label      field label
-     * @param array  $line_color line color
+     * @param int[]  $color      line color
      * @param array  $scale_data scaling parameters
      * @param string $output     expected output
      *
@@ -296,7 +296,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
         string $spatial,
         int $srid,
         string $label,
-        array $line_color,
+        array $color,
         array $scale_data,
         string $output
     ): void {
@@ -306,7 +306,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
                 $spatial,
                 $srid,
                 $label,
-                $line_color,
+                $color,
                 $scale_data
             )
         );

--- a/test/classes/Gis/GisGeometryTest.php
+++ b/test/classes/Gis/GisGeometryTest.php
@@ -129,21 +129,21 @@ class GisGeometryTest extends AbstractTestCase
             [
                 "'MULTIPOINT(125 50,156 25,178 43,175 80)',125",
                 [
-                    'srid' => '125',
+                    'srid' => 125,
                     'wkt' => 'MULTIPOINT(125 50,156 25,178 43,175 80)',
                 ],
             ],
             [
                 'MULTIPOINT(125 50,156 25,178 43,175 80)',
                 [
-                    'srid' => '0',
+                    'srid' => 0,
                     'wkt' => 'MULTIPOINT(125 50,156 25,178 43,175 80)',
                 ],
             ],
             [
                 'foo',
                 [
-                    'srid' => '0',
+                    'srid' => 0,
                     'wkt' => '',
                 ],
             ],

--- a/test/classes/Gis/GisLineStringTest.php
+++ b/test/classes/Gis/GisLineStringTest.php
@@ -131,7 +131,7 @@ class GisLineStringTest extends GisGeomTestCase
                 "'LINESTRING(5.02 8.45,6.14 0.15)',124",
                 null,
                 [
-                    'srid' => '124',
+                    'srid' => 124,
                     0 => $temp,
                 ],
             ],

--- a/test/classes/Gis/GisLineStringTest.php
+++ b/test/classes/Gis/GisLineStringTest.php
@@ -173,7 +173,7 @@ class GisLineStringTest extends GisGeomTestCase
         $return = $this->object->prepareRowAsPng(
             'LINESTRING(12 35,48 75,69 23,25 45,14 53,35 78)',
             'image',
-            '#B02EE0',
+            [176, 46, 224],
             ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
             $image
         );
@@ -186,7 +186,7 @@ class GisLineStringTest extends GisGeomTestCase
      *
      * @param string $spatial    GIS LINESTRING object
      * @param string $label      label for the GIS LINESTRING object
-     * @param string $line_color color for the GIS LINESTRING object
+     * @param int[]  $color      color for the GIS LINESTRING object
      * @param array  $scale_data array containing data related to scaling
      * @param TCPDF  $pdf        TCPDF instance
      *
@@ -195,11 +195,11 @@ class GisLineStringTest extends GisGeomTestCase
     public function testPrepareRowAsPdf(
         string $spatial,
         string $label,
-        string $line_color,
+        array $color,
         array $scale_data,
         TCPDF $pdf
     ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $line_color, $scale_data, $pdf);
+        $return = $this->object->prepareRowAsPdf($spatial, $label, $color, $scale_data, $pdf);
         $this->assertInstanceOf(TCPDF::class, $return);
     }
 
@@ -214,7 +214,7 @@ class GisLineStringTest extends GisGeomTestCase
             [
                 'LINESTRING(12 35,48 75,69 23,25 45,14 53,35 78)',
                 'pdf',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -231,7 +231,7 @@ class GisLineStringTest extends GisGeomTestCase
      *
      * @param string $spatial   GIS LINESTRING object
      * @param string $label     label for the GIS LINESTRING object
-     * @param string $lineColor color for the GIS LINESTRING object
+     * @param int[]  $color     color for the GIS LINESTRING object
      * @param array  $scaleData array containing data related to scaling
      * @param string $output    expected output
      *
@@ -240,11 +240,11 @@ class GisLineStringTest extends GisGeomTestCase
     public function testPrepareRowAsSvg(
         string $spatial,
         string $label,
-        string $lineColor,
+        array $color,
         array $scaleData,
         string $output
     ): void {
-        $svg = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
         $this->assertMatchesRegularExpression($output, $svg);
     }
 
@@ -259,7 +259,7 @@ class GisLineStringTest extends GisGeomTestCase
             [
                 'LINESTRING(12 35,48 75,69 23,25 45,14 53,35 78)',
                 'svg',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -268,7 +268,7 @@ class GisLineStringTest extends GisGeomTestCase
                 ],
                 '/^(<polyline points="0,218 72,138 114,242 26,198 4,182 46,132 " '
                 . 'name="svg" id="svg)(\d+)(" class="linestring vector" fill="none" '
-                . 'stroke="#B02EE0" stroke-width="2"\/>)$/',
+                . 'stroke="#b02ee0" stroke-width="2"\/>)$/',
             ],
         ];
     }
@@ -279,7 +279,7 @@ class GisLineStringTest extends GisGeomTestCase
      * @param string $spatial    GIS LINESTRING object
      * @param int    $srid       spatial reference ID
      * @param string $label      label for the GIS LINESTRING object
-     * @param array  $line_color color for the GIS LINESTRING object
+     * @param int[]  $color      color for the GIS LINESTRING object
      * @param array  $scale_data array containing data related to scaling
      * @param string $output     expected output
      *
@@ -289,7 +289,7 @@ class GisLineStringTest extends GisGeomTestCase
         string $spatial,
         int $srid,
         string $label,
-        array $line_color,
+        array $color,
         array $scale_data,
         string $output
     ): void {
@@ -298,7 +298,7 @@ class GisLineStringTest extends GisGeomTestCase
                 $spatial,
                 $srid,
                 $label,
-                $line_color,
+                $color,
                 $scale_data
             ),
             $output

--- a/test/classes/Gis/GisMultiLineStringTest.php
+++ b/test/classes/Gis/GisMultiLineStringTest.php
@@ -255,7 +255,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
         $return = $this->object->prepareRowAsPng(
             'MULTILINESTRING((36 14,47 23,62 75),(36 10,17 23,178 53))',
             'image',
-            '#B02EE0',
+            [176, 46, 224],
             ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
             $image
         );
@@ -268,7 +268,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
      *
      * @param string $spatial    GIS MULTILINESTRING object
      * @param string $label      label for the GIS MULTILINESTRING object
-     * @param string $line_color color for the GIS MULTILINESTRING object
+     * @param int[]  $color      color for the GIS MULTILINESTRING object
      * @param array  $scale_data array containing data related to scaling
      * @param TCPDF  $pdf        TCPDF instance
      *
@@ -277,11 +277,11 @@ class GisMultiLineStringTest extends GisGeomTestCase
     public function testPrepareRowAsPdf(
         string $spatial,
         string $label,
-        string $line_color,
+        array $color,
         array $scale_data,
         TCPDF $pdf
     ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $line_color, $scale_data, $pdf);
+        $return = $this->object->prepareRowAsPdf($spatial, $label, $color, $scale_data, $pdf);
         $this->assertInstanceOf(TCPDF::class, $return);
     }
 
@@ -296,7 +296,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
             [
                 'MULTILINESTRING((36 14,47 23,62 75),(36 10,17 23,178 53))',
                 'pdf',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -313,7 +313,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
      *
      * @param string $spatial   GIS MULTILINESTRING object
      * @param string $label     label for the GIS MULTILINESTRING object
-     * @param string $lineColor color for the GIS MULTILINESTRING object
+     * @param int[]  $color     color for the GIS MULTILINESTRING object
      * @param array  $scaleData array containing data related to scaling
      * @param string $output    expected output
      *
@@ -322,11 +322,11 @@ class GisMultiLineStringTest extends GisGeomTestCase
     public function testPrepareRowAsSvg(
         string $spatial,
         string $label,
-        string $lineColor,
+        array $color,
         array $scaleData,
         string $output
     ): void {
-        $svg = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
         $this->assertMatchesRegularExpression($output, $svg);
     }
 
@@ -341,7 +341,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
             [
                 'MULTILINESTRING((36 14,47 23,62 75),(36 10,17 23,178 53))',
                 'svg',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -349,10 +349,10 @@ class GisMultiLineStringTest extends GisGeomTestCase
                     'height' => 150,
                 ],
                 '/^(<polyline points="48,260 70,242 100,138 " name="svg" '
-                . 'class="linestring vector" fill="none" stroke="#B02EE0" '
+                . 'class="linestring vector" fill="none" stroke="#b02ee0" '
                 . 'stroke-width="2" id="svg)(\d+)("\/><polyline points="48,268 10,'
                 . '242 332,182 " name="svg" class="linestring vector" fill="none" '
-                . 'stroke="#B02EE0" stroke-width="2" id="svg)(\d+)("\/>)$/',
+                . 'stroke="#b02ee0" stroke-width="2" id="svg)(\d+)("\/>)$/',
             ],
         ];
     }
@@ -363,7 +363,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
      * @param string $spatial    GIS MULTILINESTRING object
      * @param int    $srid       spatial reference ID
      * @param string $label      label for the GIS MULTILINESTRING object
-     * @param array  $line_color color for the GIS MULTILINESTRING object
+     * @param int[]  $color      color for the GIS MULTILINESTRING object
      * @param array  $scale_data array containing data related to scaling
      * @param string $output     expected output
      *
@@ -373,7 +373,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
         string $spatial,
         int $srid,
         string $label,
-        array $line_color,
+        array $color,
         array $scale_data,
         string $output
     ): void {
@@ -383,7 +383,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
                 $spatial,
                 $srid,
                 $label,
-                $line_color,
+                $color,
                 $scale_data
             )
         );

--- a/test/classes/Gis/GisMultiLineStringTest.php
+++ b/test/classes/Gis/GisMultiLineStringTest.php
@@ -213,7 +213,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
                 "'MULTILINESTRING((5.02 8.45,6.14 0.15),(1.23 4.25,9.15 0.47))',124",
                 null,
                 [
-                    'srid' => '124',
+                    'srid' => 124,
                     0 => $temp,
                 ],
             ],

--- a/test/classes/Gis/GisMultiPointTest.php
+++ b/test/classes/Gis/GisMultiPointTest.php
@@ -175,7 +175,7 @@ class GisMultiPointTest extends GisGeomTestCase
         $return = $this->object->prepareRowAsPng(
             'MULTIPOINT(12 35,48 75,69 23,25 45,14 53,35 78)',
             'image',
-            '#B02EE0',
+            [176, 46, 224],
             ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
             $image
         );
@@ -186,22 +186,22 @@ class GisMultiPointTest extends GisGeomTestCase
     /**
      * test case for prepareRowAsPdf() method
      *
-     * @param string $spatial     GIS MULTIPOINT object
-     * @param string $label       label for the GIS MULTIPOINT object
-     * @param string $point_color color for the GIS MULTIPOINT object
-     * @param array  $scale_data  array containing data related to scaling
-     * @param TCPDF  $pdf         TCPDF instance
+     * @param string $spatial    GIS MULTIPOINT object
+     * @param string $label      label for the GIS MULTIPOINT object
+     * @param int[]  $color      color for the GIS MULTIPOINT object
+     * @param array  $scale_data array containing data related to scaling
+     * @param TCPDF  $pdf        TCPDF instance
      *
      * @dataProvider providerForPrepareRowAsPdf
      */
     public function testPrepareRowAsPdf(
         string $spatial,
         string $label,
-        string $point_color,
+        array $color,
         array $scale_data,
         TCPDF $pdf
     ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $point_color, $scale_data, $pdf);
+        $return = $this->object->prepareRowAsPdf($spatial, $label, $color, $scale_data, $pdf);
         $this->assertInstanceOf(TCPDF::class, $return);
     }
 
@@ -216,7 +216,7 @@ class GisMultiPointTest extends GisGeomTestCase
             [
                 'MULTIPOINT(12 35,48 75,69 23,25 45,14 53,35 78)',
                 'pdf',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -231,22 +231,22 @@ class GisMultiPointTest extends GisGeomTestCase
     /**
      * test case for prepareRowAsSvg() method
      *
-     * @param string $spatial    GIS MULTIPOINT object
-     * @param string $label      label for the GIS MULTIPOINT object
-     * @param string $pointColor color for the GIS MULTIPOINT object
-     * @param array  $scaleData  array containing data related to scaling
-     * @param string $output     expected output
+     * @param string $spatial   GIS MULTIPOINT object
+     * @param string $label     label for the GIS MULTIPOINT object
+     * @param int[]  $color     color for the GIS MULTIPOINT object
+     * @param array  $scaleData array containing data related to scaling
+     * @param string $output    expected output
      *
      * @dataProvider providerForPrepareRowAsSvg
      */
     public function testPrepareRowAsSvg(
         string $spatial,
         string $label,
-        string $pointColor,
+        array $color,
         array $scaleData,
         string $output
     ): void {
-        $svg = $this->object->prepareRowAsSvg($spatial, $label, $pointColor, $scaleData);
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
         $this->assertMatchesRegularExpression($output, $svg);
     }
 
@@ -261,7 +261,7 @@ class GisMultiPointTest extends GisGeomTestCase
             [
                 'MULTIPOINT(12 35,48 75,69 23,25 45,14 53,35 78)',
                 'svg',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -269,15 +269,15 @@ class GisMultiPointTest extends GisGeomTestCase
                     'height' => 150,
                 ],
                 '/^(<circle cx="72" cy="138" r="3" name="svg" class="multipoint '
-                . 'vector" fill="white" stroke="#B02EE0" stroke-width="2" id="svg)'
+                . 'vector" fill="white" stroke="#b02ee0" stroke-width="2" id="svg)'
                 . '(\d+)("\/><circle cx="114" cy="242" r="3" name="svg" class="mult'
-                . 'ipoint vector" fill="white" stroke="#B02EE0" stroke-width="2" id'
+                . 'ipoint vector" fill="white" stroke="#b02ee0" stroke-width="2" id'
                 . '="svg)(\d+)("\/><circle cx="26" cy="198" r="3" name="svg" class='
-                . '"multipoint vector" fill="white" stroke="#B02EE0" stroke-width='
+                . '"multipoint vector" fill="white" stroke="#b02ee0" stroke-width='
                 . '"2" id="svg)(\d+)("\/><circle cx="4" cy="182" r="3" name="svg" '
-                . 'class="multipoint vector" fill="white" stroke="#B02EE0" stroke-'
+                . 'class="multipoint vector" fill="white" stroke="#b02ee0" stroke-'
                 . 'width="2" id="svg)(\d+)("\/><circle cx="46" cy="132" r="3" name='
-                . '"svg" class="multipoint vector" fill="white" stroke="#B02EE0" '
+                . '"svg" class="multipoint vector" fill="white" stroke="#b02ee0" '
                 . 'stroke-width="2" id="svg)(\d+)("\/>)$/',
             ],
         ];
@@ -286,12 +286,12 @@ class GisMultiPointTest extends GisGeomTestCase
     /**
      * test case for prepareRowAsOl() method
      *
-     * @param string $spatial     GIS MULTIPOINT object
-     * @param int    $srid        spatial reference ID
-     * @param string $label       label for the GIS MULTIPOINT object
-     * @param array  $point_color color for the GIS MULTIPOINT object
-     * @param array  $scale_data  array containing data related to scaling
-     * @param string $output      expected output
+     * @param string $spatial    GIS MULTIPOINT object
+     * @param int    $srid       spatial reference ID
+     * @param string $label      label for the GIS MULTIPOINT object
+     * @param int[]  $color      color for the GIS MULTIPOINT object
+     * @param array  $scale_data array containing data related to scaling
+     * @param string $output     expected output
      *
      * @dataProvider providerForPrepareRowAsOl
      */
@@ -299,7 +299,7 @@ class GisMultiPointTest extends GisGeomTestCase
         string $spatial,
         int $srid,
         string $label,
-        array $point_color,
+        array $color,
         array $scale_data,
         string $output
     ): void {
@@ -309,7 +309,7 @@ class GisMultiPointTest extends GisGeomTestCase
                 $spatial,
                 $srid,
                 $label,
-                $point_color,
+                $color,
                 $scale_data
             )
         );

--- a/test/classes/Gis/GisMultiPointTest.php
+++ b/test/classes/Gis/GisMultiPointTest.php
@@ -133,7 +133,7 @@ class GisMultiPointTest extends GisGeomTestCase
                 "'MULTIPOINT(5.02 8.45,6.14 0.15)',124",
                 null,
                 [
-                    'srid' => '124',
+                    'srid' => 124,
                     0 => $temp1,
                 ],
             ],

--- a/test/classes/Gis/GisMultiPolygonTest.php
+++ b/test/classes/Gis/GisMultiPolygonTest.php
@@ -191,7 +191,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
                 . "(20 30,35 32,30 20,20 30)),((123 0,23 30,17 63,123 0)))',124",
                 null,
                 [
-                    'srid' => '124',
+                    'srid' => 124,
                     0 => $temp,
                 ],
             ],

--- a/test/classes/Gis/GisMultiPolygonTest.php
+++ b/test/classes/Gis/GisMultiPolygonTest.php
@@ -340,7 +340,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
         $return = $this->object->prepareRowAsPng(
             'MULTIPOLYGON(((136 40,147 83,16 75,136 40)),((105 0,56 20,78 73,105 0)))',
             'image',
-            '#B02EE0',
+            [176, 46, 224],
             ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
             $image
         );
@@ -353,7 +353,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
      *
      * @param string $spatial    GIS MULTIPOLYGON object
      * @param string $label      label for the GIS MULTIPOLYGON object
-     * @param string $fill_color color for the GIS MULTIPOLYGON object
+     * @param int[]  $color      color for the GIS MULTIPOLYGON object
      * @param array  $scale_data array containing data related to scaling
      * @param TCPDF  $pdf        TCPDF instance
      *
@@ -362,11 +362,11 @@ class GisMultiPolygonTest extends GisGeomTestCase
     public function testPrepareRowAsPdf(
         string $spatial,
         string $label,
-        string $fill_color,
+        array $color,
         array $scale_data,
         TCPDF $pdf
     ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $fill_color, $scale_data, $pdf);
+        $return = $this->object->prepareRowAsPdf($spatial, $label, $color, $scale_data, $pdf);
         $this->assertInstanceOf(TCPDF::class, $return);
     }
 
@@ -381,7 +381,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
             [
                 'MULTIPOLYGON(((136 40,147 83,16 75,136 40)),((105 0,56 20,78 73,105 0)))',
                 'pdf',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -398,7 +398,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
      *
      * @param string $spatial   GIS MULTIPOLYGON object
      * @param string $label     label for the GIS MULTIPOLYGON object
-     * @param string $fillColor color for the GIS MULTIPOLYGON object
+     * @param int[]  $color     color for the GIS MULTIPOLYGON object
      * @param array  $scaleData array containing data related to scaling
      * @param string $output    expected output
      *
@@ -407,11 +407,11 @@ class GisMultiPolygonTest extends GisGeomTestCase
     public function testPrepareRowAsSvg(
         string $spatial,
         string $label,
-        string $fillColor,
+        array $color,
         array $scaleData,
         string $output
     ): void {
-        $svg = $this->object->prepareRowAsSvg($spatial, $label, $fillColor, $scaleData);
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
         $this->assertMatchesRegularExpression($output, $svg);
     }
 
@@ -426,7 +426,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
             [
                 'MULTIPOLYGON(((136 40,147 83,16 75,136 40)),((105 0,56 20,78 73,105 0)))',
                 'svg',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -435,10 +435,10 @@ class GisMultiPolygonTest extends GisGeomTestCase
                 ],
                 '/^(<path d=" M 248, 208 L 270, 122 L 8, 138 Z " name="svg" class="'
                 . 'multipolygon vector" stroke="black" stroke-width="0.5" fill="'
-                . '#B02EE0" fill-rule="evenodd" fill-opacity="0.8" id="svg)(\d+)'
+                . '#b02ee0" fill-rule="evenodd" fill-opacity="0.8" id="svg)(\d+)'
                 . '("\/><path d=" M 186, 288 L 88, 248 L 132, 142 Z " name="svg" '
                 . 'class="multipolygon vector" stroke="black" stroke-width="0.5" '
-                . 'fill="#B02EE0" fill-rule="evenodd" fill-opacity="0.8" id="svg)'
+                . 'fill="#b02ee0" fill-rule="evenodd" fill-opacity="0.8" id="svg)'
                 . '(\d+)("\/>)$/',
             ],
         ];
@@ -450,7 +450,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
      * @param string $spatial    GIS MULTIPOLYGON object
      * @param int    $srid       spatial reference ID
      * @param string $label      label for the GIS MULTIPOLYGON object
-     * @param array  $fill_color color for the GIS MULTIPOLYGON object
+     * @param int[]  $color      color for the GIS MULTIPOLYGON object
      * @param array  $scale_data array containing data related to scaling
      * @param string $output     expected output
      *
@@ -460,7 +460,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
         string $spatial,
         int $srid,
         string $label,
-        array $fill_color,
+        array $color,
         array $scale_data,
         string $output
     ): void {
@@ -470,7 +470,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
                 $spatial,
                 $srid,
                 $label,
-                $fill_color,
+                $color,
                 $scale_data
             )
         );

--- a/test/classes/Gis/GisPointTest.php
+++ b/test/classes/Gis/GisPointTest.php
@@ -191,7 +191,7 @@ class GisPointTest extends GisGeomTestCase
         $return = $this->object->prepareRowAsPng(
             'POINT(12 35)',
             'image',
-            '#B02EE0',
+            [176, 46, 224],
             ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
             $image
         );
@@ -202,22 +202,22 @@ class GisPointTest extends GisGeomTestCase
     /**
      * test case for prepareRowAsPdf() method
      *
-     * @param string $spatial     GIS POINT object
-     * @param string $label       label for the GIS POINT object
-     * @param string $point_color color for the GIS POINT object
-     * @param array  $scale_data  array containing data related to scaling
-     * @param TCPDF  $pdf         TCPDF instance
+     * @param string $spatial    GIS POINT object
+     * @param string $label      label for the GIS POINT object
+     * @param int[]  $color      color for the GIS POINT object
+     * @param array  $scale_data array containing data related to scaling
+     * @param TCPDF  $pdf        TCPDF instance
      *
      * @dataProvider providerForPrepareRowAsPdf
      */
     public function testPrepareRowAsPdf(
         string $spatial,
         string $label,
-        string $point_color,
+        array $color,
         array $scale_data,
         TCPDF $pdf
     ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $point_color, $scale_data, $pdf);
+        $return = $this->object->prepareRowAsPdf($spatial, $label, $color, $scale_data, $pdf);
         $this->assertInstanceOf(TCPDF::class, $return);
     }
 
@@ -232,7 +232,7 @@ class GisPointTest extends GisGeomTestCase
             [
                 'POINT(12 35)',
                 'pdf',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -247,22 +247,22 @@ class GisPointTest extends GisGeomTestCase
     /**
      * test case for prepareRowAsSvg() method
      *
-     * @param string $spatial    GIS POINT object
-     * @param string $label      label for the GIS POINT object
-     * @param string $pointColor color for the GIS POINT object
-     * @param array  $scaleData  array containing data related to scaling
-     * @param string $output     expected output
+     * @param string $spatial   GIS POINT object
+     * @param string $label     label for the GIS POINT object
+     * @param int[]  $color     color for the GIS POINT object
+     * @param array  $scaleData array containing data related to scaling
+     * @param string $output    expected output
      *
      * @dataProvider providerForPrepareRowAsSvg
      */
     public function testPrepareRowAsSvg(
         string $spatial,
         string $label,
-        string $pointColor,
+        array $color,
         array $scaleData,
         string $output
     ): void {
-        $svg = $this->object->prepareRowAsSvg($spatial, $label, $pointColor, $scaleData);
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
         $this->assertMatchesRegularExpression($output, $svg);
     }
 
@@ -277,7 +277,7 @@ class GisPointTest extends GisGeomTestCase
             [
                 'POINT(12 35)',
                 'svg',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -292,12 +292,12 @@ class GisPointTest extends GisGeomTestCase
     /**
      * test case for prepareRowAsOl() method
      *
-     * @param string $spatial     GIS POINT object
-     * @param int    $srid        spatial reference ID
-     * @param string $label       label for the GIS POINT object
-     * @param array  $point_color color for the GIS POINT object
-     * @param array  $scale_data  array containing data related to scaling
-     * @param string $output      expected output
+     * @param string $spatial    GIS POINT object
+     * @param int    $srid       spatial reference ID
+     * @param string $label      label for the GIS POINT object
+     * @param int[]  $color      color for the GIS POINT object
+     * @param array  $scale_data array containing data related to scaling
+     * @param string $output     expected output
      *
      * @dataProvider providerForPrepareRowAsOl
      */
@@ -305,7 +305,7 @@ class GisPointTest extends GisGeomTestCase
         string $spatial,
         int $srid,
         string $label,
-        array $point_color,
+        array $color,
         array $scale_data,
         string $output
     ): void {
@@ -315,7 +315,7 @@ class GisPointTest extends GisGeomTestCase
                 $spatial,
                 $srid,
                 $label,
-                $point_color,
+                $color,
                 $scale_data
             )
         );

--- a/test/classes/Gis/GisPointTest.php
+++ b/test/classes/Gis/GisPointTest.php
@@ -136,7 +136,7 @@ class GisPointTest extends GisGeomTestCase
                 "'POINT(5.02 8.45)',124",
                 null,
                 [
-                    'srid' => '124',
+                    'srid' => 124,
                     0 => [
                         'POINT' => [
                             'x' => '5.02',

--- a/test/classes/Gis/GisPolygonTest.php
+++ b/test/classes/Gis/GisPolygonTest.php
@@ -426,7 +426,7 @@ class GisPolygonTest extends GisGeomTestCase
         $return = $this->object->prepareRowAsPng(
             'POLYGON((123 0,23 30,17 63,123 0))',
             'image',
-            '#B02EE0',
+            [176, 46, 224],
             ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
             $image
         );
@@ -439,7 +439,7 @@ class GisPolygonTest extends GisGeomTestCase
      *
      * @param string $spatial    GIS POLYGON object
      * @param string $label      label for the GIS POLYGON object
-     * @param string $fill_color color for the GIS POLYGON object
+     * @param int[]  $color      color for the GIS POLYGON object
      * @param array  $scale_data array containing data related to scaling
      * @param TCPDF  $pdf        TCPDF instance
      *
@@ -448,11 +448,11 @@ class GisPolygonTest extends GisGeomTestCase
     public function testPrepareRowAsPdf(
         string $spatial,
         string $label,
-        string $fill_color,
+        array $color,
         array $scale_data,
         TCPDF $pdf
     ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $fill_color, $scale_data, $pdf);
+        $return = $this->object->prepareRowAsPdf($spatial, $label, $color, $scale_data, $pdf);
         $this->assertInstanceOf(TCPDF::class, $return);
     }
 
@@ -467,7 +467,7 @@ class GisPolygonTest extends GisGeomTestCase
             [
                 'POLYGON((123 0,23 30,17 63,123 0))',
                 'pdf',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -484,7 +484,7 @@ class GisPolygonTest extends GisGeomTestCase
      *
      * @param string $spatial   GIS POLYGON object
      * @param string $label     label for the GIS POLYGON object
-     * @param string $fillColor color for the GIS POLYGON object
+     * @param int[]  $color     color for the GIS POLYGON object
      * @param array  $scaleData array containing data related to scaling
      * @param string $output    expected output
      *
@@ -493,11 +493,11 @@ class GisPolygonTest extends GisGeomTestCase
     public function testPrepareRowAsSvg(
         string $spatial,
         string $label,
-        string $fillColor,
+        array $color,
         array $scaleData,
         string $output
     ): void {
-        $svg = $this->object->prepareRowAsSvg($spatial, $label, $fillColor, $scaleData);
+        $svg = $this->object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
         $this->assertMatchesRegularExpression($output, $svg);
     }
 
@@ -512,7 +512,7 @@ class GisPolygonTest extends GisGeomTestCase
             [
                 'POLYGON((123 0,23 30,17 63,123 0))',
                 'svg',
-                '#B02EE0',
+                [176, 46, 224],
                 [
                     'x' => 12,
                     'y' => 69,
@@ -521,7 +521,7 @@ class GisPolygonTest extends GisGeomTestCase
                 ],
                 '/^(<path d=" M 222, 288 L 22, 228 L 10, 162 Z " name="svg" '
                 . 'id="svg)(\d+)(" class="polygon vector" stroke="black" '
-                . 'stroke-width="0.5" fill="#B02EE0" fill-rule="evenodd" '
+                . 'stroke-width="0.5" fill="#b02ee0" fill-rule="evenodd" '
                 . 'fill-opacity="0.8"\/>)$/',
             ],
         ];
@@ -533,7 +533,7 @@ class GisPolygonTest extends GisGeomTestCase
      * @param string $spatial    GIS POLYGON object
      * @param int    $srid       spatial reference ID
      * @param string $label      label for the GIS POLYGON object
-     * @param array  $fill_color color for the GIS POLYGON object
+     * @param int[]  $color      color for the GIS POLYGON object
      * @param array  $scale_data array containing data related to scaling
      * @param string $output     expected output
      *
@@ -543,7 +543,7 @@ class GisPolygonTest extends GisGeomTestCase
         string $spatial,
         int $srid,
         string $label,
-        array $fill_color,
+        array $color,
         array $scale_data,
         string $output
     ): void {
@@ -553,7 +553,7 @@ class GisPolygonTest extends GisGeomTestCase
                 $spatial,
                 $srid,
                 $label,
-                $fill_color,
+                $color,
                 $scale_data
             )
         );

--- a/test/classes/Gis/GisPolygonTest.php
+++ b/test/classes/Gis/GisPolygonTest.php
@@ -176,7 +176,7 @@ class GisPolygonTest extends GisGeomTestCase
                 '\'POLYGON((35 10,10 20,15 40,45 45,35 10),(20 30,35 32,30 20,20 30))\',124',
                 null,
                 [
-                    'srid' => '124',
+                    'srid' => 124,
                     0 => $temp,
                 ],
             ],


### PR DESCRIPTION
Remove the duplicate color definitions in GisVisualization and add better types for colors array.

Signed-off-by: Maximilian Krög <maxi_kroeg@web.de>