### PR TITLE
Fix countRecords return int instead of mixed

### DIFF
--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -411,9 +411,9 @@ class Sql
      * @param string $db    the current database
      * @param string $table the current table
      *
-     * @return mixed the number of rows if "retain" param is true, otherwise true
+     * @return int the number of rows
      */
-    public function findRealEndOfRows($db, $table): mixed
+    public function findRealEndOfRows($db, $table): int
     {
         $unlimNumRows = $this->dbi->getTable($db, $table)->countRecords(true);
         $_SESSION['tmpval']['pos'] = $this->getStartPosToDisplayRow($unlimNumRows);
@@ -679,8 +679,7 @@ class Sql
                      * @todo In countRecords(), MaxExactCount is also verified,
                      *       so can we avoid checking it twice?
                      */
-                    $unlimNumRows = $this->dbi->getTable($db, $table)
-                        ->countRecords(true);
+                    $unlimNumRows = $this->dbi->getTable($db, $table)->countRecords(true);
                 }
             } else {
                 $statement = $statementInfo->statement;
@@ -702,10 +701,7 @@ class Sql
 
                 $countQuery = 'SELECT COUNT(*) FROM (' . $statement->build() . ' ) as cnt';
 
-                $unlimNumRows = $this->dbi->fetchValue($countQuery);
-                if ($unlimNumRows === false) {
-                    $unlimNumRows = 0;
-                }
+                $unlimNumRows = (int) $this->dbi->fetchValue($countQuery);
             }
         } else {// not $is_select
             $unlimNumRows = 0;

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -37,6 +37,7 @@ use function htmlspecialchars;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_numeric;
 use function is_string;
 use function json_decode;
 use function json_encode;
@@ -688,24 +689,21 @@ class Table implements Stringable
     }
 
     /**
-     * Counts and returns (or displays) the number of records in a table
+     * Counts the number of records in a table
      *
      * @param bool $forceExact whether to force an exact count
-     *
-     * @return mixed the number of records if "retain" param is true,
-     *               otherwise true
      */
-    public function countRecords($forceExact = false): mixed
+    public function countRecords($forceExact = false): int
     {
         $isView = $this->isView();
         $cache = $this->dbi->getCache();
 
         $exactRowsCached = $cache->getCachedTableContent([$this->dbName, $this->name, 'ExactRows']);
-        if ($exactRowsCached != null) {
-            return $exactRowsCached;
+        if ($exactRowsCached !== null) {
+            return (int) $exactRowsCached;
         }
 
-        $rowCount = false;
+        $rowCount = null;
 
         if (! $forceExact) {
             if (($cache->getCachedTableContent([$this->dbName, $this->name, 'Rows']) == null) && ! $isView) {
@@ -715,12 +713,12 @@ class Table implements Stringable
                 }
             }
 
-            $rowCount = $cache->getCachedTableContent([$this->dbName, $this->name, 'Rows']) ?? false;
+            $rowCount = $cache->getCachedTableContent([$this->dbName, $this->name, 'Rows']);
         }
 
         // for a VIEW, $row_count is always false at this point
-        if ($rowCount !== false && $rowCount >= $GLOBALS['cfg']['MaxExactCount']) {
-            return $rowCount;
+        if ($rowCount !== null && $rowCount >= $GLOBALS['cfg']['MaxExactCount']) {
+            return (int) $rowCount;
         }
 
         if (! $isView) {
@@ -751,11 +749,13 @@ class Table implements Stringable
             }
         }
 
-        if ($rowCount) {
-            $cache->cacheTableContent([$this->dbName, $this->name, 'ExactRows'], $rowCount);
+        if (is_numeric($rowCount)) {
+            $cache->cacheTableContent([$this->dbName, $this->name, 'ExactRows'], (int) $rowCount);
+
+            return (int) $rowCount;
         }
 
-        return $rowCount;
+        return 0;
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -931,7 +931,7 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getForeignData\\(\\) should return array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, non\\-empty\\-array\\>\\|null, foreign_field\\: mixed\\} but returns array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, array\\<string, string\\|null\\>\\>\\|null, foreign_field\\: mixed\\}\\.$#"
+			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getForeignData\\(\\) should return array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, non\\-empty\\-array\\>\\|null, foreign_field\\: mixed\\} but returns array\\{foreign_link\\: bool, the_total\\: int\\|string\\|null, foreign_display\\: string, disp_row\\: array\\<int, array\\<string, string\\|null\\>\\>\\|null, foreign_field\\: mixed\\}\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 
@@ -8181,7 +8181,7 @@ parameters:
 			path: libraries/classes/Sql.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Sql\\:\\:countQueryResults\\(\\) should return int\\|numeric\\-string but returns mixed\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Sql\\:\\:countQueryResults\\(\\) should return int\\|numeric\\-string but returns float\\|int\\|numeric\\-string\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
 
