### PR TITLE
Fix #17482 - default to "Full texts" when running explain statements 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "paragonie/sodium_compat": "^1.17",
         "phpmyadmin/motranslator": "^5.0",
         "phpmyadmin/shapefile": "^3.0.1",
-        "phpmyadmin/sql-parser": "dev-master#a9cd167be77829ec2dd4496ce1010ed6abde92f8",
+        "phpmyadmin/sql-parser": "dev-master#8fddb4becdfb657db3b9ade52e952ef3c822a26b",
         "phpmyadmin/twig-i18n-extension": "^4.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3443,12 +3443,12 @@ class Results
      * Checks the posted options for viewing query results
      * and sets appropriate values in the session.
      *
+     * @param array $analyzedSqlResults the analyzed query results
+     *
      * @todo    make maximum remembered queries configurable
      * @todo    move/split into SQL class!?
      * @todo    currently this is called twice unnecessary
      * @todo    ignore LIMIT and ORDER in query!?
-     * 
-     * @param array $analyzedSqlResults the analyzed query results
      */
     public function setConfigParamsForDisplayTable(array $analyzedSqlResults): void
     {
@@ -3484,7 +3484,7 @@ class Results
             $query['pos'] = 0;
         }
 
-        // Full text is needed in case of explain statements, if not specified. 
+        // Full text is needed in case of explain statements, if not specified.
         $fullText = $analyzedSqlResults['is_explain'];
 
         if (

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3447,8 +3447,10 @@ class Results
      * @todo    move/split into SQL class!?
      * @todo    currently this is called twice unnecessary
      * @todo    ignore LIMIT and ORDER in query!?
+     * 
+     * @param array $analyzedSqlResults the analyzed query results
      */
-    public function setConfigParamsForDisplayTable(): void
+    public function setConfigParamsForDisplayTable(array $analyzedSqlResults): void
     {
         $sqlMd5 = md5($this->properties['server'] . $this->properties['db'] . $this->properties['sql_query']);
         $query = [];
@@ -3482,6 +3484,9 @@ class Results
             $query['pos'] = 0;
         }
 
+        // Full text is needed in case of explain statements, if not specified. 
+        $fullText = $analyzedSqlResults['is_explain'];
+
         if (
             isset($_REQUEST['pftext']) && in_array(
                 $_REQUEST['pftext'],
@@ -3490,6 +3495,8 @@ class Results
         ) {
             $query['pftext'] = $_REQUEST['pftext'];
             unset($_REQUEST['pftext']);
+        } elseif ($fullText) {
+            $query['pftext'] = self::DISPLAY_FULL_TEXT;
         } elseif (empty($query['pftext'])) {
             $query['pftext'] = self::DISPLAY_PARTIAL_TEXT;
         }

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1688,7 +1688,7 @@ class Sql
             $goto,
             $sqlQuery
         );
-        $displayResultsObject->setConfigParamsForDisplayTable();
+        $displayResultsObject->setConfigParamsForDisplayTable($analyzedSqlResults);
 
         // assign default full_sql_query
         $fullSqlQuery = $sqlQuery;

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -63,6 +63,7 @@ class ResultsTest extends AbstractTestCase
         $GLOBALS['text_dir'] = 'ltr';
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $_SESSION[' HMAC_secret '] = 'test';
+        $_SESSION = [' PMA_token ' => 'token'];
     }
 
     /**

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -1129,6 +1129,27 @@ class ResultsTest extends AbstractTestCase
         );
     }
 
+    public function testPftextConfigParam(): void {
+        $db = 'test_db';
+        $table = 'test_table';
+
+        $query = 'ANALYZE FORMAT=JSON SELECT * FROM test_table';
+        [$analyzedSqlResults] = ParseAnalyze::sqlQuery($query, $db);
+
+        $object = new DisplayResults($this->dbi, $db, $table, 1, '', $query);
+        $object->setConfigParamsForDisplayTable($analyzedSqlResults);
+
+        $this->assertSame('F', $_SESSION['tmpval']['pftext']);
+
+        $query = 'ANALYZE NO_WRITE_TO_BINLOG TABLE test_table';
+        [$analyzedSqlResults] = ParseAnalyze::sqlQuery($query, $db);
+
+        $object = new DisplayResults($this->dbi, $db, $table, 1, '', $query);
+        $object->setConfigParamsForDisplayTable($analyzedSqlResults);
+        
+        $this->assertSame('P', $_SESSION['tmpval']['pftext']);
+    }
+
     /**
      * @dataProvider providerSetConfigParamsForDisplayTable
      */
@@ -1147,9 +1168,10 @@ class ResultsTest extends AbstractTestCase
         $db = 'test_db';
         $table = 'test_table';
         $query = 'SELECT * FROM `test_db`.`test_table`;';
-
+        [$analyzedSqlResults] = ParseAnalyze::sqlQuery($query, $db);
+        
         $object = new DisplayResults($this->dbi, $db, $table, 1, '', $query);
-        $object->setConfigParamsForDisplayTable();
+        $object->setConfigParamsForDisplayTable($analyzedSqlResults);
 
         $this->assertArrayHasKey('tmpval', $_SESSION);
         $this->assertIsArray($_SESSION['tmpval']);

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -1129,7 +1129,8 @@ class ResultsTest extends AbstractTestCase
         );
     }
 
-    public function testPftextConfigParam(): void {
+    public function testPftextConfigParam(): void
+    {
         $db = 'test_db';
         $table = 'test_table';
 
@@ -1146,7 +1147,7 @@ class ResultsTest extends AbstractTestCase
 
         $object = new DisplayResults($this->dbi, $db, $table, 1, '', $query);
         $object->setConfigParamsForDisplayTable($analyzedSqlResults);
-        
+
         $this->assertSame('P', $_SESSION['tmpval']['pftext']);
     }
 
@@ -1169,7 +1170,7 @@ class ResultsTest extends AbstractTestCase
         $table = 'test_table';
         $query = 'SELECT * FROM `test_db`.`test_table`;';
         [$analyzedSqlResults] = ParseAnalyze::sqlQuery($query, $db);
-        
+
         $object = new DisplayResults($this->dbi, $db, $table, 1, '', $query);
         $object->setConfigParamsForDisplayTable($analyzedSqlResults);
 

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -63,7 +63,6 @@ class ResultsTest extends AbstractTestCase
         $GLOBALS['text_dir'] = 'ltr';
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
         $_SESSION[' HMAC_secret '] = 'test';
-        $_SESSION = [' PMA_token ' => 'token'];
     }
 
     /**
@@ -1186,7 +1185,7 @@ class ResultsTest extends AbstractTestCase
 
         return [
             'default values' => [
-                [],
+                [' PMA_token ' => 'token'],
                 [],
                 [],
                 [],
@@ -1240,6 +1239,7 @@ class ResultsTest extends AbstractTestCase
                             'j' => [],
                         ],
                     ],
+                    ' PMA_token ' => 'token',
                 ],
                 [],
                 [],
@@ -1278,7 +1278,7 @@ class ResultsTest extends AbstractTestCase
                 ],
             ],
             'default and request values' => [
-                [],
+                [' PMA_token ' => 'token',],
                 ['session_max_rows' => '27'],
                 ['session_max_rows' => '28'],
                 [
@@ -1341,6 +1341,7 @@ class ResultsTest extends AbstractTestCase
                             'i' => [],
                         ],
                     ],
+                    ' PMA_token ' => 'token',
                 ],
                 [],
                 ['session_max_rows' => DisplayResults::ALL_ROWS],


### PR DESCRIPTION
### Description

Hi, this should fix #17482.
Fixes #17482
