### PR TITLE
Refactor gis scale data set calculation

### DIFF
--- a/libraries/classes/Gis/GisGeometry.php
+++ b/libraries/classes/Gis/GisGeometry.php
@@ -99,9 +99,9 @@ abstract class GisGeometry
      *
      * @param string $spatial spatial data of a row
      *
-     * @return array array containing the min, max values for x and y coordinates
+     * @return ScaleData|null min, max values for x and y coordinates
      */
-    abstract public function scaleRow($spatial): array;
+    abstract public function scaleRow(string $spatial): ?ScaleData;
 
     /**
      * Generates the WKT with the set of parameters passed by the GIS editor.
@@ -142,42 +142,27 @@ abstract class GisGeometry
     /**
      * Updates the min, max values with the given point set.
      *
-     * @param string $point_set point set
-     * @param array  $min_max   existing min, max values
+     * @param string         $point_set point set
+     * @param ScaleData|null $scaleData existing min, max values
      *
-     * @return array the updated min, max values
+     * @return ScaleData|null the updated min, max values
      */
-    protected function setMinMax($point_set, array $min_max)
+    protected function setMinMax(string $point_set, ?ScaleData $scaleData = null): ?ScaleData
     {
         // Separate each point
         $points = explode(',', $point_set);
 
         foreach ($points as $point) {
             // Extract coordinates of the point
-            $cordinates = explode(' ', $point);
+            $coordinates = explode(' ', $point);
 
-            $x = (float) $cordinates[0];
-            if (! isset($min_max['maxX']) || $x > $min_max['maxX']) {
-                $min_max['maxX'] = $x;
-            }
+            $x = (float) $coordinates[0];
+            $y = (float) $coordinates[1];
 
-            if (! isset($min_max['minX']) || $x < $min_max['minX']) {
-                $min_max['minX'] = $x;
-            }
-
-            $y = (float) $cordinates[1];
-            if (! isset($min_max['maxY']) || $y > $min_max['maxY']) {
-                $min_max['maxY'] = $y;
-            }
-
-            if (isset($min_max['minY']) && $y >= $min_max['minY']) {
-                continue;
-            }
-
-            $min_max['minY'] = $y;
+            $scaleData = $scaleData === null ? new ScaleData($x, $x, $y, $y) : $scaleData->expand($x, $y);
         }
 
-        return $min_max;
+        return $scaleData;
     }
 
     /**

--- a/libraries/classes/Gis/GisGeometry.php
+++ b/libraries/classes/Gis/GisGeometry.php
@@ -101,7 +101,7 @@ abstract class GisGeometry
      *
      * @return array array containing the min, max values for x and y coordinates
      */
-    abstract public function scaleRow($spatial);
+    abstract public function scaleRow($spatial): array;
 
     /**
      * Generates the WKT with the set of parameters passed by the GIS editor.

--- a/libraries/classes/Gis/GisGeometryCollection.php
+++ b/libraries/classes/Gis/GisGeometryCollection.php
@@ -75,7 +75,7 @@ class GisGeometryCollection extends GisGeometry
 
             $scale_data = $gis_obj->scaleRow($sub_part);
 
-            $min_max = $min_max === null ? $scale_data : $scale_data->merge($min_max);
+            $min_max = $min_max === null ? $scale_data : $scale_data?->merge($min_max);
         }
 
         return $min_max;

--- a/libraries/classes/Gis/GisGeometryCollection.php
+++ b/libraries/classes/Gis/GisGeometryCollection.php
@@ -49,12 +49,10 @@ class GisGeometryCollection extends GisGeometry
      * Scales each row.
      *
      * @param string $spatial spatial data of a row
-     *
-     * @return array{maxX: float, minX: float, maxY: float, minY: float}|array{}
      */
