### PR TITLE
Change text direction on selects for RTL

### DIFF
--- a/libraries/classes/Controllers/HomeController.php
+++ b/libraries/classes/Controllers/HomeController.php
@@ -221,6 +221,8 @@ class HomeController extends AbstractController
         $git = new Git($this->config->get('ShowGitRevision') ?? true);
 
         $this->render('home/index', [
+            'lang' => $GLOBALS['lang'],
+            'text_dir' => $GLOBALS['text_dir'],
             'db' => $db,
             'table' => $table,
             'message' => $displayMessage ?? '',

--- a/libraries/classes/Language.php
+++ b/libraries/classes/Language.php
@@ -166,7 +166,7 @@ class Language
      */
     public function isRTL(): bool
     {
-        return in_array($this->code, ['ar', 'fa', 'he', 'ur']);
+        return in_array($this->code, ['ar', 'ar_LY', 'fa', 'he', 'ur']);
     }
 
     /**

--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -188,6 +188,7 @@ class AuthenticationCookie extends AuthenticationPlugin
             'server_options' => $serversOptions,
             'server' => $GLOBALS['server'],
             'lang' => $GLOBALS['lang'],
+            'text_dir' => $GLOBALS['text_dir'],
             'has_captcha' => ! empty($GLOBALS['cfg']['CaptchaApi'])
                 && ! empty($GLOBALS['cfg']['CaptchaRequestParam'])
                 && ! empty($GLOBALS['cfg']['CaptchaResponseParam'])

--- a/templates/columns_definitions/column_attributes.twig
+++ b/templates/columns_definitions/column_attributes.twig
@@ -61,7 +61,7 @@
 </td>
 <td class="text-center">
   {# column collation #}
-  <select lang="en" dir="ltr" name="field_collation[{{ column_number }}]" id="field_{{ column_number }}_{{ ci - ci_offset }}">
+  <select lang="{{ lang }}" dir="{{ text_dir }}" name="field_collation[{{ column_number }}]" id="field_{{ column_number }}_{{ ci - ci_offset }}">
     <option value=""></option>
     {% for charset in charsets %}
       <optgroup label="{{ charset.name }}" title="{{ charset.description }}">

--- a/templates/columns_definitions/column_definitions_form.twig
+++ b/templates/columns_definitions/column_definitions_form.twig
@@ -94,7 +94,7 @@
                 </td>
                 <td width="25">&nbsp;</td>
                 <td>
-                  <select lang="en" dir="ltr" name="tbl_collation">
+                  <select lang="{{ lang }}" dir="{{ text_dir }}" name="tbl_collation">
                     <option value=""></option>
                     {% for charset in charsets %}
                       <optgroup label="{{ charset.name }}" title="{{ charset.description }}">

--- a/templates/database/central_columns/edit_table_row.twig
+++ b/templates/database/central_columns/edit_table_row.twig
@@ -47,7 +47,7 @@
   </td>
 
   <td name="collation" class="text-nowrap">
-    <select lang="en" dir="ltr" name="field_collation[{{ row_num }}]" id="field_{{ row_num }}_4">
+    <select lang="{{ lang }}" dir="{{ text_dir }}" name="field_collation[{{ row_num }}]" id="field_{{ row_num }}_4">
       <option value=""></option>
       {% for charset in charsets %}
         <optgroup label="{{ charset.getName() }}" title="{{ charset.getDescription() }}">

--- a/templates/database/central_columns/main.twig
+++ b/templates/database/central_columns/main.twig
@@ -85,7 +85,7 @@
                           {% endif %}
                         </td>
                         <td name="collation" class="text-nowrap">
-                          <select lang="en" dir="ltr" name="field_collation[0]" id="field_0_4">
+                          <select lang="{{ lang }}" dir="{{ text_dir }}" name="field_collation[0]" id="field_0_4">
                             <option value=""></option>
                             {% for charset in charsets %}
                               <optgroup label="{{ charset.name }}" title="{{ charset.description }}">
@@ -326,7 +326,7 @@
                             </td>
                             <td name="collation" class="text-nowrap">
                                 <span>{{ row['col_collation'] }}</span>
-                                <select lang="en" dir="ltr" name="field_collation[{{ row_num }}]" id="field_{{ row_num }}_4">
+                                <select lang="{{ lang }}" dir="{{ text_dir }}" name="field_collation[{{ row_num }}]" id="field_{{ row_num }}_4">
                                   <option value=""></option>
                                   {% for charset in charsets %}
                                     <optgroup label="{{ charset.name }}" title="{{ charset.description }}">

--- a/templates/database/operations/index.twig
+++ b/templates/database/operations/index.twig
@@ -196,7 +196,7 @@
         <div class="mb-3 row g-3">
           <div class="col-auto">
             <label class="visually-hidden" for="select_db_collation">{% trans 'Collation' %}</label>
-            <select class="form-select" lang="en" dir="ltr" name="db_collation" id="select_db_collation">
+            <select class="form-select" lang="{{ lang }}" dir="{{ text_dir }}" name="db_collation" id="select_db_collation">
               <option value=""></option>
               {% for charset in charsets %}
                 <optgroup label="{{ charset.getName() }}" title="{{ charset.getDescription() }}">

--- a/templates/database/routines/editor_form.twig
+++ b/templates/database/routines/editor_form.twig
@@ -86,7 +86,7 @@
           <td>{% trans 'Return options' %}</td>
           <td>
             <div>
-              <select lang="en" dir="ltr" name="item_returnopts_text">
+              <select lang="{{ lang }}" dir="{{ text_dir }}" name="item_returnopts_text">
                 <option value="">{% trans 'Charset' %}</option>
                 <option value=""></option>
                 {% for charset in charsets %}

--- a/templates/database/routines/parameter_row.twig
+++ b/templates/database/routines/parameter_row.twig
@@ -27,7 +27,7 @@
   </td>
   <td class="hide no_len">---</td>
   <td class="routine_param_opts_text">
-    <select lang="en" dir="ltr" name="item_param_opts_text[{{ index }}]">
+    <select lang="{{ lang }}" dir="{{ text_dir }}" name="item_param_opts_text[{{ index }}]">
       <option value="">{% trans 'Charset' %}</option>
       <option value=""></option>
       {% for charset in charsets %}

--- a/templates/home/index.twig
+++ b/templates/home/index.twig
@@ -60,7 +60,7 @@
                       </div>
                       {% if charsets is not empty %}
                       <div class="col-12">
-                        <select lang="en" dir="ltr" name="collation_connection" id="collationConnectionSelect" class="form-select autosubmit">
+                        <select lang="{{ lang }}" dir="{{ text_dir }}" name="collation_connection" id="collationConnectionSelect" class="form-select autosubmit">
                           <option value="">{% trans 'Collation' %}</option>
                           <option value=""></option>
                           {% for charset in charsets %}
@@ -110,7 +110,7 @@
                         </label>
                       </div>
                       <div class="col-12">
-                        <select name="lang" class="form-select autosubmit w-auto" lang="en" dir="ltr" id="languageSelect">
+                        <select name="lang" class="form-select autosubmit w-auto" lang="{{ lang }}" dir="{{ text_dir }}" id="languageSelect">
                           {% for language in available_languages %}
                             <option value="{{ language.getCode()|lower }}"{{ language.isActive() ? ' selected' }}>
                               {{- language.getName()|raw -}}
@@ -133,7 +133,7 @@
                       </div>
                       <div class="col-12">
                         <div class="input-group">
-                          <select name="set_theme" class="form-select autosubmit" lang="en" dir="ltr" id="themeSelect">
+                          <select name="set_theme" class="form-select autosubmit" lang="{{ lang }}" dir="{{ text_dir }}" id="themeSelect">
                             {% for theme in themes %}
                               <option value="{{ theme.id }}"{{ theme.is_active ? ' selected' }}>{{ theme.name }}</option>
                             {% endfor %}

--- a/templates/import.twig
+++ b/templates/import.twig
@@ -110,7 +110,7 @@
               {% endfor %}
             </select>
           {% else %}
-            <select class="form-select" lang="en" dir="ltr" name="charset_of_file" id="charset_of_file">
+            <select class="form-select" lang="{{ lang }}" dir="{{ text_dir }}" name="charset_of_file" id="charset_of_file">
               <option value=""></option>
               {% for charset in charsets %}
                 <option value="{{ charset.getName() }}" title="{{ charset.getDescription() }}"{{ charset.getName() == 'utf8' ? ' selected' }}>

--- a/templates/login/form.twig
+++ b/templates/login/form.twig
@@ -31,7 +31,7 @@
       <div class="card-body">
         <form method="get" action="{{ url('/') }}" class="disableAjax">
           {{ get_hidden_inputs(form_params) }}
-          <select name="lang" class="form-select autosubmit" lang="{{ lang }}" dir="{{ text_dir }}" id="languageSelect" aria-labelledby="languageSelectLabel">
+          <select name="lang" class="form-select autosubmit" lang="en" dir="ltr" id="languageSelect" aria-labelledby="languageSelectLabel">
             {% for language in available_languages %}
               <option value="{{ language.getCode()|lower }}"{{ language.isActive() ? ' selected' }}>
                 {{- language.getName()|raw -}}

--- a/templates/login/form.twig
+++ b/templates/login/form.twig
@@ -31,7 +31,7 @@
       <div class="card-body">
         <form method="get" action="{{ url('/') }}" class="disableAjax">
           {{ get_hidden_inputs(form_params) }}
-          <select name="lang" class="form-select autosubmit" lang="en" dir="ltr" id="languageSelect" aria-labelledby="languageSelectLabel">
+          <select name="lang" class="form-select autosubmit" lang="{{ lang }}" dir="{{ text_dir }}" id="languageSelect" aria-labelledby="languageSelectLabel">
             {% for language in available_languages %}
               <option value="{{ language.getCode()|lower }}"{{ language.isActive() ? ' selected' }}>
                 {{- language.getName()|raw -}}

--- a/templates/server/databases/index.twig
+++ b/templates/server/databases/index.twig
@@ -26,7 +26,7 @@
 
             {% if charsets is not empty %}
               <div class="col-12">
-                <select lang="en" dir="ltr" name="db_collation" class="form-select" aria-label="{% trans 'Collation' %}">
+                <select lang="{{ lang }}" dir="{{ text_dir }}" name="db_collation" class="form-select" aria-label="{% trans 'Collation' %}">
                   <option value="">{% trans 'Collation' %}</option>
                   <option value=""></option>
                   {% for charset in charsets %}

--- a/templates/table/operations/index.twig
+++ b/templates/table/operations/index.twig
@@ -151,7 +151,7 @@
           <label for="collationSelect">{% trans 'Collation' %}</label>
         </div>
         <div class="col-6">
-          <select class="form-select" id="collationSelect" lang="en" dir="ltr" name="tbl_collation">
+          <select class="form-select" id="collationSelect" lang="{{ lang }}" dir="{{ text_dir }}" name="tbl_collation">
             <option value=""></option>
             {% for charset in charsets %}
               <optgroup label="{{ charset.getName() }}" title="{{ charset.getDescription() }}">


### PR DESCRIPTION
Signed-off-by: Liviu-Mihail Concioiu <liviu.concioiu@gmail.com>

### Description

This PR fixes text direction on selects for RTL languages.

Before:

![before](https://user-images.githubusercontent.com/25424343/204065422-6574d216-67ba-44d3-a08e-5d3d856fa89d.png)

After:

![after](https://user-images.githubusercontent.com/25424343/204065424-cf83bf6d-f899-419d-8e5c-2f65160da613.png)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
