### PR TITLE
Refactor Config::getConnectionParams() method 

### DIFF
--- a/libraries/classes/Common.php
+++ b/libraries/classes/Common.php
@@ -244,6 +244,7 @@ final class Common
             }
 
             $authPlugin->authenticate();
+            $currentServer = new Server($GLOBALS['cfg']['Server']);
 
             /* Enable LOAD DATA LOCAL INFILE for LDI plugin */
             if ($route === '/import' && ($_POST['format'] ?? '') === 'ldi') {
@@ -562,11 +563,11 @@ final class Common
          */
         $controlConnection = null;
         if ($currentServer->controlUser !== '') {
-            $controlConnection = $dbi->connect(Connection::TYPE_CONTROL);
+            $controlConnection = $dbi->connect($currentServer, Connection::TYPE_CONTROL);
         }
 
         // Connects to the server (validates user's login)
-        $userConnection = $dbi->connect(Connection::TYPE_USER);
+        $userConnection = $dbi->connect($currentServer, Connection::TYPE_USER);
         if ($userConnection === null) {
             $auth->showFailure('mysql-denied');
         }
@@ -579,7 +580,7 @@ final class Common
          * Open separate connection for control queries, this is needed to avoid problems with table locking used in
          * main connection and phpMyAdmin issuing queries to configuration storage, which is not locked by that time.
          */
-        $dbi->connect(Connection::TYPE_USER, null, Connection::TYPE_CONTROL);
+        $dbi->connect($currentServer, Connection::TYPE_USER, Connection::TYPE_CONTROL);
     }
 
     public static function getRequest(): ServerRequest

--- a/libraries/classes/Config/Settings/Server.php
+++ b/libraries/classes/Config/Settings/Server.php
@@ -192,13 +192,13 @@ final class Server
      * @link https://docs.phpmyadmin.net/en/latest/config.html#cfg_Servers_control_*
      * @see self::$socket
      */
-    public string $controlSocket;
+    public string|null $controlSocket;
 
     /**
      * @link https://docs.phpmyadmin.net/en/latest/config.html#cfg_Servers_control_*
      * @see self::$ssl
      */
-    public bool $controlSsl;
+    public bool|null $controlSsl;
 
     /**
      * @link https://docs.phpmyadmin.net/en/latest/config.html#cfg_Servers_control_*
@@ -235,19 +235,19 @@ final class Server
      * @see self::$sslVerify
      * @see https://bugs.php.net/68344
      */
-    public bool $controlSslVerify;
+    public bool|null $controlSslVerify;
 
     /**
      * @link https://docs.phpmyadmin.net/en/latest/config.html#cfg_Servers_control_*
      * @see self::$compress
      */
-    public bool $controlCompress;
+    public bool|null $controlCompress;
 
     /**
      * @link https://docs.phpmyadmin.net/en/latest/config.html#cfg_Servers_control_*
      * @see self::$hideConnectionErrors
      */
-    public bool $controlHideConnectionErrors;
+    public bool|null $controlHideConnectionErrors;
 
     /**
      * Authentication method (valid choices: config, http, signon or cookie)
@@ -1142,23 +1142,23 @@ final class Server
     }
 
     /** @param array<int|string, mixed> $server */
-    private function setControlSocket(array $server): string
+    private function setControlSocket(array $server): string|null
     {
         if (isset($server['control_socket'])) {
             return (string) $server['control_socket'];
         }
 
-        return '';
+        return null;
     }
 
     /** @param array<int|string, mixed> $server */
-    private function setControlSsl(array $server): bool
+    private function setControlSsl(array $server): bool|null
     {
         if (isset($server['control_ssl'])) {
             return (bool) $server['control_ssl'];
         }
 
-        return false;
+        return null;
     }
 
     /** @param array<int|string, mixed> $server */
@@ -1212,33 +1212,33 @@ final class Server
     }
 
     /** @param array<int|string, mixed> $server */
-    private function setControlSslVerify(array $server): bool
+    private function setControlSslVerify(array $server): bool|null
     {
         if (isset($server['control_ssl_verify'])) {
             return (bool) $server['control_ssl_verify'];
         }
 
-        return true;
+        return null;
     }
 
     /** @param array<int|string, mixed> $server */
