### PR TITLE
Refactor DbiDummy and improve FieldMetadata

### DIFF
--- a/libraries/classes/Controllers/Table/ChartController.php
+++ b/libraries/classes/Controllers/Table/ChartController.php
@@ -210,7 +210,7 @@ class ChartController extends AbstractController
             $tmpRow = [];
             foreach ($dataRow as $dataColumn => $dataValue) {
                 $escapedValue = $dataValue === null ? null : htmlspecialchars($dataValue);
-                $tmpRow[htmlspecialchars($dataColumn)] = $escapedValue;
+                $tmpRow[htmlspecialchars((string) $dataColumn)] = $escapedValue;
             }
 
             $sanitizedData[] = $tmpRow;

--- a/libraries/classes/Controllers/Table/GisVisualizationController.php
+++ b/libraries/classes/Controllers/Table/GisVisualizationController.php
@@ -65,10 +65,6 @@ final class GisVisualizationController extends AbstractController
         $labelCandidates = [];
         $spatialCandidates = [];
         foreach ($meta as $columnMeta) {
-            if ($columnMeta->name === '') {
-                continue;
-            }
-
             if ($columnMeta->isMappedTypeGeometry) {
                 $spatialCandidates[] = $columnMeta->name;
             } else {

--- a/libraries/classes/Dbal/MysqliResult.php
+++ b/libraries/classes/Dbal/MysqliResult.php
@@ -39,7 +39,7 @@ final class MysqliResult implements ResultInterface
      * Returns a generator that traverses through the whole result set
      * and returns each row as an associative array
      *
-     * @psalm-return Generator<int, array<string, string|null>, mixed, void>
+     * @psalm-return Generator<int, array<array-key, string|null>, mixed, void>
      */
     public function getIterator(): Generator
     {
@@ -57,7 +57,8 @@ final class MysqliResult implements ResultInterface
     /**
      * Returns the next row of the result with associative keys
      *
-     * @return array<string,string|null>
+     * @return array<string|null>
+     * @psalm-return array<array-key, string|null>
      */
     public function fetchAssoc(): array
     {
@@ -74,6 +75,7 @@ final class MysqliResult implements ResultInterface
      * Returns the next row of the result with numeric keys
      *
      * @return array<int,string|null>
+     * @psalm-return list<string|null>
      */
     public function fetchRow(): array
     {
@@ -107,7 +109,8 @@ final class MysqliResult implements ResultInterface
     /**
      * Returns all rows of the result
      *
-     * @return array<int, array<string,string|null>>
+     * @return array<array<string|null>>
+     * @psalm-return list<array<array-key, string|null>>
      */
     public function fetchAllAssoc(): array
     {
@@ -125,6 +128,7 @@ final class MysqliResult implements ResultInterface
      * Returns values from the first column of each row
      *
      * @return array<int, string|null>
+     * @psalm-return list<string|null>
      */
     public function fetchAllColumn(): array
     {
@@ -144,7 +148,8 @@ final class MysqliResult implements ResultInterface
      * SELECT id, name FROM users
      * produces: ['123' => 'John', '124' => 'Jane']
      *
-     * @return array<string, string|null>
+     * @return array<string|null>
+     * @psalm-return array<array-key, string|null>
      */
     public function fetchAllKeyPair(): array
     {
@@ -226,6 +231,7 @@ final class MysqliResult implements ResultInterface
      * Returns the names of the fields in the result
      *
      * @return array<int, string> Fields names
+     * @psalm-return list<non-empty-string>
      */
     public function getFieldNames(): array
     {
@@ -233,9 +239,6 @@ final class MysqliResult implements ResultInterface
             return [];
         }
 
-        /** @var list<string> $column */
-        $column = array_column($this->result->fetch_fields(), 'name');
-
-        return $column;
+        return array_column($this->result->fetch_fields(), 'name');
     }
 }

--- a/libraries/classes/Dbal/MysqliResult.php
+++ b/libraries/classes/Dbal/MysqliResult.php
@@ -206,6 +206,7 @@ final class MysqliResult implements ResultInterface
      * returns meta info for fields in $result
      *
      * @return array<int, FieldMetadata> meta info for fields in $result
+     * @psalm-return list<FieldMetadata>
      */
     public function getFieldsMeta(): array
     {
@@ -214,8 +215,8 @@ final class MysqliResult implements ResultInterface
         }
 
         $fields = [];
-        foreach ($this->result->fetch_fields() as $k => $field) {
-            $fields[$k] = new FieldMetadata($field->type, $field->flags, $field);
+        foreach ($this->result->fetch_fields() as $field) {
+            $fields[] = new FieldMetadata($field);
         }
 
         return $fields;

--- a/libraries/classes/Dbal/ResultInterface.php
+++ b/libraries/classes/Dbal/ResultInterface.php
@@ -14,7 +14,7 @@ use PhpMyAdmin\FieldMetadata;
 /**
  * Extension independent database result interface
  *
- * @extends IteratorAggregate<array<string, (string|null)>>
+ * @extends IteratorAggregate<array<array-key, (string|null)>>
  */
 interface ResultInterface extends IteratorAggregate
 {
@@ -22,14 +22,15 @@ interface ResultInterface extends IteratorAggregate
      * Returns a generator that traverses through the whole result set
      * and returns each row as an associative array
      *
-     * @psalm-return Generator<int, array<string, string|null>, mixed, void>
+     * @psalm-return Generator<int, array<array-key, string|null>, mixed, void>
      */
     public function getIterator(): Generator;
 
     /**
      * Returns the next row of the result with associative keys
      *
-     * @return array<string,string|null>
+     * @return array<string|null>
+     * @psalm-return array<array-key, string|null>
      */
     public function fetchAssoc(): array;
 
@@ -37,6 +38,7 @@ interface ResultInterface extends IteratorAggregate
      * Returns the next row of the result with numeric keys
      *
      * @return array<int,string|null>
+     * @psalm-return list<string|null>
      */
     public function fetchRow(): array;
 
@@ -48,7 +50,8 @@ interface ResultInterface extends IteratorAggregate
     /**
      * Returns all rows of the result
      *
-     * @return array<int, array<string,string|null>>
+     * @return array<int, array<string|null>>
+     * @psalm-return list<array<array-key, string|null>>
      */
     public function fetchAllAssoc(): array;
 
@@ -56,6 +59,7 @@ interface ResultInterface extends IteratorAggregate
      * Returns values from the first column of each row
      *
      * @return array<int, string|null>
+     * @psalm-return list<string|null>
      */
     public function fetchAllColumn(): array;
 
@@ -65,7 +69,8 @@ interface ResultInterface extends IteratorAggregate
      * e.g. "SELECT id, name FROM users"
      * produces: ['123' => 'John', '124' => 'Jane']
      *
-     * @return array<string, string|null>
+     * @return array<string|null>
+     * @psalm-return array<array-key, string|null>
      */
     public function fetchAllKeyPair(): array;
 

--- a/libraries/classes/Dbal/ResultInterface.php
+++ b/libraries/classes/Dbal/ResultInterface.php
@@ -94,6 +94,7 @@ interface ResultInterface extends IteratorAggregate
      * Returns meta info for fields in $result
      *
      * @return array<int, FieldMetadata> meta info for fields in $result
+     * @psalm-return list<FieldMetadata>
      */
     public function getFieldsMeta(): array;
 
@@ -101,6 +102,7 @@ interface ResultInterface extends IteratorAggregate
      * Returns the names of the fields in the result
      *
      * @return array<int, string> Fields names
+     * @psalm-return list<non-empty-string>
      */
     public function getFieldNames(): array;
 }

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -160,7 +160,7 @@ class InsertEdit
      * @param string   $db               name of the database
      *
      * @return array<int, string[]|ResultInterface[]|array<string, string|null>[]|bool>
-     * @phpstan-return array{string[], ResultInterface[], array<string, string|null>[], bool}
+     * @phpstan-return array{string[], ResultInterface[], array<string|null>[], bool}
      */
     private function analyzeWhereClauses(
         array $whereClauseArray,

--- a/libraries/classes/Plugins/Export/ExportJson.php
+++ b/libraries/classes/Plugins/Export/ExportJson.php
@@ -209,15 +209,15 @@ class ExportJson extends ExportPlugin
     /**
      * Export to JSON
      *
-     * @phpstan-param array{
-     * string: array{
-     *           'tables': array{
-     *              string: array{
-     *                  'columns': array{string: string}
-     *              }
-     *           }
-     *        }
-     * }|array|null $aliases
+     * @phpstan-param array<
+     *   string,
+     *   array{
+     *     tables: array<
+     *       string,
+     *       array{columns: array<string, string>}
+     *     >
+     *   }
+     * >|null $aliases
      */
     protected function doExportForQuery(
         DatabaseInterface $dbi,

--- a/libraries/classes/Server/Status/Processes.php
+++ b/libraries/classes/Server/Status/Processes.php
@@ -9,11 +9,11 @@ use PhpMyAdmin\Html\Generator;
 use PhpMyAdmin\Util;
 
 use function __;
-use function array_keys;
+use function array_change_key_case;
 use function count;
-use function mb_strtolower;
 use function strlen;
-use function ucfirst;
+
+use const CASE_LOWER;
 
 final class Processes
 {
@@ -54,26 +54,17 @@ final class Processes
         while ($process = $result->fetchAssoc()) {
             // Array keys need to modify due to the way it has used
             // to display column values
-            foreach (array_keys($process) as $key) {
-                $newKey = ucfirst(mb_strtolower($key));
-                if ($newKey === $key) {
-                    continue;
-                }
-
-                $process[$newKey] = $process[$key];
-                unset($process[$key]);
-            }
-
+            $process = array_change_key_case($process, CASE_LOWER);
             $rows[] = [
-                'id' => $process['Id'],
-                'user' => $process['User'],
-                'host' => $process['Host'],
-                'db' => ! isset($process['Db']) || strlen($process['Db']) === 0 ? '' : $process['Db'],
-                'command' => $process['Command'],
-                'time' => $process['Time'],
-                'state' => ! empty($process['State']) ? $process['State'] : '---',
-                'progress' => ! empty($process['Progress']) ? $process['Progress'] : '---',
-                'info' => ! empty($process['Info']) ? Generator::formatSql($process['Info'], ! $showFullSql) : '---',
+                'id' => $process['id'],
+                'user' => $process['user'],
+                'host' => $process['host'],
+                'db' => ! isset($process['db']) || strlen($process['db']) === 0 ? '' : $process['db'],
+                'command' => $process['command'],
+                'time' => $process['time'],
+                'state' => ! empty($process['state']) ? $process['state'] : '---',
+                'progress' => ! empty($process['progress']) ? $process['progress'] : '---',
+                'info' => ! empty($process['info']) ? Generator::formatSql($process['info'], ! $showFullSql) : '---',
             ];
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4001,31 +4001,6 @@ parameters:
 			path: libraries/classes/Export/Template.php
 
 		-
-			message: "#^Access to an uninitialized property PhpMyAdmin\\\\FieldMetadata\\:\\:\\$name\\.$#"
-			count: 1
-			path: libraries/classes/FieldMetadata.php
-
-		-
-			message: "#^Access to an uninitialized property PhpMyAdmin\\\\FieldMetadata\\:\\:\\$orgname\\.$#"
-			count: 1
-			path: libraries/classes/FieldMetadata.php
-
-		-
-			message: "#^Access to an uninitialized property PhpMyAdmin\\\\FieldMetadata\\:\\:\\$orgtable\\.$#"
-			count: 1
-			path: libraries/classes/FieldMetadata.php
-
-		-
-			message: "#^Access to an uninitialized property PhpMyAdmin\\\\FieldMetadata\\:\\:\\$table\\.$#"
-			count: 1
-			path: libraries/classes/FieldMetadata.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\FieldMetadata\\:\\:\\$mappedType \\(int\\|null\\) does not accept mixed\\.$#"
-			count: 1
-			path: libraries/classes/FieldMetadata.php
-
-		-
 			message: "#^Cannot access offset 'multi_edit' on mixed\\.$#"
 			count: 5
 			path: libraries/classes/File.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,12 +81,12 @@ parameters:
 			path: libraries/classes/BrowseForeigners.php
 
 		-
-			message: "#^Parameter \\#1 \\$state of static method PhpMyAdmin\\\\Charsets\\\\Charset\\:\\:fromServer\\(\\) expects array\\{Charset\\?\\: string, Description\\?\\: string, Default collation\\?\\: string, Maxlen\\?\\: string\\}, array\\<string, string\\|null\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$state of static method PhpMyAdmin\\\\Charsets\\\\Charset\\:\\:fromServer\\(\\) expects array\\{Charset\\?\\: string, Description\\?\\: string, Default collation\\?\\: string, Maxlen\\?\\: string\\}, array\\<string\\|null\\> given\\.$#"
 			count: 1
 			path: libraries/classes/Charsets.php
 
 		-
-			message: "#^Parameter \\#1 \\$state of static method PhpMyAdmin\\\\Charsets\\\\Collation\\:\\:fromServer\\(\\) expects array\\<string\\>, array\\<string, string\\|null\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$state of static method PhpMyAdmin\\\\Charsets\\\\Collation\\:\\:fromServer\\(\\) expects array\\<string\\>, array\\<string\\|null\\> given\\.$#"
 			count: 1
 			path: libraries/classes/Charsets.php
 
@@ -721,7 +721,7 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getForeignData\\(\\) should return array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, non\\-empty\\-array\\>\\|null, foreign_field\\: mixed\\} but returns array\\{foreign_link\\: bool, the_total\\: int\\|string\\|null, foreign_display\\: string, disp_row\\: array\\<int, array\\<string, string\\|null\\>\\>\\|null, foreign_field\\: mixed\\}\\.$#"
+			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getForeignData\\(\\) should return array\\{foreign_link\\: bool, the_total\\: mixed, foreign_display\\: string, disp_row\\: array\\<int, non\\-empty\\-array\\>\\|null, foreign_field\\: mixed\\} but returns array\\{foreign_link\\: bool, the_total\\: int\\|string\\|null, foreign_display\\: string, disp_row\\: array\\<int, array\\<string\\|null\\>\\>\\|null, foreign_field\\: mixed\\}\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 
@@ -3526,11 +3526,6 @@ parameters:
 			path: libraries/classes/Dbal/DbiMysqli.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:fetchAllKeyPair\\(\\) should return array\\<string, string\\|null\\> but returns array\\<int\\|string, mixed\\>\\.$#"
-			count: 1
-			path: libraries/classes/Dbal/MysqliResult.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Dbal\\\\MysqliResult\\:\\:numRows\\(\\) should return int\\|numeric\\-string but returns int\\|string\\.$#"
 			count: 1
 			path: libraries/classes/Dbal/MysqliResult.php
@@ -5446,8 +5441,13 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportCsv.php
 
 		-
+			message: "#^Cannot access offset non\\-empty\\-string on mixed\\.$#"
+			count: 2
+			path: libraries/classes/Plugins/Export/ExportCsv.php
+
+		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 4
+			count: 2
 			path: libraries/classes/Plugins/Export/ExportCsv.php
 
 		-
@@ -5496,8 +5496,13 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportHtmlword.php
 
 		-
+			message: "#^Cannot access offset non\\-empty\\-string on mixed\\.$#"
+			count: 2
+			path: libraries/classes/Plugins/Export/ExportHtmlword.php
+
+		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 8
+			count: 6
 			path: libraries/classes/Plugins/Export/ExportHtmlword.php
 
 		-
@@ -5511,7 +5516,7 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportHtmlword.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Export\\\\ExportJson\\:\\:doExportForQuery\\(\\) has parameter \\$aliases with no value type specified in iterable type array\\.$#"
+			message: "#^Parameter \\#4 \\$aliases of method PhpMyAdmin\\\\Plugins\\\\Export\\\\ExportJson\\:\\:doExportForQuery\\(\\) expects array\\<string, array\\{tables\\: array\\<string, array\\{columns\\: array\\<string, string\\>\\}\\>\\}\\>\\|null, array given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/ExportJson.php
 
@@ -5571,8 +5576,13 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportOds.php
 
 		-
+			message: "#^Cannot access offset non\\-empty\\-string on mixed\\.$#"
+			count: 2
+			path: libraries/classes/Plugins/Export/ExportOds.php
+
+		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 4
+			count: 2
 			path: libraries/classes/Plugins/Export/ExportOds.php
 
 		-
@@ -5626,8 +5636,13 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportOdt.php
 
 		-
+			message: "#^Cannot access offset non\\-empty\\-string on mixed\\.$#"
+			count: 2
+			path: libraries/classes/Plugins/Export/ExportOdt.php
+
+		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 8
+			count: 6
 			path: libraries/classes/Plugins/Export/ExportOdt.php
 
 		-
@@ -5711,8 +5726,13 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
+			message: "#^Cannot access offset non\\-empty\\-string on mixed\\.$#"
+			count: 2
+			path: libraries/classes/Plugins/Export/ExportSql.php
+
+		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 12
+			count: 10
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
@@ -5861,8 +5881,13 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportTexytext.php
 
 		-
+			message: "#^Cannot access offset non\\-empty\\-string on mixed\\.$#"
+			count: 2
+			path: libraries/classes/Plugins/Export/ExportTexytext.php
+
+		-
 			message: "#^Cannot access offset string on mixed\\.$#"
-			count: 8
+			count: 6
 			path: libraries/classes/Plugins/Export/ExportTexytext.php
 
 		-
@@ -9416,16 +9441,6 @@ parameters:
 			path: test/classes/DatabaseInterfaceTest.php
 
 		-
-			message: "#^Parameter \\#2 \\$result of method PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:addResult\\(\\) expects array\\<int, array\\<int, array\\{string\\: string\\}\\|bool\\|int\\|string\\|null\\>\\|bool\\>\\|bool, array given\\.$#"
-			count: 1
-			path: test/classes/DatabaseInterfaceTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$result of method PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:addResult\\(\\) expects array\\<int, array\\<int, array\\{string\\: string\\}\\|bool\\|int\\|string\\|null\\>\\|bool\\>\\|bool, array\\|false given\\.$#"
-			count: 2
-			path: test/classes/DatabaseInterfaceTest.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Display\\\\ResultsTest\\:\\:dataProviderForTestGetDataCellForNonNumericColumns\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 3
 			path: test/classes/Display/ResultsTest.php
@@ -9856,59 +9871,9 @@ parameters:
 			path: test/classes/Server/SysInfo/SysInfoTest.php
 
 		-
-			message: "#^Cannot access offset \\(int\\|string\\) on mixed\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:connect\\(\\) never returns null so it can be removed from the return type\\.$#"
 			count: 1
 			path: test/classes/Stubs/DbiDummy.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:fetchAny\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:fetchAssoc\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
-			message: "#^Method PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:fetchRow\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
-			message: "#^PHPDoc tag @var for property PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:\\$dummyQueries contains unresolvable type\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
-			message: "#^PHPDoc tag @var for property PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:\\$filoQueries contains unresolvable type\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 3
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:\\$dummyQueries type has no value type specified in iterable type array\\<string, mixed\\>\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
-			message: "#^Property PhpMyAdmin\\\\Tests\\\\Stubs\\\\DbiDummy\\:\\:\\$filoQueries type has no value type specified in iterable type array\\<string, mixed\\>\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
-			message: "#^Casting to string something that's already string\\.$#"
-			count: 1
-			path: test/classes/Stubs/DummyResult.php
 
 		-
 			message: "#^Foreach overwrites \\$value with its value variable\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6932,18 +6932,6 @@
       <code><![CDATA[$state['username']]]></code>
     </MixedArgument>
   </file>
-  <file src="libraries/classes/FieldMetadata.php">
-    <MixedAssignment>
-      <code><![CDATA[$this->charsetnr]]></code>
-      <code><![CDATA[$this->decimals]]></code>
-      <code><![CDATA[$this->length]]></code>
-      <code><![CDATA[$this->mappedType]]></code>
-      <code><![CDATA[$this->name]]></code>
-      <code><![CDATA[$this->orgname]]></code>
-      <code><![CDATA[$this->orgtable]]></code>
-      <code><![CDATA[$this->table]]></code>
-    </MixedAssignment>
-  </file>
   <file src="libraries/classes/File.php">
     <FalsableReturnStatement>
       <code><![CDATA[$this->detectCompression()]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6255,16 +6255,20 @@
       <code>is_array($row) ? $row : []</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code><![CDATA[array<int, array<string,string|null>>]]></code>
-      <code><![CDATA[array<int,string|null>]]></code>
-      <code><![CDATA[array<string,string|null>]]></code>
+      <code><![CDATA[array<array-key, string|null>]]></code>
+      <code><![CDATA[list<array<array-key, string|null>>]]></code>
+      <code><![CDATA[list<string|null>]]></code>
     </InvalidReturnType>
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[array<int, string|null>]]></code>
-      <code><![CDATA[array<string, string|null>]]></code>
+    <LessSpecificReturnStatement>
       <code><![CDATA[array_column($this->result->fetch_all(), 0)]]></code>
+    </LessSpecificReturnStatement>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[array<array-key, string|null>]]></code>
       <code><![CDATA[array_column($this->result->fetch_all(), 1, 0)]]></code>
     </MixedReturnTypeCoercion>
+    <MoreSpecificReturnType>
+      <code><![CDATA[list<string|null>]]></code>
+    </MoreSpecificReturnType>
   </file>
   <file src="libraries/classes/Display/Results.php">
     <DeprecatedMethod>
@@ -9455,13 +9459,9 @@
       <code><![CDATA[$GLOBALS['json_pretty_print']]]></code>
       <code><![CDATA[$GLOBALS['json_unicode']]]></code>
     </InvalidArrayOffset>
-    <MixedArrayOffset>
-      <code>$data[$columns[$i]]</code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code>$colAs</code>
-      <code>$columns[$i]</code>
-    </MixedAssignment>
+    <MixedArgumentTypeCoercion>
+      <code>$aliases</code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportLatex.php">
     <InvalidArrayOffset>
@@ -12533,6 +12533,9 @@
       <code>$alterUserQuery</code>
       <code>$alterUserQuery</code>
     </PossiblyNullOperand>
+    <PossiblyUndefinedArrayOffset>
+      <code>$row1[0]</code>
+    </PossiblyUndefinedArrayOffset>
     <RedundantCondition>
       <code><![CDATA[is_string($_REQUEST['dbname'])]]></code>
     </RedundantCondition>
@@ -12965,6 +12968,9 @@
       <code><![CDATA[$statementInfo->parser->list]]></code>
       <code>$table</code>
     </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code>$row[0]</code>
+    </PossiblyUndefinedArrayOffset>
     <RedundantCast>
       <code><![CDATA[(bool) $GLOBALS['cfg']['ShowSQL']]]></code>
     </RedundantCast>
@@ -14712,11 +14718,6 @@
     </MixedAssignment>
   </file>
   <file src="test/classes/DatabaseInterfaceTest.php">
-    <MixedArgumentTypeCoercion>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MixedArgumentTypeCoercion>
     <MixedInferredReturnType>
       <code>mixed[]</code>
       <code>mixed[]</code>
@@ -15379,78 +15380,16 @@
       <code>mixed[]</code>
     </MixedInferredReturnType>
   </file>
-  <file src="test/classes/Stubs/DbiDummy.php">
-    <InvalidDocblock>
-      <code>private array $dummyQueries = [];</code>
-      <code>private array $filoQueries = [];</code>
-    </InvalidDocblock>
-    <MixedArgument>
-      <code><![CDATA[$queryData['columns'] ?? []]]></code>
-      <code><![CDATA[$queryData['result']]]></code>
-      <code><![CDATA[$queryData['result']]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$queryData['columns'][$key]]]></code>
-      <code><![CDATA[$queryData['result'][$queryData['pos']]]]></code>
-      <code><![CDATA[$query['used']]]></code>
-      <code><![CDATA[$this->dummyQueries[$i]['query']]]></code>
-      <code><![CDATA[$this->dummyQueries[$i]['result']]]></code>
-      <code><![CDATA[$this->filoQueries[$i]['query']]]></code>
-      <code><![CDATA[$this->filoQueries[$i]['result']]]></code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$this->dummyQueries[$i]['pos']]]></code>
-      <code><![CDATA[$this->filoQueries[$i]['pos']]]></code>
-      <code><![CDATA[$this->filoQueries[$i]['used']]]></code>
-    </MixedArrayAssignment>
-    <MixedArrayOffset>
-      <code><![CDATA[$queryData['result'][$queryData['pos']]]]></code>
-      <code><![CDATA[$ret[$queryData['columns'][$key]]]]></code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code>$query</code>
-      <code><![CDATA[$queryData['pos']]]></code>
-      <code>$ret</code>
-      <code><![CDATA[$ret[$queryData['columns'][$key]]]]></code>
-      <code>$unUsed[]</code>
-      <code>$val</code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[array<mixed>]]></code>
-      <code>array|null</code>
-    </MixedInferredReturnType>
-    <MixedOperand>
-      <code><![CDATA[$queryData['pos']]]></code>
-    </MixedOperand>
-    <MixedReturnStatement>
-      <code>$ret</code>
-      <code><![CDATA[$this->dummyQueries[$result - self::OFFSET_GLOBAL]]]></code>
-      <code><![CDATA[$this->filoQueries[$result]]]></code>
-    </MixedReturnStatement>
-    <MixedReturnTypeCoercion>
-      <code>$unUsed</code>
-      <code>mixed[][]</code>
-    </MixedReturnTypeCoercion>
-    <UnsupportedReferenceUsage>
-      <code><![CDATA[$queryData = &$this->getQueryData($result)]]></code>
-      <code><![CDATA[$queryData = &$this->getQueryData($result)]]></code>
-    </UnsupportedReferenceUsage>
-  </file>
   <file src="test/classes/Stubs/DummyResult.php">
-    <MixedReturnTypeCoercion>
-      <code><![CDATA[$this->link->fetchAssoc($this->result) ?? []]]></code>
-      <code><![CDATA[$this->link->fetchRow($this->result) ?? []]]></code>
-      <code><![CDATA[$this->link->getFieldsMeta($this->result)]]></code>
-      <code><![CDATA[array<int, FieldMetadata>]]></code>
-      <code><![CDATA[array<int,string|null>]]></code>
-      <code><![CDATA[array<string,string|null>]]></code>
-    </MixedReturnTypeCoercion>
+    <InvalidReturnStatement>
+      <code><![CDATA[array_column($this->result, 1, 0)]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[array<array-key, string|null>]]></code>
+    </InvalidReturnType>
     <PossiblyUnusedReturnValue>
       <code>bool</code>
     </PossiblyUnusedReturnValue>
-    <RedundantCastGivenDocblockType>
-      <code>(string) $row[$field]</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="test/classes/Stubs/ResponseRenderer.php">
     <MixedAssignment>

--- a/test/classes/Controllers/Export/ExportControllerTest.php
+++ b/test/classes/Controllers/Export/ExportControllerTest.php
@@ -7,10 +7,10 @@ namespace PhpMyAdmin\Tests\Controllers\Export;
 use PhpMyAdmin\Controllers\Export\ExportController;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Export;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 
@@ -87,9 +87,13 @@ class ExportControllerTest extends AbstractTestCase
             ],
             ['id', 'name', 'datetimefield'],
             [
-                new FieldMetadata(MYSQLI_TYPE_DECIMAL, MYSQLI_PRI_KEY_FLAG | MYSQLI_NUM_FLAG, (object) ['name' => 'id']),
-                new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) ['name' => 'name']),
-                new FieldMetadata(MYSQLI_TYPE_DATETIME, 0, (object) ['name' => 'datetimefield']),
+                FieldHelper::fromArray([
+                    'type' => MYSQLI_TYPE_DECIMAL,
+                    'flags' => MYSQLI_PRI_KEY_FLAG | MYSQLI_NUM_FLAG,
+                    'name' => 'id',
+                ]),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'name' => 'name']),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_DATETIME, 'name' => 'datetimefield']),
             ],
         );
         $this->dummyDbi->addResult(

--- a/test/classes/Controllers/Export/ExportControllerTest.php
+++ b/test/classes/Controllers/Export/ExportControllerTest.php
@@ -57,10 +57,10 @@ class ExportControllerTest extends AbstractTestCase
             [['test_db']],
             ['SCHEMA_NAME'],
         );