-    public function scaleRow($spatial): array
+    public function scaleRow(string $spatial): ?ScaleData
     {
-        $min_max = [];
+        $min_max = null;
 
         // Trim to remove leading 'GEOMETRYCOLLECTION(' and trailing ')'
         $goem_col = mb_substr($spatial, 19, -1);
@@ -77,28 +75,7 @@ class GisGeometryCollection extends GisGeometry
 
             $scale_data = $gis_obj->scaleRow($sub_part);
 
-            // Update minimum/maximum values for x and y coordinates.
-            $c_maxX = (float) $scale_data['maxX'];
-            if (! isset($min_max['maxX']) || $c_maxX > $min_max['maxX']) {
-                $min_max['maxX'] = $c_maxX;
-            }
-
-            $c_minX = (float) $scale_data['minX'];
-            if (! isset($min_max['minX']) || $c_minX < $min_max['minX']) {
-                $min_max['minX'] = $c_minX;
-            }
-
-            $c_maxY = (float) $scale_data['maxY'];
-            if (! isset($min_max['maxY']) || $c_maxY > $min_max['maxY']) {
-                $min_max['maxY'] = $c_maxY;
-            }
-
-            $c_minY = (float) $scale_data['minY'];
-            if (isset($min_max['minY']) && $c_minY >= $min_max['minY']) {
-                continue;
-            }
-
-            $min_max['minY'] = $c_minY;
+            $min_max = $min_max === null ? $scale_data : $scale_data->merge($min_max);
         }
 
         return $min_max;

--- a/libraries/classes/Gis/GisGeometryCollection.php
+++ b/libraries/classes/Gis/GisGeometryCollection.php
@@ -50,9 +50,9 @@ class GisGeometryCollection extends GisGeometry
      *
      * @param string $spatial spatial data of a row
      *
-     * @return array array containing the min, max values for x and y coordinates
+     * @return array{maxX: float, minX: float, maxY: float, minY: float}|array{}
      */
