### PR TITLE
Fix #15898 - escape tbl_storage_engine argument

### DIFF
--- a/libraries/classes/CreateAddField.php
+++ b/libraries/classes/CreateAddField.php
@@ -474,7 +474,7 @@ class CreateAddField
         if (!empty($_POST['tbl_storage_engine'])
             && ($_POST['tbl_storage_engine'] != 'Default')
         ) {
-            $sqlQuery .= ' ENGINE = ' . $_POST['tbl_storage_engine'];
+            $sqlQuery .= ' ENGINE = ' . $this->dbi->escapeString($_POST['tbl_storage_engine']);
         }
         if (!empty($_POST['tbl_collation'])) {
             $sqlQuery .= Util::getCharsetQueryPart($_POST['tbl_collation']);


### PR DESCRIPTION
Signed-off-by: William Desportes <williamdes@wdes.fr>
(cherry picked from commit ca42395ee4b2936d3702524f8fb8bec1e9502bc7)

### Description

The SQL injection was discovered and fixed a long time ago. Can you include the fix in a subsequent 4.9 release? I just cherry-picked the fixing commit, and I think the original plan was to include it in the 4.9 branch, if applicable (#15898).