### PR TITLE
Fix #18212 - Query Builder doesn't replace a table name with it's alias in the `WHERE` block

### DIFF
--- a/js/src/database/query_generator.js
+++ b/js/src/database/query_generator.js
@@ -33,7 +33,10 @@ function getFormatsText () {
 }
 
 function generateCondition (criteriaDiv, table) {
-    var query = '`' + Functions.escapeBacktick(table.val()) + '`.';
+    const tableName = table.val();
+    const tableAlias = table.siblings('.table_alias').val();
+
+    var query = '`' + Functions.escapeBacktick(tableAlias == '' ? tableName : tableAlias) + '`.';
     query += '`' + Functions.escapeBacktick(table.siblings('.columnNameSelect').first().val()) + '`';
     if (criteriaDiv.find('.criteria_rhs').first().val() === 'text') {
         var formatsText = getFormatsText();


### PR DESCRIPTION
Fixes #18212 

![image](https://user-images.githubusercontent.com/60013703/223762613-c926e085-4dda-44ba-be41-cdba94952d20.png)
