### PR TITLE
Extract connection type constants to the `Dbal\Connection` class

### DIFF
--- a/libraries/classes/Bookmark.php
+++ b/libraries/classes/Bookmark.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin;
 
 use PhpMyAdmin\ConfigStorage\Features\BookmarkFeature;
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Dbal\DatabaseName;
 
 use function count;
@@ -125,7 +126,7 @@ class Bookmark
             . $this->dbi->quoteString($this->query) . ', '
             . $this->dbi->quoteString($this->label) . ')';
 
-        return (bool) $this->dbi->query($query, DatabaseInterface::CONNECT_CONTROL);
+        return (bool) $this->dbi->query($query, Connection::TYPE_CONTROL);
     }
 
     /**
@@ -142,7 +143,7 @@ class Bookmark
             . '.' . Util::backquote($bookmarkFeature->bookmark)
             . ' WHERE id = ' . $this->id;
 
-        return (bool) $this->dbi->tryQuery($query, DatabaseInterface::CONNECT_CONTROL);
+        return (bool) $this->dbi->tryQuery($query, Connection::TYPE_CONTROL);
     }
 
     /**
@@ -260,7 +261,7 @@ class Bookmark
             $query,
             null,
             null,
-            DatabaseInterface::CONNECT_CONTROL
+            Connection::TYPE_CONTROL
         );
 
         $bookmarks = [];
@@ -315,7 +316,7 @@ class Bookmark
         $query .= ' AND ' . Util::backquote($id_field)
             . ' = ' . $dbi->quoteString((string) $id) . ' LIMIT 1';
 
-        $result = $dbi->fetchSingleRow($query, DatabaseInterface::FETCH_ASSOC, DatabaseInterface::CONNECT_CONTROL);
+        $result = $dbi->fetchSingleRow($query, DatabaseInterface::FETCH_ASSOC, Connection::TYPE_CONTROL);
         if ($result !== null) {
             return self::createFromRow($dbi, $result);
         }

--- a/libraries/classes/Common.php
+++ b/libraries/classes/Common.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin;
 
 use PhpMyAdmin\Config\ConfigFile;
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Dbal\DatabaseName;
 use PhpMyAdmin\Dbal\TableName;
 use PhpMyAdmin\Exceptions\AuthenticationPluginException;
@@ -611,11 +612,11 @@ final class Common
          */
         $controlConnection = null;
         if ($GLOBALS['cfg']['Server']['controluser'] !== '') {
-            $controlConnection = $dbi->connect(DatabaseInterface::CONNECT_CONTROL);
+            $controlConnection = $dbi->connect(Connection::TYPE_CONTROL);
         }
 
         // Connects to the server (validates user's login)
-        $userConnection = $dbi->connect(DatabaseInterface::CONNECT_USER);
+        $userConnection = $dbi->connect(Connection::TYPE_USER);
         if ($userConnection === null) {
             $auth->showFailure('mysql-denied');
         }
@@ -628,7 +629,7 @@ final class Common
          * Open separate connection for control queries, this is needed to avoid problems with table locking used in
          * main connection and phpMyAdmin issuing queries to configuration storage, which is not locked by that time.
          */
-        $dbi->connect(DatabaseInterface::CONNECT_USER, null, DatabaseInterface::CONNECT_CONTROL);
+        $dbi->connect(Connection::TYPE_USER, null, Connection::TYPE_CONTROL);
     }
 
     public static function getRequest(): ServerRequest

--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin;
 
 use PhpMyAdmin\Config\Settings;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Exceptions\ConfigException;
 use Throwable;
 
@@ -69,6 +70,8 @@ use const PHP_VERSION_ID;
 
 /**
  * Configuration handling
+ *
+ * @psalm-import-type ConnectionType from Connection
  */
 class Config
 {
@@ -1213,9 +1216,9 @@ class Config
     /**
      * Return connection parameters for the database server
      *
-     * @param int        $mode   Connection mode on of CONNECT_USER, CONNECT_CONTROL
-     *                           or CONNECT_AUXILIARY.
+     * @param int        $mode   Connection mode.
      * @param array|null $server Server information like host/port/socket/persistent
+     * @psalm-param ConnectionType $mode
      *
      * @return array user, host and server settings array
      */
@@ -1224,11 +1227,11 @@ class Config
         $user = null;
         $password = null;
 
-        if ($mode == DatabaseInterface::CONNECT_USER) {
+        if ($mode == Connection::TYPE_USER) {
             $user = $GLOBALS['cfg']['Server']['user'];
             $password = $GLOBALS['cfg']['Server']['password'];
             $server = $GLOBALS['cfg']['Server'];
-        } elseif ($mode == DatabaseInterface::CONNECT_CONTROL) {
+        } elseif ($mode == Connection::TYPE_CONTROL) {
             $user = $GLOBALS['cfg']['Server']['controluser'];
             $password = $GLOBALS['cfg']['Server']['controlpass'];
 

--- a/libraries/classes/Controllers/Server/DatabasesController.php
+++ b/libraries/classes/Controllers/Server/DatabasesController.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Charsets;
 use PhpMyAdmin\CheckUserPrivileges;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Query\Utilities;
 use PhpMyAdmin\ReplicationInfo;
@@ -102,7 +103,7 @@ class DatabasesController extends AbstractController
             $this->databases = $this->dbi->getDatabasesFull(
                 null,
                 $this->hasStatistics,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 $this->sortBy,
                 $this->sortOrder,
                 $this->position,

--- a/libraries/classes/Controllers/Server/UserGroupsFormController.php
+++ b/libraries/classes/Controllers/Server/UserGroupsFormController.php
@@ -9,6 +9,7 @@ use PhpMyAdmin\ConfigStorage\Features\ConfigurableMenusFeature;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
@@ -85,7 +86,7 @@ final class UserGroupsFormController extends AbstractController
             $userTable,
             $this->dbi->escapeString($username)
         );
-        $userGroup = $this->dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL);
+        $userGroup = $this->dbi->fetchValue($sqlQuery, 0, Connection::TYPE_CONTROL);
 
         $allUserGroups = [];
         $sqlQuery = 'SELECT DISTINCT `usergroup` FROM ' . $groupTable;

--- a/libraries/classes/Database/CentralColumns.php
+++ b/libraries/classes/Database/CentralColumns.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Database;
 use PhpMyAdmin\Charsets;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Util;
@@ -136,7 +137,7 @@ class CentralColumns
         }
 
         $pmadb = $cfgCentralColumns['db'];
-        $this->dbi->selectDb($pmadb, DatabaseInterface::CONNECT_CONTROL);
+        $this->dbi->selectDb($pmadb, Connection::TYPE_CONTROL);
         $central_list_table = $cfgCentralColumns['table'];
         //get current values of $db from central column list
         if ($num == 0) {
@@ -148,7 +149,7 @@ class CentralColumns
                 . 'LIMIT ' . $from . ', ' . $num . ';';
         }
 
-        $has_list = $this->dbi->fetchResult($query, null, null, DatabaseInterface::CONNECT_CONTROL);
+        $has_list = $this->dbi->fetchResult($query, null, null, Connection::TYPE_CONTROL);
         $this->handleColumnExtra($has_list);
 
         return $has_list;
@@ -169,12 +170,12 @@ class CentralColumns
         }
 
         $pmadb = $cfgCentralColumns['db'];
-        $this->dbi->selectDb($pmadb, DatabaseInterface::CONNECT_CONTROL);
+        $this->dbi->selectDb($pmadb, Connection::TYPE_CONTROL);
         $central_list_table = $cfgCentralColumns['table'];
         $query = 'SELECT count(db_name) FROM '
             . Util::backquote($central_list_table) . ' '
             . 'WHERE db_name = \'' . $this->dbi->escapeString($db) . '\';';
-        $res = $this->dbi->fetchResult($query, null, null, DatabaseInterface::CONNECT_CONTROL);
+        $res = $this->dbi->fetchResult($query, null, null, Connection::TYPE_CONTROL);
         if (isset($res[0])) {
             return (int) $res[0];
         }
@@ -203,18 +204,18 @@ class CentralColumns
         }
 
         $pmadb = $cfgCentralColumns['db'];