-        $this->dummyDbi->addResult('SET SQL_MODE=""', [[]]);
-        $this->dummyDbi->addResult('SET time_zone = "+00:00"', [[]]);
+        $this->dummyDbi->addResult('SET SQL_MODE=""', true);
+        $this->dummyDbi->addResult('SET time_zone = "+00:00"', true);
         $this->dummyDbi->addResult('SELECT @@session.time_zone', [['SYSTEM']]);
-        $this->dummyDbi->addResult('SET time_zone = "SYSTEM"', [[]]);
+        $this->dummyDbi->addResult('SET time_zone = "SYSTEM"', true);
         $this->dummyDbi->addResult('SHOW TABLES FROM `test_db`;', [['test_table']], ['Tables_in_test_db']);
         $this->dummyDbi->addResult(
             'SELECT DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = \'test_db\' LIMIT 1',

--- a/test/classes/Controllers/Table/ChartControllerTest.php
+++ b/test/classes/Controllers/Table/ChartControllerTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers\Table;
 
 use PhpMyAdmin\Controllers\Table\ChartController;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 
 use const MYSQLI_NOT_NULL_FLAG;
@@ -37,21 +37,24 @@ class ChartControllerTest extends AbstractTestCase
         $_REQUEST['pos'] = '0';
 
         $fieldsMeta = [
-            new FieldMetadata(
-                MYSQLI_TYPE_LONG,
-                MYSQLI_PRI_KEY_FLAG | MYSQLI_NUM_FLAG | MYSQLI_NOT_NULL_FLAG,
-                (object) ['name' => 'id', 'table' => 'table_for_chart'],
-            ),
-            new FieldMetadata(
-                MYSQLI_TYPE_LONG,
-                MYSQLI_NUM_FLAG | MYSQLI_NOT_NULL_FLAG,
-                (object) ['name' => 'amount', 'table' => 'table_for_chart'],
-            ),
-            new FieldMetadata(
-                MYSQLI_TYPE_DATE,
-                MYSQLI_NOT_NULL_FLAG,
-                (object) ['name' => 'date', 'table' => 'table_for_chart'],
-            ),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_LONG,
+                'flags' => MYSQLI_PRI_KEY_FLAG | MYSQLI_NUM_FLAG | MYSQLI_NOT_NULL_FLAG,
+                'name' => 'id',
+                'table' => 'table_for_chart',
+            ]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_LONG,
+                'flags' => MYSQLI_NUM_FLAG | MYSQLI_NOT_NULL_FLAG,
+                'name' => 'amount',
+                'table' => 'table_for_chart',
+            ]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_DATE,
+                'flags' => MYSQLI_NOT_NULL_FLAG,
+                'name' => 'date',
+                'table' => 'table_for_chart',
+            ]),
         ];
 
         $dummyDbi = $this->createDbiDummy();

