### PR TITLE
Disable unnecessary tables actions when empty

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -516,7 +516,7 @@ Functions.checkPasswordStrength = function (value, meterObject, meterObjectLabel
         'my',
         'admin',
     ];
-    if (username !== null) {
+    if (username) {
         customDict.push(username);
     }
 
@@ -584,7 +584,7 @@ Functions.suggestPassword = function (passwordForm) {
     passwordForm.elements.pma_pw2.value = passwd.value;
     var meterObj = $jQueryPasswordForm.find('meter[name="pw_meter"]').first();
     var meterObjLabel = $jQueryPasswordForm.find('span[name="pw_strength"]').first();
-    Functions.checkPasswordStrength(passwd.value, meterObj, meterObjLabel);
+    Functions.checkPasswordStrength(passwd.value, meterObj, meterObjLabel, passwordForm.elements.username.value);
     return true;
 };
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: phpMyAdmin 5.2.2-dev\n"
 "Report-Msgid-Bugs-To: translators@phpmyadmin.net\n"
 "POT-Creation-Date: 2023-02-08 15:09+0000\n"
-"PO-Revision-Date: 2023-01-28 03:53+0000\n"
+"PO-Revision-Date: 2023-03-05 11:20+0000\n"
 "Last-Translator: liviuconcioiu <liviu.concioiu@gmail.com>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/phpmyadmin/5-2/"
 "ro/>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
 "20)) ? 1 : 2;\n"
-"X-Generator: Weblate 4.16-dev\n"
+"X-Generator: Weblate 4.16.2-dev\n"
 
 #: libraries/advisory_rules_generic.php:9
 msgid "Uptime below one day"
@@ -948,7 +948,7 @@ msgstr ""
 
 #: libraries/advisory_rules_generic.php:599
 msgid "Is InnoDB disabled?"
-msgstr "Este InnoDB dizactivat?"
+msgstr "Este InnoDB dezactivat?"
 
 #: libraries/advisory_rules_generic.php:603
 msgid "You do not have InnoDB enabled."

--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -49,9 +49,13 @@
         </a>
     </td>
     <td class="text-center d-print-none">
-        <a href="{{ url('/table/search', table_url_params) }}">
-          {{ may_have_rows ? get_icon('b_select', 'Search'|trans) : get_icon('bd_select', 'Search'|trans) }}
-        </a>
+        {% if may_have_rows %}
+            <a href="{{ url('/table/search', table_url_params) }}">
+                {{ get_icon('b_select', 'Search'|trans) }}
+            </a>
+        {% else %}
+            <div>{{ get_icon('bd_select', 'Search'|trans) }}</div>
+        {% endif %}
     </td>
 
     {% if not db_is_system_schema %}
@@ -67,12 +71,16 @@
             </td>
         {% else %}
           <td class="text-center d-print-none">
+            {% if may_have_rows %}
                 <a class="truncate_table_anchor ajax" href="{{ url('/sql') }}" data-post="{{ get_common(table_url_params|merge({
-                  'sql_query': empty_table_sql_query,
-                  'message_to_show': empty_table_message_to_show
+                    'sql_query': empty_table_sql_query,
+                    'message_to_show': empty_table_message_to_show
                 }), '') }}">
-                  {{ may_have_rows ? get_icon('b_empty', 'Empty'|trans) : get_icon('bd_empty', 'Empty'|trans) }}
+                    {{ get_icon('b_empty', 'Empty'|trans) }}
                 </a>
+            {% else %}
+                <div>{{ get_icon('bd_empty', 'Empty'|trans) }}</div>
+            {% endif %}
           </td>
         {% endif %}
         <td class="text-center d-print-none">


### PR DESCRIPTION
Hello 👋🏻 

In this PR I have disabled `Search` and `Empty` actions on empty tables since they have no use in this case.

## Before
You can click on `Search` and `Empty` actions on all tables.


![image](https://user-images.githubusercontent.com/60013703/224440357-0594e582-389d-4435-8b9b-26c60d101765.png)

## After
You can't click on `Search` and `Empty` actions on empty tables.


![image](https://user-images.githubusercontent.com/60013703/224440199-cc653758-7c3d-4a36-bb04-55a596f8dc83.png)
