### PR TITLE
Always use svg display in gis editor

### DIFF
--- a/templates/gis_data_editor_form.twig
+++ b/templates/gis_data_editor_form.twig
@@ -11,16 +11,14 @@
         {{ get_hidden_inputs() }}
 
         {# Visualization section #}
-        <!-- Always uses svg-view here added `and false` as a quick-fix -->
-        <div id="placeholder"{{ srid != 0 and false ? ' class="hide"' }}>
+        <div id="placeholder">
             {{ visualization|raw }}
         </div>
 
         <div id="openlayersmap" style="width: {{width}}px; height: {{height}}px;"{{ srid == 0 ? ' class="hide"' }}></div>
 
         <div class="choice float-end">
-            <!-- Always uses svg-view here added `and false` as a quick-fix -->
-            <input type="checkbox" id="choice" value="useBaseLayer"{{ srid != 0 and false ? ' checked="checked"' }}>
+            <input type="checkbox" id="choice" value="useBaseLayer">
             <label for="choice">{% trans "Use OpenStreetMaps as Base Layer" %}</label>
         </div>
 

--- a/templates/gis_data_editor_form.twig
+++ b/templates/gis_data_editor_form.twig
@@ -11,14 +11,16 @@
         {{ get_hidden_inputs() }}
 
         {# Visualization section #}
-        <div id="placeholder"{{ srid != 0 ? ' class="hide"' }}>
+        <!-- Always uses svg-view here added `and false` as a quick-fix -->
+        <div id="placeholder"{{ srid != 0 and false ? ' class="hide"' }}>
             {{ visualization|raw }}
         </div>
 
         <div id="openlayersmap" style="width: {{width}}px; height: {{height}}px;"{{ srid == 0 ? ' class="hide"' }}></div>
 
         <div class="choice float-end">
-            <input type="checkbox" id="choice" value="useBaseLayer"{{ srid != 0 ? ' checked="checked"' }}>
+            <!-- Always uses svg-view here added `and false` as a quick-fix -->
+            <input type="checkbox" id="choice" value="useBaseLayer"{{ srid != 0 and false ? ' checked="checked"' }}>
             <label for="choice">{% trans "Use OpenStreetMaps as Base Layer" %}</label>
         </div>
 


### PR DESCRIPTION
Editing geometries with SRID should display with OpenLayers visualization. As that doesn't work this now always uses the svg viewer.

Fixing the OpenLayers visualization here would be rather complicated.

Will provide a complete fix for master branch shortly ...