### PR TITLE
Refactor GisVisualization settings

### DIFF
--- a/libraries/classes/Controllers/GisDataEditorController.php
+++ b/libraries/classes/Controllers/GisDataEditorController.php
@@ -136,8 +136,8 @@ class GisDataEditorController extends AbstractController
         }
 
         $templateOutput = $this->template->render('gis_data_editor_form', [
-            'width' => $visualizationSettings['width'],
-            'height' => $visualizationSettings['height'],
+            'width' => $visualization->getWidth(),
+            'height' => $visualization->getHeight(),
             'field' => $field,
             'input_name' => $inputName,
             'srid' => $srid,

--- a/libraries/classes/Controllers/GisDataEditorController.php
+++ b/libraries/classes/Controllers/GisDataEditorController.php
@@ -103,8 +103,6 @@ class GisDataEditorController extends AbstractController
             'width' => 450,
             'height' => 300,
             'spatialColumn' => 'wkt',
-            'mysqlVersion' => $GLOBALS['dbi']->getVersion(),
-            'isMariaDB' => $GLOBALS['dbi']->isMariaDB(),
         ];
         $data = [
             [

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -130,13 +130,7 @@ final class GisVisualizationController extends AbstractController
         $this->addScriptFiles(['vendor/openlayers/OpenLayers.js', 'table/gis_visualization.js']);
 
         // If all the rows contain SRID, use OpenStreetMaps on the initial loading.
-        if (! isset($_POST['displayVisualization'])) {
-            if ($visualization->hasSrid()) {
-                $visualizationSettings['choice'] = 'useBaseLayer';
-            } else {
-                unset($visualizationSettings['choice']);
-            }
-        }
+        $useBaseLayer = isset($_POST['redraw']) ? isset($_POST['useBaseLayer']) : $visualization->hasSrid();
 
         /**
          * Displays the page
@@ -165,6 +159,7 @@ final class GisVisualizationController extends AbstractController
             'spatial_candidates' => $spatialCandidates,
             'visualization_settings' => $visualizationSettings,
             'start_and_number_of_rows_fieldset' => $startAndNumberOfRowsFieldset,
+            'useBaseLayer' => $useBaseLayer,
             'visualization' => $visualization->toImage('svg'),
             'draw_ol' => $visualization->asOl(),
         ]);

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -119,6 +119,9 @@ final class GisVisualizationController extends AbstractController
             $visualizationSettings['spatialColumn'] = $spatialCandidates[0];
         }
 
+        $visualizationSettings['width'] = 600;
+        $visualizationSettings['height'] = 450;
+
         // Download as PNG/SVG/PDF use _GET and the normal form uses _POST
         // Convert geometric columns from bytes to text.
         $pos = (int) ($_POST['pos'] ?? $_GET['pos'] ?? $_SESSION['tmpval']['pos']);

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -172,8 +172,8 @@ final class GisVisualizationController extends AbstractController
             $GLOBALS['urlParams'],
             [
                 'saveToFile' => true,
-                'session_max_rows' => $rows,
-                'pos' => $pos,
+                'session_max_rows' => $visualization->getRows(),
+                'pos' => $visualization->getPos(),
                 'visualizationSettings[spatialColumn]' => $visualizationSettings['spatialColumn'],
                 'visualizationSettings[labelColumn]' => $visualizationSettings['labelColumn'],
             ],

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -115,18 +115,8 @@ final class GisVisualizationController extends AbstractController
         $visualizationSettings['width'] = 600;
         $visualizationSettings['height'] = 450;
 
-        // Download as PNG/SVG/PDF use _GET and the normal form uses _POST
-        // Convert geometric columns from bytes to text.
-        $pos = (int) ($_POST['pos'] ?? $_GET['pos'] ?? $_SESSION['tmpval']['pos']);
-        if (isset($_POST['session_max_rows']) || isset($_GET['session_max_rows'])) {
-            $rows = (int) ($_POST['session_max_rows'] ?? $_GET['session_max_rows']);
-        } else {
-            if ($_SESSION['tmpval']['max_rows'] !== 'all') {
-                $rows = (int) $_SESSION['tmpval']['max_rows'];
-            } else {
-                $rows = (int) $GLOBALS['cfg']['MaxRows'];
-            }
-        }
+        $rows = $this->getRows();
+        $pos = $this->getPos();
 
         $visualization = GisVisualization::get($sqlQuery, $visualizationSettings, $rows, $pos);
 
@@ -212,6 +202,25 @@ final class GisVisualizationController extends AbstractController
         }
 
         return $sqlQuery === '' ? null : $sqlQuery;
+    }
+
+    private function getPos(): int
+    {
+        // Download as PNG/SVG/PDF use _GET and the normal form uses _POST
+        return (int) ($_POST['pos'] ?? $_GET['pos'] ?? $_SESSION['tmpval']['pos']);
+    }
+
+    private function getRows(): int
+    {
+        if (isset($_POST['session_max_rows']) || isset($_GET['session_max_rows'])) {
+            return (int) ($_POST['session_max_rows'] ?? $_GET['session_max_rows']);
+        }
+
+        if ($_SESSION['tmpval']['max_rows'] === 'all') {
+            return (int) $GLOBALS['cfg']['MaxRows'];
+        }
+
+        return (int) $_SESSION['tmpval']['max_rows'];
     }
 
     /**

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -138,15 +138,6 @@ final class GisVisualizationController extends AbstractController
             }
         }
 
-        $visualization->setUserSpecifiedSettings($visualizationSettings);
-        foreach ($visualization->getSettings() as $setting => $val) {
-            if (isset($visualizationSettings[$setting])) {
-                continue;
-            }
-
-            $visualizationSettings[$setting] = $val;
-        }
-
         /**
          * Displays the page
          */

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -104,10 +104,6 @@ final class GisVisualizationController extends AbstractController
             $visualizationSettings = $_GET['visualizationSettings'];
         }
 
-        // Check mysql version
-        $visualizationSettings['mysqlVersion'] = $this->dbi->getVersion();
-        $visualizationSettings['isMariaDB'] = $this->dbi->isMariaDB();
-
         if (
             ! isset($visualizationSettings['labelColumn']) ||
             ! in_array($visualizationSettings['labelColumn'], $labelCandidates, true)

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -122,7 +122,8 @@ final class GisVisualizationController extends AbstractController
 
         if (isset($_GET['saveToFile'])) {
             $this->response->disable();
-            $visualization->toFile($visualizationSettings['spatialColumn'], $_GET['fileFormat']);
+            $filename = $visualization->getSpatialColumn();
+            $visualization->toFile($filename, $_GET['fileFormat']);
 
             return;
         }
@@ -145,8 +146,8 @@ final class GisVisualizationController extends AbstractController
                 'saveToFile' => true,
                 'session_max_rows' => $visualization->getRows(),
                 'pos' => $visualization->getPos(),
-                'visualizationSettings[spatialColumn]' => $visualizationSettings['spatialColumn'],
-                'visualizationSettings[labelColumn]' => $visualizationSettings['labelColumn'],
+                'visualizationSettings[spatialColumn]' => $visualization->getSpatialColumn(),
+                'visualizationSettings[labelColumn]' => $visualization->getLabelColumn(),
             ],
         ));
 
