### PR TITLE
Ref #16451 - Increase password characters limit to 2000 during login

### DIFF
--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -297,9 +297,9 @@ class AuthenticationCookie extends AuthenticationPlugin
             $this->user = Core::sanitizeMySQLUser($_POST['pma_username']);
 
             $password = $_POST['pma_password'] ?? '';
-            if (strlen($password) >= 1000) {
+            if (strlen($password) >= 2000) {
                 $conn_error = __('Your password is too long. To prevent denial-of-service attacks, ' .
-                    'phpMyAdmin restricts passwords to less than 1000 characters.');
+                    'phpMyAdmin restricts passwords to less than 2000 characters.');
 
                 return false;
             }

--- a/test/classes/Plugins/Auth/AuthenticationCookieTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -749,22 +749,16 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
     {
         return [
             [
-                str_repeat('a', 1000),
+                str_repeat('a', 2001),
                 false,
                 'Your password is too long. To prevent denial-of-service attacks,'
-                . ' phpMyAdmin restricts passwords to less than 1000 characters.',
-            ],
-            [
-                str_repeat('a', 1001),
-                false,
-                'Your password is too long. To prevent denial-of-service attacks,'
-                . ' phpMyAdmin restricts passwords to less than 1000 characters.',
+                . ' phpMyAdmin restricts passwords to less than 2000 characters.',
             ],
             [
                 str_repeat('a', 3000),
                 false,
                 'Your password is too long. To prevent denial-of-service attacks,'
-                . ' phpMyAdmin restricts passwords to less than 1000 characters.',
+                . ' phpMyAdmin restricts passwords to less than 2000 characters.',
             ],
             [
                 str_repeat('a', 256),


### PR DESCRIPTION
### Description

This pull request is intended to increase the characters limit to 2000 from 1000 after the increase in [this pr](https://github.com/phpmyadmin/phpmyadmin/pull/16452)
The reason for increasing is that RDS IAM authentication token length is sometimes going over 1000 and even reaches lengths of 1500.

Ref: #16451
Ref: #16452 (previous bump)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
