### PR TITLE
Fix empty Appearance settings

### DIFF
--- a/templates/home/index.twig
+++ b/templates/home/index.twig
@@ -88,6 +88,7 @@
             </div>
           {% endif %}
 
+            {% if available_languages is not empty or has_theme_manager %}
             <div class="card mt-4">
               <div class="card-header">
                 {% trans 'Appearance settings' %}
@@ -148,6 +149,7 @@
                 {% endif %}
               </ul>
             </div>
+            {% endif %}
           </div>
 
       <div class="col-lg-5 col-12">


### PR DESCRIPTION
### Description

When `$cfg['ThemeManager']` is set to `false` and phpMyAdmin is only in English, then `Appearance settings` is empty. This PR fixes this issue.

Before:

![before](https://user-images.githubusercontent.com/25424343/225876686-a42181cf-5f19-4381-b1d2-7ce7fddf8e10.png)

After:

![after](https://user-images.githubusercontent.com/25424343/225876735-bc358dc8-a077-4334-bfbf-76c11af5a790.png)