@@ -8283,11 +8283,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$dtResult of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getTable\\(\\) expects PhpMyAdmin\\\\Dbal\\\\ResultInterface, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|null given\\.$#"
 			count: 1
-			path: libraries/classes/Sql.php
-
-		-
-			message: "#^Parameter \\#1 \\$numberOfLine of method PhpMyAdmin\\\\Sql\\:\\:getStartPosToDisplayRow\\(\\) expects int, mixed given\\.$#"
-			count: 2
 			path: libraries/classes/Sql.php
 
 		-
@@ -8407,7 +8402,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
+			count: 3
 			path: libraries/classes/Table.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -847,7 +847,6 @@
       <code>$key</code>
       <code>$one_key</code>
       <code>$relations</code>
-      <code>$the_total</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
@@ -1742,9 +1741,6 @@
       <code>$createTime</code>
       <code>$createTimeAll</code>
       <code>$currentTable</code>
-      <code><![CDATA[$currentTable['Rows']]]></code>
-      <code><![CDATA[$currentTable['TABLE_ROWS']]]></code>
-      <code><![CDATA[$currentTable['TABLE_ROWS']]]></code>
       <code>$dbTable</code>
       <code>$favoriteTables</code>
       <code>$overheadSize</code>
@@ -3303,7 +3299,6 @@
       <code><![CDATA[$GLOBALS['sql_query']]]></code>
       <code><![CDATA[$GLOBALS['table_from_sql']]]></code>
       <code><![CDATA[$GLOBALS['unlim_num_rows']]]></code>
-      <code><![CDATA[$GLOBALS['unlim_num_rows']]]></code>
       <code>$bkm_all_users</code>
       <code>$sql_query</code>
     </MixedAssignment>
@@ -4046,7 +4041,6 @@
       <code>$column_name</code>
       <code>$column_name</code>
       <code>$curr_rel_field</code>
-      <code><![CDATA[$extra_data['row_count']]]></code>
       <code>$multi_edit_auto_increment</code>
       <code>$multi_edit_columns</code>
       <code>$multi_edit_columns[$key]</code>
@@ -5618,7 +5612,6 @@
       <code><![CDATA[$this->formAndOrCols[$lastWhere]]]></code>
       <code>$tsize[$table]</code>
       <code>$tsize[$table]</code>
-      <code>$tsize[$table]</code>
     </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS[${'cur' . $or}][$newColumnCount]]]></code>
@@ -5638,7 +5631,6 @@
       <code>$indexColumns</code>
       <code>$isWhere</code>
       <code>$masterTable</code>
-      <code>$maxsize</code>
       <code>$name</code>
       <code>$oneField</code>
       <code>$oneKey</code>
@@ -5655,7 +5647,6 @@
       <code>$table</code>
       <code>$tempSearchTables[]</code>
       <code>$tmpCriteria</code>
