### PR TITLE
Navigation panel settings icon issues

### DIFF
--- a/libraries/classes/Controllers/Preferences/TwoFactorController.php
+++ b/libraries/classes/Controllers/Preferences/TwoFactorController.php
@@ -66,5 +66,11 @@ class TwoFactorController extends AbstractController
             'backends' => $twoFactor->getAllBackends(),
             'missing' => $twoFactor->getMissingDeps(),
         ]);
+
+        if ($this->response->isAjax()) {
+            $this->response->addJSON('disableNaviSettings', true);
+        } else {
+            define('PMA_DISABLE_NAVI_SETTINGS', true);
+        }
     }
 }

--- a/public/themes/bootstrap/scss/_common.scss
+++ b/public/themes/bootstrap/scss/_common.scss
@@ -901,7 +901,7 @@ textarea#partitiondefinition {
 
 // for elements that should be revealed only via js
 .hide {
-  display: none;
+  display: none !important;
 }
 
 #list_server {

--- a/public/themes/bootstrap/scss/_common.scss
+++ b/public/themes/bootstrap/scss/_common.scss
@@ -795,7 +795,6 @@ textarea {
 
 #maincontainer {
   ul {
-    list-style-type: disc;
     vertical-align: middle;
   }
 

--- a/public/themes/metro/scss/_common.scss
+++ b/public/themes/metro/scss/_common.scss
@@ -995,7 +995,6 @@ textarea {
 }
 
 #maincontainer ul {
-  list-style-type: square;
   vertical-align: middle;
   color: $th-color;
   margin-left: 20px;

--- a/public/themes/original/scss/_common.scss
+++ b/public/themes/original/scss/_common.scss
@@ -777,7 +777,6 @@ textarea {
 
 #maincontainer {
   ul {
-    list-style-type: disc;
     vertical-align: middle;
   }
 

--- a/public/themes/pmahomme/scss/_common.scss
+++ b/public/themes/pmahomme/scss/_common.scss
@@ -968,7 +968,6 @@ textarea {
 
 #maincontainer {
   ul {
-    list-style-type: disc;
     vertical-align: middle;
   }
 


### PR DESCRIPTION
### Description

Please describe your pull request.

Fixes 3 of the tasks in #18162:
- 5.2.2-dev, 6.0.0-dev - On all themes, the icon is still present if Two-factor authentication tab from Settings is selected.
- 5.2.2-dev, 6.0.0-dev - On Bootstrap theme, the icon is present on all tabs from Settings.
- 5.2.2-dev (not tested), 6.0.0-dev - On all themes, sometimes on Page-related settings modal some dots can be seen (see second video) only if the Settings icon is clicked from home page caused by (list-style-type: disc)

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
