### PR TITLE
Psalm ignore config.inc.iphp

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -23,6 +23,9 @@
             <directory name="vendor"/>
             <directory name="libraries/cache"/>
         </ignoreFiles>
+        <ignoreFiles allowMissingFiles="true">
+            <file name="config.inc.php"/>
+        </ignoreFiles>
     </projectFiles>
 
     <stubs>


### PR DESCRIPTION
This is more of a personal request as I want to avoid accidentally adding the baselines for my config file to commits. Unless there is an easier way to avoid it. 