### PR TITLE
Add CVE MITRE link to allowed domains

### DIFF
--- a/libraries/classes/Controllers/ChangeLogController.php
+++ b/libraries/classes/Controllers/ChangeLogController.php
@@ -75,7 +75,7 @@ class ChangeLogController extends AbstractController
 
             // CVE/CAN entries
             '/((CAN|CVE)-[0-9]+-[0-9]+)/' => '<a href="url.php?url='
-                . 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=\\1">\\1</a>',
+                . 'https://www.cve.org/CVERecord?id=\\1">\\1</a>',
 
             // PMASAentries
             '/(PMASA-[0-9]+-[0-9]+)/' => '<a href="url.php?url=https://www.phpmyadmin.net/security/\\1/">\\1</a>',

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -683,6 +683,8 @@ class Core
             'www.github.com',
             /* Percona domains */
             'www.percona.com',
+            /* CVE domain */
+            'www.cve.org',
             /* Following are doubtful ones. */
             'mysqldatabaseadministration.blogspot.com',
         ];

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -683,6 +683,8 @@ class Core
             'www.github.com',
             /* Percona domains */
             'www.percona.com',
+            /* CVE MITRE domain */
+            'cve.mitre.org',
             /* Following are doubtful ones. */
             'mysqldatabaseadministration.blogspot.com',
         ];

--- a/libraries/classes/Core.php
+++ b/libraries/classes/Core.php
@@ -683,8 +683,6 @@ class Core
             'www.github.com',
             /* Percona domains */
             'www.percona.com',
-            /* CVE MITRE domain */
-            'cve.mitre.org',
             /* Following are doubtful ones. */
             'mysqldatabaseadministration.blogspot.com',
         ];


### PR DESCRIPTION
### Description

This PR adds the CVE link to allowed domains, so it can successfully redirect to the CVE from changelog.