### PR TITLE
Export plugins refactoring

### DIFF
--- a/libraries/classes/Plugins/Export/ExportCsv.php
+++ b/libraries/classes/Plugins/Export/ExportCsv.php
@@ -214,7 +214,7 @@ class ExportCsv extends ExportPlugin
     ): bool {
         $GLOBALS['what'] = $GLOBALS['what'] ?? null;
         $GLOBALS['csv_terminated'] = $GLOBALS['csv_terminated'] ?? null;
-        $GLOBALS['csv_separator'] = $GLOBALS['csv_separator'] ?? null;
+        $GLOBALS['csv_separator'] = $GLOBALS['csv_separator'] ?? '';
         $GLOBALS['csv_enclosed'] = $GLOBALS['csv_enclosed'] ?? null;
         $GLOBALS['csv_escaped'] = $GLOBALS['csv_escaped'] ?? null;
 

--- a/libraries/classes/Plugins/Export/ExportHtmlword.php
+++ b/libraries/classes/Plugins/Export/ExportHtmlword.php
@@ -10,6 +10,7 @@ namespace PhpMyAdmin\Plugins\Export;
 use PhpMyAdmin\Database\Triggers;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Connection;
+use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -201,13 +202,17 @@ class ExportHtmlword extends ExportPlugin
             return false;
         }
 
-        // Gets the data from the database
+        /**
+         * Gets the data from the database
+         *
+         * @var ResultInterface $result
+         * @psalm-ignore-var
+         */
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
             Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
