### PR TITLE
Fix #14411 - Double tap to edit on Mobile

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -2054,8 +2054,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     }
                 });
 
-            $(g.t).find('td.data.click2')
-                .on('click', function (e) {
+            $(g.t)
+                .on('click', 'td.data.click2', function (e) {
                     var $cell = $(this);
                     // In the case of relational link, We want single click on the link
                     // to goto the link and double click to start grid-editing.
@@ -2089,7 +2089,7 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                         }
                     }
                 })
-                .on('dblclick', function (e) {
+                .on('dblclick', 'td.data.click2', function (e) {
                     if ($(e.target).is('.grid_edit a')) {
                         e.preventDefault();
                     } else {


### PR DESCRIPTION
### Description

The `click` and `dblclick` events now using event delegation, rather than binding directly to the selected element. The previous implementation made the "double tap to edit" function unusable on recent iOS browsers. 

Steps to reproduce:
- double tap/click on a simple cell to edit its contents

Fixes #14411 

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.

Signed-off-by: Barnabás Schósz <schoszbarnabas@gmail.com>