### PR TITLE
 Fixes #17951 - Allow rollbacking SET queries

### DIFF
--- a/src/Import/Import.php
+++ b/src/Import/Import.php
@@ -16,6 +16,7 @@ use PhpMyAdmin\SqlParser\Parser;
 use PhpMyAdmin\SqlParser\Statements\DeleteStatement;
 use PhpMyAdmin\SqlParser\Statements\InsertStatement;
 use PhpMyAdmin\SqlParser\Statements\ReplaceStatement;
+use PhpMyAdmin\SqlParser\Statements\SetStatement;
 use PhpMyAdmin\SqlParser\Statements\UpdateStatement;
 use PhpMyAdmin\SqlParser\Utils\Query;
 use PhpMyAdmin\Table;
@@ -1307,7 +1308,7 @@ class Import
         $queries = explode($sqlDelimiter, $sqlQuery);
         $error = false;
         $errorMsg = __(
-            'Only INSERT, UPDATE, DELETE and REPLACE '
+            'Only INSERT, UPDATE, DELETE, REPLACE and SET (without options like GLOBAL) '
             . 'SQL queries containing transactional engine tables can be rolled back.',
         );
         $dbi = DatabaseInterface::getInstance();
@@ -1363,7 +1364,11 @@ class Import
             ! (($statement instanceof InsertStatement)
             || ($statement instanceof UpdateStatement)
             || ($statement instanceof DeleteStatement)
-            || ($statement instanceof ReplaceStatement))
+            || ($statement instanceof ReplaceStatement)
+            || (
+                ($statement instanceof SetStatement)
+                && $statement->options->isEmpty()
+            ))
         ) {
             return false;
         }


### PR DESCRIPTION
### Description

Allow rollbacking composite queries with SET for creating local variables

See https://github.com/phpmyadmin/phpmyadmin/issues/17951 for more info

Fixes #17951

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
