### PR TITLE
Change $GLOBALS['sql_backquotes'] to a private property

### DIFF
--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -1521,7 +1521,7 @@ class ExportSql extends ExportPlugin
                 }
 
                 // Using appropriate quotes.
-                if (($compat === 'MSSQL') || ($GLOBALS['sql_backquotes'] === '"')) {
+                if ($compat === 'MSSQL') {
                     Context::$MODE |= Context::SQL_MODE_ANSI_QUOTES;
                 }
             }

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -69,9 +69,11 @@ class ExportSql extends ExportPlugin
      */
     private bool $sentCharset = false;
 
+    private bool $useSqlBackquotes = true;
+
     protected function init(): void
     {
-        $GLOBALS['sql_backquotes'] ??= null;
+        $this->useSqlBackquotes = isset($GLOBALS['sql_backquotes']);
     }
 
     /** @psalm-return non-empty-lowercase-string */
@@ -822,7 +824,7 @@ class ExportSql extends ExportPlugin
                     . Util::backquoteCompat(
                         $dbAlias,
                         $compat,
-                        isset($GLOBALS['sql_backquotes']),
+                        $this->useSqlBackquotes,
                     )
                     . ';' . "\n",
                 )
@@ -836,7 +838,7 @@ class ExportSql extends ExportPlugin
         }
 
         $createQuery = 'CREATE DATABASE IF NOT EXISTS '
-            . Util::backquoteCompat($dbAlias, $compat, isset($GLOBALS['sql_backquotes']));
+            . Util::backquoteCompat($dbAlias, $compat, $this->useSqlBackquotes);
         $collation = $GLOBALS['dbi']->getDbCollation($db);
         if (mb_strpos($collation, '_')) {
             $createQuery .= ' DEFAULT CHARACTER SET '
@@ -872,7 +874,7 @@ class ExportSql extends ExportPlugin
                 . Util::backquoteCompat(
                     $db,
                     $compat,
-                    isset($GLOBALS['sql_backquotes']),
+                    $this->useSqlBackquotes,
                 )
                 . ';' . "\n",
             );
@@ -901,7 +903,7 @@ class ExportSql extends ExportPlugin
                 . Util::backquoteCompat(
                     $dbAlias,
                     $compat,
-                    isset($GLOBALS['sql_backquotes']),
+                    $this->useSqlBackquotes,
                 ),
             )
             . $this->exportComment();