@@ -157,10 +158,13 @@ final class GisVisualizationController extends AbstractController
             'download_url' => $downloadUrl,
             'label_candidates' => $labelCandidates,
             'spatial_candidates' => $spatialCandidates,
-            'visualization_settings' => $visualizationSettings,
+            'spatialColumn' => $visualization->getSpatialColumn(),
+            'labelColumn' => $visualization->getLabelColumn(),
+            'width' => $visualization->getWidth(),
+            'height' => $visualization->getHeight(),
             'start_and_number_of_rows_fieldset' => $startAndNumberOfRowsFieldset,
             'useBaseLayer' => $useBaseLayer,
-            'visualization' => $visualization->toImage('svg'),
+            'visualization' => $visualization->asSVG(),
             'draw_ol' => $visualization->asOl(),
         ]);
 

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\Image\ImageWrapper;
 use PhpMyAdmin\Sanitize;
 use PhpMyAdmin\Util;
 use TCPDF;
+use Webmozart\Assert\Assert;
 
 use function array_merge;
 use function base64_encode;
@@ -59,11 +60,6 @@ class GisVisualization
             [76, 72, 155],
             [135, 201, 191],
         ],
-
-        // The width of the GIS visualization.
-        'width' => 600,
-        // The height of the GIS visualization.
-        'height' => 450,
     ];
 
     /** @var array   Options that the user has specified. */
