### PR TITLE
Fix dummy query return value in tests

### DIFF
--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -231,10 +231,7 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_db_pma'],
         );
 
-        $dummyDbi->addResult(
-            'SELECT NULL FROM `pma__userconfig` LIMIT 0',
-            [['NULL']],
-        );
+        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', []);
         $dummyDbi->addSelectDb('db_pma');
 
         $_SESSION['relation'] = [];
@@ -301,10 +298,7 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_db_pma'],
         );
 
-        $dummyDbi->addResult(
-            'SELECT NULL FROM `pma__userconfig` LIMIT 0',
-            [['NULL']],
-        );
+        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', []);
         $dummyDbi->addSelectDb('db_pma');
         $dummyDbi->addSelectDb('db_pma');
 
@@ -318,7 +312,7 @@ class RelationTest extends AbstractTestCase
                 . ' `label` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\','
                 . ' `query` text NOT NULL, PRIMARY KEY (`id`) )'
                 . ' COMMENT=\'Bookmarks\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -331,7 +325,7 @@ class RelationTest extends AbstractTestCase
                 . ' PRIMARY KEY (`master_db`,`master_table`,`master_field`),'
                 . ' KEY `foreign_field` (`foreign_db`,`foreign_table`) ) COMMENT=\'Relation table\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -340,7 +334,7 @@ class RelationTest extends AbstractTestCase
                 . '`db_name` varchar(64) NOT NULL default \'\', `table_name` varchar(64) NOT NULL default \'\','
                 . ' `display_field` varchar(64) NOT NULL default \'\', PRIMARY KEY (`db_name`,`table_name`) )'
                 . ' COMMENT=\'Table information for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
 
         $dummyDbi->addResult(
@@ -353,7 +347,7 @@ class RelationTest extends AbstractTestCase
                 . ' PRIMARY KEY (`db_name`,`table_name`,`pdf_page_number`) )'
                 . ' COMMENT=\'Table coordinates for phpMyAdmin PDF output\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -363,7 +357,7 @@ class RelationTest extends AbstractTestCase
                 . ' `page_descr` varchar(50) COLLATE utf8_general_ci NOT NULL default \'\', PRIMARY KEY (`page_nr`),'
                 . ' KEY `db_name` (`db_name`) ) COMMENT=\'PDF relation pages for phpMyAdmin\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -379,7 +373,7 @@ class RelationTest extends AbstractTestCase
                 . ' `input_transformation_options` varchar(255) NOT NULL default \'\','
                 . ' PRIMARY KEY (`id`), UNIQUE KEY `db_name` (`db_name`,`table_name`,`column_name`) )'
                 . ' COMMENT=\'Column information for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -390,7 +384,7 @@ class RelationTest extends AbstractTestCase
                 . ' `timevalue` timestamp NOT NULL default CURRENT_TIMESTAMP, `sqlquery` text NOT NULL,'
                 . ' PRIMARY KEY (`id`), KEY `username` (`username`,`db`,`table`,`timevalue`) )'
                 . ' COMMENT=\'SQL history for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -398,7 +392,7 @@ class RelationTest extends AbstractTestCase
             . '-- CREATE TABLE IF NOT EXISTS `pma__recent` ( '
                 . '`username` varchar(64) NOT NULL, `tables` text NOT NULL, PRIMARY KEY (`username`) )'
                 . ' COMMENT=\'Recently accessed tables\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -406,7 +400,7 @@ class RelationTest extends AbstractTestCase
             . '-- CREATE TABLE IF NOT EXISTS `pma__favorite` ( '
                 . '`username` varchar(64) NOT NULL, `tables` text NOT NULL, PRIMARY KEY (`username`) )'
                 . ' COMMENT=\'Favorite tables\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -417,7 +411,7 @@ class RelationTest extends AbstractTestCase
                 . ' `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,'
                 . ' PRIMARY KEY (`username`,`db_name`,`table_name`) ) COMMENT=\'Tables\'\' UI preferences\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -436,7 +430,7 @@ class RelationTest extends AbstractTestCase
                 . ' default \'1\', PRIMARY KEY (`db_name`,`table_name`,`version`) )'
                 . ' COMMENT=\'Database changes tracking for phpMyAdmin\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -446,7 +440,7 @@ class RelationTest extends AbstractTestCase
                 . ' PRIMARY KEY (`username`,`usergroup`) )'
                 . ' COMMENT=\'Users and their assignments to user groups\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -457,7 +451,7 @@ class RelationTest extends AbstractTestCase
                 . ' PRIMARY KEY (`usergroup`,`tab`,`allowed`) )'
                 . ' COMMENT=\'User groups with configured menu items\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -468,7 +462,7 @@ class RelationTest extends AbstractTestCase
                 . ' `table_name` varchar(64) NOT NULL,'
                 . ' PRIMARY KEY (`username`,`item_name`,`item_type`,`db_name`,`table_name`) )'
                 . ' COMMENT=\'Hidden items of navigation tree\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -479,7 +473,7 @@ class RelationTest extends AbstractTestCase
                 . ' `search_data` text NOT NULL, PRIMARY KEY (`id`),'
                 . ' UNIQUE KEY `u_savedsearches_username_dbname` (`username`,`db_name`,`search_name`) )'
                 . ' COMMENT=\'Saved searches\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -490,7 +484,7 @@ class RelationTest extends AbstractTestCase
                 . ' `col_extra` varchar(255) default \'\', `col_default` text,'
                 . ' PRIMARY KEY (`db_name`,`col_name`) )'
                 . ' COMMENT=\'Central list of columns\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -499,7 +493,7 @@ class RelationTest extends AbstractTestCase
                 . '`username` varchar(64) NOT NULL, `settings_data` text NOT NULL,'
                 . ' PRIMARY KEY (`username`) )'
                 . ' COMMENT=\'Settings related to Designer\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -510,7 +504,7 @@ class RelationTest extends AbstractTestCase
                 . ' `template_data` text NOT NULL, PRIMARY KEY (`id`),'
                 . ' UNIQUE KEY `u_user_type_template` (`username`,`export_type`,`template_name`) )'
                 . ' COMMENT=\'Saved export templates\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
 
         $this->assertSame('', $GLOBALS['cfg']['Server']['pmadb']);
@@ -590,10 +584,7 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_db_pma'],
         );
 
