### PR TITLE
Drop getDbnameAndOptions method and add named argument

### DIFF
--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -956,6 +956,7 @@ class Import
         array &$tables,
         array|null $analyses = null,
         array|null &$additionalSql = null,
+        bool $createDb = true,
         array|null $options = null,
         array &$sqlData = [],
     ): void {
@@ -967,7 +968,6 @@ class Import
         /* Take care of the options */
         $collation = $options['db_collation'] ?? 'utf8_general_ci';
         $charset = $options['db_charset'] ?? 'utf8';
-        $createDb = $options['create_db'] ?? true;
 
         /**
          * Create SQL code to handle the database

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -592,20 +592,6 @@ class ImportCsv extends AbstractImportCsv
             $analyses[] = $this->import->analyzeTable($tables[0]);
 
             /**
-             * string $db_name (no backquotes)
-             *
-             * array $table = array(table_name, array() column_names, array()() rows)
-             * array $tables = array of "$table"s
-             *
-             * array $analysis = array(array() column_types, array() column_sizes)
-             * array $analyses = array of "$analysis"s
-             *
-             * array $create = array of SQL strings
-             *
-             * array $options = an associative array of options
-             */
-
-            /**
              * Set database name to the currently selected one, if applicable,
              * Otherwise, check if user provided the database name in the request,
              * if not, set the default name
@@ -619,15 +605,10 @@ class ImportCsv extends AbstractImportCsv
             }
 
             $db_name = $GLOBALS['db'] !== '' ? $GLOBALS['db'] : $newDb;
-            $options = $GLOBALS['db'] !== '' ? ['create_db' => false] :null;
-
-            /* Non-applicable parameters */
-            $create = null;
+            $createDb = $GLOBALS['db'] === '';
 
             /* Created and execute necessary SQL statements from data */
-            $this->import->buildSql($db_name, $tables, $analyses, $create, $options, $sqlStatements);
-
-            unset($tables, $analyses);
+            $this->import->buildSql($db_name, $tables, $analyses, createDb:$createDb, sqlData:$sqlStatements);
         }
 
         // Commit any possible data in buffers

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -618,7 +618,8 @@ class ImportCsv extends AbstractImportCsv
                 $newDb = 'CSV_DB ' . (count($result) + 1);
             }
 
-            [$db_name, $options] = $this->getDbnameAndOptions($GLOBALS['db'], $newDb);
+            $db_name = $GLOBALS['db'] !== '' ? $GLOBALS['db'] : $newDb;
+            $options = $GLOBALS['db'] !== '' ? ['create_db' => false] :null;
 
             /* Non-applicable parameters */
             $create = null;