-        $this->dbi->selectDb($pmadb, DatabaseInterface::CONNECT_CONTROL);
+        $this->dbi->selectDb($pmadb, Connection::TYPE_CONTROL);
         $central_list_table = $cfgCentralColumns['table'];
         if ($allFields) {
             $query = 'SELECT * FROM ' . Util::backquote($central_list_table) . ' '
                 . 'WHERE db_name = \'' . $this->dbi->escapeString($db) . '\' AND col_name IN (' . $cols . ');';
-            $has_list = $this->dbi->fetchResult($query, null, null, DatabaseInterface::CONNECT_CONTROL);
+            $has_list = $this->dbi->fetchResult($query, null, null, Connection::TYPE_CONTROL);
             $this->handleColumnExtra($has_list);
         } else {
             $query = 'SELECT col_name FROM '
                 . Util::backquote($central_list_table) . ' '
                 . 'WHERE db_name = \'' . $this->dbi->escapeString($db) . '\' AND col_name IN (' . $cols . ');';
-            $has_list = $this->dbi->fetchResult($query, null, null, DatabaseInterface::CONNECT_CONTROL);
+            $has_list = $this->dbi->fetchResult($query, null, null, Connection::TYPE_CONTROL);
         }
 
         return $has_list;
@@ -360,12 +361,12 @@ class CentralColumns
             );
         }
 
-        $this->dbi->selectDb($pmadb, DatabaseInterface::CONNECT_CONTROL);
+        $this->dbi->selectDb($pmadb, Connection::TYPE_CONTROL);
         foreach ($insQuery as $query) {
-            if (! $this->dbi->tryQuery($query, DatabaseInterface::CONNECT_CONTROL)) {
+            if (! $this->dbi->tryQuery($query, Connection::TYPE_CONTROL)) {
                 $message = Message::error(__('Could not add columns!'));
                 $message->addMessage(
-                    Message::rawError($this->dbi->getError(DatabaseInterface::CONNECT_CONTROL))
+                    Message::rawError($this->dbi->getError(Connection::TYPE_CONTROL))
                 );
                 break;
             }
@@ -453,16 +454,16 @@ class CentralColumns
             );
         }
 
-        $this->dbi->selectDb($pmadb, DatabaseInterface::CONNECT_CONTROL);
+        $this->dbi->selectDb($pmadb, Connection::TYPE_CONTROL);
 
         $query = 'DELETE FROM ' . Util::backquote($central_list_table) . ' '
             . 'WHERE db_name = \'' . $this->dbi->escapeString($database) . '\' AND col_name IN (' . $cols . ');';
 
-        if (! $this->dbi->tryQuery($query, DatabaseInterface::CONNECT_CONTROL)) {
+        if (! $this->dbi->tryQuery($query, Connection::TYPE_CONTROL)) {
             $message = Message::error(__('Could not remove columns!'));
             $message->addHtml('<br>' . htmlspecialchars($cols) . '<br>');
             $message->addMessage(
-                Message::rawError($this->dbi->getError(DatabaseInterface::CONNECT_CONTROL))
+                Message::rawError($this->dbi->getError(Connection::TYPE_CONTROL))
             );
         }
 
@@ -607,7 +608,7 @@ class CentralColumns
         }
 
         $centralTable = $cfgCentralColumns['table'];
-        $this->dbi->selectDb($cfgCentralColumns['db'], DatabaseInterface::CONNECT_CONTROL);
+        $this->dbi->selectDb($cfgCentralColumns['db'], Connection::TYPE_CONTROL);
         if ($orig_col_name == '') {
             $def = [];
             $def['Type'] = $col_type;
@@ -636,8 +637,8 @@ class CentralColumns
                 . '\'';
         }
 
-        if (! $this->dbi->tryQuery($query, DatabaseInterface::CONNECT_CONTROL)) {
-            return Message::error($this->dbi->getError(DatabaseInterface::CONNECT_CONTROL));
+        if (! $this->dbi->tryQuery($query, Connection::TYPE_CONTROL)) {
+            return Message::error($this->dbi->getError(Connection::TYPE_CONTROL));
         }
 
         return true;
@@ -778,8 +779,8 @@ class CentralColumns
             $query .= ';';
         }
 
-        $this->dbi->selectDb($cfgCentralColumns['db'], DatabaseInterface::CONNECT_CONTROL);
-        $columns_list = $this->dbi->fetchResult($query, null, null, DatabaseInterface::CONNECT_CONTROL);
+        $this->dbi->selectDb($cfgCentralColumns['db'], Connection::TYPE_CONTROL);
+        $columns_list = $this->dbi->fetchResult($query, null, null, Connection::TYPE_CONTROL);
         $this->handleColumnExtra($columns_list);
 
         return $columns_list;
@@ -864,13 +865,13 @@ class CentralColumns
         }
 
         $pmadb = $cfgCentralColumns['db'];
-        $this->dbi->selectDb($pmadb, DatabaseInterface::CONNECT_CONTROL);
+        $this->dbi->selectDb($pmadb, Connection::TYPE_CONTROL);
         $central_list_table = $cfgCentralColumns['table'];
         //get current values of $db from central column list
         $query = 'SELECT COUNT(db_name) FROM ' . Util::backquote($central_list_table) . ' '
             . 'WHERE db_name = \'' . $this->dbi->escapeString($db) . '\''
             . ($num === 0 ? '' : 'LIMIT ' . $from . ', ' . $num) . ';';
-        $result = $this->dbi->fetchResult($query, null, null, DatabaseInterface::CONNECT_CONTROL);
+        $result = $this->dbi->fetchResult($query, null, null, Connection::TYPE_CONTROL);
 
         if (isset($result[0])) {
             return (int) $result[0];

--- a/libraries/classes/Database/Designer/Common.php
+++ b/libraries/classes/Database/Designer/Common.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Database\Designer;
 
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Index;
 use PhpMyAdmin\Query\Generator as QueryGenerator;
 use PhpMyAdmin\Table;
@@ -288,7 +289,7 @@ class Common
             $query,
             'name',
             null,
-            DatabaseInterface::CONNECT_CONTROL
+            Connection::TYPE_CONTROL
         );
     }
 
@@ -313,7 +314,7 @@ class Common
         $page_name = $this->dbi->fetchValue(
             $query,
             0,
-            DatabaseInterface::CONNECT_CONTROL
+            Connection::TYPE_CONTROL
         );
 
         return $page_name !== false ? $page_name : null;
@@ -368,7 +369,7 @@ class Common
         $default_page_no = $this->dbi->fetchValue(
             $query,
             0,
-            DatabaseInterface::CONNECT_CONTROL
+            Connection::TYPE_CONTROL
         );
 
         return is_string($default_page_no) ? intval($default_page_no) : -1;
@@ -395,7 +396,7 @@ class Common
             $query,
             null,
             null,
-            DatabaseInterface::CONNECT_CONTROL
+            Connection::TYPE_CONTROL
         );
 
         return $pageNos !== [];
@@ -429,7 +430,7 @@ class Common
         $min_page_no = $this->dbi->fetchValue(
             $query,
             0,
-            DatabaseInterface::CONNECT_CONTROL
+            Connection::TYPE_CONTROL
         );
 
         return is_string($min_page_no) ? intval($min_page_no) : -1;
@@ -665,7 +666,7 @@ class Common
             ];
         }
 
