### PR TITLE
Trim label before passing it on to GIS classes

### DIFF
--- a/libraries/classes/Gis/GisGeometry.php
+++ b/libraries/classes/Gis/GisGeometry.php
@@ -37,19 +37,19 @@ abstract class GisGeometry
      *
      * @return string the code related to a row in the GIS dataset
      */
-    abstract public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data);
+    abstract public function prepareRowAsSvg($spatial, string $label, array $color, array $scale_data);
 
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POLYGON object
-     * @param string|null $label      Label for the GIS POLYGON object
-     * @param int[]       $color      Color for the GIS POLYGON object
-     * @param array       $scale_data Array containing data related to scaling
+     * @param string $spatial    GIS POLYGON object
+     * @param string $label      Label for the GIS POLYGON object
+     * @param int[]  $color      Color for the GIS POLYGON object
+     * @param array  $scale_data Array containing data related to scaling
      */
     abstract public function prepareRowAsPng(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         ImageWrapper $image
@@ -58,17 +58,17 @@ abstract class GisGeometry
     /**
      * Adds to the TCPDF instance, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS data object
-     * @param string|null $label      label for the GIS data object
-     * @param int[]       $color      color for the GIS data object
-     * @param array       $scale_data array containing data related to scaling
-     * @param TCPDF       $pdf
+     * @param string $spatial    GIS data object
+     * @param string $label      label for the GIS data object
+     * @param int[]  $color      color for the GIS data object
+     * @param array  $scale_data array containing data related to scaling
+     * @param TCPDF  $pdf
      *
      * @return TCPDF the modified TCPDF instance
      */
     abstract public function prepareRowAsPdf(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         $pdf
@@ -89,7 +89,7 @@ abstract class GisGeometry
     abstract public function prepareRowAsOl(
         $spatial,
         int $srid,
-        $label,
+        string $label,
         array $color,
         array $scale_data
     );

--- a/libraries/classes/Gis/GisGeometryCollection.php
+++ b/libraries/classes/Gis/GisGeometryCollection.php
@@ -84,14 +84,14 @@ class GisGeometryCollection extends GisGeometry
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POLYGON object
-     * @param string|null $label      Label for the GIS POLYGON object
-     * @param int[]       $color      Color for the GIS POLYGON object
-     * @param array       $scale_data Array containing data related to scaling
+     * @param string $spatial    GIS POLYGON object
+     * @param string $label      Label for the GIS POLYGON object
+     * @param int[]  $color      Color for the GIS POLYGON object
+     * @param array  $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         ImageWrapper $image
@@ -123,15 +123,15 @@ class GisGeometryCollection extends GisGeometry
     /**
      * Adds to the TCPDF instance, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS GEOMETRYCOLLECTION object
-     * @param string|null $label      label for the GIS GEOMETRYCOLLECTION object
-     * @param int[]       $color      color for the GIS GEOMETRYCOLLECTION object
-     * @param array       $scale_data array containing data related to scaling
-     * @param TCPDF       $pdf
+     * @param string $spatial    GIS GEOMETRYCOLLECTION object
+     * @param string $label      label for the GIS GEOMETRYCOLLECTION object
+     * @param int[]  $color      color for the GIS GEOMETRYCOLLECTION object
+     * @param array  $scale_data array containing data related to scaling
+     * @param TCPDF  $pdf
      *
      * @return TCPDF the modified TCPDF instance
      */
-    public function prepareRowAsPdf($spatial, string|null $label, array $color, array $scale_data, $pdf)
+    public function prepareRowAsPdf($spatial, string $label, array $color, array $scale_data, $pdf)
     {
         // Trim to remove leading 'GEOMETRYCOLLECTION(' and trailing ')'
         $goem_col = mb_substr($spatial, 19, -1);
@@ -167,7 +167,7 @@ class GisGeometryCollection extends GisGeometry
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
+    public function prepareRowAsSvg($spatial, string $label, array $color, array $scale_data)
     {
         $row = '';
 
@@ -207,7 +207,7 @@ class GisGeometryCollection extends GisGeometry
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
-    public function prepareRowAsOl($spatial, int $srid, $label, array $color, array $scale_data)
+    public function prepareRowAsOl($spatial, int $srid, string $label, array $color, array $scale_data)
     {
         $row = '';
 

--- a/libraries/classes/Gis/GisLineString.php
+++ b/libraries/classes/Gis/GisLineString.php
@@ -64,14 +64,14 @@ class GisLineString extends GisGeometry
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POLYGON object
-     * @param string|null $label      Label for the GIS POLYGON object
-     * @param int[]       $color      Color for the GIS POLYGON object
-     * @param array       $scale_data Array containing data related to scaling
+     * @param string $spatial    GIS POLYGON object
+     * @param string $label      Label for the GIS POLYGON object
+     * @param int[]  $color      Color for the GIS POLYGON object
+     * @param array  $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         ImageWrapper $image
@@ -79,8 +79,6 @@ class GisLineString extends GisGeometry
         // allocate colors
         $black = $image->colorAllocate(0, 0, 0);
         $line_color = $image->colorAllocate(...$color);
-
-        $label = trim($label ?? '');
 
         // Trim to remove leading 'LINESTRING(' and trailing ')'
         $lineString = mb_substr($spatial, 11, -1);
@@ -118,22 +116,20 @@ class GisLineString extends GisGeometry
     /**
      * Adds to the TCPDF instance, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS LINESTRING object
-     * @param string|null $label      Label for the GIS LINESTRING object
-     * @param int[]       $color      Color for the GIS LINESTRING object
-     * @param array       $scale_data Array containing data related to scaling
-     * @param TCPDF       $pdf
+     * @param string $spatial    GIS LINESTRING object
+     * @param string $label      Label for the GIS LINESTRING object
+     * @param int[]  $color      Color for the GIS LINESTRING object
+     * @param array  $scale_data Array containing data related to scaling
+     * @param TCPDF  $pdf
      *
      * @return TCPDF the modified TCPDF instance
      */
-    public function prepareRowAsPdf($spatial, string|null $label, array $color, array $scale_data, $pdf)
+    public function prepareRowAsPdf($spatial, string $label, array $color, array $scale_data, $pdf)
     {
         $line = [
             'width' => 1.5,
             'color' => $color,
         ];
-
-        $label = trim($label ?? '');
 
         // Trim to remove leading 'LINESTRING(' and trailing ')'
         $linesrting = mb_substr($spatial, 11, -1);
@@ -168,7 +164,7 @@ class GisLineString extends GisGeometry
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
+    public function prepareRowAsSvg($spatial, string $label, array $color, array $scale_data)
     {
         $line_options = [
             'name' => $label,
@@ -190,7 +186,7 @@ class GisLineString extends GisGeometry
 
         $row .= '"';
         foreach ($line_options as $option => $val) {
-            $row .= ' ' . $option . '="' . trim((string) $val) . '"';
+            $row .= ' ' . $option . '="' . $val . '"';
         }
 
         $row .= '/>';
@@ -210,7 +206,7 @@ class GisLineString extends GisGeometry
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
-    public function prepareRowAsOl($spatial, int $srid, $label, array $color, array $scale_data)
+    public function prepareRowAsOl($spatial, int $srid, string $label, array $color, array $scale_data)
     {
         $stroke_style = [
             'color' => $color,
@@ -219,8 +215,8 @@ class GisLineString extends GisGeometry
 
         $result = 'var style = new ol.style.Style({'
             . 'stroke: new ol.style.Stroke(' . json_encode($stroke_style) . ')';
-        if (trim($label) !== '') {
-            $text_style = ['text' => trim($label)];
+        if ($label !== '') {
+            $text_style = ['text' => $label];
             $result .= ', text: new ol.style.Text(' . json_encode($text_style) . ')';
         }
 

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -73,14 +73,14 @@ class GisMultiLineString extends GisGeometry
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POLYGON object
-     * @param string|null $label      Label for the GIS POLYGON object
-     * @param int[]       $color      Color for the GIS POLYGON object
-     * @param array       $scale_data Array containing data related to scaling
+     * @param string $spatial    GIS POLYGON object
+     * @param string $label      Label for the GIS POLYGON object
+     * @param int[]  $color      Color for the GIS POLYGON object
+     * @param array  $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         ImageWrapper $image
@@ -88,8 +88,6 @@ class GisMultiLineString extends GisGeometry
         // allocate colors
         $black = $image->colorAllocate(0, 0, 0);
         $line_color = $image->colorAllocate(...$color);
-
-        $label = trim($label ?? '');
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
         $multilinestirng = mb_substr($spatial, 17, -2);
@@ -135,22 +133,20 @@ class GisMultiLineString extends GisGeometry
     /**
      * Adds to the TCPDF instance, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS MULTILINESTRING object
-     * @param string|null $label      Label for the GIS MULTILINESTRING object
-     * @param int[]       $color      Color for the GIS MULTILINESTRING object
-     * @param array       $scale_data Array containing data related to scaling
-     * @param TCPDF       $pdf
+     * @param string $spatial    GIS MULTILINESTRING object
+     * @param string $label      Label for the GIS MULTILINESTRING object
+     * @param int[]  $color      Color for the GIS MULTILINESTRING object
+     * @param array  $scale_data Array containing data related to scaling
+     * @param TCPDF  $pdf
      *
      * @return TCPDF the modified TCPDF instance
      */
-    public function prepareRowAsPdf($spatial, string|null $label, array $color, array $scale_data, $pdf)
+    public function prepareRowAsPdf($spatial, string $label, array $color, array $scale_data, $pdf)
     {
         $line = [
             'width' => 1.5,
             'color' => $color,
         ];
-
-        $label = trim($label ?? '');
 
         // Trim to remove leading 'MULTILINESTRING((' and trailing '))'
         $multilinestirng = mb_substr($spatial, 17, -2);
@@ -193,7 +189,7 @@ class GisMultiLineString extends GisGeometry
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
+    public function prepareRowAsSvg($spatial, string $label, array $color, array $scale_data)
     {
         $line_options = [
             'name' => $label,
@@ -220,7 +216,7 @@ class GisMultiLineString extends GisGeometry
             $row .= '"';
             $line_options['id'] = $label . $this->getRandomId();
             foreach ($line_options as $option => $val) {
-                $row .= ' ' . $option . '="' . trim((string) $val) . '"';
+                $row .= ' ' . $option . '="' . $val . '"';
             }
 
             $row .= '/>';
@@ -241,7 +237,7 @@ class GisMultiLineString extends GisGeometry
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
-    public function prepareRowAsOl($spatial, int $srid, $label, array $color, array $scale_data)
+    public function prepareRowAsOl($spatial, int $srid, string $label, array $color, array $scale_data)
     {
         $stroke_style = [
             'color' => $color,
@@ -250,8 +246,8 @@ class GisMultiLineString extends GisGeometry
 
         $row = 'var style = new ol.style.Style({'
             . 'stroke: new ol.style.Stroke(' . json_encode($stroke_style) . ')';
-        if (trim($label) !== '') {
-            $text_style = ['text' => trim($label)];
+        if ($label !== '') {
+            $text_style = ['text' => $label];
             $row .= ', text: new ol.style.Text(' . json_encode($text_style) . ')';
         }
 

--- a/libraries/classes/Gis/GisMultiPoint.php
+++ b/libraries/classes/Gis/GisMultiPoint.php
@@ -64,14 +64,14 @@ class GisMultiPoint extends GisGeometry
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POLYGON object
-     * @param string|null $label      Label for the GIS POLYGON object
-     * @param int[]       $color      Color for the GIS POLYGON object
-     * @param array       $scale_data Array containing data related to scaling
+     * @param string $spatial    GIS POLYGON object
+     * @param string $label      Label for the GIS POLYGON object
+     * @param int[]  $color      Color for the GIS POLYGON object
+     * @param array  $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         ImageWrapper $image
@@ -102,12 +102,12 @@ class GisMultiPoint extends GisGeometry
         }
 
         // print label for each point
-        if ((isset($label) && trim($label) != '') && ($points_arr[0][0] != '' && $points_arr[0][1] != '')) {
+        if ($label !== '' && ($points_arr[0][0] != '' && $points_arr[0][1] != '')) {
             $image->string(
                 1,
                 (int) round($points_arr[0][0]),
                 (int) round($points_arr[0][1]),
-                trim($label),
+                $label,
                 $black
             );
         }
@@ -118,17 +118,17 @@ class GisMultiPoint extends GisGeometry
     /**
      * Adds to the TCPDF instance, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS MULTIPOINT object
-     * @param string|null $label      Label for the GIS MULTIPOINT object
-     * @param int[]       $color      Color for the GIS MULTIPOINT object
-     * @param array       $scale_data Array containing data related to scaling
-     * @param TCPDF       $pdf
+     * @param string $spatial    GIS MULTIPOINT object
+     * @param string $label      Label for the GIS MULTIPOINT object
+     * @param int[]  $color      Color for the GIS MULTIPOINT object
+     * @param array  $scale_data Array containing data related to scaling
+     * @param TCPDF  $pdf
      *
      * @return TCPDF the modified TCPDF instance
      */
     public function prepareRowAsPdf(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         $pdf
@@ -152,10 +152,10 @@ class GisMultiPoint extends GisGeometry
         }
 
         // print label for each point
-        if ((isset($label) && trim($label) != '') && ($points_arr[0][0] != '' && $points_arr[0][1] != '')) {
+        if ($label !== '' && ($points_arr[0][0] != '' && $points_arr[0][1] != '')) {
             $pdf->setXY($points_arr[0][0], $points_arr[0][1]);
             $pdf->setFontSize(5);
-            $pdf->Cell(0, 0, trim($label));
+            $pdf->Cell(0, 0, $label);
         }
 
         return $pdf;
@@ -171,7 +171,7 @@ class GisMultiPoint extends GisGeometry
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
+    public function prepareRowAsSvg($spatial, string $label, array $color, array $scale_data)
     {
         $point_options = [
             'name' => $label,
@@ -195,7 +195,7 @@ class GisMultiPoint extends GisGeometry
                 . $point[1] . '" r="3"';
             $point_options['id'] = $label . $this->getRandomId();
             foreach ($point_options as $option => $val) {
-                $row .= ' ' . $option . '="' . trim((string) $val) . '"';
+                $row .= ' ' . $option . '="' . $val . '"';
             }
 
             $row .= '/>';
@@ -219,7 +219,7 @@ class GisMultiPoint extends GisGeometry
     public function prepareRowAsOl(
         $spatial,
         int $srid,
-        $label,
+        string $label,
         array $color,
         array $scale_data
     ) {
@@ -238,10 +238,9 @@ class GisMultiPoint extends GisGeometry
             . '}),'
             . 'fill: fill,'
             . 'stroke: stroke';
-
-        if (trim($label) !== '') {
+        if ($label !== '') {
             $text_style = [
-                'text' => trim($label),
+                'text' => $label,
                 'offsetY' => -9,
             ];
             $result .= ',text: new ol.style.Text(' . json_encode($text_style) . ')';

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -75,14 +75,14 @@ class GisMultiPolygon extends GisGeometry
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POLYGON object
-     * @param string|null $label      Label for the GIS POLYGON object
-     * @param int[]       $color      Color for the GIS POLYGON object
-     * @param array       $scale_data Array containing data related to scaling
+     * @param string $spatial    GIS POLYGON object
+     * @param string $label      Label for the GIS POLYGON object
+     * @param int[]  $color      Color for the GIS POLYGON object
+     * @param array  $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         ImageWrapper $image
@@ -90,8 +90,6 @@ class GisMultiPolygon extends GisGeometry
         // allocate colors
         $black = $image->colorAllocate(0, 0, 0);
         $fill_color = $image->colorAllocate(...$color);
-
-        $label = trim($label ?? '');
 
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
         $multipolygon = mb_substr($spatial, 15, -3);
@@ -138,18 +136,16 @@ class GisMultiPolygon extends GisGeometry
     /**
      * Adds to the TCPDF instance, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS MULTIPOLYGON object
-     * @param string|null $label      Label for the GIS MULTIPOLYGON object
-     * @param int[]       $color      Color for the GIS MULTIPOLYGON object
-     * @param array       $scale_data Array containing data related to scaling
-     * @param TCPDF       $pdf
+     * @param string $spatial    GIS MULTIPOLYGON object
+     * @param string $label      Label for the GIS MULTIPOLYGON object
+     * @param int[]  $color      Color for the GIS MULTIPOLYGON object
+     * @param array  $scale_data Array containing data related to scaling
+     * @param TCPDF  $pdf
      *
      * @return TCPDF the modified TCPDF instance
      */
-    public function prepareRowAsPdf($spatial, string|null $label, array $color, array $scale_data, $pdf)
+    public function prepareRowAsPdf($spatial, string $label, array $color, array $scale_data, $pdf)
     {
-        $label = trim($label ?? '');
-
         // Trim to remove leading 'MULTIPOLYGON(((' and trailing ')))'
         $multipolygon = mb_substr($spatial, 15, -3);
         // Separate each polygon
@@ -197,7 +193,7 @@ class GisMultiPolygon extends GisGeometry
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
+    public function prepareRowAsSvg($spatial, string $label, array $color, array $scale_data)
     {
         $polygon_options = [
             'name' => $label,
@@ -227,7 +223,7 @@ class GisMultiPolygon extends GisGeometry
             $polygon_options['id'] = $label . $this->getRandomId();
             $row .= '"';
             foreach ($polygon_options as $option => $val) {
-                $row .= ' ' . $option . '="' . trim((string) $val) . '"';
+                $row .= ' ' . $option . '="' . $val . '"';
             }
 
             $row .= '/>';
@@ -248,7 +244,7 @@ class GisMultiPolygon extends GisGeometry
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
-    public function prepareRowAsOl($spatial, int $srid, $label, array $color, array $scale_data)
+    public function prepareRowAsOl($spatial, int $srid, string $label, array $color, array $scale_data)
     {
         $color[] = 0.8;
         $fill_style = ['color' => $color];
@@ -260,8 +256,8 @@ class GisMultiPolygon extends GisGeometry
             . 'fill: new ol.style.Fill(' . json_encode($fill_style) . '),'
             . 'stroke: new ol.style.Stroke(' . json_encode($stroke_style) . ')';
 
-        if (trim($label) !== '') {
-            $text_style = ['text' => trim($label)];
+        if ($label !== '') {
+            $text_style = ['text' => $label];
             $row .= ',text: new ol.style.Text(' . json_encode($text_style) . ')';
         }
 

--- a/libraries/classes/Gis/GisPoint.php
+++ b/libraries/classes/Gis/GisPoint.php
@@ -63,14 +63,14 @@ class GisPoint extends GisGeometry
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POLYGON object
-     * @param string|null $label      Label for the GIS POLYGON object
-     * @param int[]       $color      Color for the GIS POLYGON object
-     * @param array       $scale_data Array containing data related to scaling
+     * @param string $spatial    GIS POLYGON object
+     * @param string $label      Label for the GIS POLYGON object
+     * @param int[]  $color      Color for the GIS POLYGON object
+     * @param array  $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         ImageWrapper $image
@@ -78,8 +78,6 @@ class GisPoint extends GisGeometry
         // allocate colors
         $black = $image->colorAllocate(0, 0, 0);
         $point_color = $image->colorAllocate(...$color);
-
-        $label = trim($label ?? '');
 
         // Trim to remove leading 'POINT(' and trailing ')'
         $point = mb_substr($spatial, 6, -1);
@@ -114,17 +112,17 @@ class GisPoint extends GisGeometry
     /**
      * Adds to the TCPDF instance, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POINT object
-     * @param string|null $label      Label for the GIS POINT object
-     * @param int[]       $color      Color for the GIS POINT object
-     * @param array       $scale_data Array containing data related to scaling
-     * @param TCPDF       $pdf
+     * @param string $spatial    GIS POINT object
+     * @param string $label      Label for the GIS POINT object
+     * @param int[]  $color      Color for the GIS POINT object
+     * @param array  $scale_data Array containing data related to scaling
+     * @param TCPDF  $pdf
      *
      * @return TCPDF the modified TCPDF instance
      */
     public function prepareRowAsPdf(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         $pdf
@@ -133,8 +131,6 @@ class GisPoint extends GisGeometry
             'width' => 1.25,
             'color' => $color,
         ];
-
-        $label = trim($label ?? '');
 
         // Trim to remove leading 'POINT(' and trailing ')'
         $point = mb_substr($spatial, 6, -1);
@@ -164,7 +160,7 @@ class GisPoint extends GisGeometry
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
+    public function prepareRowAsSvg($spatial, string $label, array $color, array $scale_data)
     {
         $point_options = [
             'name' => $label,
@@ -184,7 +180,7 @@ class GisPoint extends GisGeometry
             $row .= '<circle cx="' . $points_arr[0][0]
                 . '" cy="' . $points_arr[0][1] . '" r="3"';
             foreach ($point_options as $option => $val) {
-                $row .= ' ' . $option . '="' . trim((string) $val) . '"';
+                $row .= ' ' . $option . '="' . $val . '"';
             }
 
             $row .= '/>';
@@ -208,7 +204,7 @@ class GisPoint extends GisGeometry
     public function prepareRowAsOl(
         $spatial,
         int $srid,
-        $label,
+        string $label,
         array $color,
         array $scale_data
     ) {
@@ -227,10 +223,9 @@ class GisPoint extends GisGeometry
             . '}),'
             . 'fill: fill,'
             . 'stroke: stroke';
-
-        if (trim($label) !== '') {
+        if ($label !== '') {
             $text_style = [
-                'text' => trim($label),
+                'text' => $label,
                 'offsetY' => -9,
             ];
             $result .= ',text: new ol.style.Text(' . json_encode($text_style) . ')';

--- a/libraries/classes/Gis/GisPolygon.php
+++ b/libraries/classes/Gis/GisPolygon.php
@@ -71,14 +71,14 @@ class GisPolygon extends GisGeometry
     /**
      * Adds to the PNG image object, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POLYGON object
-     * @param string|null $label      Label for the GIS POLYGON object
-     * @param int[]       $color      Color for the GIS POLYGON object
-     * @param array       $scale_data Array containing data related to scaling
+     * @param string $spatial    GIS POLYGON object
+     * @param string $label      Label for the GIS POLYGON object
+     * @param int[]  $color      Color for the GIS POLYGON object
+     * @param array  $scale_data Array containing data related to scaling
      */
     public function prepareRowAsPng(
         $spatial,
-        string|null $label,
+        string $label,
         array $color,
         array $scale_data,
         ImageWrapper $image
@@ -86,8 +86,6 @@ class GisPolygon extends GisGeometry
         // allocate colors
         $black = $image->colorAllocate(0, 0, 0);
         $fill_color = $image->colorAllocate(...$color);
-
-        $label = trim($label ?? '');
 
         // Trim to remove leading 'POLYGON((' and trailing '))'
         $polygon = mb_substr($spatial, 9, -2);
@@ -118,18 +116,16 @@ class GisPolygon extends GisGeometry
     /**
      * Adds to the TCPDF instance, the data related to a row in the GIS dataset.
      *
-     * @param string      $spatial    GIS POLYGON object
-     * @param string|null $label      Label for the GIS POLYGON object
-     * @param int[]       $color      Color for the GIS POLYGON object
-     * @param array       $scale_data Array containing data related to scaling
-     * @param TCPDF       $pdf
+     * @param string $spatial    GIS POLYGON object
+     * @param string $label      Label for the GIS POLYGON object
+     * @param int[]  $color      Color for the GIS POLYGON object
+     * @param array  $scale_data Array containing data related to scaling
+     * @param TCPDF  $pdf
      *
      * @return TCPDF the modified TCPDF instance
      */
-    public function prepareRowAsPdf($spatial, string|null $label, array $color, array $scale_data, $pdf)
+    public function prepareRowAsPdf($spatial, string $label, array $color, array $scale_data, $pdf)
     {
-        $label = trim($label ?? '');
-
         // Trim to remove leading 'POLYGON((' and trailing '))'
         $polygon = mb_substr($spatial, 9, -2);
 
@@ -164,7 +160,7 @@ class GisPolygon extends GisGeometry
      *
      * @return string the code related to a row in the GIS dataset
      */
-    public function prepareRowAsSvg($spatial, $label, array $color, array $scale_data)
+    public function prepareRowAsSvg($spatial, string $label, array $color, array $scale_data)
     {
         $polygon_options = [
             'name' => $label,
@@ -189,7 +185,7 @@ class GisPolygon extends GisGeometry
 
         $row .= '"';
         foreach ($polygon_options as $option => $val) {
-            $row .= ' ' . $option . '="' . trim((string) $val) . '"';
+            $row .= ' ' . $option . '="' . $val . '"';
         }
 
         $row .= '/>';
@@ -209,7 +205,7 @@ class GisPolygon extends GisGeometry
      *
      * @return string JavaScript related to a row in the GIS dataset
      */
-    public function prepareRowAsOl($spatial, int $srid, $label, array $color, array $scale_data)
+    public function prepareRowAsOl($spatial, int $srid, string $label, array $color, array $scale_data)
     {
         $color[] = 0.8;
         $fill_style = ['color' => $color];
@@ -220,8 +216,8 @@ class GisPolygon extends GisGeometry
         $row = 'var style = new ol.style.Style({'
             . 'fill: new ol.style.Fill(' . json_encode($fill_style) . '),'
             . 'stroke: new ol.style.Stroke(' . json_encode($stroke_style) . ')';
-        if (trim($label) !== '') {
-            $text_style = ['text' => trim($label)];
+        if ($label !== '') {
+            $text_style = ['text' => $label];
             $row .= ',text: new ol.style.Text(' . json_encode($text_style) . ')';
         }
 

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -26,6 +26,7 @@ use function mb_substr;
 use function ob_get_clean;
 use function ob_start;
 use function rtrim;
+use function trim;
 
 use const PNG_ALL_FILTERS;
 
@@ -619,10 +620,7 @@ class GisVisualization
             }
 
             $color = $colors[$color_index];
-            $label = '';
-            if (isset($this->settings['labelColumn'], $row[$this->settings['labelColumn']])) {
-                $label = $row[$this->settings['labelColumn']];
-            }
+            $label = trim((string) ($row[$this->settings['labelColumn']] ?? ''));
 
             if ($format === 'svg') {
                 $results .= $gis_obj->prepareRowAsSvg(

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8557,10 +8557,6 @@
       <code><![CDATA[$this->userSpecifiedSettings === null]]></code>
     </DocblockTypeContradiction>
     <MixedArgument>
-      <code>$label</code>
-      <code>$label</code>
-      <code>$label</code>
-      <code>$label</code>
       <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
       <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
       <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
@@ -8587,7 +8583,6 @@
     </MixedArrayAccess>
     <MixedArrayOffset>
       <code><![CDATA[$row[$this->settings['labelColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['labelColumn']]]]></code>
       <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
       <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
       <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
@@ -8597,7 +8592,6 @@
       <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
-      <code>$label</code>
       <code>$pdf</code>
       <code>$plot_height</code>
       <code>$plot_width</code>


### PR DESCRIPTION
Labels can be trimmed at a single place in GisVisualization, which passes it on to the different GIS-classes.