### PR TITLE
Remove redundant code

### DIFF
--- a/libraries/classes/Charsets/Collation.php
+++ b/libraries/classes/Charsets/Collation.php
@@ -171,8 +171,7 @@ final class Collation
                 /* Next will be variant unless changed later */
                 $level = 4;
                 /* Locale name or code */
-                $found = true;
-                [$name, $level, $found] = $this->getNameForLevel1($unicode, $unknown, $part, $name, $level, $found);
+                [$name, $level, $found] = $this->getNameForLevel1($unicode, $unknown, $part, $name, $level);
                 if ($found) {
                     continue;
                 }
@@ -428,9 +427,10 @@ final class Collation
         bool $unknown,
         string $part,
         string $name,
-        int $level,
-        bool $found
+        int $level
     ): array {
+        $found = true;
+
         switch ($part) {
             case 'general':
                 break;

--- a/libraries/classes/Config/FormDisplay.php
+++ b/libraries/classes/Config/FormDisplay.php
@@ -287,7 +287,6 @@ class FormDisplay
                     $path,
                     $workPath,
                     $translatedPath,
-                    true,
                     $userPrefsAllow,
                     $jsDefault
                 );
@@ -315,19 +314,18 @@ class FormDisplay
     /**
      * Prepares data for input field display and outputs HTML code
      *
-     * @param Form      $form               Form object
-     * @param string    $field              field name as it appears in $form
-     * @param string    $systemPath         field path, eg. Servers/1/verbose
-     * @param string    $workPath           work path, eg. Servers/4/verbose
-     * @param string    $translatedPath     work path changed so that it can be
-     *                                      used as XHTML id
-     * @param bool      $showRestoreDefault whether show "restore default" button
-     *                                      besides the input field
-     * @param bool|null $userPrefsAllow     whether user preferences are enabled
-     *                                      for this field (null - no support,
-     *                                      true/false - enabled/disabled)
-     * @param array     $jsDefault          array which stores JavaScript code
-     *                                      to be displayed
+     * @param Form      $form           Form object
+     * @param string    $field          field name as it appears in $form
+     * @param string    $systemPath     field path, eg. Servers/1/verbose
+     * @param string    $workPath       work path, eg. Servers/4/verbose
+     * @param string    $translatedPath work path changed so that it can be
+     *                                  used as XHTML id
+     *                                  besides the input field
+     * @param bool|null $userPrefsAllow whether user preferences are enabled
+     *                                  for this field (null - no support,
+     *                                  true/false - enabled/disabled)
+     * @param array     $jsDefault      array which stores JavaScript code
+     *                                  to be displayed
      *
      * @return string|null HTML for input field
      */
@@ -337,7 +335,6 @@ class FormDisplay
         $systemPath,
         $workPath,
         $translatedPath,
-        $showRestoreDefault,
         $userPrefsAllow,
         array &$jsDefault
     ) {
@@ -354,7 +351,7 @@ class FormDisplay
 
         $opts = [
             'doc' => $this->getDocLink($systemPath),
-            'show_restore_default' => $showRestoreDefault,
+            'show_restore_default' => true,
             'userprefs_allow' => $userPrefsAllow,
             'userprefs_comment' => Descriptions::get($systemPath, 'cmt'),
         ];

--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -814,7 +814,7 @@ class StructureController extends AbstractController
                 [$formattedOverhead, $overheadUnit] = Util::formatByteDown(
                     $currentTable['Data_free'],
                     3,
-                    ($currentTable['Data_free'] > 0 ? 1 : 0)
+                    1
                 );
                 $overheadSize += $currentTable['Data_free'];
             }

--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -729,7 +729,6 @@ class StructureController extends AbstractController
                 // Merge or BerkleyDB table: Only row count is accurate.
                 if ($this->isShowStats) {
                     $formattedSize = ' - ';
-                    $unit = '';
                 }
 
                 break;
@@ -754,7 +753,6 @@ class StructureController extends AbstractController
                 // Unknown table type.
                 if ($this->isShowStats) {
                     $formattedSize = __('unknown');
-                    $unit = '';
                 }
         }
 

--- a/libraries/classes/Controllers/ErrorReportController.php
+++ b/libraries/classes/Controllers/ErrorReportController.php
@@ -92,7 +92,7 @@ class ErrorReportController extends AbstractController
                     $success = false;
                 } else {
                     $decoded_response = json_decode($server_response, true);
-                    $success = ! empty($decoded_response) ? $decoded_response['success'] : false;
+                    $success = ! empty($decoded_response) && $decoded_response['success'];
                 }
 
                 /* Message to show to the user */

--- a/libraries/classes/Controllers/Import/ImportController.php
+++ b/libraries/classes/Controllers/Import/ImportController.php
@@ -519,7 +519,7 @@ final class ImportController extends AbstractController
 
                 return;
             }
