### PR TITLE
Force a full page reload for top menu links

### DIFF
--- a/templates/database/multi_table_query/form.twig
+++ b/templates/database/multi_table_query/form.twig
@@ -1,12 +1,12 @@
 <ul class="nav nav-pills m-2">
   <li class="nav-item">
-    <a class="nav-link active" href="{{ url('/database/multi-table-query', {'db': db}) }}">
+    <a class="nav-link active disableAjax" href="{{ url('/database/multi-table-query', {'db': db}) }}">
       {% trans 'Multi-table query' %}
     </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link" href="{{ url('/database/qbe', {'db': db}) }}">
+    <a class="nav-link disableAjax" href="{{ url('/database/qbe', {'db': db}) }}">
       {% trans 'Query by example' %}
     </a>
   </li>

--- a/templates/database/qbe/index.twig
+++ b/templates/database/qbe/index.twig
@@ -1,12 +1,12 @@
 <ul class="nav nav-pills m-2">
   <li class="nav-item">
-    <a class="nav-link" href="{{ url('/database/multi-table-query', url_params) }}">
+    <a class="nav-link disableAjax" href="{{ url('/database/multi-table-query', url_params) }}">
       {% trans 'Multi-table query' %}
     </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link active" href="{{ url('/database/qbe', url_params) }}">
+    <a class="nav-link active disableAjax" href="{{ url('/database/qbe', url_params) }}">
       {% trans 'Query by example' %}
     </a>
   </li>

--- a/templates/preferences/header.twig
+++ b/templates/preferences/header.twig
@@ -2,49 +2,49 @@
   <div class="row">
     <ul id="user_prefs_tabs" class="nav nav-pills m-2">
       <li class="nav-item my-1">
-        <a href="{{ url('/preferences/manage') }}" class="nav-link{{ route == '/preferences/manage' ? ' active' }}">
+        <a href="{{ url('/preferences/manage') }}" class="nav-link{{ route == '/preferences/manage' ? ' active' }} disableAjax">
           {% trans 'Manage your settings' %}
         </a>
       </li>
 
       <li class="nav-item my-1">
-        <a href="{{ url('/preferences/two-factor') }}" class="nav-link{{ route == '/preferences/two-factor' ? ' active' }}">
+        <a href="{{ url('/preferences/two-factor') }}" class="nav-link{{ route == '/preferences/two-factor' ? ' active' }} disableAjax">
           {% trans 'Two-factor authentication' %}
         </a>
       </li>
 
       <li class="nav-item my-1">
-        <a href="{{ url('/preferences/features') }}" class="nav-link{{ route == '/preferences/features' ? ' active' }}">
+        <a href="{{ url('/preferences/features') }}" class="nav-link{{ route == '/preferences/features' ? ' active' }} disableAjax">
           {{ get_icon('b_tblops', 'Features'|trans, false, false, 'TabsMode') }}
         </a>
       </li>
 
       <li class="nav-item my-1">
-        <a href="{{ url('/preferences/sql') }}" class="nav-link{{ route == '/preferences/sql' ? ' active' }}">
+        <a href="{{ url('/preferences/sql') }}" class="nav-link{{ route == '/preferences/sql' ? ' active' }} disableAjax">
           {{ get_icon('b_sql', 'SQL queries'|trans, false, false, 'TabsMode') }}
         </a>
       </li>
 
       <li class="nav-item my-1">
-        <a href="{{ url('/preferences/navigation') }}" class="nav-link{{ route == '/preferences/navigation' ? ' active' }}">
+        <a href="{{ url('/preferences/navigation') }}" class="nav-link{{ route == '/preferences/navigation' ? ' active' }} disableAjax">
           {{ get_icon('b_select', 'Navigation panel'|trans, false, false, 'TabsMode') }}
         </a>
       </li>
 
       <li class="nav-item my-1">
-        <a href="{{ url('/preferences/main-panel') }}" class="nav-link{{ route == '/preferences/main-panel' ? ' active' }}">
+        <a href="{{ url('/preferences/main-panel') }}" class="nav-link{{ route == '/preferences/main-panel' ? ' active' }} disableAjax">
           {{ get_icon('b_props', 'Main panel'|trans, false, false, 'TabsMode') }}
         </a>
       </li>
 
       <li class="nav-item my-1">