-        $dummyDbi->addResult(
-            'SELECT NULL FROM `pma__userconfig` LIMIT 0',
-            [['NULL']],
-        );
+        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', []);
 
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -605,7 +596,7 @@ class RelationTest extends AbstractTestCase
                 . ' `label` varchar(255) COLLATE utf8_general_ci NOT NULL default \'\','
                 . ' `query` text NOT NULL, PRIMARY KEY (`id`) )'
                 . ' COMMENT=\'Bookmarks\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -618,7 +609,7 @@ class RelationTest extends AbstractTestCase
                 . ' PRIMARY KEY (`master_db`,`master_table`,`master_field`),'
                 . ' KEY `foreign_field` (`foreign_db`,`foreign_table`) ) COMMENT=\'Relation table\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -627,7 +618,7 @@ class RelationTest extends AbstractTestCase
                 . '`db_name` varchar(64) NOT NULL default \'\', `table_name` varchar(64) NOT NULL default \'\','
                 . ' `display_field` varchar(64) NOT NULL default \'\', PRIMARY KEY (`db_name`,`table_name`) )'
                 . ' COMMENT=\'Table information for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
 
         $dummyDbi->addResult(
@@ -640,7 +631,7 @@ class RelationTest extends AbstractTestCase
                 . ' PRIMARY KEY (`db_name`,`table_name`,`pdf_page_number`) )'
                 . ' COMMENT=\'Table coordinates for phpMyAdmin PDF output\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -650,7 +641,7 @@ class RelationTest extends AbstractTestCase
                 . ' `page_descr` varchar(50) COLLATE utf8_general_ci NOT NULL default \'\', PRIMARY KEY (`page_nr`),'
                 . ' KEY `db_name` (`db_name`) ) COMMENT=\'PDF relation pages for phpMyAdmin\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -666,7 +657,7 @@ class RelationTest extends AbstractTestCase
                 . ' `input_transformation_options` varchar(255) NOT NULL default \'\','
                 . ' PRIMARY KEY (`id`), UNIQUE KEY `db_name` (`db_name`,`table_name`,`column_name`) )'
                 . ' COMMENT=\'Column information for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -677,7 +668,7 @@ class RelationTest extends AbstractTestCase
                 . ' `timevalue` timestamp NOT NULL default CURRENT_TIMESTAMP, `sqlquery` text NOT NULL,'
                 . ' PRIMARY KEY (`id`), KEY `username` (`username`,`db`,`table`,`timevalue`) )'
                 . ' COMMENT=\'SQL history for phpMyAdmin\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -685,7 +676,7 @@ class RelationTest extends AbstractTestCase
             . '-- CREATE TABLE IF NOT EXISTS `pma__recent` ( '
                 . '`username` varchar(64) NOT NULL, `tables` text NOT NULL, PRIMARY KEY (`username`) )'
                 . ' COMMENT=\'Recently accessed tables\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -693,7 +684,7 @@ class RelationTest extends AbstractTestCase
             . '-- CREATE TABLE IF NOT EXISTS `pma__favorite` ( '
                 . '`username` varchar(64) NOT NULL, `tables` text NOT NULL, PRIMARY KEY (`username`) )'
                 . ' COMMENT=\'Favorite tables\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -704,7 +695,7 @@ class RelationTest extends AbstractTestCase
                 . ' `last_update` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,'
                 . ' PRIMARY KEY (`username`,`db_name`,`table_name`) ) COMMENT=\'Tables\'\' UI preferences\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -723,7 +714,7 @@ class RelationTest extends AbstractTestCase
                 . ' default \'1\', PRIMARY KEY (`db_name`,`table_name`,`version`) )'
                 . ' COMMENT=\'Database changes tracking for phpMyAdmin\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -733,7 +724,7 @@ class RelationTest extends AbstractTestCase
                 . ' PRIMARY KEY (`username`,`usergroup`) )'
                 . ' COMMENT=\'Users and their assignments to user groups\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -744,7 +735,7 @@ class RelationTest extends AbstractTestCase
                 . ' PRIMARY KEY (`usergroup`,`tab`,`allowed`) )'
                 . ' COMMENT=\'User groups with configured menu items\''
                 . ' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -755,7 +746,7 @@ class RelationTest extends AbstractTestCase
                 . ' `table_name` varchar(64) NOT NULL,'
                 . ' PRIMARY KEY (`username`,`item_name`,`item_type`,`db_name`,`table_name`) )'
                 . ' COMMENT=\'Hidden items of navigation tree\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -766,7 +757,7 @@ class RelationTest extends AbstractTestCase
                 . ' `search_data` text NOT NULL, PRIMARY KEY (`id`),'
                 . ' UNIQUE KEY `u_savedsearches_username_dbname` (`username`,`db_name`,`search_name`) )'
                 . ' COMMENT=\'Saved searches\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -777,7 +768,7 @@ class RelationTest extends AbstractTestCase
                 . ' `col_extra` varchar(255) default \'\', `col_default` text,'
                 . ' PRIMARY KEY (`db_name`,`col_name`) )'
                 . ' COMMENT=\'Central list of columns\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -786,7 +777,7 @@ class RelationTest extends AbstractTestCase
                 . '`username` varchar(64) NOT NULL, `settings_data` text NOT NULL,'
                 . ' PRIMARY KEY (`username`) )'
                 . ' COMMENT=\'Settings related to Designer\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             '-- -------------------------------------------------------- -- --'
@@ -797,7 +788,7 @@ class RelationTest extends AbstractTestCase
                 . ' `template_data` text NOT NULL, PRIMARY KEY (`id`),'
                 . ' UNIQUE KEY `u_user_type_template` (`username`,`export_type`,`template_name`) )'
                 . ' COMMENT=\'Saved export templates\' DEFAULT CHARACTER SET utf8 COLLATE utf8_bin;',
-            [],
+            true,
         );
 
         $this->assertSame('db_pma', $GLOBALS['cfg']['Server']['pmadb']);
