### PR TITLE
Fix #17766 - Allow to open in a new tab copy and edit row actions

### DIFF
--- a/libraries/classes/Controllers/Table/ChangeController.php
+++ b/libraries/classes/Controllers/Table/ChangeController.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Controllers\Table;
 
 use PhpMyAdmin\Config\PageSettings;
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Core;
 use PhpMyAdmin\DbTableExists;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\InsertEdit;
@@ -59,6 +60,12 @@ class ChangeController extends AbstractController
         $this->response->addHTML($pageSettings->getHTML());
 
         DbTableExists::check();
+
+        if (isset($_GET['where_clause'], $_GET['where_clause_signature'])) {
+            if (Core::checkSqlQuerySignature($_GET['where_clause'], $_GET['where_clause_signature'])) {
+                $where_clause = $_GET['where_clause'];
+            }
+        }
 
         /**
          * Determine whether Insert or Edit and set global variables

--- a/libraries/classes/Controllers/Table/ReplaceController.php
+++ b/libraries/classes/Controllers/Table/ReplaceController.php
@@ -379,7 +379,7 @@ final class ReplaceController extends AbstractController
                 $value_sets[] = implode(', ', $query_values);
             } else {
                 // build update query
-                $clauseIsUnique = $_POST['clause_is_unique'] ?? '';// Should contain 0 or 1
+                $clauseIsUnique = $_POST['clause_is_unique'] ?? $_GET['clause_is_unique'] ?? '';// Should contain 0 or 1
                 $query[] = 'UPDATE ' . Util::backquote($table)
                     . ' SET ' . implode(', ', $query_values)
                     . ' WHERE ' . $where_clause

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -2953,8 +2953,10 @@ class Results
             'db' => $this->properties['db'],
             'table' => $this->properties['table'],
             'where_clause' => $whereClause,
+            'where_clause_signature' => Core::signSqlQuery($whereClause),
             'clause_is_unique' => $clauseIsUnique,
             'sql_query' => $urlSqlQuery,
+            'sql_signature' => Core::signSqlQuery($urlSqlQuery),
             'goto' => Url::getFromRoute('/sql'),
         ];
 

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -114,6 +114,13 @@ class InsertEdit
             'err_url' => $errorUrl,
             'sql_query' => $_POST['sql_query'] ?? '',
         ];
+
+        if ($formParams['sql_query'] === '' && isset($_GET['sql_query'], $_GET['sql_signature'])) {
+            if (Core::checkSqlQuerySignature($_GET['sql_query'], $_GET['sql_signature'])) {
+                $formParams['sql_query'] = $_GET['sql_query'];
+            }
+        }
+
         if (isset($whereClauses)) {
             foreach ($whereClauseArray as $keyId => $whereClause) {
                 $formParams['where_clause[' . $keyId . ']'] = trim($whereClause);
@@ -122,6 +129,8 @@ class InsertEdit
 
         if (isset($_POST['clause_is_unique'])) {
             $formParams['clause_is_unique'] = $_POST['clause_is_unique'];
+        } elseif (isset($_GET['clause_is_unique'])) {
+            $formParams['clause_is_unique'] = $_GET['clause_is_unique'];
         }
 
         return $formParams;

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3049,9 +3049,16 @@
       <code>$biggest_max_file_size</code>
       <code>$jsvkey</code>
     </MixedOperand>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument occurrences="4">
+      <code>$_GET['where_clause']</code>
+      <code>$_GET['where_clause_signature']</code>
       <code>$current_result</code>
+      <code>$where_clause ?? null</code>
     </PossiblyInvalidArgument>
+    <PossiblyInvalidCast occurrences="2">
+      <code>$_GET['where_clause']</code>
+      <code>$_GET['where_clause_signature']</code>
+    </PossiblyInvalidCast>
     <PossiblyNullArgument occurrences="1">
       <code>$isUpload</code>
     </PossiblyNullArgument>
@@ -8299,13 +8306,17 @@
       <code>$whereClause</code>
     </MixedOperand>
     <MixedReturnStatement occurrences="1"/>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument occurrences="3">
+      <code>$_GET['sql_query']</code>
+      <code>$_GET['sql_signature']</code>
       <code>$whereClause</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>$_POST['fields']['multi_edit']</code>
     </PossiblyInvalidArrayOffset>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast occurrences="3">
+      <code>$_GET['sql_query']</code>
+      <code>$_GET['sql_signature']</code>
       <code>$whereClause</code>
     </PossiblyInvalidCast>
     <PossiblyInvalidOperand occurrences="1">

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -136,6 +136,43 @@ class InsertEditTest extends AbstractTestCase
     }
 
     /**
+     * Test for getFormParametersForInsertForm
+     */
+    public function testGetFormParametersForInsertFormGet(): void
+    {
+        $where_clause = [
+            'foo' => 'bar ',
+            '1' => ' test',
+        ];
+        $_GET['clause_is_unique'] = false;
+        $_GET['sql_query'] = 'SELECT a';
+        $_GET['sql_signature'] = Core::signSqlQuery($_GET['sql_query']);
+        $GLOBALS['goto'] = 'index.php';
+
+        $result = $this->insertEdit->getFormParametersForInsertForm(
+            'dbname',
+            'tablename',
+            [],
+            $where_clause,
+            'localhost'
+        );
+
+        $this->assertEquals(
+            [
+                'db' => 'dbname',
+                'table' => 'tablename',
+                'goto' => 'index.php',
+                'err_url' => 'localhost',
+                'sql_query' => 'SELECT a',
+                'where_clause[foo]' => 'bar',
+                'where_clause[1]' => 'test',
+                'clause_is_unique' => false,
+            ],
+            $result
+        );
+    }
+
+    /**
      * Test for getWhereClauseArray
      */
     public function testGetWhereClauseArray(): void


### PR DESCRIPTION
### Description

Allow to open in a new tab copy and edit row actions

Fixes #17766

Will be merged into 5.2.**2**
