### PR TITLE
Fix `Invalid opcode 23/1/0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.1.2",
         "ext-hash": "*",
         "ext-iconv": "*",
         "ext-json": "*",


### PR DESCRIPTION
Hello 👋🏻 

Got this error using php8.1.1
` Fatal error: Invalid opcode 23/1/0. in C:\laragon\etc\apps\phpMyAdmin\libraries\classes\Common.php on line 82`

It's a php bug which was fixed on php8.1.2
https://bugs.php.net/bug.php?id=81684

So in this PR I have forced requirement to minimum php8.1.2 which fixed it.
