### PR TITLE
Fix colspan number

### DIFF
--- a/templates/database/structure/structure_table_row.twig
+++ b/templates/database/structure/structure_table_row.twig
@@ -209,16 +209,30 @@
     {% else %}
 
         {% if db_is_system_schema %}
-            {% set action_colspan = 3 %}
+            {% set action_colspan = 2 %}
         {% else %}
-            {% set action_colspan = 6 %}
+            {% set action_colspan = 4 %}
         {% endif %}
         {% if num_favorite_tables > 0 %}
             {% set action_colspan = action_colspan + 1 %}
         {% endif %}
+        {% if show_charset %}
+            {% set action_colspan = action_colspan + 1 %}
+        {% endif %}
+        {% if show_comment %}
+            {% set action_colspan = action_colspan + 1 %}
+        {% endif %}
+        {% if show_creation %}
+            {% set action_colspan = action_colspan + 1 %}
+        {% endif %}
+        {% if show_last_update %}
+            {% set action_colspan = action_colspan + 1 %}
+        {% endif %}
+        {% if show_last_check %}
+            {% set action_colspan = action_colspan + 1 %}
+        {% endif %}
 
-        {% set colspan_for_structure = action_colspan + 3 %}
-        <td colspan="{{ colspan_for_structure - db_is_system_schema ? 6 : 9 }}"
+        <td colspan="{{ action_colspan }}"
             class="text-center">
             {% trans 'in use' %}
         </td>


### PR DESCRIPTION
### Description

This PR fixes a issue with the colspan number, when a table is in use. Before this the value was either 6 or 9 (I couldn't see this value on any database, just 6).

With this PR, it will set the real value, based on the columns that are selected from Main panel > Database structure.

Before:

https://user-images.githubusercontent.com/25424343/233683795-d58a2016-a9c6-47ef-81a9-8f43ec9fda2d.mp4

https://user-images.githubusercontent.com/25424343/233684005-1a9b0d81-317e-456c-8975-64b09cb9352d.mp4

After:

https://user-images.githubusercontent.com/25424343/233684242-a62a62bf-1118-4129-82e2-cb52f16e5bdc.mp4

https://user-images.githubusercontent.com/25424343/233683936-fe28ba6a-56c4-4278-b67a-4a6e31ca542e.mp4