### PR TITLE
Stop using PHP_EOL

### DIFF
--- a/libraries/classes/Git.php
+++ b/libraries/classes/Git.php
@@ -42,7 +42,6 @@ use function trim;
 use function unpack;
 
 use const DIRECTORY_SEPARATOR;
-use const PHP_EOL;
 
 /**
  * Git class to manipulate Git data
@@ -486,7 +485,7 @@ class Git
         }
 
         // split file to lines
-        $refLines = explode(PHP_EOL, $packedRefs);
+        $refLines = explode("\n", $packedRefs);
         foreach ($refLines as $line) {
             // skip comments
             if ($line[0] === '#') {

--- a/libraries/classes/Plugins/Export/ExportCodegen.php
+++ b/libraries/classes/Plugins/Export/ExportCodegen.php
@@ -23,8 +23,6 @@ use function preg_replace;
 use function sprintf;
 use function ucfirst;
 
-use const PHP_EOL;
-
 /**
  * Handles the export for the CodeGen class
  */
@@ -293,7 +291,7 @@ class ExportCodegen extends ExportPlugin
         $lines[] = '    #endregion';
         $lines[] = '}';
 
-        return implode(PHP_EOL, $lines);
+        return implode("\n", $lines);
     }
 
     /**
@@ -360,7 +358,7 @@ class ExportCodegen extends ExportPlugin
         $lines[] = '    </class>';
         $lines[] = '</hibernate-mapping>';
 
-        return implode(PHP_EOL, $lines);
+        return implode("\n", $lines);
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportCsv.php
+++ b/libraries/classes/Plugins/Export/ExportCsv.php
@@ -24,8 +24,6 @@ use function mb_strtolower;
 use function preg_replace;
 use function str_replace;
 
-use const PHP_EOL;
-
 /**
  * Handles the export for the CSV format
  */
