### PR TITLE
Use property promotion in ImageWrapper

### DIFF
--- a/libraries/classes/Image/ImageWrapper.php
+++ b/libraries/classes/Image/ImageWrapper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Image;
 
+use GdImage;
+
 use function extension_loaded;
 use function function_exists;
 use function imagearc;
@@ -23,21 +25,11 @@ use function imagesy;
 
 final class ImageWrapper
 {
-    /** @var resource */
-    private $image;
-
-    /**
-     * @param resource $image
-     */
-    private function __construct($image)
+    private function __construct(private GdImage $image)
     {
-        $this->image = $image;
     }
 
-    /**
-     * @return resource
-     */
-    public function getImage()
+    public function getImage(): GdImage
     {
         return $this->image;
     }


### PR DESCRIPTION
I cannot update Psalm baseline because Psalm crashes on me. 

Thanks to PHP 8.0 we can use property promotion and we replace resource with GDImage. 