-        <a href="{{ url('/preferences/export') }}" class="nav-link{{ route == '/preferences/export' ? ' active' }}">
+        <a href="{{ url('/preferences/export') }}" class="nav-link{{ route == '/preferences/export' ? ' active' }} disableAjax">
           {{ get_icon('b_export', 'Export'|trans, false, false, 'TabsMode') }}
         </a>
       </li>
 
       <li class="nav-item my-1">
-        <a href="{{ url('/preferences/import') }}" class="nav-link{{ route == '/preferences/import' ? ' active' }}">
+        <a href="{{ url('/preferences/import') }}" class="nav-link{{ route == '/preferences/import' ? ' active' }} disableAjax">
           {{ get_icon('b_import', 'Import'|trans, false, false, 'TabsMode') }}
         </a>
       </li>

--- a/templates/server/privileges/subnav.twig
+++ b/templates/server/privileges/subnav.twig
@@ -1,13 +1,13 @@
 <div class="row">
   <ul class="nav nav-pills m-2">
     <li class="nav-item">
-      <a class="nav-link{{ active == 'privileges' ? ' active' }}" href="{{ url('/server/privileges') }}">
+      <a class="nav-link{{ active == 'privileges' ? ' active' }} disableAjax" href="{{ url('/server/privileges') }}">
         {% trans 'User accounts overview' %}
       </a>
     </li>
     {% if is_super_user %}
       <li class="nav-item">
-        <a class="nav-link{{ active == 'user-groups' ? ' active' }}" href="{{ url('/server/user-groups') }}">
+        <a class="nav-link{{ active == 'user-groups' ? ' active' }} disableAjax" href="{{ url('/server/user-groups') }}">
           {% trans 'User groups' %}
         </a>
       </li>

--- a/templates/server/status/base.twig
+++ b/templates/server/status/base.twig
@@ -2,32 +2,32 @@
   <div class="row">
     <ul class="nav nav-pills m-2">
       <li class="nav-item">
-        <a href="{{ url('/server/status') }}" class="nav-link{{ active == 'status' ? ' active' }}">
+        <a href="{{ url('/server/status') }}" class="nav-link{{ active == 'status' ? ' active' }} disableAjax">
           {% trans 'Server' %}
         </a>
       </li>
       <li class="nav-item">
-        <a href="{{ url('/server/status/processes') }}" class="nav-link{{ active == 'processes' ? ' active' }}">
+        <a href="{{ url('/server/status/processes') }}" class="nav-link{{ active == 'processes' ? ' active' }} disableAjax">
           {% trans 'Processes' %}
         </a>
       </li>
       <li class="nav-item">
-        <a href="{{ url('/server/status/queries') }}" class="nav-link{{ active == 'queries' ? ' active' }}">
+        <a href="{{ url('/server/status/queries') }}" class="nav-link{{ active == 'queries' ? ' active' }} disableAjax">
           {% trans 'Query statistics' %}
         </a>
       </li>
       <li class="nav-item">
-        <a href="{{ url('/server/status/variables') }}" class="nav-link{{ active == 'variables' ? ' active' }}">
+        <a href="{{ url('/server/status/variables') }}" class="nav-link{{ active == 'variables' ? ' active' }} disableAjax">
           {% trans 'All status variables' %}
         </a>
       </li>
       <li class="nav-item">
-        <a href="{{ url('/server/status/monitor') }}" class="nav-link{{ active == 'monitor' ? ' active' }}">
+        <a href="{{ url('/server/status/monitor') }}" class="nav-link{{ active == 'monitor' ? ' active' }} disableAjax">
           {% trans 'Monitor' %}
         </a>
       </li>
       <li class="nav-item">
-        <a href="{{ url('/server/status/advisor') }}" class="nav-link{{ active == 'advisor' ? ' active' }}">
+        <a href="{{ url('/server/status/advisor') }}" class="nav-link{{ active == 'advisor' ? ' active' }} disableAjax">
           {% trans 'Advisor' %}
         </a>
       </li>

