### PR TITLE
Fix #18330 - Solved TypeError when no-datetime field is modified

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -4400,21 +4400,24 @@ Functions.ignorePhpErrors = function (clearPrevErrors) {
  * @param $inputField
  */
 Functions.toggleDatepickerIfInvalid = function ($td, $inputField) {
-    // Regex allowed by the Datetimepicker UI
-    var dtexpDate = new RegExp(['^([0-9]{4})',
-        '-(((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(3[0-1])))|((02|04|06|09|11)',
-        '-((0[1-9])|([1-2][0-9])|30)))$'].join(''));
-    var dtexpTime = new RegExp(['^(([0-1][0-9])|(2[0-3]))',
-        ':((0[0-9])|([1-5][0-9]))',
-        ':((0[0-9])|([1-5][0-9]))(.[0-9]{1,6}){0,1}$'].join(''));
+    // If the Datetimepicker UI is not present, return
+    if ($inputField.hasClass('hasDatepicker')) {
+        // Regex allowed by the Datetimepicker UI
+        var dtexpDate = new RegExp(['^([0-9]{4})',
+            '-(((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(3[0-1])))|((02|04|06|09|11)',
+            '-((0[1-9])|([1-2][0-9])|30)))$'].join(''));
+        var dtexpTime = new RegExp(['^(([0-1][0-9])|(2[0-3]))',
+            ':((0[0-9])|([1-5][0-9]))',
+            ':((0[0-9])|([1-5][0-9]))(.[0-9]{1,6}){0,1}$'].join(''));
 
-    // If key-ed in Time or Date values are unsupported by the UI, close it
-    if ($td.attr('data-type') === 'date' && ! dtexpDate.test($inputField.val())) {
-        $inputField.datepicker('hide');
-    } else if ($td.attr('data-type') === 'time' && ! dtexpTime.test($inputField.val())) {
-        $inputField.datepicker('hide');
-    } else {
-        $inputField.datepicker('show');
+        // If key-ed in Time or Date values are unsupported by the UI, close it
+        if ($td.attr('data-type') === 'date' && ! dtexpDate.test($inputField.val())) {
+            $inputField.datepicker('hide');
+        } else if ($td.attr('data-type') === 'time' && ! dtexpTime.test($inputField.val())) {
+            $inputField.datepicker('hide');
+        } else {
+            $inputField.datepicker('show');
+        }
     }
 };
 


### PR DESCRIPTION
### Description

This basically controls that the function toggleDatepickerIfInvalid is only used when a datetime field is modified. It was being called for real fields as well.

Steps to reproduce the behavior:

- Click on a date field (`datetime` type)
- Click on another field (`decimal` type in this case) and type any single letter
- No error anymore

Fixes #18330

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

Signed-off-by: Sebastian Gutierrez <sebastian.gutierrezj@udea.edu.co>
