### PR TITLE
Fix #17365 - Fix regexp too big error

### DIFF
--- a/js/src/server/status/variables.js
+++ b/js/src/server/status/variables.js
@@ -43,7 +43,7 @@ AJAX.registerOnload('server/status/variables.js', function () {
 
     $('#filterText').on('keyup', function () {
         var word = $(this).val().replace(/_/g, ' ');
-        if (word.length === 0) {
+        if (word.length === 0 || word.length >= 32768) {
             textFilter = null;
         } else {
             try {


### PR DESCRIPTION
### Description

This PR fixes the regexp too big error message. The biggest regex it can take is 2^15, 32768. If it exceeds this length, the text filter will be reset.

https://user-images.githubusercontent.com/25424343/213919216-823e0481-b13d-4f8a-8b98-274ef0e82c92.mp4

Fixes #17365

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
