### PR TITLE
Fix inserting gis-data via insert/edit form

### DIFF
--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1605,7 +1605,11 @@ class InsertEdit
             in_array($multiEditFuncs[$key], $gisFromTextFunctions)
             || in_array($multiEditFuncs[$key], $gisFromWkbFunctions)
         ) {
-            return $multiEditFuncs[$key] . "('" . $this->dbi->escapeString($currentValue) . "')";
+            preg_match('/^(\'?)(.*?)\1(?:,(\d+))?$/', $currentValue, $matches);
+            $escapedParams = "'" . $this->dbi->escapeString($matches[2])
+                . (isset($matches[3]) ? "'," . $matches[3] : "'");
+
+            return $multiEditFuncs[$key] . '(' . $escapedParams . ')';
         }
 
         if (

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -2464,6 +2464,36 @@ class InsertEditTest extends AbstractTestCase
             '0'
         );
         $this->assertTrue(password_verify("a'c", mb_substr($result, 1, -1)));
+
+        // case 7 / 8 / 9 / 10
+        $gisParams = [
+            ['ST_GeomFromText'],
+            [],
+            ['ST_GeomFromText'],
+            "'POINT(3 4)',4326",
+            [],
+            [],
+            [],
+            '0',
+        ];
+        // case 7
+        $result = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(...$gisParams);
+        $this->assertEquals('ST_GeomFromText(\'POINT(3 4)\',4326)', $result);
+
+        // case 8
+        $gisParams[3] = "POINT(3 4),4326";
+        $result = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(...$gisParams);
+        $this->assertEquals('ST_GeomFromText(\'POINT(3 4)\',4326)', $result);
+
+        // case 9
+        $gisParams[3] = "'POINT(3 4)'";
+        $result = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(...$gisParams);
+        $this->assertEquals('ST_GeomFromText(\'POINT(3 4)\')', $result);
+
+        // case 10
+        $gisParams[3] = "POINT(3 4)";
+        $result = $this->insertEdit->getCurrentValueAsAnArrayForMultipleEdit(...$gisParams);
+        $this->assertEquals('ST_GeomFromText(\'POINT(3 4)\')', $result);
     }
 
     /**


### PR DESCRIPTION
Inserting or updating gis data via the form  does not work currently because the  single quotes in the input control are escaped by call to `escapeString`.

This PR correctly escapes the input and makes the single quotes in the input optional as they are not needed for correct parsing of the wkt + srid data.