### PR TITLE
Fix issues with settings icon in nav panel

### DIFF
--- a/libraries/classes/Controllers/Preferences/TwoFactorController.php
+++ b/libraries/classes/Controllers/Preferences/TwoFactorController.php
@@ -73,5 +73,11 @@ class TwoFactorController extends AbstractController
             'backends' => $twoFactor->getAllBackends(),
             'missing' => $twoFactor->getMissingDeps(),
         ]);
+
+        if ($this->response->isAjax()) {
+            $this->response->addJSON('disableNaviSettings', true);
+        } else {
+            define('PMA_DISABLE_NAVI_SETTINGS', true);
+        }
     }
 }

--- a/themes/bootstrap/scss/_common.scss
+++ b/themes/bootstrap/scss/_common.scss
@@ -884,7 +884,7 @@ textarea#partitiondefinition {
 
 // for elements that should be revealed only via js
 .hide {
-  display: none;
+  display: none !important;
 }
 
 #list_server {


### PR DESCRIPTION
- settings icon still shows in 2FA in all themes.
- bootstrap theme still shows settings icon on all settings tabs.

### Description
Fixes task 1 and 2 from #18162
- 5.2.2-dev, 6.0.0-dev - On all themes, the icon is still present if Two-factor authentication tab from Settings is selected.
- 5.2.2-dev, 6.0.0-dev - On Bootstrap theme, the icon is present on all tabs from Settings.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
