### PR TITLE
Refactor relation

### DIFF
--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -1572,29 +1572,28 @@ class Relation
             // use the possible replaced name first and fallback on the table name
             // if no replacement exists
             if (! in_array($tableNameReplacements[$table] ?? $table, $existingTables)) {
-                if ($create) {
-                    $this->dbi->tryQuery($createQueries[$table], Connection::TYPE_CONTROL);
-
-                    $error = $this->dbi->getError(Connection::TYPE_CONTROL);
-                    if ($error) {
-                        $GLOBALS['message'] = $error;
-
-                        return;
-                    }
-
-                    $foundOne = true;
-                    if (empty($GLOBALS['cfg']['Server'][$feature])) {
-                        // Do not override a user defined value, only fill if empty
-                        $GLOBALS['cfg']['Server'][$feature] = $table;
-                    }
+                if (! $create) {
+                    continue;
                 }
-            } else {
-                $foundOne = true;
-                if (empty($GLOBALS['cfg']['Server'][$feature])) {
-                    // Do not override a user defined value, only fill if empty
-                    $GLOBALS['cfg']['Server'][$feature] = $table;
+
+                $this->dbi->tryQuery($createQueries[$table], Connection::TYPE_CONTROL);
+
+                $error = $this->dbi->getError(Connection::TYPE_CONTROL);
+                if ($error) {
+                    $GLOBALS['message'] = $error;
+
+                    return;
                 }
             }
+
+            $foundOne = true;
+
+            // Do not override a user defined value, only fill if empty
+            if (isset($GLOBALS['cfg']['Server'][$feature]) && $GLOBALS['cfg']['Server'][$feature] !== '') {
+                continue;
+            }
+
+            $GLOBALS['cfg']['Server'][$feature] = $table;
         }
 
         if (! $foundOne) {

--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -19,6 +19,7 @@ use PhpMyAdmin\Util;
 use PhpMyAdmin\Version;
 
 use function __;
+use function array_fill_keys;
 use function array_keys;
 use function array_reverse;
 use function array_search;
@@ -220,9 +221,6 @@ class Relation
      */
     private function checkRelationsParam(): array
     {
-        $relationParams = [];
-        $relationParams['version'] = Version::VERSION;
-
         $workToTable = [
             'relwork' => 'relation',
             'displaywork' => ['relation', 'table_info'],
@@ -244,10 +242,9 @@ class Relation
             'exporttemplateswork' => 'export_templates',
         ];
 
-        foreach (array_keys($workToTable) as $work) {
-            $relationParams[$work] = false;
-        }
+        $relationParams = array_fill_keys(array_keys($workToTable), false);
 
+        $relationParams['version'] = Version::VERSION;
         $relationParams['allworks'] = false;
         $relationParams['user'] = null;
         $relationParams['db'] = null;

--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -1456,7 +1456,7 @@ class Relation
      *
      * @return array<string, string> table name, create query
      */
-    public function getDefaultPmaTableNames(array $tableNameReplacements): array
+    public function getCreateTableSqlQueries(array $tableNameReplacements): array
     {
         $pmaTables = [];
         $createTablesFile = (string) file_get_contents(SQL_DIR . 'create_tables.sql');
@@ -1555,7 +1555,7 @@ class Relation
 
         $createQueries = [];
         if ($create) {
-            $createQueries = $this->getDefaultPmaTableNames($tableNameReplacements);
+            $createQueries = $this->getCreateTableSqlQueries($tableNameReplacements);
             if (! $this->dbi->selectDb($db, Connection::TYPE_CONTROL)) {
                 $GLOBALS['message'] = $this->dbi->getError(Connection::TYPE_CONTROL);
 
@@ -1590,6 +1590,7 @@ class Relation
                 continue;
             }
 
+            // Fill it with the default table name
             $GLOBALS['cfg']['Server'][$feature] = $table;
         }
 

--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -1556,7 +1556,16 @@ class Relation
 
         $tableNameReplacements = $this->getTableReplacementNames($tablesToFeatures);
 
-        $createQueries = null;
+        $createQueries = [];
+        if ($create) {
+            $createQueries = $this->getDefaultPmaTableNames($tableNameReplacements);
+            if (! $this->dbi->selectDb($db, Connection::TYPE_CONTROL)) {
+                $GLOBALS['message'] = $this->dbi->getError(Connection::TYPE_CONTROL);
+
+                return;
+            }
+        }
+
         $foundOne = false;
         foreach ($tablesToFeatures as $table => $feature) {
             // Check if the table already exists
@@ -1564,15 +1573,6 @@ class Relation
             // if no replacement exists
             if (! in_array($tableNameReplacements[$table] ?? $table, $existingTables)) {
                 if ($create) {
-                    if ($createQueries === null) { // first create
-                        $createQueries = $this->getDefaultPmaTableNames($tableNameReplacements);
-                        if (! $this->dbi->selectDb($db, Connection::TYPE_CONTROL)) {
-                            $GLOBALS['message'] = $this->dbi->getError(Connection::TYPE_CONTROL);
-
-                            return;
-                        }
-                    }
-
                     $this->dbi->tryQuery($createQueries[$table], Connection::TYPE_CONTROL);
 
                     $error = $this->dbi->getError(Connection::TYPE_CONTROL);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -711,16 +711,6 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Foreach overwrites \\$feature with its value variable\\.$#"
-			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Foreach overwrites \\$table with its key variable\\.$#"
-			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
 			message: "#^Foreach overwrites \\$work with its key variable\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
@@ -782,11 +772,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$haystack of function array_search expects array, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -711,11 +711,6 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Foreach overwrites \\$work with its key variable\\.$#"
-			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getDisplayField\\(\\) should return string\\|false but returns mixed\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -747,6 +747,7 @@
       <code><![CDATA[usort($tables, 'strnatcasecmp')]]></code>
     </InvalidArgument>
     <InvalidReturnStatement>
+      <code>$tableNameReplacements</code>
       <code><![CDATA[[
             'foreign_link' => $foreignLink,
             'the_total' => $theTotal,
@@ -756,6 +757,7 @@
         ]]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
+      <code><![CDATA[array<string, string>]]></code>
       <code><![CDATA[array{
      *     foreign_link: bool,
      *     the_total: mixed,
@@ -780,7 +782,6 @@
       <code>$foreignTable</code>
       <code>$foreign[$field]</code>
       <code><![CDATA[$oneKey['index_list']]]></code>
-      <code>$tableNameReplacements[$tableName]</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[uksort($foreign, 'strnatcasecmp')]]></code>

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -1376,7 +1376,7 @@ class RelationTest extends AbstractTestCase
 
         $this->assertSame(
             $data,
-            $relation->getDefaultPmaTableNames([]),
+            $relation->getCreateTableSqlQueries([]),
         );
 
         $data['pma__export_templates'] = implode("\n", [
@@ -1403,7 +1403,7 @@ class RelationTest extends AbstractTestCase
 
         $this->assertSame(
             $data,
-            $relation->getDefaultPmaTableNames(['pma__export_templates' => 'db_exporttemplates_pma']),
+            $relation->getCreateTableSqlQueries(['pma__export_templates' => 'db_exporttemplates_pma']),
         );
     }
 


### PR DESCRIPTION
This should also fix #18315 on master because we are now explicitly checking for an empty string. We use the default table name only if the global is an empty string, which means the user didn't override it in the config. 
The rest is just making the code easier to read. 