### PR TITLE
Fix #17910 - Added Tooltips for Datetime and Timestamp fields

### DIFF
--- a/js/src/modules/functions.js
+++ b/js/src/modules/functions.js
@@ -208,6 +208,8 @@ Functions.addDateTimePicker = function () {
                 tooltip($(this), 'input', window.Messages.strMysqlAllowedValuesTipTime);
             } else if ($(this).hasClass('datefield')) {
                 tooltip($(this), 'input', window.Messages.strMysqlAllowedValuesTipDate);
+            } else if ($(this).hasClass('datetimefield')) {
+                tooltip($(this), 'input', window.Messages.strMysqlAllowedValuesTipDatetime);
             }
         });
     }

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -520,6 +520,12 @@ final class JavaScriptMessagesController
                 . ' key in those values directly if desired',
             ),
 
+            /* For Tip to be shown on Datetime and Timestamp fields */
+            'strMysqlAllowedValuesTipDatetime' => __(
+                'MySQL accepts additional values not selectable by the datepicker or slider;'
+                . ' type those values directly if desired',
+            ),
+
             /* For Lock symbol Tooltip */
             'strLockToolTip' => __(
                 'Indicates that you have made changes to this page;'


### PR DESCRIPTION
Added Tooltips for both datetime and timestamp fields.

![image](https://user-images.githubusercontent.com/61785236/228565014-b2c62eef-8f29-44f6-a4b1-8d61c9c48786.png)

![image](https://user-images.githubusercontent.com/61785236/228565191-50aaf4be-95c8-4f25-b96f-64c968b39ba3.png)

![image](https://user-images.githubusercontent.com/61785236/228565309-9642ee1a-2493-461b-86c0-8c910544d31b.png)

![image](https://user-images.githubusercontent.com/61785236/228565406-075f1403-049f-4bf6-b288-ced3c77f832e.png)


Fixes: #17910