### PR TITLE
Remove Config::fatalErrorHandler() method

### DIFF
--- a/libraries/classes/Common.php
+++ b/libraries/classes/Common.php
@@ -40,7 +40,6 @@ use function mb_strpos;
 use function mb_strrpos;
 use function mb_substr;
 use function ob_start;
-use function register_shutdown_function;
 use function restore_error_handler;
 use function session_id;
 use function sprintf;
@@ -87,7 +86,6 @@ final class Common
     public static function run(bool $isSetupPage = false): void
     {
         $GLOBALS['lang'] = $GLOBALS['lang'] ?? null;
-        $GLOBALS['isConfigLoading'] = $GLOBALS['isConfigLoading'] ?? null;
         $GLOBALS['auth_plugin'] = $GLOBALS['auth_plugin'] ?? null;
         $GLOBALS['theme'] = $GLOBALS['theme'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
@@ -114,13 +112,6 @@ final class Common
 
         self::configurePhpSettings();
         self::cleanupPathInfo();
-
-        /* parsing configuration file                  LABEL_parsing_config_file      */
-
-        /** Indication for the error handler */
-        $GLOBALS['isConfigLoading'] = false;
-
-        register_shutdown_function([Config::class, 'fatalErrorHandler']);
 
         /** @var Config $config */
         $config = $GLOBALS['containerBuilder']->get('config');

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -222,10 +222,9 @@
       <code>$GLOBALS['cfg']['MysqlMinVersion']['internal']</code>
       <code>$GLOBALS['cfg']['Server']['user']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['auth_plugin']</code>
       <code>$GLOBALS['back']</code>
-      <code>$GLOBALS['isConfigLoading']</code>
       <code>$GLOBALS['theme']</code>
       <code>$controlLink</code>
       <code>$sqlDelimiter</code>
@@ -296,9 +295,8 @@
       <code>$this-&gt;settings['Servers'][$server]</code>
       <code>$this-&gt;settings['Servers'][$this-&gt;settings['ServerDefault']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="28">
+    <MixedAssignment occurrences="27">
       <code>$GLOBALS['cfg']['LoginCookieValidity']</code>
-      <code>$GLOBALS['isConfigLoading']</code>
       <code>$collation_connection</code>
       <code>$config_data</code>
       <code>$default_value</code>


### PR DESCRIPTION
Since there is an error handler register already, error_get_last is always empty.

Also adds a try-catch to catch exceptions from the config file.
