### PR TITLE
Remove session cache in relation

### DIFF
--- a/libraries/classes/UserPreferences.php
+++ b/libraries/classes/UserPreferences.php
@@ -169,10 +169,7 @@ class UserPreferences
                 /**
                  * When phpMyAdmin cached the configuration storage parameters, it checked if the database can be
                  * accessed, so if it could not be accessed anymore, then the cache must be cleared as it's out of date.
-                 *
-                 * @psalm-suppress MixedArrayAssignment
                  */
-                $_SESSION['relation'][$GLOBALS['server']] = [];
                 $message->addMessage(Message::error(htmlspecialchars(
                     __('The phpMyAdmin configuration storage database could not be accessed.'),
                 )), '<br><br>');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1527,7 +1527,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset mixed on mixed\\.$#"
-			count: 3
+			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
@@ -26751,11 +26751,6 @@ parameters:
 			path: libraries/classes/UserPreferences.php
 
 		-
-			message: "#^Cannot access offset mixed on mixed\\.$#"
-			count: 1
-			path: libraries/classes/UserPreferences.php
-
-		-
 			message: "#^Cannot access offset non\\-falsy\\-string on mixed\\.$#"
 			count: 4
 			path: libraries/classes/UserPreferences.php
@@ -28001,6 +27996,11 @@ parameters:
 			path: test/classes/Config/SettingsTest.php
 
 		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) with arguments 'relation', array\\{version\\: string, user\\: string\\|null, db\\: string\\|null, bookmark\\: string\\|null, central_columns\\: string\\|null, column_info\\: string\\|null, designer_settings\\: string\\|null, export_templates\\: string\\|null, \\.\\.\\.\\} and 'The cache is…' will always evaluate to true\\.$#"
+			count: 3
+			path: test/classes/ConfigStorage/RelationTest.php
+
+		-
 			message: "#^Cannot access offset 'DisableIS' on mixed\\.$#"
 			count: 2
 			path: test/classes/ConfigStorage/RelationTest.php
@@ -28118,16 +28118,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'users' on mixed\\.$#"
 			count: 15
-			path: test/classes/ConfigStorage/RelationTest.php
-
-		-
-			message: "#^Cannot access offset mixed on mixed\\.$#"
-			count: 3
-			path: test/classes/ConfigStorage/RelationTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$key of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayHasKey\\(\\) expects int\\|string, mixed given\\.$#"
-			count: 6
 			path: test/classes/ConfigStorage/RelationTest.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -698,8 +698,6 @@
       <code><![CDATA[uksort($foreign, 'strnatcasecmp')]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
-      <code><![CDATA[$_SESSION['relation'][$GLOBALS['server']]]]></code>
-      <code><![CDATA[$_SESSION['relation'][$GLOBALS['server']]]]></code>
       <code><![CDATA[$column['COLUMN_NAME']]]></code>
       <code><![CDATA[$column['DATA_TYPE']]]></code>
       <code><![CDATA[$columns['table_name']]]></code>
@@ -13185,11 +13183,6 @@
     <DocblockTypeContradiction>
       <code>assertSame</code>
     </DocblockTypeContradiction>
-    <InvalidScalarArgument>
-      <code>$_SESSION</code>
-      <code>$_SESSION</code>
-      <code>$_SESSION</code>
-    </InvalidScalarArgument>
     <PossiblyUnusedMethod>
       <code>providerForTestRenameTable</code>
     </PossiblyUnusedMethod>

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -85,7 +85,7 @@ abstract class AbstractTestCase extends TestCase
         $this->setGlobalConfig();
         Cache::purge();
 
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
     }
 
     protected function loadContainerBuilder(): void

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -236,21 +236,16 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', []);
         $dummyDbi->addSelectDb('db_pma');
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $relation->fixPmaTables('db_pma', false);
-
-        $this->assertArrayHasKey($GLOBALS['server'], $_SESSION['relation'], 'The cache is expected to be filled');
-        /** @psalm-suppress EmptyArrayAccess */
-        $this->assertIsArray($_SESSION['relation'][$GLOBALS['server']]);
 
         $relationParameters = RelationParameters::fromArray([
             'db' => 'db_pma',
             'userconfigwork' => true,
             'userconfig' => 'pma__userconfig',
         ]);
