### PR TITLE
Refactoring of properties/options

### DIFF
--- a/libraries/classes/Plugins.php
+++ b/libraries/classes/Plugins.php
@@ -19,6 +19,7 @@ use PhpMyAdmin\Properties\Options\Items\NumberPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\RadioPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\SelectPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
+use PhpMyAdmin\Properties\Options\OptionsPropertyGroup;
 use PhpMyAdmin\Properties\Options\OptionsPropertyItem;
 use SplFileInfo;
 use Throwable;
@@ -39,7 +40,6 @@ use function sprintf;
 use function str_replace;
 use function str_starts_with;
 use function strcasecmp;
-use function strcmp;
 use function usort;
 
 class Plugins
@@ -323,7 +323,7 @@ class Plugins
         $not_subgroup_header = false;
         if ($properties === null) {
             $not_subgroup_header = true;
-            if (method_exists($propertyGroup, 'getProperties')) {
+            if ($propertyGroup instanceof OptionsPropertyGroup) {
                 $properties = $propertyGroup->getProperties();
             }
         }
@@ -593,7 +593,7 @@ class Plugins
                     // check for hidden properties
                     $no_options = true;
                     foreach ($propertyMainGroup->getProperties() as $propertyItem) {
-                        if (strcmp(HiddenPropertyItem::class, $propertyItem::class)) {
+                        if (! ($propertyItem instanceof HiddenPropertyItem)) {
                             $no_options = false;
                             break;
                         }

--- a/libraries/classes/Plugins.php
+++ b/libraries/classes/Plugins.php
@@ -532,7 +532,7 @@ class Plugins
                     ) . '"'
                     . ' id="text_' . $plugin_name . '_'
                     . $pitem->getName() . '"'
-                    . ($pitem->getSize() != null
+                    . ($pitem->getSize() !== 0
                         ? ' size="' . $pitem->getSize() . '"'
                         : '')
                     . ($pitem->getLen() != null

--- a/libraries/classes/Plugins.php
+++ b/libraries/classes/Plugins.php
@@ -535,7 +535,7 @@ class Plugins
                     . ($pitem->getSize() !== 0
                         ? ' size="' . $pitem->getSize() . '"'
                         : '')
-                    . ($pitem->getLen() != null
+                    . ($pitem->getLen() !== 0
                         ? ' maxlength="' . $pitem->getLen() . '"'
                         : '')
                     . '>';

--- a/libraries/classes/Properties/Options/Groups/OptionsPropertyMainGroup.php
+++ b/libraries/classes/Properties/Options/Groups/OptionsPropertyMainGroup.php
@@ -18,10 +18,8 @@ class OptionsPropertyMainGroup extends OptionsPropertyGroup
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'main';
     }

--- a/libraries/classes/Properties/Options/Groups/OptionsPropertyRootGroup.php
+++ b/libraries/classes/Properties/Options/Groups/OptionsPropertyRootGroup.php
@@ -18,10 +18,8 @@ class OptionsPropertyRootGroup extends OptionsPropertyGroup
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'root';
     }

--- a/libraries/classes/Properties/Options/Groups/OptionsPropertySubgroup.php
+++ b/libraries/classes/Properties/Options/Groups/OptionsPropertySubgroup.php
@@ -12,12 +12,7 @@ use PhpMyAdmin\Properties\PropertyItem;
  */
 class OptionsPropertySubgroup extends OptionsPropertyGroup
 {
-    /**
-     * Subgroup Header
-     *
-     * @var PropertyItem|null
-     */
-    private $subgroupHeader;
+    private PropertyItem|null $subgroupHeader = null;
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */
 
     /**
@@ -33,22 +28,12 @@ class OptionsPropertySubgroup extends OptionsPropertyGroup
         return 'subgroup';
     }
 
-    /**
-     * Gets the subgroup header
-     *
-     * @return PropertyItem|null
-     */
-    public function getSubgroupHeader()
+    public function getSubgroupHeader(): PropertyItem|null
     {
         return $this->subgroupHeader;
     }
 
-    /**
-     * Sets the subgroup header
-     *
-     * @param PropertyItem $subgroupHeader subgroup header
-     */
-    public function setSubgroupHeader($subgroupHeader): void
+    public function setSubgroupHeader(PropertyItem $subgroupHeader): void
     {
         $this->subgroupHeader = $subgroupHeader;
     }

--- a/libraries/classes/Properties/Options/Groups/OptionsPropertySubgroup.php
+++ b/libraries/classes/Properties/Options/Groups/OptionsPropertySubgroup.php
@@ -27,10 +27,8 @@ class OptionsPropertySubgroup extends OptionsPropertyGroup
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'subgroup';
     }

--- a/libraries/classes/Properties/Options/Items/BoolPropertyItem.php
+++ b/libraries/classes/Properties/Options/Items/BoolPropertyItem.php
@@ -18,10 +18,8 @@ class BoolPropertyItem extends OptionsPropertyOneItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'bool';
     }

--- a/libraries/classes/Properties/Options/Items/DocPropertyItem.php
+++ b/libraries/classes/Properties/Options/Items/DocPropertyItem.php
@@ -18,10 +18,8 @@ class DocPropertyItem extends OptionsPropertyOneItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'doc';
     }

--- a/libraries/classes/Properties/Options/Items/HiddenPropertyItem.php
+++ b/libraries/classes/Properties/Options/Items/HiddenPropertyItem.php
@@ -18,10 +18,8 @@ class HiddenPropertyItem extends OptionsPropertyOneItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'hidden';
     }

--- a/libraries/classes/Properties/Options/Items/MessageOnlyPropertyItem.php
+++ b/libraries/classes/Properties/Options/Items/MessageOnlyPropertyItem.php
@@ -18,10 +18,8 @@ class MessageOnlyPropertyItem extends OptionsPropertyOneItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'messageOnly';
     }

--- a/libraries/classes/Properties/Options/Items/NumberPropertyItem.php
+++ b/libraries/classes/Properties/Options/Items/NumberPropertyItem.php
@@ -18,10 +18,8 @@ class NumberPropertyItem extends OptionsPropertyOneItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'number';
     }

--- a/libraries/classes/Properties/Options/Items/RadioPropertyItem.php
+++ b/libraries/classes/Properties/Options/Items/RadioPropertyItem.php
@@ -18,10 +18,8 @@ class RadioPropertyItem extends OptionsPropertyOneItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'radio';
     }

--- a/libraries/classes/Properties/Options/Items/SelectPropertyItem.php
+++ b/libraries/classes/Properties/Options/Items/SelectPropertyItem.php
@@ -18,10 +18,8 @@ class SelectPropertyItem extends OptionsPropertyOneItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'select';
     }

--- a/libraries/classes/Properties/Options/Items/TextPropertyItem.php
+++ b/libraries/classes/Properties/Options/Items/TextPropertyItem.php
@@ -18,10 +18,8 @@ class TextPropertyItem extends OptionsPropertyOneItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main"
      *  or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'text';
     }

