### PR TITLE
Fix #18093 - Checks if username is defined

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -516,7 +516,7 @@ Functions.checkPasswordStrength = function (value, meterObject, meterObjectLabel
         'my',
         'admin',
     ];
-    if (username !== null) {
+    if (username) {
         customDict.push(username);
     }
 
@@ -584,7 +584,7 @@ Functions.suggestPassword = function (passwordForm) {
     passwordForm.elements.pma_pw2.value = passwd.value;
     var meterObj = $jQueryPasswordForm.find('meter[name="pw_meter"]').first();
     var meterObjLabel = $jQueryPasswordForm.find('span[name="pw_strength"]').first();
-    Functions.checkPasswordStrength(passwd.value, meterObj, meterObjLabel);
+    Functions.checkPasswordStrength(passwd.value, meterObj, meterObjLabel, passwordForm.elements.username.value);
     return true;
 };
 


### PR DESCRIPTION
### Description

Checks if username is defined and I've also added the username to the dictionary, because it was missing.

Even if there's no error given on 5.2.2-dev, I've targeted QA_5_2 because the bug is there.

Fixes #18093

Before:

https://user-images.githubusercontent.com/25424343/222841580-9889ced3-7ab7-4593-86dc-545a201ad29c.mp4

After:

https://user-images.githubusercontent.com/25424343/222842103-df520b61-db3d-4298-bf28-a87db40c863b.mp4