@@ -908,10 +899,7 @@ class RelationTest extends AbstractTestCase
         $relation = new Relation($dbi);
 
         $dummyDbi->removeDefaultResults();
-        $dummyDbi->addResult(
-            'CREATE DATABASE IF NOT EXISTS `phpmyadmin`',
-            [],
-        );
+        $dummyDbi->addResult('CREATE DATABASE IF NOT EXISTS `phpmyadmin`', true);
 
         $dummyDbi->addResult(
             'SHOW TABLES FROM `phpmyadmin`',
@@ -1510,11 +1498,7 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_phpmyadmin'],
         );
 
-        $dummyDbi->addResult(
-            'SELECT NULL FROM `pma__userconfig` LIMIT 0',
-            [['NULL']],
-            ['NULL'],
-        );
+        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', [], ['NULL']);
 
         $_SESSION['relation'] = [];
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
@@ -1697,11 +1681,7 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_PMA-storage'],
         );
 
-        $dummyDbi->addResult(
-            'SELECT NULL FROM `pma__userconfig_custom` LIMIT 0',
-            [['NULL']],
-            ['NULL'],
-        );
+        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig_custom` LIMIT 0', [], ['NULL']);
 
         $dummyDbi->addSelectDb('PMA-storage');
 
@@ -1727,11 +1707,7 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_PMA-storage'],
         );
 
-        $dummyDbi->addResult(
-            'SELECT NULL FROM `pma__userconfig_custom` LIMIT 0',
-            [['NULL']],
-            ['NULL'],
-        );
+        $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig_custom` LIMIT 0', [], ['NULL']);
 
         $dummyDbi->addSelectDb('PMA-storage');
         /** @psalm-suppress EmptyArrayAccess */
@@ -1932,13 +1908,7 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_PMA-storage'],
         );
 
-        $dummyDbi->addResult(
-            'SELECT NULL FROM `pma__favorite_custom` LIMIT 0',
-            [
-                ['NULL'],
-            ],
-            ['NULL'],
-        );
+        $dummyDbi->addResult('SELECT NULL FROM `pma__favorite_custom` LIMIT 0', [], ['NULL']);
 
         $dummyDbi->addResult(
             'SELECT `tables` FROM `PMA-storage`.`pma__favorite_custom` WHERE `username` = \'\'',
@@ -2178,7 +2148,7 @@ class RelationTest extends AbstractTestCase
         );
 
         foreach ($queries as $query) {
-            $dummyDbi->addResult($query, []);
+            $dummyDbi->addResult($query, true);
         }
 
         $relation->renameTable('db_1', 'db_2', 'table_1', 'table_2');
@@ -2250,7 +2220,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addResult(
             'UPDATE `pma``db`.`table``coords` SET db_name = \'db\\\'1\', table_name = \'table\\\'2\''
                 . ' WHERE db_name = \'db\\\'1\' AND table_name = \'table\\\'1\'',
-            [],
+            true,
         );
 
         $relation->renameTable('db\'1', 'db\'1', 'table\'1', 'table\'2');

--- a/test/classes/Controllers/Console/Bookmark/AddControllerTest.php
+++ b/test/classes/Controllers/Console/Bookmark/AddControllerTest.php
@@ -67,8 +67,11 @@ class AddControllerTest extends AbstractTestCase
         );
 
         $dbiDummy = $this->createDbiDummy();
