### PR TITLE
Ref #17769 - Replace superglobals with serverrequest in controllers

### DIFF
--- a/libraries/classes/Controllers/Database/ImportController.php
+++ b/libraries/classes/Controllers/Database/ImportController.php
@@ -77,7 +77,9 @@ final class ImportController extends AbstractController
         $idKey = $_SESSION[$GLOBALS['SESSION_KEY']]['handler']::getIdKey();
         $hiddenInputs = [$idKey => $uploadId, 'import_type' => 'database', 'db' => $GLOBALS['db']];
 
-        $default = isset($_GET['format']) ? (string) $_GET['format'] : Plugins::getDefault('Import', 'format');
+        $default = $request->hasQueryParam('format')
+            ? (string) $request->getQueryParam('format')
+            : Plugins::getDefault('Import', 'format');
         $choice = Plugins::getChoice($importList, $default);
         $options = Plugins::getOptions('Import', $importList);
         $skipQueriesDefault = Plugins::getDefault('Import', 'skip_queries');

--- a/libraries/classes/Controllers/Server/ImportController.php
+++ b/libraries/classes/Controllers/Server/ImportController.php
@@ -73,7 +73,9 @@ final class ImportController extends AbstractController
         $idKey = $_SESSION[$GLOBALS['SESSION_KEY']]['handler']::getIdKey();
         $hiddenInputs = [$idKey => $uploadId, 'import_type' => 'server'];
 
-        $default = isset($_GET['format']) ? (string) $_GET['format'] : Plugins::getDefault('Import', 'format');
+        $default = $request->hasQueryParam('format')
+            ? (string) $request->getQueryParam('format')
+            : Plugins::getDefault('Import', 'format');
         $choice = Plugins::getChoice($importList, $default);
         $options = Plugins::getOptions('Import', $importList);
         $skipQueriesDefault = Plugins::getDefault('Import', 'skip_queries');

