### PR TITLE
Minimize form label column width

### DIFF
--- a/templates/database/events/editor_form.twig
+++ b/templates/database/events/editor_form.twig
@@ -15,6 +15,11 @@
 
     <div class="card-body">
       <table class="rte_table table table-borderless table-sm">
+        <colgroup>
+          <col>
+          <col width="100%">
+        </colgroup>
+
         <tr>
           <td>{% trans 'Event name' %}</td>
           <td>
@@ -22,7 +27,7 @@
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Status' %}</td>
+          <td class="text-nowrap">{% trans 'Status' %}</td>
           <td>
             <select name="item_status">
               {% for status in status_display %}
@@ -31,7 +36,7 @@
             </select>
           </td>
         </tr>
-        <tr>
+        <tr class="text-nowrap">
           <td>{% trans 'Event type' %}</td>
           <td>
             {% if is_ajax %}
@@ -50,13 +55,13 @@
           </td>
         </tr>
         <tr class="onetime_event_row{{ event.item_type != 'ONE TIME' ? ' hide' }}">
-          <td>{% trans 'Execute at' %}</td>
+          <td class="text-nowrap">{% trans 'Execute at' %}</td>
           <td class="text-nowrap">
             <input type="text" name="item_execute_at" value="{{ event.item_execute_at }}" class="datetimefield">
           </td>
         </tr>
         <tr class="recurring_event_row{{ event.item_type != 'RECURRING' ? ' hide' }}">
-          <td>{% trans 'Execute every' %}</td>
+          <td class="text-nowrap">{% trans 'Execute every' %}</td>
           <td>
             <input class="w-50" type="text" name="item_interval_value" value="{{ event.item_interval_value }}">
             <select class="w-50" name="item_interval_field">
@@ -67,19 +72,19 @@
           </td>
         </tr>
         <tr class="recurring_event_row{{ event.item_type != 'RECURRING' ? ' hide' }}">
-          <td>{% trans %}Start{% context %}Start of recurring event{% endtrans %}</td>
+          <td class="text-nowrap">{% trans %}Start{% context %}Start of recurring event{% endtrans %}</td>
           <td class="text-nowrap">
             <input type="text" name="item_starts" value="{{ event.item_starts }}" class="datetimefield">
           </td>
         </tr>
         <tr class="recurring_event_row{{ event.item_type != 'RECURRING' ? ' hide' }}">
-          <td>{% trans %}End{% context %}End of recurring event{% endtrans %}</td>
+          <td class="text-nowrap">{% trans %}End{% context %}End of recurring event{% endtrans %}</td>
           <td class="text-nowrap">
             <input type="text" name="item_ends" value="{{ event.item_ends }}" class="datetimefield">
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Definition' %}</td>
+          <td class="text-nowrap">{% trans 'Definition' %}</td>
           <td>
             <textarea name="item_definition" rows="15" cols="40">
               {{- event.item_definition -}}
@@ -87,19 +92,19 @@
           </td>
         </tr>
         <tr>
-          <td>{% trans 'On completion preserve' %}</td>
+          <td class="text-nowrap">{% trans 'On completion preserve' %}</td>
           <td>
             <input type="checkbox" name="item_preserve"{{ event.item_preserve|raw }}>
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Definer' %}</td>
+          <td class="text-nowrap">{% trans 'Definer' %}</td>
           <td>
             <input type="text" name="item_definer" value="{{ event.item_definer }}">
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Comment' %}</td>
+          <td class="text-nowrap">{% trans 'Comment' %}</td>
           <td>
             <input type="text" name="item_comment" value="{{ event.item_comment }}" maxlength="64">
           </td>

--- a/templates/database/routines/editor_form.twig
+++ b/templates/database/routines/editor_form.twig
@@ -16,14 +16,19 @@
 
     <div class="card-body">
       <table class="rte_table table table-borderless table-sm">
+        <colgroup>
+          <col>
+          <col width="100%">
+        </colgroup>
+
         <tr>
-          <td>{% trans 'Routine name' %}</td>
+          <td class="text-nowrap">{% trans 'Routine name' %}</td>
           <td>
             <input type="text" name="item_name" maxlength="64" value="{{ routine.item_name }}">
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Type' %}</td>
+          <td class="text-nowrap">{% trans 'Type' %}</td>
           <td>
             {% if is_ajax %}
               <select name="item_type">
@@ -40,7 +45,7 @@
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Parameters' %}</td>
+          <td class="text-nowrap">{% trans 'Parameters' %}</td>
           <td>
             <table class="routine_params_table table table-borderless table-sm">
               <thead>
@@ -72,7 +77,7 @@
           </td>
         </tr>
         <tr class="routine_return_row{{ routine.item_type == 'PROCEDURE' ? ' hide' }}">