-        // phpcs:ignore Generic.Files.LineLength.TooLong
-        $dbiDummy->addResult('INSERT INTO `pmadb`.`bookmark` (id, dbase, user, query, label) VALUES (NULL, \'test_db\', \'\', \'test_query\', \'test_label\')', []);
+        $dbiDummy->addResult(
+            'INSERT INTO `pmadb`.`bookmark` (id, dbase, user, query, label)'
+            . ' VALUES (NULL, \'test_db\', \'\', \'test_query\', \'test_label\')',
+            true,
+        );
         $dbi = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['dbi'] = $dbi;
         $response = new ResponseRenderer();

--- a/test/classes/Controllers/Normalization/MoveRepeatingGroupTest.php
+++ b/test/classes/Controllers/Normalization/MoveRepeatingGroupTest.php
@@ -22,12 +22,15 @@ class MoveRepeatingGroupTest extends AbstractTestCase
         $GLOBALS['db'] = 'test_db';
         $GLOBALS['table'] = 'test_table';
 
-        // phpcs:disable Generic.Files.LineLength.TooLong
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addSelectDb('test_db');
-        $dbiDummy->addResult('CREATE TABLE `new_table` SELECT `id`,`col1`,`col1` as `new_column` FROM `test_table` UNION SELECT `id`,`col1`,`col2` as `new_column` FROM `test_table`', []);
-        $dbiDummy->addResult('ALTER TABLE `test_table` DROP `col1`, DROP `col2`', []);
-        // phpcs:enable
+        $dbiDummy->addResult(
+            'CREATE TABLE `new_table`'
+            . ' SELECT `id`,`col1`,`col1` as `new_column` FROM `test_table` UNION'
+            . ' SELECT `id`,`col1`,`col2` as `new_column` FROM `test_table`',
+            true,
+        );
+        $dbiDummy->addResult('ALTER TABLE `test_table` DROP `col1`, DROP `col2`', true);
 
         $dbi = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['dbi'] = $dbi;

--- a/test/classes/Controllers/Normalization/SecondNormalForm/CreateNewTablesControllerTest.php
+++ b/test/classes/Controllers/Normalization/SecondNormalForm/CreateNewTablesControllerTest.php
@@ -25,9 +25,9 @@ class CreateNewTablesControllerTest extends AbstractTestCase
 
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addSelectDb('test_db');
-        $dbiDummy->addResult('CREATE TABLE `batch_log2` SELECT DISTINCT `ID`, `task` FROM `test_table`;', []);
-        $dbiDummy->addResult('CREATE TABLE `table2` SELECT DISTINCT `task`, `timestamp` FROM `test_table`;', []);
-        $dbiDummy->addResult('DROP TABLE `test_table`', []);
+        $dbiDummy->addResult('CREATE TABLE `batch_log2` SELECT DISTINCT `ID`, `task` FROM `test_table`;', true);
+        $dbiDummy->addResult('CREATE TABLE `table2` SELECT DISTINCT `task`, `timestamp` FROM `test_table`;', true);
+        $dbiDummy->addResult('DROP TABLE `test_table`', true);
 
         $dbi = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['dbi'] = $dbi;

--- a/test/classes/Controllers/Normalization/ThirdNormalForm/CreateNewTablesControllerTest.php
+++ b/test/classes/Controllers/Normalization/ThirdNormalForm/CreateNewTablesControllerTest.php
@@ -32,13 +32,19 @@ class CreateNewTablesControllerTest extends AbstractTestCase
             ],
         ]);
 
-        // phpcs:disable Generic.Files.LineLength.TooLong
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addSelectDb('test_db');
-        $dbiDummy->addResult('CREATE TABLE `event` SELECT DISTINCT `eventID`, `Start_time`, `DateOfEvent`, `NumberOfGuests`, `NameOfVenue`, `LocationOfVenue` FROM `test_table`;', []);
-        $dbiDummy->addResult('CREATE TABLE `table2` SELECT DISTINCT `Start_time`, `TypeOfEvent`, `period` FROM `test_table`;', []);
-        $dbiDummy->addResult('DROP TABLE `test_table`', []);
-        // phpcs:enable
+        $dbiDummy->addResult(
+            'CREATE TABLE `event`'
+            . ' SELECT DISTINCT `eventID`, `Start_time`, `DateOfEvent`, `NumberOfGuests`,'
+            . ' `NameOfVenue`, `LocationOfVenue` FROM `test_table`;',
+            true,
+        );
+        $dbiDummy->addResult(
+            'CREATE TABLE `table2` SELECT DISTINCT `Start_time`, `TypeOfEvent`, `period` FROM `test_table`;',
+            true,
+        );
+        $dbiDummy->addResult('DROP TABLE `test_table`', true);
 
         $dbi = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['dbi'] = $dbi;

