### PR TITLE
Bugfix for changing $cfg['RepeatCells'] no effect

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3460,9 +3460,7 @@ class Results
 
         $query['sql'] = $this->properties['sql_query'];
 
-        if (empty($query['repeat_cells'])) {
-            $query['repeat_cells'] = $GLOBALS['cfg']['RepeatCells'];
-        }
+        $query['repeat_cells'] = $GLOBALS['cfg']['RepeatCells'];
 
         // The value can also be from _GET as described on issue #16146 when sorting results
         $sessionMaxRows = $_GET['session_max_rows'] ?? $_POST['session_max_rows'] ?? '';


### PR DESCRIPTION
Fixes changing $cfg['RepeatCells'] in configuration has no effect.

I'm not sure if this is a good way to fix this or not, but it does fix this problem for me in my local environment. I'm not sure what the purpose of checking `empty($query['repeat_cells'])` was in the original code.

Signed-off-by: still-dreaming-1 <jessedickey@gmail.com>