### PR TITLE
Fix error when changing password

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -584,7 +584,11 @@ Functions.suggestPassword = function (passwordForm) {
     passwordForm.elements.pma_pw2.value = passwd.value;
     var meterObj = $jQueryPasswordForm.find('meter[name="pw_meter"]').first();
     var meterObjLabel = $jQueryPasswordForm.find('span[name="pw_strength"]').first();
-    Functions.checkPasswordStrength(passwd.value, meterObj, meterObjLabel, passwordForm.elements.username.value);
+    var username = '';
+    if (passwordForm.elements.username) {
+        username = passwordForm.elements.username.value;
+    }
+    Functions.checkPasswordStrength(passwd.value, meterObj, meterObjLabel, username);
     return true;
 };
 


### PR DESCRIPTION
### Description

This PR fixes an error introduced by #18208

Ref: #18093

`Uncaught TypeError: can't access property "value", passwordForm.elements.username is undefined` when changing password from home page.

Before:

https://user-images.githubusercontent.com/25424343/222977765-672ff0fd-696b-426f-a93b-c2ca22ac2818.mp4

After:

https://user-images.githubusercontent.com/25424343/222977781-1daf6c4e-5181-4711-b4cc-6135be95f848.mp4

Another way to solve this is to move this line, one line up. https://github.com/phpmyadmin/phpmyadmin/blob/b166c0e59b3141bcb2a696e1b9f41fad25c078db/templates/server/privileges/change_password.twig#L5