### PR TITLE
Replace superglobals with serverrequest in GetFieldController

### DIFF
--- a/libraries/classes/Controllers/Table/GetFieldController.php
+++ b/libraries/classes/Controllers/Table/GetFieldController.php
@@ -54,10 +54,11 @@ class GetFieldController extends AbstractController
             Generator::mysqlDie(__('Invalid table name'));
         }
 
+        $whereClause = (string) $request->getQueryParam('where_clause', '');
+        $whereClauseSign = (string) $request->getQueryParam('where_clause_sign', '');
         if (
-            ! isset($_GET['where_clause'])
-            || ! isset($_GET['where_clause_sign'])
-            || ! Core::checkSqlQuerySignature($_GET['where_clause'], $_GET['where_clause_sign'])
+            $whereClause === '' || $whereClauseSign === ''
+            || ! Core::checkSqlQuerySignature($whereClause, $whereClauseSign)
         ) {
             $this->response->setRequestStatus(false);
             /* l10n: In case a SQL query did not pass a security check  */
@@ -66,10 +67,11 @@ class GetFieldController extends AbstractController
             return;
         }
 
+        $transformKey = (string) $request->getQueryParam('transform_key', '');
         /* Grab data */
-        $sql = 'SELECT ' . Util::backquote($_GET['transform_key'])
+        $sql = 'SELECT ' . Util::backquote($transformKey)
             . ' FROM ' . Util::backquote($GLOBALS['table'])
-            . ' WHERE ' . $_GET['where_clause'] . ';';
+            . ' WHERE ' . $whereClause . ';';
         $result = $this->dbi->fetchValue($sql);
 
         /* Check return code */
@@ -86,7 +88,7 @@ class GetFieldController extends AbstractController
         ini_set('url_rewriter.tags', '');
 
         Core::downloadHeader(
-            $GLOBALS['table'] . '-' . $_GET['transform_key'] . '.bin',
+            $GLOBALS['table'] . '-' . $transformKey . '.bin',
             Mime::detect($result),
             mb_strlen($result, '8bit'),
         );

--- a/test/classes/Controllers/Table/GetFieldControllerTest.php
+++ b/test/classes/Controllers/Table/GetFieldControllerTest.php
@@ -24,10 +24,14 @@ class GetFieldControllerTest extends AbstractTestCase
     {
         $GLOBALS['db'] = 'test_db';
         $GLOBALS['table'] = 'table_with_blob';
-        $_GET['transform_key'] = 'file';
-        $_GET['sql_query'] = 'SELECT * FROM `test_db`.`table_with_blob`';
-        $_GET['where_clause'] = '`table_with_blob`.`id` = 1';
-        $_GET['where_clause_sign'] = Core::signSqlQuery('`table_with_blob`.`id` = 1');
+
+        $request = $this->createStub(ServerRequest::class);
+        $request->method('getQueryParam')->willReturnMap([
+            ['transform_key', '', 'file' ],
+            ['sql_query', '', 'SELECT * FROM `test_db`.`table_with_blob`'],
+            ['where_clause', '', '`table_with_blob`.`id` = 1'],
+            ['where_clause_sign', '', Core::signSqlQuery('`table_with_blob`.`id` = 1')],
+        ]);
 
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addSelectDb('test_db');
@@ -49,7 +53,7 @@ class GetFieldControllerTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface($dummyDbi);
         $GLOBALS['dbi'] = $dbi;
 
-        (new GetFieldController(new ResponseRenderer(), new Template(), $dbi))($this->createStub(ServerRequest::class));
+        (new GetFieldController(new ResponseRenderer(), new Template(), $dbi))($request);
         $this->expectOutputString('46494c45');
     }
 }


### PR DESCRIPTION
### Description
Ref https://github.com/phpmyadmin/phpmyadmin/issues/17769

Replace superglobals with ServerRequest in 

      libraries/classes/Controllers/Table/GetFieldController.php