--- a/libraries/classes/Plugins/Import/ImportMediawiki.php
+++ b/libraries/classes/Plugins/Import/ImportMediawiki.php
@@ -378,10 +378,8 @@ class ImportMediawiki extends ImportPlugin
      */
     private function executeImportTables(array &$tables, array $analyses, array &$sqlStatements): void
     {
-        // $db_name : The currently selected database name, if applicable
-        //            No backquotes
-        // $options : An associative array of options
-        [$db_name, $options] = $this->getDbnameAndOptions($GLOBALS['db'], 'mediawiki_DB');
+        $db_name = $GLOBALS['db'] !== '' ? $GLOBALS['db'] : 'mediawiki_DB';
+        $options = $GLOBALS['db'] !== '' ? ['create_db' => false] :null;
 
         // Array of SQL strings
         // Non-applicable parameters

--- a/libraries/classes/Plugins/Import/ImportMediawiki.php
+++ b/libraries/classes/Plugins/Import/ImportMediawiki.php
@@ -379,14 +379,10 @@ class ImportMediawiki extends ImportPlugin
     private function executeImportTables(array &$tables, array $analyses, array &$sqlStatements): void
     {
         $db_name = $GLOBALS['db'] !== '' ? $GLOBALS['db'] : 'mediawiki_DB';
-        $options = $GLOBALS['db'] !== '' ? ['create_db' => false] :null;
-
-        // Array of SQL strings
-        // Non-applicable parameters
-        $create = null;
+        $createDb = $GLOBALS['db'] === '';
 
         // Create and execute necessary SQL statements from data
-        $this->import->buildSql($db_name, $tables, $analyses, $create, $options, $sqlStatements);
+        $this->import->buildSql($db_name, $tables, $analyses, createDb:$createDb, sqlData:$sqlStatements);
     }
 
     /**

--- a/libraries/classes/Plugins/Import/ImportOds.php
+++ b/libraries/classes/Plugins/Import/ImportOds.php
@@ -204,7 +204,8 @@ class ImportOds extends ImportPlugin
          */
 
         /* Set database name to the currently selected one, if applicable */
-        [$db_name, $options] = $this->getDbnameAndOptions($GLOBALS['db'], 'ODS_DB');
+        $db_name = $GLOBALS['db'] !== '' ? $GLOBALS['db'] : 'ODS_DB';
+        $options = $GLOBALS['db'] !== '' ? ['create_db' => false] :null;
 
         /* Non-applicable parameters */
         $create = null;

--- a/libraries/classes/Plugins/Import/ImportOds.php
+++ b/libraries/classes/Plugins/Import/ImportOds.php
@@ -189,31 +189,12 @@ class ImportOds extends ImportPlugin
             $analyses[] = $this->import->analyzeTable($tables[$i]);
         }
 
-        /**
-         * string $db_name (no backquotes)
-         *
-         * array $table = array(table_name, array() column_names, array()() rows)
-         * array $tables = array of "$table"s
-         *
-         * array $analysis = array(array() column_types, array() column_sizes)
-         * array $analyses = array of "$analysis"s
-         *
-         * array $create = array of SQL strings
-         *
-         * array $options = an associative array of options
-         */
-
         /* Set database name to the currently selected one, if applicable */
         $db_name = $GLOBALS['db'] !== '' ? $GLOBALS['db'] : 'ODS_DB';
-        $options = $GLOBALS['db'] !== '' ? ['create_db' => false] :null;
-
-        /* Non-applicable parameters */
-        $create = null;
+        $createDb = $GLOBALS['db'] === '';
 
         /* Created and execute necessary SQL statements from data */
-        $this->import->buildSql($db_name, $tables, $analyses, $create, $options, $sqlStatements);
-
-        unset($tables, $analyses);
+        $this->import->buildSql($db_name, $tables, $analyses, createDb:$createDb, sqlData:$sqlStatements);
 
         /* Commit any possible data in buffers */
         $this->import->runQuery('', $sqlStatements);

--- a/libraries/classes/Plugins/Import/ImportShp.php
+++ b/libraries/classes/Plugins/Import/ImportShp.php
@@ -286,13 +286,8 @@ class ImportShp extends ImportPlugin
         $analyses[$table_no][Import::FORMATTEDSQL][$spatial_col] = true;
 
         // Set database name to the currently selected one, if applicable
-        if (strlen((string) $GLOBALS['db']) > 0) {
-            $db_name = $GLOBALS['db'];
-            $options = ['create_db' => false];
-        } else {
-            $db_name = 'SHP_DB';
-            $options = null;
-        }
+        $db_name = $GLOBALS['db'] !== '' ? $GLOBALS['db'] : 'SHP_DB';
+        $options = $GLOBALS['db'] !== '' ? ['create_db' => false] :null;
 
         // Created and execute necessary SQL statements from data
         $null_param = null;

--- a/libraries/classes/Plugins/Import/ImportShp.php
+++ b/libraries/classes/Plugins/Import/ImportShp.php
@@ -287,14 +287,11 @@ class ImportShp extends ImportPlugin
 
         // Set database name to the currently selected one, if applicable
         $db_name = $GLOBALS['db'] !== '' ? $GLOBALS['db'] : 'SHP_DB';