@@ -157,6 +153,9 @@ class GisVisualization
      */
     private function __construct(array|string $sqlOrData, array $options, int $rows = 0, int $pos = 0)
     {
+        Assert::positiveInteger($options['width'] ?? null);
+        Assert::positiveInteger($options['height'] ?? null);
+
         $this->pos = $pos;
         $this->rows = $rows;
 

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -14,10 +14,8 @@ use PhpMyAdmin\Util;
 use TCPDF;
 use Webmozart\Assert\Assert;
 
-use function array_merge;
 use function base64_encode;
 use function count;
-use function intval;
 use function is_string;
 use function mb_strlen;
 use function mb_strpos;
@@ -35,35 +33,38 @@ use const PNG_ALL_FILTERS;
  */
 class GisVisualization
 {
+    /** Array of colors to be used for GIS visualizations.*/
+    private const COLORS = [
+        [176, 46, 224],
+        [224, 100, 46],
+        [224, 214, 46],
+        [46, 151, 224],
+        [188, 224, 46],
+        [224, 46, 117],
+        [92, 224, 46],
+        [224, 176, 46],
+        [0, 34, 224],
+        [114, 108, 177],
+        [72, 26, 54],
+        [186, 198, 88],
+        [18, 114, 36],
+        [130, 81, 25],
+        [35, 140, 116],
+        [76, 72, 155],
+        [135, 201, 191],
+    ];
+
     /** @var mixed[][]   Raw data for the visualization */
     private array $data;
 
-    /** @var array   Set of default settings values are here. */
-    private array $settings = [
-        // Array of colors to be used for GIS visualizations.
-        'colors' => [
-            [176, 46, 224],
-            [224, 100, 46],
-            [224, 214, 46],
-            [46, 151, 224],
-            [188, 224, 46],
-            [224, 46, 117],
-            [92, 224, 46],
-            [224, 176, 46],
-            [0, 34, 224],
-            [114, 108, 177],
-            [72, 26, 54],
-            [186, 198, 88],
-            [18, 114, 36],
-            [130, 81, 25],
-            [35, 140, 116],
-            [76, 72, 155],
-            [135, 201, 191],
-        ],
-    ];
+    /** The width of the GIS visualization.*/
+    private int $width;
+    /** The height of the GIS visualization. */
+    private int $height;
 
-    /** @var array   Options that the user has specified. */
-    private array $userSpecifiedSettings;
+    private string $spatialColumn;
+
+    private string|null $labelColumn;
 
     /** Number of rows */
     private int $rows;
@@ -78,16 +79,6 @@ class GisVisualization
     public function getRows(): int
     {
         return $this->rows;
-    }
-
-    /**
-     * Returns the settings array
-     *
-     * @return array the settings array
-     */
-    public function getSettings(): array
-    {
-        return $this->settings;
     }
 
     /**
@@ -153,13 +144,25 @@ class GisVisualization
      */
     private function __construct(array|string $sqlOrData, array $options, int $rows = 0, int $pos = 0)
     {
-        Assert::positiveInteger($options['width'] ?? null);
-        Assert::positiveInteger($options['height'] ?? null);
+        $width = $options['width'] ?? null;
+        Assert::positiveInteger($width);
+        $this->width = $width;
+
+        $height = $options['height'] ?? null;
+        Assert::positiveInteger($height);
+        $this->height = $height;
+
+        $spatialColumn = $options['spatialColumn'] ?? null;
+        Assert::stringNotEmpty($spatialColumn);
+        $this->spatialColumn = $spatialColumn;
+
+        $labelColumn = $options['labelColumn'] ?? null;
+        Assert::nullOrStringNotEmpty($labelColumn);
+        $this->labelColumn = $labelColumn;
 
         $this->pos = $pos;
         $this->rows = $rows;
 
-        $this->userSpecifiedSettings = $options;
         $this->data = is_string($sqlOrData)
             ? $this->modifyQueryAndFetch($sqlOrData)
             : $sqlOrData;
@@ -171,14 +174,6 @@ class GisVisualization
         $modifiedSql = $this->modifySqlQuery($sqlQuery);
 
         return $this->fetchRawData($modifiedSql);
-    }
-
-    /**
-     * All the variable initialization, options handling has to be done here.
-     */
-    protected function init(): void
-    {
-        $this->handleOptions();
     }
 
     /**
@@ -209,20 +204,20 @@ class GisVisualization
         }
 
         // If label column is chosen add it to the query
-        if (! empty($this->userSpecifiedSettings['labelColumn'])) {
-            $modified_query .= Util::backquote($this->userSpecifiedSettings['labelColumn'])
+        if ($this->labelColumn !== null) {
+            $modified_query .= Util::backquote($this->labelColumn)
             . ', ';
         }
 
         // Wrap the spatial column with 'ST_ASTEXT()' function and add it
         $modified_query .= $spatialAsText . '('
-            . Util::backquote($this->userSpecifiedSettings['spatialColumn'])
-            . $axisOrder . ') AS ' . Util::backquote($this->userSpecifiedSettings['spatialColumn'])
+            . Util::backquote($this->spatialColumn)
+            . $axisOrder . ') AS ' . Util::backquote($this->spatialColumn)
             . ', ';
 
         // Get the SRID
         $modified_query .= $spatialSrid . '('
-            . Util::backquote($this->userSpecifiedSettings['spatialColumn'])
+            . Util::backquote($this->spatialColumn)
             . ') AS ' . Util::backquote('srid') . ' ';
 
         // Append the original query as the inner query
@@ -251,15 +246,6 @@ class GisVisualization
         }
 
         return $modified_result->fetchAllAssoc();
-    }
-
-    /**
-     * A function which handles passed parameters. Useful if desired
-     * chart needs to be a little bit different from the default one.
-     */
-    private function handleOptions(): void
-    {
-        $this->settings = array_merge($this->settings, $this->userSpecifiedSettings);
     }
 
     /**
@@ -306,8 +292,6 @@ class GisVisualization
      */
     private function svg(): string
     {
-        $this->init();
-
         $scale_data = $this->scaleDataSet($this->data);
         /** @var string $svg */
         $svg = $this->prepareDataSet($this->data, $scale_data, 'svg');
@@ -316,8 +300,8 @@ class GisVisualization
             . "\n"
             . '<svg version="1.1" xmlns:svg="http://www.w3.org/2000/svg"'
             . ' xmlns="http://www.w3.org/2000/svg"'
-            . ' width="' . intval($this->settings['width']) . '"'
-            . ' height="' . intval($this->settings['height']) . '">'
+            . ' width="' . $this->width . '"'
+            . ' height="' . $this->height . '">'
             . '<g id="groupPanel">' . $svg . '</g>'
             . '</svg>';
     }
@@ -351,11 +335,9 @@ class GisVisualization
      */
     private function png(): ImageWrapper|null
     {
-        $this->init();
-
         $image = ImageWrapper::create(
-            $this->settings['width'],
-            $this->settings['height'],
+            $this->width,
+            $this->height,
             ['red' => 229, 'green' => 229, 'blue' => 229],
         );
         if ($image === null) {
@@ -417,7 +399,6 @@ class GisVisualization
      */
     public function asOl(): string
     {
-        $this->init();
         $scale_data = $this->scaleDataSet($this->data);
         /** @var string $olCode */
         $olCode = $this->prepareDataSet($this->data, $scale_data, 'ol');
@@ -463,8 +444,6 @@ class GisVisualization
      */
     public function toFileAsPdf($file_name): void
     {
-        $this->init();
-
         // create pdf
         $pdf = new TCPDF('', 'pt', $GLOBALS['cfg']['PDFDefaultPageSize'], true, 'UTF-8', false);
 
@@ -539,12 +518,12 @@ class GisVisualization
         $min_max = null;
         $border = 15;
         // effective width and height of the plot
-        $plot_width = $this->settings['width'] - 2 * $border;
-        $plot_height = $this->settings['height'] - 2 * $border;
+        $plot_width = $this->width - 2 * $border;
+        $plot_height = $this->height - 2 * $border;
 
         foreach ($data as $row) {
             // Figure out the data type
-            $ref_data = $row[$this->settings['spatialColumn']];
+            $ref_data = $row[$this->spatialColumn];
             if (! is_string($ref_data)) {
                 continue;
             }
@@ -561,7 +540,7 @@ class GisVisualization
                 continue;
             }
 
-            $scaleData = $gis_obj->scaleRow($row[$this->settings['spatialColumn']]);
+            $scaleData = $gis_obj->scaleRow($ref_data);
 
             // Update minimum/maximum values for x and y coordinates.
             $min_max = $min_max === null ? $scaleData : $scaleData?->merge($min_max);
@@ -578,17 +557,17 @@ class GisVisualization
 
         // Center plot
         $x = $ratio == 0 || $x_ratio < $y_ratio
-            ? ($min_max->maxX + $min_max->minX - $this->settings['width'] / $scale) / 2
+            ? ($min_max->maxX + $min_max->minX - $this->width / $scale) / 2
             : $min_max->minX - ($border / $scale);
         $y = $ratio == 0 || $x_ratio >= $y_ratio
-            ? ($min_max->maxY + $min_max->minY - $this->settings['height'] / $scale) / 2
+            ? ($min_max->maxY + $min_max->minY - $this->height / $scale) / 2
             : $min_max->minY - ($border / $scale);
 
         return [
             'scale' => $scale,
             'x' => $x,
             'y' => $y,
-            'height' => $this->settings['height'],
+            'height' => $this->height,
         ];
     }
 
@@ -609,14 +588,12 @@ class GisVisualization
         $format,
         ImageWrapper|TCPDF|string $results = '',
     ): mixed {
-        /** @var int[][] $colors */
-        $colors = $this->settings['colors'];
         $color_index = 0;
 
         // loop through the rows
         foreach ($data as $row) {
             // Figure out the data type
-            $ref_data = $row[$this->settings['spatialColumn']];
+            $ref_data = $row[$this->spatialColumn];
             if (! is_string($ref_data)) {
                 continue;
             }
@@ -633,19 +610,19 @@ class GisVisualization
                 continue;
             }
 
-            $color = $colors[$color_index];
-            $label = trim((string) ($row[$this->settings['labelColumn']] ?? ''));
+            $color = self::COLORS[$color_index];
+            $label = trim((string) ($row[$this->labelColumn] ?? ''));
 
             if ($format === 'svg') {
                 $results .= $gis_obj->prepareRowAsSvg(
-                    $row[$this->settings['spatialColumn']],
+                    $ref_data,
                     $label,
                     $color,
                     $scale_data,
                 );
             } elseif ($format === 'png') {
                 $results = $gis_obj->prepareRowAsPng(
-                    $row[$this->settings['spatialColumn']],
+                    $ref_data,
                     $label,
                     $color,
                     $scale_data,
@@ -653,7 +630,7 @@ class GisVisualization
                 );
             } elseif ($format === 'pdf' && $results instanceof TCPDF) {
                 $results = $gis_obj->prepareRowAsPdf(
-                    $row[$this->settings['spatialColumn']],
+                    $ref_data,
                     $label,
                     $color,
                     $scale_data,
@@ -661,26 +638,16 @@ class GisVisualization
                 );
             } elseif ($format === 'ol') {
                 $results .= $gis_obj->prepareRowAsOl(
-                    $row[$this->settings['spatialColumn']],
+                    $ref_data,
                     (int) $row['srid'],
                     $label,
                     $color,
                 );
             }
 
-            $color_index = ($color_index + 1) % count($colors);
+            $color_index = ($color_index + 1) % count(self::COLORS);
         }
 
         return $results;
-    }
-
-    /**
-     * Set user specified settings
-     *
-     * @param array $userSpecifiedSettings User specified settings
-     */
-    public function setUserSpecifiedSettings(array $userSpecifiedSettings): void
-    {
-        $this->userSpecifiedSettings = $userSpecifiedSettings;
     }
 }

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -161,19 +161,21 @@ class GisVisualization
      */
     private function modifySqlQuery($sql_query, $rows, $pos): string
     {
-        $isMariaDb = $this->userSpecifiedSettings['isMariaDB'] === true;
         $modified_query = 'SELECT ';
         $spatialAsText = 'ASTEXT';
         $spatialSrid = 'SRID';
         $axisOrder = '';
 
-        if ($this->userSpecifiedSettings['mysqlVersion'] >= 50600) {
+        $mysqlVersion = $GLOBALS['dbi']->getVersion();
+        $isMariaDB = $GLOBALS['dbi']->isMariaDB();
+
+        if ($mysqlVersion >= 50600) {
             $spatialAsText = 'ST_ASTEXT';
             $spatialSrid = 'ST_SRID';
         }
 
         // If MYSQL version >= 8.0.1 override default axis order
-        if ($this->userSpecifiedSettings['mysqlVersion'] >= 80001 && ! $isMariaDb) {
+        if ($mysqlVersion >= 80001 && ! $isMariaDB) {
             $axisOrder = ', \'axis-order=long-lat\'';
         }
 

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -71,6 +71,16 @@ class GisVisualization
     /** Start position */
     private int $pos;
 
+    public function getWidth(): int
+    {
+        return $this->width;
+    }
+
+    public function getHeight(): int
+    {
+        return $this->height;
+    }
+
     public function getPos(): int
     {
         return $this->pos;
@@ -79,6 +89,16 @@ class GisVisualization
     public function getRows(): int
     {
         return $this->rows;
+    }
+
+    public function getSpatialColumn(): string
+    {
+        return $this->spatialColumn;
+    }
+
+    public function getLabelColumn(): string|null
+    {
+        return $this->labelColumn;
     }
 
     /**

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -14,15 +14,12 @@ use PhpMyAdmin\Util;
 use TCPDF;
 use Webmozart\Assert\Assert;
 
-use function base64_encode;
 use function count;
 use function is_string;
 use function mb_strlen;
 use function mb_strpos;
 use function mb_strtolower;
 use function mb_substr;
-use function ob_get_clean;
-use function ob_start;
 use function rtrim;
 use function trim;
 
@@ -372,29 +369,6 @@ class GisVisualization
     }
 
     /**
-     * Get the visualization as a PNG.
-     *
-     * @return string the visualization as a PNG
-     */
-    public function asPng(): string
-    {
-        $image = $this->png();
-        if ($image === null) {
-            return '';
-        }
-
-        // render and save it to variable
-        ob_start();
-        $image->png(null, 9, PNG_ALL_FILTERS);
-        $output = ob_get_clean();
-
-        // base64 encode
-        $encoded = base64_encode((string) $output);
-
-        return '<img src="data:image/png;base64,' . $encoded . '">';
-    }
-
-    /**
      * Saves as a PNG image to a file.
      *
      * @param string $file_name File name
@@ -483,30 +457,6 @@ class GisVisualization
         // sanitize file name
         $file_name = $this->sanitizeName($file_name, 'pdf');
         $pdf->Output($file_name, 'D');
-    }
-
-    /**
-     * Convert file to image
-     *
-     * @param string $format Output format
-     *
-     * @return string File
-     */
-    public function toImage($format): string
-    {
-        if ($format === 'svg') {
-            return $this->asSVG();
-        }
-
-        if ($format === 'png') {
-            return $this->asPng();
-        }
-
-        if ($format === 'ol') {
-            return $this->asOl();
-        }
-
-        return '';
     }
 
     /**

--- a/libraries/classes/Gis/GisVisualization.php
+++ b/libraries/classes/Gis/GisVisualization.php
@@ -37,8 +37,6 @@ class GisVisualization
     /** @var array   Raw data for the visualization */
     private array $data;
 
-    private string $modifiedSql = '';
-
     /** @var array   Set of default settings values are here. */
     private array $settings = [
         // Array of colors to be used for GIS visualizations.
@@ -151,12 +149,17 @@ class GisVisualization
         $this->rows = $rows;
 
         $this->userSpecifiedSettings = $options;
-        if (isset($data)) {
-            $this->data = $data;
-        } else {
-            $this->modifiedSql = $this->modifySqlQuery($sql_query);
-            $this->data = $this->fetchRawData();
-        }
+        $this->data = is_string($sql_query)
+            ? $this->modifyQueryAndFetch($sql_query)
+            : $data;
+    }
+
+    /** @return array raw data */
+    private function modifyQueryAndFetch(string $sqlQuery): array
+    {
+        $modifiedSql = $this->modifySqlQuery($sqlQuery);
+
+        return $this->fetchRawData($modifiedSql);
     }
 
     /**
@@ -228,9 +231,9 @@ class GisVisualization
      *
      * @return array the raw data.
      */
-    private function fetchRawData(): array
+    private function fetchRawData(string $modifiedSql): array
     {
-        $modified_result = $GLOBALS['dbi']->tryQuery($this->modifiedSql);
+        $modified_result = $GLOBALS['dbi']->tryQuery($modifiedSql);
 
         if ($modified_result === false) {
             return [];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2271,11 +2271,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/GetFieldController.php
 
 		-
-			message: "#^Class PhpMyAdmin\\\\Controllers\\\\Table\\\\GisVisualizationController has an uninitialized property \\$visualization\\. Give it default value or assign it in the constructor\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/GisVisualizationController.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/IndexesController.php
@@ -4606,52 +4601,17 @@ parameters:
 			path: libraries/classes/Gis/GisPolygon.php
 
 		-
-			message: "#^Call to function is_numeric\\(\\) with int will always evaluate to true\\.$#"
-			count: 2
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
 			message: "#^Cannot call method Output\\(\\) on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisVisualization.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisVisualization.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:fetchRawData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:get\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:getByData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:getByData\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:getSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:prepareDataSet\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisVisualization.php
 
@@ -4661,47 +4621,7 @@ parameters:
 			path: libraries/classes/Gis/GisVisualization.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:scaleDataSet\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:scaleDataSet\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:setUserSpecifiedSettings\\(\\) has parameter \\$userSpecifiedSettings with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Parameter \\#1 \\$sql_query of class PhpMyAdmin\\\\Gis\\\\GisVisualization constructor expects string, null given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Parameter \\#3 \\$row of class PhpMyAdmin\\\\Gis\\\\GisVisualization constructor expects int, null given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Parameter \\#4 \\$pos of class PhpMyAdmin\\\\Gis\\\\GisVisualization constructor expects int, null given\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:\\$data type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:\\$settings type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisVisualization.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Gis\\\\GisVisualization\\:\\:\\$userSpecifiedSettings type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisVisualization.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3718,44 +3718,16 @@
     </PossiblyUnusedParam>
   </file>
   <file src="libraries/classes/Controllers/Table/GisVisualizationController.php">
-    <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['errorUrl']]]></code>
-    </InvalidArrayOffset>
     <MixedArrayAccess>
       <code><![CDATA[$_SESSION['tmpval']['max_rows']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['pos']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$GLOBALS['errorUrl']]]></code>
-      <code>$val</code>
-      <code>$visualizationSettings[$setting]</code>
-    </MixedAssignment>
     <PossiblyInvalidArgument>
       <code><![CDATA[$_GET['fileFormat']]]></code>
-      <code><![CDATA[$_GET['sql_query']]]></code>
-      <code><![CDATA[$_GET['sql_signature']]]></code>
-      <code>$sqlQuery</code>
-      <code>$sqlQuery</code>
-      <code>$sqlQuery</code>
-      <code>$sqlQuery</code>
-      <code><![CDATA[$visualizationSettings['spatialColumn']]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
       <code><![CDATA[$_GET['fileFormat']]]></code>
-      <code><![CDATA[$_GET['sql_query']]]></code>
-      <code><![CDATA[$_GET['sql_signature']]]></code>
-      <code>$sqlQuery</code>
-      <code>$sqlQuery</code>
-      <code>$sqlQuery</code>
-      <code>$sqlQuery</code>
-      <code><![CDATA[$visualizationSettings['spatialColumn']]]></code>
     </PossiblyInvalidCast>
-    <PossiblyUndefinedArrayOffset>
-      <code>$spatialCandidates[0]</code>
-    </PossiblyUndefinedArrayOffset>
-    <PropertyNotSetInConstructor>
-      <code>$visualization</code>
-    </PropertyNotSetInConstructor>
     <RedundantCast>
       <code><![CDATA[(int) $GLOBALS['cfg']['MaxRows']]]></code>
     </RedundantCast>
@@ -7627,80 +7599,12 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="libraries/classes/Gis/GisVisualization.php">
-    <MixedArgument>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$this->settings['height']]]></code>
-      <code><![CDATA[$this->settings['width']]]></code>
-      <code><![CDATA[$this->userSpecifiedSettings['labelColumn']]]></code>
-      <code><![CDATA[$this->userSpecifiedSettings['spatialColumn']]]></code>
-      <code><![CDATA[$this->userSpecifiedSettings['spatialColumn']]]></code>
-      <code><![CDATA[$this->userSpecifiedSettings['spatialColumn']]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$row[$this->settings['labelColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row['srid']]]></code>
-      <code><![CDATA[$row['srid']]]></code>
-    </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$row[$this->settings['labelColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-      <code><![CDATA[$row[$this->settings['spatialColumn']]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code>$pdf</code>
-      <code>$plot_height</code>
-      <code>$plot_width</code>
-      <code>$ratio</code>
-      <code>$row</code>
-      <code>$row</code>
-      <code>$row</code>
-      <code>$scale</code>
-      <code>$x</code>
-      <code>$x_ratio</code>
-      <code>$y</code>
-      <code>$y_ratio</code>
     </MixedAssignment>
     <MixedMethodCall>
       <code>Output</code>
     </MixedMethodCall>
-    <MixedOperand>
-      <code>$border / $scale</code>
-      <code>$border / $scale</code>
-      <code><![CDATA[$min_max->maxX + $min_max->minX - $this->settings['width'] / $scale]]></code>
-      <code><![CDATA[$min_max->maxY + $min_max->minY - $this->settings['height'] / $scale]]></code>
-      <code>$plot_height</code>
-      <code>$plot_width</code>
-      <code>$ratio</code>
-      <code>$scale</code>
-      <code>$scale</code>
-      <code><![CDATA[$this->settings['height']]]></code>
-      <code><![CDATA[$this->settings['height']]]></code>
-      <code><![CDATA[$this->settings['height'] / $scale]]></code>
-      <code><![CDATA[$this->settings['width']]]></code>
-      <code><![CDATA[$this->settings['width']]]></code>
-      <code><![CDATA[$this->settings['width'] / $scale]]></code>
-    </MixedOperand>
-    <NullArgument>
-      <code>null</code>
-      <code>null</code>
-      <code>null</code>
-    </NullArgument>
     <PossiblyInvalidArgument>
       <code>$results</code>
     </PossiblyInvalidArgument>
@@ -7712,10 +7616,6 @@
       <code>mb_strtolower($user_extension) !== $required_extension</code>
       <code>mb_strtolower($user_extension) !== $required_extension</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType>
-      <code>is_numeric($pos)</code>
-      <code>is_numeric($rows)</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/Git.php">
     <MixedArgument>

--- a/templates/table/gis_visualization/gis_visualization.twig
+++ b/templates/table/gis_visualization/gis_visualization.twig
@@ -11,7 +11,7 @@
           <select name="visualizationSettings[labelColumn]" id="labelColumn" class="form-select autosubmit">
             <option value="">{% trans '-- None --' %}</option>
             {% for value in label_candidates %}
-              <option value="{{ value }}"{{ value == visualization_settings['labelColumn'] ? ' selected' }}>
+              <option value="{{ value }}"{{ value == labelColumn ? ' selected' }}>
                 {{ value }}
               </option>
             {% endfor %}
@@ -21,7 +21,7 @@
           <label class="form-label" for="spatialColumn">{% trans 'Spatial column' %}</label>
           <select name="visualizationSettings[spatialColumn]" id="spatialColumn" class="form-select autosubmit">
             {% for value in spatial_candidates %}
-              <option value="{{ value }}"{{ value == visualization_settings['spatialColumn'] ? ' selected' }}>
+              <option value="{{ value }}"{{ value == spatialColumn ? ' selected' }}>
                 {{ value }}
               </option>
             {% endfor %}
@@ -51,7 +51,7 @@
         </div>
       </form>
 
-      <div id="placeholder" style="width:{{ visualization_settings['width'] }}px;height:{{ visualization_settings['height'] }}px;">
+      <div id="placeholder" style="width:{{ width }}px;height:{{ height }}px;">
         {{ visualization|raw }}
       </div>
       <div id="openlayersmap"></div>

--- a/templates/table/gis_visualization/gis_visualization.twig
+++ b/templates/table/gis_visualization/gis_visualization.twig
@@ -28,9 +28,9 @@
           </select>
         </div>
         <div class="col-auto">
-          <input type="hidden" name="displayVisualization" value="redraw">
+          <input type="hidden" name="redraw" value="true">
           <div class="form-check form-switch">
-            <input class="form-check-input" type="checkbox" name="visualizationSettings[choice]" id="choice" value="useBaseLayer"{{ visualization_settings['choice'] is defined ? ' checked' }}>
+            <input class="form-check-input" type="checkbox" name="useBaseLayer" id="choice"{{ useBaseLayer ? ' checked' }}>
             <label class="form-check-label" for="choice" id="labelChoice">{% trans 'Use OpenStreetMaps as Base Layer' %}</label>
           </div>
         </div>

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -228,4 +228,21 @@ abstract class AbstractTestCase extends TestCase
 
         return $method->invokeArgs($object, $params);
     }
+
+    /**
+     * Set a private or protected property via reflection.
+     *
+     * @param object|null $object       The object to inspect, pass null for static objects()
+     * @param string      $className    The class name
+     * @param string      $propertyName The method name
+     * @param mixed       $value        The parameters for the invocation
+     * @phpstan-param class-string $className
+     */
+    protected function setProperty($object, string $className, string $propertyName, mixed $value): void
+    {
+        $class = new ReflectionClass($className);
+        $property = $class->getProperty($propertyName);
+
+        $property->setValue($object, $value);
+    }
 }

--- a/test/classes/Controllers/Table/GisVisualizationControllerTest.php
+++ b/test/classes/Controllers/Table/GisVisualizationControllerTest.php
@@ -75,12 +75,10 @@ class GisVisualizationControllerTest extends AbstractTestCase
             'download_url' => $downloadUrl,
             'label_candidates' => ['name'],
             'spatial_candidates' => ['shape'],
-            'visualization_settings' => [
-                'spatialColumn' => 'shape',
-                'labelColumn' => null,
-                'width' => 600,
-                'height' => 450,
-            ],
+            'spatialColumn' => 'shape',
+            'labelColumn' => null,
+            'width' => 600,
+            'height' => 450,
             'start_and_number_of_rows_fieldset' => [
                 'pos' => 0,
                 'unlim_num_rows' => 0,

--- a/test/classes/Controllers/Table/GisVisualizationControllerTest.php
+++ b/test/classes/Controllers/Table/GisVisualizationControllerTest.php
@@ -66,7 +66,7 @@ class GisVisualizationControllerTest extends AbstractTestCase
             'session_max_rows' => 25,
             'pos' => 0,
             'visualizationSettings[spatialColumn]' => 'shape',
-            'visualizationSettings[labelColumn]' => '',
+            'visualizationSettings[labelColumn]' => null,
         ]));
 
         $template = new Template();
@@ -77,7 +77,7 @@ class GisVisualizationControllerTest extends AbstractTestCase
             'spatial_candidates' => ['shape'],
             'visualization_settings' => [
                 'spatialColumn' => 'shape',
-                'labelColumn' => '',
+                'labelColumn' => null,
                 'width' => '600',
                 'height' => '450',
             ],

--- a/test/classes/Controllers/Table/GisVisualizationControllerTest.php
+++ b/test/classes/Controllers/Table/GisVisualizationControllerTest.php
@@ -13,8 +13,6 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Url;
 
-use function array_merge;
-
 use const MYSQLI_TYPE_GEOMETRY;
 use const MYSQLI_TYPE_VAR_STRING;
 
@@ -61,13 +59,14 @@ class GisVisualizationControllerTest extends AbstractTestCase
             'sql_query' => 'SELECT * FROM `gis_all`',
             'sql_signature' => Core::signSqlQuery('SELECT * FROM `gis_all`'),
         ];
-        $downloadUrl = Url::getFromRoute('/table/gis-visualization', array_merge($params, [
+        $downloadParams = [
             'saveToFile' => true,
             'session_max_rows' => 25,
             'pos' => 0,
             'visualizationSettings[spatialColumn]' => 'shape',
             'visualizationSettings[labelColumn]' => null,
-        ]));
+        ];
+        $downloadUrl = Url::getFromRoute('/table/gis-visualization', $downloadParams + $params);
 
         $template = new Template();
         $expected = $template->render('table/gis_visualization/gis_visualization', [

--- a/test/classes/Controllers/Table/GisVisualizationControllerTest.php
+++ b/test/classes/Controllers/Table/GisVisualizationControllerTest.php
@@ -78,8 +78,8 @@ class GisVisualizationControllerTest extends AbstractTestCase
             'visualization_settings' => [
                 'spatialColumn' => 'shape',
                 'labelColumn' => null,
-                'width' => '600',
-                'height' => '450',
+                'width' => 600,
+                'height' => 450,
             ],
             'start_and_number_of_rows_fieldset' => [
                 'pos' => 0,

--- a/test/classes/Controllers/Table/GisVisualizationControllerTest.php
+++ b/test/classes/Controllers/Table/GisVisualizationControllerTest.php
@@ -48,7 +48,7 @@ class GisVisualizationControllerTest extends AbstractTestCase
         );
         $dummyDbi->addResult(
             'SELECT ST_ASTEXT(`shape`) AS `shape`, ST_SRID(`shape`) AS `srid`'
-            . ' FROM (SELECT * FROM `gis_all`) AS `temp_gis` LIMIT 0, 25',
+            . ' FROM (SELECT * FROM `gis_all`) AS `temp_gis` LIMIT 25',
             [['POINT(100 250)', '0']],
             ['shape', 'srid'],
         );

--- a/test/classes/Gis/GisVisualizationTest.php
+++ b/test/classes/Gis/GisVisualizationTest.php
@@ -29,12 +29,6 @@ class GisVisualizationTest extends AbstractTestCase
     {
         $this->dbi->setVersion(['@@version' => '5.5.0']);
         $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc', 'width' => 600, 'height' => 450]);
-        $this->callFunction(
-            $gis,
-            GisVisualization::class,
-            'handleOptions',
-            [],
-        );
 
         $dataSet = $this->callFunction(
             $gis,

--- a/test/classes/Gis/GisVisualizationTest.php
+++ b/test/classes/Gis/GisVisualizationTest.php
@@ -114,11 +114,7 @@ class GisVisualizationTest extends AbstractTestCase
             GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
-            [
-                '',
-                0,
-                0,
-            ],
+            [''],
         );
 
         $this->assertEquals('SELECT ASTEXT(`abc`) AS `abc`, SRID(`abc`) AS `srid` FROM () AS `temp_gis`', $queryString);
@@ -134,11 +130,7 @@ class GisVisualizationTest extends AbstractTestCase
             GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
-            [
-                '',
-                0,
-                0,
-            ],
+            [''],
         );
 
         $this->assertEquals(
@@ -157,11 +149,7 @@ class GisVisualizationTest extends AbstractTestCase
             GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
-            [
-                'SELECT 1 FROM foo;',
-                0,
-                0,
-            ],
+            ['SELECT 1 FROM foo;'],
         );
 
         $this->assertEquals(
@@ -183,11 +171,7 @@ class GisVisualizationTest extends AbstractTestCase
             ]),
             GisVisualization::class,
             'modifySqlQuery',
-            [
-                '',
-                0,
-                0,
-            ],
+            [''],
         );
 
         $this->assertEquals(
@@ -203,31 +187,28 @@ class GisVisualizationTest extends AbstractTestCase
     public function testModifyQueryWithLimit(): void
     {
         $this->dbi->setVersion(['@@version' => '8.0.0']);
+        $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc']);
+        $this->setProperty($gis, GisVisualization::class, 'rows', 10);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
+            $gis,
             GisVisualization::class,
             'modifySqlQuery',
-            [
-                '',
-                10,// 10 rows
-                0,
-            ],
+            [''],
         );
 
         $this->assertEquals(
-            'SELECT ST_ASTEXT(`abc`) AS `abc`, ST_SRID(`abc`) AS `srid` FROM () AS `temp_gis` LIMIT 0, 10',
+            'SELECT ST_ASTEXT(`abc`) AS `abc`, ST_SRID(`abc`) AS `srid` FROM () AS `temp_gis` LIMIT 10',
             $queryString,
         );
 
+        $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc']);
+        $this->setProperty($gis, GisVisualization::class, 'pos', 10);
+        $this->setProperty($gis, GisVisualization::class, 'rows', 15);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
+            $gis,
             GisVisualization::class,
             'modifySqlQuery',
-            [
-                '',
-                15,// 15 rows
-                10,// position 10
-            ],
+            [''],
         );
 
         $this->assertEquals(
@@ -246,11 +227,7 @@ class GisVisualizationTest extends AbstractTestCase
             GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
-            [
-                '',
-                0,
-                0,
-            ],
+            [''],
         );
 
         $this->assertEquals(
@@ -269,11 +246,7 @@ class GisVisualizationTest extends AbstractTestCase
             GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
-            [
-                '',
-                0,
-                0,
-            ],
+            [''],
         );
 
         $this->assertEquals(

--- a/test/classes/Gis/GisVisualizationTest.php
+++ b/test/classes/Gis/GisVisualizationTest.php
@@ -4,28 +4,38 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Gis;
 
+use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Gis\GisVisualization;
 use PhpMyAdmin\Tests\AbstractTestCase;
 
 /** @covers \PhpMyAdmin\Gis\GisVisualization */
 class GisVisualizationTest extends AbstractTestCase
 {
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    private DatabaseInterface $dbi;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dbi = $this->createDatabaseInterface();
+        $GLOBALS['dbi'] = $this->dbi;
+    }
+
     /**
      * Scale the data set
      */
     public function testScaleDataSet(): void
     {
-        $gis = GisVisualization::getByData([], [
-            'mysqlVersion' => 50500,
-            'spatialColumn' => 'abc',
-            'isMariaDB' => false,
-        ]);
+        $this->dbi->setVersion(['@@version' => '5.5.0']);
+        $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc']);
         $this->callFunction(
             $gis,
             GisVisualization::class,
             'handleOptions',
             [],
         );
+
         $dataSet = $this->callFunction(
             $gis,
             GisVisualization::class,
@@ -46,6 +56,7 @@ class GisVisualizationTest extends AbstractTestCase
             ],
             $dataSet,
         );
+
         $dataSet = $this->callFunction(
             $gis,
             GisVisualization::class,
@@ -69,6 +80,7 @@ class GisVisualizationTest extends AbstractTestCase
             ],
             $dataSet,
         );
+
         // Regression test for bug with 0.0 sentinel values
         $dataSet = $this->callFunction(
             $gis,
@@ -97,12 +109,9 @@ class GisVisualizationTest extends AbstractTestCase
      */
     public function testModifyQueryOld(): void
     {
+        $this->dbi->setVersion(['@@version' => '5.5.0']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], [
-                'mysqlVersion' => 50500,
-                'spatialColumn' => 'abc',
-                'isMariaDB' => false,
-            ]),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
             [
@@ -120,12 +129,9 @@ class GisVisualizationTest extends AbstractTestCase
      */
     public function testModifyQuery(): void
     {
+        $this->dbi->setVersion(['@@version' => '8.0.0']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], [
-                'mysqlVersion' => 80000,
-                'spatialColumn' => 'abc',
-                'isMariaDB' => false,
-            ]),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
             [
@@ -146,12 +152,9 @@ class GisVisualizationTest extends AbstractTestCase
      */
     public function testModifyQueryTrimSqlEnd(): void
     {
+        $this->dbi->setVersion(['@@version' => '8.0.0']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], [
-                'mysqlVersion' => 80000,
-                'spatialColumn' => 'abc',
-                'isMariaDB' => false,
-            ]),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
             [
@@ -172,12 +175,11 @@ class GisVisualizationTest extends AbstractTestCase
      */
     public function testModifyQueryLabelColumn(): void
     {
+        $this->dbi->setVersion(['@@version' => '8.0.0']);
         $queryString = $this->callFunction(
             GisVisualization::getByData([], [
-                'mysqlVersion' => 80000,
                 'spatialColumn' => 'country_geom',
                 'labelColumn' => 'country name',
-                'isMariaDB' => false,
             ]),
             GisVisualization::class,
             'modifySqlQuery',
@@ -200,12 +202,9 @@ class GisVisualizationTest extends AbstractTestCase
      */
     public function testModifyQueryWithLimit(): void
     {
+        $this->dbi->setVersion(['@@version' => '8.0.0']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], [
-                'mysqlVersion' => 80000,
-                'spatialColumn' => 'abc',
-                'isMariaDB' => false,
-            ]),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
             [
@@ -221,11 +220,7 @@ class GisVisualizationTest extends AbstractTestCase
         );
 
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], [
-                'mysqlVersion' => 80000,
-                'spatialColumn' => 'abc',
-                'isMariaDB' => false,
-            ]),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
             [
@@ -246,12 +241,9 @@ class GisVisualizationTest extends AbstractTestCase
      */
     public function testModifyQueryVersion8(): void
     {
+        $this->dbi->setVersion(['@@version' => '8.0.1']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], [
-                'mysqlVersion' => 80001,
-                'spatialColumn' => 'abc',
-                'isMariaDB' => false,
-            ]),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
             [
@@ -272,12 +264,9 @@ class GisVisualizationTest extends AbstractTestCase
      */
     public function testModifyQueryMariaDB(): void
     {
+        $this->dbi->setVersion(['@@version' => '8.0.0-MariaDB']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], [
-                'mysqlVersion' => 100400,
-                'spatialColumn' => 'abc',
-                'isMariaDB' => true,
-            ]),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
             GisVisualization::class,
             'modifySqlQuery',
             [

--- a/test/classes/Gis/GisVisualizationTest.php
+++ b/test/classes/Gis/GisVisualizationTest.php
@@ -28,7 +28,7 @@ class GisVisualizationTest extends AbstractTestCase
     public function testScaleDataSet(): void
     {
         $this->dbi->setVersion(['@@version' => '5.5.0']);
-        $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc']);
+        $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc', 'width' => 600, 'height' => 450]);
         $this->callFunction(
             $gis,
             GisVisualization::class,
@@ -111,7 +111,7 @@ class GisVisualizationTest extends AbstractTestCase
     {
         $this->dbi->setVersion(['@@version' => '5.5.0']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc', 'width' => 600, 'height' => 450]),
             GisVisualization::class,
             'modifySqlQuery',
             [''],
@@ -127,7 +127,7 @@ class GisVisualizationTest extends AbstractTestCase
     {
         $this->dbi->setVersion(['@@version' => '8.0.0']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc', 'width' => 600, 'height' => 450]),
             GisVisualization::class,
             'modifySqlQuery',
             [''],
@@ -146,7 +146,7 @@ class GisVisualizationTest extends AbstractTestCase
     {
         $this->dbi->setVersion(['@@version' => '8.0.0']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc', 'width' => 600, 'height' => 450]),
             GisVisualization::class,
             'modifySqlQuery',
             ['SELECT 1 FROM foo;'],
@@ -168,6 +168,8 @@ class GisVisualizationTest extends AbstractTestCase
             GisVisualization::getByData([], [
                 'spatialColumn' => 'country_geom',
                 'labelColumn' => 'country name',
+                'width' => 600,
+                'height' => 450,
             ]),
             GisVisualization::class,
             'modifySqlQuery',
@@ -187,7 +189,7 @@ class GisVisualizationTest extends AbstractTestCase
     public function testModifyQueryWithLimit(): void
     {
         $this->dbi->setVersion(['@@version' => '8.0.0']);
-        $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc']);
+        $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc', 'width' => 600, 'height' => 450]);
         $this->setProperty($gis, GisVisualization::class, 'rows', 10);
         $queryString = $this->callFunction(
             $gis,
@@ -201,7 +203,7 @@ class GisVisualizationTest extends AbstractTestCase
             $queryString,
         );
 
-        $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc']);
+        $gis = GisVisualization::getByData([], ['spatialColumn' => 'abc', 'width' => 600, 'height' => 450]);
         $this->setProperty($gis, GisVisualization::class, 'pos', 10);
         $this->setProperty($gis, GisVisualization::class, 'rows', 15);
         $queryString = $this->callFunction(
@@ -224,7 +226,7 @@ class GisVisualizationTest extends AbstractTestCase
     {
         $this->dbi->setVersion(['@@version' => '8.0.1']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc', 'width' => 600, 'height' => 450]),
             GisVisualization::class,
             'modifySqlQuery',
             [''],
@@ -243,7 +245,7 @@ class GisVisualizationTest extends AbstractTestCase
     {
         $this->dbi->setVersion(['@@version' => '8.0.0-MariaDB']);
         $queryString = $this->callFunction(
-            GisVisualization::getByData([], ['spatialColumn' => 'abc']),
+            GisVisualization::getByData([], ['spatialColumn' => 'abc', 'width' => 600, 'height' => 450]),
             GisVisualization::class,
             'modifySqlQuery',
             [''],


### PR DESCRIPTION
This is a refactoring to  get better type safety in GisVisualization and GisVisualizationController
This gets rid of the `settings` and `userSpecifiedSettings` properties and instead stores the concrete values in class properties.