--- a/test/classes/Controllers/Table/GisVisualizationControllerTest.php
+++ b/test/classes/Controllers/Table/GisVisualizationControllerTest.php
@@ -6,10 +6,10 @@ namespace PhpMyAdmin\Tests\Controllers\Table;
 
 use PhpMyAdmin\Controllers\Table\GisVisualizationController;
 use PhpMyAdmin\Core;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Url;
 
@@ -40,8 +40,8 @@ class GisVisualizationControllerTest extends AbstractTestCase
             [['POINT', 'POINT(100 250)']],
             ['name', 'shape'],
             [
-                new FieldMetadata(MYSQLI_TYPE_VAR_STRING, 0, (object) []),
-                new FieldMetadata(MYSQLI_TYPE_GEOMETRY, 0, (object) []),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_VAR_STRING]),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_GEOMETRY]),
             ],
         );
         $dummyDbi->addResult(

--- a/test/classes/Controllers/Table/SearchControllerTest.php
+++ b/test/classes/Controllers/Table/SearchControllerTest.php
@@ -8,10 +8,10 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\Table\SearchController;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Table\Search;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseStub;
 use PhpMyAdmin\Types;
@@ -146,8 +146,8 @@ class SearchControllerTest extends AbstractTestCase
             [[1, 2]],
             ['col1', 'col2'],
             [
-                new FieldMetadata(MYSQLI_TYPE_LONG, 0, (object) ['length' => 11]),
-                new FieldMetadata(MYSQLI_TYPE_LONG, 0, (object) ['length' => 11]),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_LONG, 'length' => 11]),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_LONG, 'length' => 11]),
             ],
         );
 

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -41,10 +41,11 @@ class DatabaseInterfaceTest extends AbstractTestCase
     /**
      * Tests for DBI::getCurrentUser() method.
      *
-     * @param mixed[]|false $value           value
-     * @param string        $string          string
-     * @param mixed[]       $expected        expected result
-     * @param bool          $needsSecondCall The test will need to call another time the DB
+     * @param string[][]|false $value           value
+     * @param string           $string          string
+     * @param mixed[]          $expected        expected result
+     * @param bool             $needsSecondCall The test will need to call another time the DB
+     * @psalm-param list<non-empty-list<string>>|false $value
      *
      * @dataProvider currentUserData
      */
