### PR TITLE
Fix "IS NULL" is shown for non-nullable columns on search page

### DIFF
--- a/libraries/classes/Controllers/Table/SearchController.php
+++ b/libraries/classes/Controllers/Table/SearchController.php
@@ -157,7 +157,7 @@ class SearchController extends AbstractController
             }
 
             $this->columnTypes[] = $type;
-            $this->columnNullFlags[] = $row['Null'];
+            $this->columnNullFlags[] = $row['Null'] === 'YES';
             $this->columnCollations[] = ! empty($row['Collation']) && $row['Collation'] !== 'NULL'
                 ? $row['Collation']
                 : '';


### PR DESCRIPTION
Furthermore, this is a bug preventing adding typed params. 