### PR TITLE
Ref #17769 - replace superglobals with serverrequest in database/structure/ controllers

### DIFF
--- a/libraries/classes/Controllers/Database/Structure/AddPrefixController.php
+++ b/libraries/classes/Controllers/Database/Structure/AddPrefixController.php
@@ -13,7 +13,7 @@ final class AddPrefixController extends AbstractController
 {
     public function __invoke(ServerRequest $request): void
     {
-        $selected = $_POST['selected_tbl'] ?? [];
+        $selected = $request->getParsedBodyParam('selected_tbl', []);
 
         if (empty($selected)) {
             $this->response->setRequestStatus(false);

--- a/libraries/classes/Controllers/Database/Structure/AddPrefixTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/AddPrefixTableController.php
@@ -36,13 +36,13 @@ final class AddPrefixTableController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $selected = $_POST['selected'] ?? [];
+        $selected = $request->getParsedBodyParam('selected', []);
 
         $GLOBALS['sql_query'] = '';
         $selectedCount = count($selected);
 
         for ($i = 0; $i < $selectedCount; $i++) {
-            $newTableName = $_POST['add_prefix'] . $selected[$i];
+            $newTableName = $request->getParsedBodyParam('add_prefix', '') . $selected[$i];
             $aQuery = 'ALTER TABLE ' . Util::backquote($selected[$i])
                 . ' RENAME ' . Util::backquote($newTableName);
 

--- a/libraries/classes/Controllers/Database/Structure/ChangePrefixFormController.php
+++ b/libraries/classes/Controllers/Database/Structure/ChangePrefixFormController.php
@@ -13,8 +13,7 @@ final class ChangePrefixFormController extends AbstractController
 {
     public function __invoke(ServerRequest $request): void
     {
-        $selected = $_POST['selected_tbl'] ?? [];
-        $submitMult = $_POST['submit_mult'] ?? '';
+        $selected = $request->getParsedBodyParam('selected_tbl', []);
 
         if (empty($selected)) {
             $this->response->setRequestStatus(false);
@@ -24,7 +23,7 @@ final class ChangePrefixFormController extends AbstractController
         }
 
         $route = '/database/structure/replace-prefix';
-        if ($submitMult === 'copy_tbl_change_prefix') {
+        if ($request->getParsedBodyParam('submit_mult', '') === 'copy_tbl_change_prefix') {
             $route = '/database/structure/copy-table-with-prefix';
         }
 

--- a/libraries/classes/Controllers/Database/Structure/CopyFormController.php
+++ b/libraries/classes/Controllers/Database/Structure/CopyFormController.php
@@ -13,7 +13,7 @@ final class CopyFormController extends AbstractController
 {
     public function __invoke(ServerRequest $request): void
     {
-        $selected = $_POST['selected_tbl'] ?? [];
+        $selected = $request->getParsedBodyParam('selected_tbl', []);
 
         if (empty($selected)) {
             $this->response->setRequestStatus(false);

--- a/libraries/classes/Controllers/Database/Structure/CopyTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/CopyTableController.php
@@ -36,8 +36,8 @@ final class CopyTableController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $selected = $_POST['selected'] ?? [];
-        $targetDb = $_POST['target_db'] ?? null;
+        $selected = $request->getParsedBodyParam('selected', []);
+        $targetDb = $request->getParsedBodyParam('target_db');
         $selectedCount = count($selected);
 
         for ($i = 0; $i < $selectedCount; $i++) {
@@ -46,13 +46,13 @@ final class CopyTableController extends AbstractController
                 $selected[$i],
                 $targetDb,
                 $selected[$i],
-                $_POST['what'],
+                $request->getParsedBodyParam('what'),
                 false,
                 'one_table',
-                isset($_POST['drop_if_exists']) && $_POST['drop_if_exists'] === 'true'
+                $request->getParsedBodyParam('drop_if_exists') === 'true'
             );
 
-            if (empty($_POST['adjust_privileges'])) {
+            if (! $request->hasBodyParam('adjust_privileges')) {
                 continue;
             }
 


### PR DESCRIPTION
Signed-off-by: Evgeny Skorlov <eugene@skorlov.name>

### Description

Ref https://github.com/phpmyadmin/phpmyadmin/issues/17769

replace superglobals with serverrequest in
  Database/Structure/AddPrefixController.php
  Database/Structure/AddPrefixTableController.php
  Database/Structure/ChangePrefixFormController.php
  Database/Structure/CopyFormController.php
  Database/Structure/CopyTableController.php
