### PR TITLE
Remove escapeString from Relation

### DIFF
--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -1055,13 +1055,16 @@ class Relation
                     . '.' . Util::backquote($foreign_table);
                 $f_query_filter = $foreign_filter === '' ? '' : ' WHERE '
                     . Util::backquote($foreign_field)
-                    . ' LIKE "%' . $this->dbi->escapeString($foreign_filter) . '%"'
+                    . ' LIKE ' . $this->dbi->quoteString(
+                        '%' . $this->dbi->escapeMysqlWildcards($foreign_filter) . '%'
+                    )
                     . (
                         $foreign_display === false
                         ? ''
                         : ' OR ' . Util::backquote($foreign_display)
-                        . ' LIKE "%' . $this->dbi->escapeString($foreign_filter)
-                        . '%"'
+                        . ' LIKE ' . $this->dbi->quoteString(
+                            '%' . $this->dbi->escapeMysqlWildcards($foreign_filter) . '%'
+                        )
                     );
                 $f_query_order = $foreign_display === false ? '' : ' ORDER BY '
                     . Util::backquote($foreign_table) . '.'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -739,10 +739,6 @@
     </PossiblyInvalidCast>
   </file>
   <file src="libraries/classes/ConfigStorage/Relation.php">
-    <DeprecatedMethod occurrences="2">
-      <code>escapeString</code>
-      <code>escapeString</code>
-    </DeprecatedMethod>
     <InvalidArgument occurrences="1">
       <code>usort($tables, 'strnatcasecmp')</code>
     </InvalidArgument>
@@ -12174,6 +12170,11 @@
       <code>$row['#']</code>
       <code>$row['#']</code>
     </PossiblyNullOperand>
+  </file>
+  <file src="libraries/classes/Server/Status/Processes.php">
+    <RedundantCondition occurrences="1">
+      <code>0 !== --$sortableColCount</code>
+    </RedundantCondition>
   </file>
   <file src="libraries/classes/Session.php">
     <MixedArgument occurrences="3">


### PR DESCRIPTION
I added `escapeMysqlWildcards` assuming that it's needed here, but I honestly don't know. So unless someone can say it shouldn't be there, let's add it. 