-        $this->assertSame($relationParameters->toArray(), $_SESSION['relation'][$GLOBALS['server']]);
+        $this->assertSame($relationParameters->toArray(), $relation->getRelationParameters()->toArray());
 
         $dummyDbi->assertAllQueriesConsumed();
         $dummyDbi->assertAllSelectsConsumed();
@@ -511,14 +506,10 @@ class RelationTest extends AbstractTestCase
 
         $this->assertSame('', $GLOBALS['cfg']['Server']['pmadb']);
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $relation->fixPmaTables('db_pma', true);
         $this->assertArrayNotHasKey('message', $GLOBALS);
-        $this->assertArrayHasKey($GLOBALS['server'], $_SESSION['relation'], 'The cache is expected to be filled');
-        /** @psalm-suppress EmptyArrayAccess */
-        $this->assertIsArray($_SESSION['relation'][$GLOBALS['server']]);
         $this->assertSame('db_pma', $GLOBALS['cfg']['Server']['pmadb']);
 
         $relationParameters = RelationParameters::fromArray([
@@ -526,7 +517,7 @@ class RelationTest extends AbstractTestCase
             'userconfigwork' => true,
             'userconfig' => 'pma__userconfig',
         ]);
-        $this->assertSame($relationParameters->toArray(), $_SESSION['relation'][$GLOBALS['server']]);
+        $this->assertSame($relationParameters->toArray(), $relation->getRelationParameters()->toArray());
 
         $dummyDbi->assertAllQueriesConsumed();
         $dummyDbi->assertAllSelectsConsumed();
@@ -795,16 +786,12 @@ class RelationTest extends AbstractTestCase
 
         $this->assertSame('db_pma', $GLOBALS['cfg']['Server']['pmadb']);
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $dummyDbi->addSelectDb('db_pma');
         $dummyDbi->addSelectDb('db_pma');
         $relation->fixPmaTables('db_pma', true);
         $this->assertArrayNotHasKey('message', $GLOBALS);
-        $this->assertArrayHasKey($GLOBALS['server'], $_SESSION['relation'], 'The cache is expected to be filled');
-        /** @psalm-suppress EmptyArrayAccess */
-        $this->assertIsArray($_SESSION['relation'][$GLOBALS['server']]);
         $this->assertSame('db_pma', $GLOBALS['cfg']['Server']['pmadb']);
 
         $relationParameters = RelationParameters::fromArray([
@@ -812,7 +799,7 @@ class RelationTest extends AbstractTestCase
             'userconfigwork' => true,
             'userconfig' => 'pma__userconfig',
         ]);
-        $this->assertSame($relationParameters->toArray(), $_SESSION['relation'][$GLOBALS['server']]);
+        $this->assertSame($relationParameters->toArray(), $relation->getRelationParameters()->toArray());
 
         $dummyDbi->assertAllQueriesConsumed();
         $dummyDbi->assertAllSelectsConsumed();
@@ -874,8 +861,7 @@ class RelationTest extends AbstractTestCase
 
         $this->assertSame('', $GLOBALS['cfg']['Server']['pmadb']);
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $relation->fixPmaTables('db_pma', true);
 
@@ -883,7 +869,7 @@ class RelationTest extends AbstractTestCase
         $this->assertSame('MYSQL_ERROR', $GLOBALS['message']);
         $this->assertSame('', $GLOBALS['cfg']['Server']['pmadb']);
 
-        $this->assertSame([], $_SESSION['relation']);
+        $this->assertNull((new ReflectionProperty(Relation::class, 'cache'))->getValue());
 
         $dummyDbi->assertAllQueriesConsumed();
         $dummyDbi->assertAllErrorCodesConsumed();
@@ -1436,19 +1422,14 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_phpmyadmin'],
         );
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
 
-        $this->assertArrayHasKey($GLOBALS['server'], $_SESSION['relation'], 'The cache is expected to be filled');
-        /** @psalm-suppress EmptyArrayAccess */
-        $this->assertIsArray($_SESSION['relation'][$GLOBALS['server']]);
-
         // Should all be false for server = 0
         $relationParameters = RelationParameters::fromArray([]);