-    private function setControlCompress(array $server): bool
+    private function setControlCompress(array $server): bool|null
     {
         if (isset($server['control_compress'])) {
             return (bool) $server['control_compress'];
         }
 
-        return false;
+        return null;
     }
 
     /** @param array<int|string, mixed> $server */
-    private function setControlHideConnectionErrors(array $server): bool
+    private function setControlHideConnectionErrors(array $server): bool|null
     {
         if (isset($server['control_hide_connection_errors'])) {
             return (bool) $server['control_hide_connection_errors'];
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -1038,7 +1038,7 @@ class DatabaseInterface implements DbalInterface
      * been established. It sets the connection collation, and determines the
      * version of MySQL which is running.
      */
-    public function postConnect(): void
+    public function postConnect(Server $currentServer): void
     {
         $version = $this->fetchSingleRow('SELECT @@version, @@version_comment');
 
@@ -1065,9 +1065,9 @@ class DatabaseInterface implements DbalInterface
         }
 
         // Set timezone for the session, if required.
-        if ($GLOBALS['cfg']['Server']['SessionTimeZone'] != '') {
+        if ($currentServer->sessionTimeZone !== '') {
             $sqlQueryTz = 'SET ' . Util::backquote('time_zone') . ' = '
-                . $this->quoteString($GLOBALS['cfg']['Server']['SessionTimeZone']);
+                . $this->quoteString($currentServer->sessionTimeZone);
 
             if (! $this->tryQuery($sqlQueryTz)) {
                 $errorMessageTz = sprintf(
@@ -1078,7 +1078,7 @@ class DatabaseInterface implements DbalInterface
                         . 'phpMyAdmin is currently using the default time zone '
                         . 'of the database server.',
                     ),
-                    $GLOBALS['cfg']['Server']['SessionTimeZone'],
+                    $currentServer->sessionTimeZone,
                     $GLOBALS['server'],
                     $GLOBALS['server'],
                 );
@@ -1573,7 +1573,7 @@ class DatabaseInterface implements DbalInterface
             $this->connections[$target] = $result;
             /* Run post connect for user connections */
             if ($target === Connection::TYPE_USER) {
-                $this->postConnect();
+                $this->postConnect($currentServer);
             }
 
             return $result;

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Dbal;
 
+use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\FieldMetadata;
@@ -452,13 +453,11 @@ interface DbalInterface
     /**
      * Connects to the database server.
      *
-     * @param int          $mode   Connection mode.
-     * @param mixed[]|null $server Server information like host/port/socket/persistent
-     * @param int|null     $target How to store connection link, defaults to $mode
-     * @psalm-param ConnectionType $mode
+     * @param int|null $target How to store connection link, defaults to $mode
+     * @psalm-param ConnectionType $connectionType
      * @psalm-param ConnectionType|null $target
      */
-    public function connect(int $mode, array|null $server = null, int|null $target = null): Connection|null;
+    public function connect(Server $currentServer, int $connectionType, int|null $target = null): Connection|null;
 
     /**
      * selects given database

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -281,7 +281,7 @@ interface DbalInterface
      * been established. It sets the connection collation, and determines the
      * version of MySQL which is running.
      */
-    public function postConnect(): void;
+    public function postConnect(Server $currentServer): void;
 
     /**
      * Sets collation connection for user link

--- a/libraries/classes/Dbal/DbiExtension.php
+++ b/libraries/classes/Dbal/DbiExtension.php
@@ -17,7 +17,7 @@ interface DbiExtension
     /**
      * Connects to the database server.
      */
-    public function connect(string $user, string $password, Server $server): Connection|null;
+    public function connect(Server $server): Connection|null;
 
     /**
      * selects given database

--- a/libraries/classes/Dbal/DbiMysqli.php
+++ b/libraries/classes/Dbal/DbiMysqli.php
@@ -40,7 +40,7 @@ use const MYSQLI_USE_RESULT;
  */
 class DbiMysqli implements DbiExtension
 {
-    public function connect(string $user, string $password, Server $server): Connection|null
+    public function connect(Server $server): Connection|null
     {
         mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
@@ -95,7 +95,15 @@ class DbiMysqli implements DbiExtension
         }
 
         try {
-            $mysqli->real_connect($host, $user, $password, '', (int) $server->port, $server->socket, $clientFlags);
+            $mysqli->real_connect(
+                $host,
+                $server->user,
+                $server->password,
+                '',
+                (int) $server->port,
+                $server->socket,
+                $clientFlags,
+            );
         } catch (mysqli_sql_exception) {
             /**
              * Switch to SSL if server asked us to do so, unfortunately
@@ -120,7 +128,7 @@ class DbiMysqli implements DbiExtension
                     E_USER_WARNING,
                 );
 
-                return self::connect($user, $password, $server->withSSL(true));
+                return self::connect($server->withSSL(true));
             }
 
             if ($errorNumber === 1045 && $server->hideConnectionErrors) {

--- a/libraries/classes/Replication/Replication.php
+++ b/libraries/classes/Replication/Replication.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Replication;
 
+use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\Core;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Connection;
@@ -131,16 +132,17 @@ class Replication
         int|null $port = null,
         string|null $socket = null,
     ): Connection|null {
-        $server = [];
-        $server['user'] = $user;
-        $server['password'] = $password;
-        $server['host'] = Core::sanitizeMySQLHost($host);
-        $server['port'] = $port;
-        $server['socket'] = $socket;
+        $currentServer = new Server([
+            'user' => $user,
+            'password' => $password,
+            'host' => Core::sanitizeMySQLHost($host ?? ''),
+            'port' => $port,
+            'socket' => $socket,
+        ]);
 
         // 5th parameter set to true means that it's an auxiliary connection
         // and we must not go back to login page if it fails
-        return $this->dbi->connect(Connection::TYPE_AUXILIARY, $server);
+        return $this->dbi->connect($currentServer, Connection::TYPE_AUXILIARY);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3521,17 +3521,7 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
-			message: "#^Parameter \\#1 \\$user of method PhpMyAdmin\\\\Dbal\\\\DbiExtension\\:\\:connect\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
 			message: "#^Parameter \\#2 \\$b of static method PhpMyAdmin\\\\Query\\\\Utilities\\:\\:usortComparisonCallback\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Parameter \\#2 \\$password of method PhpMyAdmin\\\\Dbal\\\\DbiExtension\\:\\:connect\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
@@ -7317,11 +7307,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Replication\\\\Replication\\:\\:replicaBinLogPrimary\\(\\) should return array\\{File\\?\\: string, Position\\?\\: string\\} but returns array\\{\\}\\|array\\{File\\: mixed, Position\\: mixed\\}\\.$#"
-			count: 1
-			path: libraries/classes/Replication/Replication.php
-
-		-
-			message: "#^Parameter \\#1 \\$name of static method PhpMyAdmin\\\\Core\\:\\:sanitizeMySQLHost\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Replication/Replication.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -206,6 +206,7 @@
       <code><![CDATA[$GLOBALS['theme']]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
+      <code><![CDATA[$GLOBALS['cfg']['Server']]]></code>
       <code><![CDATA[$_SESSION[' PMA_token ']]]></code>
       <code>$sqlDelimiter</code>
     </MixedArgument>
@@ -231,13 +232,6 @@
     </RedundantCast>
   </file>
   <file src="libraries/classes/Config.php">
-    <InvalidArrayOffset>
-      <code><![CDATA[$GLOBALS['cfg']['Server']['controlhost']]]></code>
-      <code><![CDATA[$GLOBALS['cfg']['Server']['controlpass']]]></code>
-      <code><![CDATA[$GLOBALS['cfg']['Server']['controlport']]]></code>
-      <code><![CDATA[$GLOBALS['cfg']['Server']['controluser']]]></code>
-      <code><![CDATA[$GLOBALS['cfg']['Server']['hide_connection_errors']]]></code>
-    </InvalidArrayOffset>
     <MixedArgument>
       <code>$collationConnection</code>
       <code>$configData</code>
@@ -276,21 +270,11 @@
       <code>$defaultValue</code>
       <code>$defaultValue</code>
       <code>$evalResult</code>
-      <code>$password</code>
-      <code>$password</code>
       <code>$path</code>
       <code>$prefsType</code>
       <code>$prefsType</code>
-      <code>$server[$item]</code>
-      <code><![CDATA[$server['hide_connection_errors']]]></code>
-      <code><![CDATA[$server['host']]]></code>
-      <code><![CDATA[$server['port']]]></code>
-      <code>$server[substr($key, 8)]</code>
       <code>$url</code>
       <code>$url</code>
-      <code>$user</code>
-      <code>$user</code>
-      <code>$val</code>
       <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType>
@@ -307,9 +291,6 @@
     <PossiblyInvalidArrayOffset>
       <code><![CDATA[$_COOKIE[$this->getCookieName($cookieName)]]]></code>
     </PossiblyInvalidArrayOffset>
-    <RiskyCast>
-      <code><![CDATA[$server['port']]]></code>
-    </RiskyCast>
     <TypeDoesNotContainType>
       <code>md5($verboseToLower) === $serverToLower</code>
     </TypeDoesNotContainType>
@@ -5943,11 +5924,9 @@
     <MixedArgument>
       <code>$a</code>
       <code>$b</code>
-      <code>$password</code>
       <code><![CDATA[$tableData[$sortBy] ?? '']]></code>
       <code><![CDATA[$this->versionComment]]></code>
       <code><![CDATA[$this->versionString]]></code>
-      <code>$user</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[uksort($eachTables, 'strnatcasecmp')]]></code>
@@ -11866,9 +11845,6 @@
       <code>$output</code>
       <code><![CDATA[array{'File'?: string, 'Position'?: string}]]></code>
     </MixedReturnTypeCoercion>
-    <PossiblyNullArgument>
-      <code>$host</code>
-    </PossiblyNullArgument>
   </file>
   <file src="libraries/classes/Replication/ReplicationGui.php">
     <InvalidArrayOffset>
@@ -14142,7 +14118,6 @@
       <code><![CDATA[$gdNfo['GD Version']]]></code>
     </MixedArgument>
     <MixedInferredReturnType>
-      <code>mixed[]</code>
       <code>mixed[]</code>
       <code>mixed[]</code>
       <code>mixed[]</code>

--- a/test/classes/Config/Settings/ServerTest.php
+++ b/test/classes/Config/Settings/ServerTest.php
@@ -300,8 +300,8 @@ class ServerTest extends TestCase
         yield 'valid value with type coercion' => [1234, '1234'];
     }
 
-    /** @dataProvider valuesForSocketProvider */
-    public function testControlSocket(mixed $actual, string $expected): void
+    /** @dataProvider valuesForControlSocketProvider */
+    public function testControlSocket(mixed $actual, string|null $expected): void
     {
         $server = new Server(['control_socket' => $actual]);
         $serverArray = $server->asArray();
@@ -310,14 +310,32 @@ class ServerTest extends TestCase
         $this->assertSame($expected, $serverArray['control_socket']);
     }
 
-    /** @dataProvider booleanWithDefaultFalseProvider */
-    public function testControlSsl(mixed $actual, bool $expected): void
+    /** @return iterable<string, array{mixed, string|null}> */
+    public static function valuesForControlSocketProvider(): iterable
+    {
+        yield 'null value' => [null, null];
+        yield 'valid value' => ['test', 'test'];
+        yield 'valid value 2' => ['', ''];
+        yield 'valid value with type coercion' => [1234, '1234'];
+    }
+
+    /** @dataProvider valuesForControlSslProvider */
+    public function testControlSsl(mixed $actual, bool|null $expected): void
     {
         $server = new Server(['control_ssl' => $actual]);
         $serverArray = $server->asArray();
         $this->assertSame($expected, $server->controlSsl);
         $this->assertArrayHasKey('control_ssl', $serverArray);
         $this->assertSame($expected, $serverArray['control_ssl']);
+    }
+
+    /** @return iterable<string, array{mixed, bool|null}> */
+    public static function valuesForControlSslProvider(): iterable
+    {
+        yield 'null value' => [null, null];
+        yield 'valid value' => [false, false];
+        yield 'valid value 2' => [true, true];
+        yield 'valid value with type coercion' => [1, true];
     }
 
     /** @dataProvider valuesForSslOptionsProvider */
@@ -370,8 +388,8 @@ class ServerTest extends TestCase
         $this->assertSame($expected, $serverArray['control_ssl_ciphers']);
     }
 
-    /** @dataProvider booleanWithDefaultTrueProvider */
-    public function testControlSslVerify(mixed $actual, bool $expected): void
+    /** @dataProvider valuesForControlSslVerifyProvider */
+    public function testControlSslVerify(mixed $actual, bool|null $expected): void
     {
         $server = new Server(['control_ssl_verify' => $actual]);
         $serverArray = $server->asArray();
@@ -380,8 +398,17 @@ class ServerTest extends TestCase
         $this->assertSame($expected, $serverArray['control_ssl_verify']);
     }
 
-    /** @dataProvider booleanWithDefaultFalseProvider */
-    public function testControlCompress(mixed $actual, bool $expected): void
+    /** @return iterable<string, array{mixed, bool|null}> */
+    public static function valuesForControlSslVerifyProvider(): iterable
+    {
+        yield 'null value' => [null, null];
+        yield 'valid value' => [true, true];
+        yield 'valid value 2' => [false, false];
+        yield 'valid value with type coercion' => [0, false];
+    }
+
+    /** @dataProvider valuesForControlCompressProvider */
+    public function testControlCompress(mixed $actual, bool|null $expected): void
     {
         $server = new Server(['control_compress' => $actual]);
         $serverArray = $server->asArray();
@@ -390,14 +417,32 @@ class ServerTest extends TestCase
         $this->assertSame($expected, $serverArray['control_compress']);
     }
 
-    /** @dataProvider booleanWithDefaultFalseProvider */
-    public function testControlHideConnectionErrors(mixed $actual, bool $expected): void
+    /** @return iterable<string, array{mixed, bool|null}> */
+    public static function valuesForControlCompressProvider(): iterable
+    {
+        yield 'null value' => [null, null];
+        yield 'valid value' => [false, false];
+        yield 'valid value 2' => [true, true];
+        yield 'valid value with type coercion' => [1, true];
+    }
+
+    /** @dataProvider valuesForControlHideConnectionErrorsProvider */
+    public function testControlHideConnectionErrors(mixed $actual, bool|null $expected): void
     {
         $server = new Server(['control_hide_connection_errors' => $actual]);
         $serverArray = $server->asArray();
         $this->assertSame($expected, $server->controlHideConnectionErrors);
         $this->assertArrayHasKey('control_hide_connection_errors', $serverArray);
         $this->assertSame($expected, $serverArray['control_hide_connection_errors']);
+    }
+
+    /** @return iterable<string, array{mixed, bool|null}> */
+    public static function valuesForControlHideConnectionErrorsProvider(): iterable
+    {
+        yield 'null value' => [null, null];
+        yield 'valid value' => [false, false];
+        yield 'valid value 2' => [true, true];
+        yield 'valid value with type coercion' => [1, true];
     }
 
     /** @dataProvider valuesForAuthTypeProvider */

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -6,6 +6,7 @@ namespace PhpMyAdmin\Tests;
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Config\Settings;
+use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\Dbal\Connection;
 
 use function define;
@@ -763,24 +764,22 @@ PHP;
     /**
      * Test for getConnectionParams
      *
-     * @param mixed[]      $serverCfg Server configuration
-     * @param mixed[]|null $server    Server array to test
-     * @param mixed[]      $expected  Expected result
-     * @psalm-param ConnectionType $mode
+     * @param mixed[] $serverCfg Server configuration
+     * @param mixed[] $expected  Expected result
+     * @psalm-param ConnectionType $connectionType
      *
      * @dataProvider connectionParams
      */
-    public function testGetConnectionParams(array $serverCfg, int $mode, array|null $server, array $expected): void
+    public function testGetConnectionParams(array $serverCfg, int $connectionType, array $expected): void
     {
-        $GLOBALS['cfg']['Server'] = $serverCfg;
-        $result = Config::getConnectionParams($mode, $server);
-        $this->assertEquals($expected, $result);
+        $result = Config::getConnectionParams(new Server($serverCfg), $connectionType);
+        $this->assertEquals(new Server($expected), $result);
     }
 
     /**
      * Data provider for getConnectionParams test
      *
-     * @return mixed[]
+     * @return array<array{mixed[], ConnectionType, mixed[]}>
      */
     public static function connectionParams(): array
     {
@@ -815,118 +814,130 @@ PHP;
             [
                 $cfgBasic,
                 Connection::TYPE_USER,
-                null,
                 [
-                    'u',
-                    'pass',
-                    [
-                        'user' => 'u',
-                        'password' => 'pass',
-                        'host' => 'localhost',
-                        'socket' => null,
-                        'port' => 0,
-                        'ssl' => false,
-                        'compress' => false,
-                        'controluser' => 'u2',
-                        'controlpass' => 'p2',
-                        'hide_connection_errors' => false,
-                    ],
+                    'user' => 'u',
+                    'password' => 'pass',
+                    'host' => 'localhost',
+                    'socket' => null,
+                    'port' => 0,
+                    'ssl' => false,
+                    'compress' => false,
+                    'controluser' => 'u2',
+                    'controlpass' => 'p2',
+                    'hide_connection_errors' => false,
                 ],
             ],
             [
                 $cfgBasic,
                 Connection::TYPE_CONTROL,
-                null,
                 [
-                    'u2',
-                    'p2',
-                    [
-                        'host' => 'localhost',
-                        'socket' => null,
-                        'port' => 0,
-                        'ssl' => false,
-                        'compress' => false,
-                        'hide_connection_errors' => false,
-                    ],
+                    'user' => 'u2',
+                    'password' => 'p2',
+                    'host' => 'localhost',
+                    'socket' => null,
+                    'port' => 0,
+                    'ssl' => false,
+                    'compress' => false,
+                    'hide_connection_errors' => false,
                 ],
             ],
             [
                 $cfgSsl,
                 Connection::TYPE_USER,
-                null,
                 [
-                    'u',
-                    'pass',
-                    [
-                        'user' => 'u',
-                        'password' => 'pass',
-                        'host' => 'localhost',
-                        'socket' => null,
-                        'port' => 0,
-                        'ssl' => true,
-                        'compress' => false,
-                        'controluser' => 'u2',
-                        'controlpass' => 'p2',
-                        'hide_connection_errors' => false,
-                    ],
+                    'user' => 'u',
+                    'password' => 'pass',
+                    'host' => 'localhost',
+                    'socket' => null,
+                    'port' => 0,
+                    'ssl' => true,
+                    'compress' => false,
+                    'controluser' => 'u2',
+                    'controlpass' => 'p2',
+                    'hide_connection_errors' => false,
                 ],
             ],
             [
                 $cfgSsl,
                 Connection::TYPE_CONTROL,
-                null,
                 [
-                    'u2',
-                    'p2',
-                    [
-                        'host' => 'localhost',
-                        'socket' => null,
-                        'port' => 0,
-                        'ssl' => true,
-                        'compress' => false,
-                        'hide_connection_errors' => false,
-                    ],
+                    'user' => 'u2',
+                    'password' => 'p2',
+                    'host' => 'localhost',
+                    'socket' => null,
+                    'port' => 0,
+                    'ssl' => true,
+                    'compress' => false,
+                    'hide_connection_errors' => false,
                 ],
             ],
             [
                 $cfgControlSsl,
                 Connection::TYPE_USER,
-                null,
                 [
-                    'u',
-                    'pass',
-                    [
-                        'user' => 'u',
-                        'password' => 'pass',
-                        'host' => 'localhost',
-                        'socket' => null,
-                        'port' => 0,
-                        'ssl' => false,
-                        'compress' => false,
-                        'controluser' => 'u2',
-                        'controlpass' => 'p2',
-                        'control_ssl' => true,
-                        'hide_connection_errors' => false,
-                    ],
+                    'user' => 'u',
+                    'password' => 'pass',
+                    'host' => 'localhost',
+                    'socket' => null,
+                    'port' => 0,
+                    'ssl' => false,
+                    'compress' => false,
+                    'controluser' => 'u2',
+                    'controlpass' => 'p2',
+                    'control_ssl' => true,
+                    'hide_connection_errors' => false,
                 ],
             ],
             [
                 $cfgControlSsl,
                 Connection::TYPE_CONTROL,
-                null,
                 [
-                    'u2',
-                    'p2',
-                    [
-                        'host' => 'localhost',
-                        'socket' => null,
-                        'port' => 0,
-                        'ssl' => true,
-                        'compress' => false,
-                        'hide_connection_errors' => false,
-                    ],
+                    'user' => 'u2',
+                    'password' => 'p2',
+                    'host' => 'localhost',
+                    'socket' => null,
+                    'port' => 0,
+                    'ssl' => true,
+                    'compress' => false,
+                    'hide_connection_errors' => false,
                 ],
             ],
+        ];
+    }
+
+    /**
+     * @psalm-param ConnectionType $connectionType
+     *
+     * @dataProvider connectionParamsWhenConnectionIsUserOrAuxiliaryProvider
+     */
+    public function testGetConnectionParamsWhenConnectionIsUserOrAuxiliary(
+        int $connectionType,
+        string $host,
+        string $port,
+        string $expectedHost,
+        string $expectedPort,
+    ): void {
+        $actual = Config::getConnectionParams(new Server(['host' => $host, 'port' => $port]), $connectionType);
+        $expected = new Server(['host' => $expectedHost, 'port' => $expectedPort]);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /** @psalm-return iterable<string, array{ConnectionType, string, string, string, string}> */
+    public static function connectionParamsWhenConnectionIsUserOrAuxiliaryProvider(): iterable
+    {
+        yield 'user with only port empty' => [Connection::TYPE_USER, 'test.host', '', 'test.host', '0'];
+        yield 'user with only host empty' => [Connection::TYPE_USER, '', '12345', 'localhost', '12345'];
+        yield 'user with host and port empty' => [Connection::TYPE_USER, '', '', 'localhost', '0'];
+        yield 'user with host and port defined' => [Connection::TYPE_USER, 'test.host', '12345', 'test.host', '12345'];
+        yield 'aux with only port empty' => [Connection::TYPE_AUXILIARY, 'test.host', '', 'test.host', '0'];
+        yield 'aux with only host empty' => [Connection::TYPE_AUXILIARY, '', '12345', 'localhost', '12345'];
+        yield 'aux with host and port empty' => [Connection::TYPE_AUXILIARY, '', '', 'localhost', '0'];
+        yield 'aux with host and port defined' => [
+            Connection::TYPE_AUXILIARY,
+            'test.host',
+            '12345',
+            'test.host',
+            '12345',
         ];
     }
 }

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests;
 
+use PhpMyAdmin\Config\Settings\Server;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Connection;
@@ -117,7 +118,6 @@ class DatabaseInterfaceTest extends AbstractTestCase
     public function testPostConnectShouldNotCallSetVersionIfNoVersion(): void
     {
         $GLOBALS['lang'] = 'en';
-        $GLOBALS['cfg']['Server']['SessionTimeZone'] = '';
         LanguageManager::getInstance()->availableLanguages();
 
         $mock = $this->getMockBuilder(DatabaseInterface::class)
@@ -131,7 +131,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
 
         $mock->expects($this->never())->method('setVersion');
 
-        $mock->postConnect();
+        $mock->postConnect(new Server(['SessionTimeZone' => '']));
     }
 
     /**
@@ -141,7 +141,6 @@ class DatabaseInterfaceTest extends AbstractTestCase
     public function testPostConnectShouldCallSetVersionOnce(): void
     {
         $GLOBALS['lang'] = 'en';
-        $GLOBALS['cfg']['Server']['SessionTimeZone'] = '';
         $versionQueryResult = [
             '@@version' => '10.20.7-MariaDB-1:10.9.3+maria~ubu2204',
             '@@version_comment' => 'mariadb.org binary distribution',
@@ -159,7 +158,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
 
         $mock->expects($this->once())->method('setVersion')->with($versionQueryResult);
 
-        $mock->postConnect();
+        $mock->postConnect(new Server(['SessionTimeZone' => '']));
     }
 
     /**
@@ -181,7 +180,6 @@ class DatabaseInterfaceTest extends AbstractTestCase
         bool $isPercona,
     ): void {
         $GLOBALS['lang'] = 'en';
-        $GLOBALS['cfg']['Server']['SessionTimeZone'] = '';
         LanguageManager::getInstance()->availableLanguages();
 
         $mock = $this->getMockBuilder(DatabaseInterface::class)
@@ -193,7 +191,7 @@ class DatabaseInterfaceTest extends AbstractTestCase
             ->method('fetchSingleRow')
             ->will($this->returnValue($version));
 
-        $mock->postConnect();
+        $mock->postConnect(new Server(['SessionTimeZone' => '']));
 
         $this->assertEquals($mock->getVersion(), $versionInt);
         $this->assertEquals($mock->isMariaDB(), $isMariaDb);

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -89,7 +89,7 @@ class DbiDummy implements DbiExtension
         $this->init();
     }
 
-    public function connect(string $user, string $password, Server $server): Connection|null
+    public function connect(Server $server): Connection|null
     {
         return new Connection(new stdClass());
     }


### PR DESCRIPTION
- Add null as default for Server control_ properties
- Removes the $server array param and use the Server class instead.
- Uses the user and pass Server properties instead of returning an array.
- Add Server class as a param for DatabaseInterface::postConnect()