### PR TITLE
Remove useless Message::format() method

### DIFF
--- a/libraries/classes/Message.php
+++ b/libraries/classes/Message.php
@@ -8,8 +8,6 @@ use Stringable;
 
 use function __;
 use function _ngettext;
-use function array_unshift;
-use function count;
 use function htmlspecialchars;
 use function is_array;
 use function is_float;
@@ -585,23 +583,6 @@ class Message implements Stringable
     }
 
     /**
-     * wrapper for sprintf()
-     *
-     * @param mixed[] ...$params Params
-     *
-     * @return string formatted
-     */
-    public static function format(...$params): string
-    {
-        if (isset($params[1]) && is_array($params[1])) {
-            array_unshift($params[1], $params[0]);
-            $params = $params[1];
-        }
-
-        return sprintf(...$params);
-    }
-
-    /**
      * returns unique Message::$hash, if not exists it will be created
      *
      * @return string Message::$hash
@@ -636,8 +617,8 @@ class Message implements Stringable
             $message = $this->getMessageWithIcon($message);
         }
 
-        if (count($this->getParams()) > 0) {
-            $message = self::format($message, $this->getParams());
+        if ($this->params !== []) {
+            $message = sprintf($message, ...$this->params);
         }
 
         if ($this->useBBCode) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5611,11 +5611,6 @@ parameters:
 			path: libraries/classes/Message.php
 
 		-
-			message: "#^Right side of && is always true\\.$#"
-			count: 1
-			path: libraries/classes/Message.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Navigation\\\\Navigation\\:\\:getHiddenItems\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Navigation/Navigation.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9302,12 +9302,8 @@
     </PossiblyFalseOperand>
   </file>
   <file src="libraries/classes/Message.php">
-    <InvalidArgument>
-      <code>$message</code>
-    </InvalidArgument>
     <MixedArgument>
-      <code>$params</code>
-      <code>$params</code>
+      <code><![CDATA[$this->params]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code>$add_message</code>
@@ -9329,10 +9325,6 @@
     <MixedReturnStatement>
       <code><![CDATA[self::$level[$this->getNumber()]]]></code>
     </MixedReturnStatement>
-    <RedundantConditionGivenDocblockType>
-      <code>is_array($params[1])</code>
-      <code><![CDATA[isset($params[1]) && is_array($params[1])]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/Navigation/Navigation.php">
     <DeprecatedMethod>
@@ -16797,13 +16789,6 @@
     </InvalidArgument>
   </file>
   <file src="test/classes/MessageTest.php">
-    <InvalidArgument>
-      <code><![CDATA['%s string']]></code>
-      <code><![CDATA['a']]></code>
-      <code><![CDATA['test string']]></code>
-      <code><![CDATA['test string']]></code>
-      <code><![CDATA['test string']]></code>
-    </InvalidArgument>
     <MixedInferredReturnType>
       <code>array</code>
       <code>array</code>

--- a/test/classes/MessageTest.php
+++ b/test/classes/MessageTest.php
@@ -392,29 +392,6 @@ class MessageTest extends AbstractTestCase
     }
 
     /**
-     * testing format method
-     */
-    public function testFormat(): void
-    {
-        $this->assertEquals(
-            'test string',
-            Message::format('test string'),
-        );
-        $this->assertEquals(
-            'test string',
-            Message::format('test string', 'a'),
-        );
-        $this->assertEquals(
-            'test string',
-            Message::format('test string', []),
-        );
-        $this->assertEquals(
-            'test string',
-            Message::format('%s string', ['test']),
-        );
-    }
-
-    /**
      * testing getHash method
      */
     public function testGetHash(): void


### PR DESCRIPTION
This is needed to create typed params.