--- a/test/classes/Controllers/Table/DeleteRowsControllerTest.php
+++ b/test/classes/Controllers/Table/DeleteRowsControllerTest.php
@@ -33,7 +33,7 @@ class DeleteRowsControllerTest extends AbstractTestCase
 
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addSelectDb('test_db');
-        $dummyDbi->addResult('DELETE FROM `test_table` WHERE `test_table`.`id` = 3 LIMIT 1;', []);
+        $dummyDbi->addResult('DELETE FROM `test_table` WHERE `test_table`.`id` = 3 LIMIT 1;', true);
         $dummyDbi->addSelectDb('test_db');
         $dummyDbi->addResult(
             'SELECT * FROM `test_db`.`test_table` LIMIT 0, 25',

--- a/test/classes/Controllers/Table/DropColumnControllerTest.php
+++ b/test/classes/Controllers/Table/DropColumnControllerTest.php
@@ -37,7 +37,7 @@ class DropColumnControllerTest extends AbstractTestCase
 
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addSelectDb('test_db');
-        $dummyDbi->addResult('ALTER TABLE `test_table` DROP `name`, DROP `datetimefield`;', []);
+        $dummyDbi->addResult('ALTER TABLE `test_table` DROP `name`, DROP `datetimefield`;', true);
         $dbi = $this->createDatabaseInterface($dummyDbi);
 
         $this->assertArrayNotHasKey('flashMessages', $_SESSION);

--- a/test/classes/Controllers/Table/Structure/SaveControllerTest.php
+++ b/test/classes/Controllers/Table/Structure/SaveControllerTest.php
@@ -78,7 +78,7 @@ class SaveControllerTest extends AbstractTestCase
         $dummyDbi->addResult(
             'ALTER TABLE `test_table` CHANGE `name` `new_name` VARCHAR(21)'
             . ' CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL;',
-            [],
+            true,
         );
         $dbi = $this->createDatabaseInterface($dummyDbi);
 

--- a/test/classes/Controllers/Table/Structure/SpatialControllerTest.php
+++ b/test/classes/Controllers/Table/Structure/SpatialControllerTest.php
@@ -25,7 +25,7 @@ class SpatialControllerTest extends AbstractTestCase
 
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addSelectDb('test_db');
-        $dbiDummy->addResult('ALTER TABLE `test_table` ADD SPATIAL(`test_field`);', []);
+        $dbiDummy->addResult('ALTER TABLE `test_table` ADD SPATIAL(`test_field`);', true);
         $dbi = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['dbi'] = $dbi;
         $request = $this->createStub(ServerRequest::class);
@@ -53,7 +53,7 @@ class SpatialControllerTest extends AbstractTestCase
 
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addSelectDb('test_db');
-        $dbiDummy->addResult('ALTER TABLE `test_table` ADD SPATIAL(`test_field1`, `test_field2`);', []);
+        $dbiDummy->addResult('ALTER TABLE `test_table` ADD SPATIAL(`test_field1`, `test_field2`);', true);
         $dbi = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['dbi'] = $dbi;
         $request = $this->createStub(ServerRequest::class);

--- a/test/classes/Controllers/Table/Structure/UniqueControllerTest.php
+++ b/test/classes/Controllers/Table/Structure/UniqueControllerTest.php
@@ -25,7 +25,7 @@ class UniqueControllerTest extends AbstractTestCase
 
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addSelectDb('test_db');
-        $dbiDummy->addResult('ALTER TABLE `test_table` ADD UNIQUE(`test_field`);', []);
+        $dbiDummy->addResult('ALTER TABLE `test_table` ADD UNIQUE(`test_field`);', true);
         $dbi = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['dbi'] = $dbi;
         $request = $this->createStub(ServerRequest::class);
@@ -53,7 +53,7 @@ class UniqueControllerTest extends AbstractTestCase
 
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addSelectDb('test_db');
-        $dbiDummy->addResult('ALTER TABLE `test_table` ADD UNIQUE(`test_field1`, `test_field2`);', []);
+        $dbiDummy->addResult('ALTER TABLE `test_table` ADD UNIQUE(`test_field1`, `test_field2`);', true);
         $dbi = $this->createDatabaseInterface($dbiDummy);
         $GLOBALS['dbi'] = $dbi;
         $request = $this->createStub(ServerRequest::class);

--- a/test/classes/Database/Designer/CommonTest.php
+++ b/test/classes/Database/Designer/CommonTest.php
@@ -406,7 +406,7 @@ class CommonTest extends AbstractTestCase
                 'table\\\'1', // foreign_table
                 'field\\\'1', // foreign_field
             ),
-            [],
+            true,
         );
 
         $result = $this->designerCommon->removeRelation('db\'1.table\'1', 'field\'1', 'db\'2.table\'2', 'field\'2');
@@ -460,7 +460,7 @@ class CommonTest extends AbstractTestCase
                 'table\\\'1', // foreign_table
                 'field\\\'1', // foreign_field
             ),
-            [],
+            true,
         );
 
         $this->dummyDbi->addResult(
@@ -470,7 +470,7 @@ class CommonTest extends AbstractTestCase
                 'table\'2', // table
                 'table\'1_ibfk_field\'2', // fk name
             ),
-            [],
+            true,
         );
 
         $result = $this->designerCommon->removeRelation('db\'1.table\'1', 'field\'1', 'db\'2.table\'2', 'field\'2');

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -807,7 +807,7 @@ SQL;
         // phpcs:enable
         $dbiDummy->addResult($isViewQuery, []);
         $dbiDummy->addResult($isViewQuery, []);