-        $this->assertSame($relationParameters->toArray(), $_SESSION['relation'][$GLOBALS['server']]);
+        $this->assertSame($relationParameters->toArray(), $relation->getRelationParameters()->toArray());
 
         $this->assertEquals([
             'userconfig' => 'pma__userconfig',
@@ -1502,17 +1483,12 @@ class RelationTest extends AbstractTestCase
 
         $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', [], ['NULL']);
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $dummyDbi->addSelectDb('phpmyadmin');
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
         $dummyDbi->assertAllSelectsConsumed();
-
-        $this->assertArrayHasKey($GLOBALS['server'], $_SESSION['relation'], 'The cache is expected to be filled');
-        /** @psalm-suppress EmptyArrayAccess */
-        $this->assertIsArray($_SESSION['relation'][$GLOBALS['server']]);
 
         // Should all be false for server = 0
         $relationParameters = RelationParameters::fromArray([
@@ -1520,7 +1496,7 @@ class RelationTest extends AbstractTestCase
             'userconfigwork' => true,
             'userconfig' => 'pma__userconfig',
         ]);
-        $this->assertSame($relationParameters->toArray(), $_SESSION['relation'][$GLOBALS['server']]);
+        $this->assertSame($relationParameters->toArray(), $relation->getRelationParameters()->toArray());
 
         $this->assertSame([
             'user' => '',
@@ -1594,24 +1570,19 @@ class RelationTest extends AbstractTestCase
 
         $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', false);
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $dummyDbi->addSelectDb('phpmyadmin');
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
         $dummyDbi->assertAllSelectsConsumed();
 
-        $this->assertArrayHasKey($GLOBALS['server'], $_SESSION['relation'], 'The cache is expected to be filled');
-        /** @psalm-suppress EmptyArrayAccess */
-        $this->assertIsArray($_SESSION['relation'][$GLOBALS['server']]);
-
         $relationParameters = RelationParameters::fromArray([
             'db' => 'phpmyadmin',
             'userconfigwork' => false,
             'userconfig' => 'pma__userconfig',
         ]);
-        $this->assertSame($relationParameters->toArray(), $_SESSION['relation'][$GLOBALS['server']]);
+        $this->assertSame($relationParameters->toArray(), $relation->getRelationParameters()->toArray());
 
         $this->assertSame([
             'user' => '',
@@ -1687,15 +1658,14 @@ class RelationTest extends AbstractTestCase
 
         $dummyDbi->addSelectDb('PMA-storage');
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
 
         $this->assertArrayHasKey(
             'relation',
-            $_SESSION,
+            $relation->getRelationParameters()->toArray(),
             'The cache is expected to be filled because the custom override'
             . 'was understood (pma__userconfig vs pma__userconfig_custom)',
         );
@@ -1712,9 +1682,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig_custom` LIMIT 0', [], ['NULL']);
 
         $dummyDbi->addSelectDb('PMA-storage');
-        /** @psalm-suppress EmptyArrayAccess */
-        unset($_SESSION['relation'][$GLOBALS['server']]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
         $relationData = $relation->getRelationParameters();
         $dummyDbi->assertAllSelectsConsumed();
 
@@ -1792,15 +1760,14 @@ class RelationTest extends AbstractTestCase
             ['Tables_in_PMA-storage'],
         );
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
 
         $this->assertArrayHasKey(
             'relation',
-            $_SESSION,
+            $relation->getRelationParameters()->toArray(),
             'The cache is expected to be filled because the custom override'
             . 'was understood',
         );
@@ -1820,9 +1787,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $dummyDbi->addSelectDb('PMA-storage');
-        /** @psalm-suppress EmptyArrayAccess */
-        unset($_SESSION['relation'][$GLOBALS['server']]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
         $relationData = $relation->getRelationParameters();
         $dummyDbi->assertAllSelectsConsumed();
 
@@ -1912,9 +1877,8 @@ class RelationTest extends AbstractTestCase
 
         $dummyDbi->addResult('SELECT NULL FROM `pma__favorite_custom` LIMIT 0', [], ['NULL']);
 
-        $_SESSION['relation'] = [];
         $_SESSION['tmpval'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
         (new ReflectionProperty(RecentFavoriteTable::class, 'instances'))->setValue(null, []);
 
         $relation = new Relation($dbi);
@@ -1922,7 +1886,7 @@ class RelationTest extends AbstractTestCase
 
         $this->assertArrayHasKey(
             'relation',
-            $_SESSION,
+            $relation->getRelationParameters()->toArray(),
             'The cache is expected to be filled because the custom override'
             . 'was understood',
         );
@@ -1930,8 +1894,6 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->assertAllQueriesConsumed();
         $dummyDbi->assertAllSelectsConsumed();
 
-        /** @psalm-suppress EmptyArrayAccess */
-        unset($_SESSION['relation'][$GLOBALS['server']]);
         $relationData = $relation->getRelationParameters();
         $dummyDbi->assertAllSelectsConsumed();
 
@@ -1997,8 +1959,7 @@ class RelationTest extends AbstractTestCase
         $dbi = $this->createDatabaseInterface();
         $GLOBALS['dbi'] = $dbi;
 
-        $_SESSION['relation'] = [];
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $relation = new Relation($dbi);
 
@@ -2135,10 +2096,7 @@ class RelationTest extends AbstractTestCase
 
         $GLOBALS['server'] = 1;
         $relationParameters = RelationParameters::fromArray($params);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         foreach ($queries as $query) {
             $dummyDbi->addResult($query, true);
@@ -2206,10 +2164,7 @@ class RelationTest extends AbstractTestCase
             'pdf_pages' => 'pdf_pages',
             'table_coords' => 'table`coords',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $dummyDbi->addResult(
             'UPDATE `pma``db`.`table``coords` SET db_name = \'db\\\'1\', table_name = \'table\\\'2\''

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -1749,7 +1749,6 @@ class RelationTest extends AbstractTestCase
 
         $dummyDbi = $this->createDbiDummy();
         $dbi = $this->createDatabaseInterface($dummyDbi);
-        $GLOBALS['dbi'] = $dbi;
 
         $dummyDbi->removeDefaultResults();
         $dummyDbi->addResult(
@@ -1759,12 +1758,26 @@ class RelationTest extends AbstractTestCase
             ],
             ['Tables_in_PMA-storage'],
         );
+        $dummyDbi->addResult(
+            'SHOW TABLES FROM `PMA-storage`',
+            [
+                ['pma__tracking'],
+            ],
+            ['Tables_in_PMA-storage'],
+        );
+
+        $dummyDbi->addSelectDb('PMA-storage');
 
         (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
 
+        /**
+         * TODO: Warning! This test doesn't actually test anything.
+         * The method above does't initialize Relation param cache.
+         * A proper test is needed to verify that the user disabled features result in disabled Relation cache.
+         */
         $this->assertArrayHasKey(
             'relation',
             $relation->getRelationParameters()->toArray(),

--- a/test/classes/Controllers/Console/Bookmark/AddControllerTest.php
+++ b/test/classes/Controllers/Console/Bookmark/AddControllerTest.php
@@ -37,7 +37,7 @@ class AddControllerTest extends AbstractTestCase
     public function testWithoutRelationParameters(): void
     {
         $GLOBALS['cfg']['Server']['user'] = 'user';
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
         $dbi = $this->createDatabaseInterface();
         $GLOBALS['dbi'] = $dbi;
         $response = new ResponseRenderer();
@@ -63,10 +63,7 @@ class AddControllerTest extends AbstractTestCase
             'bookmarkwork' => true,
             'bookmark' => 'bookmark',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $dbiDummy = $this->createDbiDummy();
         $dbiDummy->addResult(

--- a/test/classes/Controllers/Export/Template/CreateControllerTest.php
+++ b/test/classes/Controllers/Export/Template/CreateControllerTest.php
@@ -44,10 +44,7 @@ class CreateControllerTest extends AbstractTestCase
             'db' => 'db',
             'export_templates' => 'table',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $GLOBALS['cfg']['Server']['user'] = 'user';
 

--- a/test/classes/Controllers/Export/Template/LoadControllerTest.php
+++ b/test/classes/Controllers/Export/Template/LoadControllerTest.php
@@ -43,10 +43,7 @@ class LoadControllerTest extends AbstractTestCase
             'db' => 'db',
             'export_templates' => 'table',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $GLOBALS['cfg']['Server']['user'] = 'user';
 

--- a/test/classes/Controllers/Table/RecentFavoriteControllerTest.php
+++ b/test/classes/Controllers/Table/RecentFavoriteControllerTest.php
@@ -44,7 +44,7 @@ class RecentFavoriteControllerTest extends AbstractTestCase
         $GLOBALS['text_dir'] = 'ltr';
         $_REQUEST['db'] = 'test_db';
         $_REQUEST['table'] = 'test_table';
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $_SESSION['tmpval'] = [];
         $_SESSION['tmpval']['recentTables'][2] = [['db' => 'test_db', 'table' => 'test_table']];
@@ -75,7 +75,7 @@ class RecentFavoriteControllerTest extends AbstractTestCase
         $GLOBALS['text_dir'] = 'ltr';
         $_REQUEST['db'] = 'invalid_db';
         $_REQUEST['table'] = 'invalid_table';
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         $_SESSION['tmpval'] = [];
         $_SESSION['tmpval']['recentTables'][2] = [['db' => 'invalid_db', 'table' => 'invalid_table']];

--- a/test/classes/Controllers/Table/ReplaceControllerTest.php
+++ b/test/classes/Controllers/Table/ReplaceControllerTest.php
@@ -65,10 +65,7 @@ class ReplaceControllerTest extends AbstractTestCase
             'uiprefswork' => true,
             'table_uiprefs' => 'table_uiprefs',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
     }
 
     public function testReplace(): void

--- a/test/classes/Controllers/Table/StructureControllerTest.php
+++ b/test/classes/Controllers/Table/StructureControllerTest.php
@@ -47,7 +47,7 @@ class StructureControllerTest extends AbstractTestCase
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['cfg']['ShowStats'] = false;
         $GLOBALS['cfg']['ShowPropertyComments'] = false;
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
         (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);
 
         $this->dummyDbi->addSelectDb('test_db');

--- a/test/classes/Database/CentralColumnsTest.php
+++ b/test/classes/Database/CentralColumnsTest.php
@@ -118,10 +118,7 @@ class CentralColumnsTest extends AbstractTestCase
             'relation' => 'relation',
             'central_columns' => 'pma_central_columns',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         // mock DBI
         $dbi = $this->getMockBuilder(DatabaseInterface::class)

--- a/test/classes/Database/Designer/CommonTest.php
+++ b/test/classes/Database/Designer/CommonTest.php
@@ -12,7 +12,6 @@ use PhpMyAdmin\Dbal\Connection;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
-use PhpMyAdmin\Version;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionProperty;
 
@@ -38,17 +37,13 @@ class CommonTest extends AbstractTestCase
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
         $GLOBALS['dbi'] = $this->dbi;
         $GLOBALS['server'] = 1;
-        $_SESSION = [
-            'relation' => [
-                '1' => [
-                    'version' => Version::VERSION,
-                    'db' => 'pmadb',
-                    'pdf_pages' => 'pdf_pages',
-                    'pdfwork' => true,
-                    'table_coords' => 'table_coords',
-                ],
-            ],
-        ];
+        $relationParameters = RelationParameters::fromArray([
+            'db' => 'pmadb',
+            'pdf_pages' => 'pdf_pages',
+            'pdfwork' => true,
+            'table_coords' => 'table_coords',
+        ]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
     }
 
     /**
@@ -355,10 +350,7 @@ class CommonTest extends AbstractTestCase
             'db' => 'pmadb',
             'relation' => 'rel db',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
@@ -381,10 +373,7 @@ class CommonTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'rel db',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
@@ -426,10 +415,7 @@ class CommonTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'rel db',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);
@@ -491,10 +477,7 @@ class CommonTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'rel db',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->dummyDbi = $this->createDbiDummy();
         $this->dbi = $this->createDatabaseInterface($this->dummyDbi);

--- a/test/classes/Database/DesignerTest.php
+++ b/test/classes/Database/DesignerTest.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Database;
 
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\Database\Designer;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
-use PhpMyAdmin\Version;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
+use ReflectionProperty;
 
 #[CoversClass(Designer::class)]
 class DesignerTest extends AbstractTestCase
@@ -35,18 +36,14 @@ class DesignerTest extends AbstractTestCase
         $GLOBALS['cfg']['Schema']['pdf_orientation'] = 'L';
         $GLOBALS['cfg']['Schema']['pdf_paper'] = 'A4';
 
-        $_SESSION = [
-            'relation' => [
-                1 => [
-                    'version' => Version::VERSION,
-                    'db' => 'pmadb',
-                    'pdf_pages' => 'pdf_pages',
-                    'table_coords' => 'table_coords',
-                    'pdfwork' => true,
-                ],
-            ],
-            ' PMA_token ' => 'token',
-        ];
+        $_SESSION = [' PMA_token ' => 'token'];
+        $relationParameters = RelationParameters::fromArray([
+            'db' => 'pmadb',
+            'pdf_pages' => 'pdf_pages',
+            'table_coords' => 'table_coords',
+            'pdfwork' => true,
+        ]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
     }
 
     /**

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -657,10 +657,7 @@ class ResultsTest extends AbstractTestCase
             'mimework' => true,
             'column_info' => 'column_info',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
         $GLOBALS['cfg']['BrowseMIME'] = true;
 
         // Basic data

--- a/test/classes/Navigation/NavigationTest.php
+++ b/test/classes/Navigation/NavigationTest.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Url;
 use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionProperty;
 
 #[CoversClass(Navigation::class)]
 class NavigationTest extends AbstractTestCase
@@ -40,7 +41,7 @@ class NavigationTest extends AbstractTestCase
             'navwork' => true,
             'navigationhiding' => 'navigationhiding',
         ]);
-        $_SESSION = ['relation' => [$GLOBALS['server'] => $relationParameters->toArray()]];
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->object = new Navigation(
             new Template(),

--- a/test/classes/Navigation/Nodes/NodeDatabaseChildTest.php
+++ b/test/classes/Navigation/Nodes/NodeDatabaseChildTest.php
@@ -44,10 +44,7 @@ class NodeDatabaseChildTest extends AbstractTestCase
             'navwork' => true,
             'navigationhiding' => 'navigationhiding',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
         $this->object = $this->getMockForAbstractClass(
             NodeDatabaseChild::class,
             ['child'],

--- a/test/classes/Plugins/Export/ExportHtmlwordTest.php
+++ b/test/classes/Plugins/Export/ExportHtmlwordTest.php
@@ -429,10 +429,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $result = $this->object->getTableDef('database', '', true, true, true);
 
@@ -501,10 +498,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $result = $this->object->getTableDef('database', '', true, true, true);
 
@@ -543,10 +537,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $result = $this->object->getTableDef('database', '', false, false, false);
 

--- a/test/classes/Plugins/Export/ExportLatexTest.php
+++ b/test/classes/Plugins/Export/ExportLatexTest.php
@@ -81,7 +81,7 @@ class ExportLatexTest extends AbstractTestCase
             'relwork' => true,
             'mimework' => true,
         ]);
-        $_SESSION = ['relation' => [$GLOBALS['server'] => $relationParameters->toArray()]];
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $method = new ReflectionMethod(ExportLatex::class, 'setProperties');
         $properties = $method->invoke($this->object, null);
@@ -597,10 +597,7 @@ class ExportLatexTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         ob_start();
         $this->assertTrue(
@@ -689,10 +686,7 @@ class ExportLatexTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         ob_start();
         $this->assertTrue(
@@ -750,10 +744,7 @@ class ExportLatexTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         ob_start();
         $this->assertTrue(

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -96,7 +96,7 @@ class ExportOdtTest extends AbstractTestCase
             'relwork' => true,
             'mimework' => true,
         ]);
-        $_SESSION = ['relation' => [$GLOBALS['server'] => $relationParameters->toArray()]];
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $method = new ReflectionMethod(ExportOdt::class, 'setProperties');
         $properties = $method->invoke($this->object, null);
@@ -625,10 +625,7 @@ class ExportOdtTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->assertTrue(
             $this->object->getTableDef(
@@ -708,10 +705,7 @@ class ExportOdtTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->assertTrue(
             $this->object->getTableDef(

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -131,7 +131,7 @@ class ExportSqlTest extends AbstractTestCase
             'relwork' => true,
             'mimework' => true,
         ]);
-        $_SESSION = ['relation' => [$GLOBALS['server'] => $relationParameters->toArray()]];
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $method = new ReflectionMethod(ExportSql::class, 'setProperties');
         $properties = $method->invoke($this->object, null);
@@ -879,10 +879,7 @@ SQL;
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
         $GLOBALS['sql_include_comments'] = true;
 
         $dbi = $this->getMockBuilder(DatabaseInterface::class)

--- a/test/classes/Plugins/Export/ExportTexytextTest.php
+++ b/test/classes/Plugins/Export/ExportTexytextTest.php
@@ -305,10 +305,7 @@ class ExportTexytextTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $result = $this->object->getTableDef('db', 'table', true, true, true);
 

--- a/test/classes/Server/PrivilegesTest.php
+++ b/test/classes/Server/PrivilegesTest.php
@@ -1139,10 +1139,7 @@ class PrivilegesTest extends AbstractTestCase
             'usergroups' => 'usergroups',
             'menuswork' => true,
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addResult(
@@ -1170,10 +1167,7 @@ class PrivilegesTest extends AbstractTestCase
             'trackingwork' => true,
             'tracking' => 'tracking',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $dummyDbi = $this->createDbiDummy();
         $dummyDbi->addResult('SELECT * FROM `pmadb`.`users`', []);
@@ -1268,10 +1262,7 @@ class PrivilegesTest extends AbstractTestCase
         $_POST['old_hostname'] = 'old_hostname';
         $_POST['old_username'] = 'old_username';
         $relationParameters = RelationParameters::fromArray([]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $queries = [];
 

--- a/test/classes/SqlQueryFormTest.php
+++ b/test/classes/SqlQueryFormTest.php
@@ -81,7 +81,7 @@ class SqlQueryFormTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'relation',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$relationParameters]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $GLOBALS['cfg']['Server']['user'] = 'user';
         $GLOBALS['cfg']['Server']['pmadb'] = 'pmadb';

--- a/test/classes/SystemDatabaseTest.php
+++ b/test/classes/SystemDatabaseTest.php
@@ -62,10 +62,7 @@ class SystemDatabaseTest extends AbstractTestCase
             'column_info' => 'column_info',
             'relation' => 'relation',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->sysDb = new SystemDatabase($dbi);
     }

--- a/test/classes/TableTest.php
+++ b/test/classes/TableTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests;
 
+use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\ConfigStorage\RelationParameters;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\Connection;
@@ -16,6 +17,7 @@ use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionProperty;
 
 #[CoversClass(Table::class)]
 class TableTest extends AbstractTestCase
@@ -891,7 +893,7 @@ class TableTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'relation',
         ]);
-        $_SESSION = ['relation' => [$GLOBALS['server'] => $relationParameters->toArray()]];
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $ret = Table::duplicateInfo('relwork', 'relation', $getFields, $whereFields, $newFields);
         $this->assertSame(-1, $ret);

--- a/test/classes/Tracking/TrackerTest.php
+++ b/test/classes/Tracking/TrackerTest.php
@@ -50,10 +50,7 @@ class TrackerTest extends AbstractTestCase
             'trackingwork' => true,
             'tracking' => 'tracking',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
@@ -92,10 +89,7 @@ class TrackerTest extends AbstractTestCase
         Tracker::enable();
 
         $relationParameters = RelationParameters::fromArray([]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->assertFalse(
             Tracker::isActive(),
@@ -106,10 +100,7 @@ class TrackerTest extends AbstractTestCase
             'db' => 'pmadb',
             'tracking' => 'tracking',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->assertTrue(
             Tracker::isActive(),
@@ -132,10 +123,7 @@ class TrackerTest extends AbstractTestCase
         Tracker::enable();
 
         $relationParameters = RelationParameters::fromArray([]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->assertFalse(
             Tracker::isTracked('', ''),
@@ -146,10 +134,7 @@ class TrackerTest extends AbstractTestCase
             'db' => 'pmadb',
             'tracking' => 'tracking',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->assertTrue(
             Tracker::isTracked('pma_test_db', 'pma_test_table'),

--- a/test/classes/Tracking/TrackingCheckerTest.php
+++ b/test/classes/Tracking/TrackingCheckerTest.php
@@ -34,10 +34,7 @@ class TrackingCheckerTest extends AbstractTestCase
             'tracking' => 'tracking',
             'trackingwork' => true,
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $this->trackingChecker = new TrackingChecker(
             $GLOBALS['dbi'],

--- a/test/classes/Tracking/TrackingTest.php
+++ b/test/classes/Tracking/TrackingTest.php
@@ -60,10 +60,7 @@ class TrackingTest extends AbstractTestCase
             'tracking' => 'tracking',
             'trackingwork' => true,
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
-            null,
-            [$GLOBALS['server'] => $relationParameters],
-        );
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $template = new Template();
         $this->tracking = new Tracking(

--- a/test/classes/TransformationsTest.php
+++ b/test/classes/TransformationsTest.php
@@ -168,13 +168,13 @@ class TransformationsTest extends AbstractTestCase
      */
     public function testGetMime(): void
     {
-        $relation = RelationParameters::fromArray([
+        $relationParameters = RelationParameters::fromArray([
             'db' => 'pmadb',
             'mimework' => true,
             'trackingwork' => true,
             'column_info' => 'column_info',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
         $this->assertEquals(
             [
                 'o' => [
@@ -212,18 +212,18 @@ class TransformationsTest extends AbstractTestCase
             ->will($this->returnValue($this->createStub(DummyResult::class)));
         $GLOBALS['dbi'] = $dbi;
 
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, null);
 
         // Case 1 : no configuration storage
         $actual = $this->transformations->clear('db');
         $this->assertFalse($actual);
 
-        $relation = RelationParameters::fromArray([
+        $relationParameters = RelationParameters::fromArray([
             'db' => 'pmadb',
             'mimework' => true,
             'column_info' => 'column_info',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         // Case 2 : database delete
         $actual = $this->transformations->clear('db');

--- a/test/classes/UserPreferencesTest.php
+++ b/test/classes/UserPreferencesTest.php
@@ -58,8 +58,8 @@ class UserPreferencesTest extends AbstractNetworkTestCase
      */
     public function testLoad(): void
     {
-        $relation = RelationParameters::fromArray([]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
+        $relationParameters = RelationParameters::fromArray([]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         unset($_SESSION['userconfig']);
 
@@ -83,13 +83,13 @@ class UserPreferencesTest extends AbstractNetworkTestCase
         $this->assertEquals('session', $result['type']);
 
         // case 2
-        $relation = RelationParameters::fromArray([
+        $relationParameters = RelationParameters::fromArray([
             'user' => 'user',
             'db' => "pma'db",
             'userconfig' => 'testconf',
             'userconfigwork' => true,
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
@@ -126,8 +126,8 @@ class UserPreferencesTest extends AbstractNetworkTestCase
     {
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['server'] = 2;
-        $relation = RelationParameters::fromArray([]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
+        $relationParameters = RelationParameters::fromArray([]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         unset($_SESSION['userconfig']);
 
@@ -160,13 +160,13 @@ class UserPreferencesTest extends AbstractNetworkTestCase
         $this->assertTrue($assert);
 
         // case 2
-        $relation = RelationParameters::fromArray([
+        $relationParameters = RelationParameters::fromArray([
             'userconfigwork' => true,
             'db' => 'pmadb',
             'userconfig' => 'testconf',
             'user' => 'user',
         ]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $query1 = 'SELECT `username` FROM `pmadb`.`testconf` WHERE `username` = \'user\'';
 
@@ -284,15 +284,15 @@ class UserPreferencesTest extends AbstractNetworkTestCase
      */
     public function testPersistOption(): void
     {
-        $relation = RelationParameters::fromArray([]);
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
+        $relationParameters = RelationParameters::fromArray([]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $_SESSION['userconfig'] = [];
         $_SESSION['userconfig']['ts'] = '123';
         $_SESSION['userconfig']['db'] = ['Server/hide_db' => true, 'Server/only_db' => true];
 
         $GLOBALS['server'] = 2;
-        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, $relationParameters);
 
         $userPreferences = new UserPreferences($GLOBALS['dbi']);
         $this->assertTrue(


### PR DESCRIPTION
So I took another look at this session cache feature and it turns out that I made it obsolete when I implemented the static cache. The session was only used by tests, which didn't need to use it. In fact, using session led to some confusing tests. The session cache needs to be removed from all tests. 

@williamdes In regards to the new test you recently added, I made it pass, but the test isn't testing anything. I tried to understand what the test was meant to do, but I gave up after some time. I left a TODO note to fix the test in the future. I think the problem for me is that I don't fully understand how `$GLOBALS['cfg']['Server']` works. If you know how to fix the test, I would appreciate. 