### PR TITLE
[RFC] Change phpMyAdmin version from 5.3 to 6.0 and bump min PHP version

### DIFF
--- a/.github/workflows/daily-snapshots.yml
+++ b/.github/workflows/daily-snapshots.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - { version: '5.2', branch: 'QA_5_2', php-version: '7.2', node-version: '12', python-version: '3.7' }
-          - { version: '5.3', branch: 'master', php-version: '7.2', node-version: '14', python-version: '3.7' }
+          - { version: '6.0', branch: 'master', php-version: '8.1', node-version: '14', python-version: '3.7' }
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["7.2"]
+        php-version: ["8.1"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["7.2"]
+        php-version: ["8.1"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/other-tools.yml
+++ b/.github/workflows/other-tools.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["7.2"]
+        php-version: ["8.1"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,13 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { php-version: '8', experimental: false, arch: 'amd64', exclude-phpunit-groups: 'extension-iconv' }
-          - { php-version: '8', experimental: false, arch: 'arm64v8', exclude-phpunit-groups: 'extension-iconv' }
-          - { php-version: '8', experimental: false, arch: 'arm32v7', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
-          - { php-version: '8', experimental: false, arch: 'arm32v6', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
-          - { php-version: '8', experimental: false, arch: 'i386', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
-          - { php-version: '8', experimental: true, arch: 'ppc64le', exclude-phpunit-groups: 'extension-iconv' }
-          - { php-version: '8', experimental: false, arch: 's390x', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
+          - { php-version: '81', experimental: false, arch: 'amd64', exclude-phpunit-groups: 'extension-iconv' }
+          - { php-version: '81', experimental: false, arch: 'arm64v8', exclude-phpunit-groups: 'extension-iconv' }
+          - { php-version: '81', experimental: false, arch: 'arm32v7', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
+          - { php-version: '81', experimental: false, arch: 'arm32v6', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
+          - { php-version: '81', experimental: false, arch: 'i386', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
+          - { php-version: '81', experimental: true, arch: 'ppc64le', exclude-phpunit-groups: 'extension-iconv' }
+          - { php-version: '81', experimental: false, arch: 's390x', exclude-phpunit-groups: 'extension-iconv,32bit-incompatible' }
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -56,10 +56,10 @@ jobs:
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
       - name: Print arch
-        run: docker run --rm ${{ matrix.arch }}/alpine:3.15 uname -a
+        run: docker run --rm ${{ matrix.arch }}/alpine:3.17 uname -a
 
       - name: Run tests on php ${{ matrix.php-version }}
-        run: docker run -v $PWD:/app --workdir /app --rm ${{ matrix.arch }}/alpine:3.15 sh /app/do-tests.sh
+        run: docker run -v $PWD:/app --workdir /app --rm ${{ matrix.arch }}/alpine:3.17 sh /app/do-tests.sh
 
   test-php:
     name: Test on PHP ${{ matrix.php-version }} and ${{ matrix.os }}
@@ -67,7 +67,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        php-version: ["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
+        php-version: ["8.1", "8.2"]
         experimental: [false]
         os: [ubuntu-latest]
         phpunit-options: ['--testsuite unit']
@@ -136,7 +136,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php-version: ["7.2"]
+        php-version: ["8.1"]
         os: [ubuntu-latest]
         extension: ["dbase", "recode"]
     steps:
@@ -196,7 +196,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.3']
+        php-version: ['8.1']
         os: [ubuntu-latest]
         php-extensions: ['mbstring, iconv, mysqli, zip, bz2']
         psr-7-library: ['guzzlehttp/psr7', 'nyholm/psr7', 'laminas/laminas-diactoros']

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -22,7 +22,7 @@ build:
   nodes:
     analysis:
       environment:
-        php: 7.2
+        php: 8.1
         node: 14
       dependencies:
         before:

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ phpMyAdmin - ChangeLog
 ======================
 
 6.0.0 (not yet released)
+- issue        Bump minimum PHP version to 8.1.0
 - issue #17842 Change js.cookie.js to js.cookie.min.js
 - issue #17632 Improve tab keypress to text fields on the login form
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 phpMyAdmin - ChangeLog
 ======================
 
-5.3.0 (not yet released)
+6.0.0 (not yet released)
 - issue #17842 Change js.cookie.js to js.cookie.min.js
 - issue #17632 Improve tab keypress to text fields on the login form
 

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 phpMyAdmin - Readme
 ===================
 
-Version 5.3.0-dev
+Version 6.0.0-dev
 
 A web interface for MySQL and MariaDB.
 

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.3.x-dev"
+            "dev-master": "6.0.x-dev"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^8.1",
         "ext-hash": "*",
         "ext-iconv": "*",
         "ext-json": "*",
@@ -105,7 +105,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.4",
         "phpstan/phpstan-webmozart-assert": "^1.0",
-        "phpunit/phpunit": "^8.5 || ^9.5",
+        "phpunit/phpunit": "^9.5",
         "pragmarx/google2fa-qrcode": "^2.1",
         "psalm/plugin-phpunit": "^0.16.1",
         "roave/security-advisories": "dev-latest",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,7 +51,7 @@ copyright = u'2012 - 2021, The phpMyAdmin devel team'
 # built documents.
 #
 # The short X.Y version.
-version = '5.3.0-dev'
+version = '6.0.0-dev'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -436,6 +436,7 @@ HHVM is supported up to phpMyAdmin 4.8.
 
 Since release 5.0, phpMyAdmin supports only PHP 7.1 and newer.
 Since release 5.2, phpMyAdmin supports only PHP 7.2 and newer.
+Since release 6.0, phpMyAdmin supports only PHP 8.1 and newer.
 
 .. _faq1_32:
 

--- a/doc/require.rst
+++ b/doc/require.rst
@@ -12,7 +12,7 @@ web server (such as Apache, nginx, :term:`IIS`) to install phpMyAdmin's files in
 PHP
 ---
 
-* You need PHP 7.2.5 or newer, with ``session`` support, the Standard PHP Library
+* You need PHP 8.1.0 or newer, with ``session`` support, the Standard PHP Library
   (SPL) extension, hash, ctype, and JSON support.
 
 * The ``mbstring`` extension (see :term:`mbstring`) is strongly recommended

--- a/index.php
+++ b/index.php
@@ -12,8 +12,8 @@ if (! defined('ROOT_PATH')) {
 define('PHPMYADMIN', true);
 // phpcs:enable
 
-if (PHP_VERSION_ID < 70205) {
-    die('<p>PHP 7.2.5+ is required.</p><p>Currently installed version is: ' . PHP_VERSION . '</p>');
+if (PHP_VERSION_ID < 80100) {
+    die('<p>PHP 8.1.0+ is required.</p><p>Currently installed version is: ' . PHP_VERSION . '</p>');
 }
 
 require_once ROOT_PATH . 'libraries/constants.php';

--- a/libraries/classes/Dbal/MysqliStatement.php
+++ b/libraries/classes/Dbal/MysqliStatement.php
@@ -7,9 +7,6 @@ namespace PhpMyAdmin\Dbal;
 use mysqli_stmt;
 
 use function count;
-use function str_repeat;
-
-use const PHP_VERSION_ID;
 
 final class MysqliStatement implements Statement
 {
@@ -33,20 +30,7 @@ final class MysqliStatement implements Statement
             return false;
         }
 
-        if (PHP_VERSION_ID >= 80100) {
-            /**
-             * @psalm-suppress TooManyArguments
-             * @phpstan-ignore-next-line
-             */
-            return $this->statement->execute($params);
-        }
-
-        $types = str_repeat('s', $paramCount);
-        if (! $this->statement->bind_param($types, ...$params)) {
-            return false;
-        }
-
-        return $this->statement->execute();
+        return $this->statement->execute($params);
     }
 
     /**

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -674,11 +674,13 @@ class Util
 
         $date = (string) preg_replace(
             '@%[aA]@',
+            // phpcs:ignore Generic.PHP.DeprecatedFunctions
             $dayOfWeek[(int) @strftime('%w', (int) $timestamp)],
             $format
         );
         $date = (string) preg_replace(
             '@%[bB]@',
+            // phpcs:ignore Generic.PHP.DeprecatedFunctions
             $month[(int) @strftime('%m', (int) $timestamp) - 1],
             $date
         );
@@ -695,6 +697,7 @@ class Util
 
         // Can return false on windows for Japanese language
         // See https://github.com/phpmyadmin/phpmyadmin/issues/15830
+        // phpcs:ignore Generic.PHP.DeprecatedFunctions
         $ret = @strftime($date, (int) $timestamp);
         // Some OSes such as Win8.1 Traditional Chinese version did not produce UTF-8
         // output here. See https://github.com/phpmyadmin/phpmyadmin/issues/10598
@@ -1594,6 +1597,7 @@ class Util
         }
 
         /* Do the replacement */
+        // phpcs:ignore Generic.PHP.DeprecatedFunctions
         return strtr((string) @strftime($string), $replace);
     }
 

--- a/libraries/classes/Version.php
+++ b/libraries/classes/Version.php
@@ -14,12 +14,12 @@ use const VERSION_SUFFIX;
 final class Version
 {
     // The VERSION_SUFFIX constant is defined at libraries/constants.php
-    public const VERSION = '5.3.0-dev' . VERSION_SUFFIX;
-    public const SERIES = '5.3';
-    public const MAJOR = 5;
-    public const MINOR = 3;
+    public const VERSION = '6.0.0-dev' . VERSION_SUFFIX;
+    public const SERIES = '6.0';
+    public const MAJOR = 6;
+    public const MINOR = 0;
     public const PATCH = 0;
-    public const ID = 50300;
+    public const ID = 60000;
     public const PRE_RELEASE_NAME = 'dev';
     public const IS_DEV = true;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phpmyadmin",
-  "version": "5.3.0-dev",
+  "version": "6.0.0-dev",
   "description": "A web interface for MySQL and MariaDB",
   "repository": "https://github.com/phpmyadmin/phpmyadmin.git",
   "author": "The phpMyAdmin Team <developers@phpmyadmin.net> (https://www.phpmyadmin.net/team/)",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,7 +26,7 @@ parameters:
 			path: libraries/classes/Advisory/Advisor.php
 
 		-
-			message: "#^Parameter \\#2 \\$args of function vsprintf expects array, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$values of function vsprintf expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Advisory/Advisor.php
 
@@ -181,7 +181,7 @@ parameters:
 			path: libraries/classes/Config.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function rtrim expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function rtrim expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Config.php
 
@@ -466,7 +466,7 @@ parameters:
 			path: libraries/classes/Config/FormDisplay.php
 
 		-
-			message: "#^Parameter \\#2 \\$pieces of function implode expects array, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$array of function implode expects array\\|null, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Config/FormDisplay.php
 
@@ -641,7 +641,7 @@ parameters:
 			path: libraries/classes/Config/Settings.php
 
 		-
-			message: "#^Parameter \\#1 \\$input of function array_keys expects array, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$array of function array_keys expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Config/Settings.php
 
@@ -1256,7 +1256,7 @@ parameters:
 			path: libraries/classes/Controllers/Database/Structure/AddPrefixTableController.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/Structure/AddPrefixTableController.php
 
@@ -1276,7 +1276,7 @@ parameters:
 			path: libraries/classes/Controllers/Database/Structure/CopyTableController.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/Structure/CopyTableController.php
 
@@ -1326,12 +1326,12 @@ parameters:
 			path: libraries/classes/Controllers/Database/Structure/CopyTableWithPrefixController.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function mb_substr expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/Structure/CopyTableWithPrefixController.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/Structure/CopyTableWithPrefixController.php
 
@@ -1401,12 +1401,12 @@ parameters:
 			path: libraries/classes/Controllers/Database/Structure/ReplacePrefixController.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function mb_substr expects string, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Controllers/Database/Structure/ReplacePrefixController.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/Structure/ReplacePrefixController.php
 
@@ -1516,7 +1516,7 @@ parameters:
 			path: libraries/classes/Controllers/Database/TrackingController.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\<int, array\\<string, string\\>\\>\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\<int, array\\<string, string\\>\\>\\|string\\|null given\\.$#"
 			count: 2
 			path: libraries/classes/Controllers/Database/TrackingController.php
 
@@ -1654,6 +1654,11 @@ parameters:
 			message: "#^Parameter \\#5 \\$bookmarkLabel of method PhpMyAdmin\\\\Sql\\:\\:storeTheQueryAsBookmark\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Controllers/Import/ImportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$separator of function explode expects non\\-empty\\-string, string given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Import/SimulateDmlController.php
 
 		-
 			message: "#^Parameter \\#1 \\$id of static method PhpMyAdmin\\\\Import\\\\Ajax\\:\\:status\\(\\) expects string, mixed given\\.$#"
@@ -2111,7 +2116,7 @@ parameters:
 			path: libraries/classes/Controllers/Table/FindReplaceController.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function mb_strlen expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function mb_strlen expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/GetFieldController.php
 
@@ -2121,7 +2126,7 @@ parameters:
 			path: libraries/classes/Controllers/Table/GetFieldController.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/IndexesController.php
 
@@ -2236,7 +2241,7 @@ parameters:
 			path: libraries/classes/Controllers/Table/Structure/PartitioningController.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\PartitionDefinition\\>\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\<PhpMyAdmin\\\\SqlParser\\\\Components\\\\PartitionDefinition\\>\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/Structure/PartitioningController.php
 
@@ -2246,7 +2251,7 @@ parameters:
 			path: libraries/classes/Controllers/Table/Structure/ReservedWordCheckController.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function trim expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Controllers/Table/Structure/ReservedWordCheckController.php
 
@@ -3371,6 +3376,21 @@ parameters:
 			path: libraries/classes/Dbal/DbalInterface.php
 
 		-
+			message: "#^Casting to int something that's already int\\.$#"
+			count: 1
+			path: libraries/classes/Dbal/DbiMysqli.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\Dbal\\\\DbiMysqli\\:\\:affectedRows\\(\\) should return int\\|numeric\\-string but returns int\\|string\\.$#"
+			count: 1
+			path: libraries/classes/Dbal/DbiMysqli.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function stripos expects string, string\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Dbal/DbiMysqli.php
+
+		-
 			message: "#^Call to function method_exists\\(\\) with mysqli_result and 'fetch_all' will always evaluate to true\\.$#"
 			count: 3
 			path: libraries/classes/Dbal/MysqliResult.php
@@ -3378,6 +3398,11 @@ parameters:
 		-
 			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:fetchAllKeyPair\\(\\) should return array\\<string, string\\|null\\> but returns array\\<int\\|string, mixed\\>\\.$#"
 			count: 2
+			path: libraries/classes/Dbal/MysqliResult.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:numRows\\(\\) should return int\\|numeric\\-string but returns int\\|string\\.$#"
+			count: 1
 			path: libraries/classes/Dbal/MysqliResult.php
 
 		-
@@ -3621,6 +3646,11 @@ parameters:
 			path: libraries/classes/Encoding.php
 
 		-
+			message: "#^Function recode_string not found\\.$#"
+			count: 1
+			path: libraries/classes/Encoding.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\Encoding\\:\\:convertString\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: libraries/classes/Encoding.php
@@ -3637,6 +3667,11 @@ parameters:
 
 		-
 			message: "#^Property PhpMyAdmin\\\\Encoding\\:\\:\\$engineorder type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: libraries/classes/Encoding.php
+
+		-
+			message: "#^Used function recode_string not found\\.$#"
 			count: 1
 			path: libraries/classes/Encoding.php
 
@@ -3746,7 +3781,7 @@ parameters:
 			path: libraries/classes/Error.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int, array\\)\\: bool\\)\\|null, array\\{\\$this\\(PhpMyAdmin\\\\ErrorHandler\\), 'handleError'\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int\\)\\: bool\\)\\|null, array\\{\\$this\\(PhpMyAdmin\\\\ErrorHandler\\), 'handleError'\\} given\\.$#"
 			count: 1
 			path: libraries/classes/ErrorHandler.php
 
@@ -4736,22 +4771,72 @@ parameters:
 			path: libraries/classes/Http/ServerRequest.php
 
 		-
-			message: "#^Function imagefilledpolygon invoked with 3 parameters, 4 required\\.$#"
-			count: 1
-			path: libraries/classes/Image/ImageWrapper.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Image\\\\ImageWrapper\\:\\:filledPolygon\\(\\) has parameter \\$points with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Image/ImageWrapper.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Image\\\\ImageWrapper\\:\\:height\\(\\) should return int but returns int\\|false\\.$#"
+			message: "#^Parameter \\#1 \\$dst_image of function imagecopyresampled expects GdImage, resource given\\.$#"
 			count: 1
 			path: libraries/classes/Image/ImageWrapper.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Image\\\\ImageWrapper\\:\\:width\\(\\) should return int but returns int\\|false\\.$#"
+			message: "#^Parameter \\#1 \\$image of class PhpMyAdmin\\\\Image\\\\ImageWrapper constructor expects resource, GdImage given\\.$#"
+			count: 3
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagearc expects GdImage, resource given\\.$#"
+			count: 1
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagecolorallocate expects GdImage, resource given\\.$#"
+			count: 1
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagedestroy expects GdImage, resource given\\.$#"
+			count: 1
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagefilledpolygon expects GdImage, resource given\\.$#"
+			count: 2
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagejpeg expects GdImage, resource given\\.$#"
+			count: 1
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imageline expects GdImage, resource given\\.$#"
+			count: 1
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagepng expects GdImage, resource given\\.$#"
+			count: 1
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagestring expects GdImage, resource given\\.$#"
+			count: 1
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagesx expects GdImage, resource given\\.$#"
+			count: 1
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#1 \\$image of function imagesy expects GdImage, resource given\\.$#"
+			count: 1
+			path: libraries/classes/Image/ImageWrapper.php
+
+		-
+			message: "#^Parameter \\#2 \\$src_image of function imagecopyresampled expects GdImage, resource given\\.$#"
 			count: 1
 			path: libraries/classes/Image/ImageWrapper.php
 
@@ -4879,6 +4964,11 @@ parameters:
 			message: "#^Method PhpMyAdmin\\\\IndexColumn\\:\\:set\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/IndexColumn.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:analyzeTableColumnsArray\\(\\) has parameter \\$column with no value type specified in iterable type array\\.$#"
@@ -5141,11 +5231,6 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:loadFirstRow\\(\\) should return array\\{PhpMyAdmin\\\\Dbal\\\\ResultInterface, array\\<false\\>\\} but returns array\\{PhpMyAdmin\\\\Dbal\\\\ResultInterface, array\\<int, false\\>\\|false\\}\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\InsertEdit\\:\\:showEmptyResultMessageOrSetUniqueCondition\\(\\) has parameter \\$rows with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
@@ -5201,17 +5286,12 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#1 \\$data of function bin2hex expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function bin2hex expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function stripslashes expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:quoteString\\(\\) expects string, string\\|false given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function stripslashes expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -5232,6 +5312,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#4 \\$data of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:foreignDropdown\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between string and false will always evaluate to true\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -5486,7 +5571,7 @@ parameters:
 			path: libraries/classes/Navigation/NavigationTree.php
 
 		-
-			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
 			count: 2
 			path: libraries/classes/Navigation/NavigationTree.php
 
@@ -5496,7 +5581,7 @@ parameters:
 			path: libraries/classes/Navigation/NavigationTree.php
 
 		-
-			message: "#^Parameter \\#1 \\$str1 of function strcasecmp expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$string1 of function strcasecmp expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Navigation/NavigationTree.php
 
@@ -5876,7 +5961,7 @@ parameters:
 			path: libraries/classes/Plugins.php
 
 		-
-			message: "#^Parameter \\#2 \\$str2 of function strcmp expects string, class\\-string\\|false given\\.$#"
+			message: "#^Parameter \\#2 \\$string2 of function strcmp expects string, class\\-string\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins.php
 
@@ -6161,12 +6246,12 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function strtoupper expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$str of static method PhpMyAdmin\\\\SqlParser\\\\Context\\:\\:escape\\(\\) expects array\\<string\\>\\|string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of static method PhpMyAdmin\\\\SqlParser\\\\Context\\:\\:escape\\(\\) expects array\\<string\\>\\|string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function strtoupper expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
@@ -6441,7 +6526,7 @@ parameters:
 			path: libraries/classes/Plugins/Import/ImportMediawiki.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function trim expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportMediawiki.php
 
@@ -6556,7 +6641,7 @@ parameters:
 			path: libraries/classes/Plugins/Import/ImportXml.php
 
 		-
-			message: "#^Parameter \\#1 \\$str1 of function strcmp expects string, array\\<int, array\\<int, string\\>\\|string\\>\\|string given\\.$#"
+			message: "#^Parameter \\#1 \\$string1 of function strcmp expects string, array\\<int, array\\<int, string\\>\\|string\\>\\|string given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportXml.php
 
@@ -7621,17 +7706,17 @@ parameters:
 			path: libraries/classes/Server/Privileges.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|null given\\.$#"
-			count: 3
-			path: libraries/classes/Server/Privileges.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:quoteString\\(\\) expects string, string\\|null given\\.$#"
 			count: 2
 			path: libraries/classes/Server/Privileges.php
 
 		-
-			message: "#^Parameter \\#2 \\$str of function explode expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function mb_substr expects string, string\\|null given\\.$#"
+			count: 3
+			path: libraries/classes/Server/Privileges.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, string\\|null given\\.$#"
 			count: 3
 			path: libraries/classes/Server/Privileges.php
 
@@ -7881,12 +7966,12 @@ parameters:
 			path: libraries/classes/Server/Status/Monitor.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function mb_strlen expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function mb_strlen expects string, string\\|null given\\.$#"
 			count: 4
 			path: libraries/classes/Server/Status/Monitor.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function mb_substr expects string, string\\|null given\\.$#"
 			count: 3
 			path: libraries/classes/Server/Status/Monitor.php
 
@@ -7921,12 +8006,12 @@ parameters:
 			path: libraries/classes/Session.php
 
 		-
-			message: "#^Parameter \\#1 \\$newid of function session_id expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$id of function session_id expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Session.php
 
 		-
-			message: "#^Parameter \\#1 \\$newname of function session_save_path expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$path of function session_save_path expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Session.php
 
@@ -8071,11 +8156,6 @@ parameters:
 			path: libraries/classes/Sql.php
 
 		-
-			message: "#^Parameter \\#1 \\$data of function bin2hex expects string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Sql.php
-
-		-
 			message: "#^Parameter \\#1 \\$dtResult of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTable\\(\\) expects PhpMyAdmin\\\\Dbal\\\\ResultInterface, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
@@ -8097,6 +8177,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$rows of static method PhpMyAdmin\\\\Message\\:\\:getMessageForInsertedRows\\(\\) expects int, int\\|string given\\.$#"
+			count: 1
+			path: libraries/classes/Sql.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function bin2hex expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
 
@@ -8401,17 +8486,17 @@ parameters:
 			path: libraries/classes/Table.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Table.php
 
 		-
-			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Table.php
 
 		-
-			message: "#^Parameter \\#2 \\$str of function explode expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Table.php
 
@@ -8446,18 +8531,13 @@ parameters:
 			path: libraries/classes/Table/ColumnsDefinition.php
 
 		-
-			message: "#^Parameter \\#2 \\$str of function explode expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Table/ColumnsDefinition.php
 
 		-
 			message: "#^Parameter \\#1 \\$gisString of static method PhpMyAdmin\\\\Utils\\\\Gis\\:\\:createData\\(\\) expects string, mixed given\\.$#"
 			count: 2
-			path: libraries/classes/Table/Search.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of function trim expects string, mixed given\\.$#"
-			count: 1
 			path: libraries/classes/Table/Search.php
 
 		-
@@ -8471,7 +8551,12 @@ parameters:
 			path: libraries/classes/Table/Search.php
 
 		-
-			message: "#^Parameter \\#2 \\$str of function explode expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Table/Search.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
 			count: 2
 			path: libraries/classes/Table/Search.php
 
@@ -8836,7 +8921,7 @@ parameters:
 			path: libraries/classes/Tracking.php
 
 		-
-			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Tracking.php
 
@@ -9091,17 +9176,17 @@ parameters:
 			path: libraries/classes/Utils/FormatConverter.php
 
 		-
-			message: "#^Parameter \\#1 \\$data of function bin2hex expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Utils/FormatConverter.php
-
-		-
 			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Utils/FormatConverter.php
 
 		-
-			message: "#^Parameter \\#1 \\$ip_address of function inet_pton expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$ip of function inet_pton expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Utils/FormatConverter.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function bin2hex expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Utils/FormatConverter.php
 
@@ -9151,6 +9236,11 @@ parameters:
 			path: libraries/classes/VersionInformation.php
 
 		-
+			message: "#^Casting to string something that's already string\\.$#"
+			count: 1
+			path: libraries/classes/ZipExtension.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\ZipExtension\\:\\:createFile\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/ZipExtension.php
@@ -9174,6 +9264,16 @@ parameters:
 			message: "#^PHPDoc tag @var for variable \\$data has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/ZipExtension.php
+
+		-
+			message: "#^Call to function method_exists\\(\\) with 'PHPUnit\\\\\\\\Framework\\\\\\\\TestCase' and 'assertFileDoesNotEx…' will always evaluate to true\\.$#"
+			count: 1
+			path: test/classes/AbstractTestCase.php
+
+		-
+			message: "#^Call to function method_exists\\(\\) with 'PHPUnit\\\\\\\\Framework\\\\\\\\TestCase' and 'assertMatchesRegula…' will always evaluate to true\\.$#"
+			count: 1
+			path: test/classes/AbstractTestCase.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\AbstractTestCase\\:\\:callFunction\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
@@ -9296,7 +9396,7 @@ parameters:
 			path: test/classes/Command/SetVersionCommandTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$array_arg of function sort expects TArray of array\\<T\\>, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$array of function sort expects TArray of array\\<T\\>, mixed given\\.$#"
 			count: 2
 			path: test/classes/Command/TwigLintCommandTest.php
 
@@ -11767,16 +11867,11 @@ parameters:
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsInt\\(\\) with 0 will always evaluate to true\\.$#"
-			count: 1
+			count: 2
 			path: test/classes/VersionTest.php
 
 		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsInt\\(\\) with 3 will always evaluate to true\\.$#"
-			count: 1
-			path: test/classes/VersionTest.php
-
-		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsInt\\(\\) with 5 will always evaluate to true\\.$#"
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsInt\\(\\) with 6 will always evaluate to true\\.$#"
 			count: 1
 			path: test/classes/VersionTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -238,9 +238,6 @@
     </RedundantCast>
   </file>
   <file src="libraries/classes/Config.php">
-    <InvalidArgument occurrences="1">
-      <code>$optionalParams</code>
-    </InvalidArgument>
     <InvalidArrayOffset occurrences="3">
       <code>$GLOBALS['cfg']['Server']['controlpass']</code>
       <code>$GLOBALS['cfg']['Server']['controluser']</code>
@@ -4652,8 +4649,9 @@
       <code>$itemName</code>
       <code>$itemName</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="10">
+    <PossiblyInvalidCast occurrences="11">
       <code>$_POST['item_comment']</code>
+      <code>$_POST['item_definer']</code>
       <code>$_POST['item_definer']</code>
       <code>$_POST['item_ends']</code>
       <code>$_POST['item_execute_at']</code>
@@ -5112,7 +5110,7 @@
     <PossiblyInvalidArrayAccess occurrences="1">
       <code>$params['dir'][$i]</code>
     </PossiblyInvalidArrayAccess>
-    <PossiblyInvalidCast occurrences="23">
+    <PossiblyInvalidCast occurrences="24">
       <code>$_GET['item_name']</code>
       <code>$_GET['item_name']</code>
       <code>$_GET['item_name']</code>
@@ -5130,6 +5128,7 @@
       <code>$_POST['item_returnopts_num']</code>
       <code>$_POST['item_returnopts_text']</code>
       <code>$_POST['item_type']</code>
+      <code>$itemDefiner</code>
       <code>$itemDefiner</code>
       <code>$itemReturnType</code>
       <code>$itemReturnType</code>
@@ -5319,7 +5318,8 @@
       <code>$itemName</code>
       <code>$itemName</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="4">
+    <PossiblyInvalidCast occurrences="5">
+      <code>$_POST['item_definer']</code>
       <code>$_POST['item_definer']</code>
       <code>$_POST['item_name']</code>
       <code>$_POST['item_original_name']</code>
@@ -5520,11 +5520,13 @@
       <code>$statementInfo-&gt;statement-&gt;expr</code>
       <code>$statementInfo-&gt;statement-&gt;where</code>
     </InvalidIterator>
-    <MixedArgument occurrences="42">
+    <MixedArgument occurrences="44">
       <code>$_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['pos'] / $_SESSION['tmpval']['max_rows']</code>
       <code>$_SESSION['tmpval']['query']</code>
       <code>$_SESSION['tmpval']['query']</code>
+      <code>$clause</code>
+      <code>$clause</code>
       <code>$clause</code>
       <code>$clauseIsUnique</code>
       <code>$clauseIsUnique</code>
@@ -7150,6 +7152,24 @@
     </RiskyCast>
   </file>
   <file src="libraries/classes/Image/ImageWrapper.php">
+    <InvalidArgument occurrences="16">
+      <code>$image</code>
+      <code>$image</code>
+      <code>$image</code>
+      <code>$sourceImage-&gt;getImage()</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+      <code>$this-&gt;image</code>
+    </InvalidArgument>
     <TooFewArguments occurrences="1">
       <code>imagefilledpolygon($this-&gt;image, $points, $color)</code>
     </TooFewArguments>
@@ -7400,6 +7420,9 @@
     </MixedAssignment>
   </file>
   <file src="libraries/classes/InsertEdit.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$column['Default']</code>
+    </DocblockTypeContradiction>
     <InvalidArgument occurrences="1">
       <code>$urlParams</code>
     </InvalidArgument>
@@ -7602,6 +7625,9 @@
     <RedundantCast occurrences="1">
       <code>(int) $GLOBALS['cfg']['InsertRows']</code>
     </RedundantCast>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$textDefault !== false</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/IpAllowDeny.php">
     <InvalidOperand occurrences="1">
@@ -8810,6 +8836,9 @@
       <code>$sessionCookieParams['secure']</code>
       <code>$single_signon_cfgupdate</code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$sessionCookieParams</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="13">
       <code>$GLOBALS['cfg']['Server']['host']</code>
       <code>$GLOBALS['cfg']['Server']['port']</code>
@@ -13693,6 +13722,12 @@
       <code>$newData[$newName]</code>
       <code>$value</code>
     </MixedAssignment>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) substr($zdata, 0, strlen($zdata) - 4)</code>
+    </RedundantCastGivenDocblockType>
+    <UnnecessaryVarAnnotation occurrences="1">
+      <code>array</code>
+    </UnnecessaryVarAnnotation>
   </file>
   <file src="libraries/config.default.php">
     <UnusedVariable occurrences="1">
@@ -13796,6 +13831,9 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="test/classes/Command/TwigLintCommandTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <MixedArgument occurrences="2">
       <code>$filesFound</code>
       <code>$filesInfos</code>
@@ -13808,6 +13846,11 @@
       <code>$filesFound</code>
       <code>$filesInfos</code>
     </MixedAssignment>
+  </file>
+  <file src="test/classes/Command/WriteGitRevisionCommandTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
   </file>
   <file src="test/classes/CommonTest.php">
     <DocblockTypeContradiction occurrences="2">
@@ -13892,6 +13935,14 @@
       <code>$this-&gt;sessionID</code>
     </MixedAssignment>
   </file>
+  <file src="test/classes/ConfigStorage/RelationCleanupTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
+  </file>
   <file src="test/classes/ConfigStorage/RelationTest.php">
     <DocblockTypeContradiction occurrences="1">
       <code>assertSame</code>
@@ -13916,7 +13967,16 @@
       <code>assertSame</code>
     </TypeDoesNotContainType>
   </file>
+  <file src="test/classes/ConfigStorage/UserGroupsTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
+  </file>
   <file src="test/classes/ConfigTest.php">
+    <DeprecatedMethod occurrences="2">
+      <code>expectError</code>
+      <code>expectErrorMessage</code>
+    </DeprecatedMethod>
     <InvalidArgument occurrences="1">
       <code>$v</code>
     </InvalidArgument>
@@ -14748,6 +14808,14 @@
       <code>array</code>
     </MixedInferredReturnType>
   </file>
+  <file src="test/classes/Navigation/NodeFactoryTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>expectError</code>
+      <code>expectError</code>
+      <code>expectErrorMessage</code>
+      <code>expectErrorMessage</code>
+    </DeprecatedMethod>
+  </file>
   <file src="test/classes/Navigation/Nodes/NodeColumnContainerTest.php">
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>assertIsArray</code>
@@ -15025,6 +15093,10 @@
     </MixedAssignment>
   </file>
   <file src="test/classes/Plugins/Export/ExportSqlTest.php">
+    <DeprecatedMethod occurrences="2">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <InvalidArrayOffset occurrences="1">
       <code>$GLOBALS['sql_constraints']</code>
     </InvalidArrayOffset>
@@ -15240,8 +15312,16 @@
       <code>assertIsArray</code>
     </RedundantCondition>
   </file>
+  <file src="test/classes/Server/Privileges/AccountLockingTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
+  </file>
   <file src="test/classes/Server/PrivilegesTest.php">
-    <DeprecatedMethod occurrences="7">
+    <DeprecatedMethod occurrences="8">
       <code>escapeString</code>
       <code>escapeString</code>
       <code>escapeString</code>
@@ -15249,6 +15329,7 @@
       <code>escapeString</code>
       <code>escapeString</code>
       <code>escapeString</code>
+      <code>withConsecutive</code>
     </DeprecatedMethod>
     <MixedArgument occurrences="2">
       <code>$real_sql_query</code>
@@ -15472,6 +15553,9 @@
     </MixedInferredReturnType>
   </file>
   <file src="test/classes/TrackerTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <MixedInferredReturnType occurrences="3">
       <code>array</code>
       <code>array</code>
@@ -15534,6 +15618,12 @@
     </TypeDoesNotContainType>
   </file>
   <file src="test/classes/UtilTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <InvalidArgument occurrences="1">
       <code>testGetMySQLDocuURL</code>
     </InvalidArgument>
@@ -15646,6 +15736,12 @@
     </MixedArrayAccess>
   </file>
   <file src="test/classes/VersionInformationTest.php">
+    <DeprecatedMethod occurrences="4">
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+      <code>withConsecutive</code>
+    </DeprecatedMethod>
     <MixedAssignment occurrences="1">
       <code>$returnValues[]</code>
     </MixedAssignment>

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -20,7 +20,7 @@ set -e
 KITS="all-languages english source"
 COMPRESSIONS="zip-7z txz tgz"
 # The version series this script is allowed to handle
-VERSION_SERIES="5.3"
+VERSION_SERIES="6.0"
 
 # Process parameters
 
@@ -473,7 +473,7 @@ if [ -f ./scripts/console ]; then
     ./scripts/console cache:warmup --routing
 fi
 
-PHP_REQ=$(sed -n '/"php"/ s/.*"\^\([0-9]\.[0-9]\.[0-9]\).*/\1/p' composer.json)
+PHP_REQ=$(sed -n '/"php"/ s/.*"\^\([0-9]\.[0-9]\.[0-9]\|[0-9]\.[0-9]\).*/\1/p' composer.json)
 
 if [ -z "$PHP_REQ" ] ; then
     echo "Failed to figure out required PHP version from composer.json"

--- a/setup/index.php
+++ b/setup/index.php
@@ -12,8 +12,8 @@ if (! defined('ROOT_PATH')) {
 define('PHPMYADMIN', true);
 // phpcs:enable
 
-if (PHP_VERSION_ID < 70205) {
-    die('<p>PHP 7.2.5+ is required.</p><p>Currently installed version is: ' . PHP_VERSION . '</p>');
+if (PHP_VERSION_ID < 80100) {
+    die('<p>PHP 8.1.0+ is required.</p><p>Currently installed version is: ' . PHP_VERSION . '</p>');
 }
 
 require_once ROOT_PATH . 'libraries/constants.php';

--- a/test/classes/EnvironmentTest.php
+++ b/test/classes/EnvironmentTest.php
@@ -19,8 +19,8 @@ class EnvironmentTest extends AbstractTestCase
     public function testPhpVersion(): void
     {
         $this->assertTrue(
-            version_compare('7.2.5', PHP_VERSION, '<='),
-            'phpMyAdmin requires PHP 7.2.5 or above'
+            version_compare('8.1.0', PHP_VERSION, '<='),
+            'phpMyAdmin requires PHP 8.1.0 or above'
         );
     }
 }

--- a/test/classes/ThemeTest.php
+++ b/test/classes/ThemeTest.php
@@ -80,7 +80,7 @@ class ThemeTest extends AbstractTestCase
         $this->object->setFsPath(TEST_PATH . 'test/classes/_data/gen_version_info/');
         $this->assertTrue($this->object->loadInfo());
         $this->assertEquals('Test Theme', $this->object->getName());
-        $this->assertEquals('5.3', $this->object->getVersion());
+        $this->assertEquals('6.0', $this->object->getVersion());
     }
 
     /**

--- a/test/classes/_data/gen_version_info/theme.json
+++ b/test/classes/_data/gen_version_info/theme.json
@@ -1,7 +1,7 @@
 {
     "name": "Test Theme",
-    "version": "5.3",
+    "version": "6.0",
     "author": "phpMyAdmin developers",
     "url": "https://www.phpmyadmin.net/",
-    "supports": ["5.2", "5.3"]
+    "supports": ["6.0"]
 }

--- a/themes/bootstrap/theme.json
+++ b/themes/bootstrap/theme.json
@@ -1,8 +1,8 @@
 {
     "name": "Bootstrap",
-    "version": "5.3",
+    "version": "6.0",
     "description": "Bootstrap theme for phpMyAdmin",
     "author": "phpMyAdmin developers",
     "url": "https://www.phpmyadmin.net/",
-    "supports": ["5.3"]
+    "supports": ["6.0"]
 }

--- a/themes/metro/theme.json
+++ b/themes/metro/theme.json
@@ -1,8 +1,8 @@
 {
     "name": "Metro",
-    "version": "5.3",
+    "version": "6.0",
     "description": "Metro theme for phpMyAdmin",
     "author": "phpMyAdmin developers and hplhu",
     "url": "https://www.phpmyadmin.net/",
-    "supports": ["5.3"]
+    "supports": ["6.0"]
 }

--- a/themes/original/theme.json
+++ b/themes/original/theme.json
@@ -1,8 +1,8 @@
 {
     "name": "Original",
-    "version": "5.3",
+    "version": "6.0",
     "description": "Original phpMyAdmin theme",
     "author": "phpMyAdmin developers",
     "url": "https://www.phpmyadmin.net/",
-    "supports": ["5.3"]
+    "supports": ["6.0"]
 }

--- a/themes/pmahomme/theme.json
+++ b/themes/pmahomme/theme.json
@@ -1,8 +1,8 @@
 {
     "name": "pmahomme",
-    "version": "5.3",
+    "version": "6.0",
     "description": "Default phpMyAdmin theme",
     "author": "phpMyAdmin developers",
     "url": "https://www.phpmyadmin.net/",
-    "supports": ["5.3"]
+    "supports": ["6.0"]
 }


### PR DESCRIPTION
This pull request changes the phpMyAdmin version in the `master` branch from `5.3.0-dev` to `6.0.0-dev` and bumps the minimum PHP version from `7.2.5` to `8.1.0`.

If this PR got merged, that means that phpMyAdmin 6.0.0 will replace the phpMyAdmin 5.3.0. The reason is that I feel that phpMyAdmin 5.2 should be supported for a longer time and that the development version in the `master` branch (`5.3.0-dev`) should have a longer development time. So, as there are some features planned for phpMyAdmin 6.0, makes sense to merge 5.3 and 6.0 and drop the 5.3 version.

With phpMyAdmin 6.0 been a new major version, I think we should drop support for old PHP versions and require at least PHP 8.1.0. The reason is that PHP 8.0 is not actively supported anymore and security support will end in November, and PHP 8.1 has a lot of benefits like enumerations and read-only properties, and the new features from PHP 7.3, 7.4 and 8.0 as well.

- Fixes https://github.com/phpmyadmin/phpmyadmin/issues/17953
- Fixes https://github.com/phpmyadmin/phpmyadmin/issues/15607