@@ -132,7 +130,7 @@ class ExportCsv extends ExportPlugin
             }
         } else {
             if (empty($GLOBALS['csv_terminated']) || mb_strtolower($GLOBALS['csv_terminated']) === 'auto') {
-                $GLOBALS['csv_terminated'] = PHP_EOL;
+                $GLOBALS['csv_terminated'] = "\n";
             } else {
                 $GLOBALS['csv_terminated'] = str_replace(
                     [

--- a/libraries/classes/Plugins/Export/ExportJson.php
+++ b/libraries/classes/Plugins/Export/ExportJson.php
@@ -25,7 +25,6 @@ use function json_encode;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_UNICODE;
-use const PHP_EOL;
 
 /**
  * Handles the export for the JSON format
@@ -116,7 +115,7 @@ class ExportJson extends ExportPlugin
             return false;
         }
 
-        return $this->export->outputHandler('[' . PHP_EOL . $data . ',' . PHP_EOL);
+        return $this->export->outputHandler('[' . "\n" . $data . ',' . "\n");
     }
 
     /**
@@ -124,7 +123,7 @@ class ExportJson extends ExportPlugin
      */
     public function exportFooter(): bool
     {
-        return $this->export->outputHandler(']' . PHP_EOL);
+        return $this->export->outputHandler(']' . "\n");
     }
 
     /**
@@ -144,7 +143,7 @@ class ExportJson extends ExportPlugin
             return false;
         }
 
-        return $this->export->outputHandler($data . ',' . PHP_EOL);
+        return $this->export->outputHandler($data . ',' . "\n");
     }
 
     /**
@@ -233,7 +232,7 @@ class ExportJson extends ExportPlugin
     ): bool {
         [$header, $footer] = explode('"@@DATA@@"', $buffer);
 
-        if (! $this->export->outputHandler($header . PHP_EOL . '[' . PHP_EOL)) {
+        if (! $this->export->outputHandler($header . "\n" . '[' . "\n")) {
             return false;
         }
 
@@ -260,7 +259,7 @@ class ExportJson extends ExportPlugin
 
             // Output table name as comment if this is the first record of the table
             if ($record_cnt > 1) {
-                if (! $this->export->outputHandler(',' . PHP_EOL)) {
+                if (! $this->export->outputHandler(',' . "\n")) {
                     return false;
                 }
             }
@@ -302,7 +301,7 @@ class ExportJson extends ExportPlugin
             }
         }
 
-        return $this->export->outputHandler(PHP_EOL . ']' . PHP_EOL . $footer . PHP_EOL);
+        return $this->export->outputHandler("\n" . ']' . "\n" . $footer . "\n");
     }
 
     /**

--- a/libraries/classes/Plugins/Export/ExportLatex.php
+++ b/libraries/classes/Plugins/Export/ExportLatex.php
@@ -27,7 +27,6 @@ use function mb_substr;
 use function str_repeat;
 use function str_replace;
 
-use const PHP_EOL;
 use const PHP_VERSION;
 
 /**
@@ -204,20 +203,20 @@ class ExportLatex extends ExportPlugin
      */
     public function exportHeader(): bool
     {
-        $head = '% phpMyAdmin LaTeX Dump' . PHP_EOL
-            . '% version ' . Version::VERSION . PHP_EOL
-            . '% https://www.phpmyadmin.net/' . PHP_EOL
-            . '%' . PHP_EOL
+        $head = '% phpMyAdmin LaTeX Dump' . "\n"
+            . '% version ' . Version::VERSION . "\n"
+            . '% https://www.phpmyadmin.net/' . "\n"
+            . '%' . "\n"
             . '% ' . __('Host:') . ' ' . $GLOBALS['cfg']['Server']['host'];
         if (! empty($GLOBALS['cfg']['Server']['port'])) {
             $head .= ':' . $GLOBALS['cfg']['Server']['port'];
         }
 
-        $head .= PHP_EOL
+        $head .= "\n"
             . '% ' . __('Generation Time:') . ' '
-            . Util::localisedDate() . PHP_EOL
-            . '% ' . __('Server version:') . ' ' . $GLOBALS['dbi']->getVersionString() . PHP_EOL
-            . '% ' . __('PHP Version:') . ' ' . PHP_VERSION . PHP_EOL;
+            . Util::localisedDate() . "\n"
+            . '% ' . __('Server version:') . ' ' . $GLOBALS['dbi']->getVersionString() . "\n"
+            . '% ' . __('PHP Version:') . ' ' . PHP_VERSION . "\n";
 
         return $this->export->outputHandler($head);
     }
@@ -242,9 +241,9 @@ class ExportLatex extends ExportPlugin
             $dbAlias = $db;
         }
 
-        $head = '% ' . PHP_EOL
-            . '% ' . __('Database:') . ' \'' . $dbAlias . '\'' . PHP_EOL
-            . '% ' . PHP_EOL;
+        $head = '% ' . "\n"
+            . '% ' . __('Database:') . ' \'' . $dbAlias . '\'' . "\n"
+            . '% ' . "\n";
 
         return $this->export->outputHandler($head);
     }
@@ -309,14 +308,14 @@ class ExportLatex extends ExportPlugin
             $columns_alias[$i] = $col_as;
         }
 
-        $buffer = PHP_EOL . '%' . PHP_EOL . '% ' . __('Data:') . ' ' . $table_alias
-            . PHP_EOL . '%' . PHP_EOL . ' \\begin{longtable}{|';
+        $buffer = "\n" . '%' . "\n" . '% ' . __('Data:') . ' ' . $table_alias
+            . "\n" . '%' . "\n" . ' \\begin{longtable}{|';
 
         $buffer .= str_repeat('l|', $columns_cnt);
 
-        $buffer .= '} ' . PHP_EOL;
+        $buffer .= '} ' . "\n";
 
-        $buffer .= ' \\hline \\endhead \\hline \\endfoot \\hline ' . PHP_EOL;
+        $buffer .= ' \\hline \\endhead \\hline \\endfoot \\hline ' . "\n";
         if (isset($GLOBALS['latex_caption'])) {
             $buffer .= ' \\caption{'
                 . Util::expandUserString(
@@ -349,7 +348,7 @@ class ExportLatex extends ExportPlugin
             }
 
             $buffer = mb_substr($buffer, 0, -2) . '\\\\ \\hline \hline ';
-            if (! $this->export->outputHandler($buffer . ' \\endfirsthead ' . PHP_EOL)) {
+            if (! $this->export->outputHandler($buffer . ' \\endfirsthead ' . "\n")) {
                 return false;
             }
 
@@ -369,7 +368,7 @@ class ExportLatex extends ExportPlugin
                 }
             }
 
-            if (! $this->export->outputHandler($buffer . '\\endhead \\endfoot' . PHP_EOL)) {
+            if (! $this->export->outputHandler($buffer . '\\endhead \\endfoot' . "\n")) {
                 return false;
             }
         } else {
@@ -397,13 +396,13 @@ class ExportLatex extends ExportPlugin
                 }
             }
 
-            $buffer .= ' \\\\ \\hline ' . PHP_EOL;
+            $buffer .= ' \\\\ \\hline ' . "\n";
             if (! $this->export->outputHandler($buffer)) {
                 return false;
             }
         }
 
-        $buffer = ' \\end{longtable}' . PHP_EOL;
+        $buffer = ' \\end{longtable}' . "\n";
 
         return $this->export->outputHandler($buffer);
     }
@@ -494,8 +493,8 @@ class ExportLatex extends ExportPlugin
         /**
          * Displays the table structure
          */
