### PR TITLE
Measure time only for user queries

### DIFF
--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -218,11 +218,14 @@ class DatabaseInterface implements DbalInterface
 
         $result = $this->extension->realQuery($query, $this->links[$link], $options);
 
+        if ($link === self::CONNECT_USER) {
+            $this->lastQueryExecutionTime = microtime(true) - $time;
+        }
+
         if ($cache_affected_rows) {
             $GLOBALS['cached_affected_rows'] = $this->affectedRows($link, false);
         }
 
-        $this->lastQueryExecutionTime = microtime(true) - $time;
         if ($debug) {
             $errorMessage = $this->getError($link);
             Utilities::debugLogQueryIntoSession(


### PR DESCRIPTION
Fixes #18296. We are only interested in the execution time of the user queries. All queries in Tracker are executed via control user. 



Ref: #16005