-    public function scaleRow($spatial)
+    public function scaleRow($spatial): array
     {
         $min_max = [];
 
@@ -263,9 +263,9 @@ class GisGeometryCollection extends GisGeometry
      *
      * @param string $geom_col geometry collection string
      *
-     * @return array the constituents of the geometry collection object
+     * @return string[] the constituents of the geometry collection object
      */
-    private function explodeGeomCol($geom_col)
+    private function explodeGeomCol($geom_col): array
     {
         $sub_parts = [];
         $br_count = 0;

--- a/libraries/classes/Gis/GisLineString.php
+++ b/libraries/classes/Gis/GisLineString.php
@@ -51,14 +51,14 @@ class GisLineString extends GisGeometry
      *
      * @param string $spatial spatial data of a row
      *
-     * @return array an array containing the min, max values for x and y coordinates
+     * @return ScaleData|null the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial): array
+    public function scaleRow(string $spatial): ?ScaleData
     {
         // Trim to remove leading 'LINESTRING(' and trailing ')'
         $linestring = mb_substr($spatial, 11, -1);
 
-        return $this->setMinMax($linestring, []);
+        return $this->setMinMax($linestring);
     }
 
     /**

--- a/libraries/classes/Gis/GisLineString.php
+++ b/libraries/classes/Gis/GisLineString.php
@@ -53,7 +53,7 @@ class GisLineString extends GisGeometry
      *
      * @return array an array containing the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial)
+    public function scaleRow($spatial): array
     {
         // Trim to remove leading 'LINESTRING(' and trailing ')'
         $linestring = mb_substr($spatial, 11, -1);

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -54,7 +54,7 @@ class GisMultiLineString extends GisGeometry
      *
      * @return array an array containing the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial)
+    public function scaleRow($spatial): array
     {
         $min_max = [];
 

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -52,11 +52,11 @@ class GisMultiLineString extends GisGeometry
      *
      * @param string $spatial spatial data of a row
      *
-     * @return array an array containing the min, max values for x and y coordinates
+     * @return ScaleData|null the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial): array
+    public function scaleRow(string $spatial): ?ScaleData
     {
-        $min_max = [];
+        $min_max = null;
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
         $multilinestirng = mb_substr($spatial, 17, -2);

--- a/libraries/classes/Gis/GisMultiPoint.php
+++ b/libraries/classes/Gis/GisMultiPoint.php
@@ -53,7 +53,7 @@ class GisMultiPoint extends GisGeometry
      *
      * @return array an array containing the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial)
+    public function scaleRow($spatial): array
     {
         // Trim to remove leading 'MULTIPOINT(' and trailing ')'
         $multipoint = mb_substr($spatial, 11, -1);

--- a/libraries/classes/Gis/GisMultiPoint.php
+++ b/libraries/classes/Gis/GisMultiPoint.php
@@ -51,14 +51,14 @@ class GisMultiPoint extends GisGeometry
      *
      * @param string $spatial spatial data of a row
      *
-     * @return array an array containing the min, max values for x and y coordinates
+     * @return ScaleData|null the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial): array
+    public function scaleRow(string $spatial): ?ScaleData
     {
         // Trim to remove leading 'MULTIPOINT(' and trailing ')'
         $multipoint = mb_substr($spatial, 11, -1);
 
-        return $this->setMinMax($multipoint, []);
+        return $this->setMinMax($multipoint);
     }
 
     /**

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -54,11 +54,11 @@ class GisMultiPolygon extends GisGeometry
      *
      * @param string $spatial spatial data of a row
      *
-     * @return array an array containing the min, max values for x and y coordinates
+     * @return ScaleData|null the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial): array
+    public function scaleRow(string $spatial): ?ScaleData
     {
-        $min_max = [];
+        $min_max = null;
 
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
         $multipolygon = mb_substr($spatial, 15, -3);

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -56,7 +56,7 @@ class GisMultiPolygon extends GisGeometry
      *
      * @return array an array containing the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial)
+    public function scaleRow($spatial): array
     {
         $min_max = [];
 

--- a/libraries/classes/Gis/GisPoint.php
+++ b/libraries/classes/Gis/GisPoint.php
@@ -52,7 +52,7 @@ class GisPoint extends GisGeometry
      *
      * @return array an array containing the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial)
+    public function scaleRow($spatial): array
     {
         // Trim to remove leading 'POINT(' and trailing ')'
         $point = mb_substr($spatial, 6, -1);

--- a/libraries/classes/Gis/GisPoint.php
+++ b/libraries/classes/Gis/GisPoint.php
@@ -50,14 +50,14 @@ class GisPoint extends GisGeometry
      *
      * @param string $spatial spatial data of a row
      *
-     * @return array an array containing the min, max values for x and y coordinates
+     * @return ScaleData|null the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial): array
+    public function scaleRow(string $spatial): ?ScaleData
     {
         // Trim to remove leading 'POINT(' and trailing ')'
         $point = mb_substr($spatial, 6, -1);
 
-        return $this->setMinMax($point, []);
+        return $this->setMinMax($point);
     }
 
     /**

--- a/libraries/classes/Gis/GisPolygon.php
+++ b/libraries/classes/Gis/GisPolygon.php
@@ -57,15 +57,15 @@ class GisPolygon extends GisGeometry
      *
      * @param string $spatial spatial data of a row
      *
-     * @return array an array containing the min, max values for x and y coordinates
+     * @return ScaleData|null the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial): array
+    public function scaleRow(string $spatial): ?ScaleData
     {
         // Trim to remove leading 'POLYGON((' and trailing '))'
         $polygon = mb_substr($spatial, 9, -2);
         $wkt_outer_ring = explode('),(', $polygon)[0];
 
-        return $this->setMinMax($wkt_outer_ring, []);
+        return $this->setMinMax($wkt_outer_ring);
     }
 
     /**

--- a/libraries/classes/Gis/GisPolygon.php
+++ b/libraries/classes/Gis/GisPolygon.php
@@ -59,7 +59,7 @@ class GisPolygon extends GisGeometry
      *
      * @return array an array containing the min, max values for x and y coordinates
      */
-    public function scaleRow($spatial)
+    public function scaleRow($spatial): array
     {
         // Trim to remove leading 'POLYGON((' and trailing '))'
         $polygon = mb_substr($spatial, 9, -2);

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -547,25 +547,25 @@ class GisVisualization
                 continue;
             }
 
-            $scale_data = $gis_obj->scaleRow($row[$this->settings['spatialColumn']]);
+            $scaleData = $gis_obj->scaleRow($row[$this->settings['spatialColumn']]);
 
             // Update minimum/maximum values for x and y coordinates.
-            $c_maxX = (float) $scale_data['maxX'];
+            $c_maxX = $scaleData->maxX;
             if ($min_max['maxX'] === 0.0 || $c_maxX > $min_max['maxX']) {
                 $min_max['maxX'] = $c_maxX;
             }
 
-            $c_minX = (float) $scale_data['minX'];
+            $c_minX = $scaleData->minX;
             if ($min_max['minX'] === 0.0 || $c_minX < $min_max['minX']) {
                 $min_max['minX'] = $c_minX;
             }
 
-            $c_maxY = (float) $scale_data['maxY'];
+            $c_maxY = $scaleData->maxY;
             if ($min_max['maxY'] === 0.0 || $c_maxY > $min_max['maxY']) {
                 $min_max['maxY'] = $c_maxY;
             }
 
-            $c_minY = (float) $scale_data['minY'];
+            $c_minY = $scaleData->minY;
             if ($min_max['minY'] !== 0.0 && $c_minY >= $min_max['minY']) {
                 continue;
             }

--- a/libraries/classes/Gis/ScaleData.php
+++ b/libraries/classes/Gis/ScaleData.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Gis;
+
+use function max;
+use function min;
+
+class ScaleData
+{
+    public function __construct(
+        public readonly float $maxX,
+        public readonly float $minX,
+        public readonly float $maxY,
+        public readonly float $minY,
+    ) {
+    }
+
+    public function expand(float $x, float $y): ScaleData
+    {
+        return new ScaleData(
+            max($this->maxX, $x),
+            min($this->minX, $x),
+            max($this->maxY, $y),
+            min($this->minY, $y),
+        );
+    }
+
+    public function merge(ScaleData $scaleData): ScaleData
+    {
+        return new ScaleData(
+            max($this->maxX, $scaleData->maxX),
+            min($this->minX, $scaleData->minX),
+            max($this->maxY, $scaleData->maxY),
+            min($this->minY, $scaleData->minY),
+        );
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4286,11 +4286,6 @@ parameters:
 			path: libraries/classes/Gis/GisGeometry.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometryCollection\\:\\:explodeGeomCol\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisGeometryCollection.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometryCollection\\:\\:generateParams\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisGeometryCollection.php
@@ -4317,11 +4312,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometryCollection\\:\\:prepareRowAsSvg\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisGeometryCollection.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometryCollection\\:\\:scaleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisGeometryCollection.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4261,21 +4261,6 @@ parameters:
 			path: libraries/classes/Gis/GisGeometry.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometry\\:\\:scaleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisGeometry.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometry\\:\\:setMinMax\\(\\) has parameter \\$min_max with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisGeometry.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisGeometry\\:\\:setMinMax\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisGeometry.php
-
-		-
 			message: "#^Only numeric types are allowed in \\+, int\\<0, max\\>\\|false given on the left side\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisGeometry.php
@@ -4356,11 +4341,6 @@ parameters:
 			path: libraries/classes/Gis/GisLineString.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisLineString\\:\\:scaleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisLineString.php
-
-		-
 			message: "#^Parameter \\#5 \\$color of method PhpMyAdmin\\\\Image\\\\ImageWrapper\\:\\:line\\(\\) expects int, int\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisLineString.php
@@ -4407,11 +4387,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiLineString\\:\\:prepareRowAsSvg\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiLineString.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiLineString\\:\\:scaleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiLineString.php
 
@@ -4471,11 +4446,6 @@ parameters:
 			path: libraries/classes/Gis/GisMultiPoint.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiPoint\\:\\:scaleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPoint.php
-
-		-
 			message: "#^Parameter \\#5 \\$color of method PhpMyAdmin\\\\Image\\\\ImageWrapper\\:\\:string\\(\\) expects int, int\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiPoint.php
@@ -4531,11 +4501,6 @@ parameters:
 			path: libraries/classes/Gis/GisMultiPolygon.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisMultiPolygon\\:\\:scaleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisMultiPolygon.php
-
-		-
 			message: "#^Parameter \\#2 \\$color of method PhpMyAdmin\\\\Image\\\\ImageWrapper\\:\\:filledPolygon\\(\\) expects int, int\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisMultiPolygon.php
@@ -4587,11 +4552,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisPoint\\:\\:prepareRowAsSvg\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPoint.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisPoint\\:\\:scaleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisPoint.php
 
@@ -4672,11 +4632,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisPolygon\\:\\:prepareRowAsSvg\\(\\) has parameter \\$scale_data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisPolygon.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisPolygon\\:\\:scaleRow\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisPolygon.php
 
@@ -10501,11 +10456,6 @@ parameters:
 			path: test/classes/Gis/GisGeomTestCase.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisGeomTestCase\\:\\:testScaleRow\\(\\) has parameter \\$min_max with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisGeomTestCase.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisGeometryCollectionTest\\:\\:providerForPrepareRowAsOl\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Gis/GisGeometryCollectionTest.php
@@ -10607,16 +10557,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisGeometryTest\\:\\:testGetPolygonArrayForOpenLayers\\(\\) has parameter \\$polygons with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisGeometryTest.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisGeometryTest\\:\\:testSetMinMax\\(\\) has parameter \\$min_max with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Gis/GisGeometryTest.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Gis\\\\GisGeometryTest\\:\\:testSetMinMax\\(\\) has parameter \\$output with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: test/classes/Gis/GisGeometryTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8655,8 +8655,8 @@
     <MixedOperand>
       <code>$border / $scale</code>
       <code>$border / $scale</code>
-      <code>$min_max['maxX'] + $min_max['minX'] - $this-&gt;settings['width'] / $scale</code>
-      <code>$min_max['maxY'] + $min_max['minY'] - $this-&gt;settings['height'] / $scale</code>
+      <code>$min_max-&gt;maxX + $min_max-&gt;minX - $this-&gt;settings['width'] / $scale</code>
+      <code>$min_max-&gt;maxY + $min_max-&gt;minY - $this-&gt;settings['height'] / $scale</code>
       <code>$plot_height</code>
       <code>$plot_width</code>
       <code>$ratio</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7954,41 +7954,12 @@
       <code>$gis_obj</code>
     </DocblockTypeContradiction>
     <MixedArgument>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
       <code>$type</code>
       <code>$wkt</code>
     </MixedArgument>
     <MixedAssignment>
       <code>$geom_count</code>
       <code>$params['srid']</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
-      <code>$sub_part</code>
       <code>$type</code>
       <code>$wkt</code>
     </MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -17389,6 +17389,7 @@
   <file src="test/classes/Gis/GisVisualizationTest.php">
     <MixedAssignment>
       <code>$dataSet</code>
+      <code>$dataSet</code>
       <code>$queryString</code>
       <code>$queryString</code>
       <code>$queryString</code>

--- a/test/classes/Gis/GisGeomTestCase.php
+++ b/test/classes/Gis/GisGeomTestCase.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisGeometry;
 use PhpMyAdmin\Gis\GisPolygon;
+use PhpMyAdmin\Gis\ScaleData;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use ReflectionProperty;
 use TCPDF;
@@ -77,12 +78,12 @@ abstract class GisGeomTestCase extends AbstractTestCase
     /**
      * test scaleRow method
      *
-     * @param string $spatial spatial data of a row
-     * @param array  $min_max expected results
+     * @param string    $spatial spatial data of a row
+     * @param ScaleData $min_max expected results
      *
      * @dataProvider providerForTestScaleRow
      */
-    public function testScaleRow(string $spatial, array $min_max): void
+    public function testScaleRow(string $spatial, ScaleData $min_max): void
     {
         $this->assertEquals(
             $min_max,

--- a/test/classes/Gis/GisGeometryCollectionTest.php
+++ b/test/classes/Gis/GisGeometryCollectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisGeometryCollection;
+use PhpMyAdmin\Gis\ScaleData;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
@@ -48,12 +49,7 @@ class GisGeometryCollectionTest extends GisGeomTestCase
         return [
             [
                 'GEOMETRYCOLLECTION(POLYGON((35 10,10 20,15 40,45 45,35 10),(20 30,35 32,30 20,20 30)))',
-                [
-                    'maxX' => 45.0,
-                    'minX' => 10.0,
-                    'maxY' => 45.0,
-                    'minY' => 10.0,
-                ],
+                new ScaleData(45, 10, 45, 10),
             ],
         ];
     }

--- a/test/classes/Gis/GisGeometryTest.php
+++ b/test/classes/Gis/GisGeometryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisGeometry;
+use PhpMyAdmin\Gis\ScaleData;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -39,13 +40,13 @@ class GisGeometryTest extends AbstractTestCase
     /**
      * tests setMinMax method
      *
-     * @param string $point_set Point set
-     * @param array  $min_max   Existing min, max values
-     * @param array  $output    Expected output array
+     * @param string         $point_set Point set
+     * @param ScaleData|null $min_max   Existing min, max values
+     * @param ScaleData|null $output    Expected output array
      *
      * @dataProvider providerForTestSetMinMax
      */
-    public function testSetMinMax(string $point_set, array $min_max, array $output): void
+    public function testSetMinMax(string $point_set, ?ScaleData $min_max, ?ScaleData $output): void
     {
         $this->assertEquals(
             $output,
@@ -71,28 +72,13 @@ class GisGeometryTest extends AbstractTestCase
         return [
             [
                 '12 35,48 75,69 23,25 45,14 53,35 78',
-                [],
-                [
-                    'minX' => 12,
-                    'maxX' => 69,
-                    'minY' => 23,
-                    'maxY' => 78,
-                ],
+                null,
+                new ScaleData(69, 12, 78, 23),
             ],
             [
                 '12 35,48 75,69 23,25 45,14 53,35 78',
-                [
-                    'minX' => 2,
-                    'maxX' => 29,
-                    'minY' => 23,
-                    'maxY' => 128,
-                ],
-                [
-                    'minX' => 2,
-                    'maxX' => 69,
-                    'minY' => 23,
-                    'maxY' => 128,
-                ],
+                new ScaleData(29, 2, 128, 23),
+                new ScaleData(69, 2, 128, 23),
             ],
         ];
     }

--- a/test/classes/Gis/GisLineStringTest.php
+++ b/test/classes/Gis/GisLineStringTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisLineString;
+use PhpMyAdmin\Gis\ScaleData;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
@@ -153,12 +154,7 @@ class GisLineStringTest extends GisGeomTestCase
         return [
             [
                 'LINESTRING(12 35,48 75,69 23,25 45,14 53,35 78)',
-                [
-                    'minX' => 12,
-                    'maxX' => 69,
-                    'minY' => 23,
-                    'maxY' => 78,
-                ],
+                new ScaleData(69, 12, 78, 23),
             ],
         ];
     }

--- a/test/classes/Gis/GisMultiLineStringTest.php
+++ b/test/classes/Gis/GisMultiLineStringTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisMultiLineString;
+use PhpMyAdmin\Gis\ScaleData;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
@@ -235,12 +236,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
         return [
             [
                 'MULTILINESTRING((36 14,47 23,62 75),(36 10,17 23,178 53))',
-                [
-                    'minX' => 17,
-                    'maxX' => 178,
-                    'minY' => 10,
-                    'maxY' => 75,
-                ],
+                new ScaleData(178, 17, 75, 10),
             ],
         ];
     }

--- a/test/classes/Gis/GisMultiPointTest.php
+++ b/test/classes/Gis/GisMultiPointTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisMultiPoint;
+use PhpMyAdmin\Gis\ScaleData;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
@@ -157,12 +158,7 @@ class GisMultiPointTest extends GisGeomTestCase
         return [
             [
                 'MULTIPOINT(12 35,48 75,69 23,25 45,14 53,35 78)',
-                [
-                    'minX' => 12,
-                    'maxX' => 69,
-                    'minY' => 23,
-                    'maxY' => 78,
-                ],
+                new ScaleData(69, 12, 78, 23),
             ],
         ];
     }

--- a/test/classes/Gis/GisMultiPolygonTest.php
+++ b/test/classes/Gis/GisMultiPolygonTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisMultiPolygon;
+use PhpMyAdmin\Gis\ScaleData;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
@@ -310,22 +311,12 @@ class GisMultiPolygonTest extends GisGeomTestCase
         return [
             [
                 'MULTIPOLYGON(((136 40,147 83,16 75,136 40)),((105 0,56 20,78 73,105 0)))',
-                [
-                    'minX' => 16,
-                    'maxX' => 147,
-                    'minY' => 0,
-                    'maxY' => 83,
-                ],
+                new ScaleData(147, 16, 83, 0),
             ],
             [
                 'MULTIPOLYGON(((35 10,10 20,15 40,45 45,35 10),(20 30,35 32,30 20'
                     . ',20 30)),((105 0,56 20,78 73,105 0)))',
-                [
-                    'minX' => 10,
-                    'maxX' => 105,
-                    'minY' => 0,
-                    'maxY' => 73,
-                ],
+                new ScaleData(105, 10, 73, 0),
             ],
         ];
     }

--- a/test/classes/Gis/GisPointTest.php
+++ b/test/classes/Gis/GisPointTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisPoint;
+use PhpMyAdmin\Gis\ScaleData;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
@@ -173,12 +174,7 @@ class GisPointTest extends GisGeomTestCase
         return [
             [
                 'POINT(12 35)',
-                [
-                    'minX' => 12,
-                    'maxX' => 12,
-                    'minY' => 35,
-                    'maxY' => 35,
-                ],
+                new ScaleData(12, 12, 35, 35),
             ],
         ];
     }