-        $buffer = PHP_EOL . '%' . PHP_EOL . '% ' . __('Structure:') . ' '
-            . $table_alias . PHP_EOL . '%' . PHP_EOL . ' \\begin{longtable}{';
+        $buffer = "\n" . '%' . "\n" . '% ' . __('Structure:') . ' '
+            . $table_alias . "\n" . '%' . "\n" . ' \\begin{longtable}{';
         if (! $this->export->outputHandler($buffer)) {
             return false;
         }
@@ -513,7 +512,7 @@ class ExportLatex extends ExportPlugin
             $alignment .= 'l|';
         }
 
-        $buffer = $alignment . '} ' . PHP_EOL;
+        $buffer = $alignment . '} ' . "\n";
 
         $header = ' \\hline ';
         $header .= '\\multicolumn{1}{|c|}{\\textbf{' . __('Column')
@@ -551,11 +550,11 @@ class ExportLatex extends ExportPlugin
                         'database' => $db_alias,
                     ]
                 )
-                . '} \\\\' . PHP_EOL;
+                . '} \\\\' . "\n";
         }
 
-        $buffer .= $header . ' \\\\ \\hline \\hline' . PHP_EOL
-            . '\\endfirsthead' . PHP_EOL;
+        $buffer .= $header . ' \\\\ \\hline \\hline' . "\n"
+            . '\\endfirsthead' . "\n";
         // Table caption on next pages
         if (isset($GLOBALS['latex_caption'])) {
             $buffer .= ' \\caption{'
@@ -564,10 +563,10 @@ class ExportLatex extends ExportPlugin
                     [static::class, 'texEscape'],
                     ['table' => $table_alias, 'database' => $db_alias]
                 )
-                . '} \\\\ ' . PHP_EOL;
+                . '} \\\\ ' . "\n";
         }
 
-        $buffer .= $header . ' \\\\ \\hline \\hline \\endhead \\endfoot ' . PHP_EOL;
+        $buffer .= $header . ' \\\\ \\hline \\hline \\endhead \\endfoot ' . "\n";
 
         if (! $this->export->outputHandler($buffer)) {
             return false;
@@ -628,14 +627,14 @@ class ExportLatex extends ExportPlugin
             }
 
             $buffer = str_replace("\000", ' & ', $local_buffer);
-            $buffer .= ' \\\\ \\hline ' . PHP_EOL;
+            $buffer .= ' \\\\ \\hline ' . "\n";
 
             if (! $this->export->outputHandler($buffer)) {
                 return false;
             }
         }
 
-        $buffer = ' \\end{longtable}' . PHP_EOL;
+        $buffer = ' \\end{longtable}' . "\n";
 
         return $this->export->outputHandler($buffer);
     }

--- a/libraries/classes/Plugins/Export/ExportPhparray.php
+++ b/libraries/classes/Plugins/Export/ExportPhparray.php
@@ -85,7 +85,7 @@ class ExportPhparray extends ExportPlugin
             . '/**' . "\n"
             . ' * Export to PHP Array plugin for PHPMyAdmin' . "\n"
             . ' * @version ' . Version::VERSION . "\n"
-            . ' */' . "\n" . "\n"
+            . ' */' . "\n\n"
         );
 
         return true;

--- a/libraries/classes/Plugins/Export/ExportPhparray.php
+++ b/libraries/classes/Plugins/Export/ExportPhparray.php
@@ -23,8 +23,6 @@ use function preg_replace;
 use function strtr;
 use function var_export;
 
-use const PHP_EOL;
-
 /**
  * Handles the export for the PHP Array class
  */
@@ -83,11 +81,11 @@ class ExportPhparray extends ExportPlugin
     public function exportHeader(): bool
     {
         $this->export->outputHandler(
-            '<?php' . PHP_EOL
-            . '/**' . PHP_EOL
-            . ' * Export to PHP Array plugin for PHPMyAdmin' . PHP_EOL
-            . ' * @version ' . Version::VERSION . PHP_EOL
-            . ' */' . PHP_EOL . PHP_EOL
+            '<?php' . "\n"
+            . '/**' . "\n"
+            . ' * Export to PHP Array plugin for PHPMyAdmin' . "\n"
+            . ' * @version ' . Version::VERSION . "\n"
+            . ' */' . "\n" . "\n"
         );
 
         return true;
@@ -114,9 +112,9 @@ class ExportPhparray extends ExportPlugin
         }
 
         $this->export->outputHandler(
-            '/**' . PHP_EOL
+            '/**' . "\n"
             . ' * Database ' . $this->commentString(Util::backquote($dbAlias))
-            . PHP_EOL . ' */' . PHP_EOL
+            . "\n" . ' */' . "\n"
         );
 
         return true;
@@ -198,9 +196,9 @@ class ExportPhparray extends ExportPlugin
         $buffer = '';
         $record_cnt = 0;
         // Output table name as comment
-        $buffer .= PHP_EOL . '/* '
+        $buffer .= "\n" . '/* '
             . $this->commentString(Util::backquote($db_alias)) . '.'