-        $dbiDummy->addResult('USE `db`', []);
+        $dbiDummy->addResult('USE `db`', true);
         $dbiDummy->addResult(
             'SHOW CREATE TABLE `db`.`table`',
             [['table', $createTableStatement]],
@@ -859,7 +859,7 @@ SQL;
         $dbiDummy->addResult('SHOW TABLE STATUS FROM `db` WHERE Name = \'table\'', []);
         $dbiDummy->addResult($isViewQuery, []);
         $dbiDummy->addResult($isViewQuery, []);
-        $dbiDummy->addResult('USE `db`', []);
+        $dbiDummy->addResult('USE `db`', true);
         $dbiDummy->addResult('SHOW CREATE TABLE `db`.`table`', []);
         $dbiDummy->addErrorCode('error occurred');
 

--- a/test/classes/Server/PrivilegesTest.php
+++ b/test/classes/Server/PrivilegesTest.php
@@ -269,13 +269,13 @@ class PrivilegesTest extends AbstractTestCase
 
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addResult('SELECT \'1\' FROM `mysql`.`user` WHERE `User` = \'\' AND `Host` = \'localhost\';', []);
-        $dummyDbi->addResult('SET `old_passwords` = 0;', []);
+        $dummyDbi->addResult('SET `old_passwords` = 0;', true);
         $dummyDbi->addResult(
             'CREATE USER \'\'@\'localhost\' IDENTIFIED WITH mysql_native_password AS \'pma_dbname\';',
-            [],
+            true,
         );
-        $dummyDbi->addResult('GRANT USAGE ON *.* TO \'\'@\'localhost\' REQUIRE NONE;', []);
-        $dummyDbi->addResult('GRANT ALL PRIVILEGES ON `pma_dbname`.* TO \'\'@\'localhost\';', []);
+        $dummyDbi->addResult('GRANT USAGE ON *.* TO \'\'@\'localhost\' REQUIRE NONE;', true);
+        $dummyDbi->addResult('GRANT ALL PRIVILEGES ON `pma_dbname`.* TO \'\'@\'localhost\';', true);
 
         $dbi = $this->createDatabaseInterface($dummyDbi);
 
@@ -318,12 +318,12 @@ class PrivilegesTest extends AbstractTestCase
 
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addResult('SELECT \'1\' FROM `mysql`.`user` WHERE `User` = \'\' AND `Host` = \'localhost\';', []);
-        $dummyDbi->addResult('SET `old_passwords` = 0;', []);
-        $dummyDbi->addResult('CREATE USER \'\'@\'localhost\';', []);
-        $dummyDbi->addResult('SET `old_passwords` = 0;', []);
-        $dummyDbi->addResult('SET PASSWORD FOR \'\'@\'localhost\' = \'pma_dbname\';', []);
-        $dummyDbi->addResult('GRANT USAGE ON *.* TO \'\'@\'localhost\' REQUIRE NONE;', []);
-        $dummyDbi->addResult('GRANT ALL PRIVILEGES ON `pma_dbname`.* TO \'\'@\'localhost\';', []);
+        $dummyDbi->addResult('SET `old_passwords` = 0;', true);
+        $dummyDbi->addResult('CREATE USER \'\'@\'localhost\';', true);
+        $dummyDbi->addResult('SET `old_passwords` = 0;', true);
+        $dummyDbi->addResult('SET PASSWORD FOR \'\'@\'localhost\' = \'pma_dbname\';', true);
+        $dummyDbi->addResult('GRANT USAGE ON *.* TO \'\'@\'localhost\' REQUIRE NONE;', true);
+        $dummyDbi->addResult('GRANT ALL PRIVILEGES ON `pma_dbname`.* TO \'\'@\'localhost\';', true);
 
         $dbi = $this->createDatabaseInterface($dummyDbi);
 
@@ -368,9 +368,9 @@ class PrivilegesTest extends AbstractTestCase
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addResult(
             'ALTER USER \'pma_username\'@\'pma_hostname\' IDENTIFIED WITH mysql_native_password BY \'pma_pw\'',
-            [],
+            true,
         );
-        $dummyDbi->addResult('FLUSH PRIVILEGES;', []);
+        $dummyDbi->addResult('FLUSH PRIVILEGES;', true);
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface($dummyDbi));
 
         $username = 'pma_username';
@@ -392,11 +392,11 @@ class PrivilegesTest extends AbstractTestCase
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addResult(
             'REVOKE ALL PRIVILEGES ON `pma_dbname`.`pma_tablename` FROM \'pma_username\'@\'pma_hostname\';',
-            [],
+            true,
         );
         $dummyDbi->addResult(
             'REVOKE GRANT OPTION ON `pma_dbname`.`pma_tablename` FROM \'pma_username\'@\'pma_hostname\';',
-            [],
+            true,
         );
 
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface($dummyDbi));
@@ -437,7 +437,7 @@ class PrivilegesTest extends AbstractTestCase
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addResult(
             'REVOKE ALL PRIVILEGES ON `pma_dbname`.`pma_tablename` FROM \'pma_username\'@\'pma_hostname\';',
-            [],
+            true,
         );
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface($dummyDbi));
 
@@ -638,7 +638,7 @@ class PrivilegesTest extends AbstractTestCase
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $dummyDbi = $this->createDbiDummy();
-        $dummyDbi->addResult('SET `old_passwords` = 0;', []);
+        $dummyDbi->addResult('SET `old_passwords` = 0;', true);
         $dbi = $this->createDatabaseInterface($dummyDbi);
 
         $dbi->setVersion(['@@version' => '8.0.11', '@@version_comment' => 'MySQL Community Server - GPL']);
@@ -704,8 +704,8 @@ class PrivilegesTest extends AbstractTestCase
         $GLOBALS['cfg']['Server']['DisableIS'] = false;
 
         $dummyDbi = $this->createDbiDummy();
