### PR TITLE
Add support for Web Authentication API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,10 @@
         "plugin:compat/recommended"
     ],
     "plugins": ["no-jquery"],
+    "parserOptions": {
+        "ecmaVersion": 2018,
+        "sourceType": "script"
+    },
     "env": {
         "browser": true,
         "es6": true,

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,8 @@
     "conflict": {
         "bacon/bacon-qr-code": "<2.0",
         "pragmarx/google2fa-qrcode": "<2.1",
-        "tecnickcom/tcpdf": "<6.4.4"
+        "tecnickcom/tcpdf": "<6.4.4",
+        "web-auth/webauthn-lib": "<3.3"
     },
     "suggest": {
         "ext-curl": "Updates checking",
@@ -93,7 +94,11 @@
         "tecnickcom/tcpdf": "For PDF support",
         "pragmarx/google2fa-qrcode": "^2.1 - For 2FA authentication",
         "bacon/bacon-qr-code": "^2.0 - For 2FA authentication",
-        "code-lts/u2f-php-server": "For FIDO U2F authentication"
+        "code-lts/u2f-php-server": "For FIDO U2F authentication",
+        "web-auth/webauthn-lib": "^3.3 - For FIDO2/WebAuthn authentication",
+        "ext-gmp": "For FIDO2/WebAuthn authentication",
+        "ext-bcmath": "For FIDO2/WebAuthn authentication",
+        "phpseclib/bcmath_compat": "For FIDO2/WebAuthn authentication"
     },
     "require-dev": {
         "bacon/bacon-qr-code": "^2.0",
@@ -111,7 +116,8 @@
         "squizlabs/php_codesniffer": "~3.6.0",
         "symfony/console": "^5.2.3",
         "tecnickcom/tcpdf": "^6.4.4",
-        "vimeo/psalm": "^4.22"
+        "vimeo/psalm": "^4.22",
+        "web-auth/webauthn-lib": "^3.3"
     },
     "extra": {
         "branch-alias": {

--- a/js/src/webauthn.js
+++ b/js/src/webauthn.js
@@ -1,0 +1,156 @@
+const base64UrlDecode = (input) => {
+    // eslint-disable-next-line no-param-reassign
+    input = input.replace(/-/g, '+').replace(/_/g, '/');
+
+    const pad = input.length % 4;
+    if (pad) {
+        if (pad === 1) {
+            throw new Error('InvalidLengthError: Input base64url string is the wrong length to determine padding');
+        }
+        // eslint-disable-next-line no-param-reassign
+        input += new Array(5 - pad).join('=');
+    }
+
+    return window.atob(input);
+};
+
+const arrayToBase64String = (a) => window.btoa(String.fromCharCode(...a));
+
+const preparePublicKeyOptions = publicKey => {
+    // Convert challenge from Base64Url string to Uint8Array
+    publicKey.challenge = Uint8Array.from(
+        base64UrlDecode(publicKey.challenge),
+        c => c.charCodeAt(0)
+    );
+
+    // Convert the user ID from Base64 string to Uint8Array
+    if (publicKey.user !== undefined) {
+        publicKey.user = {
+            ...publicKey.user,
+            id: Uint8Array.from(
+                window.atob(publicKey.user.id),
+                c => c.charCodeAt(0)
+            ),
+        };
+    }
+
+    // If excludeCredentials is defined, we convert all IDs to Uint8Array
+    if (publicKey.excludeCredentials !== undefined) {
+        publicKey.excludeCredentials = publicKey.excludeCredentials.map(
+            data => {
+                return {
+                    ...data,
+                    id: Uint8Array.from(
+                        base64UrlDecode(data.id),
+                        c => c.charCodeAt(0)
+                    ),
+                };
+            }
+        );
+    }
+
+    if (publicKey.allowCredentials !== undefined) {
+        publicKey.allowCredentials = publicKey.allowCredentials.map(
+            data => {
+                return {
+                    ...data,
+                    id: Uint8Array.from(
+                        base64UrlDecode(data.id),
+                        c => c.charCodeAt(0)
+                    ),
+                };
+            }
+        );
+    }
+
+    return publicKey;
+};
+
+const preparePublicKeyCredentials = data => {
+    const publicKeyCredential = {
+        id: data.id,
+        type: data.type,
+        rawId: arrayToBase64String(new Uint8Array(data.rawId)),
+        response: {
+            clientDataJSON: arrayToBase64String(
+                new Uint8Array(data.response.clientDataJSON)
+            ),
+        },
+    };
+
+    if (data.response.attestationObject !== undefined) {
+        publicKeyCredential.response.attestationObject = arrayToBase64String(
+            new Uint8Array(data.response.attestationObject)
+        );
+    }
+
+    if (data.response.authenticatorData !== undefined) {
+        publicKeyCredential.response.authenticatorData = arrayToBase64String(
+            new Uint8Array(data.response.authenticatorData)
+        );
+    }
+
+    if (data.response.signature !== undefined) {
+        publicKeyCredential.response.signature = arrayToBase64String(
+            new Uint8Array(data.response.signature)
+        );
+    }
+
+    if (data.response.userHandle !== undefined) {
+        publicKeyCredential.response.userHandle = arrayToBase64String(
+            new Uint8Array(data.response.userHandle)
+        );
+    }
+
+    return publicKeyCredential;
+};
+
+const createPublicKeyCredential = async function (publicKey) {
+    // eslint-disable-next-line compat/compat
+    const credentials = await navigator.credentials.create({ publicKey: publicKey });
+
+    return preparePublicKeyCredentials(credentials);
+};
+
+const getPublicKeyCredential = async function (publicKey) {
+    // eslint-disable-next-line compat/compat
+    const credentials = await navigator.credentials.get({ publicKey: publicKey });
+
+    return preparePublicKeyCredentials(credentials);
+};
+
+AJAX.registerOnload('webauthn.js', function () {
+    const $inputReg = $('#webauthn_registration_response');
+    if ($inputReg.length > 0) {
+        const $formReg = $inputReg.parents('form');
+        $formReg.find('input[type=submit]').hide();
+
+        const webauthnOptionsJson = $inputReg.attr('data-webauthn-options');
+        const webauthnOptions = JSON.parse(webauthnOptionsJson);
+        const publicKey = preparePublicKeyOptions(webauthnOptions);
+        const publicKeyCredential = createPublicKeyCredential(publicKey);
+        publicKeyCredential
+            .then((data) => {
+                $inputReg.val(JSON.stringify(data));
+                $formReg.trigger('submit');
+            })
+            .catch((error) => Functions.ajaxShowMessage(error, false, 'error'));
+    }
+
+    const $inputAuth = $('#webauthn_authentication_response');
+    if ($inputAuth.length > 0) {
+        const $formAuth = $inputAuth.parents('form');
+        $formAuth.find('input[type=submit]').hide();
+
+        const webauthnRequestJson = $inputAuth.attr('data-webauthn-request');
+        const webauthnRequest = JSON.parse(webauthnRequestJson);
+        const publicKey = preparePublicKeyOptions(webauthnRequest);
+        const publicKeyCredential = getPublicKeyCredential(publicKey);
+        publicKeyCredential
+            .then((data) => {
+                $inputAuth.val(JSON.stringify(data));
+                $formAuth.trigger('submit');
+            })
+            .catch((error) => Functions.ajaxShowMessage(error, false, 'error'));
+    }
+});

--- a/libraries/classes/Plugins/TwoFactor/Key.php
+++ b/libraries/classes/Plugins/TwoFactor/Key.php
@@ -211,6 +211,6 @@ class Key extends TwoFactorPlugin
      */
     public static function getDescription()
     {
-        return __('Provides authentication using hardware security tokens supporting FIDO U2F, such as a Yubikey.');
+        return __('Provides authentication using hardware security tokens supporting FIDO U2F, such as a YubiKey.');
     }
 }

--- a/libraries/classes/Plugins/TwoFactor/WebAuthn.php
+++ b/libraries/classes/Plugins/TwoFactor/WebAuthn.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Plugins\TwoFactor;
+
+use PhpMyAdmin\Plugins\TwoFactorPlugin;
+use PhpMyAdmin\ResponseRenderer;
+use PhpMyAdmin\TwoFactor;
+use Throwable;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\PublicKeyCredentialSourceRepository;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\Server;
+use Webmozart\Assert\Assert;
+
+use function __;
+use function array_map;
+use function base64_encode;
+use function is_array;
+use function json_encode;
+
+class WebAuthn extends TwoFactorPlugin
+{
+    /** @var string */
+    public static $id = 'WebAuthn';
+
+    /** @var PublicKeyCredentialRpEntity */
+    private $relyingPartyEntity;
+
+    /** @var PublicKeyCredentialSourceRepository */
+    private $publicKeyCredentialSourceRepository;
+
+    /** @var Server */
+    private $server;
+
+    public function __construct(TwoFactor $twofactor)
+    {
+        parent::__construct($twofactor);
+        if (
+            ! isset($this->twofactor->config['settings']['WebAuthn'])
+            || ! is_array($this->twofactor->config['settings']['WebAuthn'])
+        ) {
+            $this->twofactor->config['settings']['WebAuthn'] = [];
+        }
+
+        $this->relyingPartyEntity = new PublicKeyCredentialRpEntity('phpMyAdmin (' . $this->getAppId(false) . ')');
+        $this->publicKeyCredentialSourceRepository = $this->createPublicKeyCredentialSourceRepository();
+        $this->server = new Server($this->relyingPartyEntity, $this->publicKeyCredentialSourceRepository);
+    }
+
+    public function check(): bool
+    {
+        $this->provided = false;
+        $request = $GLOBALS['request'];
+        $authenticatorResponse = $request->getParsedBodyParam('webauthn_authentication_response');
+        if ($authenticatorResponse === null) {
+            return false;
+        }
+
+        $this->provided = true;
+        $name = $this->twofactor->user;
+        $userEntity = new PublicKeyCredentialUserEntity($name, $name, $name);
+
+        /** @var mixed $credentialRequestOptions */
+        $credentialRequestOptions = $_SESSION['WebAuthnCredentialRequestOptions'] ?? null;
+        unset($_SESSION['WebAuthnCredentialRequestOptions']);
+
+        try {
+            Assert::stringNotEmpty($authenticatorResponse);
+            Assert::isInstanceOf($credentialRequestOptions, PublicKeyCredentialRequestOptions::class);
+            $publicKeyCredentialSource = $this->server->loadAndCheckAssertionResponse(
+                $authenticatorResponse,
+                $credentialRequestOptions,
+                $userEntity,
+                $request
+            );
+        } catch (Throwable $exception) {
+            $this->message = $exception->getMessage();
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public function render(): string
+    {
+        $name = $this->twofactor->user;
+        $userEntity = new PublicKeyCredentialUserEntity($name, $name, $name);
+        $credentialSources = $this->publicKeyCredentialSourceRepository->findAllForUserEntity($userEntity);
+
+        $allowedCredentials = array_map(
+            static function (PublicKeyCredentialSource $credential): PublicKeyCredentialDescriptor {
+                return $credential->getPublicKeyCredentialDescriptor();
+            },
+            $credentialSources
+        );
+
+        $publicKeyCredentialRequestOptions = $this->server->generatePublicKeyCredentialRequestOptions(
+            PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+            $allowedCredentials
+        );
+        $requestJson = json_encode($publicKeyCredentialRequestOptions);
+        $_SESSION['WebAuthnCredentialRequestOptions'] = $publicKeyCredentialRequestOptions;
+
+        $this->loadScripts();
+
+        return $this->template->render('login/twofactor/webauthn', ['request' => $requestJson]);
+    }
+
+    public function setup(): string
+    {
+        $name = $this->twofactor->user;
+        $userEntity = new PublicKeyCredentialUserEntity($name, $name, $name);
+        $publicKeyCredentialCreationOptions = $this->server->generatePublicKeyCredentialCreationOptions($userEntity);
+
+        $optionsJson = json_encode($publicKeyCredentialCreationOptions);
+        $_SESSION['WebAuthnCredentialCreationOptions'] = $publicKeyCredentialCreationOptions;
+
+        $this->loadScripts();
+
+        return $this->template->render('login/twofactor/webauthn_configure', ['options' => $optionsJson]);
+    }
+
+    public function configure(): bool
+    {
+        $this->provided = false;
+        $request = $GLOBALS['request'];
+        $authenticatorResponse = $request->getParsedBodyParam('webauthn_registration_response');
+        if ($authenticatorResponse === null) {
+            return false;
+        }
+
+        $this->provided = true;
+
+        /** @var mixed $credentialCreationOptions */
+        $credentialCreationOptions = $_SESSION['WebAuthnCredentialCreationOptions'] ?? null;
+        unset($_SESSION['WebAuthnCredentialCreationOptions']);
+
+        try {
+            Assert::stringNotEmpty($authenticatorResponse);
+            Assert::isInstanceOf($credentialCreationOptions, PublicKeyCredentialCreationOptions::class);
+            $publicKeyCredentialSource = $this->server->loadAndCheckAttestationResponse(
+                $authenticatorResponse,
+                $credentialCreationOptions,
+                $request
+            );
+            $this->publicKeyCredentialSourceRepository->saveCredentialSource($publicKeyCredentialSource);
+        } catch (Throwable $exception) {
+            $this->message = $exception->getMessage();
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public static function getName(): string
+    {
+        return __('Hardware Security Key (FIDO2/WebAuthn)');
+    }
+
+    public static function getDescription(): string
+    {
+        return __(
+            'Provides authentication using hardware security tokens supporting FIDO2/WebAuthn, such as a YubiKey.'
+        );
+    }
+
+    private function loadScripts(): void
+    {
+        $response = ResponseRenderer::getInstance();
+        $scripts = $response->getHeader()->getScripts();
+        $scripts->addFile('webauthn.js');
+    }
+
+    private function createPublicKeyCredentialSourceRepository(): PublicKeyCredentialSourceRepository
+    {
+        return new class ($this->twofactor) implements PublicKeyCredentialSourceRepository {
+            /** @var TwoFactor */
+            private $twoFactor;
+
+            public function __construct(TwoFactor $twoFactor)
+            {
+                $this->twoFactor = $twoFactor;
+            }
+
+            public function findOneByCredentialId(string $publicKeyCredentialId): ?PublicKeyCredentialSource
+            {
+                $data = $this->read();
+                if (isset($data[base64_encode($publicKeyCredentialId)])) {
+                    return PublicKeyCredentialSource::createFromArray($data[base64_encode($publicKeyCredentialId)]);
+                }
+
+                return null;
+            }
+
+            /**
+             * @return PublicKeyCredentialSource[]
+             */
+            public function findAllForUserEntity(PublicKeyCredentialUserEntity $publicKeyCredentialUserEntity): array
+            {
+                $sources = [];
+                foreach ($this->read() as $data) {
+                    $source = PublicKeyCredentialSource::createFromArray($data);
+                    if ($source->getUserHandle() !== $publicKeyCredentialUserEntity->getId()) {
+                        continue;
+                    }
+
+                    $sources[] = $source;
+                }
+
+                return $sources;
+            }
+
+            public function saveCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource): void
+            {
+                $data = $this->read();
+                $id = $publicKeyCredentialSource->getPublicKeyCredentialId();
+                $data[base64_encode($id)] = $publicKeyCredentialSource;
+                $this->write($data);
+            }
+
+            /**
+             * @return mixed[][]
+             */
+            private function read(): array
+            {
+                return $this->twoFactor->config['settings']['WebAuthn'];
+            }
+
+            /**
+             * @param mixed[] $data
+             */
+            private function write(array $data): void
+            {
+                $this->twoFactor->config['settings']['WebAuthn'] = $data;
+            }
+        };
+    }
+}

--- a/libraries/classes/TwoFactor.php
+++ b/libraries/classes/TwoFactor.php
@@ -13,13 +13,16 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Plugins\TwoFactor\Application;
 use PhpMyAdmin\Plugins\TwoFactor\Invalid;
 use PhpMyAdmin\Plugins\TwoFactor\Key;
+use PhpMyAdmin\Plugins\TwoFactor\WebAuthn;
 use PhpMyAdmin\Plugins\TwoFactorPlugin;
 use PragmaRX\Google2FAQRCode\Google2FA;
+use Webauthn\Server;
 use XMLWriter;
 
 use function array_merge;
 use function class_exists;
 use function extension_loaded;
+use function function_exists;
 use function in_array;
 use function ucfirst;
 
@@ -135,6 +138,10 @@ class TwoFactor
             $result[] = 'application';
         }
 
+        if (class_exists(Server::class) && (function_exists('gmp_add') || function_exists('bcadd'))) {
+            $result[] = 'WebAuthn';
+        }
+
         if (class_exists(U2FServer::class)) {
             $result[] = 'key';
         }
@@ -161,6 +168,20 @@ class TwoFactor
             $result[] = [
                 'class' => Application::getName(),
                 'dep' => 'bacon/bacon-qr-code',
+            ];
+        }
+
+        if (! class_exists(Server::class)) {
+            $result[] = [
+                'class' => WebAuthn::getName(),
+                'dep' => 'web-auth/webauthn-lib',
+            ];
+        }
+
+        if (! function_exists('gmp_add') && ! function_exists('bcadd')) {
+            $result[] = [
+                'class' => WebAuthn::getName(),
+                'dep' => 'ext-gmp || ext-bcmath || phpseclib/bcmath_compat',
             ];
         }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/core": "^7.18.9",
     "@babel/preset-env": "^7.18.9",
     "@popperjs/core": "^2.11.5",
+    "@web-auth/webauthn-helper": "^0.0.13",
     "@zxcvbn-ts/core": "^2.0.1",
     "autoprefixer": "^10.4.7",
     "bootstrap": "5.2.0",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -12081,6 +12081,24 @@
       <code>$_POST['u2f_registration_response']</code>
     </PossiblyInvalidCast>
   </file>
+  <file src="libraries/classes/Plugins/TwoFactor/WebAuthn.php">
+    <MixedArrayAccess occurrences="1">
+      <code>$this-&gt;twoFactor-&gt;config['settings']['WebAuthn']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="2">
+      <code>$this-&gt;twoFactor-&gt;config['settings']['WebAuthn']</code>
+      <code>$this-&gt;twofactor-&gt;config['settings']['WebAuthn']</code>
+    </MixedArrayAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>mixed[][]</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;twoFactor-&gt;config['settings']['WebAuthn']</code>
+    </MixedReturnStatement>
+    <UnusedVariable occurrences="1">
+      <code>$publicKeyCredentialSource</code>
+    </UnusedVariable>
+  </file>
   <file src="libraries/classes/Plugins/TwoFactorPlugin.php">
     <MixedArgument occurrences="1">
       <code>$url</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -373,6 +373,7 @@
             proc_priv: bool,
             querytime: float|int,
             read_limit: int,
+            request: PhpMyAdmin\Http\ServerRequest,
             save_on_server: bool,
             server: int,
             SESSION_KEY: string,

--- a/templates/login/twofactor/webauthn.twig
+++ b/templates/login/twofactor/webauthn.twig
@@ -1,0 +1,3 @@
+<p class="card-text">{{ 'Please connect your FIDO2/WebAuthn device. Then confirm login on the device.'|trans }}</p>
+
+<input type="hidden" id="webauthn_authentication_response" name="webauthn_authentication_response" value="" data-webauthn-request="{{ request|e('html_attr') }}">

--- a/templates/login/twofactor/webauthn_configure.twig
+++ b/templates/login/twofactor/webauthn_configure.twig
@@ -1,0 +1,3 @@
+<p class="card-text">{{ 'Please connect your FIDO2/WebAuthn device. Then confirm registration on the device.'|trans }}</p>
+
+<input type="hidden" id="webauthn_registration_response" name="webauthn_registration_response" value="" data-webauthn-options="{{ options|e('html_attr') }}">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1418,6 +1418,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@web-auth/webauthn-helper@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@web-auth/webauthn-helper/-/webauthn-helper-0.0.13.tgz#2e9e6f421a3238bee233fe97c6801a6c6354cf7b"
+  integrity sha512-yEXWTiZSGFYnCVEwOqWgZFrQ4MiW9WGAiAvdRD6NQRlp7sr39THZiGIix/x3y3zmnsUsZZ0iXQA8zG/gPESwzQ==
+
 "@zxcvbn-ts/core@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@zxcvbn-ts/core/-/core-2.0.3.tgz#fbe92b3607e20f634f26fc68695eaf03813d1638"


### PR DESCRIPTION
Adds a two factor authentication plugin that supports FIDO2/WebAuthn security keys.

The automatic migration from FIDO U2F to FIDO2 WebAuthn is not implemented yet.

- Fixes https://github.com/phpmyadmin/phpmyadmin/issues/17229

Some of the functions in `webauthn.js` file are copied from the `@web-auth/webauthn-helper` Yarn package. I'll probably rewrite them to avoid installing this package or I'll install another package. It's basically for encoding and decoding base64url strings.

@williamdes, Do you have more than one security key? If you do, could you please test using a different key?