-            . $this->commentString(Util::backquote($table_alias)) . ' */' . PHP_EOL;
+            . $this->commentString(Util::backquote($table_alias)) . ' */' . "\n";
         $buffer .= '$' . $tablefixed . ' = array(';
         if (! $this->export->outputHandler($buffer)) {
             return false;
@@ -212,9 +210,9 @@ class ExportPhparray extends ExportPlugin
             $record_cnt++;
 
             if ($record_cnt == 1) {
-                $buffer .= PHP_EOL . '  array(';
+                $buffer .= "\n" . '  array(';
             } else {
-                $buffer .= ',' . PHP_EOL . '  array(';
+                $buffer .= ',' . "\n" . '  array(';
             }
 
             for ($i = 0; $i < $columns_cnt; $i++) {
@@ -232,7 +230,7 @@ class ExportPhparray extends ExportPlugin
             $buffer = '';
         }
 
-        $buffer .= PHP_EOL . ');' . PHP_EOL;
+        $buffer .= "\n" . ');' . "\n";
 
         return $this->export->outputHandler($buffer);
     }

--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -27,7 +27,6 @@ use function rtrim;
 use function str_replace;
 use function strlen;
 
-use const PHP_EOL;
 use const PHP_VERSION;
 
 /**
@@ -166,7 +165,7 @@ class ExportXml extends ExportPlugin
         $head = '';
 
         foreach ($names as $name) {
-            $head .= '            <pma:' . $type . ' name="' . htmlspecialchars($name) . '">' . PHP_EOL;
+            $head .= '            <pma:' . $type . ' name="' . htmlspecialchars($name) . '">' . "\n";
 
             if ($type === 'function') {
                 $definition = Routines::getFunctionDefinition($GLOBALS['dbi'], $db, $name);
@@ -180,8 +179,8 @@ class ExportXml extends ExportPlugin
             $sql = htmlspecialchars(rtrim((string) $definition));
             $sql = str_replace("\n", "\n                ", $sql);
 
-            $head .= '                ' . $sql . PHP_EOL;
-            $head .= '            </pma:' . $type . '>' . PHP_EOL;
+            $head .= '                ' . $sql . "\n";
+            $head .= '            </pma:' . $type . '>' . "\n";
         }
 
         return $head;
@@ -211,29 +210,29 @@ class ExportXml extends ExportPlugin
             $charset = 'utf-8';
         }
 
-        $head = '<?xml version="1.0" encoding="' . $charset . '"?>' . PHP_EOL
-            . '<!--' . PHP_EOL
-            . '- phpMyAdmin XML Dump' . PHP_EOL
-            . '- version ' . Version::VERSION . PHP_EOL
-            . '- https://www.phpmyadmin.net' . PHP_EOL
-            . '-' . PHP_EOL
+        $head = '<?xml version="1.0" encoding="' . $charset . '"?>' . "\n"
+            . '<!--' . "\n"
+            . '- phpMyAdmin XML Dump' . "\n"
+            . '- version ' . Version::VERSION . "\n"
+            . '- https://www.phpmyadmin.net' . "\n"
+            . '-' . "\n"
             . '- ' . __('Host:') . ' ' . htmlspecialchars($GLOBALS['cfg']['Server']['host']);
         if (! empty($GLOBALS['cfg']['Server']['port'])) {
             $head .= ':' . $GLOBALS['cfg']['Server']['port'];
         }
 
-        $head .= PHP_EOL
+        $head .= "\n"
             . '- ' . __('Generation Time:') . ' '
-            . Util::localisedDate() . PHP_EOL
-            . '- ' . __('Server version:') . ' ' . $GLOBALS['dbi']->getVersionString() . PHP_EOL
-            . '- ' . __('PHP Version:') . ' ' . PHP_VERSION . PHP_EOL
-            . '-->' . PHP_EOL . PHP_EOL;
+            . Util::localisedDate() . "\n"
+            . '- ' . __('Server version:') . ' ' . $GLOBALS['dbi']->getVersionString() . "\n"
+            . '- ' . __('PHP Version:') . ' ' . PHP_VERSION . "\n"
+            . '-->' . "\n" . "\n";
 
         $head .= '<pma_xml_export version="1.0"'
             . ($export_struct
                 ? ' xmlns:pma="https://www.phpmyadmin.net/some_doc_url/"'
                 : '')
-            . '>' . PHP_EOL;
+            . '>' . "\n";
 
         if ($export_struct) {
             $result = $GLOBALS['dbi']->fetchResult(
@@ -244,13 +243,13 @@ class ExportXml extends ExportPlugin
             $db_collation = $result[0]['DEFAULT_COLLATION_NAME'];
             $db_charset = $result[0]['DEFAULT_CHARACTER_SET_NAME'];
 
-            $head .= '    <!--' . PHP_EOL;
-            $head .= '    - Structure schemas' . PHP_EOL;
-            $head .= '    -->' . PHP_EOL;
-            $head .= '    <pma:structure_schemas>' . PHP_EOL;
+            $head .= '    <!--' . "\n";
+            $head .= '    - Structure schemas' . "\n";
+            $head .= '    -->' . "\n";
+            $head .= '    <pma:structure_schemas>' . "\n";
             $head .= '        <pma:database name="' . htmlspecialchars($GLOBALS['db'])
                 . '" collation="' . htmlspecialchars($db_collation) . '" charset="' . htmlspecialchars($db_charset)
-                . '">' . PHP_EOL;
+                . '">' . "\n";
 
             if (count($tables) === 0) {
                 $tables[] = $table;
@@ -283,13 +282,13 @@ class ExportXml extends ExportPlugin
                 }
 
                 $head .= '            <pma:' . $type . ' name="' . htmlspecialchars($table) . '">'
-                    . PHP_EOL;
+                    . "\n";
 
                 $tbl = '                ' . htmlspecialchars($tbl);
                 $tbl = str_replace("\n", "\n                ", $tbl);
 
-                $head .= $tbl . ';' . PHP_EOL;
-                $head .= '            </pma:' . $type . '>' . PHP_EOL;
+                $head .= $tbl . ';' . "\n";
+                $head .= '            </pma:' . $type . '>' . "\n";
 
                 if (! isset($GLOBALS['xml_export_triggers']) || ! $GLOBALS['xml_export_triggers']) {
                     continue;
@@ -304,15 +303,15 @@ class ExportXml extends ExportPlugin
                 foreach ($triggers as $trigger) {
                     $code = $trigger['create'];
                     $head .= '            <pma:trigger name="'
-                        . htmlspecialchars($trigger['name']) . '">' . PHP_EOL;
+                        . htmlspecialchars($trigger['name']) . '">' . "\n";
 
                     // Do some formatting
                     $code = mb_substr(rtrim($code), 0, -3);
                     $code = '                ' . htmlspecialchars($code);
                     $code = str_replace("\n", "\n                ", $code);
 
-                    $head .= $code . PHP_EOL;
-                    $head .= '            </pma:trigger>' . PHP_EOL;
+                    $head .= $code . "\n";
+                    $head .= '            </pma:trigger>' . "\n";
                 }
 
                 unset($trigger, $triggers);
@@ -345,11 +344,11 @@ class ExportXml extends ExportPlugin
 
             unset($result);
 
-            $head .= '        </pma:database>' . PHP_EOL;
-            $head .= '    </pma:structure_schemas>' . PHP_EOL;
+            $head .= '        </pma:database>' . "\n";
+            $head .= '    </pma:structure_schemas>' . "\n";
 
             if ($export_data) {
-                $head .= PHP_EOL;
+                $head .= "\n";
             }
         }
 
@@ -379,11 +378,11 @@ class ExportXml extends ExportPlugin
         }
 
         if (isset($GLOBALS['xml_export_contents']) && $GLOBALS['xml_export_contents']) {
-            $head = '    <!--' . PHP_EOL
+            $head = '    <!--' . "\n"
                 . '    - ' . __('Database:') . ' \''
-                . htmlspecialchars($dbAlias) . '\'' . PHP_EOL
-                . '    -->' . PHP_EOL . '    <database name="'
-                . htmlspecialchars($dbAlias) . '">' . PHP_EOL;
+                . htmlspecialchars($dbAlias) . '\'' . "\n"
+                . '    -->' . "\n" . '    <database name="'
+                . htmlspecialchars($dbAlias) . '">' . "\n";
 
             return $this->export->outputHandler($head);
         }
@@ -399,7 +398,7 @@ class ExportXml extends ExportPlugin
     public function exportDBFooter($db): bool
     {
         if (isset($GLOBALS['xml_export_contents']) && $GLOBALS['xml_export_contents']) {
-            return $this->export->outputHandler('    </database>' . PHP_EOL);
+            return $this->export->outputHandler('    </database>' . "\n");
         }
 
         return true;
@@ -452,14 +451,14 @@ class ExportXml extends ExportPlugin
             $columns = $result->getFieldNames();
 
             $buffer = '        <!-- ' . __('Table') . ' '
-                . htmlspecialchars($table_alias) . ' -->' . PHP_EOL;
+                . htmlspecialchars($table_alias) . ' -->' . "\n";
             if (! $this->export->outputHandler($buffer)) {
                 return false;
             }
 
             while ($record = $result->fetchRow()) {
                 $buffer = '        <table name="'
-                    . htmlspecialchars($table_alias) . '">' . PHP_EOL;
+                    . htmlspecialchars($table_alias) . '">' . "\n";
                 for ($i = 0; $i < $columns_cnt; $i++) {
                     $col_as = $columns[$i];
                     if (! empty($aliases[$db]['tables'][$table]['columns'][$col_as])) {
@@ -475,10 +474,10 @@ class ExportXml extends ExportPlugin
                     $buffer .= '            <column name="'
                         . htmlspecialchars($col_as) . '">'
                         . htmlspecialchars($record[$i])
-                        . '</column>' . PHP_EOL;
+                        . '</column>' . "\n";
                 }
 
-                $buffer .= '        </table>' . PHP_EOL;
+                $buffer .= '        </table>' . "\n";
 
                 if (! $this->export->outputHandler($buffer)) {
                     return false;

--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -226,7 +226,7 @@ class ExportXml extends ExportPlugin
             . Util::localisedDate() . "\n"
             . '- ' . __('Server version:') . ' ' . $GLOBALS['dbi']->getVersionString() . "\n"
             . '- ' . __('PHP Version:') . ' ' . PHP_VERSION . "\n"
-            . '-->' . "\n" . "\n";
+            . '-->' . "\n\n";
 
         $head .= '<pma_xml_export version="1.0"'
             . ($export_struct

--- a/libraries/classes/Plugins/Export/ExportYaml.php
+++ b/libraries/classes/Plugins/Export/ExportYaml.php
@@ -21,8 +21,6 @@ use function array_key_exists;
 use function is_numeric;
 use function str_replace;
 
-use const PHP_EOL;
-
 /**
  * Handles the export for the YAML format
  */