--- a/libraries/classes/Controllers/Server/UserGroupsFormController.php
+++ b/libraries/classes/Controllers/Server/UserGroupsFormController.php
@@ -17,7 +17,6 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function sprintf;
-use function strlen;
 
 final class UserGroupsFormController extends AbstractController
 {
@@ -34,15 +33,16 @@ final class UserGroupsFormController extends AbstractController
     {
         $this->response->setAjax(true);
 
-        if (! isset($_GET['username']) || strlen((string) $_GET['username']) === 0) {
+        /** @var string $username */
+        $username = $request->getQueryParam('username', '');
+
+        if ($username === '') {
             $this->response->setRequestStatus(false);
             $this->response->setHttpResponseCode(400);
             $this->response->addJSON('message', __('Missing parameter:') . ' username');
 
             return;
         }
-
-        $username = $_GET['username'];
 
         $checkUserPrivileges = new CheckUserPrivileges($this->dbi);
         $checkUserPrivileges->getPrivileges();

--- a/libraries/classes/Controllers/Sql/SqlController.php
+++ b/libraries/classes/Controllers/Sql/SqlController.php
@@ -112,9 +112,10 @@ class SqlController extends AbstractController
             $GLOBALS['sql_query'] = $bkmFields['bkm_sql_query'];
         } elseif ($sqlQuery !== null) {
             $GLOBALS['sql_query'] = $sqlQuery;
-        } elseif (isset($_GET['sql_query'], $_GET['sql_signature'])) {
-            if (Core::checkSqlQuerySignature($_GET['sql_query'], $_GET['sql_signature'])) {
-                $GLOBALS['sql_query'] = $_GET['sql_query'];
+        } elseif ($request->hasQueryParam('sql_query') && $request->hasQueryParam('sql_signature')) {
+            $sqlQuery = $request->getQueryParam('sql_query');
+            if (Core::checkSqlQuerySignature($sqlQuery, $request->getQueryParam('sql_signature'))) {
+                $GLOBALS['sql_query'] = $sqlQuery;
             }
         }
 

--- a/libraries/classes/Controllers/Table/ChangeController.php
+++ b/libraries/classes/Controllers/Table/ChangeController.php
@@ -75,9 +75,10 @@ class ChangeController extends AbstractController
 
         DbTableExists::check($GLOBALS['db'], $GLOBALS['table']);
 
-        if (isset($_GET['where_clause'], $_GET['where_clause_signature'])) {
-            if (Core::checkSqlQuerySignature($_GET['where_clause'], $_GET['where_clause_signature'])) {
-                $GLOBALS['where_clause'] = $_GET['where_clause'];
+        if ($request->hasQueryParam('where_clause') && $request->hasQueryParam('where_clause_signature')) {
+            $whereClause = $request->getQueryParam('where_clause');
+            if (Core::checkSqlQuerySignature($whereClause, $request->getQueryParam('where_clause_signature'))) {
+                $GLOBALS['where_clause'] = $whereClause;
             }
         }
 

--- a/libraries/classes/Controllers/Table/ExportController.php
+++ b/libraries/classes/Controllers/Table/ExportController.php
@@ -92,7 +92,7 @@ class ExportController extends AbstractController
             $GLOBALS['unlim_num_rows'] = 0;
         }
 
-        $GLOBALS['single_table'] = $_POST['single_table'] ?? $_GET['single_table'] ?? $GLOBALS['single_table'] ?? null;
+        $GLOBALS['single_table'] = $request->getParam('single_table') ?? $GLOBALS['single_table'] ?? null;
 
         $exportList = Plugins::getExport('table', isset($GLOBALS['single_table']));
 
@@ -105,8 +105,8 @@ class ExportController extends AbstractController
         }
 
         $exportType = 'table';
-        $isReturnBackFromRawExport = isset($_POST['export_type']) && $_POST['export_type'] === 'raw';
-        if (isset($_POST['raw_query']) || $isReturnBackFromRawExport) {
+        $isReturnBackFromRawExport = $request->getParsedBodyParam('export_type') === 'raw';
+        if ($request->hasBodyParam('raw_query') || $isReturnBackFromRawExport) {
             $exportType = 'raw';
         }
 

--- a/libraries/classes/Controllers/Table/ImportController.php
+++ b/libraries/classes/Controllers/Table/ImportController.php
@@ -89,7 +89,9 @@ final class ImportController extends AbstractController
             'table' => $GLOBALS['table'],
         ];
 
-        $default = isset($_GET['format']) ? (string) $_GET['format'] : Plugins::getDefault('Import', 'format');
+        $default = $request->hasQueryParam('format')
+            ? (string) $request->getQueryParam('format')
+            : Plugins::getDefault('Import', 'format');
         $choice = Plugins::getChoice($importList, $default);
         $options = Plugins::getOptions('Import', $importList);
         $skipQueriesDefault = Plugins::getDefault('Import', 'skip_queries');

--- a/libraries/classes/Controllers/Table/SqlController.php
+++ b/libraries/classes/Controllers/Table/SqlController.php
@@ -55,15 +55,14 @@ final class SqlController extends AbstractController
          */
         $GLOBALS['goto'] = Url::getFromRoute('/table/sql');
         $GLOBALS['back'] = Url::getFromRoute('/table/sql');
+        $delimiter = $request->getParsedBodyParam('delimiter', ';');
 
         $this->response->addHTML($this->sqlQueryForm->getHtml(
             $GLOBALS['db'],
             $GLOBALS['table'],
-            $_GET['sql_query'] ?? true,
+            $request->getQueryParam('sql_query', true),
             false,
-            isset($_POST['delimiter'])
-                ? htmlspecialchars($_POST['delimiter'])
-                : ';',
+            htmlspecialchars($delimiter),
         ));
     }
 }

--- a/libraries/classes/Controllers/View/CreateController.php
+++ b/libraries/classes/Controllers/View/CreateController.php
@@ -121,18 +121,20 @@ class CreateController extends AbstractController
         ];
 
         // Used to prefill the fields when editing a view