-        $error = $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
+        $error = $this->dbi->getError(Connection::TYPE_CONTROL);
 
         return [
             false,
@@ -734,7 +735,7 @@ class Common
         $result = $this->dbi->tryQueryAsControlUser($delete_query);
 
         if (! $result) {
-            $error = $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
+            $error = $this->dbi->getError(Connection::TYPE_CONTROL);
 
             return [
                 false,
@@ -773,7 +774,7 @@ class Common
             $orig_data = $this->dbi->fetchSingleRow(
                 $orig_data_query,
                 DatabaseInterface::FETCH_ASSOC,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             );
 
             if (! empty($orig_data)) {

--- a/libraries/classes/Dbal/Connection.php
+++ b/libraries/classes/Dbal/Connection.php
@@ -6,9 +6,17 @@ namespace PhpMyAdmin\Dbal;
 
 /**
  * @psalm-immutable
+ * @psalm-type ConnectionType = Connection::TYPE_USER|Connection::TYPE_CONTROL|Connection::TYPE_AUXILIARY
  */
 final class Connection
 {
+    /** User connection. */
+    public const TYPE_USER = 0;
+    /** Control user connection. */
+    public const TYPE_CONTROL = 1;
+    /** Auxiliary connection. Used for example for replication setup. */
+    public const TYPE_AUXILIARY = 2;
+
     /** @var object */
     public $connection;
 

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -12,6 +12,8 @@ use PhpMyAdmin\Table;
 
 /**
  * Main interface for database interactions
+ *
+ * @psalm-import-type ConnectionType from Connection
  */
 interface DbalInterface
 {
@@ -24,10 +26,11 @@ interface DbalInterface
      * @param string $query             SQL query to execute
      * @param int    $options           optional query options
      * @param bool   $cacheAffectedRows whether to cache affected rows
+     * @psalm-param ConnectionType $connectionType
      */
     public function query(
         string $query,
-        int $connectionType = DatabaseInterface::CONNECT_USER,
+        int $connectionType = Connection::TYPE_USER,
         int $options = 0,
         bool $cacheAffectedRows = true
     ): ResultInterface;
@@ -38,12 +41,13 @@ interface DbalInterface
      * @param string $query             query to run
      * @param int    $options           query options
      * @param bool   $cacheAffectedRows whether to cache affected row
+     * @psalm-param ConnectionType $connectionType
      *
      * @return mixed
      */
     public function tryQuery(
         string $query,
-        int $connectionType = DatabaseInterface::CONNECT_USER,
+        int $connectionType = Connection::TYPE_USER,
         int $options = 0,
         bool $cacheAffectedRows = true
     );
@@ -52,20 +56,22 @@ interface DbalInterface
      * Send multiple SQL queries to the database server and execute the first one
      *
      * @param string $multiQuery multi query statement to execute
+     * @psalm-param ConnectionType $connectionType
      */
     public function tryMultiQuery(
         string $multiQuery = '',
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): bool;
 
     /**
      * returns array with table names for given db
      *
      * @param string $database name of database
+     * @psalm-param ConnectionType $connectionType
      *
      * @return array<int, string>   tables names
      */
-    public function getTables(string $database, int $connectionType = DatabaseInterface::CONNECT_USER): array;
+    public function getTables(string $database, int $connectionType = Connection::TYPE_USER): array;
 
     /**
      * returns array of all tables in given db or dbs
@@ -89,6 +95,7 @@ interface DbalInterface
      * @param string       $sortBy       table attribute to sort by
      * @param string       $sortOrder    direction to sort (ASC or DESC)
      * @param string|null  $tableType    whether table or view
+     * @psalm-param ConnectionType $connectionType
      *
      * @return array           list of tables in given db(s)
      *
@@ -103,7 +110,7 @@ interface DbalInterface
         string $sortBy = 'Name',
         string $sortOrder = 'ASC',
         ?string $tableType = null,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): array;
 
     /**
@@ -124,6 +131,7 @@ interface DbalInterface
      * @param string      $sortOrder   ASC or DESC
      * @param int         $limitOffset starting offset for LIMIT
      * @param bool|int    $limitCount  row count for LIMIT or true for $GLOBALS['cfg']['MaxDbList']
+     * @psalm-param ConnectionType $connectionType
      *
      * @return array
      *
@@ -132,7 +140,7 @@ interface DbalInterface
     public function getDatabasesFull(
         ?string $database = null,
         bool $forceStats = false,
-        int $connectionType = DatabaseInterface::CONNECT_USER,
+        int $connectionType = Connection::TYPE_USER,
         string $sortBy = 'SCHEMA_NAME',
         string $sortOrder = 'ASC',
         int $limitOffset = 0,
@@ -156,6 +164,7 @@ interface DbalInterface
      * @param string|null $database name of database
      * @param string|null $table    name of table to retrieve columns from
      * @param string|null $column   name of specific column
+     * @psalm-param ConnectionType $connectionType
      *
      * @return array
      */
@@ -163,7 +172,7 @@ interface DbalInterface
         ?string $database = null,
         ?string $table = null,
         ?string $column = null,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): array;
 
     /**
@@ -173,6 +182,7 @@ interface DbalInterface
      * @param string $table    name of table to retrieve columns from
      * @param string $column   name of column
      * @param bool   $full     whether to return full info or only column names
+     * @psalm-param ConnectionType $connectionType
      *
      * @return array flat array description
      */
@@ -181,7 +191,7 @@ interface DbalInterface
         string $table,
         string $column,
         bool $full = false,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): array;
 
     /**
@@ -190,6 +200,7 @@ interface DbalInterface
      * @param string $database name of database
      * @param string $table    name of table to retrieve columns from
      * @param bool   $full     whether to return full info or only column names
+     * @psalm-param ConnectionType $connectionType
      *
      * @return array<string, array> array indexed by column names
      */
@@ -197,7 +208,7 @@ interface DbalInterface
         string $database,
         string $table,
         bool $full = false,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): array;
 
     /**
@@ -205,13 +216,14 @@ interface DbalInterface
      *
      * @param string $database name of database
      * @param string $table    name of table to retrieve columns from
+     * @psalm-param ConnectionType $connectionType
      *
      * @return string[]
      */
     public function getColumnNames(
         string $database,
         string $table,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): array;
 
     /**
@@ -219,6 +231,7 @@ interface DbalInterface
      *
      * @param string $database name of database
      * @param string $table    name of the table whose indexes are to be retrieved
+     * @psalm-param ConnectionType $connectionType
      *
      * @return array<int, array<string, string|null>>
      * @psalm-return array<int, array{
@@ -243,22 +256,22 @@ interface DbalInterface
     public function getTableIndexes(
         string $database,
         string $table,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): array;
 
     /**
      * returns value of given mysql server variable
      *
      * @param string $var  mysql server variable name
-     * @param int    $type DatabaseInterface::GETVAR_SESSION |
-     *                     DatabaseInterface::GETVAR_GLOBAL
+     * @param int    $type DatabaseInterface::GETVAR_SESSION | DatabaseInterface::GETVAR_GLOBAL
+     * @psalm-param ConnectionType $connectionType
      *
      * @return false|string|null value for mysql server variable
      */
     public function getVariable(
         string $var,
         int $type = DatabaseInterface::GETVAR_SESSION,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     );
 
     /**
@@ -266,11 +279,12 @@ interface DbalInterface
      *
      * @param string $var   variable name
      * @param string $value value to set
+     * @psalm-param ConnectionType $connectionType
      */
     public function setVariable(
         string $var,
         string $value,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): bool;
 
     /**
@@ -307,9 +321,8 @@ interface DbalInterface
      * </code>
      *
      * @param string     $query The query to execute
-     * @param int|string $field field to fetch the value from,
-     *                          starting at 0, with 0 being
-     *                          default
+     * @param int|string $field field to fetch the value from, starting at 0, with 0 being default
+     * @psalm-param ConnectionType $connectionType
      *
      * @return string|false|null value of first field in first row from result
      *               or false if not found
@@ -317,7 +330,7 @@ interface DbalInterface
     public function fetchValue(
         string $query,
         $field = 0,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     );
 
     /**
@@ -331,14 +344,14 @@ interface DbalInterface
      * </code>
      *
      * @param string $query The query to execute
-     * @param string $type  NUM|ASSOC returned array should either numeric
-     *                      associative or both
-     * @psalm-param  self::FETCH_NUM|self::FETCH_ASSOC $type
+     * @param string $type  NUM|ASSOC returned array should either numeric associative or both
+     * @psalm-param self::FETCH_NUM|self::FETCH_ASSOC $type
+     * @psalm-param ConnectionType $connectionType
      */
     public function fetchSingleRow(
         string $query,
         string $type = DbalInterface::FETCH_ASSOC,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): ?array;
 
     /**
@@ -384,13 +397,9 @@ interface DbalInterface
      * </code>
      *
      * @param string           $query query to execute
-     * @param string|int|array $key   field-name or offset
-     *                                used as key for
-     *                                array or array of
-     *                                those
-     * @param string|int       $value value-name or offset
-     *                                used as value for
-     *                                array
+     * @param string|int|array $key   field-name or offset used as key for array or array of those
+     * @param string|int       $value value-name or offset used as value for array
+     * @psalm-param ConnectionType $connectionType
      *
      * @return array resultrows or values indexed by $key
      */
@@ -398,7 +407,7 @@ interface DbalInterface
         string $query,
         $key = null,
         $value = null,
-        int $connectionType = DatabaseInterface::CONNECT_USER
+        int $connectionType = Connection::TYPE_USER
     ): array;
 
     /**
@@ -411,9 +420,11 @@ interface DbalInterface
     /**
      * returns warnings for last query
      *
+     * @psalm-param ConnectionType $connectionType
+     *
      * @return array warnings
      */
-    public function getWarnings(int $connectionType = DatabaseInterface::CONNECT_USER): array;
+    public function getWarnings(int $connectionType = Connection::TYPE_USER): array;
 
     /**
      * gets the current user with host
@@ -453,10 +464,11 @@ interface DbalInterface
     /**
      * Connects to the database server.
      *
-     * @param int        $mode   Connection mode on of CONNECT_USER, CONNECT_CONTROL
-     *                           or CONNECT_AUXILIARY.
+     * @param int        $mode   Connection mode.
      * @param array|null $server Server information like host/port/socket/persistent
      * @param int|null   $target How to store connection link, defaults to $mode
+     * @psalm-param ConnectionType $mode
+     * @psalm-param ConnectionType|null $target
      */
     public function connect(int $mode, ?array $server = null, ?int $target = null): ?Connection;
 
@@ -464,39 +476,50 @@ interface DbalInterface
      * selects given database
      *
      * @param string|DatabaseName $dbname database name to select
+     * @psalm-param ConnectionType $connectionType
      */
-    public function selectDb($dbname, int $connectionType = DatabaseInterface::CONNECT_USER): bool;
+    public function selectDb($dbname, int $connectionType = Connection::TYPE_USER): bool;
 
     /**
      * Check if there are any more query results from a multi query
+     *
+     * @psalm-param ConnectionType $connectionType
      */
-    public function moreResults(int $connectionType = DatabaseInterface::CONNECT_USER): bool;
+    public function moreResults(int $connectionType = Connection::TYPE_USER): bool;
 
     /**
      * Prepare next result from multi_query
+     *
+     * @psalm-param ConnectionType $connectionType
      */
-    public function nextResult(int $connectionType = DatabaseInterface::CONNECT_USER): bool;
+    public function nextResult(int $connectionType = Connection::TYPE_USER): bool;
 
     /**
      * Store the result returned from multi query
      *
+     * @psalm-param ConnectionType $connectionType
+     *
      * @return mixed false when empty results / result set when not empty
      */
-    public function storeResult(int $connectionType = DatabaseInterface::CONNECT_USER);
+    public function storeResult(int $connectionType = Connection::TYPE_USER);
 
     /**
      * Returns a string representing the type of connection used
      *
+     * @psalm-param ConnectionType $connectionType
+     *
      * @return string|bool type of connection used
      */
-    public function getHostInfo(int $connectionType = DatabaseInterface::CONNECT_USER);
+    public function getHostInfo(int $connectionType = Connection::TYPE_USER);
 
     /**
      * Returns the version of the MySQL protocol used
      *
+     * @psalm-param ConnectionType $connectionType
+     *
      * @return int|bool version of the MySQL protocol used
      */
-    public function getProtoInfo(int $connectionType = DatabaseInterface::CONNECT_USER);
+    public function getProtoInfo(int $connectionType = Connection::TYPE_USER);
 
     /**
      * returns a string that represents the client library version
@@ -507,8 +530,10 @@ interface DbalInterface
 
     /**
      * Returns last error message or an empty string if no errors occurred.
+     *
+     * @psalm-param ConnectionType $connectionType
      */
-    public function getError(int $connectionType = DatabaseInterface::CONNECT_USER): string;
+    public function getError(int $connectionType = Connection::TYPE_USER): string;
 
     /**
      * returns the number of rows returned by last query
@@ -525,19 +550,22 @@ interface DbalInterface
      * returns last inserted auto_increment id for given $link
      * or $GLOBALS['userlink']
      *
+     * @psalm-param ConnectionType $connectionType
+     *
      * @return int
      */
-    public function insertId(int $connectionType = DatabaseInterface::CONNECT_USER);
+    public function insertId(int $connectionType = Connection::TYPE_USER);
 
     /**
      * returns the number of rows affected by last query
      *
      * @param bool $getFromCache whether to retrieve from cache
+     * @psalm-param ConnectionType $connectionType
      *
      * @return int|string
      * @psalm-return int|numeric-string
      */
-    public function affectedRows(int $connectionType = DatabaseInterface::CONNECT_USER, bool $getFromCache = true);
+    public function affectedRows(int $connectionType = Connection::TYPE_USER, bool $getFromCache = true);
 
     /**
      * returns metainfo for fields in $result
@@ -552,12 +580,13 @@ interface DbalInterface
      * Returns properly quoted string for use in MySQL queries.
      *
      * @param string $str string to be quoted
+     * @psalm-param ConnectionType $connectionType
      *
      * @psalm-return non-empty-string
      *
      * @psalm-taint-escape sql
      */
-    public function quoteString(string $str, int $connectionType = DatabaseInterface::CONNECT_USER): string;
+    public function quoteString(string $str, int $connectionType = Connection::TYPE_USER): string;
 
     /**
      * returns properly escaped string for use in MySQL queries
@@ -565,10 +594,11 @@ interface DbalInterface
      * @deprecated Use {@see quoteString()} instead.
      *
      * @param string $str string to be escaped
+     * @psalm-param ConnectionType $connectionType
      *
      * @return string a MySQL escaped string
      */
-    public function escapeString(string $str, int $connectionType = DatabaseInterface::CONNECT_USER): string;
+    public function escapeString(string $str, int $connectionType = Connection::TYPE_USER): string;
 
     /**
      * Returns properly escaped string for use in MySQL LIKE clauses.
@@ -648,8 +678,9 @@ interface DbalInterface
      * Prepare an SQL statement for execution.
      *
      * @param string $query The query, as a string.
+     * @psalm-param ConnectionType $connectionType
      *
      * @return object|false A statement object or false.
      */
-    public function prepare(string $query, int $connectionType = DatabaseInterface::CONNECT_USER);
+    public function prepare(string $query, int $connectionType = Connection::TYPE_USER);
 }

--- a/libraries/classes/Export/TemplateModel.php
+++ b/libraries/classes/Export/TemplateModel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Export;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Dbal\DatabaseName;
 use PhpMyAdmin\Dbal\TableName;
 use PhpMyAdmin\Util;
@@ -38,7 +39,7 @@ final class TemplateModel
             return '';
         }
 