--- a/templates/table/find_replace/index.twig
+++ b/templates/table/find_replace/index.twig
@@ -1,18 +1,18 @@
 <ul class="nav nav-pills m-2">
   <li class="nav-item">
-    <a class="nav-link" href="{{ url('/table/search', {'db': db, 'table': table, 'pos': 0}) }}">
+    <a class="nav-link disableAjax" href="{{ url('/table/search', {'db': db, 'table': table, 'pos': 0}) }}">
       {{ get_icon('b_search', 'Table search'|trans, false, false, 'TabsMode') }}
     </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link" href="{{ url('/table/zoom-search', {'db': db, 'table': table}) }}">
+    <a class="nav-link disableAjax" href="{{ url('/table/zoom-search', {'db': db, 'table': table}) }}">
       {{ get_icon('b_select', 'Zoom search'|trans, false, false, 'TabsMode') }}
     </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link active" href="{{ url('/table/find-replace', {'db': db, 'table': table}) }}">
+    <a class="nav-link active disableAjax" href="{{ url('/table/find-replace', {'db': db, 'table': table}) }}">
       {{ get_icon('b_find_replace', 'Find and replace'|trans, false, false, 'TabsMode') }}
     </a>
   </li>

--- a/templates/table/page_with_secondary_tabs.twig
+++ b/templates/table/page_with_secondary_tabs.twig
@@ -1,13 +1,13 @@
 {% if relation_parameters.relationFeature is not null or is_foreign_key_supported %}
   <ul class="nav nav-pills m-2 d-print-none">
     <li class="nav-item">
-      <a href="{{ url('/table/structure', {'db': db, 'table': table}) }}" id="table_structure_id" class="nav-link{{ route == '/table/structure' ? ' active' }}">
+      <a href="{{ url('/table/structure', {'db': db, 'table': table}) }}" id="table_structure_id" class="nav-link{{ route == '/table/structure' ? ' active' }} disableAjax">
         {{ get_icon('b_props', 'Table structure'|trans, true) }}
       </a>
     </li>
 
     <li class="nav-item">
-      <a href="{{ url('/table/relation', {'db': db, 'table': table}) }}" id="table_relation_id" class="nav-link{{ route == '/table/relation' ? ' active' }}">
+      <a href="{{ url('/table/relation', {'db': db, 'table': table}) }}" id="table_relation_id" class="nav-link{{ route == '/table/relation' ? ' active' }} disableAjax">
         {{ get_icon('b_relations', 'Relation view'|trans, true) }}
       </a>
     </li>

--- a/templates/table/search/index.twig
+++ b/templates/table/search/index.twig
@@ -1,18 +1,18 @@
 <ul class="nav nav-pills m-2">
   <li class="nav-item">
-    <a class="nav-link active" href="{{ url('/table/search', {'db': db, 'table': table, 'pos': 0}) }}">
+    <a class="nav-link active disableAjax" href="{{ url('/table/search', {'db': db, 'table': table, 'pos': 0}) }}">
       {{ get_icon('b_search', 'Table search'|trans, false, false, 'TabsMode') }}
     </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link" href="{{ url('/table/zoom-search', {'db': db, 'table': table}) }}">
+    <a class="nav-link disableAjax" href="{{ url('/table/zoom-search', {'db': db, 'table': table}) }}">
       {{ get_icon('b_select', 'Zoom search'|trans, false, false, 'TabsMode') }}
     </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link" href="{{ url('/table/find-replace', {'db': db, 'table': table}) }}">
+    <a class="nav-link disableAjax" href="{{ url('/table/find-replace', {'db': db, 'table': table}) }}">
       {{ get_icon('b_find_replace', 'Find and replace'|trans, false, false, 'TabsMode') }}
     </a>
   </li>

--- a/templates/table/zoom_search/index.twig
+++ b/templates/table/zoom_search/index.twig
@@ -1,18 +1,18 @@
 <ul class="nav nav-pills m-2">
   <li class="nav-item">
-    <a class="nav-link" href="{{ url('/table/search', {'db': db, 'table': table, 'pos': 0}) }}">
+    <a class="nav-link disableAjax" href="{{ url('/table/search', {'db': db, 'table': table, 'pos': 0}) }}">
       {{ get_icon('b_search', 'Table search'|trans, false, false, 'TabsMode') }}
     </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link active" href="{{ url('/table/zoom-search', {'db': db, 'table': table}) }}">
