### PR TITLE
Remove dead code

### DIFF
--- a/libraries/classes/Controllers/Table/DeleteRowsController.php
+++ b/libraries/classes/Controllers/Table/DeleteRowsController.php
@@ -43,7 +43,6 @@ final class DeleteRowsController extends AbstractController
         $GLOBALS['active_page'] = $GLOBALS['active_page'] ?? null;
 
         $mult_btn = $_POST['mult_btn'] ?? '';
-        $original_sql_query = $_POST['original_sql_query'] ?? '';
         $selected = $_POST['selected'] ?? [];
 
         $relation = new Relation($this->dbi);
@@ -81,11 +80,8 @@ final class DeleteRowsController extends AbstractController
             $GLOBALS['disp_query'] = $GLOBALS['sql_query'];
         }
 
-        $_url_params = $GLOBALS['urlParams'];
-        $_url_params['goto'] = Url::getFromRoute('/table/sql');
-
-        if (isset($original_sql_query)) {
-            $GLOBALS['sql_query'] = $original_sql_query;
+        if ($request->hasBodyParam('original_sql_query')) {
+            $GLOBALS['sql_query'] = $request->getParsedBodyParam('original_sql_query', '');
         }
 
         $GLOBALS['active_page'] = Url::getFromRoute('/sql');

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -147,14 +147,12 @@ final class GisVisualizationController extends AbstractController
         }
 
         $this->visualization->setUserSpecifiedSettings($visualizationSettings);