-      <code>$tsize[$table]</code>
       <code>$uniqueColumns</code>
       <code>$value</code>
       <code>$whereClauseColumns</code>
@@ -6660,7 +6651,6 @@
       <code>$sqlQuery</code>
       <code>$sqlQueryAdd</code>
       <code>$tableCreateTime</code>
-      <code>$theTotal</code>
       <code>$total</code>
       <code>$value</code>
       <code><![CDATA[$whereClauseMap[$rowNumber][$meta->orgtable]]]></code>
@@ -13205,9 +13195,6 @@
       <code><![CDATA[$GLOBALS['show_as_php']]]></code>
       <code><![CDATA[$GLOBALS['show_as_php']]]></code>
     </InvalidArrayOffset>
-    <LessSpecificReturnStatement>
-      <code>$unlimNumRows</code>
-    </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$columns[$indexColumnName]['Extra']]]></code>
       <code><![CDATA[$extraData['error']]]></code>
@@ -13218,8 +13205,6 @@
       <code><![CDATA[$oneResult['Status']]]></code>
       <code>$sortCol</code>
       <code><![CDATA[$statement->expr]]></code>
-      <code>$unlimNumRows</code>
-      <code>$unlimNumRows</code>
       <code>Message::sanitize($warning)</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
@@ -13262,10 +13247,6 @@
       <code>$resultSetColumnNames[]</code>
       <code>$sortCol</code>
       <code>$unlimNumRows</code>
-      <code>$unlimNumRows</code>
-      <code>$unlimNumRows</code>
-      <code>$unlimNumRows</code>
-      <code>$unlimNumRows</code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>int</code>
@@ -13293,6 +13274,7 @@
       <code>$pos</code>
       <code>$row[$column]</code>
       <code>$unlimNumRows</code>
+      <code>$unlimNumRows</code>
       <code>@((int) ceil($numberOfLine / $maxRows) - 1) * $maxRows</code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion>
@@ -13302,9 +13284,6 @@
     <NoValue>
       <code><![CDATA[$statementInfo->statement->where]]></code>
     </NoValue>
-    <NullableReturnStatement>
-      <code>$unlimNumRows</code>
-    </NullableReturnStatement>
     <PossiblyInvalidArgument>
       <code><![CDATA[$_POST['bkm_label']]]></code>
       <code><![CDATA[$_POST['dropped_column'] ?? null]]></code>
@@ -13570,7 +13549,6 @@
       <code>$constraintName</code>
       <code>$currCreateTime</code>
       <code>$eachCol</code>
-      <code>$exactRowsCached</code>
       <code>$foreignDb</code>
       <code>$foreignDb</code>
       <code>$foreignField</code>
@@ -13593,7 +13571,6 @@
       <code>$tableAutoIncrement</code>
       <code>$tableCollation</code>
       <code>$tableComment</code>
-      <code>$tableNumRowInfo</code>
       <code>$tableNumRowInfo</code>
       <code>$tableOptions</code>
       <code>$tableRowFormat</code>
@@ -14427,7 +14404,6 @@
       <code>$p</code>
       <code>$p</code>
       <code>$row</code>
-      <code>$rowCount</code>
       <code>$table</code>
       <code>$table</code>
       <code><![CDATA[$table['disp_name']]]></code>
@@ -14436,7 +14412,6 @@
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>array</code>
-      <code>int</code>
       <code>int</code>
     </MixedInferredReturnType>
     <MixedOperand>
@@ -14448,8 +14423,6 @@
     <MixedReturnStatement>
       <code><![CDATA[$_SESSION['tmpval']['table_limit_offset']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['table_limit_offset']]]></code>
-      <code>$rowCount</code>
-      <code>$rowCount</code>
       <code>$tableGroups</code>
     </MixedReturnStatement>
     <PossiblyFalseOperand>


### PR DESCRIPTION
Fixes #18152
This method was always expected to return an int, but it was typed as mixed. We can force int as a return type. 