@@ -266,8 +267,9 @@ class DatabaseInterfaceTest extends AbstractTestCase
     /**
      * Tests for DBI::isAmazonRds() method.
      *
-     * @param mixed[] $value    value
-     * @param bool    $expected expected result
+     * @param string[][] $value    value
+     * @param bool       $expected expected result
+     * @psalm-param list<non-empty-list<string>> $value
      *
      * @dataProvider isAmazonRdsData
      */
@@ -341,10 +343,10 @@ class DatabaseInterfaceTest extends AbstractTestCase
         $dummyDbi = $this->createDbiDummy();
         $dbi = $this->createDatabaseInterface($dummyDbi);
 
-        $dummyDbi->addResult('SET collation_connection = \'utf8_czech_ci\';', [true]);
-        $dummyDbi->addResult('SET collation_connection = \'utf8mb4_bin_ci\';', [true]);
-        $dummyDbi->addResult('SET collation_connection = \'utf8_czech_ci\';', [true]);
-        $dummyDbi->addResult('SET collation_connection = \'utf8_bin_ci\';', [true]);
+        $dummyDbi->addResult('SET collation_connection = \'utf8_czech_ci\';', true);
+        $dummyDbi->addResult('SET collation_connection = \'utf8mb4_bin_ci\';', true);
+        $dummyDbi->addResult('SET collation_connection = \'utf8_czech_ci\';', true);
+        $dummyDbi->addResult('SET collation_connection = \'utf8_bin_ci\';', true);
 
         $GLOBALS['charset_connection'] = 'utf8mb4';
         $dbi->setCollation('utf8_czech_ci');
@@ -479,8 +481,8 @@ class DatabaseInterfaceTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface($dummyDbi);
 
         $sql = 'insert into PMA_bookmark A,B values(1, 2)';
