### PR TITLE
Designer controller globals

### DIFF
--- a/libraries/classes/Controllers/Database/CentralColumnsController.php
+++ b/libraries/classes/Controllers/Database/CentralColumnsController.php
@@ -37,7 +37,6 @@ class CentralColumnsController extends AbstractController
     public function __invoke(ServerRequest $request): void
     {
         $GLOBALS['message'] = $GLOBALS['message'] ?? null;
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['num_cols'] = $GLOBALS['num_cols'] ?? null;
 
         if (isset($_POST['edit_save'])) {
@@ -133,18 +132,18 @@ class CentralColumnsController extends AbstractController
             'total_rows' => $_POST['total_rows'] ?? null,
         ]);
 
-        $GLOBALS['pos'] = 0;
+        $pos = 0;
         if (isset($_POST['pos']) && is_numeric($_POST['pos'])) {
-            $GLOBALS['pos'] = (int) $_POST['pos'];
+            $pos = (int) $_POST['pos'];
         }
 
         $GLOBALS['num_cols'] = $this->centralColumns->getColumnsCount(
             $GLOBALS['db'],
-            $GLOBALS['pos'],
+            $pos,
             (int) $GLOBALS['cfg']['MaxRows']
         );
         $GLOBALS['message'] = Message::success(
-            sprintf(__('Showing rows %1$s - %2$s.'), $GLOBALS['pos'] + 1, $GLOBALS['pos'] + $GLOBALS['num_cols'])
+            sprintf(__('Showing rows %1$s - %2$s.'), $pos + 1, $pos + $GLOBALS['num_cols'])
         );
         if (! isset($tmp_msg) || $tmp_msg === true) {
             return;

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -40,7 +40,7 @@ class DesignerController extends AbstractController
     public function __invoke(ServerRequest $request): void
     {
         $GLOBALS['message'] = $GLOBALS['message'] ?? null;
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
+
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
@@ -207,8 +207,7 @@ class DesignerController extends AbstractController
             'designer/init.js',
         ]);
 
