### PR TITLE
Fix #18248: Change password modal not opening issue fixed

### DIFF
--- a/libraries/classes/Controllers/HomeController.php
+++ b/libraries/classes/Controllers/HomeController.php
@@ -239,6 +239,7 @@ class HomeController extends AbstractController
             'has_theme_manager' => $GLOBALS['cfg']['ThemeManager'],
             'themes' => $this->themeManager->getThemesArray(),
             'errors' => $this->errors,
+            'is_ajax' => $this->response->isAjax(),
         ]);
     }
 

--- a/templates/home/index.twig
+++ b/templates/home/index.twig
@@ -6,6 +6,10 @@
 
 {{ partial_logout|raw }}
 
+{% if has_change_password_link and (is_ajax) %}
+  {{ include('modals/change_password.twig') }}
+{% endif %}
+
 <div id="maincontainer">
   {{ sync_favorite_tables|raw }}
   <div class="container-fluid">


### PR DESCRIPTION
### Description

Fix issue with change password modal not opening

Added conditional rendering of change password modal on home/index template

Added is_ajax field on home/index template to detect if response is ajax or not

Fixes #18248 