### PR TITLE
Remove redundant pass-by-ref

### DIFF
--- a/libraries/classes/Config/Validator.php
+++ b/libraries/classes/Config/Validator.php
@@ -126,7 +126,7 @@ class Validator
     public static function validate(
         ConfigFile $cf,
         $validatorId,
-        array &$values,
+        array $values,
         $isPostSource
     ) {
         // find validators

--- a/libraries/classes/Controllers/Table/StructureController.php
+++ b/libraries/classes/Controllers/Table/StructureController.php
@@ -195,7 +195,7 @@ class StructureController extends AbstractController
         $row_comments = [];
         $extracted_columnspecs = [];
         $collations = [];
-        foreach ($fields as &$field) {
+        foreach ($fields as $field) {
             ++$rownum;
             $columns_list[] = $field['Field'];
 

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -198,7 +198,7 @@ class Core
      * @param array  $allowList allow list to check page against
      * @param bool   $include   whether the page is going to be included
      */
-    public static function checkPageValidity(&$page, array $allowList = [], $include = false): bool
+    public static function checkPageValidity($page, array $allowList = [], $include = false): bool
     {
         if (empty($allowList)) {
             $allowList = ['index.php'];

--- a/libraries/classes/Git.php
+++ b/libraries/classes/Git.php
@@ -415,7 +415,7 @@ class Git
      *
      * @return stdClass|null The commit body from the GitHub API
      */
-    private function isRemoteCommit(&$commit, bool &$isRemoteCommit, string $hash): ?stdClass
+    private function isRemoteCommit($commit, bool &$isRemoteCommit, string $hash): ?stdClass
     {
         $httpRequest = new HttpRequest();
 

--- a/libraries/classes/Mime.php
+++ b/libraries/classes/Mime.php
@@ -26,7 +26,7 @@ class Mime
      *
      * @return string
      */
-    public static function detect(&$test)
+    public static function detect($test)
     {
         $len = mb_strlen($test);
         if ($len >= 2 && $test[0] == chr(0xff) && $test[1] == chr(0xd8)) {

--- a/libraries/classes/Plugins/Import/ImportMediawiki.php
+++ b/libraries/classes/Plugins/Import/ImportMediawiki.php
@@ -380,7 +380,7 @@ class ImportMediawiki extends ImportPlugin
      *
      * @global string $db      name of the database to import in
      */
-    private function executeImportTables(array &$tables, array &$analyses, array &$sqlStatements): void
+    private function executeImportTables(array &$tables, array $analyses, array &$sqlStatements): void
     {
         // $db_name : The currently selected database name, if applicable
         //            No backquotes

--- a/libraries/classes/Sanitize.php
+++ b/libraries/classes/Sanitize.php
@@ -277,7 +277,7 @@ class Sanitize
      *
      * @param string[] $allowList list of variables to allow
      */
-    public static function removeRequestVars(&$allowList): void
+    public static function removeRequestVars($allowList): void
     {
         // do not check only $_REQUEST because it could have been overwritten
         // and use type casting because the variables could have become

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2111,6 +2111,16 @@ parameters:
 			path: libraries/classes/Controllers/Table/FindReplaceController.php
 
 		-
+			message: "#^Parameter \\#1 \\$str of function mb_strlen expects string, string\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/GetFieldController.php
+
+		-
+			message: "#^Parameter \\#1 \\$test of static method PhpMyAdmin\\\\Mime\\:\\:detect\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/GetFieldController.php
+
+		-
 			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/IndexesController.php
@@ -9572,6 +9582,11 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\CoreTest\\:\\:testGotoNowhere\\(\\) has parameter \\$allowList with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: test/classes/CoreTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$page of static method PhpMyAdmin\\\\Core\\:\\:checkPageValidity\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: test/classes/CoreTest.php
 


### PR DESCRIPTION
This removes all remaining redundant pass-by-ref. It will help PHPStan which cannot deal with pass-by-ref params. 