### PR TITLE
Add the `Config::getCurrentServer()` method 

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -86,9 +86,6 @@ class Config
 
     public bool $errorConfigFile = false;
 
-    /** @var mixed[] */
-    public array $defaultServer;
-
     private bool $isHttps = false;
 
     private Settings $config;
@@ -96,7 +93,6 @@ class Config
     public function __construct()
     {
         $this->config = new Settings([]);
-        $this->defaultServer = $this->config->Servers[1]->asArray();
         $config = $this->config->asArray();
         $this->default = $config;
         $this->settings = $config;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -161,31 +161,6 @@ parameters:
 			path: libraries/classes/Common.php
 
 		-
-			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: libraries/classes/Config.php
-
-		-
-			message: "#^Cannot access offset 'host' on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Config.php
-
-		-
-			message: "#^Cannot access offset 'verbose' on mixed\\.$#"
-			count: 2
-			path: libraries/classes/Config.php
-
-		-
-			message: "#^Cannot access offset float\\|int\\<min, \\-1\\>\\|int\\<1, max\\>\\|\\(non\\-falsy\\-string&numeric\\-string\\) on mixed\\.$#"
-			count: 2
-			path: libraries/classes/Config.php
-
-		-
-			message: "#^Cannot access offset mixed on mixed\\.$#"
-			count: 2
-			path: libraries/classes/Config.php
-
-		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 2
 			path: libraries/classes/Config.php
@@ -197,11 +172,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Config\\:\\:getUploadTempDir\\(\\) should return string\\|null but returns string\\|false\\.$#"
-			count: 1
-			path: libraries/classes/Config.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function mb_strtolower expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Config.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -212,17 +212,12 @@
   <file src="libraries/classes/Common.php">
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['back']]]></code>
-      <code><![CDATA[$GLOBALS['cfg']['Server']['controluser']]]></code>
       <code><![CDATA[$GLOBALS['theme']]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
-      <code><![CDATA[$GLOBALS['cfg']['Server']['user']]]></code>
       <code><![CDATA[$_SESSION[' PMA_token ']]]></code>
       <code>$sqlDelimiter</code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$GLOBALS['cfg']['Server']['user']]]></code>
-    </MixedArrayAccess>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['back']]]></code>
       <code><![CDATA[$GLOBALS['theme']]]></code>
@@ -260,7 +255,6 @@
       <code>$defaultValue</code>
       <code><![CDATA[$gdInfo['GD Version']]]></code>
       <code>$path</code>
-      <code><![CDATA[$server['verbose']]]></code>
       <code><![CDATA[$this->settings['ThemeDefault']]]></code>
       <code><![CDATA[$this->settings['ThemeDefault']]]></code>
       <code>$url</code>
@@ -272,11 +266,6 @@
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs_mtime']]]></code>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs_type']]]></code>
       <code><![CDATA[$configData['lang']]]></code>
-      <code><![CDATA[$server['host']]]></code>
-      <code><![CDATA[$server['verbose']]]></code>
-      <code><![CDATA[$server['verbose']]]></code>
-      <code><![CDATA[$this->settings['Servers'][$server]]]></code>
-      <code><![CDATA[$this->settings['Servers'][$server]]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$_SESSION['cache'][$cacheKey]]]></code>
@@ -289,10 +278,6 @@
       <code><![CDATA[$_SESSION['cache'][$cacheKey]['userprefs_type']]]></code>
       <code>$tempDir[$name]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->settings['Servers'][$server]]]></code>
-      <code><![CDATA[$this->settings['Servers'][$this->settings['ServerDefault']]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['cfg']['LoginCookieValidity']]]></code>
       <code>$collationConnection</code>
@@ -300,15 +285,11 @@
       <code>$defaultValue</code>
       <code>$defaultValue</code>
       <code>$evalResult</code>
-      <code>$i</code>
       <code>$password</code>
       <code>$password</code>
       <code>$path</code>
       <code>$prefsType</code>
       <code>$prefsType</code>
-      <code>$request</code>
-      <code>$server</code>
-      <code>$server</code>
       <code>$server[$item]</code>
       <code><![CDATA[$server['hide_connection_errors']]]></code>
       <code><![CDATA[$server['host']]]></code>
@@ -331,14 +312,10 @@
     </MixedReturnStatement>
     <PossiblyInvalidArgument>
       <code>$defaultValue</code>
-      <code>$request</code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidArrayOffset>
       <code><![CDATA[$_COOKIE[$this->getCookieName($cookieName)]]]></code>
     </PossiblyInvalidArrayOffset>
-    <PossiblyInvalidCast>
-      <code>$request</code>
-    </PossiblyInvalidCast>
     <RiskyCast>
       <code><![CDATA[$server['port']]]></code>
     </RiskyCast>

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -377,7 +377,6 @@ PHP;
         $config = $settings->asArray();
         $this->assertIsArray($config['Servers']);
         $this->assertEquals($settings, $object->getSettings());
-        $this->assertSame($config['Servers'][1], $object->defaultServer);
         $this->assertEquals($config, $object->default);
         $this->assertSame($config, $object->settings);
         $this->assertSame($config, $object->baseSettings);

