### PR TITLE
Clean up is_foreign_key_supported

### DIFF
--- a/libraries/classes/Controllers/Table/RelationController.php
+++ b/libraries/classes/Controllers/Table/RelationController.php
@@ -58,7 +58,7 @@ final class RelationController extends AbstractController
         ];
 
         $table = $this->dbi->getTable($GLOBALS['db'], $GLOBALS['table']);
-        $storageEngine = mb_strtoupper((string) $table->getStatusInfo('Engine'));
+        $storageEngine = $table->getStorageEngine();
 
         $relationParameters = $this->relation->getRelationParameters();
 
@@ -198,9 +198,8 @@ final class RelationController extends AbstractController
         ]);
 
         // common form
-        $engine = $this->dbi->getTable($GLOBALS['db'], $GLOBALS['table'])->getStorageEngine();
         $this->render('table/relation/common_form', [
-            'is_foreign_key_supported' => ForeignKey::isSupported($engine),
+            'is_foreign_key_supported' => ForeignKey::isSupported($storageEngine),
             'db' => $GLOBALS['db'],
             'table' => $GLOBALS['table'],
             'relation_parameters' => $relationParameters,

--- a/libraries/classes/Twig/UtilExtension.php
+++ b/libraries/classes/Twig/UtilExtension.php
@@ -7,7 +7,6 @@ namespace PhpMyAdmin\Twig;
 use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Html\MySQLDocumentation;
 use PhpMyAdmin\Util;
-use PhpMyAdmin\Utils\ForeignKey;
 use PhpMyAdmin\Utils\Gis;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -85,10 +84,6 @@ class UtilExtension extends AbstractExtension
             new TwigFunction(
                 'is_uuid_supported',
                 Util::isUUIDSupported(...),
-            ),
-            new TwigFunction(
-                'is_foreign_key_supported',
-                ForeignKey::isSupported(...),
             ),
             new TwigFunction(
                 'link_or_button',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2301,11 +2301,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/IndexesController.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/RelationController.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Table\\\\RelationController\\:\\:updateForForeignKeys\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/RelationController.php

--- a/templates/table/relation/common_form.twig
+++ b/templates/table/relation/common_form.twig
@@ -4,7 +4,7 @@
 <form method="post" action="{{ url('/table/relation') }}">
     {{ get_hidden_inputs(db, table) }}
     {# InnoDB #}
-    {% if is_foreign_key_supported(tbl_storage_engine) %}
+    {% if is_foreign_key_supported %}
         <fieldset class="pma-fieldset mb-3">
             <legend>{% trans 'Foreign key constraints' %}</legend>
             <div class="table-responsive-md jsresponsive">
@@ -51,7 +51,7 @@
     {% endif %}
 
     {% if relation_parameters.relationFeature is not null %}
-        {% if default_sliders_state != 'disabled' and is_foreign_key_supported(tbl_storage_engine) %}
+        {% if default_sliders_state != 'disabled' and is_foreign_key_supported %}
         <div class="mb-3">
           <button class="btn btn-sm btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#internalRelationships" aria-expanded="{{ default_sliders_state == 'open' ? 'true' : 'false' }}" aria-controls="internalRelationships">
             {% trans 'Internal relationships' %}
@@ -71,7 +71,7 @@
                     <th>{% trans 'Column' %}</th>
                     <th>
                       {% trans 'Internal relation' %}
-                      {% if is_foreign_key_supported(tbl_storage_engine) %}
+                      {% if is_foreign_key_supported %}
                         {{ show_hint('An internal relation is not necessary when a corresponding FOREIGN KEY relation exists.'|trans) }}
                       {% endif %}
                     </th>
@@ -148,7 +148,7 @@
                 </tbody>
             </table>
         </fieldset>
-        {% if default_sliders_state != 'disabled' and is_foreign_key_supported(tbl_storage_engine) %}
+        {% if default_sliders_state != 'disabled' and is_foreign_key_supported %}
         </div>
         {% endif %}
     {% endif %}


### PR DESCRIPTION
This is needed to make typed params. This was unnecessary duplication and the function does not need to be a Twig extension. 