-        } elseif (! $GLOBALS['error'] && (! isset($GLOBALS['import_text']) || empty($GLOBALS['import_text']))) {
+        } elseif (! $GLOBALS['error'] && (empty($GLOBALS['import_text']))) {
             $GLOBALS['message'] = Message::error(
                 __(
                     'No data was received to import. Either no file name was ' .

--- a/libraries/classes/Controllers/NavigationController.php
+++ b/libraries/classes/Controllers/NavigationController.php
@@ -49,8 +49,7 @@ class NavigationController extends AbstractController
             return;
         }
 
-        $getNaviSettings = $request->getParsedBodyParam('getNaviSettings');
-        if ($getNaviSettings !== null && $getNaviSettings) {
+        if ($request->hasBodyParam('getNaviSettings')) {
             $pageSettings = new PageSettings('Navi', 'pma_navigation_settings');
             $this->response->addHTML($pageSettings->getErrorHTML());
             $this->response->addJSON('message', $pageSettings->getHTML());

--- a/libraries/classes/Controllers/Server/DatabasesController.php
+++ b/libraries/classes/Controllers/Server/DatabasesController.php
@@ -46,9 +46,6 @@ class DatabasesController extends AbstractController
     /** @var bool whether to show database statistics */
     private $hasStatistics;
 
-    /** @var int position in list navigation */
-    private $position;
-
     private DatabaseInterface $dbi;
 
     public function __construct(
@@ -93,7 +90,7 @@ class DatabasesController extends AbstractController
 
         $this->setSortDetails($params['sort_by'], $params['sort_order']);
         $this->hasStatistics = ! empty($params['statistics']);
-        $this->position = ! empty($params['pos']) ? (int) $params['pos'] : 0;
+        $position = ! empty($params['pos']) ? (int) $params['pos'] : 0;
 
         /**
          * Gets the databases list
@@ -105,7 +102,7 @@ class DatabasesController extends AbstractController
                 Connection::TYPE_USER,
                 $this->sortBy,
                 $this->sortOrder,
-                $this->position,
+                $position,
                 true
             );
             $this->databaseCount = count($this->dbi->getDatabaseList());
@@ -113,7 +110,7 @@ class DatabasesController extends AbstractController
 
         $urlParams = [
             'statistics' => $this->hasStatistics,
-            'pos' => $this->position,
+            'pos' => $position,
             'sort_by' => $this->sortBy,
             'sort_order' => $this->sortOrder,
         ];
@@ -155,7 +152,7 @@ class DatabasesController extends AbstractController
             'header_statistics' => $headerStatistics,
             'charsets' => $charsetsList,
             'database_count' => $this->databaseCount,
-            'pos' => $this->position,
+            'pos' => $position,
             'url_params' => $urlParams,
             'max_db_list' => $GLOBALS['cfg']['MaxDbList'],
             'has_primary_replication' => $primaryInfo['status'],

--- a/libraries/classes/Controllers/Table/ChartController.php
+++ b/libraries/classes/Controllers/Table/ChartController.php
@@ -159,7 +159,7 @@ class ChartController extends AbstractController
             'url_params' => $url_params,
             'keys' => $keys,
             'fields_meta' => $fields_meta,
-            'table_has_a_numeric_column' => $numericColumnFound,
+            'table_has_a_numeric_column' => true,
             'start_and_number_of_rows_fieldset' => $startAndNumberOfRowsFieldset,
         ]);
     }

--- a/libraries/classes/Controllers/Table/Structure/SaveController.php
+++ b/libraries/classes/Controllers/Table/Structure/SaveController.php
@@ -119,8 +119,7 @@ final class SaveController extends AbstractController
             }
 
             if (
-                ! isset($_POST['field_adjust_privileges'][$i])
-                || empty($_POST['field_adjust_privileges'][$i])
+                empty($_POST['field_adjust_privileges'][$i])
                 || $_POST['field_orig'][$i] == $_POST['field_name'][$i]
             ) {
                 continue;

--- a/libraries/classes/Controllers/Table/Structure/SaveController.php
+++ b/libraries/classes/Controllers/Table/Structure/SaveController.php
@@ -256,7 +256,7 @@ final class SaveController extends AbstractController
 
                 $revert_query = 'ALTER TABLE ' . Util::backquote($GLOBALS['table'])
                     . ' ';
-                $revert_query .= implode(', ', $changes_revert) . '';
+                $revert_query .= implode(', ', $changes_revert);
                 $revert_query .= ';';
 
                 // Column reverted back to original

--- a/libraries/classes/CreateAddField.php
+++ b/libraries/classes/CreateAddField.php
@@ -406,7 +406,7 @@ class CreateAddField
         }
 
         if (! empty($_POST['tbl_collation'])) {
-            $sqlQuery .= Util::getCharsetQueryPart($_POST['tbl_collation'] ?? '');
+            $sqlQuery .= Util::getCharsetQueryPart($_POST['tbl_collation']);
         }
 
         if (

--- a/libraries/classes/Database/Designer/Common.php
+++ b/libraries/classes/Database/Designer/Common.php
@@ -281,7 +281,7 @@ class Common
                 1 AS `H`
             FROM " . Util::backquote($pdfFeature->database)
                 . '.' . Util::backquote($pdfFeature->tableCoords) . '
-            WHERE pdf_page_number = ' . intval($pg);
+            WHERE pdf_page_number = ' . $pg;
 
         return $this->dbi->fetchResult(
             $query,
@@ -308,7 +308,7 @@ class Common
         $query = 'SELECT `page_descr`'
             . ' FROM ' . Util::backquote($pdfFeature->database)
             . '.' . Util::backquote($pdfFeature->pdfPages)
-            . ' WHERE ' . Util::backquote('page_nr') . ' = ' . intval($pg);
+            . ' WHERE ' . Util::backquote('page_nr') . ' = ' . $pg;
         $page_name = $this->dbi->fetchValue(
             $query,
             0,

--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -311,7 +311,7 @@ class Routines
 
         // Backup the Old Privileges before dropping
         // if $_POST['item_adjust_privileges'] set
-        if (! isset($_POST['item_adjust_privileges']) || empty($_POST['item_adjust_privileges'])) {
+        if (empty($_POST['item_adjust_privileges'])) {
             return [];
         }
 

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -1652,7 +1652,7 @@ class DatabaseInterface implements DbalInterface
             return null;
         }
 
-        return $result;
+        return null;
     }
 
     /**

--- a/libraries/classes/Export.php
+++ b/libraries/classes/Export.php
@@ -907,15 +907,15 @@ class Export
             return;
         }
 
-        if (! $exportPlugin->exportRawQuery($errorUrl, $db, $sqlQuery)) {
-            $GLOBALS['message'] = Message::error(
-                // phpcs:disable Generic.Files.LineLength.TooLong
-                /* l10n: A query written by the user is a "raw query" that could be using no tables or databases in particular */
-                __('Exporting a raw query is not supported for this export method.')
-            );
-
+        if ($exportPlugin->exportRawQuery($errorUrl, $db, $sqlQuery)) {
             return;
         }
+
+        $GLOBALS['message'] = Message::error(
+            // phpcs:disable Generic.Files.LineLength.TooLong
+            /* l10n: A query written by the user is a "raw query" that could be using no tables or databases in particular */
+            __('Exporting a raw query is not supported for this export method.')
+        );
     }
 
     /**

--- a/libraries/classes/FieldMetadata.php
+++ b/libraries/classes/FieldMetadata.php
@@ -270,7 +270,6 @@ final class FieldMetadata
         $typeAr = [];
         $typeAr[MYSQLI_TYPE_DECIMAL] = self::TYPE_REAL;
         $typeAr[MYSQLI_TYPE_NEWDECIMAL] = self::TYPE_REAL;
-        $typeAr[MYSQLI_TYPE_BIT] = self::TYPE_INT;
         $typeAr[MYSQLI_TYPE_TINY] = self::TYPE_INT;
         $typeAr[MYSQLI_TYPE_SHORT] = self::TYPE_INT;
         $typeAr[MYSQLI_TYPE_LONG] = self::TYPE_INT;

--- a/libraries/classes/Git.php
+++ b/libraries/classes/Git.php
@@ -452,11 +452,9 @@ class Git
 
     private function getHashFromHeadRef(string $gitFolder, string $refHead): array
     {
-        $branch = false;
-
         // are we on any branch?
         if (! str_contains($refHead, '/')) {
-            return [trim($refHead), $branch];
+            return [trim($refHead), false];
         }
 
         // remove ref: prefix

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -544,7 +544,6 @@ class InsertEdit
      * @param string $specialCharsEncoded replaced char if the string starts
      *                                      with a \r\n pair (0x0d0a) add an extra \n
      * @param string $dataType            the html5 data-* attribute type
-     * @param bool   $readOnly            is column read only or not
      *
      * @return string                       an html snippet
      */
@@ -558,8 +557,7 @@ class InsertEdit
         $idindex,
         $textDir,
         $specialCharsEncoded,
-        $dataType,
-        $readOnly
+        $dataType
     ): string {
         $theClass = '';
         $textAreaRows = $GLOBALS['cfg']['TextareaRows'];
@@ -583,7 +581,6 @@ class InsertEdit
         return $backupField . "\n"
             . '<textarea name="fields' . $columnNameAppendix . '"'
             . ' class="' . $theClass . '"'
-            . ($readOnly ? ' readonly="readonly"' : '')
             . (isset($maxlength) ? ' data-maxlength="' . $maxlength . '"' : '')
             . ' rows="' . $textAreaRows . '"'
             . ' cols="' . $textareaCols . '"'
@@ -659,7 +656,6 @@ class InsertEdit
      * @param int    $tabindexForValue   offset for the values tabindex
      * @param int    $idindex            id index
      * @param string $dataType           the html5 data-* attribute type
-     * @param bool   $readOnly           is column read only or not
      *
      * @return string                       an html snippet
      */
@@ -672,19 +668,16 @@ class InsertEdit
         $tabindex,
         $tabindexForValue,
         $idindex,
-        $dataType,
-        $readOnly
+        $dataType
     ): string {
         $theClass = 'textfield';
         // verify True_Type which does not contain the parentheses and length
-        if (! $readOnly) {
-            if ($column['True_Type'] === 'date') {
-                $theClass .= ' datefield';
-            } elseif ($column['True_Type'] === 'time') {
-                $theClass .= ' timefield';
-            } elseif ($column['True_Type'] === 'datetime' || $column['True_Type'] === 'timestamp') {
-                $theClass .= ' datetimefield';
-            }
+        if ($column['True_Type'] === 'date') {
+            $theClass .= ' datefield';
+        } elseif ($column['True_Type'] === 'time') {
+            $theClass .= ' timefield';
+        } elseif ($column['True_Type'] === 'datetime' || $column['True_Type'] === 'timestamp') {
+            $theClass .= ' datetimefield';
         }
 
         $inputMinMax = '';
@@ -706,7 +699,6 @@ class InsertEdit
             . (isset($column['is_char']) && $column['is_char']
                 ? ' data-maxlength="' . $fieldsize . '"'
                 : '')
-            . ($readOnly ? ' readonly="readonly"' : '')
             . ($inputMinMax ? ' ' . $inputMinMax : '')
             . ' data-type="' . $dataType . '"'
             . ' class="' . $theClass . '" onchange="' . htmlspecialchars($onChangeClause, ENT_COMPAT) . '"'
@@ -810,7 +802,6 @@ class InsertEdit
      * @param array  $extractedColumnspec associative array containing type,
      *                                      spec_in_brackets and possibly
      *                                      enum_set_values (another array)
-     * @param bool   $readOnly            is column read only or not
      *
      * @return string an html snippet
      */
@@ -827,8 +818,7 @@ class InsertEdit
         $textDir,
         $specialCharsEncoded,
         $data,
-        array $extractedColumnspec,
-        $readOnly
+        array $extractedColumnspec
     ): string {
         // HTML5 data-* attribute data-type
         $dataType = $this->dbi->types->getTypeClass($column['True_Type']);
@@ -848,8 +838,7 @@ class InsertEdit
                 $idindex,
                 $textDir,
                 $specialCharsEncoded,
-                $dataType,
-                $readOnly
+                $dataType
             );
         } else {
             $htmlField = $this->getHtmlInput(
@@ -861,8 +850,7 @@ class InsertEdit
                 $tabindex,
                 $tabindexForValue,
                 $idindex,
-                $dataType,
-                $readOnly
+                $dataType
             );
         }
 
@@ -2013,8 +2001,6 @@ class InsertEdit
         array $columnMime,
         $whereClause
     ) {
-        $readOnly = false;
-
         if (! isset($column['processed'])) {
             $column = $this->analyzeTableColumnsArray($column, $commentsMap, $timestampSeen);
         }
@@ -2257,8 +2243,7 @@ class InsertEdit
                         $tabindex,
                         $tabindexForValue,
                         $idindex,
-                        'HEX',
-                        $readOnly
+                        'HEX'
                     );
                 }
             } else {
@@ -2275,8 +2260,7 @@ class InsertEdit
                     $textDir,
                     $specialCharsEncoded,
                     $data,
-                    $extractedColumnspec,
-                    $readOnly
+                    $extractedColumnspec
                 );
             }
         }
