### PR TITLE
More tracking refactoring

### DIFF
--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -112,7 +112,7 @@ class TrackingController extends AbstractController
         $trackedData = $this->tracking->getTrackedData($GLOBALS['db'], '', '1');
 
         // No tables present and no log exist
-        if ($numTables === 0 && $trackedData['ddlog'] === []) {
+        if ($numTables === 0 && $trackedData->ddlog === []) {
             echo '<p>' , __('No tables found in database.') , '</p>' , "\n";
 
             if (! $isSystemSchema) {
@@ -128,12 +128,12 @@ class TrackingController extends AbstractController
         echo $this->tracking->getHtmlForDbTrackingTables($GLOBALS['db'], $GLOBALS['urlParams'], $GLOBALS['text_dir']);
 
         // If available print out database log
-        if ($trackedData['ddlog'] === []) {
+        if ($trackedData->ddlog === []) {
             return;
         }
 
         $log = '';
-        foreach ($trackedData['ddlog'] as $entry) {
+        foreach ($trackedData->ddlog as $entry) {
             $log .= '# ' . $entry['date'] . ' ' . $entry['username'] . "\n"
                 . $entry['statement'] . "\n";
         }

--- a/libraries/classes/Controllers/Database/TrackingController.php
+++ b/libraries/classes/Controllers/Database/TrackingController.php
@@ -18,7 +18,6 @@ use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
 use function __;
-use function count;
 use function htmlspecialchars;
 use function sprintf;
 
@@ -113,7 +112,7 @@ class TrackingController extends AbstractController
         $trackedData = $this->tracking->getTrackedData($GLOBALS['db'], '', '1');
 
         // No tables present and no log exist
-        if ($numTables == 0 && count($trackedData['ddlog']) === 0) {
+        if ($numTables === 0 && $trackedData['ddlog'] === []) {
             echo '<p>' , __('No tables found in database.') , '</p>' , "\n";
 
             if (! $isSystemSchema) {
@@ -129,7 +128,7 @@ class TrackingController extends AbstractController
         echo $this->tracking->getHtmlForDbTrackingTables($GLOBALS['db'], $GLOBALS['urlParams'], $GLOBALS['text_dir']);
 
         // If available print out database log
-        if (count($trackedData['ddlog']) <= 0) {
+        if ($trackedData['ddlog'] === []) {
             return;
         }
 

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -84,7 +84,7 @@ final class TrackingController extends AbstractController
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/table/tracking');
         $GLOBALS['urlParams']['back'] = Url::getFromRoute('/table/tracking');
 
-        $trackedData = [];
+        $trackedData = null;
         $entries = [];
         $filterUsers = [];
 
@@ -104,9 +104,9 @@ final class TrackingController extends AbstractController
             $trackedData = $this->tracking->getTrackedData($GLOBALS['db'], $GLOBALS['table'], $versionParam);
 
             $dateFrom = $this->validateDateTimeParam(
-                $request->getParsedBodyParam('date_from', $trackedData['date_from']),
+                $request->getParsedBodyParam('date_from', $trackedData->dateFrom),
             );
-            $dateTo = $this->validateDateTimeParam($request->getParsedBodyParam('date_to', $trackedData['date_to']));
+            $dateTo = $this->validateDateTimeParam($request->getParsedBodyParam('date_to', $trackedData->dateTo));
 
             /** @var string $users */
             $users = $request->getParsedBodyParam('users', '*');
@@ -210,7 +210,7 @@ final class TrackingController extends AbstractController
                     $GLOBALS['db'],
                     $GLOBALS['table'],
                     $versionParam,
-                    $trackedData,
+                    $trackedData->ddlog,
                     LogTypeEnum::DDL,
                     (int) $request->getParsedBodyParam('delete_ddlog'),
                 );
@@ -221,7 +221,7 @@ final class TrackingController extends AbstractController
                     $GLOBALS['db'],
                     $GLOBALS['table'],
                     $versionParam,
-                    $trackedData,
+                    $trackedData->dmlog,
                     LogTypeEnum::DML,
                     (int) $request->getParsedBodyParam('delete_dmlog'),
                 );

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -99,9 +99,8 @@ final class TrackingController extends AbstractController
 
         $logType = $this->validateLogTypeParam($request->getParsedBodyParam('log_type'));
 
-        $dateFrom = null;
-        $dateTo = null;
         $users = '';
+        $dateFrom = $dateTo = new DateTimeImmutable();
 
         // Init vars for tracking report
         if ($report || $reportExport !== null) {
@@ -117,9 +116,6 @@ final class TrackingController extends AbstractController
 
             $filterUsers = array_map(trim(...), explode(',', $users));
         }
-
-        $dateFrom ??= new DateTimeImmutable();
-        $dateTo ??= new DateTimeImmutable();
 
         // Prepare export
         if ($reportExport !== null) {

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -117,16 +117,16 @@ final class TrackingController extends AbstractController
         // Prepare export
         if ($reportExport !== null) {
             $entries = $this->tracking->getEntries($trackedData, $filterUsers, $logType, $dateFrom, $dateTo);
-        }
 
-        // Export as file download
-        if ($reportExport !== null && $request->getParsedBodyParam('export_type') === 'sqldumpfile') {
-            $downloadInfo = $this->tracking->getDownloadInfoForExport($tableParam, $entries);
-            $this->response->disable();
-            Core::downloadHeader($downloadInfo['filename'], 'text/x-sql', mb_strlen($downloadInfo['dump']));
-            echo $downloadInfo['dump'];
+            // Export as file download
+            if ($request->getParsedBodyParam('export_type') === 'sqldumpfile') {
+                $downloadInfo = $this->tracking->getDownloadInfoForExport($tableParam, $entries);
+                $this->response->disable();
+                Core::downloadHeader($downloadInfo['filename'], 'text/x-sql', mb_strlen($downloadInfo['dump']));
+                echo $downloadInfo['dump'];
 
-            return;
+                return;
+            }
         }
 
         $actionMessage = '';

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -227,6 +227,7 @@ final class TrackingController extends AbstractController
                     $versionParam,
                     $trackedData,
                     LogTypeEnum::DDL,
+                    (int) $request->getParsedBodyParam('delete_ddlog'),
                 );
             } elseif ($request->hasBodyParam('delete_dmlog')) {
                 $trackingReportRows = $this->tracking->deleteFromTrackingReportLog(
@@ -235,6 +236,7 @@ final class TrackingController extends AbstractController
                     $versionParam,
                     $trackedData,
                     LogTypeEnum::DML,
+                    (int) $request->getParsedBodyParam('delete_dmlog'),
                 );
             }
         }

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -50,7 +50,6 @@ final class TrackingController extends AbstractController
         $GLOBALS['msg'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
         $GLOBALS['entries'] ??= null;
-        $GLOBALS['filter_users'] ??= null;
 
         $this->addScriptFiles(['vendor/jquery/jquery.tablesorter.js', 'table/tracking.js']);
 
@@ -90,7 +89,7 @@ final class TrackingController extends AbstractController
 
         $trackedData = [];
         $GLOBALS['entries'] = [];
-        $GLOBALS['filter_users'] = [];
+        $filterUsers = [];
 
         $report = $request->hasBodyParam('report');
         /** @var string $versionParam */
@@ -116,7 +115,7 @@ final class TrackingController extends AbstractController
             /** @var string $users */
             $users = $request->getParsedBodyParam('users', '*');
 
-            $GLOBALS['filter_users'] = array_map(trim(...), explode(',', $users));
+            $filterUsers = array_map(trim(...), explode(',', $users));
         }
 
         $dateFrom ??= new DateTimeImmutable();
@@ -126,7 +125,7 @@ final class TrackingController extends AbstractController
         if ($reportExport !== null) {
             $GLOBALS['entries'] = $this->tracking->getEntries(
                 $trackedData,
-                $GLOBALS['filter_users'],
+                $filterUsers,
                 $logType,
                 $dateFrom,
                 $dateTo,
@@ -247,7 +246,7 @@ final class TrackingController extends AbstractController
                 $trackedData,
                 $GLOBALS['urlParams'],
                 $logType,
-                $GLOBALS['filter_users'],
+                $filterUsers,
                 $versionParam,
                 $dateFrom,
                 $dateTo,

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -49,7 +49,6 @@ final class TrackingController extends AbstractController
         $GLOBALS['urlParams'] ??= null;
         $GLOBALS['msg'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
-        $GLOBALS['entries'] ??= null;
 
         $this->addScriptFiles(['vendor/jquery/jquery.tablesorter.js', 'table/tracking.js']);
 
@@ -88,7 +87,7 @@ final class TrackingController extends AbstractController
         $GLOBALS['urlParams']['back'] = Url::getFromRoute('/table/tracking');
 
         $trackedData = [];
-        $GLOBALS['entries'] = [];
+        $entries = [];
         $filterUsers = [];
 
         $report = $request->hasBodyParam('report');
@@ -119,18 +118,12 @@ final class TrackingController extends AbstractController
 
         // Prepare export
         if ($reportExport !== null) {
-            $GLOBALS['entries'] = $this->tracking->getEntries(
-                $trackedData,
-                $filterUsers,
-                $logType,
-                $dateFrom,
-                $dateTo,
-            );
+            $entries = $this->tracking->getEntries($trackedData, $filterUsers, $logType, $dateFrom, $dateTo);
         }
 
         // Export as file download
         if ($reportExport !== null && $request->getParsedBodyParam('export_type') === 'sqldumpfile') {
-            $downloadInfo = $this->tracking->getDownloadInfoForExport($tableParam, $GLOBALS['entries']);
+            $downloadInfo = $this->tracking->getDownloadInfoForExport($tableParam, $entries);
             $this->response->disable();
             Core::downloadHeader($downloadInfo['filename'], 'text/x-sql', mb_strlen($downloadInfo['dump']));
             echo $downloadInfo['dump'];
@@ -193,12 +186,12 @@ final class TrackingController extends AbstractController
         $sqlDump = '';
 
         if ($reportExport === 'execution') {
-            $this->tracking->exportAsSqlExecution($GLOBALS['entries']);
+            $this->tracking->exportAsSqlExecution($entries);
             $GLOBALS['msg'] = Message::success(__('SQL statements executed.'));
             $message = $GLOBALS['msg']->getDisplay();
         } elseif ($reportExport === 'sqldump') {
             $this->addScriptFiles(['sql.js']);
-            $sqlDump = $this->tracking->exportAsSqlDump($GLOBALS['entries']);
+            $sqlDump = $this->tracking->exportAsSqlDump($entries);
         }
 
         $schemaSnapshot = '';

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
+use PhpMyAdmin\Tracking\LogTypeEnum;
 use PhpMyAdmin\Tracking\Tracker;
 use PhpMyAdmin\Tracking\Tracking;
 use PhpMyAdmin\Tracking\TrackingChecker;
@@ -218,15 +219,24 @@ final class TrackingController extends AbstractController
         }
 
         $trackingReportRows = '';
-        if ($report && ($request->hasBodyParam('delete_ddlog') || $request->hasBodyParam('delete_dmlog'))) {
-            $trackingReportRows = $this->tracking->deleteTrackingReportRows(
-                $GLOBALS['db'],
-                $GLOBALS['table'],
-                $versionParam,
-                $trackedData,
-                $request->hasBodyParam('delete_ddlog'),
-                $request->hasBodyParam('delete_dmlog'),
-            );
+        if ($report) {
+            if ($request->hasBodyParam('delete_ddlog')) {
+                $trackingReportRows = $this->tracking->deleteFromTrackingReportLog(
+                    $GLOBALS['db'],
+                    $GLOBALS['table'],
+                    $versionParam,
+                    $trackedData,
+                    LogTypeEnum::DDL,
+                );
+            } elseif ($request->hasBodyParam('delete_dmlog')) {
+                $trackingReportRows = $this->tracking->deleteFromTrackingReportLog(
+                    $GLOBALS['db'],
+                    $GLOBALS['table'],
+                    $versionParam,
+                    $trackedData,
+                    LogTypeEnum::DML,
+                );
+            }
         }
 
         $trackingReport = '';

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -63,7 +63,6 @@ final class TrackingController extends AbstractController
 
         $activeMessage = '';
         $toggleActivation = $request->getParsedBodyParam('toggle_activation');
-        $reportExport = $request->getParsedBodyParam('report_export');
         $reportExportType = $request->getParsedBodyParam('export_type');
 
         $trackedTables = $this->trackingChecker->getTrackedTables($GLOBALS['db']);
@@ -101,7 +100,7 @@ final class TrackingController extends AbstractController
         $dateFrom = $dateTo = new DateTimeImmutable();
 
         // Init vars for tracking report
-        if ($report || $reportExport !== null) {
+        if ($report || $reportExportType !== null) {
             $trackedData = $this->tracking->getTrackedData($GLOBALS['db'], $GLOBALS['table'], $versionParam);
 
             $dateFrom = $this->validateDateTimeParam(
@@ -116,7 +115,7 @@ final class TrackingController extends AbstractController
         }
 
         // Prepare export
-        if ($reportExport !== null) {
+        if ($reportExportType !== null) {
             $entries = $this->tracking->getEntries($trackedData, $filterUsers, $logType, $dateFrom, $dateTo);
 
             // Export as file download
@@ -232,7 +231,7 @@ final class TrackingController extends AbstractController
         }
 
         $trackingReport = '';
-        if ($report || $reportExport !== null) {
+        if ($report || $reportExportType !== null) {
             $trackingReport = $this->tracking->getHtmlForTrackingReport(
                 $trackedData,
                 $GLOBALS['urlParams'],

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -214,6 +214,8 @@ final class TrackingController extends AbstractController
                     LogTypeEnum::DDL,
                     (int) $request->getParsedBodyParam('delete_ddlog'),
                 );
+                // After deletion reload data from the database
+                $trackedData = $this->tracking->getTrackedData($GLOBALS['db'], $GLOBALS['table'], $versionParam);
             } elseif ($request->hasBodyParam('delete_dmlog')) {
                 $trackingReportRows = $this->tracking->deleteFromTrackingReportLog(
                     $GLOBALS['db'],
@@ -223,6 +225,8 @@ final class TrackingController extends AbstractController
                     LogTypeEnum::DML,
                     (int) $request->getParsedBodyParam('delete_dmlog'),
                 );
+                // After deletion reload data from the database
+                $trackedData = $this->tracking->getTrackedData($GLOBALS['db'], $GLOBALS['table'], $versionParam);
             }
         }
 

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -64,6 +64,7 @@ final class TrackingController extends AbstractController
         $activeMessage = '';
         $toggleActivation = $request->getParsedBodyParam('toggle_activation');
         $reportExport = $request->getParsedBodyParam('report_export');
+        $reportExportType = $request->getParsedBodyParam('export_type');
 
         $trackedTables = $this->trackingChecker->getTrackedTables($GLOBALS['db']);
         if (
@@ -71,7 +72,7 @@ final class TrackingController extends AbstractController
             && isset($trackedTables[$GLOBALS['table']])
             && $trackedTables[$GLOBALS['table']]->active
             && $toggleActivation !== 'deactivate_now'
-            && $reportExport !== 'sqldumpfile'
+            && $reportExportType !== 'sqldumpfile'
         ) {
             $activeMessage = Message::notice(
                 sprintf(
@@ -119,7 +120,7 @@ final class TrackingController extends AbstractController
             $entries = $this->tracking->getEntries($trackedData, $filterUsers, $logType, $dateFrom, $dateTo);
 
             // Export as file download
-            if ($request->getParsedBodyParam('export_type') === 'sqldumpfile') {
+            if ($reportExportType === 'sqldumpfile') {
                 $downloadInfo = $this->tracking->getDownloadInfoForExport($tableParam, $entries);
                 $this->response->disable();
                 Core::downloadHeader($downloadInfo['filename'], 'text/x-sql', mb_strlen($downloadInfo['dump']));
@@ -183,10 +184,10 @@ final class TrackingController extends AbstractController
         $message = '';
         $sqlDump = '';
 
-        if ($reportExport === 'execution') {
+        if ($reportExportType === 'execution') {
             $this->tracking->exportAsSqlExecution($entries);
             $message = Message::success(__('SQL statements executed.'))->getDisplay();
-        } elseif ($reportExport === 'sqldump') {
+        } elseif ($reportExportType === 'sqldump') {
             $this->addScriptFiles(['sql.js']);
             $sqlDump = $this->tracking->exportAsSqlDump($entries);
         }

--- a/libraries/classes/Controllers/Table/TrackingController.php
+++ b/libraries/classes/Controllers/Table/TrackingController.php
@@ -47,7 +47,6 @@ final class TrackingController extends AbstractController
     {
         $GLOBALS['text_dir'] ??= null;
         $GLOBALS['urlParams'] ??= null;
-        $GLOBALS['msg'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
 
         $this->addScriptFiles(['vendor/jquery/jquery.tablesorter.js', 'table/tracking.js']);
@@ -74,13 +73,12 @@ final class TrackingController extends AbstractController
             && $toggleActivation !== 'deactivate_now'
             && $reportExport !== 'sqldumpfile'
         ) {
-            $GLOBALS['msg'] = Message::notice(
+            $activeMessage = Message::notice(
                 sprintf(
                     __('Tracking of %s is activated.'),
                     htmlspecialchars($GLOBALS['db'] . '.' . $GLOBALS['table']),
                 ),
-            );
-            $activeMessage = $GLOBALS['msg']->getDisplay();
+            )->getDisplay();
         }
 
         $GLOBALS['urlParams']['goto'] = Url::getFromRoute('/table/tracking');
@@ -187,8 +185,7 @@ final class TrackingController extends AbstractController
 
         if ($reportExport === 'execution') {
             $this->tracking->exportAsSqlExecution($entries);
-            $GLOBALS['msg'] = Message::success(__('SQL statements executed.'));
-            $message = $GLOBALS['msg']->getDisplay();
+            $message = Message::success(__('SQL statements executed.'))->getDisplay();
         } elseif ($reportExport === 'sqldump') {
             $this->addScriptFiles(['sql.js']);
             $sqlDump = $this->tracking->exportAsSqlDump($entries);

--- a/libraries/classes/Tracking/LogTypeEnum.php
+++ b/libraries/classes/Tracking/LogTypeEnum.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tracking;
+
+use function __;
+
+enum LogTypeEnum
+{
+    case DDL;
+    case DML;
+
+    /** @psalm-return literal-string */
+    public function getColumnName(): string
+    {
+        return match ($this) {
+            LogTypeEnum::DDL => 'schema_sql',
+            LogTypeEnum::DML => 'data_sql',
+        };
+    }
+
+    /** @psalm-return literal-string */
+    public function getLogName(): string
+    {
+        return match ($this) {
+            LogTypeEnum::DDL => 'ddlog',
+            LogTypeEnum::DML => 'dmlog',
+        };
+    }
+
+    public function getSuccessMessage(): string
+    {
+        return match ($this) {
+            LogTypeEnum::DDL => __('Tracking data definition successfully deleted'),
+            LogTypeEnum::DML => __('Tracking data manipulation successfully deleted'),
+        };
+    }
+}

--- a/libraries/classes/Tracking/LogTypeEnum.php
+++ b/libraries/classes/Tracking/LogTypeEnum.php
@@ -36,4 +36,21 @@ enum LogTypeEnum
             LogTypeEnum::DML => __('Tracking data manipulation successfully deleted'),
         };
     }
+
+    public function getHeaderMessage(): string
+    {
+        return match ($this) {
+            LogTypeEnum::DDL => __('Data definition statement'),
+            LogTypeEnum::DML => __('Data manipulation statement'),
+        };
+    }
+
+    /** @psalm-return literal-string */
+    public function getTableId(): string
+    {
+        return match ($this) {
+            LogTypeEnum::DDL => 'ddl_versions',
+            LogTypeEnum::DML => 'dml_versions',
+        };
+    }
 }

--- a/libraries/classes/Tracking/TrackedData.php
+++ b/libraries/classes/Tracking/TrackedData.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tracking;
+
+final class TrackedData
+{
+    /**
+     * @psalm-param list<array{date: string, username: string, statement: string}> $ddlog
+     * @psalm-param list<array{date: string, username: string, statement: string}> $dmlog
+     */
+    public function __construct(
+        public readonly string $dateFrom,
+        public readonly string $dateTo,
+        public readonly array $ddlog,
+        public readonly array $dmlog,
+        public readonly string $tracking,
+        public readonly string $schemaSnapshot,
+    ) {
+    }
+}

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -806,26 +806,20 @@ class Tracking
         string $version,
         array &$data,
         LogTypeEnum $logType,
+        int $deleteId,
     ): string {
-        $html = '';
         $whichLog = $logType->getLogName();
-        $deleteId = $_POST['delete_' . $whichLog];
 
-        // Only in case of valid id
-        if ($deleteId == (int) $deleteId) {
-            unset($data[$whichLog][$deleteId]);
+        unset($data[$whichLog][$deleteId]);
 
-            $successfullyDeleted = $this->changeTrackingData($db, $table, $version, $logType, $data[$whichLog]);
-            if ($successfullyDeleted) {
-                $msg = Message::success($logType->getSuccessMessage());
-            } else {
-                $msg = Message::rawError(__('Query error'));
-            }
-
-            $html .= $msg->getDisplay();
+        $successfullyDeleted = $this->changeTrackingData($db, $table, $version, $logType, $data[$whichLog]);
+        if ($successfullyDeleted) {
+            $msg = Message::success($logType->getSuccessMessage());
+        } else {
+            $msg = Message::rawError(__('Query error'));
         }
 
-        return $html;
+        return $msg->getDisplay();
     }
 
     /**

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -799,11 +799,9 @@ class Tracking
         LogTypeEnum $logType,
         array $newData,
     ): bool {
-        $date = Util::date('Y-m-d H:i:s');
-
         $newDataProcessed = '';
         foreach ($newData as $data) {
-            $newDataProcessed .= '# log ' . $date . ' ' . $data['username'] . $data['statement'] . "\n";
+            $newDataProcessed .= '# log ' . $data['date'] . ' ' . $data['username'] . $data['statement'] . "\n";
         }
 
         $trackingFeature = $this->relation->getRelationParameters()->trackingFeature;

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -885,7 +885,7 @@ class Tracking
 
         // Replace all multiple whitespaces by a single space
         $table = htmlspecialchars((string) preg_replace('/\s+/', ' ', $table));
-        $dump = '# ' . sprintf(__('Tracking report for table `%s`'), $table) . "\n" . '# ' . date('Y-m-d H:i:s') . "\n";
+        $dump = '# ' . sprintf(__('Tracking report for table `%s`'), $table) . "\n" . '# ' . date('Y-m-d H:i:sP') . "\n";
         foreach ($entries as $entry) {
             $dump .= $entry['statement'];
         }

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -432,7 +432,6 @@ class Tracking
             'date_from' => $dateFrom->format('Y-m-d H:i:s'),
             'date_to' => $dateTo->format('Y-m-d H:i:s'),
             'users' => $users,
-            'report_export' => 'true',
         ]);
 
         $strExport1 = '<select name="export_type">'

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -146,24 +146,20 @@ class Tracking
     /**
      * Function to get html for main page parts that do not use $_REQUEST
      *
-     * @param mixed[]  $urlParams   url parameters
-     * @param string   $textDir     text direction
-     * @param int|null $lastVersion last tracking version
+     * @param mixed[] $urlParams url parameters
+     * @param string  $textDir   text direction
      */
     public function getHtmlForMainPage(
         string $db,
         string $table,
         array $urlParams,
         string $textDir,
-        int|null $lastVersion = null,
     ): string {
         $versionSqlResult = $this->getListOfVersionsOfTable($db, $table);
-        if ($lastVersion === null && $versionSqlResult !== false) {
-            $lastVersion = $this->getTableLastVersionNumber($versionSqlResult);
-        }
-
+        $lastVersion = null;
         $versions = [];
         if ($versionSqlResult !== false) {
+            $lastVersion = $this->getTableLastVersionNumber($versionSqlResult);
             $versions = $versionSqlResult->fetchAllAssoc();
         }
 

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -884,7 +884,8 @@ class Tracking
 
         // Replace all multiple whitespaces by a single space
         $table = htmlspecialchars((string) preg_replace('/\s+/', ' ', $table));
-        $dump = '# ' . sprintf(__('Tracking report for table `%s`'), $table) . "\n" . '# ' . date('Y-m-d H:i:sP') . "\n";
+        $dump = '# ' . sprintf(__('Tracking report for table `%s`'), $table) . "\n"
+            . '# ' . date('Y-m-d H:i:sP') . "\n";
         foreach ($entries as $entry) {
             $dump .= $entry['statement'];
         }

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -793,35 +793,6 @@ class Tracking
     }
 
     /**
-     * Function to handle the tracking report
-     *
-     * @param mixed[] $data tracked data
-     *
-     * @return string HTML for the message
-     */
-    public function deleteTrackingReportRows(
-        string $db,
-        string $table,
-        string $version,
-        array &$data,
-        bool $deleteDdlog,
-        bool $deleteDmlog,
-    ): string {
-        $html = '';
-        if ($deleteDdlog) {
-            // Delete ddlog row data
-            $html .= $this->deleteFromTrackingReportLog($db, $table, $version, $data, LogTypeEnum::DDL);
-        }
-
-        if ($deleteDmlog) {
-            // Delete dmlog row data
-            $html .= $this->deleteFromTrackingReportLog($db, $table, $version, $data, LogTypeEnum::DML);
-        }
-
-        return $html;
-    }
-
-    /**
      * Function to delete from a tracking report log
      *
      * @param mixed[]     $data    tracked data

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -804,7 +804,7 @@ class Tracking
         string $db,
         string $table,
         string $version,
-        array &$data,
+        array $data,
         LogTypeEnum $logType,
         int $deleteId,
     ): string {

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -100,16 +100,14 @@ class Tracking
         $tmpEntries = [];
         $id = 0;
         foreach ($data as $entry) {
-            $timestamp = strtotime($entry['date']);
             $filteredUser = in_array($entry['username'], $filterUsers);
             if (
-                $timestamp >= $dateFrom->getTimestamp()
-                && $timestamp <= $dateTo->getTimestamp()
+                $this->isDateBetweenInclusive(new DateTimeImmutable($entry['date']), $dateFrom, $dateTo)
                 && (in_array('*', $filterUsers) || $filteredUser)
             ) {
                 $tmpEntries[] = [
                     'id' => $id,
-                    'timestamp' => $timestamp,
+                    'timestamp' => strtotime($entry['date']),
                     'username' => $entry['username'],
                     'statement' => $entry['statement'],
                 ];
@@ -551,10 +549,8 @@ class Tracking
         $offset = $lineNumber;
         $entries = [];
         foreach ($logData as $entry) {
-            $timestamp = strtotime($entry['date']);
             if (
-                $timestamp >= $dateFrom->getTimestamp()
-                && $timestamp <= $dateTo->getTimestamp()
+                $this->isDateBetweenInclusive(new DateTimeImmutable($entry['date']), $dateFrom, $dateTo)
                 && (in_array('*', $filterUsers)
                 || in_array($entry['username'], $filterUsers))
             ) {
@@ -1169,5 +1165,13 @@ class Tracking
             'text_dir' => $textDir,
             'untracked_tables' => $untrackedTables,
         ]);
+    }
+
+    private function isDateBetweenInclusive(
+        DateTimeImmutable $date,
+        DateTimeImmutable $start,
+        DateTimeImmutable $end,
+    ): bool {
+        return $date >= $start && $date <= $end;
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1431,11 +1431,6 @@ parameters:
 			path: libraries/classes/Controllers/Database/StructureController.php
 
 		-
-			message: "#^Argument of an invalid type array\\<int, array\\<string, string\\>\\>\\|string\\|null supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/TrackingController.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/TrackingController.php
@@ -2496,8 +2491,28 @@ parameters:
 			path: libraries/classes/Controllers/Table/StructureController.php
 
 		-
+			message: "#^Cannot access property \\$ddlog on PhpMyAdmin\\\\Tracking\\\\TrackedData\\|null\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/TrackingController.php
+
+		-
+			message: "#^Cannot access property \\$dmlog on PhpMyAdmin\\\\Tracking\\\\TrackedData\\|null\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/TrackingController.php
+
+		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 2
+			path: libraries/classes/Controllers/Table/TrackingController.php
+
+		-
+			message: "#^Parameter \\#1 \\$trackedData of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:getEntries\\(\\) expects PhpMyAdmin\\\\Tracking\\\\TrackedData, PhpMyAdmin\\\\Tracking\\\\TrackedData\\|null given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/TrackingController.php
+
+		-
+			message: "#^Parameter \\#1 \\$trackedData of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:getHtmlForTrackingReport\\(\\) expects PhpMyAdmin\\\\Tracking\\\\TrackedData, PhpMyAdmin\\\\Tracking\\\\TrackedData\\|null given\\.$#"
+			count: 1
 			path: libraries/classes/Controllers/Table/TrackingController.php
 
 		-
@@ -8671,11 +8686,6 @@ parameters:
 			path: libraries/classes/Tracking/Tracker.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
 			message: "#^Cannot access offset 'COLUMNS' on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Tracking/Tracking.php
@@ -8686,28 +8696,13 @@ parameters:
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
-			message: "#^Cannot access offset 'date' on mixed\\.$#"
-			count: 2
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Cannot access offset 'formated_statement' on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
-			message: "#^Cannot access offset 'line_number' on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
 			message: "#^Cannot access offset 'statement' on mixed\\.$#"
-			count: 6
+			count: 3
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
@@ -8716,17 +8711,7 @@ parameters:
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
-			message: "#^Cannot access offset 'url_params' on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
 			message: "#^Cannot access offset 'username' on mixed\\.$#"
-			count: 5
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Cannot access offset int on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Tracking/Tracking.php
 
@@ -8741,21 +8726,6 @@ parameters:
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
-			message: "#^Offset 'statement' does not exist on array\\{date\\: string, username\\: string, statement\\: string\\}\\|string\\.$#"
-			count: 4
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Offset 0 does not exist on array\\<int, array\\{date\\: string, username\\: string, statement\\: string\\}\\>\\|string\\|null\\.$#"
-			count: 3
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Offset 1 does not exist on array\\<int, array\\{date\\: string, username\\: string, statement\\: string\\}\\>\\|string\\|null\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
 			message: "#^Only numeric types are allowed in \\-, int\\<0, max\\>\\|false given on the left side\\.$#"
 			count: 2
 			path: libraries/classes/Tracking/Tracking.php
@@ -8763,21 +8733,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$columns of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:getHtmlForColumns\\(\\) expects array, mixed given\\.$#"
 			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Parameter \\#1 \\$data of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:filter\\(\\) expects array, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Parameter \\#1 \\$data of static method PhpMyAdmin\\\\Core\\:\\:safeUnserialize\\(\\) expects string, array\\<int, array\\<string, string\\>\\>\\|string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Parameter \\#1 \\$datetime of function strtotime expects string, mixed given\\.$#"
-			count: 2
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
@@ -8791,23 +8746,8 @@ parameters:
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
-			message: "#^Parameter \\#1 \\$sqlQuery of static method PhpMyAdmin\\\\Html\\\\Generator\\:\\:formatSql\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:quoteString\\(\\) expects string, string\\|null given\\.$#"
 			count: 2
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 5
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
@@ -8822,11 +8762,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#4 \\$ddlogCount of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:getHtmlForDataManipulationStatements\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
-			message: "#^Parameter \\#5 \\$newData of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:changeTrackingData\\(\\) expects array\\|string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Tracking/Tracking.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1446,11 +1446,6 @@ parameters:
 			path: libraries/classes/Controllers/Database/TrackingController.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\<int, array\\<string, string\\>\\>\\|string\\|null given\\.$#"
-			count: 2
-			path: libraries/classes/Controllers/Database/TrackingController.php
-
-		-
 			message: "#^Parameter \\#2 \\$selected of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:createTrackingForMultipleTables\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/TrackingController.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2491,28 +2491,8 @@ parameters:
 			path: libraries/classes/Controllers/Table/StructureController.php
 
 		-
-			message: "#^Cannot access property \\$ddlog on PhpMyAdmin\\\\Tracking\\\\TrackedData\\|null\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/TrackingController.php
-
-		-
-			message: "#^Cannot access property \\$dmlog on PhpMyAdmin\\\\Tracking\\\\TrackedData\\|null\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/TrackingController.php
-
-		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 2
-			path: libraries/classes/Controllers/Table/TrackingController.php
-
-		-
-			message: "#^Parameter \\#1 \\$trackedData of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:getEntries\\(\\) expects PhpMyAdmin\\\\Tracking\\\\TrackedData, PhpMyAdmin\\\\Tracking\\\\TrackedData\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/TrackingController.php
-
-		-
-			message: "#^Parameter \\#1 \\$trackedData of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:getHtmlForTrackingReport\\(\\) expects PhpMyAdmin\\\\Tracking\\\\TrackedData, PhpMyAdmin\\\\Tracking\\\\TrackedData\\|null given\\.$#"
-			count: 1
 			path: libraries/classes/Controllers/Table/TrackingController.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2496,6 +2496,11 @@ parameters:
 			path: libraries/classes/Controllers/Table/StructureController.php
 
 		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
+			path: libraries/classes/Controllers/Table/TrackingController.php
+
+		-
 			message: "#^Parameter \\#2 \\$entries of method PhpMyAdmin\\\\Tracking\\\\Tracking\\:\\:getDownloadInfoForExport\\(\\) expects array\\<int, array\\<string, int\\|string\\>\\>, array given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/TrackingController.php
@@ -8721,7 +8726,7 @@ parameters:
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
-			message: "#^Cannot access offset mixed on mixed\\.$#"
+			message: "#^Cannot access offset int on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Tracking/Tracking.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4432,15 +4432,7 @@
     </MixedAssignment>
     <PossiblyNullArgument>
       <code><![CDATA[$GLOBALS['text_dir']]]></code>
-      <code>$trackedData</code>
-      <code>$trackedData</code>
-      <code><![CDATA[$trackedData->ddlog]]></code>
-      <code><![CDATA[$trackedData->dmlog]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyFetch>
-      <code><![CDATA[$trackedData->ddlog]]></code>
-      <code><![CDATA[$trackedData->dmlog]]></code>
-    </PossiblyNullPropertyFetch>
   </file>
   <file src="libraries/classes/Controllers/Table/TriggersController.php">
     <InvalidArrayOffset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4419,7 +4419,6 @@
   </file>
   <file src="libraries/classes/Controllers/Table/TrackingController.php">
     <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['entries']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code><![CDATA[$GLOBALS['msg']]]></code>
     </InvalidArrayOffset>
@@ -4427,10 +4426,9 @@
       <code>$version</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code><![CDATA[$GLOBALS['entries']]]></code>
+      <code>$entries</code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code><![CDATA[$GLOBALS['entries']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
       <code><![CDATA[$GLOBALS['msg']]]></code>
       <code>$reportExport</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4420,7 +4420,6 @@
   <file src="libraries/classes/Controllers/Table/TrackingController.php">
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
-      <code><![CDATA[$GLOBALS['msg']]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
       <code>$version</code>
@@ -4430,7 +4429,6 @@
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
-      <code><![CDATA[$GLOBALS['msg']]]></code>
       <code>$reportExport</code>
       <code>$selectedVersions</code>
       <code>$submitMult</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -13738,9 +13738,6 @@
       <code><![CDATA[$data['ddlog']]]></code>
       <code><![CDATA[$data['schema_snapshot']]]></code>
     </PossiblyUndefinedArrayOffset>
-    <RiskyCast>
-      <code>$deleteId</code>
-    </RiskyCast>
   </file>
   <file src="libraries/classes/Tracking/TrackingChecker.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1768,11 +1768,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$GLOBALS['text_dir']]]></code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$trackedData['ddlog']]]></code>
-      <code><![CDATA[$trackedData['ddlog']]]></code>
-      <code><![CDATA[$trackedData['ddlog']]]></code>
-    </PossiblyUndefinedArrayOffset>
     <PossiblyUnusedMethod>
       <code>__construct</code>
     </PossiblyUnusedMethod>
@@ -4437,11 +4432,15 @@
     </MixedAssignment>
     <PossiblyNullArgument>
       <code><![CDATA[$GLOBALS['text_dir']]]></code>
+      <code>$trackedData</code>
+      <code>$trackedData</code>
+      <code><![CDATA[$trackedData->ddlog]]></code>
+      <code><![CDATA[$trackedData->dmlog]]></code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$trackedData['date_from']]]></code>
-      <code><![CDATA[$trackedData['date_to']]]></code>
-    </PossiblyUndefinedArrayOffset>
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$trackedData->ddlog]]></code>
+      <code><![CDATA[$trackedData->dmlog]]></code>
+    </PossiblyNullPropertyFetch>
   </file>
   <file src="libraries/classes/Controllers/Table/TriggersController.php">
     <InvalidArrayOffset>
@@ -13640,19 +13639,7 @@
   <file src="libraries/classes/Tracking/Tracking.php">
     <MixedArgument>
       <code>$columns</code>
-      <code>$data[$whichLog]</code>
-      <code><![CDATA[$data['ddlog']]]></code>
-      <code><![CDATA[$data['ddlog']]]></code>
-      <code><![CDATA[$data['ddlog']]]></code>
-      <code><![CDATA[$data['dmlog']]]></code>
-      <code><![CDATA[$data['dmlog']]]></code>
-      <code><![CDATA[$data['dmlog']]]></code>
-      <code><![CDATA[$data['tracking']]]></code>
       <code>$ddlogCount</code>
-      <code><![CDATA[$entry['date']]]></code>
-      <code><![CDATA[$entry['date']]]></code>
-      <code><![CDATA[$entry['statement']]]></code>
-      <code>$indexes</code>
       <code>$indexes</code>
       <code>$selectedTable</code>
       <code>$selectedTable</code>
@@ -13665,18 +13652,8 @@
                 ]]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
-      <code>$data[$whichLog][$deleteId]</code>
-      <code><![CDATA[$data['statement']]]></code>
-      <code><![CDATA[$data['username']]]></code>
-      <code><![CDATA[$entry['date']]]></code>
-      <code><![CDATA[$entry['date']]]></code>
       <code><![CDATA[$entry['statement']]]></code>
       <code><![CDATA[$entry['statement']]]></code>
-      <code><![CDATA[$entry['statement']]]></code>
-      <code><![CDATA[$entry['statement']]]></code>
-      <code><![CDATA[$entry['username']]]></code>
-      <code><![CDATA[$entry['username']]]></code>
-      <code><![CDATA[$entry['username']]]></code>
       <code><![CDATA[$row['id']]]></code>
       <code><![CDATA[$row['statement']]]></code>
       <code><![CDATA[$row['timestamp']]]></code>
@@ -13684,17 +13661,8 @@
       <code><![CDATA[$temp['COLUMNS']]]></code>
       <code><![CDATA[$temp['INDEXES']]]></code>
     </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$entry['formated_statement']]]></code>
-      <code><![CDATA[$entry['line_number']]]></code>
-      <code><![CDATA[$entry['url_params']]]></code>
-    </MixedArrayAssignment>
     <MixedAssignment>
       <code>$columns</code>
-      <code>$data</code>
-      <code>$entries[]</code>
-      <code>$entry</code>
-      <code>$entry</code>
       <code>$entry</code>
       <code>$entry</code>
       <code>$ids[$key]</code>
@@ -13710,8 +13678,6 @@
       <code>string</code>
     </MixedInferredReturnType>
     <MixedOperand>
-      <code><![CDATA[$data['statement']]]></code>
-      <code><![CDATA[$data['username']]]></code>
       <code><![CDATA[$entry['statement']]]></code>
       <code><![CDATA[$entry['statement']]]></code>
       <code>$temp</code>
@@ -13724,14 +13690,9 @@
       <code><![CDATA[mb_strpos($logEntry, "\n")]]></code>
     </PossiblyFalseOperand>
     <PossiblyNullArgument>
-      <code><![CDATA[$data['schema_snapshot']]]></code>
       <code>$tableName</code>
       <code>$versionNumber</code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$data['ddlog']]]></code>
-      <code><![CDATA[$data['schema_snapshot']]]></code>
-    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="libraries/classes/Tracking/TrackingChecker.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4421,7 +4421,6 @@
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['entries']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
-      <code><![CDATA[$GLOBALS['filter_users']]]></code>
       <code><![CDATA[$GLOBALS['msg']]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
@@ -4433,7 +4432,6 @@
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['entries']]]></code>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
-      <code><![CDATA[$GLOBALS['filter_users']]]></code>
       <code><![CDATA[$GLOBALS['msg']]]></code>
       <code>$reportExport</code>
       <code>$selectedVersions</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4424,7 +4424,7 @@
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['errorUrl']]]></code>
-      <code>$reportExport</code>
+      <code>$reportExportType</code>
       <code>$selectedVersions</code>
       <code>$submitMult</code>
       <code>$toggleActivation</code>

--- a/test/classes/Tracking/TrackingTest.php
+++ b/test/classes/Tracking/TrackingTest.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\SqlQueryForm;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
+use PhpMyAdmin\Tracking\LogTypeEnum;
 use PhpMyAdmin\Tracking\Tracking;
 use PhpMyAdmin\Tracking\TrackingChecker;
 use PhpMyAdmin\Url;
@@ -586,10 +587,6 @@ class TrackingTest extends AbstractTestCase
      */
     public function testChangeTrackingData(): void
     {
-        $this->assertFalse(
-            $this->tracking->changeTrackingData('', '', '', '', ''),
-        );
-
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -640,7 +637,7 @@ class TrackingTest extends AbstractTestCase
                 'pma_db',
                 'pma_table',
                 '1.0',
-                'DDL',
+                LogTypeEnum::DDL,
                 '# new_data_processed',
             ),
         );
@@ -650,7 +647,7 @@ class TrackingTest extends AbstractTestCase
                 'pma_db',
                 'pma_table',
                 '1.0',
-                'DML',
+                LogTypeEnum::DML,
                 $newData,
             ),
         );

--- a/test/classes/Tracking/TrackingTest.php
+++ b/test/classes/Tracking/TrackingTest.php
@@ -553,7 +553,7 @@ class TrackingTest extends AbstractTestCase
         ini_set('url_rewriter.tags', 'a=href,area=href,frame=src,form=,fieldset=');
         $entries = [['statement' => 'first statement'], ['statement' => 'second statement']];
         $expectedDump = '# Tracking report for table `test&gt; table`' . "\n"
-            . '# ' . date('Y-m-d H:i:s') . "\n"
+            . '# ' . date('Y-m-d H:i:sP') . "\n"
             . 'first statementsecond statement';
         $actual = $tracking->getDownloadInfoForExport('test>  table', $entries);
         $this->assertSame('log_test&gt; table.sql', $actual['filename']);

--- a/test/classes/Tracking/TrackingTest.php
+++ b/test/classes/Tracking/TrackingTest.php
@@ -613,8 +613,8 @@ class TrackingTest extends AbstractTestCase
         $date = Util::date('Y-m-d H:i:s');
 
         $newData = [
-            ['date' => '', 'username' => 'user1', 'statement' => 'test_statement1'],
-            ['date' => '', 'username' => 'user2', 'statement' => 'test_statement2'],
+            ['date' => $date, 'username' => 'user1', 'statement' => 'test_statement1'],
+            ['date' => $date, 'username' => 'user2', 'statement' => 'test_statement2'],
         ];
 
         $sqlQuery2 = 'UPDATE `pmadb`.`tracking`' .

--- a/test/classes/Tracking/TrackingTest.php
+++ b/test/classes/Tracking/TrackingTest.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Tracking\LogTypeEnum;
+use PhpMyAdmin\Tracking\TrackedData;
 use PhpMyAdmin\Tracking\Tracking;
 use PhpMyAdmin\Tracking\TrackingChecker;
 use PhpMyAdmin\Url;
@@ -242,11 +243,14 @@ class TrackingTest extends AbstractTestCase
      */
     public function testGetHtmlForTrackingReportr(): void
     {
-        $data = [
-            'tracking' => 'tracking',
-            'ddlog' => [['date' => '2022-11-02 22:15:24']],
-            'dmlog' => [['date' => '2022-11-02 22:15:24']],
-        ];
+        $data = new TrackedData(
+            '',
+            '',
+            [['statement' => 'statement', 'date' => '2022-11-02 22:15:24', 'username' => 'username']],
+            [['statement' => 'statement', 'date' => '2022-11-02 22:15:24', 'username' => 'username']],
+            'tracking',
+            '',
+        );
         $urlParams = [];
         $filterUsers = [];
 
@@ -271,7 +275,7 @@ class TrackingTest extends AbstractTestCase
             $html,
         );
 
-        $this->assertStringContainsString($data['tracking'], $html);
+        $this->assertStringContainsString($data->tracking, $html);
 
         $version = Url::getHiddenInputs($urlParams + ['report' => 'true', 'version' => '10']);
 
@@ -304,11 +308,14 @@ class TrackingTest extends AbstractTestCase
      */
     public function testGetHtmlForDataManipulationStatements(): void
     {
-        $data = [
-            'tracking' => 'tracking',
-            'dmlog' => [['statement' => 'statement', 'date' => '2013-01-01 12:34:56', 'username' => 'username']],
-            'ddlog' => ['ddlog'],
-        ];
+        $data = new TrackedData(
+            '',
+            '',
+            [],
+            [['statement' => 'statement', 'date' => '2013-01-01 12:34:56', 'username' => 'username']],
+            'tracking',
+            '',
+        );
         $urlParams = [];
         $ddlogCount = 10;
         $dropImageOrText = 'text';
@@ -340,9 +347,9 @@ class TrackingTest extends AbstractTestCase
             $html,
         );
 
-        $this->assertStringContainsString($data['dmlog'][0]['date'], $html);
+        $this->assertStringContainsString($data->dmlog[0]['date'], $html);
 
-        $this->assertStringContainsString($data['dmlog'][0]['username'], $html);
+        $this->assertStringContainsString($data->dmlog[0]['username'], $html);
     }
 
     /**
@@ -350,11 +357,14 @@ class TrackingTest extends AbstractTestCase
      */
     public function testGetHtmlForDataDefinitionStatements(): void
     {
-        $data = [
-            'tracking' => 'tracking',
-            'ddlog' => [['statement' => 'statement', 'date' => '2013-01-01 12:34:56', 'username' => 'username']],
-            'dmlog' => ['dmlog'],
-        ];
+        $data = new TrackedData(
+            '',
+            '',
+            [['statement' => 'statement', 'date' => '2013-01-01 12:34:56', 'username' => 'username']],
+            [],
+            'tracking',
+            '',
+        );
         $filterUsers = ['*'];
         $urlParams = [];
         $dropImageOrText = 'text';
@@ -391,7 +401,7 @@ class TrackingTest extends AbstractTestCase
 
         //PMA_getHtmlForDataDefinitionStatement
         $this->assertStringContainsString(
-            htmlspecialchars($data['ddlog'][0]['username']),
+            htmlspecialchars($data->ddlog[0]['username']),
             $html,
         );
 
@@ -510,11 +520,14 @@ class TrackingTest extends AbstractTestCase
      */
     public function testGetEntries(): void
     {
-        $data = [
-            'tracking' => 'tracking',
-            'ddlog' => [['statement' => 'statement1', 'date' => '2012-01-01 12:34:56', 'username' => 'username3']],
-            'dmlog' => [['statement' => 'statement1', 'date' => '2013-01-01 12:34:56', 'username' => 'username3']],
-        ];
+        $data = new TrackedData(
+            '',
+            '',
+            [['statement' => 'statement1', 'date' => '2012-01-01 12:34:56', 'username' => 'username3']],
+            [['statement' => 'statement1', 'date' => '2013-01-01 12:34:56', 'username' => 'username3']],
+            'tracking',
+            '',
+        );
         $filterUsers = ['*'];
 
         $entries = $this->tracking->getEntries(
@@ -600,8 +613,8 @@ class TrackingTest extends AbstractTestCase
         $date = Util::date('Y-m-d H:i:s');
 
         $newData = [
-            ['username' => 'user1', 'statement' => 'test_statement1'],
-            ['username' => 'user2', 'statement' => 'test_statement2'],
+            ['date' => '', 'username' => 'user1', 'statement' => 'test_statement1'],
+            ['date' => '', 'username' => 'user2', 'statement' => 'test_statement2'],
         ];
 
         $sqlQuery2 = 'UPDATE `pmadb`.`tracking`' .
@@ -637,16 +650,6 @@ class TrackingTest extends AbstractTestCase
                 'pma_db',
                 'pma_table',
                 '1.0',
-                LogTypeEnum::DDL,
-                '# new_data_processed',
-            ),
-        );
-
-        $this->assertTrue(
-            $tracking->changeTrackingData(
-                'pma_db',
-                'pma_table',
-                '1.0',
                 LogTypeEnum::DML,
                 $newData,
             ),
@@ -656,12 +659,12 @@ class TrackingTest extends AbstractTestCase
     /**
      * Test for getTrackedData()
      *
-     * @param mixed[] $fetchArrayReturn Value to be returned by mocked fetchArray
-     * @param mixed[] $expectedArray    Expected array
+     * @param mixed[]     $fetchArrayReturn Value to be returned by mocked fetchArray
+     * @param TrackedData $expected         Expected value
      *
      * @dataProvider getTrackedDataProvider
      */
-    public function testGetTrackedData(array $fetchArrayReturn, array $expectedArray): void
+    public function testGetTrackedData(array $fetchArrayReturn, TrackedData $expected): void
     {
         $resultStub = $this->createMock(DummyResult::class);
 
@@ -687,7 +690,7 @@ class TrackingTest extends AbstractTestCase
 
         $result = $tracking->getTrackedData("pma'db", "pma'table", '1.0');
 
-        $this->assertEquals($expectedArray, $result);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -708,17 +711,17 @@ class TrackingTest extends AbstractTestCase
         ];
 
         $data = [
-            [
-                'date_from' => '20-03-2013 23:33:58',
-                'date_to' => '20-03-2013 23:39:58',
-                'ddlog' => [
+            new TrackedData(
+                '20-03-2013 23:33:58',
+                '20-03-2013 23:39:58',
+                [
                     ['date' => '20-03-2013 23:33:58', 'username' => 'user1', 'statement' => "\nstat1"],
                     ['date' => '20-03-2013 23:39:58', 'username' => 'user2', 'statement' => ''],
                 ],
-                'dmlog' => [],
-                'schema_snapshot' => 'dataschema',
-                'tracking' => 'SELECT, DELETE',
-            ],
+                [],
+                'SELECT, DELETE',
+                'dataschema',
+            ),
         ];
 
         $fetchArrayReturn[1] = [
@@ -730,20 +733,20 @@ class TrackingTest extends AbstractTestCase
             'tracking' => 'SELECT, DELETE',
         ];
 
-        $data[1] = [
-            'date_from' => '20-03-2012 23:33:58',
-            'date_to' => '20-03-2013 23:39:58',
-            'ddlog' => [
+        $data[1] = new TrackedData(
+            '20-03-2012 23:33:58',
+            '20-03-2013 23:39:58',
+            [
                 ['date' => '20-03-2012 23:33:58', 'username' => 'user1', 'statement' => ''],
                 ['date' => '20-03-2012 23:39:58', 'username' => 'user2', 'statement' => ''],
             ],
-            'dmlog' => [
+            [
                 ['date' => '20-03-2013 23:33:58', 'username' => 'user3', 'statement' => ''],
                 ['date' => '20-03-2013 23:39:58', 'username' => 'user4', 'statement' => ''],
             ],
-            'schema_snapshot' => 'dataschema',
-            'tracking' => 'SELECT, DELETE',
-        ];
+            'SELECT, DELETE',
+            'dataschema',
+        );
 
         return [[$fetchArrayReturn[0], $data[0]], [$fetchArrayReturn[1], $data[1]]];
     }


### PR DESCRIPTION
This significantly simplifies the code, fixes some bugs, and improves some functionality. The fixed bugs should not be present in 5.2, so no need to backport. The changed functionality adds a time zone to SQL dump file and retains original date when deleting tracking data. Frankly, I think it was a bug as I do not find the current behaviour useful. 

BTW if anyone has an idea how to avoid `Assert::notNull($trackingFeature);` I am all ears. 