@@ -69,7 +67,7 @@ class ExportYaml extends ExportPlugin
      */
     public function exportHeader(): bool
     {
-        $this->export->outputHandler('%YAML 1.1' . PHP_EOL . '---' . PHP_EOL);
+        $this->export->outputHandler('%YAML 1.1' . "\n" . '---' . "\n");
 
         return true;
     }
@@ -79,7 +77,7 @@ class ExportYaml extends ExportPlugin
      */
     public function exportFooter(): bool
     {
-        $this->export->outputHandler('...' . PHP_EOL);
+        $this->export->outputHandler('...' . "\n");
 
         return true;
     }
@@ -161,10 +159,10 @@ class ExportYaml extends ExportPlugin
 
             // Output table name as comment if this is the first record of the table
             if ($record_cnt == 1) {
-                $buffer = '# ' . $db_alias . '.' . $table_alias . PHP_EOL;
-                $buffer .= '-' . PHP_EOL;
+                $buffer = '# ' . $db_alias . '.' . $table_alias . "\n";
+                $buffer .= '-' . "\n";
             } else {
-                $buffer = '-' . PHP_EOL;
+                $buffer = '-' . "\n";
             }
 
             for ($i = 0; $i < $columns_cnt; $i++) {
@@ -173,13 +171,13 @@ class ExportYaml extends ExportPlugin
                 }
 
                 if ($record[$i] === null) {
-                    $buffer .= '  ' . $columns[$i] . ': null' . PHP_EOL;
+                    $buffer .= '  ' . $columns[$i] . ': null' . "\n";
                     continue;
                 }
 
                 $isNotString = isset($fieldsMeta[$i]) && $fieldsMeta[$i]->isNotType(FieldMetadata::TYPE_STRING);
                 if (is_numeric($record[$i]) && $isNotString) {
-                    $buffer .= '  ' . $columns[$i] . ': ' . $record[$i] . PHP_EOL;
+                    $buffer .= '  ' . $columns[$i] . ': ' . $record[$i] . "\n";
                     continue;
                 }
 