@@ -2290,7 +2274,6 @@ class InsertEdit
             'show_function_fields' => $GLOBALS['cfg']['ShowFunctionFields'],
             'is_column_binary' => $isColumnBinary,
             'function_options' => $functionOptions,
-            'read_only' => $readOnly,
             'nullify_code' => $nullifyCode,
             'real_null_value' => $realNullValue,
             'id_index' => $idindex,

--- a/libraries/classes/Navigation/Nodes/NodeDatabase.php
+++ b/libraries/classes/Navigation/Nodes/NodeDatabase.php
@@ -14,7 +14,6 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function in_array;
-use function intval;
 use function substr;
 
 /**
@@ -462,7 +461,7 @@ class NodeDatabase extends Node
             }
 
             $query .= 'ORDER BY `ROUTINE_NAME` ASC ';
-            $query .= 'LIMIT ' . intval($pos) . ', ' . $maxItems;
+            $query .= 'LIMIT ' . $pos . ', ' . $maxItems;
 
             return $GLOBALS['dbi']->fetchResult($query);
         }
@@ -544,7 +543,7 @@ class NodeDatabase extends Node
             }
 
             $query .= 'ORDER BY `EVENT_NAME` ASC ';
-            $query .= 'LIMIT ' . intval($pos) . ', ' . $maxItems;
+            $query .= 'LIMIT ' . $pos . ', ' . $maxItems;
 
             return $GLOBALS['dbi']->fetchResult($query);
         }

--- a/libraries/classes/Navigation/Nodes/NodeTable.php
+++ b/libraries/classes/Navigation/Nodes/NodeTable.php
@@ -98,7 +98,7 @@ class NodeTable extends NodeDatabaseChild
                 } else {
                     $db = Util::backquote($db);
                     $table = Util::backquote($table);
-                    $query = 'SHOW COLUMNS FROM ' . $table . ' FROM ' . $db . '';
+                    $query = 'SHOW COLUMNS FROM ' . $table . ' FROM ' . $db;
                     $retval = (int) $GLOBALS['dbi']->queryAndGetNumRows($query);
                 }
 

--- a/libraries/classes/Normalization.php
+++ b/libraries/classes/Normalization.php
@@ -109,7 +109,7 @@ class Normalization
                     . htmlspecialchars($column) . ' [ '
                     . htmlspecialchars($def['Type']) . ' ]<br>';
             } else {
-                $selectColHtml .= '<option value="' . htmlspecialchars($column) . ''
+                $selectColHtml .= '<option value="' . htmlspecialchars($column)
                 . '">' . htmlspecialchars($column)
                 . ' [ ' . htmlspecialchars($def['Type']) . ' ]'
                 . '</option>';

--- a/libraries/classes/Normalization.php
+++ b/libraries/classes/Normalization.php
@@ -534,7 +534,7 @@ class Normalization
             return [
                 'legendText' => __('End of step'),
                 'headText' => $headText,
-                'queryError' => $error,
+                'queryError' => false,
             ];
         }
 
@@ -691,7 +691,7 @@ class Normalization
             return [
                 'legendText' => __('End of step'),
                 'headText' => $headText,
-                'queryError' => $error,
+                'queryError' => false,
             ];
         }
 

--- a/libraries/classes/Operations.php
+++ b/libraries/classes/Operations.php
@@ -674,7 +674,7 @@ class Operations
 
         if (! empty($_POST['tbl_collation']) && $_POST['tbl_collation'] !== $tableCollation) {
             $tableAlters[] = 'DEFAULT '
-                . Util::getCharsetQueryPart($_POST['tbl_collation'] ?? '');
+                . Util::getCharsetQueryPart($_POST['tbl_collation']);
         }
 
         if (

--- a/libraries/classes/OutputBuffering.php
+++ b/libraries/classes/OutputBuffering.php
@@ -41,30 +41,32 @@ class OutputBuffering
      *
      * @return int the output buffer mode
      */