-        $fields_cnt = $result->numFields();
 
         // If required, get fields name at the first line
         if (isset($GLOBALS['htmlword_columns'])) {
@@ -231,13 +236,11 @@ class ExportHtmlword extends ExportPlugin
         // Format the data
         while ($row = $result->fetchRow()) {
             $schema_insert = '<tr class="print-category">';
-            for ($j = 0; $j < $fields_cnt; $j++) {
-                if (! isset($row[$j])) {
+            foreach ($row as $field) {
+                if ($field === null) {
                     $value = $GLOBALS[$GLOBALS['what'] . '_null'];
-                } elseif ($row[$j] == '0' || $row[$j] != '') {
-                    $value = $row[$j];
                 } else {
-                    $value = '';
+                    $value = $field;
                 }
 
                 $schema_insert .= '<td class="print">'

--- a/libraries/classes/Plugins/Export/ExportTexytext.php
+++ b/libraries/classes/Plugins/Export/ExportTexytext.php
@@ -10,6 +10,7 @@ namespace PhpMyAdmin\Plugins\Export;
 use PhpMyAdmin\Database\Triggers;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Connection;
+use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\Plugins\ExportPlugin;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -181,13 +182,17 @@ class ExportTexytext extends ExportPlugin
             return false;
         }
 
-        // Gets the data from the database
+        /**
+         * Gets the data from the database
+         *
+         * @var ResultInterface $result
+         * @psalm-ignore-var
+         */
         $result = $GLOBALS['dbi']->query(
             $sqlQuery,
             Connection::TYPE_USER,
             DatabaseInterface::QUERY_UNBUFFERED
         );
-        $fields_cnt = $result->numFields();
 
         // If required, get fields name at the first line
         if (isset($GLOBALS[$GLOBALS['what'] . '_columns'])) {
@@ -209,11 +214,11 @@ class ExportTexytext extends ExportPlugin
         // Format the data
         while ($row = $result->fetchRow()) {
             $text_output = '';
-            for ($j = 0; $j < $fields_cnt; $j++) {
-                if (! isset($row[$j])) {
+            foreach ($row as $field) {
+                if ($field === null) {
                     $value = $GLOBALS[$GLOBALS['what'] . '_null'];
-                } elseif ($row[$j] == '0' || $row[$j] != '') {
-                    $value = $row[$j];
+                } elseif ($field !== '') {
+                    $value = $field;
                 } else {
                     $value = ' ';
                 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6261,6 +6261,11 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportCsv.php
 
 		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 3
+			path: libraries/classes/Plugins/Export/ExportCsv.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Export\\\\ExportHtmlword\\:\\:exportData\\(\\) has parameter \\$aliases with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/ExportHtmlword.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10935,8 +10935,6 @@
       <code>$GLOBALS['csv_enclosed']</code>
       <code>$GLOBALS['csv_escaped']</code>
       <code>$GLOBALS['csv_separator']</code>
-      <code>$GLOBALS['csv_separator']</code>
-      <code>$GLOBALS['csv_separator']</code>
     </PossiblyNullArgument>
     <PossiblyNullOperand>
       <code>$GLOBALS['csv_enclosed']</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10903,6 +10903,9 @@
     </RedundantCondition>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportCsv.php">
+    <InvalidArgument>
+      <code>$insertValues</code>
+    </InvalidArgument>
     <InvalidArrayOffset>
       <code>$GLOBALS['excel_columns']</code>
       <code>$GLOBALS['what']</code>
@@ -10911,23 +10914,28 @@
     <MixedArgument>
       <code>$col_as</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code>$insertFields</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code>$GLOBALS['what']</code>
       <code>$GLOBALS['what']</code>
       <code>$col_as</code>
+      <code>$insertFields[]</code>
+      <code>$insertValues[]</code>
     </MixedAssignment>
     <MixedOperand>
-      <code>$GLOBALS[$GLOBALS['what'] . '_null']</code>
       <code>$GLOBALS['what']</code>
       <code>$GLOBALS['what']</code>
       <code>$GLOBALS['what']</code>
-      <code>$col_as</code>
     </MixedOperand>
     <PossiblyNullArgument>
       <code>$GLOBALS['csv_enclosed']</code>
       <code>$GLOBALS['csv_enclosed']</code>
       <code>$GLOBALS['csv_enclosed']</code>
       <code>$GLOBALS['csv_escaped']</code>
+      <code>$GLOBALS['csv_separator']</code>
+      <code>$GLOBALS['csv_separator']</code>
       <code>$GLOBALS['csv_separator']</code>
     </PossiblyNullArgument>
     <PossiblyNullOperand>
@@ -10945,8 +10953,6 @@
       <code>$GLOBALS['csv_escaped']</code>
       <code>$GLOBALS['csv_escaped']</code>
       <code>$GLOBALS['csv_escaped']</code>
-      <code>$GLOBALS['csv_separator']</code>
-      <code>$GLOBALS['csv_separator']</code>
       <code>$GLOBALS['csv_terminated']</code>
       <code>$GLOBALS['csv_terminated']</code>
     </PossiblyNullOperand>

--- a/test/classes/Plugins/Export/ExportCsvTest.php
+++ b/test/classes/Plugins/Export/ExportCsvTest.php
@@ -404,7 +404,7 @@ class ExportCsvTest extends AbstractTestCase
         $result = ob_get_clean();
 
         $this->assertEquals(
-            'idnamedatetimefiel;1abcd2011-01-20 02:00:02;2foo2010-01-20 02:00:02;3Abcd2012-01-20 02:00:02;',
+            'idnamedatetimefield;1abcd2011-01-20 02:00:02;2foo2010-01-20 02:00:02;3Abcd2012-01-20 02:00:02;',
             $result
         );
 
@@ -422,7 +422,7 @@ class ExportCsvTest extends AbstractTestCase
         $result = ob_get_clean();
 
         $this->assertEquals(
-            '"id""name""datetimefield;"1""abcd""2011-01-20 02:00:02";'
+            '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
             . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
             $result
         );
@@ -443,7 +443,7 @@ class ExportCsvTest extends AbstractTestCase
         $result = ob_get_clean();
 
         $this->assertEquals(
-            '"id""name""datetimefield;"1""abcd""2011-01-20 02:00:02";'
+            '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
             . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
             $result
         );
@@ -463,7 +463,7 @@ class ExportCsvTest extends AbstractTestCase
         $result = ob_get_clean();
 
         $this->assertEquals(
-            '"id""name""datetimefield;"1""abcd""2011-01-20 02:00:02";'
+            '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
             . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
             $result
         );
@@ -483,7 +483,7 @@ class ExportCsvTest extends AbstractTestCase
         $result = ob_get_clean();
 
         $this->assertEquals(
-            '"id""name""datetimefield;"1""abcd""2011-01-20 02:00:02";'
+            '"id""name""datetimefield";"1""abcd""2011-01-20 02:00:02";'
             . '"2""foo""2010-01-20 02:00:02";"3""Abcd""2012-01-20 02:00:02";',
             $result
         );


### PR DESCRIPTION
This is a simplification of the code to remove confusing `($row[$j] == '0' || $row[$j] != '')`. To make the code simpler, I added a `@var` annotation and replace `for` with `foreach`.

I realize this adds Psalm warnings, and they are valid warnings. But they are because of dead code related to `$GLOBALS['what']`. This just looks like another nonsense of its own that needs a little more work to be removed so I kept it out of this PR. For the time being, let's keep them in Psalm baseline. 