### PR TITLE
Fix editing GEOMETRYCOLLECTION EMPTY

### DIFF
--- a/libraries/classes/Controllers/GisDataEditorController.php
+++ b/libraries/classes/Controllers/GisDataEditorController.php
@@ -15,10 +15,8 @@ use function array_merge;
 use function in_array;
 use function intval;
 use function is_array;
-use function mb_strpos;
 use function mb_strtoupper;
-use function mb_substr;
-use function substr;
+use function preg_match;
 use function trim;
 
 /**
@@ -38,7 +36,7 @@ class GisDataEditorController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        global $gis_data, $gis_types, $start, $geom_type, $gis_obj, $srid, $wkt, $wkt_with_zero;
+        global $gis_data, $geom_type, $gis_obj, $srid, $wkt, $wkt_with_zero;
         global $result, $visualizationSettings, $data, $visualization, $open_layers, $geom_count, $dbi;
 
         /** @var string|null $field */
@@ -160,9 +158,8 @@ class GisDataEditorController extends AbstractController
                 $gis_data['gis_type'] = mb_strtoupper($type);
             }
 
-            if (isset($value) && trim($value) !== '') {
-                $start = substr($value, 0, 1) == "'" ? 1 : 0;
-                $gis_data['gis_type'] = mb_substr($value, $start, (int) mb_strpos($value, '(') - $start);
+            if (isset($value) && trim($value) !== '' && preg_match('/^\'?(\w+)\b/', $value, $matches)) {
+                $gis_data['gis_type'] = $matches[1];
             }
 
             if (! isset($gis_data['gis_type']) || (! in_array($gis_data['gis_type'], self::GIS_TYPES, true))) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2071,14 +2071,6 @@
       <code>$whatStrucOrData</code>
     </PossiblyInvalidCast>
   </file>
-  <file src="libraries/classes/Controllers/GisDataEditorController.php">
-    <MixedArgument occurrences="1">
-      <code>$geom_type</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$geom_type</code>
-    </MixedAssignment>
-  </file>
   <file src="libraries/classes/Controllers/GitInfoController.php">
     <MixedArgument occurrences="3">
       <code>$commit['author']['date']</code>

--- a/test/classes/Controllers/GisDataEditorControllerTest.php
+++ b/test/classes/Controllers/GisDataEditorControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Test\Controllers;
+
+use PhpMyAdmin\Controllers\GisDataEditorController;
+use PhpMyAdmin\Template;
+use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+
+/**
+ * @covers \PhpMyAdmin\Controllers\GisDataEditorController
+ */
+class GisDataEditorControllerTest extends AbstractTestCase
+{
+    /** @var GisDataEditorController|null */
+    private $controller = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['server'] = 1;
+        $GLOBALS['text_dir'] = 'ltr';
+        $GLOBALS['PMA_PHP_SELF'] = 'index.php';
+        $GLOBALS['db'] = 'db';
+        $GLOBALS['table'] = 'table';
+
+        $this->controller = new GisDataEditorController(new ResponseRenderer(), new Template());
+    }
+
+    /**
+     * @param mixed[] $gis_data
+     * @param mixed[] $expected
+     *
+     * @group gis
+     * @dataProvider providerForTestValidateGisData
+     */
+    public function testValidateGisData(array $gis_data, string $type, ?string $value, array $expected): void
+    {
+        /** @var mixed[] $gisData */
+        $gisData = $this->callFunction(
+            $this->controller,
+            GisDataEditorController::class,
+            'validateGisData',
+            [
+                $gis_data,
+                $type,
+                $value,
+            ]
+        );
+        $this->assertEquals($expected, $gisData);
+    }
+
+    /**
+     * @return list<list<mixed[]|string|null>>
+     * @psalm-return list<array{0:mixed[],1:string,2:string|null,3:mixed[]}>
+     */
+    public static function providerForTestValidateGisData(): array
+    {
+        /** @psalm-var list<array{0:mixed[],1:string,2:string|null,3:mixed[]}> */
+        return [
+            [
+                [],
+                'GEOMETRY',
+                'GEOMETRYCOLLECTION()',
+                ['gis_type' => 'GEOMETRYCOLLECTION'],
+            ],
+            [
+                [],
+                'GEOMETRY',
+                'GEOMETRYCOLLECTION EMPTY',
+                ['gis_type' => 'GEOMETRYCOLLECTION'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
An empty geometry collection has two valid representations in wkt and MariaDB uses the latter when fetching data, which breaks editing.
`GEOMETRYCOLLECTION()` and `GEOMETRYCOLLECTION EMPTY`

With this change both formats can be successfully edited.