-    private function getMode()
+    private function getMode(): int
     {
-        $mode = 0;
-        if (! defined('TESTSUITE') && $GLOBALS['cfg']['OBGzip'] && function_exists('ob_start')) {
+        if (! defined('TESTSUITE') && $GLOBALS['cfg']['OBGzip']) {
             if (ini_get('output_handler') === 'ob_gzhandler') {
                 // If a user sets the output_handler in php.ini to ob_gzhandler, then
                 // any right frame file in phpMyAdmin will not be handled properly by
                 // the browser. My fix was to check the ini file within the
                 // PMA_outBufferModeGet() function.
-                $mode = 0;
-            } elseif (function_exists('ob_get_level') && ob_get_level() > 0) {
+                return 0;
+            }
+
+            if (ob_get_level() > 0) {
                 // happens when php.ini's output_buffering is not Off
                 ob_end_clean();
-                $mode = 1;
-            } else {
-                $mode = 1;
+
+                return 1;
             }
+
+            return 1;
         }
 
         // Zero (0) is no mode or in other words output buffering is OFF.
         // Follow 2^0, 2^1, 2^2, 2^3 type values for the modes.
         // Useful if we ever decide to combine modes.  Then a bitmask field of
         // the sum of all modes will be the natural choice.
-        return $mode;
+        return 0;
     }
 
     /**

--- a/libraries/classes/Plugins/AuthenticationPlugin.php
+++ b/libraries/classes/Plugins/AuthenticationPlugin.php
@@ -281,28 +281,11 @@ abstract class AuthenticationPlugin
         if (isset($GLOBALS['cfg']['Server']['AllowDeny']['order'])) {
             $allowDeny_forbidden = false; // default
             if ($GLOBALS['cfg']['Server']['AllowDeny']['order'] === 'allow,deny') {
-                $allowDeny_forbidden = true;
-                if ($this->ipAllowDeny->allow()) {
-                    $allowDeny_forbidden = false;
-                }
-
-                if ($this->ipAllowDeny->deny()) {
-                    $allowDeny_forbidden = true;
-                }
+                $allowDeny_forbidden = ! ($this->ipAllowDeny->allow() && ! $this->ipAllowDeny->deny());
             } elseif ($GLOBALS['cfg']['Server']['AllowDeny']['order'] === 'deny,allow') {
-                if ($this->ipAllowDeny->deny()) {
-                    $allowDeny_forbidden = true;
-                }
-
-                if ($this->ipAllowDeny->allow()) {
-                    $allowDeny_forbidden = false;
-                }
+                $allowDeny_forbidden = $this->ipAllowDeny->deny() && ! $this->ipAllowDeny->allow();
             } elseif ($GLOBALS['cfg']['Server']['AllowDeny']['order'] === 'explicit') {
-                if ($this->ipAllowDeny->allow() && ! $this->ipAllowDeny->deny()) {
-                    $allowDeny_forbidden = false;
-                } else {
-                    $allowDeny_forbidden = true;
-                }
+                $allowDeny_forbidden = ! ($this->ipAllowDeny->allow() && ! $this->ipAllowDeny->deny());
             }
 
             // Ejects the user if banished

--- a/libraries/classes/Plugins/Export/ExportHtmlword.php
+++ b/libraries/classes/Plugins/Export/ExportHtmlword.php
@@ -542,7 +542,6 @@ class ExportHtmlword extends ExportPlugin
                 $dump .= $this->getTableDef($db, $table, $do_relation, $do_comments, $do_mime, false, $aliases);
                 break;
             case 'triggers':
-                $dump = '';
                 $triggers = Triggers::getDetails($GLOBALS['dbi'], $db, $table);
                 if ($triggers) {
                     $dump .= '<h2>'

--- a/libraries/classes/Plugins/Export/ExportLatex.php
+++ b/libraries/classes/Plugins/Export/ExportLatex.php
@@ -383,7 +383,7 @@ class ExportLatex extends ExportPlugin
             $buffer = '';
             // print each row
             for ($i = 0; $i < $columns_cnt; $i++) {
-                if ($record[$columns[$i]] !== null && isset($record[$columns[$i]])) {
+                if ($record[$columns[$i]] !== null) {
                     $column_value = self::texEscape($record[$columns[$i]]);
                 } else {
                     $column_value = $GLOBALS['latex_null'];

--- a/libraries/classes/Plugins/Export/ExportLatex.php
+++ b/libraries/classes/Plugins/Export/ExportLatex.php
@@ -24,6 +24,7 @@ use function count;
 use function in_array;
 use function mb_strpos;
 use function mb_substr;
+use function str_repeat;
 use function str_replace;
 
 use const PHP_EOL;
@@ -311,9 +312,7 @@ class ExportLatex extends ExportPlugin
         $buffer = PHP_EOL . '%' . PHP_EOL . '% ' . __('Data:') . ' ' . $table_alias
             . PHP_EOL . '%' . PHP_EOL . ' \\begin{longtable}{|';
 
-        for ($index = 0; $index < $columns_cnt; $index++) {
-            $buffer .= 'l|';
-        }
+        $buffer .= str_repeat('l|', $columns_cnt);
 
         $buffer .= '} ' . PHP_EOL;
 

--- a/libraries/classes/Plugins/Export/ExportMediawiki.php
+++ b/libraries/classes/Plugins/Export/ExportMediawiki.php
@@ -180,69 +180,67 @@ class ExportMediawiki extends ExportPlugin
         $this->initAlias($aliases, $db_alias, $table_alias);
 
         $output = '';
-        switch ($exportMode) {
-            case 'create_table':
-                $columns = $GLOBALS['dbi']->getColumns($db, $table);
-                $columns = array_values($columns);
-                $row_cnt = count($columns);
+        if ($exportMode === 'create_table') {
+            $columns = $GLOBALS['dbi']->getColumns($db, $table);
+            $columns = array_values($columns);
+            $row_cnt = count($columns);
 
-                // Print structure comment
-                $output = $this->exportComment(
-                    'Table structure for '
-                    . Util::backquote($table_alias)
-                );
+            // Print structure comment
+            $output = $this->exportComment(
+                'Table structure for '
+                . Util::backquote($table_alias)
+            );
 
-                // Begin the table construction
-                $output .= '{| class="wikitable" style="text-align:center;"'
+            // Begin the table construction
+            $output .= '{| class="wikitable" style="text-align:center;"'
+                . $this->exportCRLF();
+
+            // Add the table name
+            if (isset($GLOBALS['mediawiki_caption'])) {
+                $output .= "|+'''" . $table_alias . "'''" . $this->exportCRLF();
+            }
+
+            // Add the table headers
+            if (isset($GLOBALS['mediawiki_headers'])) {
+                $output .= '|- style="background:#ffdead;"' . $this->exportCRLF();
+                $output .= '! style="background:#ffffff" | '
                     . $this->exportCRLF();
-
-                // Add the table name
-                if (isset($GLOBALS['mediawiki_caption'])) {
-                    $output .= "|+'''" . $table_alias . "'''" . $this->exportCRLF();
-                }
-
-                // Add the table headers
-                if (isset($GLOBALS['mediawiki_headers'])) {
-                    $output .= '|- style="background:#ffdead;"' . $this->exportCRLF();
-                    $output .= '! style="background:#ffffff" | '
-                    . $this->exportCRLF();
-                    for ($i = 0; $i < $row_cnt; ++$i) {
-                        $col_as = $columns[$i]['Field'];
-                        if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])) {
-                            $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
-                        }
-
-                        $output .= ' | ' . $col_as . $this->exportCRLF();
+                for ($i = 0; $i < $row_cnt; ++$i) {
+                    $col_as = $columns[$i]['Field'];
+                    if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])) {
+                        $col_as = $aliases[$db]['tables'][$table]['columns'][$col_as];
                     }
-                }
 
-                // Add the table structure
-                $output .= '|-' . $this->exportCRLF();
-                $output .= '! Type' . $this->exportCRLF();
-                for ($i = 0; $i < $row_cnt; ++$i) {
-                    $output .= ' | ' . $columns[$i]['Type'] . $this->exportCRLF();
+                    $output .= ' | ' . $col_as . $this->exportCRLF();
                 }
+            }
 
-                $output .= '|-' . $this->exportCRLF();
-                $output .= '! Null' . $this->exportCRLF();
-                for ($i = 0; $i < $row_cnt; ++$i) {
-                    $output .= ' | ' . $columns[$i]['Null'] . $this->exportCRLF();
-                }
+            // Add the table structure
+            $output .= '|-' . $this->exportCRLF();
+            $output .= '! Type' . $this->exportCRLF();
+            for ($i = 0; $i < $row_cnt; ++$i) {
+                $output .= ' | ' . $columns[$i]['Type'] . $this->exportCRLF();
+            }
 
-                $output .= '|-' . $this->exportCRLF();
-                $output .= '! Default' . $this->exportCRLF();
-                for ($i = 0; $i < $row_cnt; ++$i) {
-                    $output .= ' | ' . $columns[$i]['Default'] . $this->exportCRLF();
-                }
+            $output .= '|-' . $this->exportCRLF();
+            $output .= '! Null' . $this->exportCRLF();
+            for ($i = 0; $i < $row_cnt; ++$i) {
+                $output .= ' | ' . $columns[$i]['Null'] . $this->exportCRLF();
+            }
 
-                $output .= '|-' . $this->exportCRLF();
-                $output .= '! Extra' . $this->exportCRLF();
-                for ($i = 0; $i < $row_cnt; ++$i) {
-                    $output .= ' | ' . $columns[$i]['Extra'] . $this->exportCRLF();
-                }
+            $output .= '|-' . $this->exportCRLF();
+            $output .= '! Default' . $this->exportCRLF();
+            for ($i = 0; $i < $row_cnt; ++$i) {
+                $output .= ' | ' . $columns[$i]['Default'] . $this->exportCRLF();
+            }
 
-                $output .= '|}' . str_repeat($this->exportCRLF(), 2);
-                break;
+            $output .= '|-' . $this->exportCRLF();
+            $output .= '! Extra' . $this->exportCRLF();
+            for ($i = 0; $i < $row_cnt; ++$i) {
+                $output .= ' | ' . $columns[$i]['Extra'] . $this->exportCRLF();
+            }
+
+            $output .= '|}' . str_repeat($this->exportCRLF(), 2);
         }
 
         return $this->export->outputHandler($output);

--- a/libraries/classes/Plugins/Export/ExportMediawiki.php
+++ b/libraries/classes/Plugins/Export/ExportMediawiki.php
@@ -300,7 +300,7 @@ class ExportMediawiki extends ExportPlugin
                         $column = $aliases[$db]['tables'][$table]['columns'][$column];
                     }
 
-                    $output .= ' ! ' . $column . '' . $this->exportCRLF();
+                    $output .= ' ! ' . $column . $this->exportCRLF();
                 }
             }
         }
@@ -318,7 +318,7 @@ class ExportMediawiki extends ExportPlugin
 
             // Use '|' for separating table columns
             for ($i = 0; $i < $fields_cnt; ++$i) {
-                $output .= ' | ' . $row[$i] . '' . $this->exportCRLF();
+                $output .= ' | ' . $row[$i] . $this->exportCRLF();
             }
         }
 

--- a/libraries/classes/Plugins/Export/ExportPdf.php
+++ b/libraries/classes/Plugins/Export/ExportPdf.php
@@ -280,16 +280,15 @@ class ExportPdf extends ExportPlugin
          * comment display set true as presently in pdf
          * format, no option is present to take user input.
          */
-        $do_comments = true;
         switch ($exportMode) {
             case 'create_table':
-                $pdf->getTableDef($db, $table, $do_relation, $do_comments, $do_mime, false, $aliases);
+                $pdf->getTableDef($db, $table, $do_relation, true, $do_mime, false, $aliases);
                 break;
             case 'triggers':
                 $pdf->getTriggers($db, $table);
                 break;
             case 'create_view':
-                $pdf->getTableDef($db, $table, $do_relation, $do_comments, $do_mime, false, $aliases);
+                $pdf->getTableDef($db, $table, $do_relation, true, $do_mime, false, $aliases);
                 break;
             case 'stand_in':
                 // export a stand-in definition to resolve view dependencies

--- a/libraries/classes/Plugins/Export/ExportTexytext.php
+++ b/libraries/classes/Plugins/Export/ExportTexytext.php
@@ -522,7 +522,6 @@ class ExportTexytext extends ExportPlugin
                 );
                 break;
             case 'triggers':
-                $dump = '';
                 $triggers = Triggers::getDetails($GLOBALS['dbi'], $db, $table);
                 if ($triggers) {
                     $dump .= '== ' . __('Triggers') . ' ' . $table_alias . "\n\n";

--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -474,7 +474,7 @@ class ExportXml extends ExportPlugin
 
                     $buffer .= '            <column name="'
                         . htmlspecialchars($col_as) . '">'
-                        . htmlspecialchars((string) $record[$i])
+                        . htmlspecialchars($record[$i])
                         . '</column>' . PHP_EOL;
                 }
 

--- a/libraries/classes/Plugins/Export/Helpers/Pdf.php
+++ b/libraries/classes/Plugins/Export/Helpers/Pdf.php
@@ -61,12 +61,6 @@ class Pdf extends PdfLib
     /** @var array */
     private $colAlign;
 
-    /** @var mixed */
-    private $titleWidth;
-
-    /** @var mixed */
-    private $colFits;
-
     /** @var array */
     private $displayColumn;
 
@@ -331,8 +325,6 @@ class Pdf extends PdfLib
         unset(
             $this->tablewidths,
             $this->colTitles,
-            $this->titleWidth,
-            $this->colFits,
             $this->displayColumn,
             $this->colAlign
         );
@@ -476,8 +468,6 @@ class Pdf extends PdfLib
         unset(
             $this->tablewidths,
             $this->colTitles,
-            $this->titleWidth,
-            $this->colFits,
             $this->displayColumn,
             $this->colAlign
         );
@@ -692,8 +682,6 @@ class Pdf extends PdfLib
         unset(
             $this->tablewidths,
             $this->colTitles,
-            $this->titleWidth,
-            $this->colFits,
             $this->displayColumn,
             $this->colAlign
         );

--- a/libraries/classes/Plugins/Export/Helpers/TableProperty.php
+++ b/libraries/classes/Plugins/Export/Helpers/TableProperty.php
@@ -269,7 +269,7 @@ class TableProperty
      */
     public function format($text)
     {
-        $text = str_replace(
+        return str_replace(
             [
                 '#ucfirstName#',
                 '#dotNetPrimitiveType#',
@@ -288,7 +288,5 @@ class TableProperty
             ],
             $text
         );
-
-        return $text;
     }
 }

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -803,7 +803,6 @@ class ImportCsv extends AbstractImportCsv
                 $fields = $tmp_fields;
             } else {
                 $sqlTemplate .= ' (';
-                $fields = [];
                 $tmp = preg_split('/,( ?)/', $csvColumns);
                 if ($tmp === false) {
                     $tmp = [];

--- a/libraries/classes/Plugins/Schema/Dia/RelationStatsDia.php
+++ b/libraries/classes/Plugins/Schema/Dia/RelationStatsDia.php
@@ -138,7 +138,7 @@ class RelationStatsDia
                 '00FF00',
             ];
             shuffle($listOfColors);
-            $this->referenceColor = '#' . $listOfColors[0] . '';
+            $this->referenceColor = '#' . $listOfColors[0];
         } else {
             $this->referenceColor = '#000000';
         }

