### PR TITLE
Remove dead code in Navigation

### DIFF
--- a/libraries/classes/Html/Generator.php
+++ b/libraries/classes/Html/Generator.php
@@ -361,60 +361,27 @@ class Generator
     /**
      * Renders a single link for the top of the navigation panel
      *
-     * @param string $link        The url for the link
-     * @param bool   $showText    Whether to show the text or to
-     *                            only use it for title attributes
-     * @param string $text        The text to display and use for title attributes
-     * @param bool   $showIcon    Whether to show the icon
-     * @param string $icon        The filename of the icon to show
-     * @param string $linkId      Value to use for the ID attribute
-     * @param bool   $disableAjax Whether to disable ajax page loading for this link
-     * @param string $linkTarget  The name of the target frame for the link
-     * @param array  $classes     HTML classes to apply
+     * @param string $link   The url for the link
+     * @param string $text   The text to display and use for title attributes
+     * @param string $icon   The filename of the icon to show
+     * @param string $linkId Value to use for the ID attribute
      *
      * @return string HTML code for one link
      */
     public static function getNavigationLink(
-        $link,
-        $showText,
-        $text,
-        $showIcon,
-        $icon,
-        $linkId = '',
-        $disableAjax = false,
-        $linkTarget = '',
-        array $classes = []
+        string $link,
+        string $text,
+        string $icon,
+        string $linkId = ''
     ): string {
         $retval = '<a href="' . $link . '"';
-        if (! empty($linkId)) {
+        if ($linkId !== '') {
             $retval .= ' id="' . $linkId . '"';
         }
 
-        if (! empty($linkTarget)) {
-            $retval .= ' target="' . $linkTarget . '"';
-        }
-
-        if ($disableAjax) {
-            $classes[] = 'disableAjax';
-        }
-
-        if (! empty($classes)) {
-            $retval .= ' class="' . implode(' ', $classes) . '"';
-        }
-
         $retval .= ' title="' . $text . '">';
-        if ($showIcon) {
-            $retval .= self::getImage($icon, $text);
-        }
-
-        if ($showText) {
-            $retval .= $text;
-        }
-
+        $retval .= self::getImage($icon, $text);
         $retval .= '</a>';
-        if ($showText) {
-            $retval .= '<br>';
-        }
 
         return $retval;
     }

--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -1330,15 +1330,9 @@ class NavigationTree
      */
     private function controls(): string
     {
-        // always iconic
-        $showIcon = true;
-        $showText = false;
-
         $collapseAll = Generator::getNavigationLink(
             '#',
-            $showText,
             __('Collapse all'),
-            $showIcon,
             's_collapseall',
             'pma_navigation_collapse'
         );
@@ -1349,7 +1343,7 @@ class NavigationTree
             $title = __('Unlink from main panel');
         }
 
-        $unlink = Generator::getNavigationLink('#', $showText, $title, $showIcon, $syncImage, 'pma_navigation_sync');
+        $unlink = Generator::getNavigationLink('#', $title, $syncImage, 'pma_navigation_sync');
 
         return $this->template->render('navigation/tree/controls', [
             'collapse_all' => $collapseAll,

--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -199,8 +199,7 @@ class NavigationTree
         }
 
         // Initialize the tree by creating a root node
-        $node = NodeFactory::getInstance('NodeDatabaseContainer', 'root');
-        $this->tree = $node;
+        $this->tree = NodeFactory::getInstance('NodeDatabaseContainer', 'root');
         if (! $GLOBALS['cfg']['NavigationTreeEnableGrouping'] || ! $GLOBALS['cfg']['ShowDatabasesNavigationAsTree']) {
             return;
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4636,11 +4636,6 @@ parameters:
 			path: libraries/classes/Html/Generator.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Html\\\\Generator\\:\\:getNavigationLink\\(\\) has parameter \\$classes with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Html/Generator.php
-
-		-
 			message: "#^Parameter \\#1 \\$params of static method PhpMyAdmin\\\\Url\\:\\:getCommon\\(\\) expects array\\<string, bool\\|int\\|string\\>, array\\<int\\|string, mixed\\> given\\.$#"
 			count: 2
 			path: libraries/classes/Html/Generator.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7105,8 +7105,7 @@
       <code>$title</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
-      <code>$classes</code>
+    <MixedArgumentTypeCoercion occurrences="1">
       <code>$key</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="3">


### PR DESCRIPTION
Here's the commit that introduced this method https://github.com/phpmyadmin/phpmyadmin/commit/dfe8dc283a5caa631ae1a21380e188bf5b4489de
Since then, the images have been deleted (or renamed) and all other usages of this method are gone too. 

It's worth mentioning that these buttons (or links actually) do not show up on the UI without an image. There is JS code for them, but I have no idea what it does. The "collapse all" button might have been useful. Perhaps the buttons should get fixed again? @williamdes Any idea? 