-        return $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
+        return $this->dbi->getError(Connection::TYPE_CONTROL);
     }
 
     public function delete(DatabaseName $db, TableName $table, string $user, int $id): string
@@ -55,7 +56,7 @@ final class TemplateModel
             return '';
         }
 
-        return $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
+        return $this->dbi->getError(Connection::TYPE_CONTROL);
     }
 
     /**
@@ -72,7 +73,7 @@ final class TemplateModel
         );
         $result = $this->dbi->tryQueryAsControlUser($query);
         if ($result === false) {
-            return $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
+            return $this->dbi->getError(Connection::TYPE_CONTROL);
         }
 
         $data = [];
@@ -104,7 +105,7 @@ final class TemplateModel
             return '';
         }
 
-        return $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
+        return $this->dbi->getError(Connection::TYPE_CONTROL);
     }
 
     /**
@@ -121,7 +122,7 @@ final class TemplateModel
         );
         $result = $this->dbi->tryQueryAsControlUser($query);
         if ($result === false) {
-            return $this->dbi->getError(DatabaseInterface::CONNECT_CONTROL);
+            return $this->dbi->getError(Connection::TYPE_CONTROL);
         }
 
         $templates = [];

--- a/libraries/classes/Navigation/Nodes/Node.php
+++ b/libraries/classes/Navigation/Nodes/Node.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Navigation\Nodes;
 
 use PhpMyAdmin\ConfigStorage\Relation;
-use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Util;
 
@@ -634,7 +634,7 @@ class Node
                 . $GLOBALS['dbi']->escapeString($GLOBALS['cfg']['Server']['user']) . "'"
                 . ' GROUP BY `db_name`';
 
-            return $GLOBALS['dbi']->fetchResult($sqlQuery, 'db_name', 'count', DatabaseInterface::CONNECT_CONTROL);
+            return $GLOBALS['dbi']->fetchResult($sqlQuery, 'db_name', 'count', Connection::TYPE_CONTROL);
         }
 
         return null;

--- a/libraries/classes/Navigation/Nodes/NodeDatabase.php
+++ b/libraries/classes/Navigation/Nodes/NodeDatabase.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Navigation\Nodes;
 
-use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
@@ -360,11 +360,11 @@ class NodeDatabase extends Node
             . '.' . Util::backquote($relationParameters->navigationItemsHidingFeature->navigationHiding);
         $sqlQuery = 'SELECT `item_name` FROM ' . $navTable
             . ' WHERE `username`='
-            . $GLOBALS['dbi']->quoteString($relationParameters->user, DatabaseInterface::CONNECT_CONTROL)
+            . $GLOBALS['dbi']->quoteString($relationParameters->user, Connection::TYPE_CONTROL)
             . ' AND `item_type`='
-            . $GLOBALS['dbi']->quoteString($type, DatabaseInterface::CONNECT_CONTROL)
+            . $GLOBALS['dbi']->quoteString($type, Connection::TYPE_CONTROL)
             . ' AND `db_name`='
-            . $GLOBALS['dbi']->quoteString($this->realName, DatabaseInterface::CONNECT_CONTROL);
+            . $GLOBALS['dbi']->quoteString($this->realName, Connection::TYPE_CONTROL);
         $result = $GLOBALS['dbi']->tryQueryAsControlUser($sqlQuery);
         if ($result) {
             return $result->fetchAllColumn();

--- a/libraries/classes/Plugins/Export/ExportCsv.php
+++ b/libraries/classes/Plugins/Export/ExportCsv.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -224,7 +225,7 @@ class ExportCsv extends ExportPlugin
         // Gets the data from the database
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
         $fields_cnt = $result->numFields();

--- a/libraries/classes/Plugins/Export/ExportHtmlword.php
+++ b/libraries/classes/Plugins/Export/ExportHtmlword.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\Database\Triggers;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -203,7 +204,7 @@ class ExportHtmlword extends ExportPlugin
         // Gets the data from the database
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
         $fields_cnt = $result->numFields();

--- a/libraries/classes/Plugins/Export/ExportJson.php
+++ b/libraries/classes/Plugins/Export/ExportJson.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
@@ -238,7 +239,7 @@ class ExportJson extends ExportPlugin
             return false;
         }
 
-        $result = $dbi->query($sqlQuery, DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED);
+        $result = $dbi->query($sqlQuery, Connection::TYPE_USER, DatabaseInterface::QUERY_UNBUFFERED);
         $columns_cnt = $result->numFields();
         $fieldsMeta = $dbi->getFieldsMeta($result);
 

--- a/libraries/classes/Plugins/Export/ExportLatex.php
+++ b/libraries/classes/Plugins/Export/ExportLatex.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -291,7 +292,7 @@ class ExportLatex extends ExportPlugin
 
         $result = $GLOBALS['dbi']->tryQuery(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
 

--- a/libraries/classes/Plugins/Export/ExportMediawiki.php
+++ b/libraries/classes/Plugins/Export/ExportMediawiki.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -309,7 +310,7 @@ class ExportMediawiki extends ExportPlugin
         // Get the table data from the database
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
         $fields_cnt = $result->numFields();

--- a/libraries/classes/Plugins/Export/ExportOds.php
+++ b/libraries/classes/Plugins/Export/ExportOds.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\OpenDocument;
 use PhpMyAdmin\Plugins\ExportPlugin;
@@ -206,7 +207,7 @@ class ExportOds extends ExportPlugin
         // Gets the data from the database
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
         $fields_cnt = $result->numFields();

--- a/libraries/classes/Plugins/Export/ExportOdt.php
+++ b/libraries/classes/Plugins/Export/ExportOdt.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\Database\Triggers;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\OpenDocument;
 use PhpMyAdmin\Plugins\ExportPlugin;
@@ -235,7 +236,7 @@ class ExportOdt extends ExportPlugin
         // Gets the data from the database
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
         $fields_cnt = $result->numFields();

--- a/libraries/classes/Plugins/Export/ExportPhparray.php
+++ b/libraries/classes/Plugins/Export/ExportPhparray.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -165,7 +166,7 @@ class ExportPhparray extends ExportPlugin
 
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
 

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\Database\Events;
 use PhpMyAdmin\Database\Routines;
 use PhpMyAdmin\Database\Triggers;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
@@ -2097,7 +2098,7 @@ class ExportSql extends ExportPlugin
 
         $result = $GLOBALS['dbi']->tryQuery(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
         // a possible error: the table has crashed

--- a/libraries/classes/Plugins/Export/ExportTexytext.php
+++ b/libraries/classes/Plugins/Export/ExportTexytext.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\Database\Triggers;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -183,7 +184,7 @@ class ExportTexytext extends ExportPlugin
         // Gets the data from the database
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
         $fields_cnt = $result->numFields();

--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\Database\Events;
 use PhpMyAdmin\Database\Routines;
 use PhpMyAdmin\Database\Triggers;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -443,7 +444,7 @@ class ExportXml extends ExportPlugin
         if (isset($GLOBALS['xml_export_contents']) && $GLOBALS['xml_export_contents']) {
             $result = $GLOBALS['dbi']->query(
                 $sqlQuery,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 DatabaseInterface::QUERY_UNBUFFERED
             );
 

--- a/libraries/classes/Plugins/Export/ExportYaml.php
+++ b/libraries/classes/Plugins/Export/ExportYaml.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Export;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
@@ -137,7 +138,7 @@ class ExportYaml extends ExportPlugin
         $this->initAlias($aliases, $db_alias, $table_alias);
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
 

--- a/libraries/classes/Plugins/Export/Helpers/Pdf.php
+++ b/libraries/classes/Plugins/Export/Helpers/Pdf.php
@@ -10,6 +10,7 @@ namespace PhpMyAdmin\Plugins\Export\Helpers;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Database\Triggers;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Pdf as PdfLib;
@@ -716,7 +717,7 @@ class Pdf extends PdfLib
          */
         $this->results = $GLOBALS['dbi']->query(
             $query,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
         $this->numFields = $this->results->numFields();
@@ -849,7 +850,7 @@ class Pdf extends PdfLib
 
         $this->results = $GLOBALS['dbi']->query(
             $query,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
         $this->setY($this->tMargin);

--- a/libraries/classes/Plugins/Schema/Pdf/Pdf.php
+++ b/libraries/classes/Plugins/Schema/Pdf/Pdf.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins\Schema\Pdf;
 
 use PhpMyAdmin\ConfigStorage\Relation;
-use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Pdf as PdfLib;
 use PhpMyAdmin\Util;
 
@@ -272,7 +272,7 @@ class Pdf extends PdfLib
             $test_query = 'SELECT * FROM '
                 . Util::backquote($pdfFeature->database) . '.'
                 . Util::backquote($pdfFeature->pdfPages)
-                . ' WHERE db_name = ' . $GLOBALS['dbi']->quoteString($this->db, DatabaseInterface::CONNECT_CONTROL)
+                . ' WHERE db_name = ' . $GLOBALS['dbi']->quoteString($this->db, Connection::TYPE_CONTROL)
                 . ' AND page_nr = ' . $this->pageNumber;
             $test_rs = $GLOBALS['dbi']->queryAsControlUser($test_query);
             $pageDesc = (string) $test_rs->fetchValue('page_descr');

--- a/libraries/classes/RecentFavoriteTable.php
+++ b/libraries/classes/RecentFavoriteTable.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin;
 
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Dbal\Connection;
 
 use function __;
 use function array_key_exists;
@@ -142,7 +143,7 @@ class RecentFavoriteTable
             . ' VALUES (' . $GLOBALS['dbi']->quoteString($username) . ', '
             . $GLOBALS['dbi']->quoteString(json_encode($this->tables)) . ')';
 
-        $success = $GLOBALS['dbi']->tryQuery($sql_query, DatabaseInterface::CONNECT_CONTROL);
+        $success = $GLOBALS['dbi']->tryQuery($sql_query, Connection::TYPE_CONTROL);
 
         if (! $success) {
             $error_msg = '';
@@ -158,7 +159,7 @@ class RecentFavoriteTable
 
             $message = Message::error($error_msg);
             $message->addMessage(
-                Message::rawError($GLOBALS['dbi']->getError(DatabaseInterface::CONNECT_CONTROL)),
+                Message::rawError($GLOBALS['dbi']->getError(Connection::TYPE_CONTROL)),
                 '<br><br>'
             );
 

--- a/libraries/classes/ReplicationGui.php
+++ b/libraries/classes/ReplicationGui.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Query\Utilities;
 
 use function __;
@@ -526,7 +527,7 @@ class ReplicationGui
             );
         } else {
             // Read the current primary position
-            $position = $this->replication->replicaBinLogPrimary(DatabaseInterface::CONNECT_AUXILIARY);
+            $position = $this->replication->replicaBinLogPrimary(Connection::TYPE_AUXILIARY);
 
             if (empty($position)) {
                 $_SESSION['replication']['sr_action_status'] = 'error';
@@ -545,7 +546,7 @@ class ReplicationGui
                         $position,
                         true,
                         false,
-                        DatabaseInterface::CONNECT_USER
+                        Connection::TYPE_USER
                     )
                 ) {
                     $_SESSION['replication']['sr_action_status'] = 'error';
@@ -566,9 +567,9 @@ class ReplicationGui
     public function handleRequestForReplicaServerControl(?string $srReplicaAction, ?string $control): bool
     {
         if ($srReplicaAction === 'reset') {
-            $qStop = $this->replication->replicaControl('STOP', null, DatabaseInterface::CONNECT_USER);
+            $qStop = $this->replication->replicaControl('STOP', null, Connection::TYPE_USER);
             $qReset = $GLOBALS['dbi']->tryQuery('RESET SLAVE;');
-            $qStart = $this->replication->replicaControl('START', null, DatabaseInterface::CONNECT_USER);
+            $qStart = $this->replication->replicaControl('START', null, Connection::TYPE_USER);
 
             return $qStop !== false && $qStop !== -1 && $qReset !== false && $qStart !== false && $qStart !== -1;
         }
@@ -576,7 +577,7 @@ class ReplicationGui
         $qControl = $this->replication->replicaControl(
             $srReplicaAction,
             $control,
-            DatabaseInterface::CONNECT_USER
+            Connection::TYPE_USER
         );
 
         return $qControl !== false && $qControl !== -1;
@@ -584,9 +585,9 @@ class ReplicationGui
 
     public function handleRequestForReplicaSkipError(int $srSkipErrorsCount): bool
     {
-        $qStop = $this->replication->replicaControl('STOP', null, DatabaseInterface::CONNECT_USER);
+        $qStop = $this->replication->replicaControl('STOP', null, Connection::TYPE_USER);
         $qSkip = $GLOBALS['dbi']->tryQuery('SET GLOBAL SQL_SLAVE_SKIP_COUNTER = ' . $srSkipErrorsCount . ';');
-        $qStart = $this->replication->replicaControl('START', null, DatabaseInterface::CONNECT_USER);
+        $qStart = $this->replication->replicaControl('START', null, Connection::TYPE_USER);
 
         return $qStop !== false && $qStop !== -1 && $qSkip !== false && $qStart !== false && $qStart !== -1;
     }

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\Database\Routines;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Dbal\DatabaseName;
 use PhpMyAdmin\Dbal\MysqliResult;
 use PhpMyAdmin\Dbal\ResultInterface;
@@ -590,7 +591,7 @@ class Privileges
 
         $sqlQuery = 'SELECT `usergroup` FROM ' . $userTable
             . " WHERE `username` = '" . $this->dbi->escapeString($username) . "'";
-        $oldUserGroup = $this->dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL);
+        $oldUserGroup = $this->dbi->fetchValue($sqlQuery, 0, Connection::TYPE_CONTROL);
 
         if ($oldUserGroup === false) {
             $updQuery = 'INSERT INTO ' . $userTable . '(`username`, `usergroup`)'
@@ -1550,7 +1551,7 @@ class Privileges
             . '.' . Util::backquote($configurableMenusFeature->userGroups);
         $sqlQuery = 'SELECT COUNT(*) FROM ' . $userGroupTable;
 
-        return (int) $this->dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL);
+        return (int) $this->dbi->fetchValue($sqlQuery, 0, Connection::TYPE_CONTROL);
     }
 
     /**
@@ -1573,7 +1574,7 @@ class Privileges
             . ' WHERE `username` = \'' . $username . '\''
             . ' LIMIT 1';
 
-        $usergroup = $this->dbi->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL);
+        $usergroup = $this->dbi->fetchValue($sqlQuery, 0, Connection::TYPE_CONTROL);
 
         if ($usergroup === false) {
             return null;

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin;
 
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Plugins\Export\ExportSql;
 use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\AlterStatement;
@@ -153,7 +154,7 @@ class Tracker
             $GLOBALS['dbi']->escapeString($tableName)
         );
 
-        $result = $GLOBALS['dbi']->fetchValue($sqlQuery, 0, DatabaseInterface::CONNECT_CONTROL) == 1;
+        $result = $GLOBALS['dbi']->fetchValue($sqlQuery, 0, Connection::TYPE_CONTROL) == 1;
 
         self::$trackingCache[$dbName][$tableName] = $result;
 

--- a/libraries/classes/Transformations.php
+++ b/libraries/classes/Transformations.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin;
 
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Plugins\TransformationsInterface;
 
 use function array_shift;
@@ -327,7 +328,7 @@ class Transformations
          *     input_transformation_options: string
          * }> $result
          */
-        $result = $GLOBALS['dbi']->fetchResult($com_qry, 'column_name', null, DatabaseInterface::CONNECT_CONTROL);
+        $result = $GLOBALS['dbi']->fetchResult($com_qry, 'column_name', null, Connection::TYPE_CONTROL);
 
         foreach ($result as $column => $values) {
             // convert mimetype to new format (f.e. Text_Plain, etc)

--- a/libraries/classes/UserPreferences.php
+++ b/libraries/classes/UserPreferences.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin;
 use PhpMyAdmin\Config\ConfigFile;
 use PhpMyAdmin\Config\Forms\User\UserFormList;
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Dbal\DatabaseName;
 
 use function __;
@@ -101,7 +102,7 @@ class UserPreferences
         $row = $GLOBALS['dbi']->fetchSingleRow(
             $query,
             DatabaseInterface::FETCH_ASSOC,
-            DatabaseInterface::CONNECT_CONTROL
+            Connection::TYPE_CONTROL
         );
         if (! is_array($row) || ! isset($row['config_data']) || ! isset($row['ts'])) {
             return ['config_data' => [], 'mtime' => time(), 'type' => 'db'];
@@ -153,7 +154,7 @@ class UserPreferences
             . $GLOBALS['dbi']->escapeString($relationParameters->user)
             . '\'';
 
-        $has_config = $GLOBALS['dbi']->fetchValue($query, 0, DatabaseInterface::CONNECT_CONTROL);
+        $has_config = $GLOBALS['dbi']->fetchValue($query, 0, Connection::TYPE_CONTROL);
         $config_data = json_encode($config_array);
         if ($has_config) {
             $query = 'UPDATE ' . $query_table
@@ -175,10 +176,10 @@ class UserPreferences
             unset($_SESSION['cache'][$cache_key]['userprefs']);
         }
 
-        if (! $GLOBALS['dbi']->tryQuery($query, DatabaseInterface::CONNECT_CONTROL)) {
+        if (! $GLOBALS['dbi']->tryQuery($query, Connection::TYPE_CONTROL)) {
             $message = Message::error(__('Could not save configuration'));
             $message->addMessage(
-                Message::error($GLOBALS['dbi']->getError(DatabaseInterface::CONNECT_CONTROL)),
+                Message::error($GLOBALS['dbi']->getError(Connection::TYPE_CONTROL)),
                 '<br><br>'
             );
             if (! $this->hasAccessToDatabase($relationParameters->db)) {
@@ -211,7 +212,7 @@ class UserPreferences
                 );
         }
 
-        return (bool) $GLOBALS['dbi']->fetchSingleRow($query, 'ASSOC', DatabaseInterface::CONNECT_CONTROL);
+        return (bool) $GLOBALS['dbi']->fetchSingleRow($query, 'ASSOC', Connection::TYPE_CONTROL);
     }
 
     /**

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -6,7 +6,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\Settings;
-use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 
 use function array_merge;
 use function array_replace_recursive;
@@ -38,6 +38,7 @@ use const PHP_OS;
 
 /**
  * @covers \PhpMyAdmin\Config
+ * @psalm-import-type ConnectionType from Connection
  */
 class ConfigTest extends AbstractTestCase
 {
@@ -1201,9 +1202,9 @@ class ConfigTest extends AbstractTestCase
      * Test for getConnectionParams
      *
      * @param array      $server_cfg Server configuration
-     * @param int        $mode       Mode to test
      * @param array|null $server     Server array to test
      * @param array      $expected   Expected result
+     * @psalm-param ConnectionType $mode
      *
      * @dataProvider connectionParams
      */
@@ -1251,7 +1252,7 @@ class ConfigTest extends AbstractTestCase
         return [
             [
                 $cfg_basic,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 null,
                 [
                     'u',
@@ -1272,7 +1273,7 @@ class ConfigTest extends AbstractTestCase
             ],
             [
                 $cfg_basic,
-                DatabaseInterface::CONNECT_CONTROL,
+                Connection::TYPE_CONTROL,
                 null,
                 [
                     'u2',
@@ -1289,7 +1290,7 @@ class ConfigTest extends AbstractTestCase
             ],
             [
                 $cfg_ssl,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 null,
                 [
                     'u',
@@ -1310,7 +1311,7 @@ class ConfigTest extends AbstractTestCase
             ],
             [
                 $cfg_ssl,
-                DatabaseInterface::CONNECT_CONTROL,
+                Connection::TYPE_CONTROL,
                 null,
                 [
                     'u2',
@@ -1327,7 +1328,7 @@ class ConfigTest extends AbstractTestCase
             ],
             [
                 $cfg_control_ssl,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 null,
                 [
                     'u',
@@ -1349,7 +1350,7 @@ class ConfigTest extends AbstractTestCase
             ],
             [
                 $cfg_control_ssl,
-                DatabaseInterface::CONNECT_CONTROL,
+                Connection::TYPE_CONTROL,
                 null,
                 [
                     'u2',

--- a/test/classes/Controllers/Server/VariablesControllerTest.php
+++ b/test/classes/Controllers/Server/VariablesControllerTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests\Controllers\Server;
 
 use PhpMyAdmin\Controllers\Server\VariablesController;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Providers\ServerVariables\ServerVariablesProvider;
@@ -64,14 +65,14 @@ class VariablesControllerTest extends AbstractTestCase
                 'SHOW SESSION VARIABLES;',
                 0,
                 1,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 $serverSessionVariables,
             ],
             [
                 'SHOW GLOBAL VARIABLES;',
                 0,
                 1,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 $serverGlobalVariables,
             ],
         ];

--- a/test/classes/Database/CentralColumnsTest.php
+++ b/test/classes/Database/CentralColumnsTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests\Database;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\Database\CentralColumns;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Types;
 
@@ -210,7 +211,7 @@ class CentralColumnsTest extends AbstractTestCase
                 'SELECT count(db_name) FROM `pma_central_columns` WHERE db_name = \'phpmyadmin\';',
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will(
                 $this->returnValue([3])
@@ -275,7 +276,7 @@ class CentralColumnsTest extends AbstractTestCase
                 . "WHERE db_name = 'PMA_db' AND col_name IN ('id','col1','col2');",
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will(
                 $this->returnValue(['id', 'col1'])
@@ -307,7 +308,7 @@ class CentralColumnsTest extends AbstractTestCase
                 . "WHERE db_name = 'PMA_db' AND col_name IN ('id','col1','col2');",
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will(
                 $this->returnValue(array_slice($this->columnData, 0, 2))
@@ -413,7 +414,7 @@ class CentralColumnsTest extends AbstractTestCase
                 . "WHERE db_name = 'phpmyadmin' AND col_name IN ('col1','col2');",
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will(
                 $this->returnValue($this->columnData)
@@ -460,7 +461,7 @@ class CentralColumnsTest extends AbstractTestCase
                 'SELECT * FROM `pma_central_columns` WHERE db_name = \'phpmyadmin\';',
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will(
                 $this->returnValue($this->columnData)
@@ -487,7 +488,7 @@ class CentralColumnsTest extends AbstractTestCase
                 . "NOT IN ('id','col1','col2');",
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will(
                 $this->returnValue($this->columnData)
@@ -512,7 +513,7 @@ class CentralColumnsTest extends AbstractTestCase
                 'SELECT * FROM `pma_central_columns` WHERE db_name = \'phpmyadmin\' AND col_name IN (\'col1\');',
                 null,
                 null,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will(
                 $this->returnValue(array_slice($this->columnData, 1, 1))

--- a/test/classes/Database/Designer/CommonTest.php
+++ b/test/classes/Database/Designer/CommonTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\Database\Designer\Common;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
@@ -79,7 +80,7 @@ class CommonTest extends AbstractTestCase
             WHERE pdf_page_number = " . $pg,
                 'name',
                 null,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             );
         $GLOBALS['dbi'] = $dbi;
 
@@ -108,7 +109,7 @@ class CommonTest extends AbstractTestCase
                 'SELECT `page_descr` FROM `pmadb`.`pdf_pages`'
                 . ' WHERE `page_nr` = ' . $pg,
                 0,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will($this->returnValue($pageName));
         $GLOBALS['dbi'] = $dbi;
@@ -166,7 +167,7 @@ class CommonTest extends AbstractTestCase
                 . " WHERE `db_name` = '" . $db . "'"
                 . " AND `page_descr` = '" . $db . "'",
                 0,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will($this->returnValue($default_pg));
         $dbi->expects($this->any())->method('escapeString')
@@ -197,7 +198,7 @@ class CommonTest extends AbstractTestCase
                 . " WHERE `db_name` = '" . $db . "'"
                 . " AND `page_descr` = '" . $db . "'",
                 0,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will($this->returnValue(false));
         $dbi->expects($this->any())->method('escapeString')
@@ -229,7 +230,7 @@ class CommonTest extends AbstractTestCase
                 . " WHERE `db_name` = '" . $db . "'"
                 . " AND `page_descr` = '" . $db . "'",
                 0,
-                DatabaseInterface::CONNECT_CONTROL
+                Connection::TYPE_CONTROL
             )
             ->will($this->returnValue($default_pg));
         $dbi->expects($this->any())->method('escapeString')

--- a/test/classes/Database/RoutinesTest.php
+++ b/test/classes/Database/RoutinesTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests\Database;
 
 use PhpMyAdmin\Database\Routines;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -1153,17 +1154,17 @@ class RoutinesTest extends AbstractTestCase
                     [
                         [
                             'foo',
-                            DatabaseInterface::CONNECT_USER,
+                            Connection::TYPE_USER,
                             'foo',
                         ],
                         [
                             "foo's bar",
-                            DatabaseInterface::CONNECT_USER,
+                            Connection::TYPE_USER,
                             "foo\'s bar",
                         ],
                         [
                             '',
-                            DatabaseInterface::CONNECT_USER,
+                            Connection::TYPE_USER,
                             '',
                         ],
                     ]

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests;
 use mysqli_stmt;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Dbal\DbiExtension;
 use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\LanguageManager;
@@ -787,7 +788,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
         $databaseList = $dbi->getDatabasesFull(
             null,
             true,
-            DatabaseInterface::CONNECT_USER,
+            Connection::TYPE_USER,
             'SCHEMA_DATA_LENGTH',
             'ASC',
             0,
@@ -831,7 +832,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
             ->with($this->isType('object'), $this->equalTo($query))
             ->willReturn($stmtStub);
         $dbi = $this->createDatabaseInterface($dummyDbi);
-        $stmt = $dbi->prepare($query, DatabaseInterface::CONNECT_CONTROL);
+        $stmt = $dbi->prepare($query, Connection::TYPE_CONTROL);
         $this->assertSame($stmtStub, $stmt);
     }
 

--- a/test/classes/NormalizationTest.php
+++ b/test/classes/NormalizationTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Normalization;
 use PhpMyAdmin\Template;
@@ -82,13 +83,13 @@ class NormalizationTest extends AbstractTestCase
             [
                 'PMA_db',
                 'PMA_table1',
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [],
             ],
             [
                 'PMA_db',
                 'PMA_table',
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [
                     [
                         'Key_name' => 'PRIMARY',
@@ -99,7 +100,7 @@ class NormalizationTest extends AbstractTestCase
             [
                 'PMA_db',
                 'PMA_table2',
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [
                     [
                         'Key_name' => 'PRIMARY',

--- a/test/classes/Plugins/Export/ExportOdsTest.php
+++ b/test/classes/Plugins/Export/ExportOdsTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests\Plugins\Export;
 
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Export;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\Export\ExportOds;
@@ -250,7 +251,7 @@ class ExportOdsTest extends AbstractTestCase
 
         $dbi->expects($this->once())
             ->method('query')
-            ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
+            ->with('SELECT', Connection::TYPE_USER, DatabaseInterface::QUERY_UNBUFFERED)
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())
@@ -334,7 +335,7 @@ class ExportOdsTest extends AbstractTestCase
 
         $dbi->expects($this->once())
             ->method('query')
-            ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
+            ->with('SELECT', Connection::TYPE_USER, DatabaseInterface::QUERY_UNBUFFERED)
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())
@@ -386,7 +387,7 @@ class ExportOdsTest extends AbstractTestCase
 
         $dbi->expects($this->once())
             ->method('query')
-            ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
+            ->with('SELECT', Connection::TYPE_USER, DatabaseInterface::QUERY_UNBUFFERED)
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests\Plugins\Export;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Export;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\Export\ExportOdt;
@@ -379,7 +380,7 @@ class ExportOdtTest extends AbstractTestCase
 
         $dbi->expects($this->once())
             ->method('query')
-            ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
+            ->with('SELECT', Connection::TYPE_USER, DatabaseInterface::QUERY_UNBUFFERED)
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())
@@ -453,7 +454,7 @@ class ExportOdtTest extends AbstractTestCase
 
         $dbi->expects($this->once())
             ->method('query')
-            ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
+            ->with('SELECT', Connection::TYPE_USER, DatabaseInterface::QUERY_UNBUFFERED)
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())
@@ -505,7 +506,7 @@ class ExportOdtTest extends AbstractTestCase
 
         $dbi->expects($this->once())
             ->method('query')
-            ->with('SELECT', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
+            ->with('SELECT', Connection::TYPE_USER, DatabaseInterface::QUERY_UNBUFFERED)
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests\Plugins\Export;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Export;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\Export\ExportSql;
@@ -575,8 +576,8 @@ class ExportSqlTest extends AbstractTestCase
         $dbi->expects($this->exactly(2))
             ->method('fetchValue')
             ->will($this->returnValueMap([
-                ['SHOW CREATE EVENT `db`.`f1`', 'Create Event', DatabaseInterface::CONNECT_USER, 'f1event'],
-                ['SHOW CREATE EVENT `db`.`f2`', 'Create Event', DatabaseInterface::CONNECT_USER, 'f2event'],
+                ['SHOW CREATE EVENT `db`.`f1`', 'Create Event', Connection::TYPE_USER, 'f1event'],
+                ['SHOW CREATE EVENT `db`.`f2`', 'Create Event', Connection::TYPE_USER, 'f2event'],
             ]));
         $dbi->expects($this->any())->method('quoteString')
             ->will($this->returnCallback(static function (string $string) {
@@ -1168,7 +1169,7 @@ class ExportSqlTest extends AbstractTestCase
 
         $dbi->expects($this->once())
             ->method('tryQuery')
-            ->with('SELECT a FROM b WHERE 1', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
+            ->with('SELECT a FROM b WHERE 1', Connection::TYPE_USER, DatabaseInterface::QUERY_UNBUFFERED)
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())
@@ -1276,7 +1277,7 @@ class ExportSqlTest extends AbstractTestCase
 
         $dbi->expects($this->once())
             ->method('tryQuery')
-            ->with('SELECT a FROM b WHERE 1', DatabaseInterface::CONNECT_USER, DatabaseInterface::QUERY_UNBUFFERED)
+            ->with('SELECT a FROM b WHERE 1', Connection::TYPE_USER, DatabaseInterface::QUERY_UNBUFFERED)
             ->will($this->returnValue($resultStub));
 
         $resultStub->expects($this->once())

--- a/test/classes/TableTest.php
+++ b/test/classes/TableTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Index;
 use PhpMyAdmin\ListDatabase;
 use PhpMyAdmin\Query\Cache;
@@ -77,7 +78,7 @@ class TableTest extends AbstractTestCase
                 $sql_analyzeStructure_true,
                 null,
                 null,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [
                     [
                         'COLUMN_NAME' => 'COLUMN_NAME',
@@ -92,7 +93,7 @@ class TableTest extends AbstractTestCase
                     null,
                 ],
                 'Column_name',
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [
                     ['index1'],
                     ['index3'],
@@ -103,7 +104,7 @@ class TableTest extends AbstractTestCase
                 $getUniqueColumns_sql,
                 'Column_name',
                 'Column_name',
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [
                     'column1',
                     'column3',
@@ -117,7 +118,7 @@ class TableTest extends AbstractTestCase
                 'SHOW COLUMNS FROM `PMA`.`PMA_BookMark`',
                 'Field',
                 'Field',
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [
                     'column1',
                     'column3',
@@ -131,7 +132,7 @@ class TableTest extends AbstractTestCase
                 'SHOW COLUMNS FROM `PMA`.`PMA_BookMark`',
                 null,
                 null,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [
                     [
                         'Field' => 'COLUMN_NAME1',
@@ -155,7 +156,7 @@ class TableTest extends AbstractTestCase
                 'SHOW TRIGGERS FROM `PMA` LIKE \'PMA_BookMark\';',
                 null,
                 null,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [
                     [
                         'Trigger' => 'name1',
@@ -187,7 +188,7 @@ class TableTest extends AbstractTestCase
                 'SHOW TRIGGERS FROM `PMA` LIKE \'PMA_.BookMark\';',
                 null,
                 null,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [
                     [
                         'Trigger' => 'name1',
@@ -221,31 +222,31 @@ class TableTest extends AbstractTestCase
             [
                 $sql_isView_true,
                 0,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 ['PMA_BookMark'],
             ],
             [
                 $sql_copy_data,
                 0,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [],
             ],
             [
                 $sql_isView_false,
                 0,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [],
             ],
             [
                 $sql_isUpdatableView_true,
                 0,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 ['PMA_BookMark'],
             ],
             [
                 $sql_isUpdatableView_false,
                 0,
-                DatabaseInterface::CONNECT_USER,
+                Connection::TYPE_USER,
                 [],
             ],
         ];

--- a/test/classes/TrackerTest.php
+++ b/test/classes/TrackerTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests;
 use PhpMyAdmin\Cache;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Tracker;
 use PhpMyAdmin\Util;
@@ -506,17 +507,17 @@ class TrackerTest extends AbstractTestCase
                     [
                         [
                             "pma'db",
-                            DatabaseInterface::CONNECT_USER,
+                            Connection::TYPE_USER,
                             "pma\'db",
                         ],
                         [
                             "pma'table",
-                            DatabaseInterface::CONNECT_USER,
+                            Connection::TYPE_USER,
                             "pma\'table",
                         ],
                         [
                             '1.0',
-                            DatabaseInterface::CONNECT_USER,
+                            Connection::TYPE_USER,
                             '1.0',
                         ],
                     ]

--- a/test/classes/UserPreferencesTest.php
+++ b/test/classes/UserPreferencesTest.php
@@ -7,6 +7,7 @@ namespace PhpMyAdmin\Tests;
 use PhpMyAdmin\Config\ConfigFile;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\UserPreferences;
@@ -106,7 +107,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
 
         $dbi->expects($this->once())
             ->method('fetchSingleRow')
-            ->with($query, DatabaseInterface::FETCH_ASSOC, DatabaseInterface::CONNECT_CONTROL)
+            ->with($query, DatabaseInterface::FETCH_ASSOC, Connection::TYPE_CONTROL)
             ->will(
                 $this->returnValue(
                     [
@@ -195,12 +196,12 @@ class UserPreferencesTest extends AbstractNetworkTestCase
 
         $dbi->expects($this->once())
             ->method('fetchValue')
-            ->with($query1, 0, DatabaseInterface::CONNECT_CONTROL)
+            ->with($query1, 0, Connection::TYPE_CONTROL)
             ->will($this->returnValue(true));
 
         $dbi->expects($this->once())
             ->method('tryQuery')
-            ->with($query2, DatabaseInterface::CONNECT_CONTROL)
+            ->with($query2, Connection::TYPE_CONTROL)
             ->will($this->returnValue(true));
 
         $dbi->expects($this->any())
@@ -226,17 +227,17 @@ class UserPreferencesTest extends AbstractNetworkTestCase
 
         $dbi->expects($this->once())
             ->method('fetchValue')
-            ->with($query1, 0, DatabaseInterface::CONNECT_CONTROL)
+            ->with($query1, 0, Connection::TYPE_CONTROL)
             ->will($this->returnValue(false));
 
         $dbi->expects($this->once())
             ->method('tryQuery')
-            ->with($query2, DatabaseInterface::CONNECT_CONTROL)
+            ->with($query2, Connection::TYPE_CONTROL)
             ->will($this->returnValue(false));
 
         $dbi->expects($this->once())
             ->method('getError')
-            ->with(DatabaseInterface::CONNECT_CONTROL)
+            ->with(Connection::TYPE_CONTROL)
             ->will($this->returnValue('err1'));
         $dbi->expects($this->any())
             ->method('escapeString')


### PR DESCRIPTION
Moves the `DatabaseInterface::CONNECT_USER`, `DatabaseInterface::CONNECT_CONTROL` and `DatabaseInterface::CONNECT_AUXILIARY` class constants to `Dbal\Connection::TYPE_USER`, `Dbal\Connection::TYPE_CONTROL` and `Dbal\Connection::TYPE_AUXILIARY` respectively.