-        $dummyDbi->addResult('SET `old_passwords` = 0;', []);
-        $dummyDbi->addResult('GRANT USAGE ON *.* TO \'PMA_username\'@\'PMA_hostname\' REQUIRE NONE;', []);
+        $dummyDbi->addResult('SET `old_passwords` = 0;', true);
+        $dummyDbi->addResult('GRANT USAGE ON *.* TO \'PMA_username\'@\'PMA_hostname\' REQUIRE NONE;', true);
 
         $dbi = $this->createDatabaseInterface($dummyDbi);
 

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -68,7 +68,7 @@ class DbiDummy implements DbiExtension
     private array $fifoDatabasesToSelect = [];
 
     /**
-     * @var array<array<string,array<int,array<string,string|float|int|null>>|bool|string[]|FieldMetaData[]>>
+     * @var array<array<string,array<int,array<string,string|float|int|null>>|bool|string[]|FieldMetadata[]>>
      * @phpstan-var list<array{
      *     query: string,
      *     result: list<non-empty-list<string|float|int|null>>|bool,
@@ -823,7 +823,7 @@ class DbiDummy implements DbiExtension
                     . ' AND TABLE_SCHEMA=\'pma\\\\_test\' AND TABLE_NAME=\'table1\'',
                 'result' => [],
             ],
-            ['query' => 'RENAME TABLE `pma_test`.`table1` TO `pma_test`.`table3`;', 'result' => []],
+            ['query' => 'RENAME TABLE `pma_test`.`table1` TO `pma_test`.`table3`;', 'result' => true],
             [
                 'query' => 'SELECT TRIGGER_SCHEMA, TRIGGER_NAME, EVENT_MANIPULATION,'
                     . ' EVENT_OBJECT_TABLE, ACTION_TIMING, ACTION_STATEMENT, '
@@ -1064,7 +1064,7 @@ class DbiDummy implements DbiExtension
             ],
             ['query' => "SHOW PROCEDURE STATUS WHERE `Db`='default'", 'result' => []],
             ['query' => 'SHOW EVENTS FROM `default`', 'result' => []],
-            ['query' => 'FLUSH PRIVILEGES', 'result' => []],
+            ['query' => 'FLUSH PRIVILEGES', 'result' => true],
             ['query' => 'SELECT * FROM `mysql`.`db` LIMIT 1', 'result' => []],
             ['query' => 'SELECT * FROM `mysql`.`columns_priv` LIMIT 1', 'result' => []],
             ['query' => 'SELECT * FROM `mysql`.`tables_priv` LIMIT 1', 'result' => []],
@@ -1424,8 +1424,8 @@ class DbiDummy implements DbiExtension
                     ['update sql_text', 11, 'argument3 argument4'],
                 ],
             ],
-            ['query' => 'SET PROFILING=1;', 'result' => []],
-            ['query' => 'query', 'result' => []],
+            ['query' => 'SET PROFILING=1;', 'result' => true],
+            ['query' => 'query', 'result' => true],
             [
                 'query' => 'EXPLAIN query',
                 'columns' => ['sql_text', '#', 'argument'],
@@ -1449,7 +1449,7 @@ class DbiDummy implements DbiExtension
             [
                 'query' => 'INSERT INTO `db`.`table` (`username`, `export_type`, `template_name`, `template_data`)'
                     . ' VALUES (\'user\', \'type\', \'name\', \'data\');',
-                'result' => [],
+                'result' => true,
             ],
             [
                 'query' => 'SELECT * FROM `db`.`table` WHERE `username` = \'user\''
@@ -1457,7 +1457,7 @@ class DbiDummy implements DbiExtension
                 'columns' => ['id', 'username', 'export_type', 'template_name', 'template_data'],
                 'result' => [['1', 'user1', 'type1', 'name1', 'data1'], ['2', 'user2', 'type2', 'name2', 'data2']],
             ],
-            ['query' => 'DELETE FROM `db`.`table` WHERE `id` = 1 AND `username` = \'user\';', 'result' => []],
+            ['query' => 'DELETE FROM `db`.`table` WHERE `id` = 1 AND `username` = \'user\';', 'result' => true],
             [
                 'query' => 'SELECT * FROM `db`.`table` WHERE `id` = 1 AND `username` = \'user\';',
                 'columns' => ['id', 'username', 'export_type', 'template_name', 'template_data'],
@@ -1466,7 +1466,7 @@ class DbiDummy implements DbiExtension
             [
                 'query' => 'UPDATE `db`.`table` SET `template_data` = \'data\''
                     . ' WHERE `id` = 1 AND `username` = \'user\';',
-                'result' => [],
+                'result' => true,
             ],
             [
                 'query' => 'SHOW SLAVE HOSTS',
@@ -1750,11 +1750,11 @@ class DbiDummy implements DbiExtension
                 'columns' => ['Function', 'Create Function'],
                 'result' => [['test_func', 'CREATE FUNCTION `test_func` (p INT) RETURNS int(11) BEGIN END']],
             ],
-            ['query' => 'USE `test_db`', 'result' => []],
-            ['query' => 'SET SQL_QUOTE_SHOW_CREATE = 0', 'result' => []],
-            ['query' => 'SET SQL_QUOTE_SHOW_CREATE = 1', 'result' => []],
-            ['query' => 'UPDATE `test_tbl` SET `vc` = \'…zff s sf\' WHERE `test`.`ser` = 2', 'result' => []],
-            ['query' => 'UPDATE `test_tbl` SET `vc` = \'…ss s s\' WHERE `test`.`ser` = 1', 'result' => []],
+            ['query' => 'USE `test_db`', 'result' => true],
+            ['query' => 'SET SQL_QUOTE_SHOW_CREATE = 0', 'result' => true],
+            ['query' => 'SET SQL_QUOTE_SHOW_CREATE = 1', 'result' => true],
+            ['query' => 'UPDATE `test_tbl` SET `vc` = \'…zff s sf\' WHERE `test`.`ser` = 2', 'result' => true],
+            ['query' => 'UPDATE `test_tbl` SET `vc` = \'…ss s s\' WHERE `test`.`ser` = 1', 'result' => true],
             ['query' => 'SELECT LAST_INSERT_ID();', 'result' => []],
             ['query' => 'SHOW WARNINGS', 'result' => []],
             [
@@ -1833,22 +1833,22 @@ class DbiDummy implements DbiExtension
             [
                 'query' => 'CREATE TABLE `event` SELECT DISTINCT `eventID`, `Start_time`,'
                 . ' `DateOfEvent`, `NumberOfGuests`, `NameOfVenue`, `LocationOfVenue` FROM `test_tbl`;',
-                'result' => [],
+                'result' => true,
             ],
-            ['query' => 'ALTER TABLE `event` ADD PRIMARY KEY(`eventID`);', 'result' => []],
+            ['query' => 'ALTER TABLE `event` ADD PRIMARY KEY(`eventID`);', 'result' => true],
             [
                 'query' => 'CREATE TABLE `table2` SELECT DISTINCT `Start_time`,'
                             . ' `TypeOfEvent`, `period` FROM `test_tbl`;',
                 'result' => [],
             ],
-            ['query' => 'ALTER TABLE `table2` ADD PRIMARY KEY(`Start_time`);', 'result' => []],
-            ['query' => 'DROP TABLE `test_tbl`', 'result' => []],
-            ['query' => 'CREATE TABLE `batch_log2` SELECT DISTINCT `ID`, `task` FROM `test_tbl`;', 'result' => []],
-            ['query' => 'ALTER TABLE `batch_log2` ADD PRIMARY KEY(`ID`, `task`);', 'result' => []],
-            ['query' => 'CREATE TABLE `table2` SELECT DISTINCT `task`, `timestamp` FROM `test_tbl`;', 'result' => []],
-            ['query' => 'ALTER TABLE `table2` ADD PRIMARY KEY(`task`);', 'result' => []],
+            ['query' => 'ALTER TABLE `table2` ADD PRIMARY KEY(`Start_time`);', 'result' => true],
+            ['query' => 'DROP TABLE `test_tbl`', 'result' => true],
+            ['query' => 'CREATE TABLE `batch_log2` SELECT DISTINCT `ID`, `task` FROM `test_tbl`;', 'result' => true],
+            ['query' => 'ALTER TABLE `batch_log2` ADD PRIMARY KEY(`ID`, `task`);', 'result' => true],
+            ['query' => 'CREATE TABLE `table2` SELECT DISTINCT `task`, `timestamp` FROM `test_tbl`;', 'result' => true],
+            ['query' => 'ALTER TABLE `table2` ADD PRIMARY KEY(`task`);', 'result' => true],
             ['query' => 'CREATE DATABASE `test_db_error`;', 'result' => false],
-            ['query' => 'CREATE DATABASE `test_db` DEFAULT CHARSET=utf8 COLLATE utf8_general_ci;', 'result' => []],
+            ['query' => 'CREATE DATABASE `test_db` DEFAULT CHARSET=utf8 COLLATE utf8_general_ci;', 'result' => true],
             [
                 'query' => 'SHOW TABLE STATUS FROM `test_db`',
                 'columns' => ['Name', 'Engine', 'Version', 'Row_format', 'Rows', 'Avg_row_length', 'Data_length', 'Max_data_length', 'Index_length', 'Data_free', 'Auto_increment', 'Create_time', 'Update_time', 'Check_time', 'Collation', 'Checksum', 'Create_options', 'Comment', 'Max_index_length', 'Temporary'],

--- a/test/classes/TwoFactorTest.php
+++ b/test/classes/TwoFactorTest.php
@@ -93,11 +93,7 @@ class TwoFactorTest extends AbstractTestCase
             ['Tables_in_phpmyadmin'],
         );
 
-        $this->dummyDbi->addResult(
-            'SELECT NULL FROM `pma__userconfig` LIMIT 0',
-            [['NULL']],
-            ['NULL'],
-        );
+        $this->dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', [], ['NULL']);
     }
 
     /**
@@ -141,7 +137,7 @@ class TwoFactorTest extends AbstractTestCase
         $this->dummyDbi->addResult(
             'UPDATE `phpmyadmin`.`pma__userconfig` SET `timevalue` = NOW(),'
             . ' `config_data` = \'' . $jsonData . '\' WHERE `username` = \'groot\'',
-            [],
+            true,
         );
     }
 


### PR DESCRIPTION
Non-select statements should return true or false in tests. 
Query with limit 0 should return an empty array.

Behavior is unchanged as nobody is trying to read result of non-select queries.