-        if (isset($_GET['db'], $_GET['table'])) {
+        if ($request->hasQueryParam('db') && $request->hasQueryParam('table')) {
+            $db = $request->getQueryParam('db');
+            $table = $request->getQueryParam('table');
             $item = $this->dbi->fetchSingleRow(
                 sprintf(
                     'SELECT `VIEW_DEFINITION`, `CHECK_OPTION`, `DEFINER`, `SECURITY_TYPE`
                         FROM `INFORMATION_SCHEMA`.`VIEWS`
                         WHERE TABLE_SCHEMA=%s
                         AND TABLE_NAME=%s;',
-                    $this->dbi->quoteString($_GET['db']),
-                    $this->dbi->quoteString($_GET['table']),
+                    $this->dbi->quoteString($db),
+                    $this->dbi->quoteString($table),
                 ),
             );
-            $createView = $this->dbi->getTable($_GET['db'], $_GET['table'])
+            $createView = $this->dbi->getTable($db, $table)
                 ->showCreate();
 
             // CREATE ALGORITHM=<ALGORITHM> DE...
@@ -141,7 +143,7 @@ class CreateController extends AbstractController
             $viewData['operation'] = 'alter';
             $viewData['definer'] = $item['DEFINER'];
             $viewData['sql_security'] = $item['SECURITY_TYPE'];
-            $viewData['name'] = $_GET['table'];
+            $viewData['name'] = $table;
             $viewData['as'] = $item['VIEW_DEFINITION'];
             $viewData['with'] = $item['CHECK_OPTION'];
             $viewData['algorithm'] = $item['ALGORITHM'];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1036,6 +1036,11 @@ parameters:
 			path: libraries/classes/Controllers/Database/DesignerController.php
 
 		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Database/ImportController.php
+
+		-
 			message: "#^Parameter \\#1 \\$sqlQuery of static method PhpMyAdmin\\\\Database\\\\MultiTableQuery\\:\\:displayResults\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/MultiTableQuery/QueryController.php
@@ -1811,6 +1816,11 @@ parameters:
 			path: libraries/classes/Controllers/Server/DatabasesController.php
 
 		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Server/ImportController.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\Controllers\\\\Server\\\\PrivilegesController\\:\\:getExportPageTitle\\(\\) has parameter \\$selectedUsers with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Server/PrivilegesController.php
@@ -2076,9 +2086,29 @@ parameters:
 			path: libraries/classes/Controllers/Sql/SetValuesController.php
 
 		-
+			message: "#^Parameter \\#1 \\$sqlQuery of static method PhpMyAdmin\\\\Core\\:\\:checkSqlQuerySignature\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Sql/SqlController.php
+
+		-
+			message: "#^Parameter \\#2 \\$signature of static method PhpMyAdmin\\\\Core\\:\\:checkSqlQuerySignature\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Sql/SqlController.php
+
+		-
 			message: "#^Parameter \\#1 \\$target of static method PhpMyAdmin\\\\Util\\:\\:getScriptNameForOption\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/AddFieldController.php
+
+		-
+			message: "#^Parameter \\#1 \\$sqlQuery of static method PhpMyAdmin\\\\Core\\:\\:checkSqlQuerySignature\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/ChangeController.php
+
+		-
+			message: "#^Parameter \\#2 \\$signature of static method PhpMyAdmin\\\\Core\\:\\:checkSqlQuerySignature\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/ChangeController.php
 
 		-
 			message: "#^Parameter \\#2 \\$offset of class PhpMyAdmin\\\\SqlParser\\\\Components\\\\Limit constructor expects int, \\(float\\|int\\) given\\.$#"
@@ -2129,6 +2159,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$test of static method PhpMyAdmin\\\\Mime\\:\\:detect\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/GetFieldController.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/ImportController.php
 
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
@@ -2274,6 +2309,16 @@ parameters:
 			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/SearchController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/SqlController.php
+
+		-
+			message: "#^Parameter \\#3 \\$query of method PhpMyAdmin\\\\SqlQueryForm\\:\\:getHtml\\(\\) expects bool\\|string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/SqlController.php
 
 		-
 			message: "#^Parameter \\#1 \\$selected of method PhpMyAdmin\\\\Controllers\\\\Table\\\\Structure\\\\ChangeController\\:\\:displayHtmlForColumnChange\\(\\) expects array\\<string\\>, array\\<int, mixed\\> given\\.$#"
@@ -2611,7 +2656,22 @@ parameters:
 			path: libraries/classes/Controllers/View/CreateController.php
 
 		-
+			message: "#^Parameter \\#1 \\$dbName of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTable\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/View/CreateController.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:quoteString\\(\\) expects string, mixed given\\.$#"
+			count: 2
+			path: libraries/classes/Controllers/View/CreateController.php
+
+		-
 			message: "#^Parameter \\#2 \\$string of function explode expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/View/CreateController.php
+
+		-
+			message: "#^Parameter \\#2 \\$tableName of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTable\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/View/CreateController.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1191,15 +1191,9 @@
     <MixedMethodCall>
       <code><![CDATA[$_SESSION[$GLOBALS['SESSION_KEY']]['handler']::getIdKey()]]></code>
     </MixedMethodCall>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$_GET['format']]]></code>
-    </PossiblyInvalidCast>
     <PossiblyUnusedMethod>
       <code>__construct</code>
     </PossiblyUnusedMethod>