--- a/test/classes/Controllers/Export/ExportControllerTest.php
+++ b/test/classes/Controllers/Export/ExportControllerTest.php
@@ -49,7 +49,7 @@ class ExportControllerTest extends AbstractTestCase
         $GLOBALS['lang'] = 'en';
         $GLOBALS['sql_indexes'] = null;
         $GLOBALS['sql_auto_increments'] = null;
-        $GLOBALS['config']->selectServer();
+        $GLOBALS['config']->selectServer('1');
         $GLOBALS['cfg'] = $GLOBALS['config']->settings;
 
         $this->dummyDbi->addResult(

--- a/test/classes/Controllers/Table/AddFieldControllerTest.php
+++ b/test/classes/Controllers/Table/AddFieldControllerTest.php
@@ -21,7 +21,7 @@ class AddFieldControllerTest extends AbstractTestCase
         $GLOBALS['db'] = 'test_db';
         $GLOBALS['table'] = 'test_table';
         $GLOBALS['regenerate'] = null;
-        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->defaultServer;
+        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->getSettings()->Servers[1]->asArray();
         $_POST = [
             'db' => 'test_db',
             'table' => 'test_table',

--- a/test/classes/Controllers/Table/CreateControllerTest.php
+++ b/test/classes/Controllers/Table/CreateControllerTest.php
@@ -22,7 +22,7 @@ class CreateControllerTest extends AbstractTestCase
     {
         $GLOBALS['db'] = 'test_db';
         $GLOBALS['table'] = 'new_test_table';
-        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->defaultServer;
+        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->getSettings()->Servers[1]->asArray();
         $_POST = ['db' => 'test_db', 'table' => 'new_test_table', 'num_fields' => '2'];
 
         $dummyDbi = $this->createDbiDummy();

--- a/test/classes/Controllers/Table/DeleteRowsControllerTest.php
+++ b/test/classes/Controllers/Table/DeleteRowsControllerTest.php
@@ -21,7 +21,7 @@ class DeleteRowsControllerTest extends AbstractTestCase
         $GLOBALS['db'] = 'test_db';
         $GLOBALS['table'] = 'test_table';
         $GLOBALS['urlParams'] = [];
-        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->defaultServer;
+        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->getSettings()->Servers[1]->asArray();
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $_POST = [
             'db' => 'test_db',

--- a/test/classes/Controllers/Table/ExportControllerTest.php
+++ b/test/classes/Controllers/Table/ExportControllerTest.php
@@ -33,7 +33,7 @@ class ExportControllerTest extends AbstractTestCase
 
         $GLOBALS['db'] = 'test_db';
         $GLOBALS['table'] = 'test_table';
-        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->defaultServer;
+        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->getSettings()->Servers[1]->asArray();
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['single_table'] = '1';
 

--- a/test/classes/Controllers/Table/ImportControllerTest.php
+++ b/test/classes/Controllers/Table/ImportControllerTest.php
@@ -25,7 +25,7 @@ class ImportControllerTest extends AbstractTestCase
         $GLOBALS['table'] = 'test_table';
         $GLOBALS['text_dir'] = 'ltr';
         $GLOBALS['lang'] = 'en';
-        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->defaultServer;
+        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->getSettings()->Servers[1]->asArray();
         $_GET['format'] = 'xml';
 
         $dummyDbi = $this->createDbiDummy();

--- a/test/classes/Controllers/Table/OperationsControllerTest.php
+++ b/test/classes/Controllers/Table/OperationsControllerTest.php
@@ -38,7 +38,7 @@ class OperationsControllerTest extends AbstractTestCase
         $GLOBALS['db'] = 'test_db';
         $GLOBALS['table'] = 'test_table';
 
-        $GLOBALS['config']->selectServer();
+        $GLOBALS['config']->selectServer('1');
         $GLOBALS['cfg'] = $GLOBALS['config']->settings;
         $GLOBALS['cfg']['MaxDbList'] = 0;
 

--- a/test/classes/Controllers/Table/SqlControllerTest.php
+++ b/test/classes/Controllers/Table/SqlControllerTest.php
@@ -41,7 +41,7 @@ class SqlControllerTest extends AbstractTestCase
         $GLOBALS['table'] = 'test_table';
         $GLOBALS['lang'] = 'en';
         $GLOBALS['text_dir'] = 'ltr';
-        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->defaultServer;
+        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->getSettings()->Servers[1]->asArray();
 
         $this->dummyDbi->addSelectDb('test_db');
         $this->dummyDbi->addResult('SHOW TABLES LIKE \'test_table\';', [['test_table']]);

--- a/test/classes/Controllers/Table/StructureControllerTest.php
+++ b/test/classes/Controllers/Table/StructureControllerTest.php
@@ -41,7 +41,7 @@ class StructureControllerTest extends AbstractTestCase
         $GLOBALS['table'] = 'test_table';
         $GLOBALS['text_dir'] = 'ltr';
         $GLOBALS['lang'] = 'en';
-        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->defaultServer;
+        $GLOBALS['cfg']['Server'] = $GLOBALS['config']->getSettings()->Servers[1]->asArray();
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['cfg']['ShowStats'] = false;
         $GLOBALS['cfg']['ShowPropertyComments'] = false;


### PR DESCRIPTION
The `Config::getCurrentServer()` method returns the current server configuration.
It's a value object that is equivalent to `$GLOBALS['cfg']['Server']` setting.