### PR TITLE
Fix inverted logic hide serverlist

### DIFF
--- a/libraries/classes/Controllers/HomeController.php
+++ b/libraries/classes/Controllers/HomeController.php
@@ -108,9 +108,13 @@ class HomeController extends AbstractController
         $hasServer = $server > 0 || count($cfg['Servers']) > 1;
         if ($hasServer) {
             $hasServerSelection = $cfg['ServerDefault'] == 0
-                || (! $cfg['NavigationDisplayServers']
-                && (count($cfg['Servers']) > 1
-                || ($server == 0 && count($cfg['Servers']) === 1)));
+                || (
+                    ! $cfg['NavigationDisplayServers']
+                    && (
+                        count($cfg['Servers']) > 1
+                        || ($server == 0 && count($cfg['Servers']) === 1)
+                    )
+                );
             if ($hasServerSelection) {
                 $serverSelection = Select::render(true, true);
             }

--- a/libraries/classes/Controllers/HomeController.php
+++ b/libraries/classes/Controllers/HomeController.php
@@ -109,7 +109,7 @@ class HomeController extends AbstractController
         if ($hasServer) {
             $hasServerSelection = $cfg['ServerDefault'] == 0
                 || (
-                    ! $cfg['NavigationDisplayServers']
+                    $cfg['NavigationDisplayServers']
                     && (
                         count($cfg['Servers']) > 1
                         || ($server == 0 && count($cfg['Servers']) === 1)


### PR DESCRIPTION
### Description

I may be misunderstanding something, but I have this setup with multiple servers where I want to hide the server list from any page.

I set `NavigationDisplayServers` to `false` and that hid the list from the side panel, but amusingly it appeared in the home.




-------------
Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
  - I mean… I have tried to reflow the code in a separate commit, if you don't like it I can just drop that part
- [x] Any new functionality is covered by tests.