--- a/libraries/classes/Properties/Options/OptionsPropertyGroup.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyGroup.php
@@ -61,10 +61,8 @@ abstract class OptionsPropertyGroup extends OptionsPropertyItem implements Count
 
     /**
      * Gets the instance of the class
-     *
-     * @return OptionsPropertyGroup
      */
-    public function getGroup()
+    public function getGroup(): static
     {
         return $this;
     }

--- a/libraries/classes/Properties/Options/OptionsPropertyGroup.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyGroup.php
@@ -8,10 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Properties\Options;
 
 use Countable;
-
-use function array_diff;
-use function count;
-use function in_array;
+use SplObjectStorage;
 
 /**
  * Parents group property items and provides methods to manage groups of
@@ -24,9 +21,15 @@ abstract class OptionsPropertyGroup extends OptionsPropertyItem implements Count
     /**
      * Holds a group of properties (PhpMyAdmin\Properties\Options\OptionsPropertyItem instances)
      *
-     * @var array
+     * @var SplObjectStorage<OptionsPropertyItem, null>
      */
-    private $properties;
+    private SplObjectStorage $properties;
+
+    public function __construct(string|null $name = null, string|null $text = null)
+    {
+        parent::__construct($name, $text);
+        $this->properties = new SplObjectStorage();
+    }
 
     /**
      * Adds a property to the group of properties
@@ -34,13 +37,9 @@ abstract class OptionsPropertyGroup extends OptionsPropertyItem implements Count
      * @param OptionsPropertyItem $property the property instance to be added
      *                                      to the group
      */
-    public function addProperty($property): void
+    public function addProperty(OptionsPropertyItem $property): void
     {
-        if (! $this->getProperties() == null && in_array($property, $this->getProperties(), true)) {
-            return;
-        }
-
-        $this->properties[] = $property;
+        $this->properties->attach($property);
     }
 
     /**
@@ -49,12 +48,9 @@ abstract class OptionsPropertyGroup extends OptionsPropertyItem implements Count
      * @param OptionsPropertyItem $property the property instance to be removed
      *                                      from the group
      */
-    public function removeProperty($property): void
+    public function removeProperty(OptionsPropertyItem $property): void
     {
-        $this->properties = array_diff(
-            $this->getProperties(),
-            [$property]
-        );
+        $this->properties->detach($property);
     }
 
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */
@@ -70,9 +66,9 @@ abstract class OptionsPropertyGroup extends OptionsPropertyItem implements Count
     /**
      * Gets the group of properties
      *
-     * @return array
+     * @return SplObjectStorage<OptionsPropertyItem, null>
      */
-    public function getProperties()
+    public function getProperties(): SplObjectStorage
     {
         return $this->properties;
     }
@@ -82,11 +78,7 @@ abstract class OptionsPropertyGroup extends OptionsPropertyItem implements Count
      */
     public function getNrOfProperties(): int
     {
-        if ($this->properties === null) {
-            return 0;
-        }
-
-        return count($this->properties);
+        return $this->properties->count();
     }
 
     /**

--- a/libraries/classes/Properties/Options/OptionsPropertyItem.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyItem.php
@@ -115,10 +115,8 @@ abstract class OptionsPropertyItem extends PropertyItem
 
     /**
      * Returns the property type ( either "options", or "plugin" ).
-     *
-     * @return string
      */
-    public function getPropertyType()
+    public function getPropertyType(): string
     {
         return 'options';
     }

--- a/libraries/classes/Properties/Options/OptionsPropertyItem.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyItem.php
@@ -31,10 +31,8 @@ abstract class OptionsPropertyItem extends PropertyItem
     private $text;
     /**
      * What to force
-     *
-     * @var string|null
      */
-    private $force;
+    private ?string $force = null;
 
     /**
      * @param string $name Item name
@@ -110,7 +108,7 @@ abstract class OptionsPropertyItem extends PropertyItem
      *
      * @param string $force force parameter
      */
-    public function setForce($force): void
+    public function setForce(string $force): void
     {
         $this->force = $force;
     }