+    <a class="nav-link active disableAjax" href="{{ url('/table/zoom-search', {'db': db, 'table': table}) }}">
       {{ get_icon('b_select', 'Zoom search'|trans, false, false, 'TabsMode') }}
     </a>
   </li>
 
   <li class="nav-item">
-    <a class="nav-link" href="{{ url('/table/find-replace', {'db': db, 'table': table}) }}">
+    <a class="nav-link disableAjax" href="{{ url('/table/find-replace', {'db': db, 'table': table}) }}">
       {{ get_icon('b_find_replace', 'Find and replace'|trans, false, false, 'TabsMode') }}
     </a>
   </li>

--- a/templates/top_menu.twig
+++ b/templates/top_menu.twig
@@ -8,7 +8,7 @@
       <ul id="topmenu" class="navbar-nav">
         {% for tab in tabs %}
           <li class="nav-item{{ tab.active ? ' active' }}">
-            <a class="nav-link text-nowrap" href="{{ url(tab.route, url_params|merge(tab.args ?? [])) }}">
+            <a class="nav-link text-nowrap disableAjax" href="{{ url(tab.route, url_params|merge(tab.args ?? [])) }}">
               {{ get_icon(tab.icon, tab.text, false, true, 'TabsMode') }}
               {% if tab.active %}
                 <span class="visually-hidden">{% trans %}(current){% notes %}Current page{% endtrans %}</span>

--- a/test/selenium/ServerSettingsTest.php
+++ b/test/selenium/ServerSettingsTest.php
@@ -27,8 +27,6 @@ class ServerSettingsTest extends TestBase
         $this->expandMore();
         $this->waitForElement('partialLinkText', 'Settings')->click();
         $this->waitAjax();
-
-        $this->waitForElement('xpath', "//a[@class='nav-link text-nowrap' and contains(., 'Settings')]");
     }
 
     /**

--- a/test/selenium/Table/CreateTest.php
+++ b/test/selenium/Table/CreateTest.php
@@ -16,11 +16,7 @@ class CreateTest extends TestBase
         parent::setUp();
 
         $this->login();
-        $this->waitForElement('partialLinkText', 'Databases')->click();
-        $this->waitAjax();
-
-        // go to specific database page
-        $this->waitForElement('partialLinkText', $this->databaseName)->click();
+        $this->navigateDatabase($this->databaseName);
     }
 
     /**

--- a/test/selenium/Table/OperationsTest.php
+++ b/test/selenium/Table/OperationsTest.php
@@ -218,8 +218,6 @@ class OperationsTest extends TestBase
             '//div[@class=\'alert alert-success\' and contains(., \'MySQL returned an empty result set\')]',
         );
 
-        $this->waitForElement('xpath', "//a[@class='nav-link text-nowrap' and contains(., 'Structure')]");
-
         $this->dbQuery(
             'USE `' . $this->databaseName . '`;'
             . 'SHOW TABLES',

--- a/test/selenium/TestBase.php
+++ b/test/selenium/TestBase.php
@@ -959,8 +959,6 @@ abstract class TestBase extends TestCase
         // go to table page
         $this->waitForElement('xpath', "//th//a[contains(., '" . $table . "')]")->click();
         $this->waitAjax();
-
-        $this->waitForElement('xpath', "//a[@class='nav-link text-nowrap' and contains(., 'Browse')]");
     }
 
     /**
@@ -985,9 +983,6 @@ abstract class TestBase extends TestCase
             '//tr[(contains(@class, "db-row"))]//a[contains(., "' . $database . '")]',
         )->click();
         $this->waitAjax();
-
-        // Wait for it to load
-        $this->waitForElement('xpath', "//a[@class='nav-link text-nowrap' and contains(., 'Structure')]");
     }
 
     /**


### PR DESCRIPTION
Each page is a different page, so it makes more sense to do a full page reload instead of using AJAX to load the main content.

This also avoid some possible issues with broken event handlers and not properly loaded pages.
