### PR TITLE
Change 'reCaptcha' text to 'Captcha'

### DIFF
--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -248,7 +248,7 @@ class AuthenticationCookie extends AuthenticationPlugin
             ) {
                 if (empty($_POST[$GLOBALS['cfg']['CaptchaResponseParam']])) {
                     $GLOBALS['conn_error'] = __(
-                        'Missing reCAPTCHA verification, maybe it has been blocked by adblock?',
+                        'Missing Captcha verification, maybe it has been blocked by adblock?',
                     );
 
                     return false;


### PR DESCRIPTION
### Description

PhpMyAdmin now supports multiple Captcha services, such as hCaptcha, Cloudflare Turnstile, and ReCaptcha. However, no matter the captcha provider, PhpMyAdmin will still display an error messages addressing 'reCaptcha' even though the captcha service enabled may not be reCaptcha.

This commit changes the text displayed on the login screen when an empty captcha is submitted from:
> Missing reCAPTCHA verification, maybe it has been blocked by adblock?

to 

> Missing Captcha verification, maybe it has been blocked by adblock?


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
