### PR TITLE
Fix #18266 - bug preventing disabling tracking feature

### DIFF
--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -1626,6 +1626,11 @@ class Relation
         $createQueries = null;
         $foundOne = false;
         foreach ($tablesToFeatures as $table => $feature) {
+            if (($GLOBALS['cfg']['Server'][$feature] ?? null) === false) {
+                // The feature is disabled by the user in config
+                continue;
+            }
+
             // Check if the table already exists
             // use the possible replaced name first and fallback on the table name
             // if no replacement exists


### PR DESCRIPTION
This is an alternative to #18315. 

It's based on William's proposal. I am wondering if skipping the table creation makes sense. Technically, what we only want to do is prevent filling the `$GLOBALS['cfg']['Server'][$feature]` if it equals `false`. In this PR I added a new if at the start of the loop, but on master, we can just stick with the one at the end of the loop like I showed in the other PR #18318. 

Fixes: #18266