### PR TITLE
Convert var annotations to typed properties

### DIFF
--- a/libraries/classes/Advisory/Advisor.php
+++ b/libraries/classes/Advisory/Advisor.php
@@ -31,8 +31,7 @@ use function vsprintf;
  */
 class Advisor
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /** @var array */
     private $variables;
@@ -54,8 +53,7 @@ class Advisor
         'errors' => [],
     ];
 
-    /** @var ExpressionLanguage */
-    private $expression;
+    private ExpressionLanguage $expression;
 
     /**
      * @param DatabaseInterface  $dbi        DatabaseInterface object

--- a/libraries/classes/Bookmark.php
+++ b/libraries/classes/Bookmark.php
@@ -56,11 +56,9 @@ class Bookmark
      */
     private $query;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(DatabaseInterface $dbi, Relation $relation)
     {

--- a/libraries/classes/BrowseForeigners.php
+++ b/libraries/classes/BrowseForeigners.php
@@ -22,14 +22,10 @@ use function mb_substr;
  */
 class BrowseForeigners
 {
-    /** @var int */
-    private $limitChars;
-    /** @var int */
-    private $maxRows;
-    /** @var int */
-    private $repeatCells;
-    /** @var bool */
-    private $showAll;
+    private int $limitChars;
+    private int $maxRows;
+    private int $repeatCells;
+    private bool $showAll;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Charsets/Charset.php
+++ b/libraries/classes/Charsets/Charset.php
@@ -14,31 +14,23 @@ final class Charset
 {
     /**
      * The character set name
-     *
-     * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * A description of the character set
-     *
-     * @var string
      */
-    private $description;
+    private string $description;
 
     /**
      * The default collation for the character set
-     *
-     * @var string
      */
-    private $defaultCollation;
+    private string $defaultCollation;
 
     /**
      * The maximum number of bytes required to store one character
-     *
-     * @var int
      */
-    private $maxLength;
+    private int $maxLength;
 
     /**
      * @param string $name             Charset name

--- a/libraries/classes/Charsets/Collation.php
+++ b/libraries/classes/Charsets/Collation.php
@@ -20,59 +20,43 @@ final class Collation
 {
     /**
      * The collation name
-     *
-     * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * A description of the collation
-     *
-     * @var string
      */
-    private $description;
+    private string $description;
 
     /**
      * The name of the character set with which the collation is associated
-     *
-     * @var string
      */
-    private $charset;
+    private string $charset;
 
     /**
      * The collation ID
-     *
-     * @var int
      */
-    private $id;
+    private int $id;
 
     /**
      * Whether the collation is the default for its character set
-     *
-     * @var bool
      */
-    private $isDefault;
+    private bool $isDefault;
 
     /**
      * Whether the character set is compiled into the server
-     *
-     * @var bool
      */
-    private $isCompiled;
+    private bool $isCompiled;
 
     /**
      * Used for determining the memory used to sort strings in this collation
-     *
-     * @var int
      */
-    private $sortLength;
+    private int $sortLength;
 
     /**
      * The collation pad attribute
-     *
-     * @var string
      */
-    private $padAttribute;
+    private string $padAttribute;
 
     /**
      * @param string $name         Collation name

--- a/libraries/classes/CheckUserPrivileges.php
+++ b/libraries/classes/CheckUserPrivileges.php
@@ -21,8 +21,7 @@ use function str_contains;
  */
 class CheckUserPrivileges
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * @param DatabaseInterface $dbi DatabaseInterface object

--- a/libraries/classes/Config/ConfigFile.php
+++ b/libraries/classes/Config/ConfigFile.php
@@ -26,10 +26,8 @@ class ConfigFile
      * Stores default phpMyAdmin config
      *
      * @see Settings
-     *
-     * @var array
      */
-    private $defaultCfg;
+    private array $defaultCfg;
 
     /**
      * Stores allowed values for non-standard fields
@@ -47,10 +45,8 @@ class ConfigFile
 
     /**
      * Whether we are currently working in PMA Setup context
-     *
-     * @var bool
      */
-    private $isInSetup;
+    private bool $isInSetup;
 
     /**
      * Keys which will be always written to config file
@@ -77,10 +73,8 @@ class ConfigFile
     /**
      * Instance id (key in $_SESSION array, separate for each server -
      * ConfigFile{server id})
-     *
-     * @var string
      */
-    private $id;
+    private string $id;
 
     /**
      * @param array|null $baseConfig base configuration read from

--- a/libraries/classes/Config/Form.php
+++ b/libraries/classes/Config/Form.php
@@ -68,10 +68,8 @@ class Form
 
     /**
      * ConfigFile instance
-     *
-     * @var ConfigFile
      */
-    private $configFile;
+    private ConfigFile $configFile;
 
     /**
      * A counter for the number of groups

--- a/libraries/classes/Config/FormDisplay.php
+++ b/libraries/classes/Config/FormDisplay.php
@@ -48,10 +48,8 @@ class FormDisplay
 {
     /**
      * ConfigFile instance
-     *
-     * @var ConfigFile
      */
-    private $configFile;
+    private ConfigFile $configFile;
 
     /**
      * Form list
@@ -105,8 +103,7 @@ class FormDisplay
      */
     private $userprefsDisallow;
 
-    /** @var FormDisplayTemplate */
-    private $formDisplayTemplate;
+    private FormDisplayTemplate $formDisplayTemplate;
 
     /**
      * @param ConfigFile $cf Config file instance

--- a/libraries/classes/Config/FormDisplayTemplate.php
+++ b/libraries/classes/Config/FormDisplayTemplate.php
@@ -23,8 +23,7 @@ class FormDisplayTemplate
     /** @var int */
     public $group;
 
-    /** @var Config */
-    protected $config;
+    protected Config $config;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Config/PageSettings.php
+++ b/libraries/classes/Config/PageSettings.php
@@ -43,13 +43,10 @@ class PageSettings
 
     /**
      * Contains HTML of settings
-     *
-     * @var string
      */
-    private $HTML = '';
+    private string $HTML = '';
 
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
     /**
      * @param string $formGroupName The name of config form group to display

--- a/libraries/classes/Config/ServerConfigChecks.php
+++ b/libraries/classes/Config/ServerConfigChecks.php
@@ -31,7 +31,7 @@ use const SODIUM_CRYPTO_SECRETBOX_KEYBYTES;
 class ServerConfigChecks
 {
     /** @var ConfigFile configurations being checked */
-    protected $cfg;
+    protected ConfigFile $cfg;
 
     /**
      * @param ConfigFile $cfg Configuration

--- a/libraries/classes/Console.php
+++ b/libraries/classes/Console.php
@@ -33,8 +33,7 @@ class Console
      */
     private $isAjax = false;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Controllers/AbstractController.php
+++ b/libraries/classes/Controllers/AbstractController.php
@@ -18,11 +18,9 @@ use function defined;
 
 abstract class AbstractController
 {
-    /** @var ResponseRenderer */
-    protected $response;
+    protected ResponseRenderer $response;
 
-    /** @var Template */
-    protected $template;
+    protected Template $template;
 
     public function __construct(ResponseRenderer $response, Template $template)
     {

--- a/libraries/classes/Controllers/BrowseForeignersController.php
+++ b/libraries/classes/Controllers/BrowseForeignersController.php
@@ -15,11 +15,9 @@ use PhpMyAdmin\Template;
  */
 class BrowseForeignersController extends AbstractController
 {
-    /** @var BrowseForeigners */
-    private $browseForeigners;
+    private BrowseForeigners $browseForeigners;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/CheckRelationsController.php
+++ b/libraries/classes/Controllers/CheckRelationsController.php
@@ -17,8 +17,7 @@ use const SQL_DIR;
  */
 class CheckRelationsController extends AbstractController
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(ResponseRenderer $response, Template $template, Relation $relation)
     {

--- a/libraries/classes/Controllers/CollationConnectionController.php
+++ b/libraries/classes/Controllers/CollationConnectionController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Url;
 
 final class CollationConnectionController extends AbstractController
 {
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(ResponseRenderer $response, Template $template, Config $config)
     {

--- a/libraries/classes/Controllers/ColumnController.php
+++ b/libraries/classes/Controllers/ColumnController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class ColumnController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Config/GetConfigController.php
+++ b/libraries/classes/Controllers/Config/GetConfigController.php
@@ -13,8 +13,7 @@ use PhpMyAdmin\Template;
 
 final class GetConfigController extends AbstractController
 {
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(ResponseRenderer $response, Template $template, Config $config)
     {

--- a/libraries/classes/Controllers/Config/SetConfigController.php
+++ b/libraries/classes/Controllers/Config/SetConfigController.php
@@ -15,8 +15,7 @@ use function json_decode;
 
 final class SetConfigController extends AbstractController
 {
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(ResponseRenderer $response, Template $template, Config $config)
     {

--- a/libraries/classes/Controllers/Console/Bookmark/AddController.php
+++ b/libraries/classes/Controllers/Console/Bookmark/AddController.php
@@ -16,8 +16,7 @@ use function is_string;
 
 final class AddController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Database/CentralColumns/PopulateColumnsController.php
+++ b/libraries/classes/Controllers/Database/CentralColumns/PopulateColumnsController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class PopulateColumnsController extends AbstractController
 {
-    /** @var CentralColumns */
-    private $centralColumns;
+    private CentralColumns $centralColumns;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/CentralColumnsController.php
+++ b/libraries/classes/Controllers/Database/CentralColumnsController.php
@@ -22,8 +22,7 @@ use function sprintf;
 
 class CentralColumnsController extends AbstractController
 {
-    /** @var CentralColumns */
-    private $centralColumns;
+    private CentralColumns $centralColumns;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/DataDictionaryController.php
+++ b/libraries/classes/Controllers/Database/DataDictionaryController.php
@@ -19,14 +19,11 @@ use function str_replace;
 
 class DataDictionaryController extends AbstractController
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -20,11 +20,9 @@ use function sprintf;
 
 class DesignerController extends AbstractController
 {
-    /** @var Designer */
-    private $databaseDesigner;
+    private Designer $databaseDesigner;
 
-    /** @var DesignerCommon */
-    private $designerCommon;
+    private DesignerCommon $designerCommon;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/EventsController.php
+++ b/libraries/classes/Controllers/Database/EventsController.php
@@ -17,11 +17,9 @@ use function strlen;
 
 final class EventsController extends AbstractController
 {
-    /** @var Events */
-    private $events;
+    private Events $events;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/ExportController.php
+++ b/libraries/classes/Controllers/Database/ExportController.php
@@ -22,11 +22,9 @@ use function is_array;
 
 final class ExportController extends AbstractController
 {
-    /** @var Export */
-    private $export;
+    private Export $export;
 
-    /** @var Options */
-    private $exportOptions;
+    private Options $exportOptions;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -26,8 +26,7 @@ use function is_numeric;
 
 final class ImportController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Database/MultiTableQuery/TablesController.php
+++ b/libraries/classes/Controllers/Database/MultiTableQuery/TablesController.php
@@ -15,8 +15,7 @@ use function rtrim;
 
 final class TablesController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Database/MultiTableQueryController.php
+++ b/libraries/classes/Controllers/Database/MultiTableQueryController.php
@@ -16,8 +16,7 @@ use PhpMyAdmin\Template;
  */
 class MultiTableQueryController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Database/Operations/CollationController.php
+++ b/libraries/classes/Controllers/Database/Operations/CollationController.php
@@ -18,11 +18,9 @@ use function __;
 
 final class CollationController extends AbstractController
 {
-    /** @var Operations */
-    private $operations;
+    private Operations $operations;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/OperationsController.php
+++ b/libraries/classes/Controllers/Database/OperationsController.php
@@ -32,20 +32,15 @@ use function strlen;
  */
 class OperationsController extends AbstractController
 {
-    /** @var Operations */
-    private $operations;
+    private Operations $operations;
 
-    /** @var CheckUserPrivileges */
-    private $checkUserPrivileges;
+    private CheckUserPrivileges $checkUserPrivileges;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var RelationCleanup */
-    private $relationCleanup;
+    private RelationCleanup $relationCleanup;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/PrivilegesController.php
+++ b/libraries/classes/Controllers/Database/PrivilegesController.php
@@ -27,11 +27,9 @@ use function mb_strtolower;
  */
 class PrivilegesController extends AbstractController
 {
-    /** @var Privileges */
-    private $privileges;
+    private Privileges $privileges;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/QueryByExampleController.php
+++ b/libraries/classes/Controllers/Database/QueryByExampleController.php
@@ -25,11 +25,9 @@ use function stripos;
 
 class QueryByExampleController extends AbstractController
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/RoutinesController.php
+++ b/libraries/classes/Controllers/Database/RoutinesController.php
@@ -23,14 +23,11 @@ use function strlen;
  */
 class RoutinesController extends AbstractController
 {
-    /** @var CheckUserPrivileges */
-    private $checkUserPrivileges;
+    private CheckUserPrivileges $checkUserPrivileges;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Routines */
-    private $routines;
+    private Routines $routines;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/SearchController.php
+++ b/libraries/classes/Controllers/Database/SearchController.php
@@ -19,8 +19,7 @@ use function __;
 
 class SearchController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Database/SqlAutoCompleteController.php
+++ b/libraries/classes/Controllers/Database/SqlAutoCompleteController.php
@@ -15,8 +15,7 @@ use PhpMyAdmin\Template;
  */
 class SqlAutoCompleteController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Database/SqlController.php
+++ b/libraries/classes/Controllers/Database/SqlController.php
@@ -20,8 +20,7 @@ use function htmlspecialchars;
  */
 class SqlController extends AbstractController
 {
-    /** @var SqlQueryForm */
-    private $sqlQueryForm;
+    private SqlQueryForm $sqlQueryForm;
 
     public function __construct(ResponseRenderer $response, Template $template, SqlQueryForm $sqlQueryForm)
     {

--- a/libraries/classes/Controllers/Database/Structure/AddPrefixTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/AddPrefixTableController.php
@@ -17,11 +17,9 @@ use function count;
 
 final class AddPrefixTableController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/Structure/CentralColumns/AddController.php
+++ b/libraries/classes/Controllers/Database/Structure/CentralColumns/AddController.php
@@ -17,11 +17,9 @@ use function __;
 
 final class AddController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/Structure/CentralColumns/MakeConsistentController.php
+++ b/libraries/classes/Controllers/Database/Structure/CentralColumns/MakeConsistentController.php
@@ -17,11 +17,9 @@ use function __;
 
 final class MakeConsistentController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/Structure/CentralColumns/RemoveController.php
+++ b/libraries/classes/Controllers/Database/Structure/CentralColumns/RemoveController.php
@@ -17,11 +17,9 @@ use function __;
 
 final class RemoveController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/Structure/CopyTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/CopyTableController.php
@@ -17,11 +17,9 @@ use function count;
 
 final class CopyTableController extends AbstractController
 {
-    /** @var Operations */
-    private $operations;
+    private Operations $operations;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/Structure/CopyTableWithPrefixController.php
+++ b/libraries/classes/Controllers/Database/Structure/CopyTableWithPrefixController.php
@@ -18,8 +18,7 @@ use function mb_substr;
 
 final class CopyTableWithPrefixController extends AbstractController
 {
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/Structure/DropFormController.php
+++ b/libraries/classes/Controllers/Database/Structure/DropFormController.php
@@ -18,8 +18,7 @@ use function in_array;
 
 final class DropFormController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Database/Structure/DropTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/DropTableController.php
@@ -21,14 +21,11 @@ use function in_array;
 
 final class DropTableController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var RelationCleanup */
-    private $relationCleanup;
+    private RelationCleanup $relationCleanup;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/Structure/EmptyTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/EmptyTableController.php
@@ -25,23 +25,17 @@ use function count;
 
 final class EmptyTableController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var RelationCleanup */
-    private $relationCleanup;
+    private RelationCleanup $relationCleanup;
 
-    /** @var Operations */
-    private $operations;
+    private Operations $operations;
 
-    /** @var FlashMessages */
-    private $flash;
+    private FlashMessages $flash;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/Structure/FavoriteTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/FavoriteTableController.php
@@ -22,8 +22,7 @@ use function sha1;
 
 final class FavoriteTableController extends AbstractController
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(ResponseRenderer $response, Template $template, Relation $relation)
     {

--- a/libraries/classes/Controllers/Database/Structure/RealRowCountController.php
+++ b/libraries/classes/Controllers/Database/Structure/RealRowCountController.php
@@ -19,8 +19,7 @@ use function json_encode;
  */
 final class RealRowCountController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Database/Structure/ReplacePrefixController.php
+++ b/libraries/classes/Controllers/Database/Structure/ReplacePrefixController.php
@@ -19,11 +19,9 @@ use function mb_substr;
 
 final class ReplacePrefixController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/Structure/ShowCreateController.php
+++ b/libraries/classes/Controllers/Database/Structure/ShowCreateController.php
@@ -15,8 +15,7 @@ use function __;
 
 final class ShowCreateController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Database/StructureController.php
+++ b/libraries/classes/Controllers/Database/StructureController.php
@@ -66,17 +66,13 @@ class StructureController extends AbstractController
     /** @var bool whether stats show or not */
     protected $isShowStats;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Replication */
-    private $replication;
+    private Replication $replication;
 
-    /** @var ReplicationInfo */
-    private $replicationInfo;
+    private ReplicationInfo $replicationInfo;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -28,11 +28,9 @@ use function sprintf;
  */
 class TrackingController extends AbstractController
 {
-    /** @var Tracking */
-    private $tracking;
+    private Tracking $tracking;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Database/TriggersController.php
+++ b/libraries/classes/Controllers/Database/TriggersController.php
@@ -22,11 +22,9 @@ use function strlen;
  */
 class TriggersController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Triggers */
-    private $triggers;
+    private Triggers $triggers;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/ErrorReportController.php
+++ b/libraries/classes/Controllers/ErrorReportController.php
@@ -28,14 +28,11 @@ use function time;
  */
 class ErrorReportController extends AbstractController
 {
-    /** @var ErrorReport */
-    private $errorReport;
+    private ErrorReport $errorReport;
 
-    /** @var ErrorHandler */
-    private $errorHandler;
+    private ErrorHandler $errorHandler;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Export/ExportController.php
+++ b/libraries/classes/Controllers/Export/ExportController.php
@@ -38,8 +38,7 @@ use function time;
 
 final class ExportController extends AbstractController
 {
-    /** @var Export */
-    private $export;
+    private Export $export;
 
     public function __construct(ResponseRenderer $response, Template $template, Export $export)
     {

--- a/libraries/classes/Controllers/Export/TablesController.php
+++ b/libraries/classes/Controllers/Export/TablesController.php
@@ -14,8 +14,7 @@ use function __;
 
 final class TablesController extends AbstractController
 {
-    /** @var ExportController */
-    private $exportController;
+    private ExportController $exportController;
 
     public function __construct(ResponseRenderer $response, Template $template, ExportController $exportController)
     {

--- a/libraries/classes/Controllers/Export/Template/CreateController.php
+++ b/libraries/classes/Controllers/Export/Template/CreateController.php
@@ -16,11 +16,9 @@ use function is_array;
 
 final class CreateController extends AbstractController
 {
-    /** @var TemplateModel */
-    private $model;
+    private TemplateModel $model;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Export/Template/DeleteController.php
+++ b/libraries/classes/Controllers/Export/Template/DeleteController.php
@@ -13,11 +13,9 @@ use PhpMyAdmin\Template;
 
 final class DeleteController extends AbstractController
 {
-    /** @var TemplateModel */
-    private $model;
+    private TemplateModel $model;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Export/Template/LoadController.php
+++ b/libraries/classes/Controllers/Export/Template/LoadController.php
@@ -14,11 +14,9 @@ use PhpMyAdmin\Template;
 
 final class LoadController extends AbstractController
 {
-    /** @var TemplateModel */
-    private $model;
+    private TemplateModel $model;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Export/Template/UpdateController.php
+++ b/libraries/classes/Controllers/Export/Template/UpdateController.php
@@ -14,11 +14,9 @@ use PhpMyAdmin\Template;
 
 final class UpdateController extends AbstractController
 {
-    /** @var TemplateModel */
-    private $model;
+    private TemplateModel $model;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/GitInfoController.php
+++ b/libraries/classes/Controllers/GitInfoController.php
@@ -15,8 +15,7 @@ use function strtotime;
 
 final class GitInfoController extends AbstractController
 {
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(ResponseRenderer $response, Template $template, Config $config)
     {

--- a/libraries/classes/Controllers/HomeController.php
+++ b/libraries/classes/Controllers/HomeController.php
@@ -37,14 +37,11 @@ use const SODIUM_CRYPTO_SECRETBOX_KEYBYTES;
 
 class HomeController extends AbstractController
 {
-    /** @var Config */
-    private $config;
+    private Config $config;
 
-    /** @var ThemeManager */
-    private $themeManager;
+    private ThemeManager $themeManager;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * @var array<int, array<string, string>>

--- a/libraries/classes/Controllers/Import/ImportController.php
+++ b/libraries/classes/Controllers/Import/ImportController.php
@@ -50,14 +50,11 @@ use function trim;
 
 final class ImportController extends AbstractController
 {
-    /** @var Import */
-    private $import;
+    private Import $import;
 
-    /** @var Sql */
-    private $sql;
+    private Sql $sql;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Import/SimulateDmlController.php
+++ b/libraries/classes/Controllers/Import/SimulateDmlController.php
@@ -21,8 +21,7 @@ use function explode;
 
 final class SimulateDmlController extends AbstractController
 {
-    /** @var SimulateDml */
-    private $simulateDml;
+    private SimulateDml $simulateDml;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Import/StatusController.php
+++ b/libraries/classes/Controllers/Import/StatusController.php
@@ -24,8 +24,7 @@ use function usleep;
  */
 class StatusController
 {
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     public function __construct(Template $template)
     {

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -18,7 +18,7 @@ use function time;
 final class JavaScriptMessagesController
 {
     /** @var array<string, string> */
-    private $messages;
+    private array $messages;
 
     public function __construct()
     {

--- a/libraries/classes/Controllers/LogoutController.php
+++ b/libraries/classes/Controllers/LogoutController.php
@@ -10,8 +10,7 @@ use PhpMyAdmin\Plugins\AuthenticationPluginFactory;
 
 class LogoutController
 {
-    /** @var AuthenticationPluginFactory */
-    private $authPluginFactory;
+    private AuthenticationPluginFactory $authPluginFactory;
 
     public function __construct(AuthenticationPluginFactory $authPluginFactory)
     {

--- a/libraries/classes/Controllers/NavigationController.php
+++ b/libraries/classes/Controllers/NavigationController.php
@@ -22,11 +22,9 @@ use function __;
  */
 class NavigationController extends AbstractController
 {
-    /** @var Navigation */
-    private $navigation;
+    private Navigation $navigation;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Normalization/AddNewPrimaryController.php
+++ b/libraries/classes/Controllers/Normalization/AddNewPrimaryController.php
@@ -15,8 +15,7 @@ use PhpMyAdmin\Url;
 
 final class AddNewPrimaryController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/CreateNewColumnController.php
+++ b/libraries/classes/Controllers/Normalization/CreateNewColumnController.php
@@ -16,8 +16,7 @@ use function min;
 
 final class CreateNewColumnController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/FirstNormalForm/FirstStepController.php
+++ b/libraries/classes/Controllers/Normalization/FirstNormalForm/FirstStepController.php
@@ -14,8 +14,7 @@ use function in_array;
 
 final class FirstStepController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/FirstNormalForm/FourthStepController.php
+++ b/libraries/classes/Controllers/Normalization/FirstNormalForm/FourthStepController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class FourthStepController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/FirstNormalForm/SecondStepController.php
+++ b/libraries/classes/Controllers/Normalization/FirstNormalForm/SecondStepController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class SecondStepController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/FirstNormalForm/ThirdStepController.php
+++ b/libraries/classes/Controllers/Normalization/FirstNormalForm/ThirdStepController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class ThirdStepController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/GetColumnsController.php
+++ b/libraries/classes/Controllers/Normalization/GetColumnsController.php
@@ -15,8 +15,7 @@ use function _pgettext;
 
 final class GetColumnsController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/MoveRepeatingGroup.php
+++ b/libraries/classes/Controllers/Normalization/MoveRepeatingGroup.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class MoveRepeatingGroup extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/PartialDependenciesController.php
+++ b/libraries/classes/Controllers/Normalization/PartialDependenciesController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class PartialDependenciesController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/SecondNormalForm/CreateNewTablesController.php
+++ b/libraries/classes/Controllers/Normalization/SecondNormalForm/CreateNewTablesController.php
@@ -14,8 +14,7 @@ use function json_decode;
 
 final class CreateNewTablesController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/SecondNormalForm/FirstStepController.php
+++ b/libraries/classes/Controllers/Normalization/SecondNormalForm/FirstStepController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class FirstStepController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/SecondNormalForm/NewTablesController.php
+++ b/libraries/classes/Controllers/Normalization/SecondNormalForm/NewTablesController.php
@@ -14,8 +14,7 @@ use function json_decode;
 
 final class NewTablesController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/ThirdNormalForm/CreateNewTablesController.php
+++ b/libraries/classes/Controllers/Normalization/ThirdNormalForm/CreateNewTablesController.php
@@ -14,8 +14,7 @@ use function json_decode;
 
 final class CreateNewTablesController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/ThirdNormalForm/FirstStepController.php
+++ b/libraries/classes/Controllers/Normalization/ThirdNormalForm/FirstStepController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class FirstStepController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Normalization/ThirdNormalForm/NewTablesController.php
+++ b/libraries/classes/Controllers/Normalization/ThirdNormalForm/NewTablesController.php
@@ -14,8 +14,7 @@ use function json_decode;
 
 final class NewTablesController extends AbstractController
 {
-    /** @var Normalization */
-    private $normalization;
+    private Normalization $normalization;
 
     public function __construct(ResponseRenderer $response, Template $template, Normalization $normalization)
     {

--- a/libraries/classes/Controllers/Preferences/ExportController.php
+++ b/libraries/classes/Controllers/Preferences/ExportController.php
@@ -21,14 +21,11 @@ use function ltrim;
 
 class ExportController extends AbstractController
 {
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Preferences/FeaturesController.php
+++ b/libraries/classes/Controllers/Preferences/FeaturesController.php
@@ -21,14 +21,11 @@ use function ltrim;
 
 class FeaturesController extends AbstractController
 {
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Preferences/ImportController.php
+++ b/libraries/classes/Controllers/Preferences/ImportController.php
@@ -21,14 +21,11 @@ use function ltrim;
 
 class ImportController extends AbstractController
 {
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Preferences/MainPanelController.php
+++ b/libraries/classes/Controllers/Preferences/MainPanelController.php
@@ -21,14 +21,11 @@ use function ltrim;
 
 class MainPanelController extends AbstractController
 {
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Preferences/ManageController.php
+++ b/libraries/classes/Controllers/Preferences/ManageController.php
@@ -45,14 +45,11 @@ use const UPLOAD_ERR_OK;
  */
 class ManageController extends AbstractController
 {
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Preferences/NavigationController.php
+++ b/libraries/classes/Controllers/Preferences/NavigationController.php
@@ -21,14 +21,11 @@ use function ltrim;
 
 class NavigationController extends AbstractController
 {
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Preferences/SqlController.php
+++ b/libraries/classes/Controllers/Preferences/SqlController.php
@@ -21,14 +21,11 @@ use function ltrim;
 
 class SqlController extends AbstractController
 {
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Preferences/TwoFactorController.php
+++ b/libraries/classes/Controllers/Preferences/TwoFactorController.php
@@ -17,8 +17,7 @@ use function count;
 
 class TwoFactorController extends AbstractController
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(ResponseRenderer $response, Template $template, Relation $relation)
     {

--- a/libraries/classes/Controllers/SchemaExportController.php
+++ b/libraries/classes/Controllers/SchemaExportController.php
@@ -22,11 +22,9 @@ use function mb_strlen;
  */
 class SchemaExportController
 {
-    /** @var Export */
-    private $export;
+    private Export $export;
 
-    /** @var ResponseRenderer */
-    private $response;
+    private ResponseRenderer $response;
 
     public function __construct(Export $export, ResponseRenderer $response)
     {

--- a/libraries/classes/Controllers/Server/BinlogController.php
+++ b/libraries/classes/Controllers/Server/BinlogController.php
@@ -23,13 +23,10 @@ class BinlogController extends AbstractController
 {
     /**
      * binary log files
-     *
-     * @var array
      */
-    protected $binaryLogs;
+    protected array $binaryLogs;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/CollationsController.php
+++ b/libraries/classes/Controllers/Server/CollationsController.php
@@ -20,13 +20,12 @@ use PhpMyAdmin\Url;
 class CollationsController extends AbstractController
 {
     /** @var array<string, Charset> */
-    private $charsets;
+    private array $charsets;
 
     /** @var array<string, array<string, Collation>> */
-    private $collations;
+    private array $collations;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * @param array<string, Charset>|null                  $charsets

--- a/libraries/classes/Controllers/Server/Databases/CreateController.php
+++ b/libraries/classes/Controllers/Server/Databases/CreateController.php
@@ -24,8 +24,7 @@ use function str_contains;
 
 final class CreateController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/Databases/DestroyController.php
+++ b/libraries/classes/Controllers/Server/Databases/DestroyController.php
@@ -22,14 +22,11 @@ use function is_array;
 
 final class DestroyController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var RelationCleanup */
-    private $relationCleanup;
+    private RelationCleanup $relationCleanup;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/DatabasesController.php
+++ b/libraries/classes/Controllers/Server/DatabasesController.php
@@ -49,8 +49,7 @@ class DatabasesController extends AbstractController
     /** @var int position in list navigation */
     private $position;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/EnginesController.php
+++ b/libraries/classes/Controllers/Server/EnginesController.php
@@ -17,8 +17,7 @@ use PhpMyAdmin\Url;
  */
 class EnginesController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/ExportController.php
+++ b/libraries/classes/Controllers/Server/ExportController.php
@@ -20,11 +20,9 @@ use function array_merge;
 
 final class ExportController extends AbstractController
 {
-    /** @var Options */
-    private $export;
+    private Options $export;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, Options $export, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/ImportController.php
+++ b/libraries/classes/Controllers/Server/ImportController.php
@@ -26,8 +26,7 @@ use function is_numeric;
 
 final class ImportController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/PluginsController.php
+++ b/libraries/classes/Controllers/Server/PluginsController.php
@@ -22,11 +22,9 @@ use function preg_replace;
  */
 class PluginsController extends AbstractController
 {
-    /** @var Plugins */
-    private $plugins;
+    private Plugins $plugins;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Privileges/AccountLockController.php
+++ b/libraries/classes/Controllers/Server/Privileges/AccountLockController.php
@@ -16,8 +16,7 @@ use function __;
 
 final class AccountLockController extends AbstractController
 {
-    /** @var AccountLocking */
-    private $model;
+    private AccountLocking $model;
 
     public function __construct(ResponseRenderer $response, Template $template, AccountLocking $accountLocking)
     {

--- a/libraries/classes/Controllers/Server/Privileges/AccountUnlockController.php
+++ b/libraries/classes/Controllers/Server/Privileges/AccountUnlockController.php
@@ -16,8 +16,7 @@ use function __;
 
 final class AccountUnlockController extends AbstractController
 {
-    /** @var AccountLocking */
-    private $model;
+    private AccountLocking $model;
 
     public function __construct(ResponseRenderer $response, Template $template, AccountLocking $accountLocking)
     {

--- a/libraries/classes/Controllers/Server/PrivilegesController.php
+++ b/libraries/classes/Controllers/Server/PrivilegesController.php
@@ -33,11 +33,9 @@ use function urlencode;
  */
 class PrivilegesController extends AbstractController
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/ReplicationController.php
+++ b/libraries/classes/Controllers/Server/ReplicationController.php
@@ -23,11 +23,9 @@ use function is_array;
  */
 class ReplicationController extends AbstractController
 {
-    /** @var ReplicationGui */
-    private $replicationGui;
+    private ReplicationGui $replicationGui;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/ShowEngineController.php
+++ b/libraries/classes/Controllers/Server/ShowEngineController.php
@@ -17,8 +17,7 @@ use PhpMyAdmin\Url;
  */
 final class ShowEngineController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/SqlController.php
+++ b/libraries/classes/Controllers/Server/SqlController.php
@@ -18,11 +18,9 @@ use PhpMyAdmin\Url;
  */
 class SqlController extends AbstractController
 {
-    /** @var SqlQueryForm */
-    private $sqlQueryForm;
+    private SqlQueryForm $sqlQueryForm;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Status/AbstractController.php
+++ b/libraries/classes/Controllers/Server/Status/AbstractController.php
@@ -11,8 +11,7 @@ use PhpMyAdmin\Template;
 
 abstract class AbstractController extends Controller
 {
-    /** @var Data */
-    protected $data;
+    protected Data $data;
 
     public function __construct(ResponseRenderer $response, Template $template, Data $data)
     {

--- a/libraries/classes/Controllers/Server/Status/AdvisorController.php
+++ b/libraries/classes/Controllers/Server/Status/AdvisorController.php
@@ -15,8 +15,7 @@ use PhpMyAdmin\Template;
  */
 class AdvisorController extends AbstractController
 {
-    /** @var Advisor */
-    private $advisor;
+    private Advisor $advisor;
 
     public function __construct(ResponseRenderer $response, Template $template, Data $data, Advisor $advisor)
     {

--- a/libraries/classes/Controllers/Server/Status/Monitor/ChartingDataController.php
+++ b/libraries/classes/Controllers/Server/Status/Monitor/ChartingDataController.php
@@ -15,11 +15,9 @@ use PhpMyAdmin\Url;
 
 final class ChartingDataController extends AbstractController
 {
-    /** @var Monitor */
-    private $monitor;
+    private Monitor $monitor;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Status/Monitor/GeneralLogController.php
+++ b/libraries/classes/Controllers/Server/Status/Monitor/GeneralLogController.php
@@ -15,11 +15,9 @@ use PhpMyAdmin\Url;
 
 final class GeneralLogController extends AbstractController
 {
-    /** @var Monitor */
-    private $monitor;
+    private Monitor $monitor;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Status/Monitor/LogVarsController.php
+++ b/libraries/classes/Controllers/Server/Status/Monitor/LogVarsController.php
@@ -15,11 +15,9 @@ use PhpMyAdmin\Url;
 
 final class LogVarsController extends AbstractController
 {
-    /** @var Monitor */
-    private $monitor;
+    private Monitor $monitor;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Status/Monitor/QueryAnalyzerController.php
+++ b/libraries/classes/Controllers/Server/Status/Monitor/QueryAnalyzerController.php
@@ -15,11 +15,9 @@ use PhpMyAdmin\Url;
 
 final class QueryAnalyzerController extends AbstractController
 {
-    /** @var Monitor */
-    private $monitor;
+    private Monitor $monitor;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Status/Monitor/SlowLogController.php
+++ b/libraries/classes/Controllers/Server/Status/Monitor/SlowLogController.php
@@ -15,11 +15,9 @@ use PhpMyAdmin\Url;
 
 final class SlowLogController extends AbstractController
 {
-    /** @var Monitor */
-    private $monitor;
+    private Monitor $monitor;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Status/MonitorController.php
+++ b/libraries/classes/Controllers/Server/Status/MonitorController.php
@@ -17,8 +17,7 @@ use function microtime;
 
 class MonitorController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, Data $data, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/Status/Processes/KillController.php
+++ b/libraries/classes/Controllers/Server/Status/Processes/KillController.php
@@ -16,8 +16,7 @@ use function __;
 
 final class KillController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, Data $data, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/Status/Processes/RefreshController.php
+++ b/libraries/classes/Controllers/Server/Status/Processes/RefreshController.php
@@ -13,8 +13,7 @@ use PhpMyAdmin\Template;
 
 final class RefreshController extends AbstractController
 {
-    /** @var Processes */
-    private $processes;
+    private Processes $processes;
 
     public function __construct(ResponseRenderer $response, Template $template, Data $data, Processes $processes)
     {

--- a/libraries/classes/Controllers/Server/Status/ProcessesController.php
+++ b/libraries/classes/Controllers/Server/Status/ProcessesController.php
@@ -14,11 +14,9 @@ use PhpMyAdmin\Url;
 
 class ProcessesController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Processes */
-    private $processes;
+    private Processes $processes;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Status/QueriesController.php
+++ b/libraries/classes/Controllers/Server/Status/QueriesController.php
@@ -22,8 +22,7 @@ use function str_replace;
 
 class QueriesController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, Data $data, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/Status/StatusController.php
+++ b/libraries/classes/Controllers/Server/Status/StatusController.php
@@ -21,11 +21,9 @@ use function implode;
  */
 class StatusController extends AbstractController
 {
-    /** @var ReplicationGui */
-    private $replicationGui;
+    private ReplicationGui $replicationGui;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Status/VariablesController.php
+++ b/libraries/classes/Controllers/Server/Status/VariablesController.php
@@ -22,8 +22,7 @@ use function str_contains;
 
 class VariablesController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, Data $data, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/UserGroupsController.php
+++ b/libraries/classes/Controllers/Server/UserGroupsController.php
@@ -20,11 +20,9 @@ use function __;
  */
 class UserGroupsController extends AbstractController
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/UserGroupsFormController.php
+++ b/libraries/classes/Controllers/Server/UserGroupsFormController.php
@@ -21,11 +21,9 @@ use function strlen;
 
 final class UserGroupsFormController extends AbstractController
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Server/Variables/GetVariableController.php
+++ b/libraries/classes/Controllers/Server/Variables/GetVariableController.php
@@ -17,8 +17,7 @@ use function implode;
 
 final class GetVariableController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/Variables/SetVariableController.php
+++ b/libraries/classes/Controllers/Server/Variables/SetVariableController.php
@@ -22,8 +22,7 @@ use function trim;
 
 final class SetVariableController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Server/VariablesController.php
+++ b/libraries/classes/Controllers/Server/VariablesController.php
@@ -26,8 +26,7 @@ use function trim;
  */
 class VariablesController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/Setup/AbstractController.php
+++ b/libraries/classes/Controllers/Setup/AbstractController.php
@@ -13,11 +13,9 @@ use function in_array;
 
 abstract class AbstractController
 {
-    /** @var ConfigFile */
-    protected $config;
+    protected ConfigFile $config;
 
-    /** @var Template */
-    protected $template;
+    protected Template $template;
 
     public function __construct(ConfigFile $config, Template $template)
     {

--- a/libraries/classes/Controllers/Sql/ColumnPreferencesController.php
+++ b/libraries/classes/Controllers/Sql/ColumnPreferencesController.php
@@ -19,11 +19,9 @@ use function is_string;
 
 final class ColumnPreferencesController extends AbstractController
 {
-    /** @var CheckUserPrivileges */
-    private $checkUserPrivileges;
+    private CheckUserPrivileges $checkUserPrivileges;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Sql/DefaultForeignKeyCheckValueController.php
+++ b/libraries/classes/Controllers/Sql/DefaultForeignKeyCheckValueController.php
@@ -13,8 +13,7 @@ use PhpMyAdmin\Utils\ForeignKey;
 
 final class DefaultForeignKeyCheckValueController extends AbstractController
 {
-    /** @var CheckUserPrivileges */
-    private $checkUserPrivileges;
+    private CheckUserPrivileges $checkUserPrivileges;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Sql/EnumValuesController.php
+++ b/libraries/classes/Controllers/Sql/EnumValuesController.php
@@ -19,11 +19,9 @@ use const ENT_COMPAT;
 
 final class EnumValuesController extends AbstractController
 {
-    /** @var Sql */
-    private $sql;
+    private Sql $sql;
 
-    /** @var CheckUserPrivileges */
-    private $checkUserPrivileges;
+    private CheckUserPrivileges $checkUserPrivileges;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Sql/RelationalValuesController.php
+++ b/libraries/classes/Controllers/Sql/RelationalValuesController.php
@@ -15,11 +15,9 @@ use function strval;
 
 final class RelationalValuesController extends AbstractController
 {
-    /** @var Sql */
-    private $sql;
+    private Sql $sql;
 
-    /** @var CheckUserPrivileges */
-    private $checkUserPrivileges;
+    private CheckUserPrivileges $checkUserPrivileges;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Sql/SetValuesController.php
+++ b/libraries/classes/Controllers/Sql/SetValuesController.php
@@ -18,11 +18,9 @@ use const ENT_COMPAT;
 
 final class SetValuesController extends AbstractController
 {
-    /** @var Sql */
-    private $sql;
+    private Sql $sql;
 
-    /** @var CheckUserPrivileges */
-    private $checkUserPrivileges;
+    private CheckUserPrivileges $checkUserPrivileges;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Sql/SqlController.php
+++ b/libraries/classes/Controllers/Sql/SqlController.php
@@ -28,14 +28,11 @@ use function urlencode;
 
 class SqlController extends AbstractController
 {
-    /** @var Sql */
-    private $sql;
+    private Sql $sql;
 
-    /** @var CheckUserPrivileges */
-    private $checkUserPrivileges;
+    private CheckUserPrivileges $checkUserPrivileges;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/AddFieldController.php
+++ b/libraries/classes/Controllers/Table/AddFieldController.php
@@ -33,17 +33,13 @@ use function strlen;
  */
 class AddFieldController extends AbstractController
 {
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var ColumnsDefinition */
-    private $columnsDefinition;
+    private ColumnsDefinition $columnsDefinition;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/ChangeController.php
+++ b/libraries/classes/Controllers/Table/ChangeController.php
@@ -30,11 +30,9 @@ use function strpos;
  */
 class ChangeController extends AbstractController
 {
-    /** @var InsertEdit */
-    private $insertEdit;
+    private InsertEdit $insertEdit;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/ChangeRowsController.php
+++ b/libraries/classes/Controllers/Table/ChangeRowsController.php
@@ -15,8 +15,7 @@ use function is_array;
 
 final class ChangeRowsController extends AbstractController
 {
-    /** @var ChangeController */
-    private $changeController;
+    private ChangeController $changeController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/ChartController.php
+++ b/libraries/classes/Controllers/Table/ChartController.php
@@ -31,8 +31,7 @@ use function strlen;
  */
 class ChartController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/CreateController.php
+++ b/libraries/classes/Controllers/Table/CreateController.php
@@ -29,17 +29,13 @@ use function strlen;
  */
 class CreateController extends AbstractController
 {
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var ColumnsDefinition */
-    private $columnsDefinition;
+    private ColumnsDefinition $columnsDefinition;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/DeleteRowsController.php
+++ b/libraries/classes/Controllers/Table/DeleteRowsController.php
@@ -23,8 +23,7 @@ use function sprintf;
 
 final class DeleteRowsController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/DropColumnController.php
+++ b/libraries/classes/Controllers/Table/DropColumnController.php
@@ -20,14 +20,11 @@ use function count;
 
 final class DropColumnController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var FlashMessages */
-    private $flash;
+    private FlashMessages $flash;
 
-    /** @var RelationCleanup */
-    private $relationCleanup;
+    private RelationCleanup $relationCleanup;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/ExportController.php
+++ b/libraries/classes/Controllers/Table/ExportController.php
@@ -25,8 +25,7 @@ use function is_array;
 
 class ExportController extends AbstractController
 {
-    /** @var Options */
-    private $export;
+    private Options $export;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/ExportRowsController.php
+++ b/libraries/classes/Controllers/Table/ExportRowsController.php
@@ -15,8 +15,7 @@ use function is_array;
 
 final class ExportRowsController extends AbstractController
 {
-    /** @var ExportController */
-    private $exportController;
+    private ExportController $exportController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/FindReplaceController.php
+++ b/libraries/classes/Controllers/Table/FindReplaceController.php
@@ -39,11 +39,9 @@ class FindReplaceController extends AbstractController
     /** @var array */
     private $columnTypes;
 
-    /** @var string */
-    private $connectionCharSet;
+    private string $connectionCharSet;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/GetFieldController.php
+++ b/libraries/classes/Controllers/Table/GetFieldController.php
@@ -26,8 +26,7 @@ use function sprintf;
  */
 class GetFieldController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -28,8 +28,7 @@ final class GisVisualizationController extends AbstractController
     /** @var GisVisualization */
     private $visualization;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/ImportController.php
+++ b/libraries/classes/Controllers/Table/ImportController.php
@@ -27,8 +27,7 @@ use function is_numeric;
 
 final class ImportController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/IndexRenameController.php
+++ b/libraries/classes/Controllers/Table/IndexRenameController.php
@@ -19,11 +19,9 @@ use function is_array;
 
 final class IndexRenameController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Indexes */
-    private $indexes;
+    private Indexes $indexes;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/IndexesController.php
+++ b/libraries/classes/Controllers/Table/IndexesController.php
@@ -26,11 +26,9 @@ use function min;
  */
 class IndexesController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Indexes */
-    private $indexes;
+    private Indexes $indexes;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Maintenance/AnalyzeController.php
+++ b/libraries/classes/Controllers/Table/Maintenance/AnalyzeController.php
@@ -23,11 +23,9 @@ use function count;
 
 final class AnalyzeController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Maintenance/CheckController.php
+++ b/libraries/classes/Controllers/Table/Maintenance/CheckController.php
@@ -23,11 +23,9 @@ use function count;
 
 final class CheckController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Maintenance/ChecksumController.php
+++ b/libraries/classes/Controllers/Table/Maintenance/ChecksumController.php
@@ -23,11 +23,9 @@ use function count;
 
 final class ChecksumController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Maintenance/OptimizeController.php
+++ b/libraries/classes/Controllers/Table/Maintenance/OptimizeController.php
@@ -23,11 +23,9 @@ use function count;
 
 final class OptimizeController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Maintenance/RepairController.php
+++ b/libraries/classes/Controllers/Table/Maintenance/RepairController.php
@@ -23,11 +23,9 @@ use function count;
 
 final class RepairController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/OperationsController.php
+++ b/libraries/classes/Controllers/Table/OperationsController.php
@@ -38,17 +38,13 @@ use function urldecode;
 
 class OperationsController extends AbstractController
 {
-    /** @var Operations */
-    private $operations;
+    private Operations $operations;
 
-    /** @var CheckUserPrivileges */
-    private $checkUserPrivileges;
+    private CheckUserPrivileges $checkUserPrivileges;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Partition/AnalyzeController.php
+++ b/libraries/classes/Controllers/Table/Partition/AnalyzeController.php
@@ -21,8 +21,7 @@ use function __;
 
 final class AnalyzeController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Partition/CheckController.php
+++ b/libraries/classes/Controllers/Table/Partition/CheckController.php
@@ -21,8 +21,7 @@ use function __;
 
 final class CheckController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Partition/DropController.php
+++ b/libraries/classes/Controllers/Table/Partition/DropController.php
@@ -21,8 +21,7 @@ use function __;
 
 final class DropController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Partition/OptimizeController.php
+++ b/libraries/classes/Controllers/Table/Partition/OptimizeController.php
@@ -21,8 +21,7 @@ use function __;
 
 final class OptimizeController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Partition/RebuildController.php
+++ b/libraries/classes/Controllers/Table/Partition/RebuildController.php
@@ -21,8 +21,7 @@ use function __;
 
 final class RebuildController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Partition/RepairController.php
+++ b/libraries/classes/Controllers/Table/Partition/RepairController.php
@@ -21,8 +21,7 @@ use function __;
 
 final class RepairController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Partition/TruncateController.php
+++ b/libraries/classes/Controllers/Table/Partition/TruncateController.php
@@ -21,8 +21,7 @@ use function __;
 
 final class TruncateController extends AbstractController
 {
-    /** @var Maintenance */
-    private $model;
+    private Maintenance $model;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/PrivilegesController.php
+++ b/libraries/classes/Controllers/Table/PrivilegesController.php
@@ -28,11 +28,9 @@ use function mb_strtolower;
  */
 class PrivilegesController extends AbstractController
 {
-    /** @var Privileges */
-    private $privileges;
+    private Privileges $privileges;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/RelationController.php
+++ b/libraries/classes/Controllers/Table/RelationController.php
@@ -36,11 +36,9 @@ use function usort;
  */
 final class RelationController extends AbstractController
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/ReplaceController.php
+++ b/libraries/classes/Controllers/Table/ReplaceController.php
@@ -41,17 +41,13 @@ use function sprintf;
  */
 final class ReplaceController extends AbstractController
 {
-    /** @var InsertEdit */
-    private $insertEdit;
+    private InsertEdit $insertEdit;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/SearchController.php
+++ b/libraries/classes/Controllers/Table/SearchController.php
@@ -73,10 +73,8 @@ class SearchController extends AbstractController
     private $columnNullFlags;
     /**
      * Whether a geometry column is present
-     *
-     * @var bool
      */
-    private $geomColumnFlag;
+    private bool $geomColumnFlag;
     /**
      * Foreign Keys
      *
@@ -84,14 +82,11 @@ class SearchController extends AbstractController
      */
     private $foreigners;
 
-    /** @var Search */
-    private $search;
+    private Search $search;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/SqlController.php
+++ b/libraries/classes/Controllers/Table/SqlController.php
@@ -21,8 +21,7 @@ use function htmlspecialchars;
  */
 final class SqlController extends AbstractController
 {
-    /** @var SqlQueryForm */
-    private $sqlQueryForm;
+    private SqlQueryForm $sqlQueryForm;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Structure/AbstractIndexController.php
+++ b/libraries/classes/Controllers/Table/Structure/AbstractIndexController.php
@@ -17,11 +17,9 @@ use function is_array;
 
 abstract class AbstractIndexController extends AbstractController
 {
-    /** @var StructureController */
-    protected $structureController;
+    protected StructureController $structureController;
 
-    /** @var Indexes */
-    protected $indexes;
+    protected Indexes $indexes;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Structure/AddKeyController.php
+++ b/libraries/classes/Controllers/Table/Structure/AddKeyController.php
@@ -13,11 +13,9 @@ use PhpMyAdmin\Template;
 
 final class AddKeyController extends AbstractController
 {
-    /** @var SqlController */
-    private $sqlController;
+    private SqlController $sqlController;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Structure/BrowseController.php
+++ b/libraries/classes/Controllers/Table/Structure/BrowseController.php
@@ -19,8 +19,7 @@ use function sprintf;
 
 final class BrowseController extends AbstractController
 {
-    /** @var Sql */
-    private $sql;
+    private Sql $sql;
 
     public function __construct(ResponseRenderer $response, Template $template, Sql $sql)
     {

--- a/libraries/classes/Controllers/Table/Structure/CentralColumnsAddController.php
+++ b/libraries/classes/Controllers/Table/Structure/CentralColumnsAddController.php
@@ -17,11 +17,9 @@ use function is_array;
 
 final class CentralColumnsAddController extends AbstractController
 {
-    /** @var CentralColumns */
-    private $centralColumns;
+    private CentralColumns $centralColumns;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Structure/CentralColumnsRemoveController.php
+++ b/libraries/classes/Controllers/Table/Structure/CentralColumnsRemoveController.php
@@ -17,11 +17,9 @@ use function is_array;
 
 final class CentralColumnsRemoveController extends AbstractController
 {
-    /** @var CentralColumns */
-    private $centralColumns;
+    private CentralColumns $centralColumns;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Structure/ChangeController.php
+++ b/libraries/classes/Controllers/Table/Structure/ChangeController.php
@@ -19,11 +19,9 @@ use function is_array;
 
 final class ChangeController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var ColumnsDefinition */
-    private $columnsDefinition;
+    private ColumnsDefinition $columnsDefinition;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
+++ b/libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
@@ -26,11 +26,9 @@ use function str_replace;
 
 final class MoveColumnsController extends AbstractController
 {
-    /** @var Table  The table object */
-    private $tableObj;
+    private Table $tableObj;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Structure/PartitioningController.php
+++ b/libraries/classes/Controllers/Table/Structure/PartitioningController.php
@@ -30,14 +30,11 @@ use function trim;
 
 final class PartitioningController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var CreateAddField */
-    private $createAddField;
+    private CreateAddField $createAddField;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Structure/PrimaryController.php
+++ b/libraries/classes/Controllers/Table/Structure/PrimaryController.php
@@ -21,11 +21,9 @@ use function is_array;
 
 final class PrimaryController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/Structure/SaveController.php
+++ b/libraries/classes/Controllers/Table/Structure/SaveController.php
@@ -31,20 +31,15 @@ use function strlen;
 
 final class SaveController extends AbstractController
 {
-    /** @var Table  The table object */
-    private $tableObj;
+    private Table $tableObj;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var StructureController */
-    private $structureController;
+    private StructureController $structureController;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/StructureController.php
+++ b/libraries/classes/Controllers/Table/StructureController.php
@@ -41,17 +41,13 @@ use function str_contains;
  */
 class StructureController extends AbstractController
 {
-    /** @var Table  The table object */
-    protected $tableObj;
+    protected Table $tableObj;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -31,8 +31,7 @@ use function sprintf;
 
 final class TrackingController extends AbstractController
 {
-    /** @var Tracking */
-    private $tracking;
+    private Tracking $tracking;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/TriggersController.php
+++ b/libraries/classes/Controllers/Table/TriggersController.php
@@ -22,11 +22,9 @@ use function strlen;
  */
 class TriggersController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Triggers */
-    private $triggers;
+    private Triggers $triggers;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -42,11 +42,9 @@ use function strtoupper;
  */
 class ZoomSearchController extends AbstractController
 {
-    /** @var Search */
-    private $search;
+    private Search $search;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     /** @var array */
     private $columnNames;
@@ -64,13 +62,12 @@ class ZoomSearchController extends AbstractController
     private $columnNullFlags;
 
     /** @var bool Whether a geometry column is present */
-    private $geomColumnFlag;
+    private bool $geomColumnFlag;
 
     /** @var array Foreign keys */
     private $foreigners;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/TableController.php
+++ b/libraries/classes/Controllers/TableController.php
@@ -12,8 +12,7 @@ use PhpMyAdmin\Template;
 
 final class TableController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Controllers/ThemeSetController.php
+++ b/libraries/classes/Controllers/ThemeSetController.php
@@ -15,11 +15,9 @@ use function is_string;
 
 final class ThemeSetController extends AbstractController
 {
-    /** @var ThemeManager */
-    private $themeManager;
+    private ThemeManager $themeManager;
 
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/ThemesController.php
+++ b/libraries/classes/Controllers/ThemesController.php
@@ -11,8 +11,7 @@ use PhpMyAdmin\ThemeManager;
 
 class ThemesController extends AbstractController
 {
-    /** @var ThemeManager */
-    private $themeManager;
+    private ThemeManager $themeManager;
 
     public function __construct(ResponseRenderer $response, Template $template, ThemeManager $themeManager)
     {

--- a/libraries/classes/Controllers/Transformation/OverviewController.php
+++ b/libraries/classes/Controllers/Transformation/OverviewController.php
@@ -17,8 +17,7 @@ use function array_keys;
  */
 class OverviewController extends AbstractController
 {
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
     public function __construct(ResponseRenderer $response, Template $template, Transformations $transformations)
     {

--- a/libraries/classes/Controllers/Transformation/WrapperController.php
+++ b/libraries/classes/Controllers/Transformation/WrapperController.php
@@ -37,14 +37,11 @@ use function strtolower;
  */
 class WrapperController extends AbstractController
 {
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/UserPasswordController.php
+++ b/libraries/classes/Controllers/UserPasswordController.php
@@ -19,11 +19,9 @@ use function __;
  */
 class UserPasswordController extends AbstractController
 {
-    /** @var UserPassword */
-    private $userPassword;
+    private UserPassword $userPassword;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/Controllers/VersionCheckController.php
+++ b/libraries/classes/Controllers/VersionCheckController.php
@@ -19,8 +19,7 @@ use function sprintf;
  */
 class VersionCheckController extends AbstractController
 {
-    /** @var VersionInformation */
-    private $versionInformation;
+    private VersionInformation $versionInformation;
 
     public function __construct(ResponseRenderer $response, Template $template, VersionInformation $versionInformation)
     {

--- a/libraries/classes/Controllers/View/CreateController.php
+++ b/libraries/classes/Controllers/View/CreateController.php
@@ -33,8 +33,7 @@ use function substr;
  */
 class CreateController extends AbstractController
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /** @todo Move the whole view rebuilding logic to SQL parser */
     private const VIEW_SECURITY_OPTIONS = [

--- a/libraries/classes/Controllers/View/OperationsController.php
+++ b/libraries/classes/Controllers/View/OperationsController.php
@@ -24,11 +24,9 @@ use function is_string;
  */
 class OperationsController extends AbstractController
 {
-    /** @var Operations */
-    private $operations;
+    private Operations $operations;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         ResponseRenderer $response,

--- a/libraries/classes/CreateAddField.php
+++ b/libraries/classes/CreateAddField.php
@@ -22,8 +22,7 @@ use function trim;
  */
 class CreateAddField
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * @param DatabaseInterface $dbi DatabaseInterface interface

--- a/libraries/classes/Database/CentralColumns.php
+++ b/libraries/classes/Database/CentralColumns.php
@@ -32,12 +32,7 @@ use function trim;
 
 class CentralColumns
 {
-    /**
-     * DatabaseInterface instance
-     *
-     * @var DatabaseInterface
-     */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * Current user
@@ -48,10 +43,8 @@ class CentralColumns
 
     /**
      * Number of rows displayed when browsing a result set
-     *
-     * @var int
      */
-    private $maxRows;
+    private int $maxRows;
 
     /**
      * Which editor should be used for CHAR/VARCHAR fields
@@ -62,13 +55,10 @@ class CentralColumns
 
     /**
      * Disable use of INFORMATION_SCHEMA
-     *
-     * @var bool
      */
-    private $disableIs;
+    private bool $disableIs;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Database/Designer.php
+++ b/libraries/classes/Database/Designer.php
@@ -26,11 +26,9 @@ use function str_contains;
  */
 class Designer
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Database/Designer/Common.php
+++ b/libraries/classes/Database/Designer/Common.php
@@ -32,11 +32,9 @@ use function rawurlencode;
  */
 class Common
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * @param DatabaseInterface $dbi      DatabaseInterface object

--- a/libraries/classes/Database/Designer/DesignerTable.php
+++ b/libraries/classes/Database/Designer/DesignerTable.php
@@ -11,17 +11,13 @@ use PhpMyAdmin\Utils\ForeignKey;
  */
 class DesignerTable
 {
-    /** @var string */
-    private $tableName;
+    private string $tableName;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $tableEngine;
+    private string $tableEngine;
 
-    /** @var string|null */
-    private $displayField;
+    private ?string $displayField;
 
     /**
      * Create a new DesignerTable

--- a/libraries/classes/Database/Events.php
+++ b/libraries/classes/Database/Events.php
@@ -62,11 +62,9 @@ class Events
         'MINUTE_SECOND',
     ];
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     /** @var ResponseRenderer */
     private $response;

--- a/libraries/classes/Database/MultiTableQuery.php
+++ b/libraries/classes/Database/MultiTableQuery.php
@@ -27,10 +27,8 @@ class MultiTableQuery
 {
     /**
      * DatabaseInterface instance
-     *
-     * @var DatabaseInterface
      */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * Database name
@@ -51,7 +49,7 @@ class MultiTableQuery
      *
      * @var array<int, string>
      */
-    private $tables;
+    private array $tables;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -57,11 +57,9 @@ class Routines
     /** @var array<int, string> */
     private $numericOptions = ['UNSIGNED', 'ZEROFILL', 'UNSIGNED ZEROFILL'];
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     /** @var ResponseRenderer */
     private $response;

--- a/libraries/classes/Database/Search.php
+++ b/libraries/classes/Database/Search.php
@@ -40,10 +40,8 @@ class Search
 
     /**
      * Type of search
-     *
-     * @var array
      */
-    private $searchTypes;
+    private array $searchTypes;
 
     /**
      * Already set search type
@@ -80,8 +78,7 @@ class Search
      */
     private $criteriaColumnName;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Database/Triggers.php
+++ b/libraries/classes/Database/Triggers.php
@@ -37,11 +37,9 @@ class Triggers
     /** @var array<int, string> */
     private $event = ['INSERT', 'UPDATE', 'DELETE'];
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     /** @var ResponseRenderer */
     private $response;

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -92,8 +92,7 @@ class DatabaseInterface implements DbalInterface
      */
     public const GETVAR_GLOBAL = 2;
 
-    /** @var DbiExtension */
-    private $extension;
+    private DbiExtension $extension;
 
     /**
      * Opened database connections.
@@ -126,8 +125,7 @@ class DatabaseInterface implements DbalInterface
     /** @var Types MySQL types data */
     public $types;
 
-    /** @var Cache */
-    private $cache;
+    private Cache $cache;
 
     /** @var float */
     public $lastQueryExecutionTime = 0;

--- a/libraries/classes/Dbal/MysqliResult.php
+++ b/libraries/classes/Dbal/MysqliResult.php
@@ -27,10 +27,8 @@ final class MysqliResult implements ResultInterface
 {
     /**
      * The result identifier produced by the DBiExtension
-     *
-     * @var mysqli_result|null $result
      */
-    private $result;
+    private ?mysqli_result $result;
 
     /**
      * @param mysqli_result|bool $result

--- a/libraries/classes/Dbal/MysqliStatement.php
+++ b/libraries/classes/Dbal/MysqliStatement.php
@@ -10,8 +10,7 @@ use function count;
 
 final class MysqliStatement implements Statement
 {
-    /** @var mysqli_stmt */
-    private $statement;
+    private mysqli_stmt $statement;
 
     public function __construct(mysqli_stmt $statement)
     {

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -232,14 +232,11 @@ class Results
      */
     public $transformationInfo;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Error.php
+++ b/libraries/classes/Error.php
@@ -115,10 +115,8 @@ class Error extends Message
 
     /**
      * Holds the backtrace for this error
-     *
-     * @var array
      */
-    protected $backtrace = [];
+    protected array $backtrace = [];
 
     /**
      * Hide location of errors

--- a/libraries/classes/ErrorHandler.php
+++ b/libraries/classes/ErrorHandler.php
@@ -56,10 +56,8 @@ class ErrorHandler
 
     /**
      * Initial error reporting state
-     *
-     * @var int
      */
-    protected $errorReporting = 0;
+    protected int $errorReporting = 0;
 
     public function __construct()
     {

--- a/libraries/classes/ErrorReport.php
+++ b/libraries/classes/ErrorReport.php
@@ -33,17 +33,13 @@ class ErrorReport
      */
     private $submissionUrl = 'https://reports.phpmyadmin.net/incidents/create';
 
-    /** @var HttpRequest */
-    private $httpRequest;
+    private HttpRequest $httpRequest;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Template */
-    public $template;
+    public Template $template;
 
-    /** @var Config */
-    private $config;
+    private Config $config;
 
     /**
      * @param HttpRequest $httpRequest HttpRequest instance

--- a/libraries/classes/Export/Options.php
+++ b/libraries/classes/Export/Options.php
@@ -24,11 +24,9 @@ use function urldecode;
 
 final class Options
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var TemplateModel */
-    private $templateModel;
+    private TemplateModel $templateModel;
 
     public function __construct(Relation $relation, TemplateModel $templateModel)
     {

--- a/libraries/classes/Export/Template.php
+++ b/libraries/classes/Export/Template.php
@@ -7,20 +7,16 @@ namespace PhpMyAdmin\Export;
 /** @psalm-immutable */
 final class Template
 {
-    /** @var int */
-    private $id;
+    private int $id;
 
-    /** @var string */
-    private $username;
+    private string $username;
 
-    /** @var string */
-    private $exportType;
+    private string $exportType;
 
-    /** @var string */
-    private $name;
+    private string $name;
 
     /** @var string JSON */
-    private $data;
+    private string $data;
 
     private function __construct(int $id, string $username, string $exportType, string $name, string $data)
     {

--- a/libraries/classes/Export/TemplateModel.php
+++ b/libraries/classes/Export/TemplateModel.php
@@ -14,8 +14,7 @@ use function sprintf;
 
 final class TemplateModel
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/File.php
+++ b/libraries/classes/File.php
@@ -81,8 +81,7 @@ class File
     /** @var string charset of file */
     protected $charset = null;
 
-    /** @var ZipExtension */
-    private $zipExtension;
+    private ZipExtension $zipExtension;
 
     /**
      * @param bool|string $name file name or false

--- a/libraries/classes/Footer.php
+++ b/libraries/classes/Footer.php
@@ -27,10 +27,8 @@ class Footer
 {
     /**
      * Scripts instance
-     *
-     * @var Scripts
      */
-    private $scripts;
+    private Scripts $scripts;
     /**
      * Whether we are servicing an ajax request.
      *
@@ -40,22 +38,16 @@ class Footer
     /**
      * Whether to only close the BODY and HTML tags
      * or also include scripts, errors and links
-     *
-     * @var bool
      */
-    private $isMinimal;
+    private bool $isMinimal;
     /**
      * Whether to display anything
-     *
-     * @var bool
      */
-    private $isEnabled;
+    private bool $isEnabled;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     /**
      * Creates a new class instance

--- a/libraries/classes/Git.php
+++ b/libraries/classes/Git.php
@@ -51,10 +51,8 @@ class Git
 {
     /**
      * Enable Git information search and process
-     *
-     * @var bool
      */
-    private $showGitRevision;
+    private bool $showGitRevision;
 
     /**
      * Git has been found and the data fetched

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -32,71 +32,49 @@ class Header
 {
     /**
      * Scripts instance
-     *
-     * @var Scripts
      */
-    private $scripts;
+    private Scripts $scripts;
     /**
      * PhpMyAdmin\Console instance
-     *
-     * @var Console
      */
-    private $console;
+    private Console $console;
     /**
      * Menu instance
-     *
-     * @var Menu
      */
-    private $menu;
+    private Menu $menu;
     /**
      * The page title
-     *
-     * @var string
      */
-    private $title;
+    private string $title;
     /**
      * The value for the id attribute for the body tag
-     *
-     * @var string
      */
-    private $bodyId;
+    private string $bodyId;
     /**
      * Whether to show the top menu
-     *
-     * @var bool
      */
-    private $menuEnabled;
+    private bool $menuEnabled;
     /**
      * Whether to show the warnings
-     *
-     * @var bool
      */
-    private $warningsEnabled;
+    private bool $warningsEnabled;
     /**
      * Whether we are servicing an ajax request.
-     *
-     * @var bool
      */
-    private $isAjax;
+    private bool $isAjax;
     /**
      * Whether to display anything
-     *
-     * @var bool
      */
-    private $isEnabled;
+    private bool $isEnabled;
     /**
      * Whether the HTTP headers (and possibly some HTML)
      * have already been sent to the browser
-     *
-     * @var bool
      */
-    private $headerIsSent;
+    private bool $headerIsSent;
 
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     /** @var bool */
     private $isTransformationWrapper = false;

--- a/libraries/classes/Http/Factory/ServerRequestFactory.php
+++ b/libraries/classes/Http/Factory/ServerRequestFactory.php
@@ -35,11 +35,9 @@ use const PHP_URL_QUERY;
 
 class ServerRequestFactory
 {
-    /** @var ServerRequestFactoryInterface */
-    private $serverRequestFactory;
+    private ServerRequestFactoryInterface $serverRequestFactory;
 
-    /** @var UriFactoryInterface */
-    private $uriFactory;
+    private UriFactoryInterface $uriFactory;
 
     public function __construct(
         ?ServerRequestFactoryInterface $serverRequestFactory = null,

--- a/libraries/classes/Http/ServerRequest.php
+++ b/libraries/classes/Http/ServerRequest.php
@@ -15,8 +15,7 @@ use function property_exists;
 
 class ServerRequest implements ServerRequestInterface
 {
-    /** @var ServerRequestInterface */
-    private $serverRequest;
+    private ServerRequestInterface $serverRequest;
 
     final public function __construct(ServerRequestInterface $serverRequest)
     {

--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -19,8 +19,7 @@ use function strtoupper;
 
 final class SimulateDml
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -53,20 +53,15 @@ use const PASSWORD_DEFAULT;
 
 class InsertEdit
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var FileListing */
-    private $fileListing;
+    private FileListing $fileListing;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     private const FUNC_OPTIONAL_PARAM = [
         'RAND',

--- a/libraries/classes/Language.php
+++ b/libraries/classes/Language.php
@@ -31,8 +31,7 @@ class Language
     /** @var string */
     protected $native;
 
-    /** @var string */
-    protected $regex;
+    protected string $regex;
 
     /** @var string */
     protected $mysql;

--- a/libraries/classes/Menu.php
+++ b/libraries/classes/Menu.php
@@ -27,26 +27,19 @@ class Menu
 {
     /**
      * Database name
-     *
-     * @var string
      */
-    private $db;
+    private string $db;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * Table name
-     *
-     * @var string
      */
-    private $table;
+    private string $table;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     /**
      * Creates a new instance of Menu

--- a/libraries/classes/Navigation/Navigation.php
+++ b/libraries/classes/Navigation/Navigation.php
@@ -44,8 +44,7 @@ class Navigation
     /** @var DatabaseInterface */
     private $dbi;
 
-    /** @var NavigationTree */
-    private $tree;
+    private NavigationTree $tree;
 
     /**
      * @param Template          $template Template instance

--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -64,7 +64,7 @@ class NavigationTree
     private const SPECIAL_NODE_NAMES = ['tables', 'views', 'functions', 'procedures', 'events'];
 
     /** @var Node Reference to the root node of the tree */
-    private $tree;
+    private Node $tree;
     /**
      * @var array The actual paths to all expanded nodes in the tree
      *            This does not include nodes created after the grouping
@@ -125,8 +125,7 @@ class NavigationTree
     /** @var Template */
     private $template;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * @param Template          $template Template instance

--- a/libraries/classes/Navigation/Nodes/Node.php
+++ b/libraries/classes/Navigation/Nodes/Node.php
@@ -119,8 +119,7 @@ class Node
      */
     public $pos3 = 0;
 
-    /** @var Relation */
-    protected $relation;
+    protected Relation $relation;
 
     /** @var string $displayName  display name for the navigation tree */
     public $displayName;

--- a/libraries/classes/Normalization.php
+++ b/libraries/classes/Normalization.php
@@ -34,16 +34,12 @@ class Normalization
 {
     /**
      * DatabaseInterface instance
-     *
-     * @var DatabaseInterface
      */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Operations.php
+++ b/libraries/classes/Operations.php
@@ -31,11 +31,9 @@ use function urldecode;
  */
 class Operations
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * @param DatabaseInterface $dbi      DatabaseInterface object

--- a/libraries/classes/OutputBuffering.php
+++ b/libraries/classes/OutputBuffering.php
@@ -23,8 +23,7 @@ use function sprintf;
  */
 class OutputBuffering
 {
-    /** @var int */
-    private $mode;
+    private int $mode;
 
     /** @var string */
     private $content = '';

--- a/libraries/classes/Partitioning/Maintenance.php
+++ b/libraries/classes/Partitioning/Maintenance.php
@@ -13,8 +13,7 @@ use function sprintf;
 
 final class Maintenance
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/Plugins/AuthenticationPlugin.php
+++ b/libraries/classes/Plugins/AuthenticationPlugin.php
@@ -52,8 +52,7 @@ abstract class AuthenticationPlugin
      */
     public $password = '';
 
-    /** @var IpAllowDeny */
-    protected $ipAllowDeny;
+    protected IpAllowDeny $ipAllowDeny;
 
     /** @var Template */
     public $template;

--- a/libraries/classes/Plugins/Export/Helpers/Pdf.php
+++ b/libraries/classes/Plugins/Export/Helpers/Pdf.php
@@ -91,11 +91,9 @@ class Pdf extends PdfLib
     /** @var array */
     private $aliases;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
     /**
      * Constructs PDF and configures standard parameters.

--- a/libraries/classes/Plugins/ExportPlugin.php
+++ b/libraries/classes/Plugins/ExportPlugin.php
@@ -25,19 +25,15 @@ abstract class ExportPlugin implements Plugin
 {
     /**
      * Object containing the specific export plugin type properties.
-     *
-     * @var ExportPluginProperties
      */
-    protected $properties;
+    protected ExportPluginProperties $properties;
 
     /** @var Relation */
     public $relation;
 
-    /** @var Export */
-    protected $export;
+    protected Export $export;
 
-    /** @var Transformations */
-    protected $transformations;
+    protected Transformations $transformations;
 
     final public function __construct(Relation $relation, Export $export, Transformations $transformations)
     {

--- a/libraries/classes/Plugins/ImportPlugin.php
+++ b/libraries/classes/Plugins/ImportPlugin.php
@@ -22,13 +22,10 @@ abstract class ImportPlugin implements Plugin
 {
     /**
      * Object containing the import plugin properties.
-     *
-     * @var ImportPluginProperties
      */
-    protected $properties;
+    protected ImportPluginProperties $properties;
 
-    /** @var Import */
-    protected $import;
+    protected Import $import;
 
     final public function __construct()
     {

--- a/libraries/classes/Plugins/Schema/ExportRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/ExportRelationSchema.php
@@ -53,8 +53,7 @@ class ExportRelationSchema
     /** @var bool */
     protected $offline = false;
 
-    /** @var Relation */
-    protected $relation;
+    protected Relation $relation;
 
     /**
      * @param string                               $db      database name

--- a/libraries/classes/Plugins/Schema/Pdf/Pdf.php
+++ b/libraries/classes/Plugins/Schema/Pdf/Pdf.php
@@ -79,8 +79,7 @@ class Pdf extends PdfLib
     /** @var string */
     private $db;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     /**
      * Constructs PDF for schema export.

--- a/libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -96,8 +96,7 @@ class PdfRelationSchema extends ExportRelationSchema
     /** @var RelationStatsPdf[] */
     protected $relations = [];
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
     /**
      * @see Schema\Pdf

--- a/libraries/classes/Plugins/Schema/TableStats.php
+++ b/libraries/classes/Plugins/Schema/TableStats.php
@@ -71,11 +71,9 @@ abstract class TableStats
     /** @var bool */
     protected $offline;
 
-    /** @var Relation */
-    protected $relation;
+    protected Relation $relation;
 
-    /** @var Font */
-    protected $font;
+    protected Font $font;
 
     /**
      * @param Pdf\Pdf|Svg\Svg|Eps\Eps|Dia\Dia $diagram        schema diagram

--- a/libraries/classes/Plugins/SchemaPlugin.php
+++ b/libraries/classes/Plugins/SchemaPlugin.php
@@ -25,10 +25,8 @@ abstract class SchemaPlugin implements Plugin
 {
     /**
      * Object containing the specific schema export plugin type properties.
-     *
-     * @var SchemaPluginProperties
      */
-    protected $properties;
+    protected SchemaPluginProperties $properties;
 
     final public function __construct()
     {

--- a/libraries/classes/Plugins/TwoFactor/Application.php
+++ b/libraries/classes/Plugins/TwoFactor/Application.php
@@ -27,8 +27,7 @@ class Application extends TwoFactorPlugin
     /** @var string */
     public static $id = 'application';
 
-    /** @var Google2FA */
-    protected $google2fa;
+    protected Google2FA $google2fa;
 
     /**
      * Creates object

--- a/libraries/classes/Plugins/TwoFactor/WebAuthn.php
+++ b/libraries/classes/Plugins/TwoFactor/WebAuthn.php
@@ -38,8 +38,7 @@ class WebAuthn extends TwoFactorPlugin
     /** @var string */
     public static $id = 'WebAuthn';
 
-    /** @var Server */
-    private $server;
+    private Server $server;
 
     /** @var ServerRequest|null */
     public $serverRequest = null;

--- a/libraries/classes/Plugins/TwoFactorPlugin.php
+++ b/libraries/classes/Plugins/TwoFactorPlugin.php
@@ -37,8 +37,7 @@ class TwoFactorPlugin
      */
     public static $showSubmit = true;
 
-    /** @var TwoFactor */
-    protected $twofactor;
+    protected TwoFactor $twofactor;
 
     /** @var bool */
     protected $provided = false;

--- a/libraries/classes/RecentFavoriteTable.php
+++ b/libraries/classes/RecentFavoriteTable.php
@@ -46,10 +46,8 @@ class RecentFavoriteTable
 
     /**
      * Defines type of action, Favorite or Recent table.
-     *
-     * @var string
      */
-    private $tableType;
+    private string $tableType;
 
     /**
      * RecentFavoriteTable instances.
@@ -58,8 +56,7 @@ class RecentFavoriteTable
      */
     private static $instances = [];
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     /**
      * Creates a new instance of RecentFavoriteTable

--- a/libraries/classes/Replication.php
+++ b/libraries/classes/Replication.php
@@ -17,8 +17,7 @@ use function mb_strtoupper;
  */
 class Replication
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/ReplicationGui.php
+++ b/libraries/classes/ReplicationGui.php
@@ -26,11 +26,9 @@ use function time;
  */
 class ReplicationGui
 {
-    /** @var Replication */
-    private $replication;
+    private Replication $replication;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     /**
      * @param Replication $replication Replication instance

--- a/libraries/classes/ReplicationInfo.php
+++ b/libraries/classes/ReplicationInfo.php
@@ -70,8 +70,7 @@ final class ReplicationInfo
     /** @var array */
     private $replicaInfo = [];
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/ResponseRenderer.php
+++ b/libraries/classes/ResponseRenderer.php
@@ -35,16 +35,12 @@ class ResponseRenderer
 
     /**
      * Header instance
-     *
-     * @var Header
      */
-    protected $header;
+    protected Header $header;
     /**
      * HTML data to be used in the response
-     *
-     * @var string
      */
-    private $HTML;
+    private string $HTML;
     /**
      * An array of JSON key-value pairs
      * to be sent back for ajax requests
@@ -54,10 +50,8 @@ class ResponseRenderer
     private $JSON;
     /**
      * PhpMyAdmin\Footer instance
-     *
-     * @var Footer
      */
-    protected $footer;
+    protected Footer $footer;
     /**
      * Whether we are servicing an ajax request.
      *
@@ -66,17 +60,13 @@ class ResponseRenderer
     protected $isAjax = false;
     /**
      * Whether response object is disabled
-     *
-     * @var bool
      */
-    protected $isDisabled;
+    protected bool $isDisabled;
     /**
      * Whether there were any errors during the processing of the request
      * Only used for ajax responses
-     *
-     * @var bool
      */
-    protected $isSuccess;
+    protected bool $isSuccess;
 
     /**
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
@@ -155,8 +145,7 @@ class ResponseRenderer
         511 => 'Network Authentication Required',
     ];
 
-    /** @var OutputBuffering */
-    private $buffer;
+    private OutputBuffering $buffer;
 
     private function __construct()
     {

--- a/libraries/classes/Scripts.php
+++ b/libraries/classes/Scripts.php
@@ -24,13 +24,10 @@ class Scripts
     private $files;
     /**
      * A string of discrete javascript code snippets
-     *
-     * @var string
      */
-    private $code;
+    private string $code;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     /**
      * Generates new Scripts objects

--- a/libraries/classes/Server/Plugin.php
+++ b/libraries/classes/Server/Plugin.php
@@ -12,44 +12,31 @@ namespace PhpMyAdmin\Server;
  */
 final class Plugin
 {
-    /** @var string */
-    private $name;
+    private string $name;
 
-    /** @var string|null */
-    private $version;
+    private ?string $version;
 
-    /** @var string */
-    private $status;
+    private string $status;
 
-    /** @var string */
-    private $type;
+    private string $type;
 
-    /** @var string|null */
-    private $typeVersion;
+    private ?string $typeVersion;
 
-    /** @var string|null */
-    private $library;
+    private ?string $library;
 
-    /** @var string|null */
-    private $libraryVersion;
+    private ?string $libraryVersion;
 
-    /** @var string|null */
-    private $author;
+    private ?string $author;
 
-    /** @var string|null */
-    private $description;
+    private ?string $description;
 
-    /** @var string */
-    private $license;
+    private string $license;
 
-    /** @var string|null */
-    private $loadOption;
+    private ?string $loadOption;
 
-    /** @var string|null */
-    private $maturity;
+    private ?string $maturity;
 
-    /** @var string|null */
-    private $authVersion;
+    private ?string $authVersion;
 
     /**
      * @param string      $name           Name of the plugin

--- a/libraries/classes/Server/Plugins.php
+++ b/libraries/classes/Server/Plugins.php
@@ -10,8 +10,7 @@ use function __;
 
 class Plugins
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * @param DatabaseInterface $dbi DatabaseInterface instance

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -63,8 +63,7 @@ class Privileges
     /** @var Template */
     public $template;
 
-    /** @var RelationCleanup */
-    private $relationCleanup;
+    private RelationCleanup $relationCleanup;
 
     /** @var DatabaseInterface */
     public $dbi;
@@ -72,8 +71,7 @@ class Privileges
     /** @var Relation */
     public $relation;
 
-    /** @var Plugins */
-    private $plugins;
+    private Plugins $plugins;
 
     /**
      * @param Template          $template        Template object

--- a/libraries/classes/Server/Privileges/AccountLocking.php
+++ b/libraries/classes/Server/Privileges/AccountLocking.php
@@ -13,8 +13,7 @@ use function sprintf;
 
 final class AccountLocking
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/Server/Status/Data.php
+++ b/libraries/classes/Server/Status/Data.php
@@ -58,11 +58,9 @@ class Data
     /** @var bool */
     public $dataLoaded;
 
-    /** @var ReplicationInfo */
-    private $replicationInfo;
+    private ReplicationInfo $replicationInfo;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function getReplicationInfo(): ReplicationInfo
     {

--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -17,8 +17,7 @@ use function ucfirst;
 
 final class Processes
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -45,23 +45,17 @@ use function ucwords;
  */
 class Sql
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var RelationCleanup */
-    private $relationCleanup;
+    private RelationCleanup $relationCleanup;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
-    /** @var Operations */
-    private $operations;
+    private Operations $operations;
 
-    /** @var Template */
-    private $template;
+    private Template $template;
 
     public function __construct(
         DatabaseInterface $dbi,

--- a/libraries/classes/SqlQueryForm.php
+++ b/libraries/classes/SqlQueryForm.php
@@ -28,11 +28,9 @@ use function strlen;
  */
 class SqlQueryForm
 {
-    /** @var Template */
-    private $template;
+    private Template $template;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     /**
      * @param Template $template Template object

--- a/libraries/classes/SystemDatabase.php
+++ b/libraries/classes/SystemDatabase.php
@@ -12,11 +12,9 @@ use function sprintf;
 
 class SystemDatabase
 {
-    /** @var DatabaseInterface */
-    protected $dbi;
+    protected DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     /**
      * Get instance of SystemDatabase

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -95,11 +95,9 @@ class Table implements Stringable
     /** @var string  database name */
     protected $dbName = '';
 
-    /** @var DatabaseInterface */
-    protected $dbi;
+    protected DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     /**
      * @param string            $tableName table name

--- a/libraries/classes/Table/ColumnsDefinition.php
+++ b/libraries/classes/Table/ColumnsDefinition.php
@@ -36,14 +36,11 @@ use function trim;
  */
 final class ColumnsDefinition
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
-    /** @var Transformations */
-    private $transformations;
+    private Transformations $transformations;
 
     public function __construct(DatabaseInterface $dbi, Relation $relation, Transformations $transformations)
     {

--- a/libraries/classes/Table/Indexes.php
+++ b/libraries/classes/Table/Indexes.php
@@ -21,14 +21,11 @@ use function __;
 
 final class Indexes
 {
-    /** @var ResponseRenderer */
-    protected $response;
+    protected ResponseRenderer $response;
 
-    /** @var Template */
-    protected $template;
+    protected Template $template;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(ResponseRenderer $response, Template $template, DatabaseInterface $dbi)
     {

--- a/libraries/classes/Table/Maintenance.php
+++ b/libraries/classes/Table/Maintenance.php
@@ -18,8 +18,7 @@ use function sprintf;
 
 final class Maintenance
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/Table/Search.php
+++ b/libraries/classes/Table/Search.php
@@ -23,8 +23,7 @@ use function trim;
 
 final class Search
 {
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/ThemeManager.php
+++ b/libraries/classes/ThemeManager.php
@@ -33,10 +33,10 @@ class ThemeManager
     private static $instance;
 
     /** @var string file-system path to the theme folder */
-    private $themesPath;
+    private string $themesPath;
 
     /** @var string path to theme folder as an URL */
-    private $themesPathUrl;
+    private string $themesPathUrl;
 
     /** @var array<string,Theme> available themes */
     public $themes = [];

--- a/libraries/classes/Tracking.php
+++ b/libraries/classes/Tracking.php
@@ -36,17 +36,13 @@ use const SORT_ASC;
  */
 class Tracking
 {
-    /** @var SqlQueryForm */
-    private $sqlQueryForm;
+    private SqlQueryForm $sqlQueryForm;
 
-    /** @var Template */
-    public $template;
+    public Template $template;
 
-    /** @var Relation */
-    protected $relation;
+    protected Relation $relation;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         SqlQueryForm $sqlQueryForm,

--- a/libraries/classes/TwoFactor.php
+++ b/libraries/classes/TwoFactor.php
@@ -39,17 +39,14 @@ class TwoFactor
      */
     public $config;
 
-    /** @var bool */
-    protected $writable;
+    protected bool $writable;
 
     /** @var TwoFactorPlugin */
     protected $backend;
 
-    /** @var array */
-    protected $available;
+    protected array $available;
 
-    /** @var UserPreferences */
-    private $userPreferences;
+    private UserPreferences $userPreferences;
 
     /**
      * Creates new TwoFactor object

--- a/libraries/classes/UserPassword.php
+++ b/libraries/classes/UserPassword.php
@@ -17,14 +17,11 @@ use function strlen;
  */
 class UserPassword
 {
-    /** @var Privileges */
-    private $serverPrivileges;
+    private Privileges $serverPrivileges;
 
-    /** @var AuthenticationPluginFactory */
-    private $authPluginFactory;
+    private AuthenticationPluginFactory $authPluginFactory;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(
         Privileges $serverPrivileges,

--- a/libraries/classes/UserPreferences.php
+++ b/libraries/classes/UserPreferences.php
@@ -31,14 +31,12 @@ use function urlencode;
  */
 class UserPreferences
 {
-    /** @var Relation */
-    private $relation;
+    private Relation $relation;
 
     /** @var Template */
     public $template;
 
-    /** @var DatabaseInterface */
-    private $dbi;
+    private DatabaseInterface $dbi;
 
     public function __construct(DatabaseInterface $dbi)
     {

--- a/libraries/classes/WebAuthn/WebauthnLibServer.php
+++ b/libraries/classes/WebAuthn/WebauthnLibServer.php
@@ -29,8 +29,7 @@ use const SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING;
 
 final class WebauthnLibServer implements Server
 {
-    /** @var TwoFactor */
-    private $twofactor;
+    private TwoFactor $twofactor;
 
     public function __construct(TwoFactor $twofactor)
     {
@@ -203,8 +202,7 @@ final class WebauthnLibServer implements Server
     private function createPublicKeyCredentialSourceRepository(): PublicKeyCredentialSourceRepository
     {
         return new class ($this->twofactor) implements PublicKeyCredentialSourceRepository {
-            /** @var TwoFactor */
-            private $twoFactor;
+            private TwoFactor $twoFactor;
 
             public function __construct(TwoFactor $twoFactor)
             {

--- a/libraries/classes/ZipExtension.php
+++ b/libraries/classes/ZipExtension.php
@@ -32,8 +32,7 @@ use function substr;
  */
 class ZipExtension
 {
-    /** @var ZipArchive|null */
-    private $zip;
+    private ?ZipArchive $zip;
 
     public function __construct(?ZipArchive $zip = null)
     {


### PR DESCRIPTION
Used Rector to convert some var annotations to typed properties. This does not cover all properties, only the ones which are relatively safe using an automated tool. 