-        $options = $GLOBALS['db'] !== '' ? ['create_db' => false] :null;
+        $createDb = $GLOBALS['db'] === '';
 
         // Created and execute necessary SQL statements from data
-        $null_param = null;
         $sqlStatements = [];
-        $this->import->buildSql($db_name, $tables, $analyses, $null_param, $options, $sqlStatements);
-
-        unset($tables, $analyses);
+        $this->import->buildSql($db_name, $tables, $analyses, createDb:$createDb, sqlData:$sqlStatements);
 
         $GLOBALS['finished'] = true;
         $GLOBALS['error'] = false;

--- a/libraries/classes/Plugins/Import/ImportXml.php
+++ b/libraries/classes/Plugins/Import/ImportXml.php
@@ -310,25 +310,11 @@ class ImportXml extends ImportPlugin
             }
         }
 
-        /**
-         * string $db_name (no backquotes)
-         *
-         * array $table = array(table_name, array() column_names, array()() rows)
-         * array $tables = array of "$table"s
-         *
-         * array $analysis = array(array() column_types, array() column_sizes)
-         * array $analyses = array of "$analysis"s
-         *
-         * array $create = array of SQL strings
-         *
-         * array $options = an associative array of options
-         */
-
         /* Set database name to the currently selected one, if applicable */
-        if (strlen((string) $GLOBALS['db'])) {
+        if ($GLOBALS['db'] !== '') {
             /* Override the database name in the XML file, if one is selected */
             $db_name = $GLOBALS['db'];
-            $options = ['create_db' => false];
+            $options = null;
         } else {
             /* Set database collation/charset */
             $options = [
@@ -337,11 +323,11 @@ class ImportXml extends ImportPlugin
             ];
         }
 
+        $createDb = $GLOBALS['db'] === '';
+
         /* Created and execute necessary SQL statements from data */
         $sqlStatements = [];
-        $this->import->buildSql($db_name, $tables, $analyses, $create, $options, $sqlStatements);
-
-        unset($analyses, $tables, $create);
+        $this->import->buildSql($db_name, $tables, $analyses, $create, $createDb, $options, $sqlStatements);
 
         /* Commit any possible data in buffers */
         $this->import->runQuery('', $sqlStatements);

--- a/libraries/classes/Plugins/ImportPlugin.php
+++ b/libraries/classes/Plugins/ImportPlugin.php
@@ -12,8 +12,6 @@ use PhpMyAdmin\Import;
 use PhpMyAdmin\Properties\Plugins\ImportPluginProperties;
 use PhpMyAdmin\Properties\Plugins\PluginPropertyItem;
 
-use function strlen;
-
 /**
  * Provides a common interface that will have to be implemented by all of the
  * import plugins.
@@ -62,30 +60,6 @@ abstract class ImportPlugin implements Plugin
      * Sets the export plugins properties and is implemented by each import plugin.
      */
     abstract protected function setProperties(): ImportPluginProperties;
-
-    /**
-     * Define DB name and options
-     *
-     * @param string $currentDb DB
-     * @param string $defaultDb Default DB name
-     *
-     * @return array DB name and options (an associative array of options)
-     */
-    protected function getDbnameAndOptions($currentDb, $defaultDb): array
-    {
-        $db_name = $defaultDb;
-        $options = null;
-
-        if (strlen((string) $currentDb) > 0) {
-            $db_name = $currentDb;
-            $options = ['create_db' => false];
-        }
-
-        return [
-            $db_name,
-            $options,
-        ];
-    }
 
     public static function isAvailable(): bool
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6761,16 +6761,6 @@ parameters:
 			path: libraries/classes/Plugins/Import/Upload/UploadSession.php
 
 		-
-			message: "#^Casting to string something that's already string\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/ImportPlugin.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\ImportPlugin\\:\\:getDbnameAndOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/ImportPlugin.php
-
-		-
 			message: "#^Parameter \\#2 \\$masterField of method PhpMyAdmin\\\\Plugins\\\\Schema\\\\Dia\\\\DiaRelationSchema\\:\\:addRelation\\(\\) expects string, \\(int\\|string\\) given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Schema/Dia/DiaRelationSchema.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8077,7 +8077,6 @@
       <code>$cellValue</code>
       <code>$charset</code>
       <code>$collation</code>
-      <code>$createDb</code>
       <code>$importPlugin</code>
       <code>$size</code>
       <code>$size</code>
@@ -10785,9 +10784,7 @@
       <code><![CDATA[$GLOBALS['csv_new_line']]]></code>
       <code>$col_name</code>
       <code>$columnNames</code>
-      <code>$db_name</code>
       <code><![CDATA[$field['Field']]]></code>
-      <code>$options</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$result</code>
@@ -10828,12 +10825,13 @@
       <code>$columnNames</code>
     </MixedReturnStatement>
     <PossiblyInvalidArgument>
-      <code>$newDb</code>
+      <code>$db_name</code>
+      <code>$sqlStatements</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$_REQUEST['csv_new_db_name']]]></code>
       <code><![CDATA[$_REQUEST['csv_new_tbl_name']]]></code>
