### PR TITLE
Remove space and align right

### DIFF
--- a/templates/database/structure/overhead.twig
+++ b/templates/database/structure/overhead.twig
@@ -1,4 +1,3 @@
 <a href="{{ url('/table/structure', table_url_params) }}#showusage" id="overhead">
-  <span>{{ formatted_overhead }}</span>&nbsp;
-  <span class="unit">{{ overhead_unit }}</span>
+  <span>{{ formatted_overhead }}</span>&nbsp;<span class="unit">{{ overhead_unit }}</span>
 </a>

--- a/themes/pmahomme/scss/_tables.scss
+++ b/themes/pmahomme/scss/_tables.scss
@@ -9,7 +9,6 @@
 
   th {
     color: $th-color;
-    text-align: left;
   }
 
   td {


### PR DESCRIPTION
### Description

This PR fixes two issues. One with a double space and another one with alignment.

Before:
![doublespace_before](https://user-images.githubusercontent.com/25424343/233495230-ccb19ab9-9b84-4e4d-b139-3c0f5267ad2e.png)

After:
![doublespace_after](https://user-images.githubusercontent.com/25424343/233495259-fe11465e-c628-4f0d-9064-371ac61f0e06.png)

Before:
![whitespace1_before](https://user-images.githubusercontent.com/25424343/233495080-92f832ce-5f35-4d82-b450-28964d82b405.png)

After:
![whitespace1_after](https://user-images.githubusercontent.com/25424343/233495053-603374d3-4e15-4d7e-810f-f3acddd6ed5c.png)

