### PR TITLE
Fix #18060 - Console height "Not a non-negative number" error

### DIFF
--- a/js/src/console.js
+++ b/js/src/console.js
@@ -487,7 +487,7 @@ var ConsoleResizer = {
      * @return {void}
      */
     mouseUp: function () {
-        Console.setConfig('Height', ConsoleResizer.resultHeight);
+        Console.setConfig('Height', Math.round(ConsoleResizer.resultHeight));
         Console.show();
         $(document).off('mousemove');
         $(document).off('mouseup');


### PR DESCRIPTION
Fixes #18060 

The console height gets stored in SESSION in decimal format. But the form expects it to be in a `NonNegativeNumber` format. 

As a fix I've passed the Console height through `Math.round()` function before it gets stored in the session. 

Signed-off-by: Ajmal Hassan <iamajmalhassan@gmail.com>