-    <UnusedParam>
-      <code>$request</code>
-    </UnusedParam>
   </file>
   <file src="libraries/classes/Controllers/Database/MultiTableQuery/QueryController.php">
     <MixedArgument>
@@ -2802,15 +2796,9 @@
     <MixedMethodCall>
       <code><![CDATA[$_SESSION[$GLOBALS['SESSION_KEY']]['handler']::getIdKey()]]></code>
     </MixedMethodCall>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$_GET['format']]]></code>
-    </PossiblyInvalidCast>
     <PossiblyUnusedMethod>
       <code>__construct</code>
     </PossiblyUnusedMethod>
-    <UnusedParam>
-      <code>$request</code>
-    </UnusedParam>
   </file>
   <file src="libraries/classes/Controllers/Server/PluginsController.php">
     <PossiblyUnusedParam>
@@ -3085,22 +3073,12 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="libraries/classes/Controllers/Server/UserGroupsFormController.php">
-    <PossiblyInvalidArgument>
-      <code>$username</code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$_GET['username']]]></code>
-      <code>$username</code>
-    </PossiblyInvalidCast>
     <PossiblyNullArrayOffset>
       <code>$allUserGroups</code>
     </PossiblyNullArrayOffset>
     <PossiblyUnusedMethod>
       <code>__construct</code>
     </PossiblyUnusedMethod>
-    <UnusedParam>
-      <code>$request</code>
-    </UnusedParam>
   </file>
   <file src="libraries/classes/Controllers/Server/Variables/GetVariableController.php">
     <MixedArgument>
@@ -3235,6 +3213,8 @@
       <code><![CDATA[$GLOBALS['message_to_show'] ?? null]]></code>
       <code><![CDATA[$GLOBALS['sql_query']]]></code>
       <code><![CDATA[$GLOBALS['sql_query']]]></code>
+      <code><![CDATA[$request->getQueryParam('sql_signature')]]></code>
+      <code>$sqlQuery</code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$GLOBALS['ajax_reload']['reload']]]></code>
@@ -3255,22 +3235,11 @@
       <code><![CDATA[$GLOBALS['unlim_num_rows']]]></code>
       <code>$bkmAllUsers</code>
       <code>$sqlQuery</code>
+      <code>$sqlQuery</code>
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </MixedOperand>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$GLOBALS['sql_query']]]></code>
-      <code><![CDATA[$GLOBALS['sql_query']]]></code>
-      <code><![CDATA[$_GET['sql_query']]]></code>
-      <code><![CDATA[$_GET['sql_signature']]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$GLOBALS['sql_query']]]></code>
-      <code><![CDATA[$GLOBALS['sql_query']]]></code>
-      <code><![CDATA[$_GET['sql_query']]]></code>
-      <code><![CDATA[$_GET['sql_signature']]]></code>
-    </PossiblyInvalidCast>
   </file>
   <file src="libraries/classes/Controllers/Table/AddFieldController.php">
     <InvalidArrayOffset>
@@ -3346,6 +3315,8 @@
       <code><![CDATA[$GLOBALS['unsaved_values']]]></code>
       <code><![CDATA[$GLOBALS['where_clause'] ?? null]]></code>
       <code>$isUpload</code>
+      <code><![CDATA[$request->getQueryParam('where_clause_signature')]]></code>
+      <code>$whereClause</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$rowId</code>
@@ -3379,17 +3350,11 @@
       <code><![CDATA[$GLOBALS['where_clause_array']]]></code>
       <code><![CDATA[$GLOBALS['where_clauses']]]></code>
       <code>$isUpload</code>
+      <code>$whereClause</code>
     </MixedAssignment>
     <PossiblyInvalidArgument>
       <code><![CDATA[$GLOBALS['current_result']]]></code>
-      <code><![CDATA[$GLOBALS['where_clause'] ?? null]]></code>
-      <code><![CDATA[$_GET['where_clause']]]></code>
-      <code><![CDATA[$_GET['where_clause_signature']]]></code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$_GET['where_clause']]]></code>
-      <code><![CDATA[$_GET['where_clause_signature']]]></code>
-    </PossiblyInvalidCast>
     <PossiblyNullArgument>
       <code><![CDATA[$GLOBALS['text_dir']]]></code>
       <code>$isUpload</code>
@@ -3557,9 +3522,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$parser->list]]></code>
     </PossiblyNullArgument>
