### PR TITLE
Fix warning on non-existent table

### DIFF
--- a/libraries/classes/Plugins/Export/ExportXml.php
+++ b/libraries/classes/Plugins/Export/ExportXml.php
@@ -275,6 +275,11 @@ class ExportXml extends ExportPlugin
                     . Util::backquote($table),
                     0
                 );
+
+                if ($result === []) {
+                    continue;
+                }
+
                 $tbl = (string) $result[$table][1];
 
                 $is_view = $dbi->getTable($db, $table)


### PR DESCRIPTION
Fixes #18195

I think this bug should manifest itself in a lot more places. The codebase is not very strict when it comes to validating input data. 