-        [
-            $GLOBALS['tables'],
+        [,
             $GLOBALS['num_tables'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -42,7 +42,7 @@ class DesignerController extends AbstractController
         $GLOBALS['message'] = $GLOBALS['message'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
@@ -213,8 +213,7 @@ class DesignerController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],
-            $GLOBALS['total_num_tables'],,,
+            $GLOBALS['num_tables'],,,,
             $GLOBALS['tooltip_truename'],
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -40,7 +40,6 @@ class DesignerController extends AbstractController
     public function __invoke(ServerRequest $request): void
     {
         $GLOBALS['message'] = $GLOBALS['message'] ?? null;
-        $GLOBALS['params'] = $GLOBALS['params'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
@@ -198,11 +197,6 @@ class DesignerController extends AbstractController
         $classesSideMenu = $this->databaseDesigner->returnClassNamesFromMenuButtons();
 
         $scriptContr = $this->designerCommon->getScriptContr($scriptDisplayField);
-
-        $GLOBALS['params'] = ['lang' => $GLOBALS['lang']];
-        if (isset($_GET['db'])) {
-            $GLOBALS['params']['db'] = $_GET['db'];
-        }
 
         $this->response->setMinimalFooter();
         $header = $this->response->getHeader();

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -40,8 +40,6 @@ class DesignerController extends AbstractController
     public function __invoke(ServerRequest $request): void
     {
         $GLOBALS['message'] = $GLOBALS['message'] ?? null;
-
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
         if (isset($_POST['dialog'])) {
@@ -207,8 +205,7 @@ class DesignerController extends AbstractController
             'designer/init.js',
         ]);
 
-        [,
-            $GLOBALS['num_tables'],
+        [,,
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         // Embed some data into HTML, later it will be read

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -44,7 +44,7 @@ class DesignerController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
@@ -213,8 +213,7 @@ class DesignerController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,
-            $GLOBALS['tooltip_aliasname'],
+            $GLOBALS['num_tables'],,,,,,
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -43,7 +43,7 @@ class DesignerController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -213,8 +213,7 @@ class DesignerController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,
-            $GLOBALS['tooltip_truename'],
+            $GLOBALS['num_tables'],,,,,
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -42,10 +42,6 @@ class DesignerController extends AbstractController
         $GLOBALS['message'] = $GLOBALS['message'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
         if (isset($_POST['dialog'])) {
@@ -213,8 +209,7 @@ class DesignerController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,,
-            $GLOBALS['pos'],
+            $GLOBALS['num_tables'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         // Embed some data into HTML, later it will be read

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -205,9 +205,6 @@ class DesignerController extends AbstractController
             'designer/init.js',
         ]);
 
-        [,,
-        ] = Util::getDbInfo($request, $GLOBALS['db']);
-
         // Embed some data into HTML, later it will be read
         // by designer/init.js and converted to JS variables.
         $this->response->addHTML(

--- a/libraries/classes/Controllers/Database/EventsController.php
+++ b/libraries/classes/Controllers/Database/EventsController.php
@@ -51,9 +51,6 @@ final class EventsController extends AbstractController
             if (! $this->hasDatabase()) {
                 return;
             }
-
-            [,,
-            ] = Util::getDbInfo($request, $GLOBALS['db']);
         } elseif (strlen($GLOBALS['db']) > 0) {
             $this->dbi->selectDb($GLOBALS['db']);
         }

--- a/libraries/classes/Controllers/Database/EventsController.php
+++ b/libraries/classes/Controllers/Database/EventsController.php
@@ -38,12 +38,8 @@ final class EventsController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['text_dir'] = $GLOBALS['text_dir'] ?? null;
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
         $this->addScriptFiles(['database/events.js']);
@@ -60,8 +56,7 @@ final class EventsController extends AbstractController
 
             [
                 $GLOBALS['tables'],
-                $GLOBALS['num_tables'],,,,,,
-                $GLOBALS['pos'],
+                $GLOBALS['num_tables'],
             ] = Util::getDbInfo($request, $GLOBALS['db']);
         } elseif (strlen($GLOBALS['db']) > 0) {
             $this->dbi->selectDb($GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/EventsController.php
+++ b/libraries/classes/Controllers/Database/EventsController.php
@@ -38,7 +38,7 @@ final class EventsController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['text_dir'] = $GLOBALS['text_dir'] ?? null;
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
@@ -60,8 +60,7 @@ final class EventsController extends AbstractController
 
             [
                 $GLOBALS['tables'],
-                $GLOBALS['num_tables'],
-                $GLOBALS['total_num_tables'],,,
+                $GLOBALS['num_tables'],,,,
                 $GLOBALS['tooltip_truename'],
                 $GLOBALS['tooltip_aliasname'],
                 $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Database/EventsController.php
+++ b/libraries/classes/Controllers/Database/EventsController.php
@@ -36,7 +36,6 @@ final class EventsController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['text_dir'] = $GLOBALS['text_dir'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -53,8 +52,7 @@ final class EventsController extends AbstractController
                 return;
             }
 
-            [,
-                $GLOBALS['num_tables'],
+            [,,
             ] = Util::getDbInfo($request, $GLOBALS['db']);
         } elseif (strlen($GLOBALS['db']) > 0) {
             $this->dbi->selectDb($GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/EventsController.php
+++ b/libraries/classes/Controllers/Database/EventsController.php
@@ -41,7 +41,7 @@ final class EventsController extends AbstractController
 
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['text_dir'] = $GLOBALS['text_dir'] ?? null;
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -60,8 +60,7 @@ final class EventsController extends AbstractController
 
             [
                 $GLOBALS['tables'],
-                $GLOBALS['num_tables'],,,,
-                $GLOBALS['tooltip_truename'],
+                $GLOBALS['num_tables'],,,,,
                 $GLOBALS['tooltip_aliasname'],
                 $GLOBALS['pos'],
             ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/EventsController.php
+++ b/libraries/classes/Controllers/Database/EventsController.php
@@ -42,7 +42,7 @@ final class EventsController extends AbstractController
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['text_dir'] = $GLOBALS['text_dir'] ?? null;
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
@@ -60,8 +60,7 @@ final class EventsController extends AbstractController
 
             [
                 $GLOBALS['tables'],
-                $GLOBALS['num_tables'],,,,,
-                $GLOBALS['tooltip_aliasname'],
+                $GLOBALS['num_tables'],,,,,,
                 $GLOBALS['pos'],
             ] = Util::getDbInfo($request, $GLOBALS['db']);
         } elseif (strlen($GLOBALS['db']) > 0) {

--- a/libraries/classes/Controllers/Database/EventsController.php
+++ b/libraries/classes/Controllers/Database/EventsController.php
@@ -36,7 +36,6 @@ final class EventsController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['text_dir'] = $GLOBALS['text_dir'] ?? null;
@@ -54,8 +53,7 @@ final class EventsController extends AbstractController
                 return;
             }
 
-            [
-                $GLOBALS['tables'],
+            [,
                 $GLOBALS['num_tables'],
             ] = Util::getDbInfo($request, $GLOBALS['db']);
         } elseif (strlen($GLOBALS['db']) > 0) {

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -46,7 +46,7 @@ final class ExportController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['table_select'] = $GLOBALS['table_select'] ?? null;
         $GLOBALS['unlim_num_rows'] = $GLOBALS['unlim_num_rows'] ?? null;
@@ -71,8 +71,7 @@ final class ExportController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,
-            $GLOBALS['tooltip_aliasname'],
+            $GLOBALS['num_tables'],,,,,,
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db'], false);
 

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -44,7 +44,7 @@ final class ExportController extends AbstractController
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
@@ -71,8 +71,7 @@ final class ExportController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],
-            $GLOBALS['total_num_tables'],,,
+            $GLOBALS['num_tables'],,,,
             $GLOBALS['tooltip_truename'],
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -43,7 +43,6 @@ final class ExportController extends AbstractController
     {
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['table_select'] = $GLOBALS['table_select'] ?? null;
         $GLOBALS['unlim_num_rows'] = $GLOBALS['unlim_num_rows'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -44,10 +44,6 @@ final class ExportController extends AbstractController
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['table_select'] = $GLOBALS['table_select'] ?? null;
         $GLOBALS['unlim_num_rows'] = $GLOBALS['unlim_num_rows'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -71,8 +67,7 @@ final class ExportController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,,
-            $GLOBALS['pos'],
+            $GLOBALS['num_tables'],
         ] = Util::getDbInfo($request, $GLOBALS['db'], false);
 
         // exit if no tables in db found

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -45,7 +45,7 @@ final class ExportController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['table_select'] = $GLOBALS['table_select'] ?? null;
@@ -71,8 +71,7 @@ final class ExportController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,
-            $GLOBALS['tooltip_truename'],
+            $GLOBALS['num_tables'],,,,,
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db'], false);

--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -55,9 +55,6 @@ final class ImportController extends AbstractController
             return;
         }
 
-        [,,
-        ] = Util::getDbInfo($request, $GLOBALS['db']);
-
         [$GLOBALS['SESSION_KEY'], $uploadId] = Ajax::uploadProgressSetup();
 
         $importList = Plugins::getImport('database');

--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -37,7 +37,6 @@ final class ImportController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['SESSION_KEY'] = $GLOBALS['SESSION_KEY'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -57,8 +56,7 @@ final class ImportController extends AbstractController
             return;
         }
 
-        [
-            $GLOBALS['tables'],
+        [,
             $GLOBALS['num_tables'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 

--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -39,10 +39,6 @@ final class ImportController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['SESSION_KEY'] = $GLOBALS['SESSION_KEY'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
@@ -63,8 +59,7 @@ final class ImportController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,,
-            $GLOBALS['pos'],
+            $GLOBALS['num_tables'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         [$GLOBALS['SESSION_KEY'], $uploadId] = Ajax::uploadProgressSetup();

--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -40,7 +40,7 @@ final class ImportController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['SESSION_KEY'] = $GLOBALS['SESSION_KEY'] ?? null;
@@ -63,8 +63,7 @@ final class ImportController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,
-            $GLOBALS['tooltip_truename'],
+            $GLOBALS['num_tables'],,,,,
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -37,7 +37,6 @@ final class ImportController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['SESSION_KEY'] = $GLOBALS['SESSION_KEY'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
@@ -56,8 +55,7 @@ final class ImportController extends AbstractController
             return;
         }
 
-        [,
-            $GLOBALS['num_tables'],
+        [,,
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         [$GLOBALS['SESSION_KEY'], $uploadId] = Ajax::uploadProgressSetup();

--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -41,7 +41,7 @@ final class ImportController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['SESSION_KEY'] = $GLOBALS['SESSION_KEY'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -63,8 +63,7 @@ final class ImportController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,
-            $GLOBALS['tooltip_aliasname'],
+            $GLOBALS['num_tables'],,,,,,
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 

--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -39,7 +39,7 @@ final class ImportController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
@@ -63,8 +63,7 @@ final class ImportController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],
-            $GLOBALS['total_num_tables'],,,
+            $GLOBALS['num_tables'],,,,
             $GLOBALS['tooltip_truename'],
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Database/OperationsController.php
+++ b/libraries/classes/Controllers/Database/OperationsController.php
@@ -74,7 +74,7 @@ class OperationsController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['single_table'] = $GLOBALS['single_table'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
@@ -265,8 +265,7 @@ class OperationsController extends AbstractController
         [
             $GLOBALS['tables'],
             $GLOBALS['num_tables'],,,
-            $isSystemSchema,,
-            $GLOBALS['tooltip_aliasname'],
+            $isSystemSchema,,,
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 

--- a/libraries/classes/Controllers/Database/OperationsController.php
+++ b/libraries/classes/Controllers/Database/OperationsController.php
@@ -73,7 +73,7 @@ class OperationsController extends AbstractController
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['single_table'] = $GLOBALS['single_table'] ?? null;
@@ -265,8 +265,7 @@ class OperationsController extends AbstractController
         [
             $GLOBALS['tables'],
             $GLOBALS['num_tables'],,,
-            $isSystemSchema,
-            $GLOBALS['tooltip_truename'],
+            $isSystemSchema,,
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/OperationsController.php
+++ b/libraries/classes/Controllers/Database/OperationsController.php
@@ -72,7 +72,7 @@ class OperationsController extends AbstractController
         $GLOBALS['reload'] = $GLOBALS['reload'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
@@ -264,8 +264,7 @@ class OperationsController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],
-            $GLOBALS['total_num_tables'],,
+            $GLOBALS['num_tables'],,,
             $isSystemSchema,
             $GLOBALS['tooltip_truename'],
             $GLOBALS['tooltip_aliasname'],

--- a/libraries/classes/Controllers/Database/OperationsController.php
+++ b/libraries/classes/Controllers/Database/OperationsController.php
@@ -71,7 +71,7 @@ class OperationsController extends AbstractController
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
         $GLOBALS['reload'] = $GLOBALS['reload'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
+
         $GLOBALS['single_table'] = $GLOBALS['single_table'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
@@ -258,8 +258,7 @@ class OperationsController extends AbstractController
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/operations');
 
-        [
-            $GLOBALS['tables'],
+        [,
             $GLOBALS['num_tables'],,,
             $isSystemSchema,
         ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/OperationsController.php
+++ b/libraries/classes/Controllers/Database/OperationsController.php
@@ -256,10 +256,6 @@ class OperationsController extends AbstractController
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/operations');
 
-        [,,,,
-            $isSystemSchema,
-        ] = Util::getDbInfo($request, $GLOBALS['db']);
-
         $oldMessage = '';
         if (isset($GLOBALS['message'])) {
             $oldMessage = Generator::getMessage($GLOBALS['message'], $GLOBALS['sql_query']);
@@ -281,7 +277,7 @@ class OperationsController extends AbstractController
             && $GLOBALS['col_priv'] && $GLOBALS['proc_priv'] && $GLOBALS['is_reload_priv'];
 
         $isDropDatabaseAllowed = ($this->dbi->isSuperUser() || $GLOBALS['cfg']['AllowUserDropDatabase'])
-            && ! $isSystemSchema && $GLOBALS['db'] !== 'mysql';
+            && $GLOBALS['db'] !== 'mysql';
 
         $switchToNew = isset($_SESSION['pma_switch_to_new']) && $_SESSION['pma_switch_to_new'];
 

--- a/libraries/classes/Controllers/Database/OperationsController.php
+++ b/libraries/classes/Controllers/Database/OperationsController.php
@@ -71,9 +71,7 @@ class OperationsController extends AbstractController
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
         $GLOBALS['reload'] = $GLOBALS['reload'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
-
         $GLOBALS['single_table'] = $GLOBALS['single_table'] ?? null;
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
         $this->checkUserPrivileges->getPrivileges();
 
@@ -258,8 +256,7 @@ class OperationsController extends AbstractController
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/operations');
 
-        [,
-            $GLOBALS['num_tables'],,,
+        [,,,,
             $isSystemSchema,
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 

--- a/libraries/classes/Controllers/Database/OperationsController.php
+++ b/libraries/classes/Controllers/Database/OperationsController.php
@@ -72,10 +72,6 @@ class OperationsController extends AbstractController
         $GLOBALS['reload'] = $GLOBALS['reload'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
-
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['single_table'] = $GLOBALS['single_table'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
@@ -265,8 +261,7 @@ class OperationsController extends AbstractController
         [
             $GLOBALS['tables'],
             $GLOBALS['num_tables'],,,
-            $isSystemSchema,,,
-            $GLOBALS['pos'],
+            $isSystemSchema,
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         $oldMessage = '';

--- a/libraries/classes/Controllers/Database/PrivilegesController.php
+++ b/libraries/classes/Controllers/Database/PrivilegesController.php
@@ -93,8 +93,7 @@ class PrivilegesController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,
-            $GLOBALS['tooltip_truename'],
+            $GLOBALS['num_tables'],,,,,
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $db->getName());

--- a/libraries/classes/Controllers/Database/PrivilegesController.php
+++ b/libraries/classes/Controllers/Database/PrivilegesController.php
@@ -93,8 +93,7 @@ class PrivilegesController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],
-            $GLOBALS['total_num_tables'],,,
+            $GLOBALS['num_tables'],,,,
             $GLOBALS['tooltip_truename'],
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Database/PrivilegesController.php
+++ b/libraries/classes/Controllers/Database/PrivilegesController.php
@@ -91,8 +91,7 @@ class PrivilegesController extends AbstractController
 
         ob_start();
 
-        [
-            $GLOBALS['tables'],
+        [,
             $GLOBALS['num_tables'],
         ] = Util::getDbInfo($request, $db->getName());
 

--- a/libraries/classes/Controllers/Database/PrivilegesController.php
+++ b/libraries/classes/Controllers/Database/PrivilegesController.php
@@ -21,8 +21,6 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function mb_strtolower;
-use function ob_get_clean;
-use function ob_start;
 
 /**
  * Controller for database privileges
@@ -88,14 +86,6 @@ class PrivilegesController extends AbstractController
                 __('You do not have the privileges to administrate the users!')
             )->getDisplay());
         }
-
-        ob_start();
-
-        [,,
-        ] = Util::getDbInfo($request, $db->getName());
-
-        $content = ob_get_clean();
-        $this->response->addHTML($content . "\n");
 
         $scriptName = Util::getScriptNameForOption($GLOBALS['cfg']['DefaultTabDatabase'], 'database');
 

--- a/libraries/classes/Controllers/Database/PrivilegesController.php
+++ b/libraries/classes/Controllers/Database/PrivilegesController.php
@@ -93,8 +93,7 @@ class PrivilegesController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,,
-            $GLOBALS['pos'],
+            $GLOBALS['num_tables'],
         ] = Util::getDbInfo($request, $db->getName());
 
         $content = ob_get_clean();

--- a/libraries/classes/Controllers/Database/PrivilegesController.php
+++ b/libraries/classes/Controllers/Database/PrivilegesController.php
@@ -93,8 +93,7 @@ class PrivilegesController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,
-            $GLOBALS['tooltip_aliasname'],
+            $GLOBALS['num_tables'],,,,,,
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $db->getName());
 

--- a/libraries/classes/Controllers/Database/PrivilegesController.php
+++ b/libraries/classes/Controllers/Database/PrivilegesController.php
@@ -91,8 +91,7 @@ class PrivilegesController extends AbstractController
 
         ob_start();
 
-        [,
-            $GLOBALS['num_tables'],
+        [,,
         ] = Util::getDbInfo($request, $db->getName());
 
         $content = ob_get_clean();

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -52,7 +52,7 @@ class QueryByExampleController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -192,8 +192,7 @@ class QueryByExampleController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,
-            $GLOBALS['tooltip_aliasname'],
+            $GLOBALS['num_tables'],,,,,,
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -50,10 +50,6 @@ class QueryByExampleController extends AbstractController
         $GLOBALS['goto'] = $GLOBALS['goto'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
@@ -192,8 +188,7 @@ class QueryByExampleController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,,,
-            $GLOBALS['pos'],
+            $GLOBALS['num_tables'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         $databaseQbe = new Qbe(

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -48,8 +48,6 @@ class QueryByExampleController extends AbstractController
         $GLOBALS['savedSearch'] = $GLOBALS['savedSearch'] ?? null;
         $GLOBALS['currentSearchId'] = $GLOBALS['currentSearchId'] ?? null;
         $GLOBALS['goto'] = $GLOBALS['goto'] ?? null;
-
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
@@ -186,8 +184,7 @@ class QueryByExampleController extends AbstractController
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/qbe');
 
-        [,
-            $GLOBALS['num_tables'],
+        [,,
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         $databaseQbe = new Qbe(

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -51,7 +51,7 @@ class QueryByExampleController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
@@ -192,8 +192,7 @@ class QueryByExampleController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],,,,
-            $GLOBALS['tooltip_truename'],
+            $GLOBALS['num_tables'],,,,,
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -48,7 +48,7 @@ class QueryByExampleController extends AbstractController
         $GLOBALS['savedSearch'] = $GLOBALS['savedSearch'] ?? null;
         $GLOBALS['currentSearchId'] = $GLOBALS['currentSearchId'] ?? null;
         $GLOBALS['goto'] = $GLOBALS['goto'] ?? null;
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
+
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -186,8 +186,7 @@ class QueryByExampleController extends AbstractController
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/qbe');
 
-        [
-            $GLOBALS['tables'],
+        [,
             $GLOBALS['num_tables'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -184,9 +184,6 @@ class QueryByExampleController extends AbstractController
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/database/qbe');
 
-        [,,
-        ] = Util::getDbInfo($request, $GLOBALS['db']);
-
         $databaseQbe = new Qbe(
             $this->relation,
             $this->template,

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -50,7 +50,7 @@ class QueryByExampleController extends AbstractController
         $GLOBALS['goto'] = $GLOBALS['goto'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
@@ -192,8 +192,7 @@ class QueryByExampleController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],
-            $GLOBALS['total_num_tables'],,,
+            $GLOBALS['num_tables'],,,,
             $GLOBALS['tooltip_truename'],
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Database/RoutinesController.php
+++ b/libraries/classes/Controllers/Database/RoutinesController.php
@@ -49,7 +49,7 @@ class RoutinesController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
@@ -89,8 +89,7 @@ class RoutinesController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],
-                    $GLOBALS['total_num_tables'],,,
+                    $GLOBALS['num_tables'],,,,
                     $GLOBALS['tooltip_truename'],
                     $GLOBALS['tooltip_aliasname'],
                     $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Database/RoutinesController.php
+++ b/libraries/classes/Controllers/Database/RoutinesController.php
@@ -49,10 +49,6 @@ class RoutinesController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
@@ -89,8 +85,7 @@ class RoutinesController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],,,,,,
-                    $GLOBALS['pos'],
+                    $GLOBALS['num_tables'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }
         } elseif (strlen($GLOBALS['db']) > 0) {

--- a/libraries/classes/Controllers/Database/RoutinesController.php
+++ b/libraries/classes/Controllers/Database/RoutinesController.php
@@ -51,7 +51,7 @@ class RoutinesController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -89,8 +89,7 @@ class RoutinesController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],,,,,
-                    $GLOBALS['tooltip_aliasname'],
+                    $GLOBALS['num_tables'],,,,,,
                     $GLOBALS['pos'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }

--- a/libraries/classes/Controllers/Database/RoutinesController.php
+++ b/libraries/classes/Controllers/Database/RoutinesController.php
@@ -47,7 +47,6 @@ class RoutinesController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -83,8 +82,7 @@ class RoutinesController extends AbstractController
                     return;
                 }
 
-                [
-                    $GLOBALS['tables'],
+                [,
                     $GLOBALS['num_tables'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }

--- a/libraries/classes/Controllers/Database/RoutinesController.php
+++ b/libraries/classes/Controllers/Database/RoutinesController.php
@@ -50,7 +50,7 @@ class RoutinesController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
@@ -89,8 +89,7 @@ class RoutinesController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],,,,
-                    $GLOBALS['tooltip_truename'],
+                    $GLOBALS['num_tables'],,,,,
                     $GLOBALS['tooltip_aliasname'],
                     $GLOBALS['pos'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/RoutinesController.php
+++ b/libraries/classes/Controllers/Database/RoutinesController.php
@@ -80,9 +80,6 @@ class RoutinesController extends AbstractController
                 if (! $this->hasDatabase()) {
                     return;
                 }
-
-                [,,
-                ] = Util::getDbInfo($request, $GLOBALS['db']);
             }
         } elseif (strlen($GLOBALS['db']) > 0) {
             $this->dbi->selectDb($GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/RoutinesController.php
+++ b/libraries/classes/Controllers/Database/RoutinesController.php
@@ -47,7 +47,6 @@ class RoutinesController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
@@ -82,8 +81,7 @@ class RoutinesController extends AbstractController
                     return;
                 }
 
-                [,
-                    $GLOBALS['num_tables'],
+                [,,
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }
         } elseif (strlen($GLOBALS['db']) > 0) {

--- a/libraries/classes/Controllers/Database/SearchController.php
+++ b/libraries/classes/Controllers/Database/SearchController.php
@@ -35,10 +35,6 @@ class SearchController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
-
         $this->addScriptFiles(['database/search.js', 'sql.js', 'makegrid.js']);
 
         $this->checkParameters(['db']);
@@ -76,8 +72,7 @@ class SearchController extends AbstractController
         if (! $this->response->isAjax()) {
             [
                 $GLOBALS['tables'],
-                $GLOBALS['num_tables'],,,,,,
-                $GLOBALS['pos'],
+                $GLOBALS['num_tables'],
             ] = Util::getDbInfo($request, $GLOBALS['db']);
         }
 

--- a/libraries/classes/Controllers/Database/SearchController.php
+++ b/libraries/classes/Controllers/Database/SearchController.php
@@ -33,8 +33,6 @@ class SearchController extends AbstractController
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
 
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
         $this->addScriptFiles(['database/search.js', 'sql.js', 'makegrid.js']);
 
         $this->checkParameters(['db']);
@@ -70,8 +68,7 @@ class SearchController extends AbstractController
 
         // Display top links if we are not in an Ajax request
         if (! $this->response->isAjax()) {
-            [,
-                $GLOBALS['num_tables'],
+            [,,
             ] = Util::getDbInfo($request, $GLOBALS['db']);
         }
 

--- a/libraries/classes/Controllers/Database/SearchController.php
+++ b/libraries/classes/Controllers/Database/SearchController.php
@@ -34,7 +34,7 @@ class SearchController extends AbstractController
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
@@ -76,8 +76,7 @@ class SearchController extends AbstractController
         if (! $this->response->isAjax()) {
             [
                 $GLOBALS['tables'],
-                $GLOBALS['num_tables'],
-                $GLOBALS['total_num_tables'],,,
+                $GLOBALS['num_tables'],,,,
                 $GLOBALS['tooltip_truename'],
                 $GLOBALS['tooltip_aliasname'],
                 $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Database/SearchController.php
+++ b/libraries/classes/Controllers/Database/SearchController.php
@@ -66,12 +66,6 @@ class SearchController extends AbstractController
         // Create a database search instance
         $databaseSearch = new Search($this->dbi, $GLOBALS['db'], $this->template);
 
-        // Display top links if we are not in an Ajax request
-        if (! $this->response->isAjax()) {
-            [,,
-            ] = Util::getDbInfo($request, $GLOBALS['db']);
-        }
-
         // Main search form has been submitted, get results
         if ($request->hasBodyParam('submit_search')) {
             $this->response->addHTML($databaseSearch->getSearchResults());

--- a/libraries/classes/Controllers/Database/SearchController.php
+++ b/libraries/classes/Controllers/Database/SearchController.php
@@ -32,7 +32,7 @@ class SearchController extends AbstractController
     {
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
+
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
         $this->addScriptFiles(['database/search.js', 'sql.js', 'makegrid.js']);
@@ -70,8 +70,7 @@ class SearchController extends AbstractController
 
         // Display top links if we are not in an Ajax request
         if (! $this->response->isAjax()) {
-            [
-                $GLOBALS['tables'],
+            [,
                 $GLOBALS['num_tables'],
             ] = Util::getDbInfo($request, $GLOBALS['db']);
         }

--- a/libraries/classes/Controllers/Database/SearchController.php
+++ b/libraries/classes/Controllers/Database/SearchController.php
@@ -35,7 +35,7 @@ class SearchController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
 
@@ -76,8 +76,7 @@ class SearchController extends AbstractController
         if (! $this->response->isAjax()) {
             [
                 $GLOBALS['tables'],
-                $GLOBALS['num_tables'],,,,
-                $GLOBALS['tooltip_truename'],
+                $GLOBALS['num_tables'],,,,,
                 $GLOBALS['tooltip_aliasname'],
                 $GLOBALS['pos'],
             ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/SearchController.php
+++ b/libraries/classes/Controllers/Database/SearchController.php
@@ -36,7 +36,7 @@ class SearchController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
 
         $this->addScriptFiles(['database/search.js', 'sql.js', 'makegrid.js']);
@@ -76,8 +76,7 @@ class SearchController extends AbstractController
         if (! $this->response->isAjax()) {
             [
                 $GLOBALS['tables'],
-                $GLOBALS['num_tables'],,,,,
-                $GLOBALS['tooltip_aliasname'],
+                $GLOBALS['num_tables'],,,,,,
                 $GLOBALS['pos'],
             ] = Util::getDbInfo($request, $GLOBALS['db']);
         }

--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -102,12 +102,11 @@ class StructureController extends AbstractController
             $tables,
             $numTables,
             $totalNumTables,
-            $position,
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         $this->tables = $tables;
         $this->numTables = $numTables;
-        $this->position = $position;
+        $this->position = Util::getTableListPosition($request, $GLOBALS['db']);
         $this->totalNumTables = $totalNumTables;
 
         /**

--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Http\ServerRequest;
+use PhpMyAdmin\Query\Utilities;
 use PhpMyAdmin\RecentFavoriteTable;
 use PhpMyAdmin\Replication;
 use PhpMyAdmin\ReplicationInfo;
@@ -101,17 +102,30 @@ class StructureController extends AbstractController
             $tables,
             $numTables,
             $totalNumTables,
-            $isShowStats,
-            $dbIsSystemSchema,,,
             $position,
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         $this->tables = $tables;
         $this->numTables = $numTables;
         $this->position = $position;
-        $this->dbIsSystemSchema = $dbIsSystemSchema;
         $this->totalNumTables = $totalNumTables;
-        $this->isShowStats = $isShowStats;
+
+        /**
+         * whether to display extended stats
+         */
+        $this->isShowStats = $GLOBALS['cfg']['ShowStats'];
+
+        /**
+         * whether selected db is information_schema
+         */
+        $this->dbIsSystemSchema = false;
+
+        if (! Utilities::isSystemSchema($GLOBALS['db'])) {
+            return;
+        }
+
+        $this->isShowStats = false;
+        $this->dbIsSystemSchema = true;
     }
 
     public function __invoke(ServerRequest $request): void

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -52,7 +52,7 @@ class TrackingController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
@@ -73,8 +73,7 @@ class TrackingController extends AbstractController
         [
             $GLOBALS['tables'],
             $GLOBALS['num_tables'],,,
-            $isSystemSchema,
-            $GLOBALS['tooltip_truename'],
+            $isSystemSchema,,
             $GLOBALS['tooltip_aliasname'],
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -48,7 +48,7 @@ class TrackingController extends AbstractController
     {
         $GLOBALS['text_dir'] = $GLOBALS['text_dir'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
+
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
@@ -66,8 +66,7 @@ class TrackingController extends AbstractController
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/table/tracking');
         $GLOBALS['urlParams']['back'] = Url::getFromRoute('/database/tracking');
 
-        [
-            $GLOBALS['tables'],
+        [,
             $GLOBALS['num_tables'],,,
             $isSystemSchema,
         ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -50,10 +50,6 @@ class TrackingController extends AbstractController
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
-
-
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
         $this->addScriptFiles(['vendor/jquery/jquery.tablesorter.js', 'database/tracking.js']);
@@ -73,8 +69,7 @@ class TrackingController extends AbstractController
         [
             $GLOBALS['tables'],
             $GLOBALS['num_tables'],,,
-            $isSystemSchema,,,
-            $GLOBALS['pos'],
+            $isSystemSchema,
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
         if (isset($_POST['delete_tracking'], $_POST['table'])) {

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -53,7 +53,7 @@ class TrackingController extends AbstractController
 
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
         $this->addScriptFiles(['vendor/jquery/jquery.tablesorter.js', 'database/tracking.js']);
@@ -73,8 +73,7 @@ class TrackingController extends AbstractController
         [
             $GLOBALS['tables'],
             $GLOBALS['num_tables'],,,
-            $isSystemSchema,,
-            $GLOBALS['tooltip_aliasname'],
+            $isSystemSchema,,,
             $GLOBALS['pos'],
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -48,8 +48,6 @@ class TrackingController extends AbstractController
     {
         $GLOBALS['text_dir'] = $GLOBALS['text_dir'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
-
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
 
         $this->addScriptFiles(['vendor/jquery/jquery.tablesorter.js', 'database/tracking.js']);
@@ -67,7 +65,7 @@ class TrackingController extends AbstractController
         $GLOBALS['urlParams']['back'] = Url::getFromRoute('/database/tracking');
 
         [,
-            $GLOBALS['num_tables'],,,
+            $numTables,,,
             $isSystemSchema,
         ] = Util::getDbInfo($request, $GLOBALS['db']);
 
@@ -120,7 +118,7 @@ class TrackingController extends AbstractController
         $trackedData = Tracker::getTrackedData($GLOBALS['db'], '', '1');
 
         // No tables present and no log exist
-        if ($GLOBALS['num_tables'] == 0 && count($trackedData['ddlog']) === 0) {
+        if ($numTables == 0 && count($trackedData['ddlog']) === 0) {
             echo '<p>' , __('No tables found in database.') , '</p>' , "\n";
 
             if (empty($isSystemSchema)) {

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
+use PhpMyAdmin\Query\Utilities;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tracker;
@@ -64,10 +65,8 @@ class TrackingController extends AbstractController
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/table/tracking');
         $GLOBALS['urlParams']['back'] = Url::getFromRoute('/database/tracking');
 
-        [,
-            $numTables,,,
-            $isSystemSchema,
-        ] = Util::getDbInfo($request, $GLOBALS['db']);
+        [, $numTables] = Util::getDbInfo($request, $GLOBALS['db']);
+        $isSystemSchema = Utilities::isSystemSchema($GLOBALS['db']);
 
         if (isset($_POST['delete_tracking'], $_POST['table'])) {
             Tracker::deleteTracking($GLOBALS['db'], $_POST['table']);
@@ -121,7 +120,7 @@ class TrackingController extends AbstractController
         if ($numTables == 0 && count($trackedData['ddlog']) === 0) {
             echo '<p>' , __('No tables found in database.') , '</p>' , "\n";
 
-            if (empty($isSystemSchema)) {
+            if (! $isSystemSchema) {
                 $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
                 $checkUserPrivileges->getPrivileges();
 

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -50,7 +50,7 @@ class TrackingController extends AbstractController
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
@@ -72,8 +72,7 @@ class TrackingController extends AbstractController
 
         [
             $GLOBALS['tables'],
-            $GLOBALS['num_tables'],
-            $GLOBALS['total_num_tables'],,
+            $GLOBALS['num_tables'],,,
             $isSystemSchema,
             $GLOBALS['tooltip_truename'],
             $GLOBALS['tooltip_aliasname'],

--- a/libraries/classes/Controllers/Database/TriggersController.php
+++ b/libraries/classes/Controllers/Database/TriggersController.php
@@ -70,9 +70,6 @@ class TriggersController extends AbstractController
                 if (! $this->hasDatabase()) {
                     return;
                 }
-
-                [,,
-                ] = Util::getDbInfo($request, $GLOBALS['db']);
             }
         } elseif (strlen($GLOBALS['db']) > 0) {
             $this->dbi->selectDb($GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/TriggersController.php
+++ b/libraries/classes/Controllers/Database/TriggersController.php
@@ -41,7 +41,6 @@ class TriggersController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -72,8 +71,7 @@ class TriggersController extends AbstractController
                     return;
                 }
 
-                [,
-                    $GLOBALS['num_tables'],
+                [,,
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }
         } elseif (strlen($GLOBALS['db']) > 0) {

--- a/libraries/classes/Controllers/Database/TriggersController.php
+++ b/libraries/classes/Controllers/Database/TriggersController.php
@@ -41,7 +41,6 @@ class TriggersController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
@@ -73,8 +72,7 @@ class TriggersController extends AbstractController
                     return;
                 }
 
-                [
-                    $GLOBALS['tables'],
+                [,
                     $GLOBALS['num_tables'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }

--- a/libraries/classes/Controllers/Database/TriggersController.php
+++ b/libraries/classes/Controllers/Database/TriggersController.php
@@ -43,10 +43,6 @@ class TriggersController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -79,8 +75,7 @@ class TriggersController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],,,,,,
-                    $GLOBALS['pos'],
+                    $GLOBALS['num_tables'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }
         } elseif (strlen($GLOBALS['db']) > 0) {

--- a/libraries/classes/Controllers/Database/TriggersController.php
+++ b/libraries/classes/Controllers/Database/TriggersController.php
@@ -44,7 +44,7 @@ class TriggersController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
@@ -79,8 +79,7 @@ class TriggersController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],,,,
-                    $GLOBALS['tooltip_truename'],
+                    $GLOBALS['num_tables'],,,,,
                     $GLOBALS['tooltip_aliasname'],
                     $GLOBALS['pos'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Database/TriggersController.php
+++ b/libraries/classes/Controllers/Database/TriggersController.php
@@ -43,7 +43,7 @@ class TriggersController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
@@ -79,8 +79,7 @@ class TriggersController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],
-                    $GLOBALS['total_num_tables'],,,
+                    $GLOBALS['num_tables'],,,,
                     $GLOBALS['tooltip_truename'],
                     $GLOBALS['tooltip_aliasname'],
                     $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Database/TriggersController.php
+++ b/libraries/classes/Controllers/Database/TriggersController.php
@@ -45,7 +45,7 @@ class TriggersController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
@@ -79,8 +79,7 @@ class TriggersController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],,,,,
-                    $GLOBALS['tooltip_aliasname'],
+                    $GLOBALS['num_tables'],,,,,,
                     $GLOBALS['pos'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }

--- a/libraries/classes/Controllers/Export/ExportController.php
+++ b/libraries/classes/Controllers/Export/ExportController.php
@@ -66,7 +66,6 @@ final class ExportController extends AbstractController
         $GLOBALS['table_select'] = $GLOBALS['table_select'] ?? null;
         $GLOBALS['time_start'] = $GLOBALS['time_start'] ?? null;
         $GLOBALS['charset'] = $GLOBALS['charset'] ?? null;
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['active_page'] = $GLOBALS['active_page'] ?? null;
         $GLOBALS['table_data'] = $GLOBALS['table_data'] ?? null;
 

--- a/libraries/classes/Controllers/Preferences/ManageController.php
+++ b/libraries/classes/Controllers/Preferences/ManageController.php
@@ -77,7 +77,6 @@ class ManageController extends AbstractController
         $GLOBALS['return_url'] = $GLOBALS['return_url'] ?? null;
         $GLOBALS['form_display'] = $GLOBALS['form_display'] ?? null;
         $GLOBALS['all_ok'] = $GLOBALS['all_ok'] ?? null;
-        $GLOBALS['params'] = $GLOBALS['params'] ?? null;
         $GLOBALS['query'] = $GLOBALS['query'] ?? null;
 
         $route = $request->getRoute();
@@ -202,7 +201,7 @@ class ManageController extends AbstractController
                 }
 
                 // check for ThemeDefault
-                $GLOBALS['params'] = [];
+                $redirectParams = [];
                 $tmanager = ThemeManager::getInstance();
                 if (
                     isset($configuration['ThemeDefault'])
@@ -214,7 +213,7 @@ class ManageController extends AbstractController
                 }
 
                 if (isset($configuration['lang']) && $configuration['lang'] != $GLOBALS['lang']) {
-                    $GLOBALS['params']['lang'] = $configuration['lang'];
+                    $redirectParams['lang'] = $configuration['lang'];
                 }
 
                 // save settings
@@ -231,7 +230,7 @@ class ManageController extends AbstractController
                                 continue;
                             }
 
-                            $GLOBALS['params'][$k] = mb_substr($q, $pos + 1);
+                            $redirectParams[$k] = mb_substr($q, $pos + 1);
                         }
                     } else {
                         $GLOBALS['return_url'] = 'index.php?route=/preferences/manage';
@@ -239,7 +238,7 @@ class ManageController extends AbstractController
 
                     // reload config
                     $this->config->loadUserPreferences();
-                    $this->userPreferences->redirect($GLOBALS['return_url'] ?? '', $GLOBALS['params']);
+                    $this->userPreferences->redirect($GLOBALS['return_url'] ?? '', $redirectParams);
 
                     return;
                 }
@@ -249,10 +248,9 @@ class ManageController extends AbstractController
         } elseif ($request->hasBodyParam('submit_clear')) {
             $result = $this->userPreferences->save([]);
             if ($result === true) {
-                $GLOBALS['params'] = [];
                 $this->config->removeCookie('pma_collaction_connection');
                 $this->config->removeCookie('pma_lang');
-                $this->userPreferences->redirect('index.php?route=/preferences/manage', $GLOBALS['params']);
+                $this->userPreferences->redirect('index.php?route=/preferences/manage');
 
                 return;
             }

--- a/libraries/classes/Controllers/Server/ExportController.php
+++ b/libraries/classes/Controllers/Server/ExportController.php
@@ -35,10 +35,8 @@ final class ExportController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['unlim_num_rows'] = $GLOBALS['unlim_num_rows'] ?? null;
         $GLOBALS['errorUrl'] = Url::getFromRoute('/');
-
         $GLOBALS['tmp_select'] = $GLOBALS['tmp_select'] ?? null;
         $GLOBALS['select_item'] = $GLOBALS['select_item'] ?? null;
 

--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -61,7 +61,7 @@ class PrivilegesController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
 
         $checkUserPrivileges = new CheckUserPrivileges($this->dbi);

--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -57,7 +57,6 @@ class PrivilegesController extends AbstractController
         $GLOBALS['username'] = $GLOBALS['username'] ?? null;
         $GLOBALS['hostname'] = $GLOBALS['hostname'] ?? null;
         $GLOBALS['dbname'] = $GLOBALS['dbname'] ?? null;
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
         $checkUserPrivileges = new CheckUserPrivileges($this->dbi);

--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -59,7 +59,7 @@ class PrivilegesController extends AbstractController
         $GLOBALS['dbname'] = $GLOBALS['dbname'] ?? null;
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;

--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -57,7 +57,6 @@ class PrivilegesController extends AbstractController
         $GLOBALS['username'] = $GLOBALS['username'] ?? null;
         $GLOBALS['hostname'] = $GLOBALS['hostname'] ?? null;
         $GLOBALS['dbname'] = $GLOBALS['dbname'] ?? null;
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
         $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
         $checkUserPrivileges->getPrivileges();

--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -60,10 +60,6 @@ class PrivilegesController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
-
         $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
         $checkUserPrivileges->getPrivileges();
 

--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -60,7 +60,7 @@ class PrivilegesController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
 

--- a/libraries/classes/Controllers/Table/ExportController.php
+++ b/libraries/classes/Controllers/Table/ExportController.php
@@ -43,7 +43,6 @@ class ExportController extends AbstractController
         $GLOBALS['replaces'] = $GLOBALS['replaces'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
         $GLOBALS['where_clause'] = $GLOBALS['where_clause'] ?? null;
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['unlim_num_rows'] = $GLOBALS['unlim_num_rows'] ?? null;
 
         $pageSettings = new PageSettings('Export');

--- a/libraries/classes/Controllers/Table/TriggersController.php
+++ b/libraries/classes/Controllers/Table/TriggersController.php
@@ -70,9 +70,6 @@ class TriggersController extends AbstractController
                 if (! $this->hasDatabase()) {
                     return;
                 }
-
-                [,,
-                ] = Util::getDbInfo($request, $GLOBALS['db']);
             }
         } elseif (strlen($GLOBALS['db']) > 0) {
             $this->dbi->selectDb($GLOBALS['db']);

--- a/libraries/classes/Controllers/Table/TriggersController.php
+++ b/libraries/classes/Controllers/Table/TriggersController.php
@@ -41,7 +41,6 @@ class TriggersController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -72,8 +71,7 @@ class TriggersController extends AbstractController
                     return;
                 }
 
-                [,
-                    $GLOBALS['num_tables'],
+                [,,
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }
         } elseif (strlen($GLOBALS['db']) > 0) {

--- a/libraries/classes/Controllers/Table/TriggersController.php
+++ b/libraries/classes/Controllers/Table/TriggersController.php
@@ -41,7 +41,6 @@ class TriggersController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
@@ -73,8 +72,7 @@ class TriggersController extends AbstractController
                     return;
                 }
 
-                [
-                    $GLOBALS['tables'],
+                [,
                     $GLOBALS['num_tables'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }

--- a/libraries/classes/Controllers/Table/TriggersController.php
+++ b/libraries/classes/Controllers/Table/TriggersController.php
@@ -43,10 +43,6 @@ class TriggersController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-
-
-
-        $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
         $GLOBALS['errorUrl'] = $GLOBALS['errorUrl'] ?? null;
@@ -79,8 +75,7 @@ class TriggersController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],,,,,,
-                    $GLOBALS['pos'],
+                    $GLOBALS['num_tables'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }
         } elseif (strlen($GLOBALS['db']) > 0) {

--- a/libraries/classes/Controllers/Table/TriggersController.php
+++ b/libraries/classes/Controllers/Table/TriggersController.php
@@ -44,7 +44,7 @@ class TriggersController extends AbstractController
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
-        $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
+
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
@@ -79,8 +79,7 @@ class TriggersController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],,,,
-                    $GLOBALS['tooltip_truename'],
+                    $GLOBALS['num_tables'],,,,,
                     $GLOBALS['tooltip_aliasname'],
                     $GLOBALS['pos'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);

--- a/libraries/classes/Controllers/Table/TriggersController.php
+++ b/libraries/classes/Controllers/Table/TriggersController.php
@@ -43,7 +43,7 @@ class TriggersController extends AbstractController
     {
         $GLOBALS['tables'] = $GLOBALS['tables'] ?? null;
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
-        $GLOBALS['total_num_tables'] = $GLOBALS['total_num_tables'] ?? null;
+
         $GLOBALS['tooltip_truename'] = $GLOBALS['tooltip_truename'] ?? null;
         $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
@@ -79,8 +79,7 @@ class TriggersController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],
-                    $GLOBALS['total_num_tables'],,,
+                    $GLOBALS['num_tables'],,,,
                     $GLOBALS['tooltip_truename'],
                     $GLOBALS['tooltip_aliasname'],
                     $GLOBALS['pos'],

--- a/libraries/classes/Controllers/Table/TriggersController.php
+++ b/libraries/classes/Controllers/Table/TriggersController.php
@@ -45,7 +45,7 @@ class TriggersController extends AbstractController
         $GLOBALS['num_tables'] = $GLOBALS['num_tables'] ?? null;
 
 
-        $GLOBALS['tooltip_aliasname'] = $GLOBALS['tooltip_aliasname'] ?? null;
+
         $GLOBALS['pos'] = $GLOBALS['pos'] ?? null;
         $GLOBALS['errors'] = $GLOBALS['errors'] ?? null;
         $GLOBALS['urlParams'] = $GLOBALS['urlParams'] ?? null;
@@ -79,8 +79,7 @@ class TriggersController extends AbstractController
 
                 [
                     $GLOBALS['tables'],
-                    $GLOBALS['num_tables'],,,,,
-                    $GLOBALS['tooltip_aliasname'],
+                    $GLOBALS['num_tables'],,,,,,
                     $GLOBALS['pos'],
                 ] = Util::getDbInfo($request, $GLOBALS['db']);
             }

--- a/libraries/classes/Database/Designer.php
+++ b/libraries/classes/Database/Designer.php
@@ -310,7 +310,7 @@ class Designer
      * @param DesignerTable[] $scriptDisplayField   displayed tables in designer with their display fields
      * @param int             $displayPage          page number of the selected page
      * @param bool            $visualBuilderMode    whether this is visual query builder
-     * @param string          $selectedPage         name of the selected page
+     * @param string|null     $selectedPage         name of the selected page
      * @param array           $paramsArray          array with class name for various buttons on side menu
      * @param array           $tablePositions       table positions
      * @param array           $tabColumn            table column info
@@ -328,7 +328,7 @@ class Designer
         array $scriptDisplayField,
         int $displayPage,
         bool $visualBuilderMode,
-        $selectedPage,
+        ?string $selectedPage,
         array $paramsArray,
         array $tablePositions,
         array $tabColumn,

--- a/libraries/classes/Query/Utilities.php
+++ b/libraries/classes/Query/Utilities.php
@@ -58,6 +58,8 @@ class Utilities
      * @param string $schema_name        Name of schema (database) to test
      * @param bool   $testForMysqlSchema Whether 'mysql' schema should
      *                                   be treated the same as IS and DD
+     *
+     * @psalm-pure
      */
     public static function isSystemSchema(
         string $schema_name,

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2045,7 +2045,8 @@ class Util
     /**
      * Gets the list of tables in the current db and information about these tables if possible.
      *
-     * @return array
+     * @return array<int, array|int>
+     * @psalm-return array{array, int, int}
      */
     public static function getDbInfo(ServerRequest $request, string $db, bool $isResultLimited = true): array
     {
@@ -2066,7 +2067,8 @@ class Util
             }
         }
 
-        if (empty($tables)) {
+        $totalNumTables = null;
+        if ($tables === []) {
             // Set some sorting defaults
             $sort = 'Name';
             $sortOrder = 'ASC';
@@ -2117,21 +2119,18 @@ class Util
 
                 if (is_string($tableGroupParam) && $tableGroupParam !== '') {
                     // only tables for selected group
-                    $tableGroup = $tableGroupParam;
-                    // include the table with the exact name of the group if such
-                    // exists
+                    // include the table with the exact name of the group if such exists
                     $groupTable = $GLOBALS['dbi']->getTablesFull(
                         $db,
-                        $tableGroup,
+                        $tableGroupParam,
                         false,
-                        $limitOffset,
-                        $limitCount,
+                        0,
+                        false,
                         $sort,
                         $sortOrder,
                         $tableType
                     );
-                    $groupWithSeparator = $tableGroup
-                        . $GLOBALS['cfg']['NavigationTreeTableSeparator'];
+                    $groupWithSeparator = $tableGroupParam . $GLOBALS['cfg']['NavigationTreeTableSeparator'];
                 }
             } else {
                 // all tables in db
@@ -2159,13 +2158,11 @@ class Util
         }
 
         $numTables = count($tables);
-        //  (needed for proper working of the MaxTableList feature)
-        $totalNumTables = $totalNumTables ?? $numTables;
 
         return [
             $tables,
             $numTables,
-            $totalNumTables,
+            $totalNumTables ?? $numTables, // needed for proper working of the MaxTableList feature
         ];
     }
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2050,22 +2050,6 @@ class Util
     public static function getDbInfo(ServerRequest $request, string $db, bool $isResultLimited = true): array
     {
         /**
-         * limits for table list
-         */
-        if (! isset($_SESSION['tmpval']['table_limit_offset']) || $_SESSION['tmpval']['table_limit_offset_db'] != $db) {
-            $_SESSION['tmpval']['table_limit_offset'] = 0;
-            $_SESSION['tmpval']['table_limit_offset_db'] = $db;
-        }
-
-        /** @var mixed $posParam */
-        $posParam = $request->getParam('pos');
-        if (is_numeric($posParam)) {
-            $_SESSION['tmpval']['table_limit_offset'] = (int) $posParam;
-        }
-
-        $pos = $_SESSION['tmpval']['table_limit_offset'];
-
-        /**
          * information about tables in db
          */
         $tables = [];
@@ -2156,7 +2140,7 @@ class Util
                 $totalNumTables = count($GLOBALS['dbi']->getTables($db));
                 if ($isResultLimited) {
                     // fetch the details for a possible limited subset
-                    $limitOffset = $pos;
+                    $limitOffset = self::getTableListPosition($request, $db);
                     $limitCount = true;
                 }
             }
@@ -2182,7 +2166,6 @@ class Util
             $tables,
             $numTables,
             $totalNumTables,
-            $pos,
         ];
     }
 
@@ -2552,5 +2535,21 @@ class Util
         }
 
         return function_exists('error_reporting');
+    }
+
+    public static function getTableListPosition(ServerRequest $request, string $db): int
+    {
+        if (! isset($_SESSION['tmpval']['table_limit_offset']) || $_SESSION['tmpval']['table_limit_offset_db'] != $db) {
+            $_SESSION['tmpval']['table_limit_offset'] = 0;
+            $_SESSION['tmpval']['table_limit_offset_db'] = $db;
+        }
+
+        /** @var string|null $posParam */
+        $posParam = $request->getParam('pos');
+        if (is_numeric($posParam)) {
+            $_SESSION['tmpval']['table_limit_offset'] = (int) $posParam;
+        }
+
+        return $_SESSION['tmpval']['table_limit_offset'];
     }
 }

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2171,8 +2171,7 @@ class Util
                 // all tables in db
                 // - get the total number of tables
                 //  (needed for proper working of the MaxTableList feature)
-                $tables = $GLOBALS['dbi']->getTables($db);
-                $totalNumTables = count($tables);
+                $totalNumTables = count($GLOBALS['dbi']->getTables($db));
                 if ($isResultLimited) {
                     // fetch the details for a possible limited subset
                     $limitOffset = $pos;
@@ -2195,9 +2194,7 @@ class Util
 
         $numTables = count($tables);
         //  (needed for proper working of the MaxTableList feature)
-        if (! isset($totalNumTables)) {
-            $totalNumTables = $numTables;
-        }
+        $totalNumTables = $totalNumTables ?? $numTables;
 
         return [
             $tables,

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2066,27 +2066,9 @@ class Util
         $pos = $_SESSION['tmpval']['table_limit_offset'];
 
         /**
-         * whether to display extended stats
-         */
-        $isShowStats = $GLOBALS['cfg']['ShowStats'];
-
-        /**
-         * whether selected db is information_schema
-         */
-        $isSystemSchema = false;
-
-        if (Utilities::isSystemSchema($db)) {
-            $isShowStats = false;
-            $isSystemSchema = true;
-        }
-
-        /**
          * information about tables in db
          */
         $tables = [];
-
-        $tooltipTrueName = [];
-        $tooltipAliasName = [];
 
         // Special speedup for newer MySQL Versions (in 4.0 format changed)
         if ($GLOBALS['cfg']['SkipLockedTables'] === true) {
@@ -2200,10 +2182,6 @@ class Util
             $tables,
             $numTables,
             $totalNumTables,
-            $isShowStats,
-            $isSystemSchema,
-            $tooltipTrueName,
-            $tooltipAliasName,
             $pos,
         ];
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1621,9 +1621,9 @@ parameters:
 			path: libraries/classes/Controllers/Preferences/ManageController.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method PhpMyAdmin\\\\TwoFactor\\:\\:configure\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$file_name of method PhpMyAdmin\\\\UserPreferences\\:\\:redirect\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
-			path: libraries/classes/Controllers/Preferences/TwoFactorController.php
+			path: libraries/classes/Controllers/Preferences/ManageController.php
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1626,6 +1626,11 @@ parameters:
 			path: libraries/classes/Controllers/Preferences/ManageController.php
 
 		-
+			message: "#^Parameter \\#1 \\$name of method PhpMyAdmin\\\\TwoFactor\\:\\:configure\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Preferences/TwoFactorController.php
+
+		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Server/BinlogController.php
@@ -2159,6 +2164,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$database of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTables\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/TableController.php
+
+		-
+			message: "#^Parameter \\#1 \\$password of method PhpMyAdmin\\\\UserPassword\\:\\:changePassword\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/UserPasswordController.php
 
 		-
 			message: "#^Parameter \\#1 \\$pmaPw of method PhpMyAdmin\\\\UserPassword\\:\\:setChangePasswordMsg\\(\\) expects string, mixed given\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1633,7 +1633,7 @@
     <MixedArrayAssignment occurrences="1">
       <code>$currentTable['TABLE_ROWS']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="26">
+    <MixedAssignment occurrences="25">
       <code>$GLOBALS['errorUrl']</code>
       <code>$charset</code>
       <code>$checkTime</code>
@@ -1653,7 +1653,6 @@
       <code>$searchTable</code>
       <code>$sumEntries</code>
       <code>$this-&gt;numTables</code>
-      <code>$this-&gt;position</code>
       <code>$this-&gt;tables</code>
       <code>$this-&gt;totalNumTables</code>
       <code>$truename</code>
@@ -13638,8 +13637,7 @@
       <code>$table['disp_name']</code>
       <code>$units[$d]</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="6">
-      <code>$limitOffset</code>
+    <MixedArgument occurrences="5">
       <code>$maxSize</code>
       <code>$maxUnit</code>
       <code>$row[$i] ?? null</code>
@@ -13694,7 +13692,7 @@
     <MixedArrayTypeCoercion occurrences="1">
       <code>$array[$p]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="27">
+    <MixedAssignment occurrences="25">
       <code>$array</code>
       <code>$columnNames[]</code>
       <code>$columnNames[]</code>
@@ -13707,10 +13705,8 @@
       <code>$indexesInfo[$row['Key_name']]['Sequences'][]</code>
       <code>$indexes[]</code>
       <code>$lastIndex</code>
-      <code>$limitOffset</code>
       <code>$p</code>
       <code>$p</code>
-      <code>$pos</code>
       <code>$retval[]</code>
       <code>$retval[]</code>
       <code>$row</code>
@@ -13723,7 +13719,8 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType occurrences="2">
+      <code>int</code>
       <code>int</code>
     </MixedInferredReturnType>
     <MixedOperand occurrences="4">
@@ -13732,7 +13729,8 @@
       <code>$unit</code>
       <code>$unit</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement occurrences="2">
+      <code>$_SESSION['tmpval']['table_limit_offset']</code>
       <code>$rowCount</code>
     </MixedReturnStatement>
     <MixedStringOffsetAssignment occurrences="2">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1080,12 +1080,11 @@
       <code>$position['tableName']</code>
       <code>$position['tableName']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$position</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">
@@ -1163,13 +1162,12 @@
     </RiskyCast>
   </file>
   <file src="libraries/classes/Controllers/Database/EventsController.php">
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/ExportController.php">
@@ -1189,14 +1187,13 @@
       <code>$each_table['Name']</code>
       <code>$each_table['Name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="8">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['single_table']</code>
       <code>$GLOBALS['table_select']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['unlim_num_rows']</code>
       <code>$each_table</code>
     </MixedAssignment>
@@ -1216,12 +1213,11 @@
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$idKey</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
@@ -1265,14 +1261,13 @@
       <code>$GLOBALS['cfg']['AllowUserDropDatabase']</code>
       <code>$GLOBALS['cfg']['PmaNoRelation_DisableWarning']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['reload']</code>
       <code>$GLOBALS['single_table']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
       <code>$_POST['comment']</code>
@@ -1291,7 +1286,7 @@
     <InvalidArgument occurrences="1">
       <code>$_POST['searchId']</code>
     </InvalidArgument>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['currentSearchId']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
@@ -1299,7 +1294,6 @@
       <code>$GLOBALS['savedSearch']</code>
       <code>$GLOBALS['savedSearchList']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="2">
       <code>$_POST['db']</code>
@@ -1314,13 +1308,12 @@
     <MixedArgument occurrences="1">
       <code>$item</code>
     </MixedArgument>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$item</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
@@ -1331,12 +1324,11 @@
     <InvalidArrayOffset occurrences="1">
       <code>$GLOBALS['cfg']['UseDbSearch']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/SqlAutoCompleteController.php">
@@ -1737,12 +1729,11 @@
       <code>$entry['statement']</code>
       <code>$entry['username']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$entry</code>
       <code>$table</code>
     </MixedAssignment>
@@ -1774,13 +1765,12 @@
     </PossiblyNullIterator>
   </file>
   <file src="libraries/classes/Controllers/Database/TriggersController.php">
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/ErrorReportController.php">
@@ -2565,14 +2555,13 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$queries</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['dbname']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['message']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$db_name</code>
     </MixedAssignment>
     <PossiblyNullArgument occurrences="1">
@@ -3877,13 +3866,12 @@
     </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/TriggersController.php">
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tooltip_aliasname']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/ZoomSearchController.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1029,10 +1029,9 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$variables</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['message']</code>
       <code>$GLOBALS['num_cols']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$columnDefault</code>
       <code>$columnDefault</code>
     </MixedAssignment>
@@ -1080,10 +1079,9 @@
       <code>$position['tableName']</code>
       <code>$position['tableName']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$position</code>
     </MixedAssignment>
@@ -1162,11 +1160,10 @@
     </RiskyCast>
   </file>
   <file src="libraries/classes/Controllers/Database/EventsController.php">
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
     </MixedAssignment>
   </file>
@@ -1187,10 +1184,9 @@
       <code>$each_table['Name']</code>
       <code>$each_table['Name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['single_table']</code>
       <code>$GLOBALS['table_select']</code>
       <code>$GLOBALS['tables']</code>
@@ -1213,10 +1209,9 @@
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$idKey</code>
     </MixedAssignment>
@@ -1261,10 +1256,9 @@
       <code>$GLOBALS['cfg']['AllowUserDropDatabase']</code>
       <code>$GLOBALS['cfg']['PmaNoRelation_DisableWarning']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['reload']</code>
       <code>$GLOBALS['single_table']</code>
       <code>$GLOBALS['tables']</code>
@@ -1286,11 +1280,10 @@
     <InvalidArgument occurrences="1">
       <code>$_POST['searchId']</code>
     </InvalidArgument>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['currentSearchId']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['savedSearch']</code>
       <code>$GLOBALS['savedSearchList']</code>
       <code>$GLOBALS['tables']</code>
@@ -1308,11 +1301,10 @@
     <MixedArgument occurrences="1">
       <code>$item</code>
     </MixedArgument>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$item</code>
     </MixedAssignment>
@@ -1324,10 +1316,9 @@
     <InvalidArrayOffset occurrences="1">
       <code>$GLOBALS['cfg']['UseDbSearch']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
     </MixedAssignment>
   </file>
@@ -1729,10 +1720,9 @@
       <code>$entry['statement']</code>
       <code>$entry['username']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$entry</code>
       <code>$table</code>
@@ -1765,11 +1755,10 @@
     </PossiblyNullIterator>
   </file>
   <file src="libraries/classes/Controllers/Database/TriggersController.php">
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
     </MixedAssignment>
   </file>
@@ -2555,12 +2544,11 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$queries</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['dbname']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['message']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$db_name</code>
     </MixedAssignment>
@@ -3866,11 +3854,10 @@
     </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/TriggersController.php">
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
     </MixedAssignment>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1069,10 +1069,10 @@
       <code>$_POST['selected_page']</code>
     </InvalidScalarArgument>
     <MixedArgument occurrences="4">
-      <code>$GLOBALS['success']</code>
       <code>$html</code>
       <code>$position['dbName']</code>
       <code>$position['tableName']</code>
+      <code>$success</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="4">
       <code>$position['dbName']</code>
@@ -1080,21 +1080,12 @@
       <code>$position['tableName']</code>
       <code>$position['tableName']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="18">
-      <code>$GLOBALS['classes_side_menu']</code>
+    <MixedAssignment occurrences="8">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['page']</code>
       <code>$GLOBALS['params']</code>
       <code>$GLOBALS['pos']</code>
-      <code>$GLOBALS['script_contr']</code>
-      <code>$GLOBALS['script_tables']</code>
-      <code>$GLOBALS['selected_page']</code>
-      <code>$GLOBALS['success']</code>
-      <code>$GLOBALS['tab_column']</code>
       <code>$GLOBALS['tables']</code>
-      <code>$GLOBALS['tables_all_keys']</code>
-      <code>$GLOBALS['tables_pk_or_unique_keys']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
       <code>$GLOBALS['total_num_tables']</code>
@@ -1105,7 +1096,6 @@
       <code>$position['tableName']</code>
     </MixedOperand>
     <PossiblyInvalidArgument occurrences="33">
-      <code>$GLOBALS['page']</code>
       <code>$_GET['db']</code>
       <code>$_GET['db']</code>
       <code>$_GET['db']</code>
@@ -1138,6 +1128,7 @@
       <code>$_POST['table']</code>
       <code>$_POST['table']</code>
       <code>$_POST['value']</code>
+      <code>$page</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast occurrences="29">
       <code>$_GET['db']</code>
@@ -1170,9 +1161,6 @@
       <code>$_POST['table']</code>
       <code>$_POST['value']</code>
     </PossiblyInvalidCast>
-    <PossiblyNullArgument occurrences="1">
-      <code>$GLOBALS['selected_page']</code>
-    </PossiblyNullArgument>
     <RiskyCast occurrences="1">
       <code>$_GET['page']</code>
     </RiskyCast>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1080,13 +1080,12 @@
       <code>$position['tableName']</code>
       <code>$position['tableName']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
       <code>$position</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">
@@ -1164,14 +1163,13 @@
     </RiskyCast>
   </file>
   <file src="libraries/classes/Controllers/Database/EventsController.php">
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/ExportController.php">
@@ -1191,7 +1189,7 @@
       <code>$each_table['Name']</code>
       <code>$each_table['Name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment occurrences="9">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
@@ -1199,7 +1197,6 @@
       <code>$GLOBALS['table_select']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
       <code>$GLOBALS['unlim_num_rows']</code>
       <code>$each_table</code>
     </MixedAssignment>
@@ -1219,13 +1216,12 @@
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
       <code>$idKey</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
@@ -1269,7 +1265,7 @@
       <code>$GLOBALS['cfg']['AllowUserDropDatabase']</code>
       <code>$GLOBALS['cfg']['PmaNoRelation_DisableWarning']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
@@ -1277,7 +1273,6 @@
       <code>$GLOBALS['single_table']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
       <code>$_POST['comment']</code>
@@ -1296,7 +1291,7 @@
     <InvalidArgument occurrences="1">
       <code>$_POST['searchId']</code>
     </InvalidArgument>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="8">
       <code>$GLOBALS['currentSearchId']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
@@ -1305,7 +1300,6 @@
       <code>$GLOBALS['savedSearchList']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="2">
       <code>$_POST['db']</code>
@@ -1320,14 +1314,13 @@
     <MixedArgument occurrences="1">
       <code>$item</code>
     </MixedArgument>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
       <code>$item</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
@@ -1338,13 +1331,12 @@
     <InvalidArrayOffset occurrences="1">
       <code>$GLOBALS['cfg']['UseDbSearch']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/SqlAutoCompleteController.php">
@@ -1745,13 +1737,12 @@
       <code>$entry['statement']</code>
       <code>$entry['username']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
       <code>$entry</code>
       <code>$table</code>
     </MixedAssignment>
@@ -1783,14 +1774,13 @@
     </PossiblyNullIterator>
   </file>
   <file src="libraries/classes/Controllers/Database/TriggersController.php">
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/ErrorReportController.php">
@@ -2575,7 +2565,7 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$queries</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="8">
       <code>$GLOBALS['dbname']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['message']</code>
@@ -2583,7 +2573,6 @@
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
       <code>$db_name</code>
     </MixedAssignment>
     <PossiblyNullArgument occurrences="1">
@@ -3888,14 +3877,13 @@
     </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/TriggersController.php">
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
-      <code>$GLOBALS['tooltip_truename']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/ZoomSearchController.php">
@@ -13759,7 +13747,7 @@
     <MixedArrayTypeCoercion occurrences="1">
       <code>$array[$p]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="26">
+    <MixedAssignment occurrences="27">
       <code>$array</code>
       <code>$columnNames[]</code>
       <code>$columnNames[]</code>
@@ -13783,6 +13771,7 @@
       <code>$subvalue</code>
       <code>$table</code>
       <code>$table['disp_name']</code>
+      <code>$totalNumTables</code>
       <code>$unit</code>
       <code>$value</code>
       <code>$value</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1080,14 +1080,13 @@
       <code>$position['tableName']</code>
       <code>$position['tableName']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
       <code>$position</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">
@@ -1165,7 +1164,7 @@
     </RiskyCast>
   </file>
   <file src="libraries/classes/Controllers/Database/EventsController.php">
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
@@ -1173,7 +1172,6 @@
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/ExportController.php">
@@ -1193,7 +1191,7 @@
       <code>$each_table['Name']</code>
       <code>$each_table['Name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment occurrences="10">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
@@ -1202,7 +1200,6 @@
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
       <code>$GLOBALS['unlim_num_rows']</code>
       <code>$each_table</code>
     </MixedAssignment>
@@ -1222,14 +1219,13 @@
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
       <code>$idKey</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
@@ -1273,7 +1269,7 @@
       <code>$GLOBALS['cfg']['AllowUserDropDatabase']</code>
       <code>$GLOBALS['cfg']['PmaNoRelation_DisableWarning']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="8">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
@@ -1282,7 +1278,6 @@
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
       <code>$_POST['comment']</code>
@@ -1301,7 +1296,7 @@
     <InvalidArgument occurrences="1">
       <code>$_POST['searchId']</code>
     </InvalidArgument>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment occurrences="9">
       <code>$GLOBALS['currentSearchId']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
@@ -1311,7 +1306,6 @@
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="2">
       <code>$_POST['db']</code>
@@ -1326,7 +1320,7 @@
     <MixedArgument occurrences="1">
       <code>$item</code>
     </MixedArgument>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="8">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
@@ -1334,7 +1328,6 @@
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
       <code>$item</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
@@ -1345,14 +1338,13 @@
     <InvalidArrayOffset occurrences="1">
       <code>$GLOBALS['cfg']['UseDbSearch']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/SqlAutoCompleteController.php">
@@ -1753,14 +1745,13 @@
       <code>$entry['statement']</code>
       <code>$entry['username']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment occurrences="8">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
       <code>$entry</code>
       <code>$table</code>
     </MixedAssignment>
@@ -1792,7 +1783,7 @@
     </PossiblyNullIterator>
   </file>
   <file src="libraries/classes/Controllers/Database/TriggersController.php">
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
@@ -1800,7 +1791,6 @@
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/ErrorReportController.php">
@@ -2585,7 +2575,7 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$queries</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment occurrences="9">
       <code>$GLOBALS['dbname']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['message']</code>
@@ -2594,7 +2584,6 @@
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
       <code>$db_name</code>
     </MixedAssignment>
     <PossiblyNullArgument occurrences="1">
@@ -3899,7 +3888,7 @@
     </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/TriggersController.php">
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
@@ -3907,7 +3896,6 @@
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>
       <code>$GLOBALS['tooltip_truename']</code>
-      <code>$GLOBALS['total_num_tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/ZoomSearchController.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1083,7 +1083,6 @@
     <MixedAssignment occurrences="8">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['params']</code>
       <code>$GLOBALS['pos']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['tooltip_aliasname']</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1079,9 +1079,8 @@
       <code>$position['tableName']</code>
       <code>$position['tableName']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$GLOBALS['errorUrl']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$position</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">
@@ -1159,13 +1158,15 @@
     </RiskyCast>
   </file>
   <file src="libraries/classes/Controllers/Database/EventsController.php">
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
-      <code>$GLOBALS['num_tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/ExportController.php">
+    <InvalidArrayOffset occurrences="1">
+      <code>$GLOBALS['num_tables']</code>
+    </InvalidArrayOffset>
     <MixedArgument occurrences="7">
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['table_select']</code>
@@ -1184,16 +1185,12 @@
     </MixedArrayAccess>
     <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['single_table']</code>
       <code>$GLOBALS['table_select']</code>
       <code>$GLOBALS['tables']</code>
       <code>$GLOBALS['unlim_num_rows']</code>
       <code>$each_table</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="1">
-      <code>$GLOBALS['num_tables']</code>
-    </PossiblyNullArgument>
     <PossiblyNullIterator occurrences="1">
       <code>$GLOBALS['tables']</code>
     </PossiblyNullIterator>
@@ -1207,9 +1204,8 @@
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$GLOBALS['errorUrl']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$idKey</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
@@ -1253,9 +1249,8 @@
       <code>$GLOBALS['cfg']['AllowUserDropDatabase']</code>
       <code>$GLOBALS['cfg']['PmaNoRelation_DisableWarning']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$GLOBALS['errorUrl']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['reload']</code>
       <code>$GLOBALS['single_table']</code>
     </MixedAssignment>
@@ -1276,10 +1271,9 @@
     <InvalidArgument occurrences="1">
       <code>$_POST['searchId']</code>
     </InvalidArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['currentSearchId']</code>
       <code>$GLOBALS['errorUrl']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['savedSearch']</code>
       <code>$GLOBALS['savedSearchList']</code>
     </MixedAssignment>
@@ -1296,10 +1290,9 @@
     <MixedArgument occurrences="1">
       <code>$item</code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$item</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
@@ -1310,9 +1303,8 @@
     <InvalidArrayOffset occurrences="1">
       <code>$GLOBALS['cfg']['UseDbSearch']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$GLOBALS['errorUrl']</code>
-      <code>$GLOBALS['num_tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/SqlAutoCompleteController.php">
@@ -1713,9 +1705,8 @@
       <code>$entry['statement']</code>
       <code>$entry['username']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$GLOBALS['errorUrl']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$entry</code>
       <code>$table</code>
     </MixedAssignment>
@@ -1747,10 +1738,9 @@
     </PossiblyNullIterator>
   </file>
   <file src="libraries/classes/Controllers/Database/TriggersController.php">
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
-      <code>$GLOBALS['num_tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/ErrorReportController.php">
@@ -1819,7 +1809,7 @@
     <MixedArrayAssignment occurrences="1">
       <code>$_SESSION['tmpval']['aliases']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="122">
+    <MixedAssignment occurrences="121">
       <code>$GLOBALS['active_page']</code>
       <code>$GLOBALS['charset']</code>
       <code>$GLOBALS['codegen_format']</code>
@@ -1865,7 +1855,6 @@
       <code>$GLOBALS['mediawiki_caption']</code>
       <code>$GLOBALS['mediawiki_headers']</code>
       <code>$GLOBALS['mediawiki_structure_or_data']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['ods_columns']</code>
       <code>$GLOBALS['ods_null']</code>
       <code>$GLOBALS['ods_structure_or_data']</code>
@@ -2488,8 +2477,7 @@
       <code>$GLOBALS['select_item']</code>
       <code>$GLOBALS['unlim_num_rows']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="6">
-      <code>$GLOBALS['num_tables']</code>
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['select_item']</code>
       <code>$GLOBALS['select_item']</code>
       <code>$GLOBALS['single_table']</code>
@@ -2535,11 +2523,10 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$queries</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['dbname']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['message']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$db_name</code>
     </MixedAssignment>
     <PossiblyNullArgument occurrences="1">
@@ -3076,9 +3063,8 @@
       <code>$GLOBALS['replaces'][]</code>
       <code>$GLOBALS['replaces'][]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['errorUrl']</code>
-      <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['replaces']</code>
       <code>$GLOBALS['single_table']</code>
       <code>$GLOBALS['unlim_num_rows']</code>
@@ -3844,10 +3830,9 @@
     </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/TriggersController.php">
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
-      <code>$GLOBALS['num_tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/ZoomSearchController.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1164,11 +1164,7 @@
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/ExportController.php">
-    <InvalidArrayOffset occurrences="1">
-      <code>$GLOBALS['num_tables']</code>
-    </InvalidArrayOffset>
-    <MixedArgument occurrences="7">
-      <code>$GLOBALS['num_tables']</code>
+    <MixedArgument occurrences="6">
       <code>$GLOBALS['table_select']</code>
       <code>$GLOBALS['unlim_num_rows']</code>
       <code>$each_table['Name']</code>
@@ -1191,9 +1187,6 @@
       <code>$GLOBALS['unlim_num_rows']</code>
       <code>$each_table</code>
     </MixedAssignment>
-    <PossiblyNullIterator occurrences="1">
-      <code>$GLOBALS['tables']</code>
-    </PossiblyNullIterator>
   </file>
   <file src="libraries/classes/Controllers/Database/ImportController.php">
     <MixedArrayAccess occurrences="2">
@@ -1633,7 +1626,7 @@
     <MixedArrayAssignment occurrences="1">
       <code>$currentTable['TABLE_ROWS']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="25">
+    <MixedAssignment occurrences="22">
       <code>$GLOBALS['errorUrl']</code>
       <code>$charset</code>
       <code>$checkTime</code>
@@ -1652,9 +1645,6 @@
       <code>$searchDoDBInTruename</code>
       <code>$searchTable</code>
       <code>$sumEntries</code>
-      <code>$this-&gt;numTables</code>
-      <code>$this-&gt;tables</code>
-      <code>$this-&gt;totalNumTables</code>
       <code>$truename</code>
       <code>$updateTime</code>
       <code>$updateTimeAll</code>
@@ -13692,7 +13682,7 @@
     <MixedArrayTypeCoercion occurrences="1">
       <code>$array[$p]</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="25">
+    <MixedAssignment occurrences="24">
       <code>$array</code>
       <code>$columnNames[]</code>
       <code>$columnNames[]</code>
@@ -13714,7 +13704,6 @@
       <code>$subvalue</code>
       <code>$table</code>
       <code>$table['disp_name']</code>
-      <code>$totalNumTables</code>
       <code>$unit</code>
       <code>$value</code>
       <code>$value</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2380,20 +2380,19 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="15">
+    <MixedAssignment occurrences="14">
       <code>$GLOBALS['all_ok']</code>
       <code>$GLOBALS['cf']</code>
       <code>$GLOBALS['form_display']</code>
       <code>$GLOBALS['json']</code>
       <code>$GLOBALS['json']</code>
       <code>$GLOBALS['new_config']</code>
-      <code>$GLOBALS['params']</code>
-      <code>$GLOBALS['params']['lang']</code>
       <code>$GLOBALS['query']</code>
       <code>$GLOBALS['return_url']</code>
       <code>$GLOBALS['return_url']</code>
       <code>$_POST[str_replace('/', '-', (string) $k)]</code>
       <code>$configuration</code>
+      <code>$redirectParams['lang']</code>
       <code>$v</code>
       <code>$val</code>
     </MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1633,7 +1633,7 @@
     <MixedArrayAssignment occurrences="1">
       <code>$currentTable['TABLE_ROWS']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="28">
+    <MixedAssignment occurrences="26">
       <code>$GLOBALS['errorUrl']</code>
       <code>$charset</code>
       <code>$checkTime</code>
@@ -1652,8 +1652,6 @@
       <code>$searchDoDBInTruename</code>
       <code>$searchTable</code>
       <code>$sumEntries</code>
-      <code>$this-&gt;dbIsSystemSchema</code>
-      <code>$this-&gt;isShowStats</code>
       <code>$this-&gt;numTables</code>
       <code>$this-&gt;position</code>
       <code>$this-&gt;tables</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1079,10 +1079,9 @@
       <code>$position['tableName']</code>
       <code>$position['tableName']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['tables']</code>
       <code>$position</code>
     </MixedAssignment>
     <MixedOperand occurrences="2">
@@ -1160,11 +1159,10 @@
     </RiskyCast>
   </file>
   <file src="libraries/classes/Controllers/Database/EventsController.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/ExportController.php">
@@ -1184,7 +1182,7 @@
       <code>$each_table['Name']</code>
       <code>$each_table['Name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['single_table']</code>
@@ -1209,10 +1207,9 @@
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
       <code>$_SESSION[$GLOBALS['SESSION_KEY']]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['tables']</code>
       <code>$idKey</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
@@ -1256,12 +1253,11 @@
       <code>$GLOBALS['cfg']['AllowUserDropDatabase']</code>
       <code>$GLOBALS['cfg']['PmaNoRelation_DisableWarning']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['reload']</code>
       <code>$GLOBALS['single_table']</code>
-      <code>$GLOBALS['tables']</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
       <code>$_POST['comment']</code>
@@ -1280,13 +1276,12 @@
     <InvalidArgument occurrences="1">
       <code>$_POST['searchId']</code>
     </InvalidArgument>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['currentSearchId']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
       <code>$GLOBALS['savedSearch']</code>
       <code>$GLOBALS['savedSearchList']</code>
-      <code>$GLOBALS['tables']</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="2">
       <code>$_POST['db']</code>
@@ -1301,11 +1296,10 @@
     <MixedArgument occurrences="1">
       <code>$item</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['tables']</code>
       <code>$item</code>
     </MixedAssignment>
     <PossiblyInvalidArgument occurrences="1">
@@ -1316,10 +1310,9 @@
     <InvalidArrayOffset occurrences="1">
       <code>$GLOBALS['cfg']['UseDbSearch']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="2">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Database/SqlAutoCompleteController.php">
@@ -1720,10 +1713,9 @@
       <code>$entry['statement']</code>
       <code>$entry['username']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="4">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['tables']</code>
       <code>$entry</code>
       <code>$table</code>
     </MixedAssignment>
@@ -1755,11 +1747,10 @@
     </PossiblyNullIterator>
   </file>
   <file src="libraries/classes/Controllers/Database/TriggersController.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/ErrorReportController.php">
@@ -2544,12 +2535,11 @@
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$queries</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['dbname']</code>
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['message']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['tables']</code>
       <code>$db_name</code>
     </MixedAssignment>
     <PossiblyNullArgument occurrences="1">
@@ -3854,11 +3844,10 @@
     </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/TriggersController.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="3">
       <code>$GLOBALS['errorUrl']</code>
       <code>$GLOBALS['errors']</code>
       <code>$GLOBALS['num_tables']</code>
-      <code>$GLOBALS['tables']</code>
     </MixedAssignment>
   </file>
   <file src="libraries/classes/Controllers/Table/ZoomSearchController.php">

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\SqlParser\Token;
 use PhpMyAdmin\Util;
 use PhpMyAdmin\Utils\SessionCache;
 use PhpMyAdmin\Version;
+use Psr\Http\Message\ServerRequestInterface;
 
 use function __;
 use function _setlocale;
@@ -2473,9 +2474,28 @@ class UtilTest extends AbstractTestCase
             'TABLE_COMMENT' => '',
             'TABLE_TYPE' => 'BASE TABLE',
         ];
-        $expected = [['test_table' => $tableInfo], 1, 1, true, false, [], [], 0];
+        $expected = [['test_table' => $tableInfo], 1, 1];
         $actual = Util::getDbInfo($this->createStub(ServerRequest::class), 'test_db');
         $this->assertSame($expected, $actual);
+    }
+
+    public function testGetTableListPosition(): void
+    {
+        // Default 0
+        $actual = Util::getTableListPosition($this->createStub(ServerRequest::class), 'test_db');
+        $this->assertSame(0, $actual);
+
+        // From POST
+        $requestStub = $this->createStub(ServerRequestInterface::class);
+        $requestStub->method('getQueryParams')->willReturn([]);
+        $requestStub->method('getParsedBody')->willReturn(['pos' => '250']);
+        $request = new ServerRequest($requestStub);
+        $actual = Util::getTableListPosition($request, 'test_db');
+        $this->assertSame(250, $actual);
+
+        // From SESSION
+        $actual = Util::getTableListPosition($this->createStub(ServerRequest::class), 'test_db');
+        $this->assertSame(250, $actual);
     }
 
     /**


### PR DESCRIPTION
This PR is a mess. I don't know what it's about anymore. I started removing and I kept on removing. Something was wrong with this getDbInfo method. It is still smelly, but at least it's more readable. 

By removing `getDbInfo` we actually can improve performance by a lot for certain actions. 