### PR TITLE
Fix key navigation between select inputs

### DIFF
--- a/js/src/keyhandler.js
+++ b/js/src/keyhandler.js
@@ -70,9 +70,6 @@ function onKeyDownArrowsHandler (event) {
         return;
     }
 
-    // eslint-disable-next-line compat/compat
-    var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox/') > -1;
-
     var id = 'field_' + y + '_' + x;
 
     var nO = document.getElementById(id);
@@ -86,38 +83,7 @@ function onKeyDownArrowsHandler (event) {
         return;
     }
 
-    // for firefox select tag
-    var lvalue = o.selectedIndex;
-    var nOvalue = nO.selectedIndex;
-
     nO.focus();
-
-    if (isFirefox) {
-        var ffcheck = 0;
-        var ffversion;
-        for (ffversion = 3 ; ffversion < 25 ; ffversion++) {
-            var isFirefoxV24 = navigator.userAgent.toLowerCase().indexOf('firefox/' + ffversion) > -1;
-            if (isFirefoxV24) {
-                ffcheck = 1;
-                break;
-            }
-        }
-        if (ffcheck === 1) {
-            if (e.which === 38 || e.which === 37) {
-                nOvalue++;
-            } else if (e.which === 40 || e.which === 39) {
-                nOvalue--;
-            }
-            nO.selectedIndex = nOvalue;
-        } else {
-            if (e.which === 38 || e.which === 37) {
-                lvalue++;
-            } else if (e.which === 40 || e.which === 39) {
-                lvalue--;
-            }
-            o.selectedIndex = lvalue;
-        }
-    }
 
     if (nO.tagName !== 'SELECT') {
         nO.select();


### PR DESCRIPTION
This compatibility fix is no longer necessary and actually causing issues with current Firefox versions.
Not sure since what version it is no longer necessary, but was probably fixed a long time ago in Firefox.

Test by going to the insert form, focus a select input and press Ctrl + Down or Ctrl + Up. It should not change the value in the  select but  focus the one below or above.

As a side note:
It checked versions from 3 to 24 but actually also matched all versions >= 30 as no word boundary check was made on the version number

Signed-off-by: Maximilian Krög <maxi_kroeg@web.de>

See #1100

