### PR TITLE
Fix #18314 - dragged row in index form

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,7 @@ phpMyAdmin - ChangeLog
 - issue #18212 Fix Query Builder doesn't replace a table name with it's alias in the `WHERE` block
 - issue        Keep the criteria box collapsed by the user when un-checking the criteria checkbox
 - issue        Fix colspan for actions column on database table list
+- issue #18314 Fix dragged row in index form
 
 5.2.1 (2023-02-07)
 - issue #17522 Fix case where the routes cache file is invalid

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -3518,13 +3518,27 @@ Functions.showIndexEditDialog = function ($outer) {
     Indexes.checkIndexType();
     Functions.checkIndexName('index_frm');
     var $indexColumns = $('#index_columns');
-    $indexColumns.find('td').each(function () {
-        $(this).css('width', $(this).width() + 'px');
-    });
     $indexColumns.find('tbody').sortable({
         axis: 'y',
         containment: $indexColumns.find('tbody'),
-        tolerance: 'pointer'
+        tolerance: 'pointer',
+        forcePlaceholderSize: true,
+        // Add custom dragged row
+        helper: function (event, tr) {
+            var $originalCells = tr.children();
+            var $helper = tr.clone();
+            $helper.children().each(function (index) {
+                // Set cell width in dragged row
+                $(this).width($originalCells.eq(index).outerWidth());
+                var $childrenSelect = $originalCells.eq(index).children('select');
+                if ($childrenSelect.length) {
+                    var selectedIndex = $childrenSelect.prop('selectedIndex');
+                    // Set correct select value in dragged row
+                    $(this).children('select').prop('selectedIndex', parseInt(selectedIndex));
+                }
+            });
+            return $helper;
+        }
     });
     Functions.showHints($outer);
     // Add a slider for selecting how many columns to add to the index

--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -3534,7 +3534,7 @@ Functions.showIndexEditDialog = function ($outer) {
                 if ($childrenSelect.length) {
                     var selectedIndex = $childrenSelect.prop('selectedIndex');
                     // Set correct select value in dragged row
-                    $(this).children('select').prop('selectedIndex', parseInt(selectedIndex));
+                    $(this).children('select').prop('selectedIndex', selectedIndex);
                 }
             });
             return $helper;


### PR DESCRIPTION
### Description

This PR fixes a issue with the width of the dragged row in index form. Before this the width was very small. Now the width of the dragged row will be the same as the original.
The problem was in the lines below. It doesn’t work here. 
```js
$indexColumns.find('td').each(function () {
    $(this).css('width', $(this).width() + 'px');
});
```

Before

https://user-images.githubusercontent.com/36403726/236654450-01f783e9-4040-4f9f-8202-39c963afe622.mp4

After

https://user-images.githubusercontent.com/36403726/236654476-a61e2271-cdbe-4fac-a70c-120b32724554.mp4

Fixes #18314

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