-        $dummyDbi->addResult($sql, [true]);
-        $dummyDbi->addResult($sql, [true]);
+        $dummyDbi->addResult($sql, true);
+        $dummyDbi->addResult($sql, true);
         $dummyDbi->addResult('Invalid query', false);
 
         $this->assertInstanceOf(

--- a/test/classes/FieldHelper.php
+++ b/test/classes/FieldHelper.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Tests;
+
+use PhpMyAdmin\FieldMetadata;
+
+class FieldHelper
+{
+    /**
+     * @param array<string,string|int> $metadata
+     * @psalm-param array{
+     *     name?: non-empty-string,
+     *     orgname?: string,
+     *     table?: string,
+     *     orgtable?: string,
+     *     max_length?: int,
+     *     length?: int,
+     *     charsetnr?: int,
+     *     flags?: int,
+     *     type: int,
+     *     decimals?: int,
+     *     db?: string,
+     *     def?: string,
+     *     catalog?: string,
+     * } $metadata
+     */
+    public static function fromArray(array $metadata): FieldMetadata
+    {
+        return new FieldMetadata((object) ($metadata + [
+            'name' => 'c',
+            'orgname' => '',
+            'table' => '',
+            'orgtable' => '',
+            'max_length' => 0,
+            'length' => 0,
+            'charsetnr' => -1,
+            'flags' => 0,
+            // 'type' => MYSQLI_TYPE_STRING,
+            'decimals' => 0,
+            'catalog' => 'def',
+            'db' => '',
+            'def' => '',
+        ]));
+    }
+}

--- a/test/classes/FieldMetadataTest.php
+++ b/test/classes/FieldMetadataTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests;
 
-use PhpMyAdmin\FieldMetadata;
-use stdClass;
-
 use const MYSQLI_BLOB_FLAG;
 use const MYSQLI_NUM_FLAG;
 use const MYSQLI_TYPE_FLOAT;
@@ -18,7 +15,7 @@ class FieldMetadataTest extends AbstractTestCase
 {
     public function testEmptyConstruct(): void
     {
-        $fm = new FieldMetadata(-1, 0, (object) []);
+        $fm = FieldHelper::fromArray(['type' => -1]);
         $this->assertSame('', $fm->getMappedType());
         $this->assertFalse($fm->isBinary());
         $this->assertFalse($fm->isEnum());
@@ -34,9 +31,7 @@ class FieldMetadataTest extends AbstractTestCase
 
     public function testIsBinary(): void
     {
-        $obj = new stdClass();
-        $obj->charsetnr = 63;
-        $fm = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $obj);
+        $fm = FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'charsetnr' => 63]);
         $this->assertTrue($fm->isBinary());
         $this->assertFalse($fm->isEnum());
         $this->assertFalse($fm->isUniqueKey());
@@ -51,7 +46,7 @@ class FieldMetadataTest extends AbstractTestCase
 
     public function testIsNumeric(): void
     {
-        $fm = new FieldMetadata(MYSQLI_TYPE_INT24, MYSQLI_NUM_FLAG, (object) []);
+        $fm = FieldHelper::fromArray(['type' => MYSQLI_TYPE_INT24, 'flags' => MYSQLI_NUM_FLAG]);
         $this->assertSame('int', $fm->getMappedType());
         $this->assertFalse($fm->isBinary());
         $this->assertFalse($fm->isEnum());
@@ -68,7 +63,7 @@ class FieldMetadataTest extends AbstractTestCase
 
     public function testIsBlob(): void
     {
-        $fm = new FieldMetadata(-1, MYSQLI_BLOB_FLAG, (object) []);
+        $fm = FieldHelper::fromArray(['type' => -1, 'flags' => MYSQLI_BLOB_FLAG]);
         $this->assertSame('', $fm->getMappedType());
         $this->assertFalse($fm->isBinary());
         $this->assertFalse($fm->isEnum());
@@ -84,7 +79,7 @@ class FieldMetadataTest extends AbstractTestCase
 
     public function testIsNumericFloat(): void
     {
-        $fm = new FieldMetadata(MYSQLI_TYPE_FLOAT, MYSQLI_NUM_FLAG, (object) []);
+        $fm = FieldHelper::fromArray(['type' => MYSQLI_TYPE_FLOAT, 'flags' => MYSQLI_NUM_FLAG]);
         $this->assertSame('real', $fm->getMappedType());
         $this->assertFalse($fm->isBinary());
         $this->assertFalse($fm->isEnum());

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1671,7 +1671,7 @@ class InsertEditTest extends AbstractTestCase
 
         $resultStub->expects($this->once())
             ->method('numRows')
-            ->will($this->returnValue('2'));
+            ->will($this->returnValue(2));
 
         $resultStub->expects($this->once())
             ->method('fetchValue')

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -9,7 +9,6 @@ use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Warning;
 use PhpMyAdmin\EditField;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\FileListing;
 use PhpMyAdmin\InsertEdit;
 use PhpMyAdmin\ResponseRenderer;
@@ -20,7 +19,6 @@ use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Url;
 use ReflectionProperty;
-use stdClass;
 
 use function hash;
 use function is_object;
@@ -278,10 +276,12 @@ class InsertEditTest extends AbstractTestCase
      */
     public function testShowEmptyResultMessageOrSetUniqueCondition(): void
     {
-        $temp = new stdClass();
-        $temp->orgname = 'orgname';
-        $temp->table = 'table';
-        $metaArr = [new FieldMetadata(MYSQLI_TYPE_DECIMAL, MYSQLI_PRI_KEY_FLAG, $temp)];
+        $meta = FieldHelper::fromArray([
+            'type' => MYSQLI_TYPE_DECIMAL,
+            'flags' => MYSQLI_PRI_KEY_FLAG,
+            'table' => 'table',
+            'orgname' => 'orgname',
+        ]);
 
         $resultStub = $this->createMock(DummyResult::class);
 
@@ -292,7 +292,7 @@ class InsertEditTest extends AbstractTestCase
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
             ->with($resultStub)
-            ->will($this->returnValue($metaArr));
+            ->will($this->returnValue([$meta]));
 
         $GLOBALS['dbi'] = $dbi;
         $this->insertEdit = new InsertEdit(
@@ -1444,11 +1444,13 @@ class InsertEditTest extends AbstractTestCase
      */
     public function testSetSessionForEditNext(): void
     {
-        $temp = new stdClass();
-        $temp->orgname = 'orgname';
-        $temp->table = 'table';
-        $temp->orgtable = 'table';
-        $metaArr = [new FieldMetadata(MYSQLI_TYPE_DECIMAL, MYSQLI_PRI_KEY_FLAG, $temp)];
+        $meta = FieldHelper::fromArray([
+            'type' => MYSQLI_TYPE_DECIMAL,
+            'flags' => MYSQLI_PRI_KEY_FLAG,
+            'orgname' => 'orgname',
+            'table' => 'table',
+            'orgtable' => 'table',
+        ]);
 
         $row = ['1' => 1];
 
@@ -1470,7 +1472,7 @@ class InsertEditTest extends AbstractTestCase
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
             ->with($resultStub)
-            ->will($this->returnValue($metaArr));
+            ->will($this->returnValue([$meta]));
 
         $GLOBALS['dbi'] = $dbi;
         $GLOBALS['db'] = 'db';
@@ -2373,9 +2375,9 @@ class InsertEditTest extends AbstractTestCase
             ->with('SELECT `table`.`a` FROM `db`.`table` WHERE 1')
             ->willReturn($resultStub);
 
-        $meta1 = new FieldMetadata(MYSQLI_TYPE_TINY, 0, (object) []);
-        $meta2 = new FieldMetadata(MYSQLI_TYPE_TINY, 0, (object) []);
-        $meta3 = new FieldMetadata(MYSQLI_TYPE_TIMESTAMP, 0, (object) []);
+        $meta1 = FieldHelper::fromArray(['type' => MYSQLI_TYPE_TINY]);
+        $meta2 = FieldHelper::fromArray(['type' => MYSQLI_TYPE_TINY]);
+        $meta3 = FieldHelper::fromArray(['type' => MYSQLI_TYPE_TIMESTAMP]);
         $dbi->expects($this->exactly(3))
             ->method('getFieldsMeta')
             ->will($this->onConsecutiveCalls([$meta1], [$meta2], [$meta3]));
@@ -2602,7 +2604,7 @@ class InsertEditTest extends AbstractTestCase
         $resultStub = $this->createMock(DummyResult::class);
         $resultStub->expects($this->any())
             ->method('getFieldsMeta')
-            ->will($this->returnValue([new FieldMetadata(0, 0, (object) ['length' => -1])]));
+            ->will($this->returnValue([FieldHelper::fromArray(['type' => 0, 'length' => -1])]));
 
         // Test w/ input transformation
         $actual = $this->callFunction(
@@ -2775,7 +2777,7 @@ class InsertEditTest extends AbstractTestCase
         $resultStub = $this->createMock(DummyResult::class);
         $resultStub->expects($this->any())
             ->method('getFieldsMeta')
-            ->will($this->returnValue([new FieldMetadata(0, 0, (object) ['length' => -1])]));
+            ->will($this->returnValue([FieldHelper::fromArray(['type' => 0, 'length' => -1])]));
 
         $actual = $this->insertEdit->getHtmlForInsertEditRow(
             [],
@@ -2851,9 +2853,9 @@ class InsertEditTest extends AbstractTestCase
         $resultStub->expects($this->any())
             ->method('getFieldsMeta')
             ->will($this->returnValue([
-                new FieldMetadata(0, 0, (object) ['length' => -1]),
-                new FieldMetadata(0, 0, (object) ['length' => -1]),
-                new FieldMetadata(0, 0, (object) ['length' => -1]),
+                FieldHelper::fromArray(['type' => 0, 'length' => -1]),
+                FieldHelper::fromArray(['type' => 0, 'length' => -1]),
+                FieldHelper::fromArray(['type' => 0, 'length' => -1]),
             ]));
 
         $actual = $this->insertEdit->getHtmlForInsertEditRow(

--- a/test/classes/Plugins/Export/ExportOdsTest.php
+++ b/test/classes/Plugins/Export/ExportOdsTest.php
@@ -8,7 +8,6 @@ use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Export;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\Export\ExportOds;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -17,11 +16,11 @@ use PhpMyAdmin\Properties\Options\Items\HiddenPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
 use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use ReflectionMethod;
 use ReflectionProperty;
-use stdClass;
 
 use function bin2hex;
 
@@ -216,31 +215,26 @@ class ExportOdsTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $flags = [];
-        $flags[] = new FieldMetadata(-1, 0, (object) []);
-
-        $a = new stdClass();
-        $a->charsetnr = 63;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_TINY_BLOB, MYSQLI_BLOB_FLAG, $a);
-
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_DATE, 0, (object) []);
-
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_TIME, 0, (object) []);
-
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_DATETIME, 0, (object) []);
-
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_DECIMAL, 0, (object) []);
-
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_DECIMAL, 0, (object) []);
-
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) []);
-
+        $fields = [
+            FieldHelper::fromArray(['type' => -1]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_TINY_BLOB,
+                'flags' => MYSQLI_BLOB_FLAG,
+                'charsetnr' => 63,
+            ]),
+            FieldHelper::fromArray(['type' => MYSQLI_TYPE_DATE]),
+            FieldHelper::fromArray(['type' => MYSQLI_TYPE_TIME]),
+            FieldHelper::fromArray(['type' => MYSQLI_TYPE_DATETIME]),
+            FieldHelper::fromArray(['type' => MYSQLI_TYPE_DECIMAL]),
+            FieldHelper::fromArray(['type' => MYSQLI_TYPE_DECIMAL]),
+            FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING]),
+        ];
         $resultStub = $this->createMock(DummyResult::class);
 
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
             ->with($resultStub)
-            ->will($this->returnValue($flags));
+            ->will($this->returnValue($fields));
 
         $dbi->expects($this->once())
             ->method('query')
@@ -300,22 +294,25 @@ class ExportOdsTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $flags = [];
-        $a = new stdClass();
-        $a->name = 'fna\"me';
-        $a->length = 20;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $a);
-        $b = new stdClass();
-        $b->name = 'fnam/<e2';
-        $b->length = 20;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $b);
+        $fields = [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
+                'name' => 'fna\"me',
+                'length' => 20,
+            ]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
+                'name' => 'fnam/<e2',
+                'length' => 20,
+            ]),
+        ];
 
         $resultStub = $this->createMock(DummyResult::class);
 
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
             ->with($resultStub)
-            ->will($this->returnValue($flags));
+            ->will($this->returnValue($fields));
 
         $dbi->expects($this->once())
             ->method('query')

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -9,7 +9,6 @@ use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Export;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\Export\ExportOdt;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -18,12 +17,12 @@ use PhpMyAdmin\Properties\Options\Items\RadioPropertyItem;
 use PhpMyAdmin\Properties\Options\Items\TextPropertyItem;
 use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use ReflectionClass;
 use ReflectionMethod;
-use stdClass;
 
 use function __;
 use function bin2hex;
@@ -353,24 +352,22 @@ class ExportOdtTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $flags = [];
-        $a = new stdClass();
-        $flags[] = new FieldMetadata(-1, 0, $a);
-
-        $a = new stdClass();
-        $a->charsetnr = 63;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_BLOB, MYSQLI_BLOB_FLAG, $a);
-
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_DECIMAL, MYSQLI_NUM_FLAG, (object) []);
-
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) []);
-
+        $fields = [
+            FieldHelper::fromArray(['type' => -1]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_BLOB,
+                'flags' => MYSQLI_BLOB_FLAG,
+                'charsetnr' => 63,
+            ]),
+            FieldHelper::fromArray(['type' => MYSQLI_TYPE_DECIMAL, 'flags' => MYSQLI_NUM_FLAG]),
+            FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING]),
+        ];
         $resultStub = $this->createMock(DummyResult::class);
 
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
             ->with($resultStub)