--- a/libraries/classes/Plugins/Schema/Dia/TableStatsDia.php
+++ b/libraries/classes/Plugins/Schema/Dia/TableStatsDia.php
@@ -94,7 +94,7 @@ class TableStatsDia extends TableStats
                 '00FF00',
             ];
             shuffle($listOfColors);
-            $this->tableColor = '#' . $listOfColors[0] . '';
+            $this->tableColor = '#' . $listOfColors[0];
         } else {
             $this->tableColor = '#000000';
         }
@@ -104,7 +104,7 @@ class TableStatsDia extends TableStats
         $this->diagram->startElement('dia:object');
         $this->diagram->writeAttribute('type', 'Database - Table');
         $this->diagram->writeAttribute('version', '0');
-        $this->diagram->writeAttribute('id', '' . $this->tableId . '');
+        $this->diagram->writeAttribute('id', '' . $this->tableId);
         $this->diagram->writeRaw(
             '<dia:attribute name="obj_pos">
                 <dia:point val="'

--- a/libraries/classes/Plugins/Schema/Eps/Eps.php
+++ b/libraries/classes/Plugins/Schema/Eps/Eps.php
@@ -33,8 +33,7 @@ class Eps
      */
     public function __construct()
     {
-        $this->stringCommands = '';
-        $this->stringCommands .= "%!PS-Adobe-3.0 EPSF-3.0 \n";
+        $this->stringCommands = "%!PS-Adobe-3.0 EPSF-3.0 \n";
     }
 
     /**

--- a/libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -423,7 +423,7 @@ class PdfRelationSchema extends ExportRelationSchema
             }
 
             $this->diagram->setXY(0, $l * $gridSize + $topSpace);
-            $label = (string) sprintf(
+            $label = sprintf(
                 '%.0f',
                 ($l * $gridSize + $topSpace - $this->topMargin)
                 * $this->scale + $this->yMin
@@ -440,7 +440,7 @@ class PdfRelationSchema extends ExportRelationSchema
                 $this->diagram->getPageHeight() - $bottomSpace
             );
             $this->diagram->setXY($j * $gridSize, $topSpace);
-            $label = (string) sprintf('%.0f', ($j * $gridSize - $this->leftMargin) * $this->scale + $this->xMin);
+            $label = sprintf('%.0f', ($j * $gridSize - $this->leftMargin) * $this->scale + $this->xMin);
             $this->diagram->Cell($labelWidth, $labelHeight, $label);
         }
     }

--- a/libraries/classes/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
+++ b/libraries/classes/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
@@ -143,7 +143,7 @@ abstract class DateFormatTransformationsPlugin extends TransformationsPlugin
             }
 
             return '<dfn onclick="alert(' . htmlspecialchars((string) json_encode($source), ENT_COMPAT) . ');" title="'
-                . htmlspecialchars((string) $source) . '">' . htmlspecialchars((string) $text) . '</dfn>';
+                . htmlspecialchars($source) . '">' . htmlspecialchars((string) $text) . '</dfn>';
         }
 
         return htmlspecialchars((string) $buffer);

--- a/libraries/classes/Query/Cache.php
+++ b/libraries/classes/Query/Cache.php
@@ -34,7 +34,7 @@ class Cache
         //  array_merge() renumbers numeric keys starting with 0, therefore
         //  we would lose a db name that consists only of numbers
 
-        foreach ($tables as $one_database => $_) {
+        foreach ($tables as $one_database => $tablesInDatabase) {
             if (isset($this->tableCache[$one_database])) {
                 // the + operator does not do the intended effect
                 // when the cache for one table already exists
@@ -42,9 +42,9 @@ class Cache
                     unset($this->tableCache[$one_database][$table]);
                 }
 
-                $this->tableCache[$one_database] += $tables[$one_database];
+                $this->tableCache[$one_database] += $tablesInDatabase;
             } else {
-                $this->tableCache[$one_database] = $tables[$one_database];
+                $this->tableCache[$one_database] = $tablesInDatabase;
             }
         }
     }

--- a/libraries/classes/ReplicationGui.php
+++ b/libraries/classes/ReplicationGui.php
@@ -499,8 +499,6 @@ class ReplicationGui
         $_SESSION['replication']['m_hostname'] = $hostname;
         $_SESSION['replication']['m_port'] = $port;
         $_SESSION['replication']['m_correct'] = '';
-        $_SESSION['replication']['sr_action_status'] = 'error';
-        $_SESSION['replication']['sr_action_info'] = __('Unknown error');
 
         // Attempt to connect to the new primary server
         $connectionToPrimary = $this->replication->connectToPrimary(

--- a/libraries/classes/Routing.php
+++ b/libraries/classes/Routing.php
@@ -22,7 +22,6 @@ use function file_put_contents;
 use function htmlspecialchars;
 use function is_array;
 use function is_readable;
-use function is_string;
 use function is_writable;
 use function rawurldecode;
 use function sprintf;
@@ -175,10 +174,9 @@ class Routing
     private static function isRoutesCacheFileValid($dispatchData): bool
     {
         return is_array($dispatchData)
-            && isset($dispatchData[0], $dispatchData[1])
-            && is_array($dispatchData[0]) && is_array($dispatchData[1])
-            && isset($dispatchData[0]['GET']) && is_array($dispatchData[0]['GET'])
-            && isset($dispatchData[0]['GET']['/']) && is_string($dispatchData[0]['GET']['/'])
+            && isset($dispatchData[1])
+            && is_array($dispatchData[1])
+            && isset($dispatchData[0]['GET']['/'])
             && $dispatchData[0]['GET']['/'] === HomeController::class;
     }
 

--- a/libraries/classes/Tracker.php
+++ b/libraries/classes/Tracker.php
@@ -109,9 +109,8 @@ class Tracker
         $tableName = $str[0];
 
         $tableName = str_replace([';', '`'], '', $tableName);
-        $tableName = trim($tableName);
 
-        return $tableName;
+        return trim($tableName);
     }
 
     /**

--- a/libraries/classes/Tracking.php
+++ b/libraries/classes/Tracking.php
@@ -958,9 +958,7 @@ class Tracking
             $tracking_set .= 'TRUNCATE,';
         }
 
-        $tracking_set = rtrim($tracking_set, ',');
-
-        return $tracking_set;
+        return rtrim($tracking_set, ',');
     }
 
     /**

--- a/libraries/classes/Transformations.php
+++ b/libraries/classes/Transformations.php
@@ -191,11 +191,7 @@ class Transformations
      */
     public function getClassName($filename)
     {
-        // get the transformation class name
-        $class_name = explode('.php', $filename);
-        $class_name = 'PhpMyAdmin\\' . str_replace('/', '\\', mb_substr($class_name[0], 18));
-
-        return $class_name;
+        return 'PhpMyAdmin\\' . str_replace('/', '\\', mb_substr(explode('.php', $filename)[0], 18));
     }
 
     /**

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -155,11 +155,8 @@ class Util
 
         foreach ($quotes as $quote) {
             if (mb_substr($quotedString, 0, 1) === $quote && mb_substr($quotedString, -1, 1) === $quote) {
-                $unquotedString = mb_substr($quotedString, 1, -1);
                 // replace escaped quotes
-                $unquotedString = str_replace($quote . $quote, $quote, $unquotedString);
-
-                return $unquotedString;
+                return str_replace($quote . $quote, $quote, mb_substr($quotedString, 1, -1));
             }
         }
 
@@ -1227,9 +1224,7 @@ class Util
             $printable = strrev($printable);
         }
 
-        $printable = str_pad($printable, $length, '0', STR_PAD_LEFT);
-
-        return $printable;
+        return str_pad($printable, $length, '0', STR_PAD_LEFT);
     }
 
     /**

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -190,8 +190,6 @@ class Util
                 $mysql = '5.7';
             } elseif ($serverVersion >= 50600) {
                 $mysql = '5.6';
-            } elseif ($serverVersion >= 50500) {
-                $mysql = '5.5';
             }
         }
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -2005,7 +2005,6 @@ class Util
 
             // Retains keys informations
             if ($row['Key_name'] != $lastIndex) {
-                $indexes[] = $row['Key_name'];
                 $lastIndex = $row['Key_name'];
             }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7066,11 +7066,6 @@ parameters:
 			path: libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
 
 		-
-			message: "#^Casting to string something that's already string\\.$#"
-			count: 2
-			path: libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
-
-		-
 			message: "#^For loop initial assignment overwrites variable \\$size\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -7267,7 +7262,7 @@ parameters:
 
 		-
 			message: "#^Casting to string something that's already string\\.$#"
-			count: 4
+			count: 3
 			path: libraries/classes/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6631,11 +6631,6 @@ parameters:
 			path: libraries/classes/Plugins/Export/Helpers/Pdf.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\Plugins\\\\Export\\\\Helpers\\\\Pdf\\:\\:\\$colFits is never written, only read\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/Helpers/Pdf.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\Plugins\\\\Export\\\\Helpers\\\\Pdf\\:\\:\\$colTitles type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/Helpers/Pdf.php
@@ -6652,11 +6647,6 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\Plugins\\\\Export\\\\Helpers\\\\Pdf\\:\\:\\$tablewidths type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/Helpers/Pdf.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Plugins\\\\Export\\\\Helpers\\\\Pdf\\:\\:\\$titleWidth is never written, only read\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/Helpers/Pdf.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2403,7 +2403,6 @@
     <MixedAssignment>
       <code>$_SESSION['error_subm_count']</code>
       <code>$decoded_response</code>
-      <code>$success</code>
     </MixedAssignment>
     <MixedOperand>
       <code>$_SESSION['error_subm_count']</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11670,6 +11670,7 @@
     </InvalidArrayOffset>
     <MixedArgument>
       <code>$GLOBALS['maxY'] - $this-&gt;tMargin</code>
+      <code>$cellFontSize</code>
       <code>$col_as</code>
       <code>$column['Type']</code>
       <code>$fullwidth + $l</code>
@@ -11722,7 +11723,6 @@
       <code>$this-&gt;FontSizePt</code>
       <code>$this-&gt;FontSizePt</code>
       <code>$this-&gt;FontSizePt</code>
-      <code>$this-&gt;cellFontSize</code>
       <code>$this-&gt;colAlign[$col]</code>
       <code>$this-&gt;colAlign[$col]</code>
       <code>$this-&gt;colAlign[$col]</code>
@@ -11786,6 +11786,7 @@
       <code>$GLOBALS['maxY']</code>
       <code>$GLOBALS['maxY']</code>
       <code>$availableWidth</code>
+      <code>$cellFontSize</code>
       <code>$col_as</code>
       <code>$current_page</code>
       <code>$currpage</code>
@@ -11844,6 +11845,7 @@
       <code>$old_page_olm</code>
       <code>$old_page_orm</code>
       <code>$oldpage</code>
+      <code>$sColWidth</code>
       <code>$startpage</code>
       <code>$startpage</code>
       <code>$startpage</code>
@@ -11852,9 +11854,7 @@
       <code>$t</code>
       <code>$t</code>
       <code>$t</code>
-      <code>$this-&gt;cellFontSize</code>
       <code>$this-&gt;dataY</code>
-      <code>$this-&gt;sColWidth</code>
       <code>$this_page_olm</code>
       <code>$this_page_orm</code>
       <code>$trigger</code>
@@ -11896,6 +11896,9 @@
       <code>$maxpage</code>
       <code>$res_rel[$field_name]['foreign_field']</code>
       <code>$res_rel[$field_name]['foreign_table']</code>
+      <code>$sColWidth</code>
+      <code>$sColWidth</code>
+      <code>$sColWidth</code>
       <code>$surplus</code>
       <code>$this-&gt;FontSizePt</code>
       <code>$this-&gt;FontSizePt</code>
@@ -11915,9 +11918,6 @@
       <code>$this-&gt;page</code>
       <code>$this-&gt;page</code>
       <code>$this-&gt;page</code>
-      <code>$this-&gt;sColWidth</code>
-      <code>$this-&gt;sColWidth</code>
-      <code>$this-&gt;sColWidth</code>
       <code>$this-&gt;tMargin</code>
       <code>$this-&gt;tMargin</code>
       <code>$this-&gt;tMargin</code>
@@ -11929,7 +11929,7 @@
       <code>$x</code>
       <code>$x</code>
       <code>$y</code>
-      <code>count($colFits) * $this-&gt;sColWidth</code>
+      <code>count($colFits) * $sColWidth</code>
     </MixedOperand>
     <ParamNameMismatch>
       <code>$topMargin</code>
@@ -11955,7 +11955,6 @@
     </PossiblyUnusedParam>
     <PropertyNotSetInConstructor>
       <code>$aliases</code>
-      <code>$cellFontSize</code>
       <code>$colAlign</code>
       <code>$colTitles</code>
       <code>$currentDb</code>
@@ -11963,12 +11962,9 @@
       <code>$dataY</code>
       <code>$dbAlias</code>
       <code>$displayColumn</code>
-      <code>$fields</code>
       <code>$headerset</code>
-      <code>$numFields</code>
       <code>$purpose</code>
       <code>$results</code>
-      <code>$sColWidth</code>
       <code>$tableAlias</code>
       <code>$tablewidths</code>
       <code>$titleFontSize</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -15955,7 +15955,6 @@
       <code>$row['Key_name']</code>
       <code>$row['Key_name']</code>
       <code>$row['Key_name']</code>
-      <code>$row['Key_name']</code>
       <code>$row['Non_unique']</code>
       <code>$row['Seq_in_index']</code>
       <code>$row['Seq_in_index']</code>
@@ -16007,7 +16006,6 @@
       <code>$indexesInfo[$row['Key_name']]['Comment']</code>
       <code>$indexesInfo[$row['Key_name']]['Non_unique']</code>
       <code>$indexesInfo[$row['Key_name']]['Sequences'][]</code>
-      <code>$indexes[]</code>
       <code>$lastIndex</code>
       <code>$p</code>
       <code>$p</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5582,7 +5582,7 @@
       <code>$_POST['indexes']</code>
       <code>$_POST['primary_indexes']</code>
       <code>$_POST['spatial_indexes']</code>
-      <code>$_POST['tbl_collation'] ?? ''</code>
+      <code>$_POST['tbl_collation']</code>
       <code>$_POST['tbl_storage_engine']</code>
       <code>$_POST['unique_indexes']</code>
     </PossiblyInvalidArgument>
@@ -5605,7 +5605,7 @@
       <code>$_POST['indexes']</code>
       <code>$_POST['primary_indexes']</code>
       <code>$_POST['spatial_indexes']</code>
-      <code>$_POST['tbl_collation'] ?? ''</code>
+      <code>$_POST['tbl_collation']</code>
       <code>$_POST['tbl_storage_engine']</code>
       <code>$_POST['unique_indexes']</code>
     </PossiblyInvalidCast>
@@ -10444,7 +10444,7 @@
       <code>$_POST['db_collation'] ?? ''</code>
       <code>$_POST['new_auto_increment']</code>
       <code>$_POST['prev_comment']</code>
-      <code>$_POST['tbl_collation'] ?? ''</code>
+      <code>$_POST['tbl_collation']</code>
       <code>$_POST['what']</code>
       <code>$copyMode ?? 'data'</code>
       <code>$newRowFormat</code>
@@ -10455,7 +10455,7 @@
       <code>$_POST['db_collation'] ?? ''</code>
       <code>$_POST['new_auto_increment']</code>
       <code>$_POST['prev_comment']</code>
-      <code>$_POST['tbl_collation'] ?? ''</code>
+      <code>$_POST['tbl_collation']</code>
       <code>$_POST['what']</code>
       <code>$copyMode ?? 'data'</code>
       <code>$newRowFormat</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13966,8 +13966,6 @@
       <code>$_SESSION['replication']['sr_action_info']</code>
       <code>$_SESSION['replication']['sr_action_info']</code>
       <code>$_SESSION['replication']['sr_action_info']</code>
-      <code>$_SESSION['replication']['sr_action_info']</code>
-      <code>$_SESSION['replication']['sr_action_status']</code>
       <code>$_SESSION['replication']['sr_action_status']</code>
       <code>$_SESSION['replication']['sr_action_status']</code>
       <code>$_SESSION['replication']['sr_action_status']</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -634,7 +634,6 @@
                     $path,
                     $workPath,
                     $translatedPath,
-                    true,
                     $userPrefsAllow,
                     $jsDefault
                 )</code>
@@ -3391,7 +3390,6 @@
     </PossiblyInvalidArgument>
     <PropertyNotSetInConstructor>
       <code>$hasStatistics</code>
-      <code>$position</code>
       <code>$sortBy</code>
       <code>$sortOrder</code>
     </PropertyNotSetInConstructor>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13781,6 +13781,7 @@
       <code>$key</code>
       <code>$loc</code>
       <code>$loc[array_shift($contentPath)]</code>
+      <code>$tablesInDatabase</code>
     </MixedAssignment>
     <MixedOperand>
       <code>$this-&gt;tableCache[$one_database]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2966,7 +2966,6 @@
     </MixedArgument>
     <MixedAssignment>
       <code>$dbName</code>
-      <code>$getNaviSettings</code>
       <code>$itemName</code>
       <code>$itemType</code>
       <code>$tableName</code>
@@ -10187,7 +10186,7 @@
       <code>[
                 'legendText' =&gt; __('End of step'),
                 'headText' =&gt; $headText,
-                'queryError' =&gt; $error,
+                'queryError' =&gt; false,
             ]</code>
       <code>[
             'legendText' =&gt; __('End of step'),

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11651,9 +11651,6 @@
     <PropertyNotSetInConstructor>
       <code>$table</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType>
-      <code>(string) $record[$i]</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportYaml.php">
     <MixedAssignment>
@@ -13111,14 +13108,6 @@
     <PossiblyUnusedMethod>
       <code>isWithDataDictionary</code>
     </PossiblyUnusedMethod>
-    <RedundantCastGivenDocblockType>
-      <code>(string) sprintf(
-                '%.0f',
-                ($l * $gridSize + $topSpace - $this-&gt;topMargin)
-                * $this-&gt;scale + $this-&gt;yMin
-            )</code>
-      <code>(string) sprintf('%.0f', ($j * $gridSize - $this-&gt;leftMargin) * $this-&gt;scale + $this-&gt;xMin)</code>
-    </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType>
       <code>isset($this-&gt;orientation)</code>
     </RedundantConditionGivenDocblockType>
@@ -13475,7 +13464,6 @@
     <RedundantCastGivenDocblockType>
       <code>(string) $buffer</code>
       <code>(string) $buffer</code>
-      <code>(string) $source</code>
       <code>(string) $text</code>
     </RedundantCastGivenDocblockType>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14016,6 +14016,9 @@
     <InvalidArrayOffset>
       <code>$GLOBALS['cfg']['environment']</code>
     </InvalidArrayOffset>
+    <MixedArrayAccess>
+      <code>$dispatchData[0]['GET']['/']</code>
+    </MixedArrayAccess>
   </file>
   <file src="libraries/classes/Sanitize.php">
     <MixedArgument>

--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -25,7 +25,7 @@
   {% endif %}
 
   <td>
-    {% if column.Null|upper == 'YES' and not read_only %}
+    {% if column.Null|upper == 'YES' %}
       <input type="hidden" name="fields_null_prev[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]"{{ real_null_value and not column.first_timestamp ? ' value="on"' }}>
       <input type="checkbox" class="checkbox_null" name="fields_null[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_2" aria-label="{% trans 'Use the NULL value for this column.' %}"{{ real_null_value ? ' checked' }}>
       <input type="hidden" class="nullify_code" name="nullify_code[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ nullify_code }}">


### PR DESCRIPTION
PHPStorm has been a little annoying with showing all these code issues. I took some time to analyse most of them and fix whichever were easy to fix. This kind of change should improve future maintenance as developers do not need to wonder what a line of code does. Code that has no impact on functionality should be removed. 