### PR TITLE
Fix centering of generated gis images

### DIFF
--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -606,17 +606,13 @@ class GisVisualization
 
         $scale = $ratio != 0 ? 1 / $ratio : 1;
 
-        if ($x_ratio < $y_ratio) {
-            // center horizontally
-            $x = ($min_max['maxX'] + $min_max['minX'] - $this->settings['width'] / $scale) / 2;
-            // fit vertically
-            $y = $min_max['minY'] - ($border / $scale);
-        } else {
-            // fit horizontally
-            $x = $min_max['minX'] - ($border / $scale);
-            // center vertically
-            $y = ($min_max['maxY'] + $min_max['minY'] - $this->settings['height'] / $scale) / 2;
-        }
+        // Center plot
+        $x = $ratio == 0 || $x_ratio < $y_ratio
+            ? ($min_max['maxX'] + $min_max['minX'] - $this->settings['width'] / $scale) / 2
+            : $min_max['minX'] - ($border / $scale);
+        $y = $ratio == 0 || $x_ratio >= $y_ratio
+            ? ($min_max['maxY'] + $min_max['minY'] - $this->settings['height'] / $scale) / 2
+            : $min_max['minY'] - ($border / $scale);
 
         return [
             'scale' => $scale,

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -608,14 +608,14 @@ class GisVisualization
 
         if ($x_ratio < $y_ratio) {
             // center horizontally
-            $x = ($min_max['maxX'] + $min_max['minX'] - $plot_width / $scale) / 2;
+            $x = ($min_max['maxX'] + $min_max['minX'] - $this->settings['width'] / $scale) / 2;
             // fit vertically
             $y = $min_max['minY'] - ($border / $scale);
         } else {
             // fit horizontally
             $x = $min_max['minX'] - ($border / $scale);
             // center vertically
-            $y = ($min_max['maxY'] + $min_max['minY'] - $plot_height / $scale) / 2;
+            $y = ($min_max['maxY'] + $min_max['minY'] - $this->settings['height'] / $scale) / 2;
         }
 
         return [

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7569,11 +7569,9 @@
     <MixedOperand occurrences="15">
       <code>$border / $scale</code>
       <code>$border / $scale</code>
-      <code>$min_max['maxX'] + $min_max['minX'] - $plot_width / $scale</code>
-      <code>$min_max['maxY'] + $min_max['minY'] - $plot_height / $scale</code>
+      <code>$min_max['maxX'] + $min_max['minX'] - $this-&gt;settings['width'] / $scale</code>
+      <code>$min_max['maxY'] + $min_max['minY'] - $this-&gt;settings['height'] / $scale</code>
       <code>$plot_height</code>
-      <code>$plot_height</code>
-      <code>$plot_width</code>
       <code>$plot_width</code>
       <code>$ratio</code>
       <code>$scale</code>
@@ -7581,6 +7579,8 @@
       <code>$this-&gt;prepareDataSet($this-&gt;data, $scale_data, 'ol', '')</code>
       <code>$this-&gt;prepareDataSet($this-&gt;data, $scale_data, 'svg', '')</code>
       <code>$this-&gt;settings['height']</code>
+      <code>$this-&gt;settings['height']</code>
+      <code>$this-&gt;settings['width']</code>
       <code>$this-&gt;settings['width']</code>
     </MixedOperand>
     <NullArgument occurrences="3">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7546,7 +7546,7 @@
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
       <code>$row[$this-&gt;settings['spatialColumn']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="15">
+    <MixedAssignment occurrences="13">
       <code>$label</code>
       <code>$pdf</code>
       <code>$plot_height</code>
@@ -7557,9 +7557,7 @@
       <code>$row</code>
       <code>$scale</code>
       <code>$x</code>
-      <code>$x</code>
       <code>$x_ratio</code>
-      <code>$y</code>
       <code>$y</code>
       <code>$y_ratio</code>
     </MixedAssignment>

--- a/test/classes/Gis/GisVisualizationTest.php
+++ b/test/classes/Gis/GisVisualizationTest.php
@@ -43,7 +43,7 @@ class GisVisualizationTest extends AbstractTestCase
             [
                 'scale' => 1,
                 'x' => -15.0,
-                'y' => -210.0,
+                'y' => -225.0,
                 'minX' => 0.0,
                 'maxX' => 0.0,
                 'minY' => 0.0,
@@ -69,7 +69,7 @@ class GisVisualizationTest extends AbstractTestCase
         $this->assertSame(
             [
                 'scale' => 2.1,
-                'x' => -38.21428571428572,
+                'x' => -45.35714285714286,
                 'y' => 42.85714285714286,
                 'minX' => 17.0,
                 'maxX' => 178.0,

--- a/test/classes/Gis/GisVisualizationTest.php
+++ b/test/classes/Gis/GisVisualizationTest.php
@@ -42,7 +42,7 @@ class GisVisualizationTest extends AbstractTestCase
         $this->assertSame(
             [
                 'scale' => 1,
-                'x' => -15.0,
+                'x' => -300.0,
                 'y' => -225.0,
                 'minX' => 0.0,
                 'maxX' => 0.0,


### PR DESCRIPTION
When generating images (png, svg, pdf) from gis data, the plot is not centered correctly.

- The image was not centered because the border (either x or y) was
not included in the calculation
- When the ratio in one or both dimensions is zero (all points at the same
width or height) place it in the center.

Signed-off-by: Maximilian Krög <maxi_kroeg@web.de>