-        if ($visualizationSettings != null) {
-            foreach ($this->visualization->getSettings() as $setting => $val) {
-                if (isset($visualizationSettings[$setting])) {
-                    continue;
-                }
-
-                $visualizationSettings[$setting] = $val;
+        foreach ($this->visualization->getSettings() as $setting => $val) {
+            if (isset($visualizationSettings[$setting])) {
+                continue;
             }
+
+            $visualizationSettings[$setting] = $val;
         }
 
         /**

--- a/libraries/classes/Controllers/View/CreateController.php
+++ b/libraries/classes/Controllers/View/CreateController.php
@@ -24,7 +24,6 @@ use function array_merge;
 use function explode;
 use function htmlspecialchars;
 use function in_array;
-use function is_string;
 use function sprintf;
 use function str_contains;
 use function substr;
@@ -270,7 +269,7 @@ class CreateController extends AbstractController
             $GLOBALS['view']['algorithm'] = $GLOBALS['item']['ALGORITHM'];
 
             // MySQL 8.0+ - issue #16194
-            if (empty($GLOBALS['view']['as']) && is_string($createView)) {
+            if (empty($GLOBALS['view']['as'])) {
                 $parser = new Parser($createView);
                 /**
                  * @var CreateStatement $stmt

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3246,7 +3246,7 @@ class Results
         // The value can also be from _GET as described on issue #16146 when sorting results
         $sessionMaxRows = $_GET['session_max_rows'] ?? $_POST['session_max_rows'] ?? '';
 
-        if (isset($sessionMaxRows) && is_numeric($sessionMaxRows)) {
+        if (is_numeric($sessionMaxRows)) {
             $query['max_rows'] = (int) $sessionMaxRows;
             unset($_GET['session_max_rows'], $_POST['session_max_rows']);
         } elseif ($sessionMaxRows === self::ALL_ROWS) {

--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -139,7 +139,7 @@ final class SimulateDml
             $diff[] = $set->column . $notEqualOperator . $set->value;
         }
 
-        if (! empty($diff)) {
+        if ($diff !== []) {
             $where .= ' AND (' . implode(' OR ', $diff) . ')';
         }
 

--- a/libraries/classes/Plugins/Auth/AuthenticationHttp.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationHttp.php
@@ -180,12 +180,12 @@ class AuthenticationHttp extends AuthenticationPlugin
 
         // User logged out -> ensure the new username is not the same
         $old_usr = $_REQUEST['old_usr'] ?? '';
-        if (! empty($old_usr) && (isset($this->user) && hash_equals($old_usr, $this->user))) {
+        if (! empty($old_usr) && hash_equals($old_usr, $this->user)) {
             $this->user = '';
         }
 
         // Returns whether we get authentication settings or not
-        return ! empty($this->user);
+        return $this->user !== '';
     }
 
     /**

--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -10,7 +10,6 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function array_keys;
-use function count;
 use function mb_strtolower;
 use function strlen;
 use function ucfirst;
@@ -144,8 +143,6 @@ final class Processes
             'order_by_field' => 'Info',
         ];
 
-        $sortableColCount = count($sortableColumns);
-
         $columns = [];
         foreach ($sortableColumns as $columnKey => $column) {
             $is_sorted = $orderByField !== ''
@@ -169,10 +166,6 @@ final class Processes
                 'has_full_query' => false,
                 'is_full' => false,
             ];
-
-            if (0 !== --$sortableColCount) {
-                continue;
-            }
 
             $columns[$columnKey]['has_full_query'] = true;
             if (! $showFullSql) {

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -2540,12 +2540,10 @@ class Table implements Stringable
 
     /**
      * Returns the CREATE statement for this table
-     *
-     * @return mixed
      */
-    public function showCreate()
+    public function showCreate(): string
     {
-        return $this->dbi->fetchValue(
+        return (string) $this->dbi->fetchValue(
             'SHOW CREATE TABLE ' . Util::backquote($this->dbName) . '.'
             . Util::backquote($this->name),
             1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -936,11 +936,6 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Parameter \\#1 \\$list of class PhpMyAdmin\\\\SqlParser\\\\Parser constructor expects PhpMyAdmin\\\\SqlParser\\\\TokensList\\|PhpMyAdmin\\\\SqlParser\\\\UtfString\\|string\\|null, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
 			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(string\\|null, string\\|null\\)\\: int, 'strnatcasecmp' given\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
@@ -1244,11 +1239,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/Structure/ReplacePrefixController.php
-
-		-
-			message: "#^Parameter \\#1 \\$buffer of static method PhpMyAdmin\\\\Core\\:\\:mimeDefaultFunction\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/Structure/ShowCreateController.php
 
 		-
 			message: "#^Parameter \\#1 \\$selected of method PhpMyAdmin\\\\Controllers\\\\Database\\\\Structure\\\\ShowCreateController\\:\\:getShowCreateTables\\(\\) expects array\\<string\\>, mixed given\\.$#"
@@ -2036,11 +2026,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/Structure/PartitioningController.php
 
 		-
-			message: "#^Parameter \\#1 \\$list of class PhpMyAdmin\\\\SqlParser\\\\Parser constructor expects PhpMyAdmin\\\\SqlParser\\\\TokensList\\|PhpMyAdmin\\\\SqlParser\\\\UtfString\\|string\\|null, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/PartitioningController.php
-
-		-
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\PartitionDefinition\\>\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/Structure/PartitioningController.php
@@ -2197,11 +2182,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var for variable \\$view has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/View/CreateController.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function substr expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/View/CreateController.php
 
@@ -5726,11 +5706,6 @@ parameters:
 			path: libraries/classes/Plugins/Auth/AuthenticationCookie.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\Plugins\\\\AuthenticationPlugin\\:\\:\\$user \\(string\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Auth/AuthenticationHttp.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Auth\\\\AuthenticationSignon\\:\\:setCookieParams\\(\\) has parameter \\$sessionCookieParams with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Auth/AuthenticationSignon.php
@@ -8252,11 +8227,6 @@ parameters:
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
-			count: 1
-			path: libraries/classes/Table.php
-
-		-
-			message: "#^Parameter \\#1 \\$list of class PhpMyAdmin\\\\SqlParser\\\\Parser constructor expects PhpMyAdmin\\\\SqlParser\\\\TokensList\\|PhpMyAdmin\\\\SqlParser\\\\UtfString\\|string\\|null, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Table.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -768,7 +768,7 @@
     </InvalidArgument>
     <InvalidReturnStatement occurrences="1"/>
     <InvalidReturnType occurrences="1"/>
-    <MixedArgument occurrences="18">
+    <MixedArgument occurrences="17">
       <code>$_SESSION['sql_history']</code>
       <code>$_SESSION['sql_history']</code>
       <code>$_SESSION['sql_history']</code>
@@ -785,7 +785,6 @@
       <code>$foreign_table</code>
       <code>$foreign_table</code>
       <code>$one_key['index_list']</code>
-      <code>$show_create_table</code>
       <code>$tableNameReplacements[$tableName]</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
@@ -818,7 +817,7 @@
       <code>$foreign[$key]</code>
       <code>$one_key['ref_index_list'][$column_index]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="25">
+    <MixedAssignment occurrences="24">
       <code>$child_references</code>
       <code>$column</code>
       <code>$columns</code>
@@ -840,7 +839,6 @@
       <code>$key</code>
       <code>$one_key</code>
       <code>$relations</code>
-      <code>$show_create_table</code>
       <code>$the_total</code>
       <code>$value</code>
       <code>$value</code>
@@ -1621,8 +1619,7 @@
     </RedundantCast>
   </file>
   <file src="libraries/classes/Controllers/Database/Structure/ShowCreateController.php">
-    <MixedArgument occurrences="2">
-      <code>$object-&gt;showCreate()</code>
+    <MixedArgument occurrences="1">
       <code>$selected</code>
     </MixedArgument>
     <MixedAssignment occurrences="1">
@@ -3122,32 +3119,25 @@
     <InvalidArgument occurrences="1">
       <code>$_REQUEST['pos']</code>
     </InvalidArgument>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="4">
       <code>$GLOBALS['disp_message'] ?? null</code>
       <code>$GLOBALS['disp_query'] ?? null</code>
+      <code>$GLOBALS['sql_query']</code>
       <code>$row</code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="5">
       <code>$GLOBALS['active_page']</code>
       <code>$GLOBALS['disp_message']</code>
       <code>$GLOBALS['disp_query']</code>
+      <code>$GLOBALS['sql_query']</code>
       <code>$row</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$GLOBALS['sql_query']</code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="1">
-      <code>$GLOBALS['sql_query']</code>
-    </PossiblyInvalidCast>
     <PossiblyInvalidIterator occurrences="1">
       <code>$selected</code>
     </PossiblyInvalidIterator>
     <PossiblyNullArgument occurrences="1">
       <code>$GLOBALS['goto']</code>
     </PossiblyNullArgument>
-    <RedundantCondition occurrences="1">
-      <code>isset($original_sql_query)</code>
-    </RedundantCondition>
   </file>
   <file src="libraries/classes/Controllers/Table/DropColumnController.php">
     <MixedArgument occurrences="3">
@@ -3741,12 +3731,6 @@
     </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/PartitioningController.php">
-    <MixedArgument occurrences="1">
-      <code>$createTable</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$createTable</code>
-    </MixedAssignment>
     <PossiblyNullArgument occurrences="2">
       <code>$stmt-&gt;partitions</code>
       <code>$stmt-&gt;partitions[0]-&gt;subpartitions</code>
@@ -4096,8 +4080,7 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$GLOBALS['view']['as']</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="8">
-      <code>$createView</code>
+    <MixedArgument occurrences="7">
       <code>$view['as']</code>
       <code>$view['column_names']</code>
       <code>$view['definer']</code>
@@ -4106,7 +4089,7 @@
       <code>$view['name']</code>
       <code>$view['name']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="20">
+    <MixedAssignment occurrences="19">
       <code>$GLOBALS['arr']</code>
       <code>$GLOBALS['column_map']</code>
       <code>$GLOBALS['item']</code>
@@ -4126,7 +4109,6 @@
       <code>$GLOBALS['view_columns']</code>
       <code>$GLOBALS['view_security_options']</code>
       <code>$GLOBALS['view_with_options']</code>
-      <code>$createView</code>
     </MixedAssignment>
     <MixedOperand occurrences="5">
       <code>$view['algorithm']</code>
@@ -4147,10 +4129,6 @@
       <code>$_GET['table']</code>
       <code>$_GET['table']</code>
     </PossiblyInvalidCast>
-    <RedundantCondition occurrences="2">
-      <code>empty($GLOBALS['view']['as']) &amp;&amp; is_string($createView)</code>
-      <code>is_string($createView)</code>
-    </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>isset($stmt-&gt;body)</code>
     </RedundantConditionGivenDocblockType>
@@ -6031,9 +6009,8 @@
       <code>(int) $GLOBALS['cfg']['LimitChars']</code>
       <code>(int) $GLOBALS['cfg']['LimitChars']</code>
     </RedundantCast>
-    <RedundantCondition occurrences="2">
+    <RedundantCondition occurrences="1">
       <code>empty($statementInfo-&gt;statement-&gt;from)</code>
-      <code>isset($sessionMaxRows)</code>
     </RedundantCondition>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>isset($meta-&gt;internalMediaType)</code>
@@ -7562,8 +7539,9 @@
     <PossiblyNullIterator occurrences="1">
       <code>$statement-&gt;set</code>
     </PossiblyNullIterator>
-    <RedundantCondition occurrences="1">
-      <code>empty($diff)</code>
+    <RedundantCondition occurrences="2">
+      <code>$diff !== []</code>
+      <code>$diff !== []</code>
     </RedundantCondition>
   </file>
   <file src="libraries/classes/Index.php">
@@ -9013,9 +8991,6 @@
     <PossiblyInvalidCast occurrences="1">
       <code>$old_usr</code>
     </PossiblyInvalidCast>
-    <RedundantCondition occurrences="1">
-      <code>isset($this-&gt;user)</code>
-    </RedundantCondition>
   </file>
   <file src="libraries/classes/Plugins/Auth/AuthenticationSignon.php">
     <MixedArgument occurrences="6">
@@ -12546,11 +12521,6 @@
       <code>$row['#']</code>
     </PossiblyNullOperand>
   </file>
-  <file src="libraries/classes/Server/Status/Processes.php">
-    <RedundantCondition occurrences="1">
-      <code>0 !== --$sortableColCount</code>
-    </RedundantCondition>
-  </file>
   <file src="libraries/classes/Session.php">
     <MixedArgument occurrences="3">
       <code>$config-&gt;getCookie('phpMyAdmin')</code>
@@ -12883,7 +12853,7 @@
     <InvalidReturnStatement occurrences="1">
       <code>$tableAutoIncrement ?? ''</code>
     </InvalidReturnStatement>
-    <MixedArgument occurrences="49">
+    <MixedArgument occurrences="48">
       <code>$GLOBALS['sql_auto_increments']</code>
       <code>$GLOBALS['sql_indexes']</code>
       <code>$_POST['constraint_name'][$masterFieldMd5]</code>
@@ -12894,7 +12864,6 @@
       <code>$column['Extra']</code>
       <code>$column['Extra']</code>
       <code>$column['Extra']</code>
-      <code>$createTable</code>
       <code>$eachCol</code>
       <code>$eachCol</code>
       <code>$existrelForeign[$masterFieldMd5]['constraint']</code>
@@ -13002,7 +12971,7 @@
       <code>$optionsArray[$existrelForeign[$masterFieldMd5]['on_delete'] ?? '']</code>
       <code>$optionsArray[$existrelForeign[$masterFieldMd5]['on_update'] ?? '']</code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="49">
+    <MixedAssignment occurrences="48">
       <code>$GLOBALS['errorUrl']</code>
       <code>$altered</code>
       <code>$altered</code>
@@ -13013,7 +12982,6 @@
       <code>$column</code>
       <code>$columns[$row['Field']]</code>
       <code>$constraintName</code>
-      <code>$createTable</code>
       <code>$currCreateTime</code>
       <code>$eachCol</code>
       <code>$exactRowsCached</code>


### PR DESCRIPTION
This removes some more dead code to simplify SA. 
I do not know why Psalm still complains about `$diff !== []`. There must be something I cannot see. 