### PR TITLE
Fix #17398 - Fixing clicking on `JSON` columns triggers `update` query 

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -10,7 +10,7 @@
 
 /**
  * general function, usually for data manipulation pages
- *
+ * @test-module Functions
  */
 var Functions = {};
 
@@ -3989,13 +3989,11 @@ Functions.getCellValue = function (td) {
  * @return {string}
  */
 Functions.stringifyJSON = function (json, replacer = null, space = 0) {
-    let stringifiedJSON = json;
     try {
-        stringifiedJSON = JSON.stringify(JSON.parse(json), replacer, space);
+        return JSON.stringify(JSON.parse(json), replacer, space);
     } catch (e) {
-        // will be returned as it's
+        return json;
     }
-    return stringifiedJSON;
 };
 
 /**

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -3981,6 +3981,21 @@ Functions.getCellValue = function (td) {
 };
 
 /**
+ * Validate and return stringified JSON inputs, or plain if invalid.
+ *
+ * @param json the json input to be validated and stringified
+ * @param replacer An array of strings and numbers that acts as an approved list for selecting the object properties that will be stringified.
+ * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+ * @return {string}
+ */
+Functions.stringifyJSON = function (json, replacer = null, space = 0) {
+    try {
+        json = JSON.stringify(JSON.parse(json), replacer, space);
+    } catch (e) { }
+    return json;
+};
+
+/**
  * Unbind all event handlers before tearing down a page
  */
 AJAX.registerTeardown('functions.js', function () {

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -3989,10 +3989,13 @@ Functions.getCellValue = function (td) {
  * @return {string}
  */
 Functions.stringifyJSON = function (json, replacer = null, space = 0) {
+    let stringifiedJSON = json;
     try {
-        json = JSON.stringify(JSON.parse(json), replacer, space);
-    } catch (e) { }
-    return json;
+        stringifiedJSON = JSON.stringify(JSON.parse(json), replacer, space);
+    } catch (e) {
+        // will be returned as it's
+    }
+    return stringifiedJSON;
 };
 
 /**

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -1509,7 +1509,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     thisFieldParams[fieldName] = $(g.cEdit).find('.edit_box').val();
                 }
 
-                var isValueUpdated;
+                let isValueUpdated;
                 if ($thisField.attr('data-type') !== 'json') {
                     isValueUpdated = thisFieldParams[fieldName] !== Functions.getCellValue(g.currentEditCell);
                 } else {

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -631,11 +631,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     // fill the cell edit with text from <td>
                     var value = Functions.getCellValue(cell);
                     if ($cell.attr('data-type') === 'json' && $cell.is('.truncated') === false) {
-                        try {
-                            value = JSON.stringify(JSON.parse(value), null, 4);
-                        } catch (e) {
-                            // Show as is
-                        }
+                        value = Functions.stringifyJSON(value, null, 4);
                     }
                     $(g.cEdit).find('.edit_box').val(value);
 
@@ -1053,11 +1049,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             $editArea.removeClass('edit_area_loading');
                             if (typeof data !== 'undefined' && data.success === true) {
                                 if ($td.attr('data-type') === 'json') {
-                                    try {
-                                        data.value = JSON.stringify(JSON.parse(data.value), null, 4);
-                                    } catch (e) {
-                                        // Show as is
-                                    }
+                                    data.value = Functions.stringifyJSON(data.value, null, 4);
                                 }
                                 $td.data('original_data', data.value);
                                 $(g.cEdit).find('.edit_box').val(data.value);
@@ -1278,7 +1270,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         if ($thisField.attr('data-type') !== 'json') {
                             fields.push($thisField.data('value'));
                         } else {
-                            fields.push(JSON.stringify(JSON.parse($thisField.data('value'))));
+                            const JSONString = Functions.stringifyJSON($thisField.data('value'));
+                            fields.push(JSONString);
                         }
 
                         var cellIndex = $thisField.index('.to_be_saved');
@@ -1520,7 +1513,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 if ($thisField.attr('data-type') !== 'json') {
                     isValueUpdated = thisFieldParams[fieldName] !== Functions.getCellValue(g.currentEditCell);
                 } else {
-                    isValueUpdated = JSON.stringify(JSON.parse(thisFieldParams[fieldName])) !== JSON.stringify(JSON.parse(Functions.getCellValue(g.currentEditCell)));
+                    const JSONString = Functions.stringifyJSON(thisFieldParams[fieldName]);
+                    isValueUpdated = JSONString !== JSON.stringify(JSON.parse(Functions.getCellValue(g.currentEditCell)));
                 }
 
                 if (g.wasEditedCellNull || isValueUpdated) {

--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -1274,7 +1274,12 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             fieldsType.push('hex');
                         }
                         fieldsNull.push('');
-                        fields.push($thisField.data('value'));
+
+                        if ($thisField.attr('data-type') !== 'json') {
+                            fields.push($thisField.data('value'));
+                        } else {
+                            fields.push(JSON.stringify(JSON.parse($thisField.data('value'))));
+                        }
 
                         var cellIndex = $thisField.index('.to_be_saved');
                         if ($thisField.is(':not(.relation, .enum, .set, .bit)')) {
@@ -1510,7 +1515,15 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                 } else {
                     thisFieldParams[fieldName] = $(g.cEdit).find('.edit_box').val();
                 }
-                if (g.wasEditedCellNull || thisFieldParams[fieldName] !== Functions.getCellValue(g.currentEditCell)) {
+
+                var isValueUpdated;
+                if ($thisField.attr('data-type') !== 'json') {
+                    isValueUpdated = thisFieldParams[fieldName] !== Functions.getCellValue(g.currentEditCell);
+                } else {
+                    isValueUpdated = JSON.stringify(JSON.parse(thisFieldParams[fieldName])) !== JSON.stringify(JSON.parse(Functions.getCellValue(g.currentEditCell)));
+                }
+
+                if (g.wasEditedCellNull || isValueUpdated) {
                     needToPost = true;
                 }
             }

--- a/test/javascript/functions.test.js
+++ b/test/javascript/functions.test.js
@@ -1,0 +1,17 @@
+/* eslint-env node, jest */
+
+const Functions = require('phpmyadmin/functions');
+
+describe('Functions', () => {
+    describe('Testing stringifyJSON', function() { 
+        test('Should return the stringified JSON input', () => {
+            const stringifiedJSON = Functions.stringifyJSON('{ "lang": "php"}', null, 4);
+            expect(stringifiedJSON).toEqual('{\n    "lang": "php"\n}');
+        });
+
+        test('Should return the input as it is', () => {
+            const stringifiedJSON = Functions.stringifyJSON('{ "name": "notvalid}');
+            expect(stringifiedJSON).toEqual('{ "name": "notvalid}');
+        });
+     });
+});

--- a/test/javascript/functions.test.js
+++ b/test/javascript/functions.test.js
@@ -3,7 +3,7 @@
 const Functions = require('phpmyadmin/functions');
 
 describe('Functions', () => {
-    describe('Testing stringifyJSON', function() { 
+    describe('Testing stringifyJSON', function () {
         test('Should return the stringified JSON input', () => {
             const stringifiedJSON = Functions.stringifyJSON('{ "lang": "php"}', null, 4);
             expect(stringifiedJSON).toEqual('{\n    "lang": "php"\n}');
@@ -13,5 +13,5 @@ describe('Functions', () => {
             const stringifiedJSON = Functions.stringifyJSON('{ "name": "notvalid}');
             expect(stringifiedJSON).toEqual('{ "name": "notvalid}');
         });
-     });
+    });
 });


### PR DESCRIPTION
### Description

Hi, This PR is fixing the two issues mentioned at #17398
1- An `update` query is executed when clicking on the `JSON` columns
2- The `JSON` columns values are saved with unneeded spaces and lines when updated


https://user-images.githubusercontent.com/46695441/208328428-ce2656bc-bd32-4536-9604-b9c37fc10482.mov


Fixes #17398