-            ->will($this->returnValue($flags));
+            ->will($this->returnValue($fields));
 
         $dbi->expects($this->once())
             ->method('query')
@@ -424,22 +421,25 @@ class ExportOdtTest extends AbstractTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $flags = [];
-        $a = new stdClass();
-        $a->name = 'fna\"me';
-        $a->length = 20;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $a);
-        $b = new stdClass();
-        $b->name = 'fnam/<e2';
-        $b->length = 20;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $b);
+        $fields = [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
+                'name' => 'fna\"me',
+                'length' => 20,
+            ]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
+                'name' => 'fnam/<e2',
+                'length' => 20,
+            ]),
+        ];
 
         $resultStub = $this->createMock(DummyResult::class);
 
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
             ->with($resultStub)
-            ->will($this->returnValue($flags));
+            ->will($this->returnValue($fields));
 
         $dbi->expects($this->once())
             ->method('query')

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -9,7 +9,6 @@ use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Export;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Plugins\Export\ExportSql;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyMainGroup;
 use PhpMyAdmin\Properties\Options\Groups\OptionsPropertyRootGroup;
@@ -23,11 +22,11 @@ use PhpMyAdmin\Properties\Options\OptionsPropertyGroup;
 use PhpMyAdmin\Properties\Plugins\ExportPluginProperties;
 use PhpMyAdmin\Table;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use ReflectionClass;
 use ReflectionMethod;
-use stdClass;
 
 use function ob_get_clean;
 use function ob_start;
@@ -1049,41 +1048,44 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $flags = [];
-        $a = new stdClass();
-        $a->name = 'name';
-        $a->length = 2;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_LONG, 0, $a);
-
-        $a = new stdClass();
-        $a->name = 'name';
-        $a->length = 2;
-        $flags[] = new FieldMetadata(-1, MYSQLI_NUM_FLAG, $a);
-
-        $a = new stdClass();
-        $a->name = 'name';
-        $a->length = 2;
-        $a->charsetnr = 63;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $a);
-
-        $a = new stdClass();
-        $a->name = 'name';
-        $a->length = 2;
-        $a->charsetnr = 63;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, $a);
-
-        $a = new stdClass();
-        $a->name = 'name';
-        $a->length = 2;
-        $a->charsetnr = 63;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_BLOB, 0, $a);
+        $fields = [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_LONG,
+                'name' => 'name',
+                'length' => 2,
+            ]),
+            FieldHelper::fromArray([
+                'type' => -1,
+                'flags' => MYSQLI_NUM_FLAG,
+                'name' => 'name',
+                'length' => 2,
+            ]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
+                'name' => 'name',
+                'length' => 2,
+                'charsetnr' => 63,
+            ]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
+                'name' => 'name',
+                'length' => 2,
+                'charsetnr' => 63,
+            ]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_BLOB,
+                'name' => 'name',
+                'length' => 2,
+                'charsetnr' => 63,
+            ]),
+        ];
 
         $resultStub = $this->createMock(DummyResult::class);
 
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
             ->with($resultStub)
-            ->will($this->returnValue($flags));
+            ->will($this->returnValue($fields));
 
         $dbi->expects($this->once())
             ->method('tryQuery')
@@ -1162,29 +1164,33 @@ SQL;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $flags = [];
-        $a = new stdClass();
-        $a->name = 'name';
-        $a->orgname = 'pma';
-        $a->table = 'tbl';
-        $a->orgtable = 'tbl';
-        $a->length = 2;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_FLOAT, MYSQLI_PRI_KEY_FLAG, $a);
-
-        $a = new stdClass();
-        $a->name = 'name';
-        $a->orgname = 'pma';
-        $a->table = 'tbl';
-        $a->orgtable = 'tbl';
-        $a->length = 2;
-        $flags[] = new FieldMetadata(MYSQLI_TYPE_FLOAT, MYSQLI_UNIQUE_KEY_FLAG, $a);
+        $fields = [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_FLOAT,
+                'flags' => MYSQLI_PRI_KEY_FLAG,
+                'name' => 'name',
+                'orgname' => 'pma',
+                'table' => 'tbl',
+                'orgtable' => 'tbl',
+                'length' => 2,
+            ]),
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_FLOAT,
+                'flags' => MYSQLI_UNIQUE_KEY_FLAG,
+                'name' => 'name',
+                'orgname' => 'pma',
+                'table' => 'tbl',
+                'orgtable' => 'tbl',
+                'length' => 2,
+            ]),
+        ];
 
         $resultStub = $this->createMock(DummyResult::class);
 
         $dbi->expects($this->once())
             ->method('getFieldsMeta')
             ->with($resultStub)
-            ->will($this->returnValue($flags));
+            ->will($this->returnValue($fields));
 
         $dbi->expects($this->once())
             ->method('tryQuery')

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -25,6 +25,7 @@ use PhpMyAdmin\Plugins\Transformations\Text_Plain_PreApPend;
 use PhpMyAdmin\Plugins\Transformations\Text_Plain_Substring;
 use PhpMyAdmin\Plugins\TransformationsPlugin;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\FieldHelper;
 use ReflectionMethod;
 
 use function date_default_timezone_set;
@@ -442,27 +443,27 @@ class TransformationPluginsTest extends AbstractTestCase
             ],
             [
                 new Text_Plain_Dateformat(),
-                ['12345', [0], new FieldMetadata(MYSQLI_TYPE_TINY, 0, (object) [])],
+                ['12345', [0], FieldHelper::fromArray(['type' => MYSQLI_TYPE_TINY])],
                 '<dfn onclick="alert(&quot;12345&quot;);" title="12345">Jan 01, 1970 at 03:25 AM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
-                ['12345678', [0], new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [])],
+                ['12345678', [0], FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING])],
                 '<dfn onclick="alert(&quot;12345678&quot;);" title="12345678">May 23, 1970 at 09:21 PM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
-                ['123456789', [0], new FieldMetadata(-1, 0, (object) [])],
+                ['123456789', [0], FieldHelper::fromArray(['type' => -1])],
                 '<dfn onclick="alert(&quot;123456789&quot;);" title="123456789">Nov 29, 1973 at 09:33 PM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
-                ['20100201', [0], new FieldMetadata(-1, 0, (object) [])],
+                ['20100201', [0], FieldHelper::fromArray(['type' => -1])],
                 '<dfn onclick="alert(&quot;20100201&quot;);" title="20100201">Feb 01, 2010 at 12:00 AM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
-                ['1617153941', ['0', '%B %d, %Y at %I:%M %p', 'local'], new FieldMetadata(-1, 0, (object) [])],
+                ['1617153941', ['0', '%B %d, %Y at %I:%M %p', 'local'], FieldHelper::fromArray(['type' => -1])],
                 '<dfn onclick="alert(&quot;1617153941&quot;);" title="1617153941">Mar 31, 2021 at 01:25 AM</dfn>',
             ],
             [
@@ -474,7 +475,7 @@ class TransformationPluginsTest extends AbstractTestCase
                         '',// Empty uses the "Y-m-d  H:i:s" format
                         'utc',
                     ],
-                    new FieldMetadata(-1, 0, (object) []),
+                    FieldHelper::fromArray(['type' => -1]),
                 ],
                 '<dfn onclick="alert(&quot;1617153941&quot;);" title="1617153941">2021-03-31  01:25:41</dfn>',
             ],
@@ -487,13 +488,13 @@ class TransformationPluginsTest extends AbstractTestCase
                         '',// Empty uses the "%B %d, %Y at %I:%M %p" format
                         'local',
                     ],
-                    new FieldMetadata(-1, 0, (object) []),
+                    FieldHelper::fromArray(['type' => -1]),
                 ],
                 '<dfn onclick="alert(&quot;1617153941&quot;);" title="1617153941">Mar 31, 2021 at 01:25 AM</dfn>',
             ],
             [
                 new Text_Plain_Dateformat(),
-                ['1617153941', ['0', 'H:i:s Y-d-m', 'utc'], new FieldMetadata(-1, 0, (object) [])],
+                ['1617153941', ['0', 'H:i:s Y-d-m', 'utc'], FieldHelper::fromArray(['type' => -1])],
                 '<dfn onclick="alert(&quot;1617153941&quot;);" title="1617153941">01:25:41 2021-31-03</dfn>',
             ],
             [

--- a/test/classes/SqlTest.php
+++ b/test/classes/SqlTest.php
@@ -7,7 +7,6 @@ namespace PhpMyAdmin\Tests;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationCleanup;
 use PhpMyAdmin\DatabaseInterface;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Operations;
 use PhpMyAdmin\ParseAnalyze;
 use PhpMyAdmin\Sql;
@@ -454,9 +453,9 @@ class SqlTest extends AbstractTestCase
             ],
             ['country_id', 'country', 'last_update'],
             [
-                new FieldMetadata(MYSQLI_TYPE_SHORT, 0, (object) ['length' => 5]),
-                new FieldMetadata(MYSQLI_TYPE_VAR_STRING, 0, (object) ['length' => 200]),
-                new FieldMetadata(MYSQLI_TYPE_TIMESTAMP, 0, (object) ['length' => 19]),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_SHORT, 'length' => 5]),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_VAR_STRING, 'length' => 200]),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_TIMESTAMP, 'length' => 19]),
             ],
         );
         $this->dummyDbi->addResult(

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -18,6 +18,7 @@ use PhpMyAdmin\Dbal\DbiExtension;
 use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\Dbal\Statement;
 use PhpMyAdmin\FieldMetadata;
+use PhpMyAdmin\Tests\FieldHelper;
 use PHPUnit\Framework\Assert;
 use stdClass;
 
@@ -408,7 +409,7 @@ class DbiDummy implements DbiExtension
                 if (isset($metadata[$i])) {
                     $metadata[$i]->name = $column;
                 } else {
-                    $metadata[$i] = new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) ['name' => $column]);
+                    $metadata[$i] = FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'name' => $column]);
                 }
             }
         }
