### PR TITLE
Fix editing new values with gis editor

### DIFF
--- a/libraries/classes/Gis/GisGeometry.php
+++ b/libraries/classes/Gis/GisGeometry.php
@@ -11,6 +11,7 @@ use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
 use function array_map;
+use function array_reverse;
 use function defined;
 use function explode;
 use function json_encode;
@@ -184,8 +185,7 @@ abstract class GisGeometry
         $data = $this->parseWktAndSrid($value);
         $index = 0;
         $wkt = $data['wkt'];
-        preg_match('/^\w+/', $wkt, $matches);
-        $wktType = strtoupper($matches[0]);
+        $wktType = strtoupper(array_reverse(explode('Gis', static::class))[0]);
 
         return ['srid' => $data['srid'], $index => [$wktType => $this->getCoordinateParams($wkt)]];
     }

--- a/test/classes/Gis/GisLineStringTest.php
+++ b/test/classes/Gis/GisLineStringTest.php
@@ -106,6 +106,21 @@ class GisLineStringTest extends GisGeomTestCase
                     ],
                 ],
             ],
+            [
+                '',
+                [
+                    'srid' => 0,
+                    0 => [
+                        'LINESTRING' => [
+                            'no_of_points' => 1,
+                            0 => [
+                                'x' => 0,
+                                'y' => 0,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/test/classes/Gis/GisPointTest.php
+++ b/test/classes/Gis/GisPointTest.php
@@ -95,7 +95,32 @@ class GisPointTest extends GisGeomTestCase
      */
     public static function providerForTestGenerateParams(): array
     {
-        return [["'POINT(5.02 8.45)',124", ['srid' => 124, 0 => ['POINT' => ['x' => 5.02, 'y' => 8.45]]]]];
+        return [
+            [
+                "'POINT(5.02 8.45)',124",
+                [
+                    'srid' => 124,
+                    0 => [
+                        'POINT' => [
+                            'x' => 5.02,
+                            'y' => 8.45,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                '',
+                [
+                    'srid' => 0,
+                    0 => [
+                        'POINT' => [
+                            'x' => 0.0,
+                            'y' => 0.0,
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
This makes it possible to insert a new Gis value via the editor. Opening the editor failed for empty string values since #18118