### PR TITLE
[UX] Keep the criteria box collapsed by the user when un-checking the criteria checkbox

### DIFF
--- a/js/src/database/multi_table_query.js
+++ b/js/src/database/multi_table_query.js
@@ -195,7 +195,10 @@ AJAX.registerOnload('database/multi_table_query.js', function () {
         $('.criteria_col').each(function () {
             $(this).on('change', function () {
                 var $anchor = $(this).siblings('.jsCriteriaButton').first();
-                if ($(this).is(':checked') && ! $anchor.hasClass('collapsed')) {
+                if (
+                    ($(this).is(':checked') && ! $anchor.hasClass('collapsed'))
+                    || (! $(this).is(':checked') && $anchor.hasClass('collapsed'))
+                ) {
                     // Do not collapse on checkbox tick as it does not make sense
                     // The user has it open and wants to tick the box
                     return;


### PR DESCRIPTION
Hello 👋🏻 

As you can see when `criteria options` is collapsed, uncheck the box expands the `criteria options` 

Expected:
When `criteria options` is collapsed, uncheck the box should keep the `criteria options` collapsed.

[Screencast from 05-03-23 19:56:39.webm](https://user-images.githubusercontent.com/60013703/222980802-fd14e03b-fe1f-4b78-872a-5613600c7974.webm)


I have fixed this issue in this PR.