@@ -198,7 +196,7 @@ class ExportYaml extends ExportPlugin
                     ],
                     $record[$i]
                 );
-                $buffer .= '  ' . $columns[$i] . ': "' . $record[$i] . '"' . PHP_EOL;
+                $buffer .= '  ' . $columns[$i] . ': "' . $record[$i] . '"' . "\n";
             }
 
             if (! $this->export->outputHandler($buffer)) {

--- a/libraries/classes/Plugins/Import/ImportLdi.php
+++ b/libraries/classes/Plugins/Import/ImportLdi.php
@@ -19,8 +19,6 @@ use function preg_split;
 use function strlen;
 use function trim;
 
-use const PHP_EOL;
-
 /**
  * CSV import plugin for phpMyAdmin using LOAD DATA
  */
@@ -148,7 +146,7 @@ class ImportLdi extends AbstractImportCsv
 
         if (strlen((string) $GLOBALS['ldi_new_line']) > 0) {
             if ($GLOBALS['ldi_new_line'] === 'auto') {
-                $GLOBALS['ldi_new_line'] = PHP_EOL == "\n"
+                $GLOBALS['ldi_new_line'] = "\n" == "\n"
                     ? '\n'
                     : '\r\n';
             }

--- a/libraries/classes/Plugins/Import/ImportLdi.php
+++ b/libraries/classes/Plugins/Import/ImportLdi.php
@@ -19,6 +19,8 @@ use function preg_split;
 use function strlen;
 use function trim;
 
+use const PHP_EOL;
+
 /**
  * CSV import plugin for phpMyAdmin using LOAD DATA
  */
@@ -146,9 +148,7 @@ class ImportLdi extends AbstractImportCsv
 
         if (strlen((string) $GLOBALS['ldi_new_line']) > 0) {
             if ($GLOBALS['ldi_new_line'] === 'auto') {
-                $GLOBALS['ldi_new_line'] = "\n" == "\n"
-                    ? '\n'
-                    : '\r\n';
+                $GLOBALS['ldi_new_line'] = PHP_EOL;
             }
 
             $sql .= ' LINES TERMINATED BY \'' . $GLOBALS['ldi_new_line'] . '\'';

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -33,7 +33,6 @@ use function unlink;
 use const CONFIG_FILE;
 use const DIRECTORY_SEPARATOR;
 use const INFO_MODULES;
-use const PHP_EOL;
 use const PHP_OS;
 use const TEST_PATH;
 
@@ -103,7 +102,7 @@ class ConfigTest extends AbstractTestCase
         $config->loadAndCheck($tmpConfig);
         $this->assertSame($defaultConfig->settings, $config->settings);
 
-        $contents = '<?php' . PHP_EOL
+        $contents = '<?php' . "\n"
                     . '$cfg[\'ProtectBinary\'] = true;';
         file_put_contents($tmpConfig, $contents);
 
@@ -139,7 +138,7 @@ class ConfigTest extends AbstractTestCase
         $config->loadAndCheck($tmpConfig);
         $this->assertSame($defaultConfig->settings, $config->settings);
 
-        $contents = '<?php' . PHP_EOL
+        $contents = '<?php' . "\n"
                     . '$cfg[\'fooBar\'] = true;';
         file_put_contents($tmpConfig, $contents);
 
@@ -151,11 +150,11 @@ class ConfigTest extends AbstractTestCase
         $this->assertEquals($defaultConfig->settings, $config->settings);
         unset($defaultConfig->settings['fooBar']);
 
-        $contents = '<?php' . PHP_EOL
-                    . '$cfg[\'/InValidKey\'] = true;' . PHP_EOL
-                    . '$cfg[\'In/ValidKey\'] = true;' . PHP_EOL
-                    . '$cfg[\'/InValid/Key\'] = true;' . PHP_EOL
-                    . '$cfg[\'In/Valid/Key\'] = true;' . PHP_EOL
+        $contents = '<?php' . "\n"
+                    . '$cfg[\'/InValidKey\'] = true;' . "\n"
+                    . '$cfg[\'In/ValidKey\'] = true;' . "\n"
+                    . '$cfg[\'/InValid/Key\'] = true;' . "\n"
+                    . '$cfg[\'In/Valid/Key\'] = true;' . "\n"
                     . '$cfg[\'ValidKey\'] = true;';
         file_put_contents($tmpConfig, $contents);
 

--- a/test/classes/GitTest.php
+++ b/test/classes/GitTest.php
@@ -18,7 +18,6 @@ use function sys_get_temp_dir;
 use function unlink;
 
 use const DIRECTORY_SEPARATOR;
-use const PHP_EOL;
 
 /**
  * @covers \PhpMyAdmin\Git
@@ -191,10 +190,10 @@ class GitTest extends AbstractTestCase
 
         file_put_contents(
             '.git/packed-refs',
-            '# pack-refs with: peeled fully-peeled sorted' . PHP_EOL .
-            'c1f2ff2eb0c3fda741f859913fd589379f4e4a8f refs/tags/4.3.10' . PHP_EOL .
-            '^6f2e60343b0a324c65f2d1411bf4bd03e114fb98' . PHP_EOL .
-            '17bf8b7309919f8ac593d7c563b31472780ee83b refs/remotes/origin/master' . PHP_EOL
+            '# pack-refs with: peeled fully-peeled sorted' . "\n" .
+            'c1f2ff2eb0c3fda741f859913fd589379f4e4a8f refs/tags/4.3.10' . "\n" .
+            '^6f2e60343b0a324c65f2d1411bf4bd03e114fb98' . "\n" .
+            '17bf8b7309919f8ac593d7c563b31472780ee83b refs/remotes/origin/master' . "\n"
         );
         mkdir('.git/objects/pack', 0777, true);//default = 0777, recursive mode
 
@@ -307,19 +306,19 @@ class GitTest extends AbstractTestCase
 
         file_put_contents(
             '.git/packed-refs',
-            '# pack-refs with: peeled fully-peeled sorted' . PHP_EOL .
-            'c1f2ff2eb0c3fda741f859913fd589379f4e4a8f refs/tags/4.3.10' . PHP_EOL .
-            '^6f2e60343b0a324c65f2d1411bf4bd03e114fb98' . PHP_EOL .
-            '17bf8b7309919f8ac593d7c563b31472780ee83b refs/remotes/origin/master' . PHP_EOL
+            '# pack-refs with: peeled fully-peeled sorted' . "\n" .
+            'c1f2ff2eb0c3fda741f859913fd589379f4e4a8f refs/tags/4.3.10' . "\n" .
+            '^6f2e60343b0a324c65f2d1411bf4bd03e114fb98' . "\n" .
+            '17bf8b7309919f8ac593d7c563b31472780ee83b refs/remotes/origin/master' . "\n"
         );
         mkdir('.git/objects/info', 0777, true);
         file_put_contents(
             '.git/objects/info/packs',
-            'P pack-faea49765800da462c70bea555848cc8c7a1c28d.pack' . PHP_EOL .
-            '  pack-.pack' . PHP_EOL .
-            PHP_EOL .
-            'P pack-420568bae521465fd11863bff155a2b2831023.pack' . PHP_EOL .
-            PHP_EOL
+            'P pack-faea49765800da462c70bea555848cc8c7a1c28d.pack' . "\n" .
+            '  pack-.pack' . "\n" .
+            "\n" .
+            'P pack-420568bae521465fd11863bff155a2b2831023.pack' . "\n" .
+            "\n"
         );
 
         $commit = $this->object->checkGitRevision();

--- a/test/classes/Plugins/Export/ExportJsonTest.php
+++ b/test/classes/Plugins/Export/ExportJsonTest.php
@@ -19,8 +19,6 @@ use ReflectionProperty;
 
 use function array_shift;
 
-use const PHP_EOL;
-
 /**
  * @covers \PhpMyAdmin\Plugins\Export\ExportJson
  * @group medium
@@ -138,7 +136,7 @@ class ExportJsonTest extends AbstractTestCase
 
     public function testExportFooter(): void
     {
-        $this->expectOutputString(']' . PHP_EOL);
+        $this->expectOutputString(']' . "\n");
 
         $this->assertTrue(
             $this->object->exportFooter()

--- a/test/classes/Plugins/Export/ExportPhparrayTest.php
+++ b/test/classes/Plugins/Export/ExportPhparrayTest.php
@@ -20,8 +20,6 @@ use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
-use const PHP_EOL;
-
 /**
  * @covers \PhpMyAdmin\Plugins\Export\ExportPhparray
  * @group medium
@@ -133,7 +131,7 @@ class ExportPhparrayTest extends AbstractTestCase
 
         $this->assertIsString($result);
 
-        $this->assertStringContainsString('<?php' . PHP_EOL, $result);
+        $this->assertStringContainsString('<?php' . "\n", $result);
     }
 
     public function testExportFooter(): void

--- a/test/selenium/TestBase.php
+++ b/test/selenium/TestBase.php
@@ -58,7 +58,6 @@ use const CURLOPT_USERPWD;
 use const DIRECTORY_SEPARATOR;
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
-use const PHP_EOL;
 
 abstract class TestBase extends TestCase
 {
@@ -1163,7 +1162,7 @@ JS;
 
         curl_exec($ch);
         if (curl_errno($ch)) {
-            echo 'Error: ' . curl_error($ch) . PHP_EOL;
+            echo 'Error: ' . curl_error($ch) . "\n";
         }
 
         curl_close($ch);
@@ -1185,7 +1184,7 @@ JS;
         );
         $result = curl_exec($ch);
         if (is_bool($result)) {
-            echo 'Error: ' . curl_error($ch) . PHP_EOL;
+            echo 'Error: ' . curl_error($ch) . "\n";
 
             return;
         }
@@ -1193,11 +1192,11 @@ JS;
         $proj = json_decode($result);
         if (is_object($proj) && property_exists($proj, 'automation_session')) {
             // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-            echo 'Test failed, get more information here: ' . $proj->automation_session->public_url . PHP_EOL;
+            echo 'Test failed, get more information here: ' . $proj->automation_session->public_url . "\n";
         }
 
         if (curl_errno($ch)) {
-            echo 'Error: ' . curl_error($ch) . PHP_EOL;
+            echo 'Error: ' . curl_error($ch) . "\n";
         }
 
         curl_close($ch);


### PR DESCRIPTION
On Windows, these cause a lot of tests to fail. The failures are bogus IMHO but either the tests need to be adapted for cross-OS compatibility or we should stop using `PHP_EOL` and stick with `"\n"`. I assume it is safe to do this but please correct me if I am wrong. For example, one import class actually used it (in a stupid way though). I don't know if the Git class needs it or not. The Config class used it to generate a config file which I think should be created with only `"\n"`. 