### PR TITLE
Remove `Config::checkServers()` method

### DIFF
--- a/libraries/classes/Common.php
+++ b/libraries/classes/Common.php
@@ -633,7 +633,6 @@ final class Common
 
     private static function setCurrentServerGlobal(ContainerInterface $container, Config $config): void
     {
-        $config->checkServers();
         $server = $config->selectServer();
         $GLOBALS['server'] = $server;
         $GLOBALS['urlParams']['server'] = $server;

--- a/libraries/classes/Config/Settings.php
+++ b/libraries/classes/Config/Settings.php
@@ -13,6 +13,7 @@ use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\Config\Settings\SqlQueryBox;
 use PhpMyAdmin\Config\Settings\Transformations;
 
+use function __;
 use function array_map;
 use function count;
 use function defined;
@@ -21,6 +22,7 @@ use function is_array;
 use function is_int;
 use function is_string;
 use function min;
+use function sprintf;
 use function strlen;
 
 use const DIRECTORY_SEPARATOR;
@@ -2929,19 +2931,28 @@ final class Settings
         }
 
         $servers = [];
-        /**
-         * @var int|string $key
-         * @var mixed $server
-         */
         foreach ($settings['Servers'] as $key => $server) {
             if (! is_int($key) || $key < 1 || ! is_array($server)) {
                 continue;
             }
 
             $servers[$key] = new Server($server);
+            if ($servers[$key]->host !== '' || $servers[$key]->verbose !== '') {
+                continue;
+            }
+
+            /**
+             * Ensures that the database server has a name.
+             *
+             * @link https://github.com/phpmyadmin/phpmyadmin/issues/6878
+             *
+             * @psalm-suppress ImpureFunctionCall
+             */
+            $server['verbose'] = sprintf(__('Server %d'), $key);
+            $servers[$key] = new Server($server);
         }
 
-        if (count($servers) === 0) {
+        if ($servers === []) {
             return [1 => new Server()];
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -162,7 +162,7 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 2
+			count: 1
 			path: libraries/classes/Config.php
 
 		-
@@ -213,11 +213,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$url of function parse_url expects string, mixed given\\.$#"
 			count: 2
-			path: libraries/classes/Config.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 1
 			path: libraries/classes/Config.php
 
 		-
@@ -9186,23 +9181,8 @@ parameters:
 			path: test/classes/Config/SettingsTest.php
 
 		-
-			message: "#^Cannot access offset 1 on mixed\\.$#"
-			count: 1
-			path: test/classes/ConfigTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$haystack of function mb_strstr expects string, array\\<string\\> given\\.$#"
 			count: 1
-			path: test/classes/ConfigTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
-			count: 3
-			path: test/classes/ConfigTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$array of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayNotHasKey\\(\\) expects array\\|ArrayAccess, mixed given\\.$#"
-			count: 7
 			path: test/classes/ConfigTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -261,7 +261,6 @@
       <code><![CDATA[$gdInfo['GD Version']]]></code>
       <code>$path</code>
       <code><![CDATA[$server['verbose']]]></code>
-      <code><![CDATA[$this->settings['Servers']]]></code>
       <code><![CDATA[$this->settings['ThemeDefault']]]></code>
       <code><![CDATA[$this->settings['ThemeDefault']]]></code>
       <code>$url</code>
@@ -14151,8 +14150,6 @@
       <code><![CDATA[$gdNfo['GD Version']]]></code>
     </MixedArgument>
     <MixedInferredReturnType>
-      <code>mixed[]</code>
-      <code>mixed[]</code>
       <code>mixed[]</code>
       <code>mixed[]</code>
       <code>mixed[]</code>

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -167,7 +167,6 @@ abstract class AbstractTestCase extends TestCase
     protected function setGlobalConfig(): void
     {
         $GLOBALS['config'] = $this->createConfig();
-        $GLOBALS['config']->checkServers();
         $GLOBALS['config']->set('environment', 'development');
         $GLOBALS['cfg'] = $GLOBALS['config']->settings;
     }

--- a/test/classes/Config/SettingsTest.php
+++ b/test/classes/Config/SettingsTest.php
@@ -1172,6 +1172,11 @@ class SettingsTest extends TestCase
         yield 'null value' => [null, [1 => $server]];
         yield 'valid value' => [[1 => [], 2 => []], [1 => $server, 2 => $server]];
         yield 'valid value 2' => [[2 => ['host' => 'test']], [2 => new Server(['host' => 'test'])]];
+        yield 'valid value 3' => [
+            [4 => ['host' => '', 'verbose' => '']],
+            [4 => new Server(['host' => '', 'verbose' => 'Server 4'])],
+        ];
+
         yield 'invalid value' => ['invalid', [1 => $server]];
         yield 'invalid value 2' => [[0 => [], 2 => 'invalid', 'invalid' => [], 4 => []], [4 => $server]];
         yield 'invalid value 3' => [[0 => []], [1 => $server]];


### PR DESCRIPTION
Removes the `Config::checkServers()` method as it's duplicated in `Config\Settings` class.

Also uses the `Settings` class to filter invalid config keys when loading a config file.