@@ -1352,7 +1354,6 @@ class ExportSql extends ExportPlugin
         array $aliases = [],
     ): string {
         $GLOBALS['sql_drop_table'] ??= null;
-        $GLOBALS['sql_backquotes'] ??= null;
         $GLOBALS['sql_constraints'] ??= null;
         $GLOBALS['sql_constraints_query'] ??= null;
         $GLOBALS['sql_indexes'] ??= null;
@@ -1370,20 +1371,20 @@ class ExportSql extends ExportPlugin
 
         if (! empty($GLOBALS['sql_drop_table']) && $GLOBALS['dbi']->getTable($db, $table)->isView()) {
             $schemaCreate .= 'DROP VIEW IF EXISTS '
-                . Util::backquoteCompat($tableAlias, 'NONE', $GLOBALS['sql_backquotes']) . ';'
+                . Util::backquoteCompat($tableAlias, 'NONE', $this->useSqlBackquotes) . ';'
                 . "\n";
         }
 
         // no need to generate a DROP VIEW here, it was done earlier
         if (! empty($GLOBALS['sql_drop_table']) && ! $GLOBALS['dbi']->getTable($db, $table)->isView()) {
             $schemaCreate .= 'DROP TABLE IF EXISTS '
-                . Util::backquoteCompat($tableAlias, 'NONE', $GLOBALS['sql_backquotes']) . ';'
+                . Util::backquoteCompat($tableAlias, 'NONE', $this->useSqlBackquotes) . ';'
                 . "\n";
         }
 
         // Complete table dump,
         // Whether to quote table and column names or not
-        if ($GLOBALS['sql_backquotes']) {
+        if ($this->useSqlBackquotes) {
             $GLOBALS['dbi']->query('SET SQL_QUOTE_SHOW_CREATE = 1');
         } else {
             $GLOBALS['dbi']->query('SET SQL_QUOTE_SHOW_CREATE = 0');
@@ -1513,7 +1514,7 @@ class ExportSql extends ExportPlugin
             // Views have no constraints, indexes, etc. They do not require any
             // analysis.
             if (! $view) {
-                if (empty($GLOBALS['sql_backquotes'])) {
+                if (! $this->useSqlBackquotes) {
                     // Option "Enclose table and column names with backquotes"
                     // was checked.
                     Context::$MODE |= Context::SQL_MODE_NO_ENCLOSING_QUOTES;
@@ -1625,7 +1626,7 @@ class ExportSql extends ExportPlugin
                 /**
                  * The header of the `ALTER` statement (`ALTER TABLE tbl`).
                  */
-                $alterHeader = 'ALTER TABLE ' . Util::backquoteCompat($tableAlias, $compat, $GLOBALS['sql_backquotes']);
+                $alterHeader = 'ALTER TABLE ' . Util::backquoteCompat($tableAlias, $compat, $this->useSqlBackquotes);
 
                 /**
                  * The footer of the `ALTER` statement (usually ';')
@@ -1747,8 +1748,6 @@ class ExportSql extends ExportPlugin
         bool $doMime = false,
         array $aliases = [],
     ): string {
-        $GLOBALS['sql_backquotes'] ??= null;
-
         $dbAlias = $db;
         $tableAlias = $table;
         $this->initAlias($aliases, $dbAlias, $tableAlias);
@@ -1774,19 +1773,19 @@ class ExportSql extends ExportPlugin
                 . $this->exportComment()
                 . $this->exportComment(
                     __('MEDIA TYPES FOR TABLE') . ' '
-                    . Util::backquoteCompat($table, 'NONE', $GLOBALS['sql_backquotes']) . ':',
+                    . Util::backquoteCompat($table, 'NONE', $this->useSqlBackquotes) . ':',
                 );
             foreach ($mimeMap as $mimeField => $mime) {
                 $schemaCreate .= $this->exportComment(
                     '  '
-                    . Util::backquoteCompat($mimeField, 'NONE', $GLOBALS['sql_backquotes']),
+                    . Util::backquoteCompat($mimeField, 'NONE', $this->useSqlBackquotes),
                 )
                 . $this->exportComment(
                     '      '
                     . Util::backquoteCompat(
                         $mime['mimetype'],
                         'NONE',
-                        $GLOBALS['sql_backquotes'],
+                        $this->useSqlBackquotes,
                     ),
                 );
             }
@@ -1799,7 +1798,7 @@ class ExportSql extends ExportPlugin
                 . $this->exportComment()
                 . $this->exportComment(
                     __('RELATIONSHIPS FOR TABLE') . ' '
-                    . Util::backquoteCompat($tableAlias, 'NONE', $GLOBALS['sql_backquotes'])
+                    . Util::backquoteCompat($tableAlias, 'NONE', $this->useSqlBackquotes)
                     . ':',
                 );
 
@@ -1814,7 +1813,7 @@ class ExportSql extends ExportPlugin
                         . Util::backquoteCompat(
                             $relFieldAlias,
                             'NONE',
-                            $GLOBALS['sql_backquotes'],
+                            $this->useSqlBackquotes,
                         ),
                     )
                     . $this->exportComment(
@@ -1822,13 +1821,13 @@ class ExportSql extends ExportPlugin
                         . Util::backquoteCompat(
                             $rel['foreign_table'],
                             'NONE',
-                            $GLOBALS['sql_backquotes'],
+                            $this->useSqlBackquotes,
                         )
                         . ' -> '
                         . Util::backquoteCompat(
                             $rel['foreign_field'],
                             'NONE',
-                            $GLOBALS['sql_backquotes'],
+                            $this->useSqlBackquotes,
                         ),
                     );
                 } else {
@@ -1843,7 +1842,7 @@ class ExportSql extends ExportPlugin
                                 . Util::backquoteCompat(
                                     $relFieldAlias,
                                     'NONE',
-                                    $GLOBALS['sql_backquotes'],
+                                    $this->useSqlBackquotes,
                                 ),
                             )
                             . $this->exportComment(
@@ -1851,13 +1850,13 @@ class ExportSql extends ExportPlugin
                                 . Util::backquoteCompat(
                                     $oneKey['ref_table_name'],
                                     'NONE',
-                                    $GLOBALS['sql_backquotes'],
+                                    $this->useSqlBackquotes,
                                 )
                                 . ' -> '
                                 . Util::backquoteCompat(
                                     $oneKey['ref_index_list'][$index],
                                     'NONE',
-                                    $GLOBALS['sql_backquotes'],
+                                    $this->useSqlBackquotes,
                                 ),
                             );
                         }
@@ -1924,7 +1923,7 @@ class ExportSql extends ExportPlugin
         $this->initAlias($aliases, $dbAlias, $tableAlias);
         $compat = $GLOBALS['sql_compatibility'] ?? 'NONE';
 
-        $formattedTableName = Util::backquoteCompat($tableAlias, $compat, isset($GLOBALS['sql_backquotes']));
+        $formattedTableName = Util::backquoteCompat($tableAlias, $compat, $this->useSqlBackquotes);
         $dump = $this->possibleCRLF()
             . $this->exportComment(str_repeat('-', 56))
             . $this->possibleCRLF()
@@ -2049,8 +2048,6 @@ class ExportSql extends ExportPlugin
         $sqlQuery,
         array $aliases = [],
     ): bool {
-        $GLOBALS['sql_backquotes'] ??= null;
-
         // Do not export data for merge tables
         if ($GLOBALS['dbi']->getTable($db, $table)->isMerge()) {
             return true;
@@ -2062,7 +2059,7 @@ class ExportSql extends ExportPlugin
 
         $compat = $GLOBALS['sql_compatibility'] ?? 'NONE';
 
-        $formattedTableName = Util::backquoteCompat($tableAlias, $compat, $GLOBALS['sql_backquotes']);
+        $formattedTableName = Util::backquoteCompat($tableAlias, $compat, $this->useSqlBackquotes);
 
         // Do not export data for a VIEW, unless asked to export the view as a table
         // (For a VIEW, this is called only when exporting a single VIEW)
@@ -2113,7 +2110,7 @@ class ExportSql extends ExportPlugin
                 $colAs = $aliases[$db]['tables'][$table]['columns'][$colAs];
             }
 
-            $fieldSet[$j] = Util::backquoteCompat($colAs, $compat, $GLOBALS['sql_backquotes']);
+            $fieldSet[$j] = Util::backquoteCompat($colAs, $compat, $this->useSqlBackquotes);
         }
 
         if (isset($GLOBALS['sql_type']) && $GLOBALS['sql_type'] === 'UPDATE') {
@@ -2124,7 +2121,7 @@ class ExportSql extends ExportPlugin
             }
 
             // avoid EOL blank
-            $schemaInsert .= Util::backquoteCompat($tableAlias, $compat, $GLOBALS['sql_backquotes']) . ' SET';
+            $schemaInsert .= Util::backquoteCompat($tableAlias, $compat, $this->useSqlBackquotes) . ' SET';
         } else {
             // insert or replace
             if (isset($GLOBALS['sql_type']) && $GLOBALS['sql_type'] === 'REPLACE') {
@@ -2148,7 +2145,7 @@ class ExportSql extends ExportPlugin
             //truncate table before insert
             if (isset($GLOBALS['sql_truncate']) && $GLOBALS['sql_truncate'] && $sqlCommand === 'INSERT') {
                 $truncate = 'TRUNCATE TABLE '
-                    . Util::backquoteCompat($tableAlias, $compat, $GLOBALS['sql_backquotes']) . ';';
+                    . Util::backquoteCompat($tableAlias, $compat, $this->useSqlBackquotes) . ';';
                 $truncatehead = $this->possibleCRLF()
                     . $this->exportComment()
                     . $this->exportComment(
@@ -2165,11 +2162,11 @@ class ExportSql extends ExportPlugin
             if ($GLOBALS['sql_insert_syntax'] === 'complete' || $GLOBALS['sql_insert_syntax'] === 'both') {
                 $fields = implode(', ', $fieldSet);
                 $schemaInsert = $sqlCommand . $insertDelayed . ' INTO '
-                    . Util::backquoteCompat($tableAlias, $compat, $GLOBALS['sql_backquotes'])
+                    . Util::backquoteCompat($tableAlias, $compat, $this->useSqlBackquotes)
                     . ' (' . $fields . ') VALUES'; // avoid EOL blank
             } else {
                 $schemaInsert = $sqlCommand . $insertDelayed . ' INTO '
-                    . Util::backquoteCompat($tableAlias, $compat, $GLOBALS['sql_backquotes'])
+                    . Util::backquoteCompat($tableAlias, $compat, $this->useSqlBackquotes)
                     . ' VALUES';
             }
         }
@@ -2216,7 +2213,7 @@ class ExportSql extends ExportPlugin
                         . Util::backquoteCompat(
                             $tableAlias,
                             $compat,
-                            $GLOBALS['sql_backquotes'],
+                            $this->useSqlBackquotes,
                         )
                         . ' ON ;' . "\n",
                     )
@@ -2341,7 +2338,7 @@ class ExportSql extends ExportPlugin
                 . Util::backquoteCompat(
                     $tableAlias,
                     $compat,
-                    $GLOBALS['sql_backquotes'],
+                    $this->useSqlBackquotes,
                 )
                 . ' OFF;' . "\n",
             );
@@ -2674,7 +2671,7 @@ class ExportSql extends ExportPlugin
                     $comment2 . ' ' . Util::backquoteCompat(
                         $tableAlias,
                         $compat,
-                        isset($GLOBALS['sql_backquotes']),
+                        $this->useSqlBackquotes,
                     ),
                 )
                 . $this->exportComment();

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10023,15 +10023,6 @@
       <code><![CDATA[$GLOBALS['sql_auto_increments']]]></code>
       <code><![CDATA[$GLOBALS['sql_auto_increments']]]></code>
       <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
       <code><![CDATA[$GLOBALS['sql_create_database']]]></code>
       <code><![CDATA[$GLOBALS['sql_delayed']]]></code>
       <code><![CDATA[$GLOBALS['sql_disable_fk']]]></code>
@@ -10064,27 +10055,6 @@
     <MixedArgument>
       <code><![CDATA[$GLOBALS['sql_auto_increments']]]></code>
       <code><![CDATA[$GLOBALS['sql_auto_increments']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
       <code><![CDATA[$GLOBALS['sql_header_comment']]]></code>
       <code><![CDATA[$GLOBALS['sql_indexes']]]></code>
       <code><![CDATA[$GLOBALS['sql_indexes']]]></code>
@@ -10138,10 +10108,6 @@
     </MixedArrayTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['sql_auto_increments']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
-      <code><![CDATA[$GLOBALS['sql_backquotes']]]></code>
       <code><![CDATA[$GLOBALS['sql_drop_table']]]></code>
       <code><![CDATA[$GLOBALS['sql_indexes']]]></code>
       <code><![CDATA[$GLOBALS['sql_indexes_query']]]></code>

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -491,6 +491,13 @@ class ExportSqlTest extends AbstractTestCase
 
         $GLOBALS['dbi'] = $dbi;
 
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
+
         ob_start();
         $this->assertTrue(
             $this->object->exportDBCreate('db', 'database'),
@@ -526,6 +533,13 @@ class ExportSqlTest extends AbstractTestCase
 
         $GLOBALS['dbi'] = $dbi;
 
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
+
         ob_start();
         $this->assertTrue(
             $this->object->exportDBCreate('db', 'database'),
@@ -550,6 +564,13 @@ class ExportSqlTest extends AbstractTestCase
         $GLOBALS['sql_backquotes'] = true;
         $GLOBALS['sql_include_comments'] = true;
 
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
+
         ob_start();
         $this->assertTrue(
             $this->object->exportDBHeader('testDB'),
@@ -563,6 +584,13 @@ class ExportSqlTest extends AbstractTestCase
         // case 2
         unset($GLOBALS['sql_compatibility']);
         unset($GLOBALS['sql_backquotes']);
+
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
 
         ob_start();
         $this->assertTrue(
@@ -817,6 +845,13 @@ SQL;
         $GLOBALS['dbi'] = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
+
         $result = $this->object->getTableDef('db', 'table', true, true, false);
 
         $dbiDummy->assertAllQueriesConsumed();
@@ -864,6 +899,13 @@ SQL;
 
         $GLOBALS['dbi'] = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
+
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
 
         $result = $this->object->getTableDef('db', 'table', true, true, false);
 
@@ -938,6 +980,13 @@ SQL;
         $GLOBALS['sql_backquotes'] = true;
         $GLOBALS['sql_include_comments'] = true;
 
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
+
         // case 1
         ob_start();
         $this->assertTrue(
@@ -961,6 +1010,13 @@ SQL;
 
         $GLOBALS['sql_create_trigger'] = true;
         $GLOBALS['sql_drop_table'] = true;
+
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
 
         ob_start();
         $this->assertTrue(
@@ -987,6 +1043,13 @@ SQL;
         // case 3
         $GLOBALS['sql_views_as_tables'] = false;
         $GLOBALS['sql_backquotes'] = null;
+
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
 
         ob_start();
         $this->assertTrue(
@@ -1140,6 +1203,13 @@ SQL;
         $GLOBALS['sql_hex_for_binary'] = true;
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
+
         ob_start();
         $this->object->exportData('db', 'table', 'example.com/err', 'SELECT a FROM b WHERE 1');
         $result = ob_get_clean();
@@ -1240,6 +1310,13 @@ SQL;
         $GLOBALS['sql_hex_for_binary'] = true;
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
+
         ob_start();
         $this->object->exportData('db', 'table', 'example.com/err', 'SELECT a FROM b WHERE 1');
         $result = ob_get_clean();
@@ -1282,6 +1359,13 @@ SQL;
         $oldVal = $GLOBALS['sql_compatibility'] ?? '';
         $GLOBALS['sql_compatibility'] = 'NONE';
         $GLOBALS['sql_backquotes'] = true;
+
+        // Reset the object
+        $this->object = new ExportSql(
+            new Relation($GLOBALS['dbi']),
+            new Export($GLOBALS['dbi']),
+            new Transformations(),
+        );
 
         ob_start();
         $this->assertTrue(


### PR DESCRIPTION
This is necessary for setting native param types. The `$GLOBALS['sql_backquotes']` is still global in other places of the code as the goal was only to fix the usage and type of this parameter in ExportSql. 