-      <code>$newDb</code>
+      <code>$db_name</code>
     </PossiblyInvalidCast>
     <PossiblyInvalidOperand>
       <code>$max_lines</code>
@@ -10912,8 +10910,6 @@
     <MixedArgument>
       <code>$cell</code>
       <code>$cell</code>
-      <code>$db_name</code>
-      <code>$options</code>
       <code>$table[0]</code>
       <code>$table[1]</code>
       <code>$table[2][0]</code>
@@ -10944,8 +10940,14 @@
       <code><![CDATA[! $GLOBALS['finished']]]></code>
       <code><![CDATA[$GLOBALS['finished']]]></code>
     </RedundantCondition>
+    <ReferenceConstraintViolation>
+      <code>$sqlStatements</code>
+    </ReferenceConstraintViolation>
   </file>
   <file src="libraries/classes/Plugins/Import/ImportOds.php">
+    <InvalidArgument>
+      <code>$sqlStatements</code>
+    </InvalidArgument>
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['timeout_passed']]]></code>
     </InvalidArrayOffset>
@@ -10953,9 +10955,7 @@
       <code>$cell_attrs</code>
       <code>$col_names</code>
       <code>$col_names</code>
-      <code>$db_name</code>
       <code>$max_cols</code>
-      <code>$options</code>
       <code>$rows</code>
       <code>$rows[$j][Import::TBL_NAME]</code>
       <code>$tables</code>
@@ -11118,11 +11118,7 @@
     </PossiblyUnusedReturnValue>
     <RedundantCast>
       <code><![CDATA[(string) $GLOBALS['db']]]></code>
-      <code><![CDATA[(string) $GLOBALS['db']]]></code>
     </RedundantCast>
-    <UnusedVariable>
-      <code>$null_param</code>
-    </UnusedVariable>
   </file>
   <file src="libraries/classes/Plugins/Import/ImportSql.php">
     <InvalidArrayOffset>
@@ -11214,9 +11210,6 @@
     <PossiblyUnusedReturnValue>
       <code>string[]</code>
     </PossiblyUnusedReturnValue>
-    <RedundantCast>
-      <code><![CDATA[(string) $GLOBALS['db']]]></code>
-    </RedundantCast>
     <UnnecessaryVarAnnotation>
       <code>SimpleXMLElement</code>
     </UnnecessaryVarAnnotation>
@@ -11360,11 +11353,6 @@
     <UnusedClass>
       <code>UploadSession</code>
     </UnusedClass>
-  </file>
-  <file src="libraries/classes/Plugins/ImportPlugin.php">
-    <RedundantCastGivenDocblockType>
-      <code>(string) $currentDb</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Plugins/Plugin.php">
     <PossiblyUnusedMethod>


### PR DESCRIPTION
This reduces strange polymorphism in plugins and redundant code. Psalm complains about invalid types but I tested this and I cannot see any bug. I raised a bug report with Vimeo. 