-    <PossiblyUnusedParam>
-      <code>$request</code>
-    </PossiblyUnusedParam>
   </file>
   <file src="libraries/classes/Controllers/Table/ExportRowsController.php">
     <InvalidArrayOffset>
@@ -3691,12 +3653,6 @@
     <MixedMethodCall>
       <code><![CDATA[$_SESSION[$GLOBALS['SESSION_KEY']]['handler']::getIdKey()]]></code>
     </MixedMethodCall>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$_GET['format']]]></code>
-    </PossiblyInvalidCast>
-    <UnusedParam>
-      <code>$request</code>
-    </UnusedParam>
   </file>
   <file src="libraries/classes/Controllers/Table/IndexRenameController.php">
     <InvalidArrayOffset>
@@ -4048,17 +4004,15 @@
       <code><![CDATA[$GLOBALS['back']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
     </InvalidArrayOffset>
+    <MixedArgument>
+      <code>$delimiter</code>
+      <code><![CDATA[$request->getQueryParam('sql_query', true)]]></code>
+    </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['back']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
+      <code>$delimiter</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$_GET['sql_query'] ?? true]]></code>
-      <code><![CDATA[$_POST['delimiter']]]></code>
-    </PossiblyInvalidArgument>
-    <UnusedParam>
-      <code>$request</code>
-    </UnusedParam>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/AbstractIndexController.php">
     <MixedArgumentTypeCoercion>
@@ -4588,6 +4542,8 @@
       <code><![CDATA[$viewData['as']]]></code>
     </DocblockTypeContradiction>
     <MixedArgument>
+      <code>$db</code>
+      <code>$table</code>
       <code><![CDATA[$view['as']]]></code>
       <code><![CDATA[$view['column_names']]]></code>
       <code><![CDATA[$view['definer']]]></code>
@@ -4598,6 +4554,8 @@
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['sql_query']]]></code>
+      <code>$db</code>
+      <code>$table</code>
       <code><![CDATA[$viewData['as']]]></code>
       <code><![CDATA[$viewData['as']]]></code>
       <code><![CDATA[$viewData['definer']]]></code>
@@ -4611,18 +4569,6 @@
       <code><![CDATA[$view['sql_security']]]></code>
       <code><![CDATA[$view['with']]]></code>
     </MixedOperand>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$_GET['db']]]></code>
-      <code><![CDATA[$_GET['db']]]></code>
-      <code><![CDATA[$_GET['table']]]></code>
-      <code><![CDATA[$_GET['table']]]></code>
-    </PossiblyInvalidArgument>
-    <PossiblyInvalidCast>
-      <code><![CDATA[$_GET['db']]]></code>
-      <code><![CDATA[$_GET['db']]]></code>
-      <code><![CDATA[$_GET['table']]]></code>
-      <code><![CDATA[$_GET['table']]]></code>
-    </PossiblyInvalidCast>
     <PossiblyUnusedMethod>
       <code>__construct</code>
     </PossiblyUnusedMethod>

--- a/test/classes/Controllers/Table/SqlControllerTest.php
+++ b/test/classes/Controllers/Table/SqlControllerTest.php
@@ -78,10 +78,14 @@ class SqlControllerTest extends AbstractTestCase
             'is_foreign_key_check' => true,
         ]);
 
+        $request = $this->createStub(ServerRequest::class);
+        $request->method('getParsedBodyParam')->willReturnMap([['delimiter', ';', ';']]);
+        $request->method('getQueryParam')->willReturnMap([['sql_query', true, true]]);
+
         $response = new ResponseRenderer();
         (
             new SqlController($response, $template, new SqlQueryForm($template, $this->dbi))
-        )($this->createStub(ServerRequest::class));
+        )($request);
         $this->assertSame($expected, $response->getHTMLResult());
     }
 }


### PR DESCRIPTION
### Description

Ref https://github.com/phpmyadmin/phpmyadmin/issues/17769

Replace superglobals with ServerRequest in

      libraries/classes/Controllers/Database/ImportController.php
      libraries/classes/Controllers/Server/ImportController.php
      libraries/classes/Controllers/Server/UserGroupsFormController.php
      libraries/classes/Controllers/Sql/SqlController.php
      libraries/classes/Controllers/Table/ChangeController.php
      libraries/classes/Controllers/Table/ExportController.php
      libraries/classes/Controllers/Table/ImportController.php
      libraries/classes/Controllers/Table/SqlController.php
      libraries/classes/Controllers/View/CreateController.php