--- a/libraries/classes/Properties/Options/OptionsPropertyItem.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyItem.php
@@ -18,96 +18,39 @@ use PhpMyAdmin\Properties\PropertyItem;
 abstract class OptionsPropertyItem extends PropertyItem
 {
     /**
-     * Name
-     *
-     * @var string|null
-     */
-    private $name;
-    /**
-     * Text
-     *
-     * @var string|null
-     */
-    private $text;
-    /**
      * What to force
      */
-    private ?string $force = null;
+    private string|null $force = null;
 
-    /**
-     * @param string $name Item name
-     * @param string $text Item text
-     */
-    public function __construct($name = null, $text = null)
+    public function __construct(private string|null $name = null, private string|null $text = null)
     {
-        if ($name) {
-            $this->name = $name;
-        }
-
-        if (! $text) {
-            return;
-        }
-
-        $this->text = $text;
     }
 
-    /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */
-
-    /**
-     * Gets the name
-     *
-     * @return string|null
-     */
-    public function getName()
+    public function getName(): string|null
     {
         return $this->name;
     }
 
-    /**
-     * Sets the name
-     *
-     * @param string $name name
-     */
-    public function setName($name): void
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * Gets the text
-     *
-     * @return string|null
-     */
-    public function getText()
+    public function getText(): string|null
     {
         return $this->text;
     }
 
-    /**
-     * Sets the text
-     *
-     * @param string $text text
-     */
-    public function setText($text): void
+    public function setText(string $text): void
     {
         $this->text = $text;
     }
 
-    /**
-     * Gets the force parameter
-     *
-     * @return string|null
-     */
-    public function getForce()
+    public function getForce(): string|null
     {
         return $this->force;
     }
 
-    /**
-     * Sets the force parameter
-     *
-     * @param string $force force parameter
-     */
     public function setForce(string $force): void
     {
         $this->force = $force;

--- a/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
@@ -13,13 +13,9 @@ namespace PhpMyAdmin\Properties\Options;
  */
 abstract class OptionsPropertyOneItem extends OptionsPropertyItem
 {
-    /**
-     * Values
-     *
-     * @var array
-     */
-    private $values;
+    private array $values = [];
 
+    /** @var string|string[] */
     private string|array $doc = '';
 
     private int $len = 0;
@@ -29,10 +25,8 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
 
     /**
      * Gets the values
-     *
-     * @return array
      */
-    public function getValues()
+    public function getValues(): array
     {
         return $this->values;
     }
@@ -52,7 +46,7 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
      *
      * @return string|string[]
      */
-    public function getDoc()
+    public function getDoc(): array|string
     {
         return $this->doc;
     }

--- a/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
@@ -25,12 +25,8 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
      * @var string|array
      */
     private $doc;
-    /**
-     * Length
-     *
-     * @var int
-     */
-    private $len;
+
+    private int $len = 0;
 
     private int $size = 0;
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */
@@ -75,22 +71,12 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
         $this->doc = $doc;
     }
 
-    /**
-     * Gets the length
-     *
-     * @return int
-     */
-    public function getLen()
+    public function getLen(): int
     {
         return $this->len;
     }
 
-    /**
-     * Sets the length
-     *
-     * @param int $len length
-     */
-    public function setLen($len): void
+    public function setLen(int $len): void
     {
         $this->len = $len;
     }

--- a/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
@@ -31,12 +31,8 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
      * @var int
      */
     private $len;
-    /**
-     * Size
-     *
-     * @var int
-     */
-    private $size;
+
+    private int $size = 0;
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */
 
     /**
@@ -99,22 +95,12 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
         $this->len = $len;
     }
 
-    /**
-     * Gets the size
-     *
-     * @return int
-     */
-    public function getSize()
+    public function getSize(): int
     {
         return $this->size;
     }
 
-    /**
-     * Sets the size
-     *
-     * @param int $size size
-     */
-    public function setSize($size): void
+    public function setSize(int $size): void
     {
         $this->size = $size;
     }

--- a/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
@@ -14,12 +14,6 @@ namespace PhpMyAdmin\Properties\Options;
 abstract class OptionsPropertyOneItem extends OptionsPropertyItem
 {
     /**
-     * Whether to force or not
-     *
-     * @var bool|string
-     */
-    private $forceOne;
-    /**
      * Values
      *
      * @var array
@@ -44,26 +38,6 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
      */
     private $size;
     /* ~~~~~~~~~~~~~~~~~~~~ Getters and Setters ~~~~~~~~~~~~~~~~~~~~ */
-
-    /**
-     * Gets the force parameter
-     *
-     * @return bool|string
-     */
-    public function getForce()
-    {
-        return $this->forceOne;
-    }
-
-    /**
-     * Sets the force parameter
-     *
-     * @param bool|string $force force parameter
-     */
-    public function setForce($force): void
-    {
-        $this->forceOne = $force;
-    }
 
     /**
      * Gets the values

--- a/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
+++ b/libraries/classes/Properties/Options/OptionsPropertyOneItem.php
@@ -19,12 +19,8 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
      * @var array
      */
     private $values;
-    /**
-     * Doc
-     *
-     * @var string|array
-     */
-    private $doc;
+
+    private string|array $doc = '';
 
     private int $len = 0;
 
@@ -54,7 +50,7 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
     /**
      * Gets MySQL documentation pointer
      *
-     * @return string|array
+     * @return string|string[]
      */
     public function getDoc()
     {
@@ -64,9 +60,9 @@ abstract class OptionsPropertyOneItem extends OptionsPropertyItem
     /**
      * Sets the doc
      *
-     * @param string|array $doc MySQL documentation pointer
+     * @param string|string[] $doc MySQL documentation pointer
      */
-    public function setDoc($doc): void
+    public function setDoc(string|array $doc): void
     {
         $this->doc = $doc;
     }

--- a/libraries/classes/Properties/Plugins/ExportPluginProperties.php
+++ b/libraries/classes/Properties/Plugins/ExportPluginProperties.php
@@ -26,10 +26,8 @@ class ExportPluginProperties extends PluginPropertyItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyOneItem ( f.e. "bool", "text", "radio", etc ) or
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main" or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'export';
     }

--- a/libraries/classes/Properties/Plugins/ExportPluginProperties.php
+++ b/libraries/classes/Properties/Plugins/ExportPluginProperties.php
@@ -16,10 +16,8 @@ class ExportPluginProperties extends PluginPropertyItem
 {
     /**
      * Whether each plugin has to be saved as a file
-     *
-     * @var bool
      */
-    private $forceFile = false;
+    private bool $forceFile = false;
 
     /**
      * Returns the property item type of either an instance of

--- a/libraries/classes/Properties/Plugins/ImportPluginProperties.php
+++ b/libraries/classes/Properties/Plugins/ImportPluginProperties.php
@@ -17,10 +17,8 @@ class ImportPluginProperties extends PluginPropertyItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyOneItem ( f.e. "bool", "text", "radio", etc ) or
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main" or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'import';
     }

--- a/libraries/classes/Properties/Plugins/PluginPropertyItem.php
+++ b/libraries/classes/Properties/Plugins/PluginPropertyItem.php
@@ -152,10 +152,8 @@ abstract class PluginPropertyItem extends PropertyItem
 
     /**
      * Returns the property type ( either "options", or "plugin" ).
-     *
-     * @return string
      */
-    public function getPropertyType()
+    public function getPropertyType(): string
     {
         return 'plugin';
     }

--- a/libraries/classes/Properties/Plugins/PluginPropertyItem.php
+++ b/libraries/classes/Properties/Plugins/PluginPropertyItem.php
@@ -19,133 +19,58 @@ use PhpMyAdmin\Properties\PropertyItem;
  */
 abstract class PluginPropertyItem extends PropertyItem
 {
-    /**
-     * Text
-     *
-     * @var string
-     */
-    private $text;
-    /**
-     * Extension
-     *
-     * @var string
-     */
-    private $extension;
-    /**
-     * Options
-     *
-     * @var OptionsPropertyRootGroup|null
-     */
-    private $options = null;
-    /**
-     * Options text
-     *
-     * @var string
-     */
-    private $optionsText;
-    /**
-     * MIME Type
-     *
-     * @var string
-     */
-    private $mimeType;
+    private string $text = '';
+    private string $extension = '';
+    private OptionsPropertyRootGroup|null $options = null;
+    private string $optionsText = '';
+    private string $mimeType = '';
 
-    /**
-     * Gets the text
-     *
-     * @return string
-     */
-    public function getText()
+    public function getText(): string
     {
         return $this->text;
     }
 
-    /**
-     * Sets the text
-     *
-     * @param string $text text
-     */
-    public function setText($text): void
+    public function setText(string $text): void
     {
         $this->text = $text;
     }
 
-    /**
-     * Gets the extension
-     *
-     * @return string
-     */
-    public function getExtension()
+    public function getExtension(): string
     {
         return $this->extension;
     }
 
-    /**
-     * Sets the extension
-     *
-     * @param string $extension extension
-     */
-    public function setExtension($extension): void
+    public function setExtension(string $extension): void
     {
         $this->extension = $extension;
     }
 
-    /**
-     * Gets the options
-     *
-     * @return OptionsPropertyRootGroup|null
-     */
-    public function getOptions()
+    public function getOptions(): OptionsPropertyRootGroup|null
     {
         return $this->options;
     }
 
-    /**
-     * Sets the options
-     *
-     * @param OptionsPropertyRootGroup $options options
-     */
-    public function setOptions($options): void
+    public function setOptions(OptionsPropertyRootGroup $options): void
     {
         $this->options = $options;
     }
 
-    /**
-     * Gets the options text
-     *
-     * @return string
-     */
-    public function getOptionsText()
+    public function getOptionsText(): string
     {
         return $this->optionsText;
     }
 
-    /**
-     * Sets the options text
-     *
-     * @param string $optionsText optionsText
-     */
-    public function setOptionsText($optionsText): void
+    public function setOptionsText(string $optionsText): void
     {
         $this->optionsText = $optionsText;
     }
 
-    /**
-     * Gets the MIME type
-     *
-     * @return string
-     */
-    public function getMimeType()
+    public function getMimeType(): string
     {
         return $this->mimeType;
     }
 
-    /**
-     * Sets the MIME type
-     *
-     * @param string $mimeType MIME type
-     */
-    public function setMimeType($mimeType): void
+    public function setMimeType(string $mimeType): void
     {
         $this->mimeType = $mimeType;
     }

--- a/libraries/classes/Properties/Plugins/SchemaPluginProperties.php
+++ b/libraries/classes/Properties/Plugins/SchemaPluginProperties.php
@@ -17,10 +17,8 @@ class SchemaPluginProperties extends PluginPropertyItem
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyOneItem ( f.e. "bool", "text", "radio", etc ) or
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main" or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    public function getItemType()
+    public function getItemType(): string
     {
         return 'schema';
     }

--- a/libraries/classes/Properties/PropertyItem.php
+++ b/libraries/classes/Properties/PropertyItem.php
@@ -14,30 +14,24 @@ abstract class PropertyItem
 {
     /**
      * Returns the property type ( either "Options", or "Plugin" ).
-     *
-     * @return string
      */
-    abstract public function getPropertyType();
+    abstract public function getPropertyType(): string;
 
     /**
      * Returns the property item type of either an instance of
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyOneItem ( f.e. "bool", "text", "radio", etc ) or
      *  - PhpMyAdmin\Properties\Options\OptionsPropertyGroup   ( "root", "main" or "subgroup" )
      *  - PhpMyAdmin\Properties\Plugins\PluginPropertyItem     ( "export", "import", "transformations" )
-     *
-     * @return string
      */
-    abstract public function getItemType();
+    abstract public function getItemType(): string;
 
     /**
      * Only overwritten in the PhpMyAdmin\Properties\Options\OptionsPropertyGroup class:
      * Used to tell whether we can use the current item as a group by calling
      * the addProperty() or removeProperty() methods, which are not available
      * for simple PhpMyAdmin\Properties\Options\OptionsPropertyOneItem subclasses.
-     *
-     * @return object|null
      */
-    public function getGroup()
+    public function getGroup(): static|null
     {
         return null;
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11536,11 +11536,6 @@ parameters:
 			path: test/classes/PluginsTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$subgroupHeader of method PhpMyAdmin\\\\Properties\\\\Options\\\\Groups\\\\OptionsPropertySubgroup\\:\\:setSubgroupHeader\\(\\) expects PhpMyAdmin\\\\Properties\\\\PropertyItem, string given\\.$#"
-			count: 1
-			path: test/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
-
-		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpMyAdmin\\\\\\\\Properties\\\\\\\\Options\\\\\\\\OptionsPropertyGroup' and PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyGroup&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject will always evaluate to true\\.$#"
 			count: 1
 			path: test/classes/Properties/Options/OptionsPropertyGroupTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11471,11 +11471,6 @@ parameters:
 			path: test/classes/Plugins/Export/ExportOdtTest.php
 
 		-
-			message: "#^Call to an undefined method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyItem\\:\\:getProperties\\(\\)\\.$#"
-			count: 1
-			path: test/classes/Plugins/Export/ExportSqlTest.php
-
-		-
 			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: test/classes/Plugins/Export/ExportSqlTest.php
@@ -11547,21 +11542,6 @@ parameters:
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpMyAdmin\\\\\\\\Properties\\\\\\\\Options\\\\\\\\OptionsPropertyGroup' and PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyGroup&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject will always evaluate to true\\.$#"
-			count: 1
-			path: test/classes/Properties/Options/OptionsPropertyGroupTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$property of method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyGroup\\:\\:addProperty\\(\\) expects PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyItem, int given\\.$#"
-			count: 1
-			path: test/classes/Properties/Options/OptionsPropertyGroupTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$property of method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyGroup\\:\\:addProperty\\(\\) expects PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyItem, string given\\.$#"
-			count: 1
-			path: test/classes/Properties/Options/OptionsPropertyGroupTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$property of method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyGroup\\:\\:removeProperty\\(\\) expects PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyItem, string given\\.$#"
 			count: 1
 			path: test/classes/Properties/Options/OptionsPropertyGroupTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6096,6 +6096,11 @@ parameters:
 			path: libraries/classes/Pdf.php
 
 		-
+			message: "#^Call to an undefined method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyItem\\:\\:getProperties\\(\\)\\.$#"
+			count: 1
+			path: libraries/classes/Plugins.php
+
+		-
 			message: "#^Call to function method_exists\\(\\) with PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyItem and 'getText' will always evaluate to true\\.$#"
 			count: 1
 			path: libraries/classes/Plugins.php
@@ -7411,27 +7416,7 @@ parameters:
 			path: libraries/classes/Plugins/UploadInterface.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyGroup\\:\\:getProperties\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Properties/Options/OptionsPropertyGroup.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyGroup\\:\\:\\$properties type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Properties/Options/OptionsPropertyGroup.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyOneItem\\:\\:getDoc\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Properties/Options/OptionsPropertyOneItem.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyOneItem\\:\\:getValues\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Properties/Options/OptionsPropertyOneItem.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyOneItem\\:\\:setDoc\\(\\) has parameter \\$doc with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Properties/Options/OptionsPropertyOneItem.php
 
@@ -7441,17 +7426,7 @@ parameters:
 			path: libraries/classes/Properties/Options/OptionsPropertyOneItem.php
 
 		-
-			message: "#^Property PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyOneItem\\:\\:\\$doc type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Properties/Options/OptionsPropertyOneItem.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyOneItem\\:\\:\\$values type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Properties/Options/OptionsPropertyOneItem.php
-
-		-
-			message: "#^Return type \\(bool\\|string\\) of method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyOneItem\\:\\:getForce\\(\\) should be covariant with return type \\(string\\|null\\) of method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyItem\\:\\:getForce\\(\\)$#"
 			count: 1
 			path: libraries/classes/Properties/Options/OptionsPropertyOneItem.php
 
@@ -11496,6 +11471,11 @@ parameters:
 			path: test/classes/Plugins/Export/ExportOdtTest.php
 
 		-
+			message: "#^Call to an undefined method PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyItem\\:\\:getProperties\\(\\)\\.$#"
+			count: 1
+			path: test/classes/Plugins/Export/ExportSqlTest.php
+
+		-
 			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, mixed given\\.$#"
 			count: 2
 			path: test/classes/Plugins/Export/ExportSqlTest.php
@@ -11566,7 +11546,7 @@ parameters:
 			path: test/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
 
 		-
-			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpMyAdmin\\\\\\\\Properties\\\\\\\\Options\\\\\\\\OptionsPropertyGroup' and PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyGroup will always evaluate to true\\.$#"
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpMyAdmin\\\\\\\\Properties\\\\\\\\Options\\\\\\\\OptionsPropertyGroup' and PhpMyAdmin\\\\Properties\\\\Options\\\\OptionsPropertyGroup&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject will always evaluate to true\\.$#"
 			count: 1
 			path: test/classes/Properties/Options/OptionsPropertyGroupTest.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -17663,11 +17663,6 @@
       <code>assertIsArray</code>
     </RedundantCondition>
   </file>
-  <file src="test/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php">
-    <InvalidArgument>
-      <code><![CDATA['subGroupHeader123']]></code>
-    </InvalidArgument>
-  </file>
   <file src="test/classes/Properties/Options/OptionsPropertyItemTest.php">
     <PossiblyUndefinedMethod>
       <code>getForce</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10481,7 +10481,6 @@
       <code>$doc[1]</code>
       <code>$doc[1]</code>
       <code>$doc[2]</code>
-      <code>$propertyMainGroup</code>
       <code>$val</code>
       <code>$val</code>
       <code>$val</code>
@@ -10489,15 +10488,12 @@
     </MixedArgument>
     <MixedAssignment>
       <code>$doc</code>
-      <code>$properties</code>
       <code>$propertyItem</code>
-      <code>$propertyMainGroup</code>
       <code>$val</code>
       <code>$val</code>
       <code>$val</code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>getProperties</code>
       <code>new $class()</code>
     </MixedMethodCall>
     <PossiblyInvalidArgument>
@@ -10544,6 +10540,9 @@
       <code>$property_class === SelectPropertyItem::class</code>
       <code>$property_class === TextPropertyItem::class</code>
     </TypeDoesNotContainType>
+    <UndefinedMethod>
+      <code>getProperties</code>
+    </UndefinedMethod>
   </file>
   <file src="libraries/classes/Plugins/Auth/AuthenticationConfig.php">
     <InvalidArrayOffset>
@@ -13479,11 +13478,6 @@
       <code><![CDATA[$dbi->fetchResult('SHOW PROFILE;')]]></code>
       <code><![CDATA[array<string, string>|null]]></code>
     </MixedReturnTypeCoercion>
-  </file>
-  <file src="libraries/classes/Properties/Options/OptionsPropertyGroup.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[$this->properties === null]]></code>
-    </DocblockTypeContradiction>
   </file>
   <file src="libraries/classes/Query/Cache.php">
     <MixedArrayAccess>
@@ -17490,33 +17484,11 @@
       <code>$result</code>
     </MixedAssignment>
   </file>
-  <file src="test/classes/Plugins/Export/ExportCsvTest.php">
-    <MixedAssignment>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-    </MixedAssignment>
-  </file>
-  <file src="test/classes/Plugins/Export/ExportExcelTest.php">
-    <MixedAssignment>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-    </MixedAssignment>
-  </file>
   <file src="test/classes/Plugins/Export/ExportHtmlwordTest.php">
     <MixedArgument>
       <code>$result</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$generalOptions</code>
-      <code>$property</code>
-      <code>$property</code>
       <code>$result</code>
     </MixedAssignment>
   </file>
@@ -17524,23 +17496,6 @@
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['latex_caption']]]></code>
     </InvalidArrayOffset>
-    <MixedAssignment>
-      <code>$generalOptions</code>
-      <code>$generalOptions</code>
-      <code>$generalOptions</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-    </MixedAssignment>
     <PossiblyInvalidArrayOffset>
       <code><![CDATA[$GLOBALS['plugin_param']['export_type']]]></code>
       <code><![CDATA[$GLOBALS['plugin_param']['export_type']]]></code>
@@ -17548,20 +17503,10 @@
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
     </PossiblyInvalidArrayOffset>
   </file>
-  <file src="test/classes/Plugins/Export/ExportMediawikiTest.php">
-    <MixedAssignment>
-      <code>$property</code>
-      <code>$property</code>
-    </MixedAssignment>
-  </file>
   <file src="test/classes/Plugins/Export/ExportOdsTest.php">
     <InternalMethod>
       <code>setOutputCallback</code>
     </InternalMethod>
-    <MixedAssignment>
-      <code>$property</code>
-      <code>$property</code>
-    </MixedAssignment>
   </file>
   <file src="test/classes/Plugins/Export/ExportOdtTest.php">
     <InternalMethod>
@@ -17574,13 +17519,6 @@
       <code>$result</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$generalOptions</code>
-      <code>$generalOptions</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
       <code>$result</code>
     </MixedAssignment>
     <PossiblyInvalidArrayOffset>
@@ -17589,12 +17527,6 @@
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
     </PossiblyInvalidArrayOffset>
-  </file>
-  <file src="test/classes/Plugins/Export/ExportPdfTest.php">
-    <MixedAssignment>
-      <code>$generalOptions</code>
-      <code>$property</code>
-    </MixedAssignment>
   </file>
   <file src="test/classes/Plugins/Export/ExportSqlTest.php">
     <DeprecatedMethod>
@@ -17611,60 +17543,20 @@
       <code><![CDATA[$GLOBALS['sql_constraints']]]></code>
       <code><![CDATA[$GLOBALS['sql_constraints']]]></code>
       <code><![CDATA[$GLOBALS['sql_constraints']]]></code>
-      <code><![CDATA[$properties[1]->getProperties()]]></code>
       <code>$result</code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$leaf</code>
-      <code>$leaf</code>
-      <code>$leaf</code>
-      <code>$leaf</code>
-      <code>$leaf</code>
-      <code>$leaf</code>
-      <code>$leaf</code>
-      <code>$leaf</code>
-      <code>$leaf</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
       <code>$result</code>
       <code>$result</code>
       <code>$result</code>
       <code>$result</code>
     </MixedAssignment>
-    <MixedMethodCall>
-      <code>getProperties</code>
-    </MixedMethodCall>
     <PossiblyInvalidArrayOffset>
       <code><![CDATA[$GLOBALS['plugin_param']['export_type']]]></code>
       <code><![CDATA[$GLOBALS['plugin_param']['export_type']]]></code>
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
     </PossiblyInvalidArrayOffset>
-  </file>
-  <file src="test/classes/Plugins/Export/ExportTexytextTest.php">
-    <MixedAssignment>
-      <code>$generalOptions</code>
-      <code>$property</code>
-      <code>$property</code>
-    </MixedAssignment>
-  </file>
-  <file src="test/classes/Plugins/Export/ExportXmlTest.php">
-    <MixedAssignment>
-      <code>$generalOptions</code>
-      <code>$generalOptions</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-      <code>$property</code>
-    </MixedAssignment>
   </file>
   <file src="test/classes/Plugins/Export/Helpers/TablePropertyTest.php">
     <MixedInferredReturnType>
@@ -17775,21 +17667,6 @@
     <InvalidArgument>
       <code><![CDATA['subGroupHeader123']]></code>
     </InvalidArgument>
-  </file>
-  <file src="test/classes/Properties/Options/OptionsPropertyGroupTest.php">
-    <InvalidArgument>
-      <code><![CDATA['2']]></code>
-      <code><![CDATA['test']]></code>
-      <code>2</code>
-    </InvalidArgument>
-    <PossiblyUndefinedMethod>
-      <code>addProperty</code>
-      <code>addProperty</code>
-      <code>getGroup</code>
-      <code>getNrOfProperties</code>
-      <code>getProperties</code>
-      <code>removeProperty</code>
-    </PossiblyUndefinedMethod>
   </file>
   <file src="test/classes/Properties/Options/OptionsPropertyItemTest.php">
     <PossiblyUndefinedMethod>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13485,11 +13485,6 @@
       <code><![CDATA[$this->properties === null]]></code>
     </DocblockTypeContradiction>
   </file>
-  <file src="libraries/classes/Properties/Options/OptionsPropertyOneItem.php">
-    <ImplementedReturnTypeMismatch>
-      <code>bool|string</code>
-    </ImplementedReturnTypeMismatch>
-  </file>
   <file src="libraries/classes/Query/Cache.php">
     <MixedArrayAccess>
       <code><![CDATA[$this->tableCache[$one_database][$table]]]></code>

--- a/test/classes/Plugins/Export/ExportCodegenTest.php
+++ b/test/classes/Plugins/Export/ExportCodegenTest.php
@@ -110,7 +110,7 @@ class ExportCodegenTest extends AbstractTestCase
         );
 
         $generalOptionsArray = $options->getProperties();
-        $generalOptions = $generalOptionsArray[0];
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -121,7 +121,8 @@ class ExportCodegenTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $hidden = $generalProperties[0];
+        $hidden = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(HiddenPropertyItem::class, $hidden);
 
@@ -130,7 +131,7 @@ class ExportCodegenTest extends AbstractTestCase
             $hidden->getName()
         );
 
-        $select = $generalProperties[1];
+        $select = $generalProperties->current();
 
         $this->assertInstanceOf(SelectPropertyItem::class, $select);
 

--- a/test/classes/Plugins/Export/ExportCsvTest.php
+++ b/test/classes/Plugins/Export/ExportCsvTest.php
@@ -18,7 +18,6 @@ use PhpMyAdmin\Transformations;
 use ReflectionMethod;
 use ReflectionProperty;
 
-use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
@@ -104,7 +103,7 @@ class ExportCsvTest extends AbstractTestCase
         );
 
         $generalOptionsArray = $options->getProperties();
-        $generalOptions = $generalOptionsArray[0];
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -115,7 +114,8 @@ class ExportCsvTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -129,7 +129,8 @@ class ExportCsvTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -143,7 +144,8 @@ class ExportCsvTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -157,7 +159,8 @@ class ExportCsvTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -171,7 +174,8 @@ class ExportCsvTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -185,7 +189,8 @@ class ExportCsvTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -199,7 +204,8 @@ class ExportCsvTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -213,7 +219,7 @@ class ExportCsvTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(HiddenPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportExcelTest.php
+++ b/test/classes/Plugins/Export/ExportExcelTest.php
@@ -19,8 +19,6 @@ use PhpMyAdmin\Transformations;
 use ReflectionMethod;
 use ReflectionProperty;
 
-use function array_shift;
-
 /**
  * @covers \PhpMyAdmin\Plugins\Export\ExportExcel
  * @group medium
@@ -94,7 +92,7 @@ class ExportExcelTest extends AbstractTestCase
         );
 
         $generalOptionsArray = $options->getProperties();
-        $generalOptions = $generalOptionsArray[0];
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -105,7 +103,8 @@ class ExportExcelTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -119,7 +118,8 @@ class ExportExcelTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -133,7 +133,8 @@ class ExportExcelTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -147,7 +148,8 @@ class ExportExcelTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(SelectPropertyItem::class, $property);
 
@@ -170,7 +172,7 @@ class ExportExcelTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(HiddenPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportHtmlwordTest.php
+++ b/test/classes/Plugins/Export/ExportHtmlwordTest.php
@@ -23,7 +23,6 @@ use ReflectionMethod;
 use ReflectionProperty;
 
 use function __;
-use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
@@ -123,7 +122,8 @@ class ExportHtmlwordTest extends AbstractTestCase
         );
 
         $generalOptionsArray = $options->getProperties();
-        $generalOptions = $generalOptionsArray[0];
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -139,7 +139,7 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(RadioPropertyItem::class, $property);
 
@@ -157,7 +157,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             $property->getValues()
         );
 
-        $generalOptions = $generalOptionsArray[1];
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -178,7 +178,8 @@ class ExportHtmlwordTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -192,7 +193,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportJsonTest.php
+++ b/test/classes/Plugins/Export/ExportJsonTest.php
@@ -17,8 +17,6 @@ use PhpMyAdmin\Version;
 use ReflectionMethod;
 use ReflectionProperty;
 
-use function array_shift;
-
 /**
  * @covers \PhpMyAdmin\Plugins\Export\ExportJson
  * @group medium
@@ -97,7 +95,7 @@ class ExportJsonTest extends AbstractTestCase
         );
 
         $generalOptionsArray = $options->getProperties();
-        $generalOptions = $generalOptionsArray[0];
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -108,7 +106,7 @@ class ExportJsonTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(HiddenPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportLatexTest.php
+++ b/test/classes/Plugins/Export/ExportLatexTest.php
@@ -21,7 +21,6 @@ use PhpMyAdmin\Transformations;
 use ReflectionMethod;
 
 use function __;
-use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
@@ -118,7 +117,8 @@ class ExportLatexTest extends AbstractTestCase
 
         $generalOptionsArray = $options->getProperties();
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -129,7 +129,7 @@ class ExportLatexTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -143,7 +143,8 @@ class ExportLatexTest extends AbstractTestCase
             $property->getText()
         );
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -159,7 +160,7 @@ class ExportLatexTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(RadioPropertyItem::class, $property);
 
@@ -178,7 +179,8 @@ class ExportLatexTest extends AbstractTestCase
         );
 
         // hide structure
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -199,7 +201,8 @@ class ExportLatexTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -218,7 +221,8 @@ class ExportLatexTest extends AbstractTestCase
             $property->getDoc()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -237,7 +241,8 @@ class ExportLatexTest extends AbstractTestCase
             $property->getDoc()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -256,7 +261,8 @@ class ExportLatexTest extends AbstractTestCase
             $property->getDoc()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -270,7 +276,8 @@ class ExportLatexTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -284,7 +291,7 @@ class ExportLatexTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -299,7 +306,7 @@ class ExportLatexTest extends AbstractTestCase
         );
 
         // data options
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -320,7 +327,8 @@ class ExportLatexTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -334,7 +342,8 @@ class ExportLatexTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -353,7 +362,8 @@ class ExportLatexTest extends AbstractTestCase
             $property->getDoc()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -372,7 +382,8 @@ class ExportLatexTest extends AbstractTestCase
             $property->getDoc()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -391,7 +402,7 @@ class ExportLatexTest extends AbstractTestCase
             $property->getDoc()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportMediawikiTest.php
+++ b/test/classes/Plugins/Export/ExportMediawikiTest.php
@@ -20,7 +20,6 @@ use ReflectionMethod;
 use ReflectionProperty;
 
 use function __;
-use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
@@ -107,7 +106,7 @@ class ExportMediawikiTest extends AbstractTestCase
         );
 
         $generalOptionsArray = $options->getProperties();
-        $generalOptions = $generalOptionsArray[0];
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -123,7 +122,8 @@ class ExportMediawikiTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(OptionsPropertySubgroup::class, $property);
 
@@ -155,7 +155,8 @@ class ExportMediawikiTest extends AbstractTestCase
             $sgHeader->getValues()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -169,7 +170,7 @@ class ExportMediawikiTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportOdsTest.php
+++ b/test/classes/Plugins/Export/ExportOdsTest.php
@@ -23,8 +23,6 @@ use ReflectionMethod;
 use ReflectionProperty;
 use stdClass;
 
-use function array_shift;
-
 use const MYSQLI_BLOB_FLAG;
 use const MYSQLI_TYPE_DATE;
 use const MYSQLI_TYPE_DATETIME;
@@ -116,7 +114,7 @@ class ExportOdsTest extends AbstractTestCase
         );
 
         $generalOptionsArray = $options->getProperties();
-        $generalOptions = $generalOptionsArray[0];
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -127,7 +125,8 @@ class ExportOdsTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -141,7 +140,8 @@ class ExportOdsTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -155,7 +155,7 @@ class ExportOdsTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(HiddenPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -25,7 +25,6 @@ use ReflectionMethod;
 use stdClass;
 
 use function __;
-use function array_shift;
 
 use const MYSQLI_BLOB_FLAG;
 use const MYSQLI_NUM_FLAG;
@@ -138,7 +137,8 @@ class ExportOdtTest extends AbstractTestCase
 
         $generalOptionsArray = $options->getProperties();
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -154,7 +154,7 @@ class ExportOdtTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(RadioPropertyItem::class, $property);
 
@@ -172,7 +172,8 @@ class ExportOdtTest extends AbstractTestCase
             $property->getValues()
         );
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -193,7 +194,8 @@ class ExportOdtTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -207,7 +209,8 @@ class ExportOdtTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -221,7 +224,7 @@ class ExportOdtTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -236,7 +239,7 @@ class ExportOdtTest extends AbstractTestCase
         );
 
         // hide structure
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -257,7 +260,8 @@ class ExportOdtTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -271,7 +275,7 @@ class ExportOdtTest extends AbstractTestCase
             $property->getText()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportPdfTest.php
+++ b/test/classes/Plugins/Export/ExportPdfTest.php
@@ -19,7 +19,6 @@ use ReflectionMethod;
 use ReflectionProperty;
 
 use function __;
-use function array_shift;
 
 /**
  * @covers \PhpMyAdmin\Plugins\Export\ExportPdf
@@ -104,7 +103,8 @@ class ExportPdfTest extends AbstractTestCase
 
         $generalOptionsArray = $options->getProperties();
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -115,7 +115,7 @@ class ExportPdfTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 
@@ -124,7 +124,7 @@ class ExportPdfTest extends AbstractTestCase
             $property->getName()
         );
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -140,7 +140,7 @@ class ExportPdfTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(RadioPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportPhparrayTest.php
+++ b/test/classes/Plugins/Export/ExportPhparrayTest.php
@@ -16,7 +16,6 @@ use PhpMyAdmin\Transformations;
 use ReflectionMethod;
 use ReflectionProperty;
 
-use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
@@ -103,7 +102,7 @@ class ExportPhparrayTest extends AbstractTestCase
         );
 
         $generalOptionsArray = $options->getProperties();
-        $generalOptions = $generalOptionsArray[0];
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -114,7 +113,7 @@ class ExportPhparrayTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(HiddenPropertyItem::class, $property);
     }

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -19,6 +19,7 @@ use PhpMyAdmin\Properties\Options\Items\MessageOnlyPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\RadioPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\SelectPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
+use PhpMyAdmin\Properties\Options\OptionsPropertyGroup;
 use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Table;
 use PhpMyAdmin\Tests\AbstractTestCase;
@@ -27,7 +28,6 @@ use PhpMyAdmin\Transformations;
 use ReflectionMethod;
 use stdClass;
 
-use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
@@ -149,13 +149,15 @@ class ExportSqlTest extends AbstractTestCase
 
         $generalOptionsArray = $options->getProperties();
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
         $properties = $generalOptions->getProperties();
 
-        $property = array_shift($properties);
+        $property = $properties->current();
+        $properties->next();
 
         $this->assertInstanceOf(OptionsPropertySubgroup::class, $property);
 
@@ -166,31 +168,40 @@ class ExportSqlTest extends AbstractTestCase
 
         $leaves = $property->getProperties();
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(TextPropertyItem::class, $leaf);
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $leaf);
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $leaf);
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $leaf);
 
-        $property = array_shift($properties);
+        $property = $properties->current();
+        $properties->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $property = array_shift($properties);
+        $property = $properties->current();
+        $properties->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $property = array_shift($properties);
+        $property = $properties->current();
+        $properties->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $property = array_shift($properties);
+        $property = $properties->current();
+        $properties->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $property = array_shift($properties);
+        $property = $properties->current();
+        $properties->next();
         $this->assertInstanceOf(SelectPropertyItem::class, $property);
 
         $this->assertEquals(
@@ -201,7 +212,7 @@ class ExportSqlTest extends AbstractTestCase
             $property->getValues()
         );
 
-        $property = array_shift($properties);
+        $property = $properties->current();
         $this->assertInstanceOf(OptionsPropertySubgroup::class, $property);
 
         $this->assertInstanceOf(
@@ -209,13 +220,15 @@ class ExportSqlTest extends AbstractTestCase
             $property->getSubgroupHeader()
         );
 
-        $structureOptions = array_shift($generalOptionsArray);
+        $structureOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $structureOptions);
 
         $properties = $structureOptions->getProperties();
 
-        $property = array_shift($properties);
+        $property = $properties->current();
+        $properties->next();
 
         $this->assertInstanceOf(OptionsPropertySubgroup::class, $property);
 
@@ -226,10 +239,12 @@ class ExportSqlTest extends AbstractTestCase
 
         $leaves = $property->getProperties();
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $leaf);
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $leaf);
 
         $this->assertEquals(
@@ -237,7 +252,8 @@ class ExportSqlTest extends AbstractTestCase
             $leaf->getText()
         );
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(OptionsPropertySubgroup::class, $leaf);
 
         $this->assertCount(
@@ -250,7 +266,8 @@ class ExportSqlTest extends AbstractTestCase
             $leaf->getSubgroupHeader()
         );
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(OptionsPropertySubgroup::class, $leaf);
 
         $this->assertCount(
@@ -263,25 +280,32 @@ class ExportSqlTest extends AbstractTestCase
             $leaf->getSubgroupHeader()
         );
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $leaf);
 
-        $leaf = array_shift($leaves);
+        $leaf = $leaves->current();
+        $leaves->next();
         $this->assertInstanceOf(BoolPropertyItem::class, $leaf);
 
-        $property = array_shift($properties);
+        $property = $properties->current();
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $dataOptions = array_shift($generalOptionsArray);
+        $dataOptions = $generalOptionsArray->current();
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $dataOptions);
 
         $properties = $dataOptions->getProperties();
 
         $this->assertCount(7, $properties);
 
+        $properties->next();
+
+        $property = $properties->current();
+        $this->assertInstanceOf(OptionsPropertyGroup::class, $property);
+
         $this->assertCount(
             2,
-            $properties[1]->getProperties()
+            $property->getProperties()
         );
     }
 

--- a/test/classes/Plugins/Export/ExportTexytextTest.php
+++ b/test/classes/Plugins/Export/ExportTexytextTest.php
@@ -21,7 +21,6 @@ use PhpMyAdmin\Transformations;
 use ReflectionMethod;
 use ReflectionProperty;
 
-use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
@@ -115,7 +114,8 @@ class ExportTexytextTest extends AbstractTestCase
 
         $generalOptionsArray = $options->getProperties();
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -131,11 +131,11 @@ class ExportTexytextTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(RadioPropertyItem::class, $property);
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -146,7 +146,8 @@ class ExportTexytextTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
+        $generalProperties->next();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
@@ -155,7 +156,7 @@ class ExportTexytextTest extends AbstractTestCase
             $property->getName()
         );
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(TextPropertyItem::class, $property);
 

--- a/test/classes/Plugins/Export/ExportXmlTest.php
+++ b/test/classes/Plugins/Export/ExportXmlTest.php
@@ -19,7 +19,6 @@ use PhpMyAdmin\Transformations;
 use ReflectionMethod;
 use ReflectionProperty;
 
-use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
@@ -104,7 +103,8 @@ class ExportXmlTest extends AbstractTestCase
 
         $generalOptionsArray = $options->getProperties();
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -115,11 +115,12 @@ class ExportXmlTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(HiddenPropertyItem::class, $property);
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
+        $generalOptionsArray->next();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -130,27 +131,27 @@ class ExportXmlTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -161,7 +162,7 @@ class ExportXmlTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(BoolPropertyItem::class, $property);
     }

--- a/test/classes/Plugins/Export/ExportYamlTest.php
+++ b/test/classes/Plugins/Export/ExportYamlTest.php
@@ -16,7 +16,6 @@ use PhpMyAdmin\Transformations;
 use ReflectionMethod;
 use ReflectionProperty;
 
-use function array_shift;
 use function ob_get_clean;
 use function ob_start;
 
@@ -98,7 +97,7 @@ class ExportYamlTest extends AbstractTestCase
 
         $generalOptionsArray = $options->getProperties();
 
-        $generalOptions = array_shift($generalOptionsArray);
+        $generalOptions = $generalOptionsArray->current();
 
         $this->assertInstanceOf(OptionsPropertyMainGroup::class, $generalOptions);
 
@@ -109,7 +108,7 @@ class ExportYamlTest extends AbstractTestCase
 
         $generalProperties = $generalOptions->getProperties();
 
-        $property = array_shift($generalProperties);
+        $property = $generalProperties->current();
 
         $this->assertInstanceOf(HiddenPropertyItem::class, $property);
     }

--- a/test/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
+++ b/test/classes/Properties/Options/Groups/OptionsPropertySubgroupTest.php
@@ -48,10 +48,11 @@ class OptionsPropertySubgroupTest extends AbstractTestCase
      */
     public function testGetSetSubgroupHeader(): void
     {
-        $this->object->setSubgroupHeader('subGroupHeader123');
+        $propertyItem = new OptionsPropertySubgroup();
+        $this->object->setSubgroupHeader($propertyItem);
 
         $this->assertEquals(
-            'subGroupHeader123',
+            $propertyItem,
             $this->object->getSubgroupHeader()
         );
     }

--- a/test/classes/Properties/Options/OptionsPropertyGroupTest.php
+++ b/test/classes/Properties/Options/OptionsPropertyGroupTest.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Properties\Options;
 
+use PhpMyAdmin\Properties\Options\Items\BoolPropertyItem;
 use PhpMyAdmin\Properties\Options\OptionsPropertyGroup;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use ReflectionProperty;
 
 /**
  * @covers \PhpMyAdmin\Properties\Options\OptionsPropertyGroup
  */
 class OptionsPropertyGroupTest extends AbstractTestCase
 {
-    /** @var OptionsPropertyGroup|MockObject */
+    /** @var OptionsPropertyGroup&MockObject */
     protected $stub;
 
     /**
@@ -37,38 +37,31 @@ class OptionsPropertyGroupTest extends AbstractTestCase
 
     public function testAddProperty(): void
     {
-        $properties = new ReflectionProperty(OptionsPropertyGroup::class, 'properties');
+        $propertyItem = new BoolPropertyItem();
+        $this->stub->addProperty($propertyItem);
+        $this->stub->addProperty($propertyItem);
 
-        $properties->setValue($this->stub, [1, 2, 3]);
-
-        $this->stub->addProperty(2);
-        $this->stub->addProperty('2');
-
+        $this->assertTrue(
+            $this->stub->getProperties()->contains($propertyItem)
+        );
         $this->assertEquals(
-            [
-                1,
-                2,
-                3,
-                '2',
-            ],
-            $properties->getValue($this->stub)
+            1,
+            $this->stub->getNrOfProperties()
         );
     }
 
     public function testRemoveProperty(): void
     {
-        $properties = new ReflectionProperty(OptionsPropertyGroup::class, 'properties');
+        $propertyItem = new BoolPropertyItem();
 
-        $properties->setValue($this->stub, [1, 2, 'test', 3]);
-        $this->stub->removeProperty('test');
+        $this->stub->addProperty($propertyItem);
+        $this->assertTrue(
+            $this->stub->getProperties()->contains($propertyItem)
+        );
 
-        $this->assertEquals(
-            [
-                0 => 1,
-                1 => 2,
-                3 => 3,
-            ],
-            $properties->getValue($this->stub)
+        $this->stub->removeProperty($propertyItem);
+        $this->assertFalse(
+            $this->stub->getProperties()->contains($propertyItem)
         );
     }
 
@@ -82,26 +75,23 @@ class OptionsPropertyGroupTest extends AbstractTestCase
 
     public function testGetProperties(): void
     {
-        $properties = new ReflectionProperty(OptionsPropertyGroup::class, 'properties');
-        $properties->setValue($this->stub, [1, 2, 3]);
+        $propertyItem = new BoolPropertyItem();
+        $this->stub->addProperty($propertyItem);
 
-        $this->assertEquals(
-            [
-                1,
-                2,
-                3,
-            ],
-            $this->stub->getProperties()
+        $this->assertTrue(
+            $this->stub->getProperties()->contains($propertyItem)
         );
     }
 
     public function testGetNrOfProperties(): void
     {
-        $properties = new ReflectionProperty(OptionsPropertyGroup::class, 'properties');
-        $properties->setValue($this->stub, [1, 2, 3]);
-
+        $propertyItem = new BoolPropertyItem();
+        $this->stub->addProperty($propertyItem);
+        $this->stub->addProperty($propertyItem);
+        $propertyItem2 = new BoolPropertyItem();
+        $this->stub->addProperty($propertyItem2);
         $this->assertEquals(
-            3,
+            2,
             $this->stub->getNrOfProperties()
         );
     }


### PR DESCRIPTION
This adds native types, fixes tests and fixes a bug caused by using `array_diff` on an array of objects. This probably needs more refactoring to get rid of all `method_exists` checks and weird class name comparisons, but this can be done in the future. Fixing the tests was already very annoying and they should probably be simplified too. 