--- a/test/classes/Gis/GisPolygonTest.php
+++ b/test/classes/Gis/GisPolygonTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisPolygon;
+use PhpMyAdmin\Gis\ScaleData;
 use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
@@ -397,21 +398,11 @@ class GisPolygonTest extends GisGeomTestCase
         return [
             [
                 'POLYGON((123 0,23 30,17 63,123 0))',
-                [
-                    'minX' => 17,
-                    'maxX' => 123,
-                    'minY' => 0,
-                    'maxY' => 63,
-                ],
+                new ScaleData(123, 17, 63, 0),
             ],
             [
                 'POLYGON((35 10,10 20,15 40,45 45,35 10),(20 30,35 32,30 20,20 30)))',
-                [
-                    'minX' => 10,
-                    'maxX' => 45,
-                    'minY' => 10,
-                    'maxY' => 45,
-                ],
+                new ScaleData(45, 10, 45, 10),
             ],
         ];
     }

--- a/test/classes/Gis/GisVisualizationTest.php
+++ b/test/classes/Gis/GisVisualizationTest.php
@@ -80,6 +80,32 @@ class GisVisualizationTest extends AbstractTestCase
             ],
             $dataSet
         );
+        // Regression test for bug with 0.0 sentinel values
+        $dataSet = $this->callFunction(
+            $gis,
+            GisVisualization::class,
+            'scaleDataSet',
+            [
+                [
+                    ['abc' => 'MULTIPOLYGON(((0 0,0 3,3 3,3 0,0 0),(1 1,1 2,2 2,2 1,1 1)))'],
+                    ['abc' => 'MULTIPOLYGON(((10 10,10 13,13 13,13 10,10 10),(11 11,11 12,12 12,12 11,11 11)))'],
+                ],
+            ]
+        );
+        $this->assertSame(
+            [
+                'scale' => 32.30769230769231,
+                'x' => -2.7857142857142865,
+                'y' => -0.4642857142857143,
+                'minX' => 0.0,
+                'maxX' => 13.0,
+                'minY' => 0.0,
+                'maxY' => 13.0,
+                'height' => 450,
+
+            ],
+            $dataSet
+        );
     }
 
     /**


### PR DESCRIPTION
One bug less. 
I don't understand why this was written in such a complicated way, but hopefully it's much clearer after adding a value object. The VO is immutable, but I had to indicate a lack of value so I used null union (although the actual result should always be a VO and never null). 
This started with me trying to add an array shape, but I uncovered a bug and decided to fix it. I don't think it's worth the effort to backport it to 5.2 as this is only a minor visual bug. I added a regression test for it.