-          <td>{% trans 'Return type' %}</td>
+          <td class="text-nowrap">{% trans 'Return type' %}</td>
           <td>
             <select name="item_returntype">
               {{ get_supported_datatypes(true, routine.item_returntype) }}
@@ -80,14 +85,14 @@
           </td>
         </tr>
         <tr class="routine_return_row{{ routine.item_type == 'PROCEDURE' ? ' hide' }}">
-          <td>{% trans 'Return length/values' %}</td>
+          <td class="text-nowrap">{% trans 'Return length/values' %}</td>
           <td>
             <input type="text" name="item_returnlength" value="{{ routine.item_returnlength }}">
           </td>
           <td class="hide no_len">---</td>
         </tr>
         <tr class="routine_return_row{{ routine.item_type == 'PROCEDURE' ? ' hide' }}">
-          <td>{% trans 'Return options' %}</td>
+          <td class="text-nowrap">{% trans 'Return options' %}</td>
           <td>
             <div>
               <select lang="en" dir="ltr" name="item_returnopts_text">
@@ -110,13 +115,13 @@
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Definition' %}</td>
+          <td class="text-nowrap">{% trans 'Definition' %}</td>
           <td>
             <textarea name="item_definition" rows="15" cols="40">{{ routine.item_definition }}</textarea>
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Is deterministic' %}</td>
+          <td class="text-nowrap">{% trans 'Is deterministic' %}</td>
           <td>
             <input type="checkbox" name="item_isdeterministic"{{ routine.item_isdeterministic|raw }}>
           </td>
@@ -124,7 +129,7 @@
 
         {% if is_edit_mode %}
           <tr>
-            <td>
+            <td class="text-nowrap">
               {% trans 'Adjust privileges' %}
               {{ show_docu('faq', 'faq6-39') }}
             </td>
@@ -139,13 +144,13 @@
         {% endif %}
 
         <tr>
-          <td>{% trans 'Definer' %}</td>
+          <td class="text-nowrap">{% trans 'Definer' %}</td>
           <td>
             <input type="text" name="item_definer" value="{{ routine.item_definer }}">
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Security type' %}</td>
+          <td class="text-nowrap">{% trans 'Security type' %}</td>
           <td>
             <select name="item_securitytype">
               <option value="DEFINER"{{ routine.item_securitytype_definer|raw }}>DEFINER</option>
@@ -154,7 +159,7 @@
           </td>
         </tr>
         <tr>
-          <td>{% trans 'SQL data access' %}</td>
+          <td class="text-nowrap">{% trans 'SQL data access' %}</td>
           <td>
             <select name="item_sqldataaccess">
               {% for value in sql_data_access %}
@@ -164,7 +169,7 @@
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Comment' %}</td>
+          <td class="text-nowrap">{% trans 'Comment' %}</td>
           <td>
             <input type="text" name="item_comment" maxlength="64" value="{{ routine.item_comment }}">
           </td>

--- a/templates/database/triggers/editor_form.twig
+++ b/templates/database/triggers/editor_form.twig
@@ -19,12 +19,17 @@
 
     <div class="card-body">
       <table class="rte_table table table-borderless table-sm">
+        <colgroup>
+          <col>
+          <col width="100%">
+        </colgroup>
+
         <tr>
-          <td>{% trans 'Trigger name' %}</td>
+          <td class="text-nowrap">{% trans 'Trigger name' %}</td>
           <td><input type="text" name="item_name" maxlength="64" value="{{ item.item_name }}"></td>
         </tr>
         <tr>
-          <td>{% trans 'Table' %}</td>
+          <td class="text-nowrap">{% trans 'Table' %}</td>
           <td>
             <select name="item_table">
               {% for item_table in tables %}
@@ -34,7 +39,7 @@
           </td>
         </tr>
         <tr>
-          <td>{% trans %}Time{% context %}Trigger action time{% endtrans %}</td>
+          <td class="text-nowrap">{% trans %}Time{% context %}Trigger action time{% endtrans %}</td>
           <td>
             <select name="item_timing">
               {% for item_time in time %}
@@ -44,7 +49,7 @@
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Event' %}</td>
+          <td class="text-nowrap">{% trans 'Event' %}</td>
           <td>
             <select name="item_event">
               {% for event in events %}
@@ -54,11 +59,11 @@
           </td>
         </tr>
         <tr>
-          <td>{% trans 'Definition' %}</td>
+          <td class="text-nowrap">{% trans 'Definition' %}</td>
           <td><textarea name="item_definition" rows="15" cols="40">{{ item.item_definition }}</textarea></td>
         </tr>
         <tr>
-          <td>{% trans 'Definer' %}</td>
+          <td class="text-nowrap">{% trans 'Definer' %}</td>
           <td><input type="text" name="item_definer" value="{{ item.item_definer }}"></td>
         </tr>
       </table>


### PR DESCRIPTION
There is no reason why the label column should become wider than necessary.

This changes the Routine, Event and Trigger modals.