@@ -1821,10 +1822,10 @@ class DbiDummy implements DbiExtension
                 'query' => 'SELECT * FROM `test_db`.`test_table_yaml`;',
                 'columns' => ['id', 'name', 'datetimefield', 'textfield'],
                 'metadata' => [
-                    new FieldMetadata(MYSQLI_TYPE_DECIMAL, 0, (object) []),
-                    new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) []),
-                    new FieldMetadata(MYSQLI_TYPE_DATETIME, 0, (object) []),
-                    new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) []),
+                    FieldHelper::fromArray(['type' => MYSQLI_TYPE_DECIMAL]),
+                    FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING]),
+                    FieldHelper::fromArray(['type' => MYSQLI_TYPE_DATETIME]),
+                    FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING]),
                 ],
                 'result' => [
                     ['1', 'abcd', '2011-01-20 02:00:02', null],
@@ -1852,10 +1853,10 @@ class DbiDummy implements DbiExtension
                     ['', '0x1', 'шеллы', '0x2'],
                 ],
                 'metadata' => [
-                    new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) ['charsetnr' => 33]),
-                    new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) ['charsetnr' => 63]),
-                    new FieldMetadata(MYSQLI_TYPE_BLOB, 0, (object) ['charsetnr' => 23]),
-                    new FieldMetadata(MYSQLI_TYPE_BLOB, 0, (object) ['charsetnr' => 63]),
+                    FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'charsetnr' => 33]),
+                    FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'charsetnr' => 63]),
+                    FieldHelper::fromArray(['type' => MYSQLI_TYPE_BLOB, 'charsetnr' => 23]),
+                    FieldHelper::fromArray(['type' => MYSQLI_TYPE_BLOB, 'charsetnr' => 63]),
                 ],
             ],
             [

--- a/test/classes/Stubs/DummyResult.php
+++ b/test/classes/Stubs/DummyResult.php
@@ -10,10 +10,14 @@ namespace PhpMyAdmin\Tests\Stubs;
 use Generator;
 use PhpMyAdmin\Dbal\ResultInterface;
 use PhpMyAdmin\FieldMetadata;
+use PhpMyAdmin\Tests\FieldHelper;
 
 use function array_column;
 use function array_key_exists;
+use function count;
 use function is_string;
+
+use const MYSQLI_TYPE_STRING;
 
 /**
  * Extension independent database result
@@ -22,29 +26,50 @@ class DummyResult implements ResultInterface
 {
     /**
      * The result identifier produced by the DBiExtension
+     *
+     * @var mixed[][]|null
+     * @psalm-var list<non-empty-list<string|null>>
      */
-    private int|false $result;
+    private array|null $result;
 
     /**
-     * Link to DbiDummy instance
+     * @var string[]
+     * @psalm-var list<non-empty-string>
      */
-    private DbiDummy $link;
+    private array $columns;
 
-    public function __construct(DbiDummy $link, int|false $result)
+    /**
+     * @var FieldMetadata[]
+     * @psalm-var list<FieldMetadata>
+     */
+    private array $metadata;
+
+    private int $pos = 0;
+
+    /**
+     * @psalm-param array{
+     *     query: string,
+     *     result: list<non-empty-list<string|null>>|true,
+     *     columns?: list<non-empty-string>,
+     *     metadata?: list<FieldMetadata>,
+     * } $query
+     */
+    public function __construct(array $query)
     {
-        $this->link = $link;
-        $this->result = $result;
+        $this->columns = $query['columns'] ?? [];
+        $this->metadata = $query['metadata'] ?? [];
+        $this->result = $query['result'] === true ? null : $query['result'];
     }
 
     /**
      * Returns a generator that traverses through the whole result set
      * and returns each row as an associative array
      *
-     * @psalm-return Generator<int, array<string, string|null>, mixed, void>
+     * @psalm-return Generator<int, array<array-key, string|null>, mixed, void>
      */
     public function getIterator(): Generator
     {
-        if ($this->result === false) {
+        if (! $this->result) {
             return;
         }
 
@@ -57,29 +82,40 @@ class DummyResult implements ResultInterface
     /**
      * Returns the next row of the result with associative keys
      *
-     * @return array<string,string|null>
+     * @return array<string|null>
      */
     public function fetchAssoc(): array
     {
-        if ($this->result === false) {
+        if (! $this->result) {
             return [];
         }
 
-        return $this->link->fetchAssoc($this->result) ?? [];
+        $row = $this->result[$this->pos++] ?? [];
+        if (! $this->columns) {
+            return $row;
+        }
+
+        $ret = [];
+        foreach ($row as $key => $val) {
+            $ret[$this->columns[$key]] = $val;
+        }
+
+        return $ret;
     }
 
     /**
      * Returns the next row of the result with numeric keys
      *
      * @return array<int,string|null>
+     * @psalm-return list<string|null>
      */
     public function fetchRow(): array
     {
-        if ($this->result === false) {
+        if (! $this->result || $this->pos >= count($this->result)) {
             return [];
         }
 
-        return $this->link->fetchRow($this->result) ?? [];
+        return $this->result[$this->pos++];
     }
 
     /**
@@ -97,22 +133,18 @@ class DummyResult implements ResultInterface
             return false;
         }
 
-        /**
-         * PMA uses mostly textual mysqli protocol. In comparison to prepared statements (binary protocol),
-         * it returns all data types as strings. PMA is not ready to enable automatic cast to int/float, so
-         * in our dummy class we will force string cast on all values.
-         */
-        return $row[$field] === null ? null : (string) $row[$field];
+        return $row[$field] ?? null;
     }
 
     /**
      * Returns all rows of the result
      *
-     * @return array<int, array<string,string|null>>
+     * @return array<array<string|null>>
+     * @psalm-return list<array<string|null>>
      */
     public function fetchAllAssoc(): array
     {
-        if ($this->result === false) {
+        if (! $this->result) {
             return [];
         }
 
@@ -131,22 +163,18 @@ class DummyResult implements ResultInterface
      * Returns values from the first column of each row
      *
      * @return array<int, string|null>
+     * @psalm-return list<string|null>
      */
     public function fetchAllColumn(): array
     {
-        if ($this->result === false) {
+        if (! $this->result) {
             return [];
         }
 
         // This function should return all rows, not only the remaining rows
         $this->seek(0);
 
-        $rows = [];
-        while ($row = $this->fetchRow()) {
-            $rows[] = $row[0];
-        }
-
-        return $rows;
+        return array_column($this->result, 0);
     }
 
     /**
@@ -155,23 +183,19 @@ class DummyResult implements ResultInterface
      * SELECT id, name FROM users
      * produces: ['123' => 'John', '124' => 'Jane']
      *
-     * @return array<string, string|null>
+     * @return array<string|null>
+     * @psalm-return array<array-key, string|null>
      */
     public function fetchAllKeyPair(): array
     {
-        if ($this->result === false) {
+        if (! $this->result) {
             return [];
         }
 
         // This function should return all rows, not only the remaining rows
         $this->seek(0);
 
-        $rows = [];
-        while ($row = $this->fetchRow()) {
-            $rows[$row[0] ?? ''] = $row[1];
-        }
-
-        return $rows;
+        return array_column($this->result, 1, 0);
     }
 
     /**
@@ -179,21 +203,25 @@ class DummyResult implements ResultInterface
      */
     public function numFields(): int
     {
-        if ($this->result === false) {
+        if (! $this->result) {
             return 0;
         }
 
-        return $this->link->numFields($this->result);
+        return count($this->columns);
     }
 
     /**
      * Returns the number of rows in the result
      *
-     * @psalm-return int|numeric-string
+     * @psalm-return int
      */
-    public function numRows(): string|int
+    public function numRows(): int
     {
-        return $this->link->numRows($this->result);
+        if (! $this->result) {
+            return 0;
+        }
+
+        return count($this->result);
     }
 
     /**
@@ -205,38 +233,47 @@ class DummyResult implements ResultInterface
      */
     public function seek(int $offset): bool
     {
-        if ($this->result === false) {
+        if (! $this->result) {
             return false;
         }
 
-        return $this->link->dataSeek($this->result, $offset);
+        $this->pos = $offset;
+
+        return $offset < count($this->result);
     }
 
     /**
      * returns meta info for fields in $result
      *
      * @return array<int, FieldMetadata> meta info for fields in $result
+     * @psalm-return list<FieldMetadata>
      */
     public function getFieldsMeta(): array
     {
-        if ($this->result === false) {
-            return [];
+        $metadata = $this->metadata;
+        foreach ($this->columns as $i => $column) {
+            if (isset($metadata[$i])) {
+                $metadata[$i]->name = $column;
+            } else {
+                $metadata[] = FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'name' => $column]);
+            }
         }
 
-        return $this->link->getFieldsMeta($this->result);
+        return $metadata;
     }
 
     /**
      * Returns the names of the fields in the result
      *
      * @return array<int, string> Fields names
+     * @psalm-return list<non-empty-string>
      */
     public function getFieldNames(): array
     {
-        if ($this->result === false) {
+        if (! $this->result) {
             return [];
         }
 
-        return array_column($this->link->getFieldsMeta($this->result), 'name');
+        return array_column($this->getFieldsMeta(), 'name');
     }
 }

--- a/test/classes/SystemDatabaseTest.php
+++ b/test/classes/SystemDatabaseTest.php
@@ -126,7 +126,7 @@ class SystemDatabaseTest extends AbstractTestCase
 
         $dummyDbi->addResult(
             'PMA_sql_query',
-            [true],
+            true,
             [],
             [
                 FieldHelper::fromArray([

--- a/test/classes/SystemDatabaseTest.php
+++ b/test/classes/SystemDatabaseTest.php
@@ -12,6 +12,8 @@ use PhpMyAdmin\SystemDatabase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use ReflectionClass;
 
+use const MYSQLI_TYPE_STRING;
+
 /** @covers \PhpMyAdmin\SystemDatabase */
 class SystemDatabaseTest extends AbstractTestCase
 {
@@ -127,8 +129,16 @@ class SystemDatabaseTest extends AbstractTestCase
             [true],
             [],
             [
-                (object) ['table' => 'meta1_table', 'name' => 'meta1_name'],
-                (object) ['table' => 'meta2_table', 'name' => 'meta2_name'],
+                FieldHelper::fromArray([
+                    'type' => MYSQLI_TYPE_STRING,
+                    'table' => 'meta1_table',
+                    'name' => 'meta1_name',
+                ]),
+                FieldHelper::fromArray([
+                    'type' => MYSQLI_TYPE_STRING,
+                    'table' => 'meta2_table',
+                    'name' => 'meta2_name',
+                ]),
             ],
         );
 

--- a/test/classes/Table/ColumnsDefinitionTest.php
+++ b/test/classes/Table/ColumnsDefinitionTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Table;
 
 use PhpMyAdmin\ConfigStorage\Relation;
-use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Table\ColumnsDefinition;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use PhpMyAdmin\Tests\FieldHelper;
 use PhpMyAdmin\Transformations;
 
 use function array_merge;
@@ -102,10 +102,10 @@ SQL;
             'fields_meta' => [$columnMeta],
             'is_backup' => true,
             'move_columns' => [
-                new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) ['name' => 'actor_id']),
-                new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) ['name' => 'first_name']),
-                new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) ['name' => 'last_name']),
-                new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) ['name' => 'last_update']),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'name' => 'actor_id']),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'name' => 'first_name']),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'name' => 'last_name']),
+                FieldHelper::fromArray(['type' => MYSQLI_TYPE_STRING, 'name' => 'last_update']),
             ],
             'available_mime' => [],
             'mime_map' => [],

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -80,73 +80,81 @@ class UtilTest extends AbstractTestCase
         $GLOBALS['dbi'] = $this->createDatabaseInterface();
 
         $meta = [
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field1',
                 'table' => 'table',
                 'orgtable' => 'table',
             ]),
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field2',
                 'table' => 'table',
                 'orgtable' => 'table',
             ]),
-            new FieldMetadata(MYSQLI_TYPE_SHORT, MYSQLI_NUM_FLAG, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_SHORT,
+                'flags' => MYSQLI_NUM_FLAG,
                 'name' => 'field3',
                 'table' => 'table',
                 'orgtable' => 'table',
             ]),
-            new FieldMetadata(MYSQLI_TYPE_LONG, MYSQLI_NUM_FLAG, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_LONG,
+                'flags' => MYSQLI_NUM_FLAG,
                 'name' => 'field4',
                 'table' => 'table',
                 'orgtable' => 'table',
             ]),
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field5',
                 'table' => 'table',
                 'orgtable' => 'table',
                 'charsetnr' => 63, // binary
             ]),
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field6',
                 'table' => 'table',
                 'orgtable' => 'table',
                 'charsetnr' => 63, // binary
             ]),
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field7',
                 'table' => 'table',
                 'orgtable' => 'table',
-                'numeric' => false,
-                'type' => 'blob',
                 'charsetnr' => 32, // armscii8_general_ci
             ]),
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field8',
                 'table' => 'table',
                 'orgtable' => 'table',
-                'numeric' => false,
-                'type' => 'blob',
                 'charsetnr' => 48, // latin1_general_ci
             ]),
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field9',
                 'table' => 'table',
                 'orgtable' => 'table',
-                'numeric' => false,
-                'type' => 'blob',
                 'charsetnr' => 63, // binary
             ]),
-            new FieldMetadata(MYSQLI_TYPE_GEOMETRY, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_GEOMETRY,
                 'name' => 'field10',
                 'table' => 'table',
                 'orgtable' => 'table',
             ]),
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field11',
                 'table' => 'table2',
                 'orgtable' => 'table2',
             ]),
-            new FieldMetadata(MYSQLI_TYPE_BIT, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_BIT,
                 'name' => 'field12',
                 'table' => 'table',
                 'orgtable' => 'table',
@@ -197,7 +205,8 @@ class UtilTest extends AbstractTestCase
     public function testGetUniqueConditionWithSingleBigBinaryField(): void
     {
         $meta = [
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field',
                 'table' => 'table',
                 'orgtable' => 'table',
@@ -217,12 +226,15 @@ class UtilTest extends AbstractTestCase
         $GLOBALS['dbi'] = $this->createDatabaseInterface();
 
         $meta = [
-            new FieldMetadata(MYSQLI_TYPE_LONG, MYSQLI_PRI_KEY_FLAG | MYSQLI_NUM_FLAG, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_LONG,
+                'flags' => MYSQLI_PRI_KEY_FLAG | MYSQLI_NUM_FLAG,
                 'name' => 'id',
                 'table' => 'table',
                 'orgtable' => 'table',
             ]),
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field',
                 'table' => 'table',
                 'orgtable' => 'table',
@@ -238,12 +250,15 @@ class UtilTest extends AbstractTestCase
         $GLOBALS['dbi'] = $this->createDatabaseInterface();
 
         $meta = [
-            new FieldMetadata(MYSQLI_TYPE_STRING, MYSQLI_UNIQUE_KEY_FLAG, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
+                'flags' => MYSQLI_UNIQUE_KEY_FLAG,
                 'name' => 'id',
                 'table' => 'table',
                 'orgtable' => 'table',
             ]),
-            new FieldMetadata(MYSQLI_TYPE_STRING, 0, (object) [
+            FieldHelper::fromArray([
+                'type' => MYSQLI_TYPE_STRING,
                 'name' => 'field',
                 'table' => 'table',
                 'orgtable' => 'table',
@@ -286,7 +301,9 @@ class UtilTest extends AbstractTestCase
         return [
             'field type is integer, value is number - not escape string' => [
                 [
-                    new FieldMetadata(FIELD_TYPE_INTEGER, MYSQLI_NUM_FLAG, (object) [
+                    FieldHelper::fromArray([
+                        'type' => FIELD_TYPE_INTEGER,
+                        'flags' => MYSQLI_NUM_FLAG,
                         'name' => 'col',
                         'table' => 'table',
                         'orgtable' => 'table',
@@ -297,7 +314,9 @@ class UtilTest extends AbstractTestCase
             ],
             'field type is unknown, value is string - escape string' => [
                 [
-                    new FieldMetadata(FIELD_TYPE_UNKNOWN, MYSQLI_NUM_FLAG, (object) [
+                    FieldHelper::fromArray([
+                        'type' => FIELD_TYPE_UNKNOWN,
+                        'flags' => MYSQLI_NUM_FLAG,
                         'name' => 'col',
                         'table' => 'table',
                         'orgtable' => 'table',
@@ -308,7 +327,9 @@ class UtilTest extends AbstractTestCase
             ],
             'field type is varchar, value is string - escape string' => [
                 [
-                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                    FieldHelper::fromArray([
+                        'type' => FIELD_TYPE_VARCHAR,
+                        'flags' => MYSQLI_NUM_FLAG,
                         'name' => 'col',
                         'table' => 'table',
                         'orgtable' => 'table',
@@ -319,7 +340,9 @@ class UtilTest extends AbstractTestCase
             ],
             'field type is varchar, value is string with double quote - escape string' => [
                 [
-                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                    FieldHelper::fromArray([
+                        'type' => FIELD_TYPE_VARCHAR,
+                        'flags' => MYSQLI_NUM_FLAG,
                         'name' => 'col',
                         'table' => 'table',
                         'orgtable' => 'table',
@@ -330,7 +353,9 @@ class UtilTest extends AbstractTestCase
             ],
             'field type is varchar, value is string with single quote - escape string' => [
                 [
-                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                    FieldHelper::fromArray([
+                        'type' => FIELD_TYPE_VARCHAR,
+                        'flags' => MYSQLI_NUM_FLAG,
                         'name' => 'col',
                         'table' => 'table',
                         'orgtable' => 'table',
@@ -341,12 +366,16 @@ class UtilTest extends AbstractTestCase
             ],
             'group by multiple columns and field type is mixed' => [
                 [
-                    new FieldMetadata(FIELD_TYPE_VARCHAR, MYSQLI_NUM_FLAG, (object) [
+                    FieldHelper::fromArray([
+                        'type' => FIELD_TYPE_VARCHAR,
+                        'flags' => MYSQLI_NUM_FLAG,
                         'name' => 'col',
                         'table' => 'table',
                         'orgtable' => 'table',
                     ]),
-                    new FieldMetadata(FIELD_TYPE_INTEGER, MYSQLI_NUM_FLAG, (object) [
+                    FieldHelper::fromArray([
+                        'type' => FIELD_TYPE_INTEGER,
+                        'flags' => MYSQLI_NUM_FLAG,
                         'name' => 'status_id',
                         'table' => 'table',
                         'orgtable' => 'table',


### PR DESCRIPTION
- addResult was called with `[true]` or `[[]]` in some tests, should be just `true`
- fetch_assoc may return array with int key when the column name is an int
- the result handling is now done in DummyResult, it gets constructed with column, result and fieldlmetadata
- instead of marking results as used they are now deleted
- when a Dummy result is created, the result values are now always converted to `string|null`, it's fine to use int/float when calling addResult in tests, this was previouly done only in `fetchValue`
- addResult now expects the row values always as a list, if fetchAssoc is called a separate column config is require. it was used like this most times, but not always

And it fixes a bug in ChartController when a column has an integer name by casting the name to string.
Found due to the now wider return type of fetchAssoc `array<string|null>` instead of `array<string, string|null>`