### PR TITLE
InsertEdit refactoring - part 3

### DIFF
--- a/libraries/classes/ColumnFull.php
+++ b/libraries/classes/ColumnFull.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin;
+
+final class ColumnFull
+{
+    public function __construct(
+        public readonly string $field,
+        public readonly string $type,
+        public readonly string|null $collation,
+        public readonly bool $isNull,
+        public readonly string $key,
+        public readonly string|null $default,
+        public readonly string $extra,
+        public readonly string $privileges,
+        public readonly string $comment,
+    ) {
+    }
+}

--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -531,7 +531,7 @@ class Relation
      * @param string $db    the name of the db to check for
      * @param string $table the name of the table to check for
      *
-     * @return mixed[]    [column_name] = comment
+     * @return string[]    [column_name] = comment
      */
     public function getComments(string $db, string $table = ''): array
     {
@@ -544,7 +544,7 @@ class Relation
         // MySQL native column comments
         $columns = $this->dbi->getColumns($db, $table, true);
         foreach ($columns as $column) {
-            if (empty($column['Comment'])) {
+            if ($column['Comment'] === '') {
                 continue;
             }
 

--- a/libraries/classes/Controllers/Database/DataDictionaryController.php
+++ b/libraries/classes/Controllers/Database/DataDictionaryController.php
@@ -84,7 +84,7 @@ class DataDictionaryController extends AbstractController
                     'has_primary_key' => isset($primaryKeys[$row['Field']]),
                     'type' => $extractedColumnSpec['type'],
                     'print_type' => $extractedColumnSpec['print_type'],
-                    'is_nullable' => $row['Null'] !== '' && $row['Null'] !== 'NO',
+                    'is_nullable' => $row['Null'] !== 'NO',
                     'default' => $row['Default'] ?? null,
                     'comment' => $columnsComments[$row['Field']] ?? '',
                     'mime' => $mime,

--- a/libraries/classes/Controllers/Table/ChangeController.php
+++ b/libraries/classes/Controllers/Table/ChangeController.php
@@ -163,8 +163,8 @@ class ChangeController extends AbstractController
         $GLOBALS['urlParams'] = $this->urlParamsInEditMode($GLOBALS['urlParams'], $whereClauseArray);
 
         $hasBlobField = false;
-        foreach ($tableColumns as $column) {
-            if ($this->insertEdit->isColumn($column, ['blob', 'tinyblob', 'mediumblob', 'longblob'])) {
+        foreach ($tableColumns as $tableColumn) {
+            if ($this->insertEdit->isColumn($tableColumn->type, ['blob', 'tinyblob', 'mediumblob', 'longblob'])) {
                 $hasBlobField = true;
                 break;
             }

--- a/libraries/classes/Controllers/Table/FindReplaceController.php
+++ b/libraries/classes/Controllers/Table/FindReplaceController.php
@@ -91,7 +91,7 @@ class FindReplaceController extends AbstractController
             // set column name
             $this->columnNames[] = $row['Field'];
 
-            $type = (string) $row['Type'];
+            $type = $row['Type'];
             // reformat mysql query output
             if (strncasecmp($type, 'set', 3) == 0 || strncasecmp($type, 'enum', 4) == 0) {
                 $type = str_replace(',', ', ', $type);

--- a/libraries/classes/Controllers/Table/SearchController.php
+++ b/libraries/classes/Controllers/Table/SearchController.php
@@ -109,7 +109,7 @@ class SearchController extends AbstractController
             // set column name
             $this->columnNames[] = $row['Field'];
 
-            $type = (string) $row['Type'];
+            $type = $row['Type'];
             // before any replacement
             $this->originalColumnTypes[] = mb_strtolower($type);
             // check whether table contains geometric columns

--- a/libraries/classes/Controllers/Table/Structure/ChangeController.php
+++ b/libraries/classes/Controllers/Table/Structure/ChangeController.php
@@ -61,7 +61,7 @@ final class ChangeController extends AbstractController
         $fieldsMeta = [];
         foreach ($selected as $column) {
             $value = $this->dbi->getColumn($GLOBALS['db'], $GLOBALS['table'], $column, true);
-            if ($value === []) {
+            if ($value === null) {
                 $message = Message::error(
                     __('Failed to get description of column %s!'),
                 );

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -165,7 +165,7 @@ class ZoomSearchController extends AbstractController
             // set column name
             $this->columnNames[] = $row['Field'];
 
-            $type = (string) $row['Type'];
+            $type = $row['Type'];
             // before any replacement
             $this->originalColumnTypes[] = mb_strtolower($type);
             // check whether table contains geometric columns

--- a/libraries/classes/Database/CentralColumns.php
+++ b/libraries/classes/Database/CentralColumns.php
@@ -293,7 +293,7 @@ class CentralColumns
             $hasList = $this->findExistingColNames($db, trim($cols, ','));
             foreach ($fieldSelect as $table) {
                 foreach ($fields[$table] as $def) {
-                    $field = (string) $def['Field'];
+                    $field = $def['Field'];
                     if (! in_array($field, $hasList)) {
                         $hasList[] = $field;
                         $insQuery[] = $this->getInsertQuery($field, $def, $db, $centralListTable);

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -849,7 +849,7 @@ class DatabaseInterface implements DbalInterface
      *  Extra: string,
      *  Privileges?: string,
      *  Comment?: string
-     * }
+     * }|null
      */
     public function getColumn(
         string $database,
@@ -857,7 +857,7 @@ class DatabaseInterface implements DbalInterface
         string $column,
         bool $full = false,
         int $connectionType = Connection::TYPE_USER,
-    ): array {
+    ): array|null {
         $sql = QueryGenerator::getColumnsSql(
             $database,
             $table,
@@ -869,7 +869,7 @@ class DatabaseInterface implements DbalInterface
 
         $columns = $this->attachIndexInfoToColumns($database, $table, $fields);
 
-        return array_shift($columns) ?? [];
+        return array_shift($columns);
     }
 
     /**

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -839,7 +839,17 @@ class DatabaseInterface implements DbalInterface
      * @param bool   $full     whether to return full info or only column names
      * @psalm-param ConnectionType $connectionType
      *
-     * @return (string|null)[] flat array description
+     * @return array{
+     *  Field: string,
+     *  Type: string,
+     *  Collation?: string|null,
+     *  Null:'YES'|'NO',
+     *  Key: string,
+     *  Default: string|null,
+     *  Extra: string,
+     *  Privileges?: string,
+     *  Comment?: string
+     * }
      */
     public function getColumn(
         string $database,
@@ -870,7 +880,17 @@ class DatabaseInterface implements DbalInterface
      * @param bool   $full     whether to return full info or only column names
      * @psalm-param ConnectionType $connectionType
      *
-     * @return (string|null)[][] array indexed by column names
+     * @return array{
+     *  Field: string,
+     *  Type: string,
+     *  Collation?: string|null,
+     *  Null:'YES'|'NO',
+     *  Key: string,
+     *  Default: string|null,
+     *  Extra: string,
+     *  Privileges?: string,
+     *  Comment?: string
+     * }[] array indexed by column names
      */
     public function getColumns(
         string $database,

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -839,7 +839,7 @@ class DatabaseInterface implements DbalInterface
      * @param bool   $full     whether to return full info or only column names
      * @psalm-param ConnectionType $connectionType
      *
-     * @return mixed[] flat array description
+     * @return (string|null)[] flat array description
      */
     public function getColumn(
         string $database,
@@ -854,7 +854,7 @@ class DatabaseInterface implements DbalInterface
             $this->escapeString($this->escapeMysqlWildcards($column)),
             $full,
         );
-        /** @var array<string, array> $fields */
+        /** @var (string|null)[][] $fields */
         $fields = $this->fetchResult($sql, 'Field', null, $connectionType);
 
         $columns = $this->attachIndexInfoToColumns($database, $table, $fields);
@@ -870,7 +870,7 @@ class DatabaseInterface implements DbalInterface
      * @param bool   $full     whether to return full info or only column names
      * @psalm-param ConnectionType $connectionType
      *
-     * @return mixed[][] array indexed by column names
+     * @return (string|null)[][] array indexed by column names
      */
     public function getColumns(
         string $database,
@@ -879,7 +879,7 @@ class DatabaseInterface implements DbalInterface
         int $connectionType = Connection::TYPE_USER,
     ): array {
         $sql = QueryGenerator::getColumnsSql($database, $table, null, $full);
-        /** @var array[] $fields */
+        /** @var (string|null)[][] $fields */
         $fields = $this->fetchResult($sql, 'Field', null, $connectionType);
 
         return $this->attachIndexInfoToColumns($database, $table, $fields);
@@ -888,11 +888,11 @@ class DatabaseInterface implements DbalInterface
     /**
      * Attach index information to the column definition
      *
-     * @param string    $database name of database
-     * @param string    $table    name of table to retrieve columns from
-     * @param mixed[][] $fields   column array indexed by their names
+     * @param string            $database name of database
+     * @param string            $table    name of table to retrieve columns from
+     * @param (string|null)[][] $fields   column array indexed by their names
      *
-     * @return mixed[][] Column defintions with index information
+     * @return (string|null)[][] Column defintions with index information
      */
     private function attachIndexInfoToColumns(
         string $database,

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -173,7 +173,17 @@ interface DbalInterface
      * @param bool   $full     whether to return full info or only column names
      * @psalm-param ConnectionType $connectionType
      *
-     * @return mixed[] flat array description
+     * @return array{
+     *  Field: string,
+     *  Type: string,
+     *  Collation?: string|null,
+     *  Null:'YES'|'NO',
+     *  Key: string,
+     *  Default: string|null,
+     *  Extra: string,
+     *  Privileges?: string,
+     *  Comment?: string
+     * }
      */
     public function getColumn(
         string $database,
@@ -191,7 +201,17 @@ interface DbalInterface
      * @param bool   $full     whether to return full info or only column names
      * @psalm-param ConnectionType $connectionType
      *
-     * @return mixed[][] array indexed by column names
+     * @return array{
+     *  Field: string,
+     *  Type: string,
+     *  Collation?: string|null,
+     *  Null:'YES'|'NO',
+     *  Key: string,
+     *  Default: string|null,
+     *  Extra: string,
+     *  Privileges?: string,
+     *  Comment?: string
+     * }[] array indexed by column names
      */
     public function getColumns(
         string $database,

--- a/libraries/classes/Dbal/DbalInterface.php
+++ b/libraries/classes/Dbal/DbalInterface.php
@@ -183,7 +183,7 @@ interface DbalInterface
      *  Extra: string,
      *  Privileges?: string,
      *  Comment?: string
-     * }
+     * }|null
      */
     public function getColumn(
         string $database,
@@ -191,7 +191,7 @@ interface DbalInterface
         string $column,
         bool $full = false,
         int $connectionType = Connection::TYPE_USER,
-    ): array;
+    ): array|null;
 
     /**
      * Returns descriptions of columns in given table

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -304,8 +304,8 @@ class InsertEdit
     /**
      * Analyze the table column array
      *
-     * @param mixed[] $column      description of column in given table
-     * @param mixed[] $commentsMap comments for every column that has a comment
+     * @param mixed[]  $column      description of column in given table
+     * @param string[] $commentsMap comments for every column that has a comment
      *
      * @return mixed[]                   description of column in given table
      */
@@ -350,8 +350,8 @@ class InsertEdit
     /**
      * Retrieve the column title
      *
-     * @param mixed[] $column      description of column in given table
-     * @param mixed[] $commentsMap comments for every column that has a comment
+     * @param mixed[]  $column      description of column in given table
+     * @param string[] $commentsMap comments for every column that has a comment
      *
      * @return string              column title
      */
@@ -1600,7 +1600,7 @@ class InsertEdit
      * @param string $db    current database
      * @param string $table current table
      *
-     * @return mixed[] comments for columns
+     * @return string[] comments for columns
      */
     public function getCommentsMap(string $db, string $table): array
     {
@@ -1657,7 +1657,7 @@ class InsertEdit
      *
      * @param mixed[]         $column             column
      * @param int             $columnNumber       column index in table_columns
-     * @param mixed[]         $commentsMap        comments map
+     * @param string[]        $commentsMap        comments map
      * @param ResultInterface $currentResult      current result
      * @param bool            $insertMode         whether insert mode
      * @param mixed[]         $currentRow         current row
@@ -2000,7 +2000,7 @@ class InsertEdit
      *
      * @param mixed[]         $urlParams        url parameters
      * @param mixed[][]       $tableColumns     table columns
-     * @param mixed[]         $commentsMap      comments map
+     * @param string[]        $commentsMap      comments map
      * @param ResultInterface $currentResult    current result
      * @param bool            $insertMode       whether insert mode
      * @param mixed[]         $currentRow       current row

--- a/libraries/classes/Normalization.php
+++ b/libraries/classes/Normalization.php
@@ -72,7 +72,7 @@ class Normalization
         $type = '';
         $selectColHtml = '';
         foreach ($columns as $def) {
-            $column = (string) $def['Field'];
+            $column = $def['Field'];
             if (isset($def['Type'])) {
                 $extractedColumnSpec = Util::extractColumnSpec($def['Type']);
                 $type = $extractedColumnSpec['type'];

--- a/libraries/classes/Plugins/Export/ExportLatex.php
+++ b/libraries/classes/Plugins/Export/ExportLatex.php
@@ -574,8 +574,7 @@ class ExportLatex extends ExportPlugin
             }
 
             $localBuffer = $colAs . "\000" . $type . "\000"
-                . ($row['Null'] == '' || $row['Null'] === 'NO'
-                    ? __('No') : __('Yes'))
+                . ($row['Null'] === 'NO' ? __('No') : __('Yes'))
                 . "\000" . ($row['Default'] ?? '');
 
             if ($doRelation && $haveRel) {

--- a/libraries/classes/Plugins/Export/Helpers/Pdf.php
+++ b/libraries/classes/Plugins/Export/Helpers/Pdf.php
@@ -568,7 +568,7 @@ class Pdf extends PdfLib
 
             $data[] = $column['Field'];
             $data[] = $type;
-            $data[] = $column['Null'] == '' || $column['Null'] === 'NO'
+            $data[] = $column['Null'] === 'NO'
                 ? 'No'
                 : 'Yes';
             $data[] = $column['Default'] ?? '';

--- a/libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php
@@ -680,7 +680,7 @@ class PdfRelationSchema extends ExportRelationSchema
                 $type = $extractedColumnSpec['print_type'];
                 $attribute = $extractedColumnSpec['attribute'];
                 if (! isset($row['Default'])) {
-                    if ($row['Null'] != '' && $row['Null'] !== 'NO') {
+                    if ($row['Null'] !== 'NO') {
                         $row['Default'] = 'NULL';
                     }
                 }
@@ -712,7 +712,7 @@ class PdfRelationSchema extends ExportRelationSchema
                     $fieldName,
                     $type,
                     $attribute,
-                    $row['Null'] == '' || $row['Null'] === 'NO'
+                    $row['Null'] === 'NO'
                         ? __('No')
                         : __('Yes'),
                     $row['Default'] ?? '',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2271,11 +2271,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/Structure/ChangeController.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\} and array\\{\\} will always evaluate to false\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/Structure/ChangeController.php
-
-		-
 			message: "#^Cannot access offset 'COLUMN_COMMENT' on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/Structure/MoveColumnsController.php
@@ -2782,6 +2777,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#10 \\$colDefault of method PhpMyAdmin\\\\Database\\\\CentralColumns\\:\\:updateOneColumn\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/Database/CentralColumns.php
+
+		-
+			message: "#^Parameter \\#2 \\$def of method PhpMyAdmin\\\\Database\\\\CentralColumns\\:\\:getInsertQuery\\(\\) expects array, array\\<string, string\\|null\\>\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Database/CentralColumns.php
 
@@ -3301,7 +3301,7 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumn\\(\\) should return array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\} but returns array\\<string\\|null\\>\\.$#"
+			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumn\\(\\) should return array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\}\\|null but returns array\\<string\\|null\\>\\|null\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4577,7 +4577,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 2
+			count: 3
 			path: libraries/classes/InsertEdit.php
 
 		-
@@ -4617,6 +4617,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$data of static method PhpMyAdmin\\\\Utils\\\\Gis\\:\\:convertToWellKnownText\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Parameter \\#1 \\$defaultValue of method PhpMyAdmin\\\\InsertEdit\\:\\:getSpecialCharsForInsertingMode\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -656,6 +656,11 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
+			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getComments\\(\\) should return array\\<string\\> but returns array\\<int\\|string, mixed\\>\\.$#"
+			count: 1
+			path: libraries/classes/ConfigStorage/Relation.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getDisplayField\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
@@ -4657,7 +4662,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
-			count: 3
+			count: 2
 			path: libraries/classes/InsertEdit.php
 
 		-
@@ -5342,7 +5347,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
-			count: 8
+			count: 7
 			path: libraries/classes/Plugins/Export/ExportHtmlword.php
 
 		-
@@ -5482,7 +5487,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
-			count: 9
+			count: 8
 			path: libraries/classes/Plugins/Export/ExportOdt.php
 
 		-
@@ -5727,7 +5732,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
-			count: 5
+			count: 4
 			path: libraries/classes/Plugins/Export/ExportTexytext.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4616,12 +4616,17 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
+			message: "#^Parameter \\#1 \\$columnSpecification of static method PhpMyAdmin\\\\Util\\:\\:extractColumnSpec\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
 			message: "#^Parameter \\#1 \\$data of static method PhpMyAdmin\\\\Utils\\\\Gis\\:\\:convertToWellKnownText\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function mb_stripos expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$field of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -4657,16 +4662,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function bin2hex expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function md5 expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -4716,7 +4711,42 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
+			message: "#^Parameter \\#2 \\$type of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Parameter \\#3 \\$collation of class PhpMyAdmin\\\\ColumnFull constructor expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
 			message: "#^Parameter \\#3 \\$row of static method PhpMyAdmin\\\\Util\\:\\:getUniqueCondition\\(\\) expects array\\<int, mixed\\>, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Parameter \\#5 \\$key of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Parameter \\#6 \\$default of class PhpMyAdmin\\\\ColumnFull constructor expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Parameter \\#7 \\$extra of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Parameter \\#8 \\$privileges of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Parameter \\#9 \\$comment of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -656,11 +656,6 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getComments\\(\\) should return array\\<string\\> but returns array\\<string, string\\|null\\>\\.$#"
-			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getDisplayField\\(\\) should return string but returns mixed\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
@@ -687,6 +682,11 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:searchColumnInForeigners\\(\\) should return array\\|false but returns mixed\\.$#"
+			count: 1
+			path: libraries/classes/ConfigStorage/Relation.php
+
+		-
+			message: "#^Offset 'Comment' does not exist on array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\}\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 
@@ -776,7 +776,7 @@ parameters:
 			path: libraries/classes/Controllers/Database/CentralColumnsController.php
 
 		-
-			message: "#^Cannot access offset string\\|null on mixed\\.$#"
+			message: "#^Cannot access offset string on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/DataDictionaryController.php
 
@@ -786,12 +786,7 @@ parameters:
 			path: libraries/classes/Controllers/Database/DataDictionaryController.php
 
 		-
-			message: "#^Parameter \\#1 \\$columnSpecification of static method PhpMyAdmin\\\\Util\\:\\:extractColumnSpec\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/DataDictionaryController.php
-
-		-
-			message: "#^Parameter \\#2 \\$column of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:searchColumnInForeigners\\(\\) expects string, string\\|null given\\.$#"
+			message: "#^Strict comparison using \\!\\=\\= between 'NO'\\|'YES' and '' will always evaluate to true\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/DataDictionaryController.php
 
@@ -2096,6 +2091,11 @@ parameters:
 			path: libraries/classes/Controllers/Table/FindReplaceController.php
 
 		-
+			message: "#^Casting to string something that's already string\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/FindReplaceController.php
+
+		-
 			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
 			count: 16
 			path: libraries/classes/Controllers/Table/FindReplaceController.php
@@ -2166,11 +2166,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/RelationController.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function md5 expects string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/RelationController.php
-
-		-
 			message: "#^Parameter \\#2 \\$callback of function usort expects callable\\(mixed, mixed\\)\\: int, 'strnatcasecmp' given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/RelationController.php
@@ -2212,6 +2207,11 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/SearchController.php
+
+		-
+			message: "#^Casting to string something that's already string\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/SearchController.php
 
@@ -2282,6 +2282,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$selected of method PhpMyAdmin\\\\Controllers\\\\Table\\\\Structure\\\\ChangeController\\:\\:displayHtmlForColumnChange\\(\\) expects array\\<string\\>, array\\<int, mixed\\> given\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/Structure/ChangeController.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\} and array\\{\\} will always evaluate to false\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/Structure/ChangeController.php
 
@@ -2521,6 +2526,11 @@ parameters:
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
 
 		-
+			message: "#^Casting to string something that's already string\\.$#"
+			count: 1
+			path: libraries/classes/Controllers/Table/ZoomSearchController.php
+
+		-
 			message: "#^Parameter \\#1 \\$columnSpecification of static method PhpMyAdmin\\\\Util\\:\\:extractColumnSpec\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -2736,6 +2746,11 @@ parameters:
 			path: libraries/classes/Database/CentralColumns.php
 
 		-
+			message: "#^Casting to string something that's already string\\.$#"
+			count: 1
+			path: libraries/classes/Database/CentralColumns.php
+
+		-
 			message: "#^Foreach overwrites \\$table with its value variable\\.$#"
 			count: 2
 			path: libraries/classes/Database/CentralColumns.php
@@ -2773,11 +2788,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, mixed given\\.$#"
 			count: 5
-			path: libraries/classes/Database/CentralColumns.php
-
-		-
-			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
 			path: libraries/classes/Database/CentralColumns.php
 
 		-
@@ -3316,7 +3326,17 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
+			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumn\\(\\) should return array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\} but returns array\\<string\\|null\\>\\.$#"
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
 			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumnNames\\(\\) should return array\\<string\\> but returns array\\.$#"
+			count: 1
+			path: libraries/classes/DatabaseInterface.php
+
+		-
+			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumns\\(\\) should return array\\<array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\}\\> but returns array\\<array\\<string\\|null\\>\\>\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
@@ -4596,6 +4616,21 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
+			message: "#^Offset 'Collation' does not exist on array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Offset 'Comment' does not exist on array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Offset 'Privileges' does not exist on array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\}\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
 			message: "#^Parameter \\#1 \\$buffer of method PhpMyAdmin\\\\Plugins\\\\TransformationsPlugin\\:\\:applyTransformation\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
@@ -4607,11 +4642,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$data of static method PhpMyAdmin\\\\Utils\\\\Gis\\:\\:convertToWellKnownText\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$field of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -4696,32 +4726,7 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#2 \\$type of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
 			message: "#^Parameter \\#3 \\$row of static method PhpMyAdmin\\\\Util\\:\\:getUniqueCondition\\(\\) expects array\\<int, mixed\\>, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#5 \\$key of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#7 \\$extra of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#8 \\$privileges of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#9 \\$comment of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -4962,7 +4967,7 @@ parameters:
 
 		-
 			message: "#^Casting to string something that's already string\\.$#"
-			count: 1
+			count: 2
 			path: libraries/classes/Normalization.php
 
 		-
@@ -4977,6 +4982,11 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Normalization\\:\\:createNewTablesFor3NF\\(\\) should return array\\{legendText\\: string, headText\\: string, queryError\\: string\\|false, extra\\?\\: string\\} but returns array\\{legendText\\: string, headText\\: non\\-falsy\\-string, queryError\\: bool, extra\\: ''\\|PhpMyAdmin\\\\Message\\}\\.$#"
+			count: 1
+			path: libraries/classes/Normalization.php
+
+		-
+			message: "#^Offset 'Type' on array\\{Field\\: string, Type\\: string, Collation\\?\\: string\\|null, Null\\: 'NO'\\|'YES', Key\\: string, Default\\: string\\|null, Extra\\: string, Privileges\\?\\: string, \\.\\.\\.\\} in isset\\(\\) always exists and is not nullable\\.$#"
 			count: 1
 			path: libraries/classes/Normalization.php
 
@@ -5002,11 +5012,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/Normalization.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|null given\\.$#"
 			count: 2
 			path: libraries/classes/Normalization.php
 
@@ -7891,11 +7896,6 @@ parameters:
 			path: libraries/classes/Sql.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Sql.php
-
-		-
 			message: "#^Parameter \\#1 \\$message of static method PhpMyAdmin\\\\Message\\:\\:rawError\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
@@ -9084,6 +9084,11 @@ parameters:
 			message: "#^PHPDoc tag @var for variable \\$result has no value type specified in iterable type array\\.$#"
 			count: 2
 			path: test/classes/Controllers/Table/ReplaceControllerTest.php
+
+		-
+			message: "#^Casting to string something that's already string\\.$#"
+			count: 3
+			path: test/classes/Controllers/Table/StructureControllerTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<string\\> will always evaluate to true\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -656,7 +656,7 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getComments\\(\\) should return array\\<string\\> but returns array\\<int\\|string, mixed\\>\\.$#"
+			message: "#^Method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:getComments\\(\\) should return array\\<string\\> but returns array\\<string, string\\|null\\>\\.$#"
 			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 
@@ -776,7 +776,7 @@ parameters:
 			path: libraries/classes/Controllers/Database/CentralColumnsController.php
 
 		-
-			message: "#^Cannot access offset mixed on mixed\\.$#"
+			message: "#^Cannot access offset string\\|null on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/DataDictionaryController.php
 
@@ -786,12 +786,12 @@ parameters:
 			path: libraries/classes/Controllers/Database/DataDictionaryController.php
 
 		-
-			message: "#^Parameter \\#1 \\$columnSpecification of static method PhpMyAdmin\\\\Util\\:\\:extractColumnSpec\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$columnSpecification of static method PhpMyAdmin\\\\Util\\:\\:extractColumnSpec\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/DataDictionaryController.php
 
 		-
-			message: "#^Parameter \\#2 \\$column of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:searchColumnInForeigners\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$column of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:searchColumnInForeigners\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/DataDictionaryController.php
 
@@ -2096,11 +2096,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/FindReplaceController.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/FindReplaceController.php
-
-		-
 			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
 			count: 16
 			path: libraries/classes/Controllers/Table/FindReplaceController.php
@@ -2171,12 +2166,7 @@ parameters:
 			path: libraries/classes/Controllers/Table/RelationController.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function md5 expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/RelationController.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function uksort expects callable\\(int\\|string, int\\|string\\)\\: int, 'strnatcasecmp' given\\.$#"
+			message: "#^Parameter \\#1 \\$string of function md5 expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/RelationController.php
 
@@ -2222,7 +2212,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 2
+			count: 1
 			path: libraries/classes/Controllers/Table/SearchController.php
 
 		-
@@ -2527,7 +2517,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 3
+			count: 2
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
 
 		-
@@ -2742,7 +2732,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 4
+			count: 3
 			path: libraries/classes/Database/CentralColumns.php
 
 		-
@@ -2782,7 +2772,12 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, mixed given\\.$#"
-			count: 6
+			count: 5
+			path: libraries/classes/Database/CentralColumns.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
 			path: libraries/classes/Database/CentralColumns.php
 
 		-
@@ -3146,11 +3141,6 @@ parameters:
 			path: libraries/classes/Database/Routines.php
 
 		-
-			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Search.php
-
-		-
 			message: "#^Property PhpMyAdmin\\\\Database\\\\Search\\:\\:\\$searchTypeDescription \\(string\\) does not accept mixed\\.$#"
 			count: 1
 			path: libraries/classes/Database/Search.php
@@ -3348,11 +3338,6 @@ parameters:
 		-
 			message: "#^Method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTableIndexes\\(\\) should return array\\<int, array\\{Table\\: string, Non_unique\\: '0'\\|'1', Key_name\\: string, Seq_in_index\\: string, Column_name\\: string\\|null, Collation\\: 'A'\\|'D'\\|null, Cardinality\\: string, Sub_part\\: string\\|null, \\.\\.\\.\\}\\> but returns array\\.$#"
 			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$fields has no value type specified in iterable type array\\.$#"
-			count: 2
 			path: libraries/classes/DatabaseInterface.php
 
 		-
@@ -4626,7 +4611,7 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#1 \\$field of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$field of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -4711,12 +4696,7 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#2 \\$type of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#3 \\$collation of class PhpMyAdmin\\\\ColumnFull constructor expects string\\|null, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$type of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -4726,27 +4706,22 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#5 \\$key of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
+			message: "#^Parameter \\#5 \\$key of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#6 \\$default of class PhpMyAdmin\\\\ColumnFull constructor expects string\\|null, mixed given\\.$#"
+			message: "#^Parameter \\#7 \\$extra of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#7 \\$extra of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
+			message: "#^Parameter \\#8 \\$privileges of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#8 \\$privileges of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#9 \\$comment of class PhpMyAdmin\\\\ColumnFull constructor expects string, mixed given\\.$#"
+			message: "#^Parameter \\#9 \\$comment of class PhpMyAdmin\\\\ColumnFull constructor expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -4986,11 +4961,6 @@ parameters:
 			path: libraries/classes/Normalization.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: libraries/classes/Normalization.php
-
-		-
 			message: "#^Casting to string something that's already string\\.$#"
 			count: 1
 			path: libraries/classes/Normalization.php
@@ -5016,11 +4986,6 @@ parameters:
 			path: libraries/classes/Normalization.php
 
 		-
-			message: "#^Parameter \\#1 \\$columnSpecification of static method PhpMyAdmin\\\\Util\\:\\:extractColumnSpec\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Normalization.php
-
-		-
 			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, \\(int\\|string\\) given\\.$#"
 			count: 3
 			path: libraries/classes/Normalization.php
@@ -5037,6 +5002,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, mixed given\\.$#"
+			count: 2
+			path: libraries/classes/Normalization.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function htmlspecialchars expects string, string\\|null given\\.$#"
 			count: 2
 			path: libraries/classes/Normalization.php
 
@@ -7921,7 +7891,7 @@ parameters:
 			path: libraries/classes/Sql.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
 
@@ -9114,11 +9084,6 @@ parameters:
 			message: "#^PHPDoc tag @var for variable \\$result has no value type specified in iterable type array\\.$#"
 			count: 2
 			path: test/classes/Controllers/Table/ReplaceControllerTest.php
-
-		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 3
-			path: test/classes/Controllers/Table/StructureControllerTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<string\\> will always evaluate to true\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -786,11 +786,6 @@ parameters:
 			path: libraries/classes/Controllers/Database/DataDictionaryController.php
 
 		-
-			message: "#^Strict comparison using \\!\\=\\= between 'NO'\\|'YES' and '' will always evaluate to true\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/DataDictionaryController.php
-
-		-
 			message: "#^Cannot access offset 'dbName' on mixed\\.$#"
 			count: 2
 			path: libraries/classes/Controllers/Database/DesignerController.php
@@ -2091,11 +2086,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/FindReplaceController.php
 
 		-
-			message: "#^Casting to string something that's already string\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/FindReplaceController.php
-
-		-
 			message: "#^Parameter \\#1 \\$identifier of static method PhpMyAdmin\\\\Util\\:\\:backquote\\(\\) expects string\\|Stringable\\|null, mixed given\\.$#"
 			count: 16
 			path: libraries/classes/Controllers/Table/FindReplaceController.php
@@ -2207,11 +2197,6 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/SearchController.php
-
-		-
-			message: "#^Casting to string something that's already string\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/SearchController.php
 
@@ -2526,11 +2511,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
 
 		-
-			message: "#^Casting to string something that's already string\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/ZoomSearchController.php
-
-		-
 			message: "#^Parameter \\#1 \\$columnSpecification of static method PhpMyAdmin\\\\Util\\:\\:extractColumnSpec\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -2743,11 +2723,6 @@ parameters:
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 3
-			path: libraries/classes/Database/CentralColumns.php
-
-		-
-			message: "#^Casting to string something that's already string\\.$#"
-			count: 1
 			path: libraries/classes/Database/CentralColumns.php
 
 		-
@@ -4967,7 +4942,7 @@ parameters:
 
 		-
 			message: "#^Casting to string something that's already string\\.$#"
-			count: 2
+			count: 1
 			path: libraries/classes/Normalization.php
 
 		-
@@ -9084,11 +9059,6 @@ parameters:
 			message: "#^PHPDoc tag @var for variable \\$result has no value type specified in iterable type array\\.$#"
 			count: 2
 			path: test/classes/Controllers/Table/ReplaceControllerTest.php
-
-		-
-			message: "#^Casting to string something that's already string\\.$#"
-			count: 3
-			path: test/classes/Controllers/Table/StructureControllerTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array\\<string\\> will always evaluate to true\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7630,12 +7630,16 @@
     </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$columnMime['input_transformation_options']]]></code>
+      <code><![CDATA[$column['Collation']]]></code>
+      <code><![CDATA[$column['Comment']]]></code>
+      <code><![CDATA[$column['Default']]]></code>
+      <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Field']]]></code>
       <code><![CDATA[$column['Field']]]></code>
       <code><![CDATA[$column['Field']]]></code>
-      <code><![CDATA[$column['Field']]]></code>
-      <code><![CDATA[$column['Field']]]></code>
+      <code><![CDATA[$column['Key']]]></code>
+      <code><![CDATA[$column['Privileges']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
@@ -7643,8 +7647,6 @@
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
-      <code><![CDATA[$column['Type']]]></code>
-      <code><![CDATA[$column['Type']]]></code>
       <code><![CDATA[$column['Type']]]></code>
       <code><![CDATA[$column['Type']]]></code>
       <code><![CDATA[$column['Type']]]></code>
@@ -7700,8 +7702,6 @@
       <code><![CDATA[$extraData['transformations'][$cellIndex]]]></code>
     </MixedArrayAssignment>
     <MixedArrayOffset>
-      <code><![CDATA[$commentsMap[$column['Field']]]]></code>
-      <code><![CDATA[$commentsMap[$column['Field']]]]></code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>
@@ -7724,12 +7724,9 @@
       <code><![CDATA[$currentRow[$column['Field']]]]></code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$mimeMap[$tableColumn['Field']]]]></code>
-      <code><![CDATA[$mimeMap[$tableColumn['Field']]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
       <code>$columnSetValues</code>
-      <code><![CDATA[$column['pma_type']]]></code>
       <code><![CDATA[$column['values']]]></code>
       <code>$currCellEditedValues</code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3932,10 +3932,6 @@
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['num_fields']]]></code>
     </MixedAssignment>
-    <TypeDoesNotContainType>
-      <code>$value === []</code>
-      <code>$value === []</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/MoveColumnsController.php">
     <MixedArgument>
@@ -4899,6 +4895,9 @@
       <code>$db</code>
       <code>$table</code>
     </PossiblyInvalidCast>
+    <PossiblyNullArgument>
+      <code>$field</code>
+    </PossiblyNullArgument>
     <RedundantCast>
       <code><![CDATA[(bool) $GLOBALS['cfg']['Server']['DisableIS']]]></code>
       <code><![CDATA[(int) $GLOBALS['cfg']['MaxRows']]]></code>
@@ -5775,18 +5774,7 @@
      *   Visible?: string,
      *   Expression?: string|null
      * }>]]></code>
-      <code>array_shift($columns) ?? []</code>
-      <code><![CDATA[array{
-     *  Field: string,
-     *  Type: string,
-     *  Collation?: string|null,
-     *  Null:'YES'|'NO',
-     *  Key: string,
-     *  Default: string|null,
-     *  Extra: string,
-     *  Privileges?: string,
-     *  Comment?: string
-     * }]]></code>
+      <code>array_shift($columns)</code>
       <code><![CDATA[array{
      *  Field: string,
      *  Type: string,
@@ -5798,6 +5786,17 @@
      *  Privileges?: string,
      *  Comment?: string
      * }[]]]></code>
+      <code><![CDATA[array{
+     *  Field: string,
+     *  Type: string,
+     *  Collation?: string|null,
+     *  Null:'YES'|'NO',
+     *  Key: string,
+     *  Default: string|null,
+     *  Extra: string,
+     *  Privileges?: string,
+     *  Comment?: string
+     * }|null]]></code>
       <code>string[]</code>
     </MixedReturnTypeCoercion>
     <NullableReturnStatement>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -686,12 +686,10 @@
       <code><![CDATA[usort($tables, 'strnatcasecmp')]]></code>
     </InvalidArgument>
     <InvalidReturnStatement>
-      <code>$comments</code>
       <code>$tableNameReplacements</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code><![CDATA[array<string, string>]]></code>
-      <code>string[]</code>
     </InvalidReturnType>
     <LessSpecificReturnStatement>
       <code><![CDATA[[
@@ -803,9 +801,10 @@
     <PossiblyInvalidArgument>
       <code>$foreigners</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArrayOffset>
-      <code>$comments</code>
-    </PossiblyNullArrayOffset>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$column['Comment']]]></code>
+      <code><![CDATA[$column['Comment']]]></code>
+    </PossiblyUndefinedArrayOffset>
     <PossiblyUnusedMethod>
       <code>getDbComments</code>
     </PossiblyUnusedMethod>
@@ -962,6 +961,9 @@
     </RedundantCast>
   </file>
   <file src="libraries/classes/Controllers/Database/DataDictionaryController.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[$row['Null'] !== '']]></code>
+    </DocblockTypeContradiction>
     <MixedAssignment>
       <code>$relation</code>
     </MixedAssignment>
@@ -969,21 +971,15 @@
       <code><![CDATA[$foreigner['foreign_field']]]></code>
       <code>$relation</code>
     </MixedOperand>
-    <PossiblyNullArgument>
-      <code><![CDATA[$row['Field']]]></code>
-      <code><![CDATA[$row['Type']]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullArrayOffset>
-      <code>$columnsComments</code>
-      <code>$mimeMap</code>
-      <code>$rows</code>
-    </PossiblyNullArrayOffset>
     <PossiblyUnusedMethod>
       <code>__construct</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code>$request</code>
     </PossiblyUnusedParam>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[$row['Null'] !== '']]></code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/Controllers/Database/DesignerController.php">
     <InvalidArrayOffset>
@@ -3462,6 +3458,9 @@
     <PossiblyUnusedParam>
       <code>$request</code>
     </PossiblyUnusedParam>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $row['Type']]]></code>
+    </RedundantCastGivenDocblockType>
     <RiskyCast>
       <code><![CDATA[$_POST['columnIndex']]]></code>
       <code><![CDATA[$_POST['columnIndex']]]></code>
@@ -3710,13 +3709,6 @@
       <code>$foreignTable</code>
       <code>$foreignTable</code>
     </PossiblyInvalidCast>
-    <PossiblyNullArgument>
-      <code><![CDATA[$column['Field']]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullArrayOffset>
-      <code>$columnArray</code>
-      <code>$columnHashArray</code>
-    </PossiblyNullArrayOffset>
   </file>
   <file src="libraries/classes/Controllers/Table/ReplaceController.php">
     <InvalidArgument>
@@ -3876,6 +3868,9 @@
     <PossiblyUnusedParam>
       <code>$request</code>
     </PossiblyUnusedParam>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $row['Type']]]></code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Controllers/Table/SqlController.php">
     <InvalidArrayOffset>
@@ -3949,6 +3944,10 @@
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['num_fields']]]></code>
     </MixedAssignment>
+    <TypeDoesNotContainType>
+      <code>$value === []</code>
+      <code>$value === []</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="libraries/classes/Controllers/Table/Structure/MoveColumnsController.php">
     <MixedArgument>
@@ -4324,6 +4323,9 @@
     <PossiblyUnusedParam>
       <code>$request</code>
     </PossiblyUnusedParam>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $row['Type']]]></code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Controllers/TableController.php">
     <MixedArgument>
@@ -4767,7 +4769,6 @@
       <code><![CDATA[$def['Type']]]></code>
       <code>$default</code>
       <code><![CDATA[$extractedColumnSpec['attribute']]]></code>
-      <code>$field</code>
       <code>$key</code>
       <code><![CDATA[$meta['DefaultValue']]]></code>
       <code><![CDATA[$meta['DefaultValue']]]></code>
@@ -4859,7 +4860,6 @@
       <code>$defaultValue</code>
       <code>$defaultValues[$rowNum]</code>
       <code>$extra</code>
-      <code>$field</code>
       <code>$hasList[]</code>
       <code>$key</code>
       <code>$length</code>
@@ -4918,6 +4918,9 @@
       <code><![CDATA[(bool) $GLOBALS['cfg']['Server']['DisableIS']]]></code>
       <code><![CDATA[(int) $GLOBALS['cfg']['MaxRows']]]></code>
     </RedundantCast>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $def['Field']]]></code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Database/Designer.php">
     <DeprecatedMethod>
@@ -5769,6 +5772,7 @@
       <code>reset($columns)</code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion>
+      <code><![CDATA[$this->attachIndexInfoToColumns($database, $table, $fields)]]></code>
       <code><![CDATA[$this->fetchResult($sql, null, 'Field', $connectionType)]]></code>
       <code><![CDATA[$this->fetchResult($sql, null, null, $connectionType)]]></code>
       <code><![CDATA[array<int, array{
@@ -5789,6 +5793,29 @@
      *   Visible?: string,
      *   Expression?: string|null
      * }>]]></code>
+      <code>array_shift($columns) ?? []</code>
+      <code><![CDATA[array{
+     *  Field: string,
+     *  Type: string,
+     *  Collation?: string|null,
+     *  Null:'YES'|'NO',
+     *  Key: string,
+     *  Default: string|null,
+     *  Extra: string,
+     *  Privileges?: string,
+     *  Comment?: string
+     * }]]></code>
+      <code><![CDATA[array{
+     *  Field: string,
+     *  Type: string,
+     *  Collation?: string|null,
+     *  Null:'YES'|'NO',
+     *  Key: string,
+     *  Default: string|null,
+     *  Extra: string,
+     *  Privileges?: string,
+     *  Comment?: string
+     * }[]]]></code>
       <code>string[]</code>
     </MixedReturnTypeCoercion>
     <NullableReturnStatement>
@@ -7783,15 +7810,10 @@
     <PossiblyInvalidOperand>
       <code><![CDATA[$_POST['where_clause'][0]]]></code>
     </PossiblyInvalidOperand>
-    <PossiblyNullArgument>
-      <code><![CDATA[$column['Comment']]]></code>
-      <code><![CDATA[$column['Extra']]]></code>
-      <code><![CDATA[$column['Field']]]></code>
-      <code><![CDATA[$column['Key']]]></code>
-      <code><![CDATA[$column['Privileges']]]></code>
-      <code><![CDATA[$column['Type']]]></code>
-    </PossiblyNullArgument>
     <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$column['Collation']]]></code>
+      <code><![CDATA[$column['Comment']]]></code>
+      <code><![CDATA[$column['Privileges']]]></code>
       <code><![CDATA[$column['is_blob']]]></code>
     </PossiblyUndefinedArrayOffset>
     <RedundantCast>
@@ -8314,6 +8336,9 @@
     <RedundantCast>
       <code>(string) $dependon</code>
     </RedundantCast>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $def['Field']]]></code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Operations.php">
     <DeprecatedMethod>
@@ -8968,19 +8993,12 @@
       <code>$value</code>
     </PossiblyInvalidCast>
     <PossiblyNullArgument>
-      <code>$colAs</code>
-      <code>$colAs</code>
-      <code>$fieldName</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayOffset>
-      <code>$comments</code>
-      <code>$mimeMap</code>
-    </PossiblyNullArrayOffset>
     <PossiblyUndefinedVariable>
       <code>$comments</code>
       <code>$mimeMap</code>
@@ -8999,6 +9017,10 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportLatex.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[$row['Null'] == '']]></code>
+      <code><![CDATA[$row['Null'] == '']]></code>
+    </DocblockTypeContradiction>
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['latex_caption']]]></code>
       <code><![CDATA[$GLOBALS['latex_caption']]]></code>
@@ -9040,9 +9062,7 @@
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
     </PossiblyInvalidArrayOffset>
     <PossiblyNullArgument>
-      <code>$fieldName</code>
       <code>$record[$columns[$i]]</code>
-      <code><![CDATA[$row['Type']]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
       <code><![CDATA[$GLOBALS['plugin_param']['export_type']]]></code>
@@ -9075,9 +9095,6 @@
     </ParamNameMismatch>
     <PossiblyNullOperand>
       <code><![CDATA[$columns[$i]['Default']]]></code>
-      <code><![CDATA[$columns[$i]['Extra']]]></code>
-      <code><![CDATA[$columns[$i]['Null']]]></code>
-      <code><![CDATA[$columns[$i]['Type']]]></code>
       <code>$row[$i]</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
@@ -9179,8 +9196,6 @@
     </PossiblyInvalidArrayOffset>
     <PossiblyNullArgument>
       <code>$colAs</code>
-      <code>$colAs</code>
-      <code>$fieldName</code>
       <code>$row[$j]</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
@@ -9366,7 +9381,6 @@
       <code>Context::escape($alias)</code>
     </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyNullArgument>
-      <code><![CDATA[$column['Type']]]></code>
       <code>$createQuery</code>
       <code>$definition</code>
       <code><![CDATA[$field->name]]></code>
@@ -9383,7 +9397,6 @@
       <code><![CDATA[$aliases[$oldDatabase]['tables']]]></code>
     </PossiblyNullArrayOffset>
     <PossiblyNullOperand>
-      <code><![CDATA[$column['Type']]]></code>
       <code>$eventDef</code>
     </PossiblyNullOperand>
     <PossiblyNullPropertyAssignment>
@@ -9470,13 +9483,7 @@
     </PossiblyInvalidArgument>
     <PossiblyNullArgument>
       <code>$colAs</code>
-      <code>$colAs</code>
-      <code>$fieldName</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayOffset>
-      <code>$comments</code>
-      <code>$mimeMap</code>
-    </PossiblyNullArrayOffset>
     <PossiblyNullOperand>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
@@ -9557,6 +9564,10 @@
     </PossiblyNullOperand>
   </file>
   <file src="libraries/classes/Plugins/Export/Helpers/Pdf.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[$column['Null'] == '']]></code>
+      <code><![CDATA[$column['Null'] == '']]></code>
+    </DocblockTypeContradiction>
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['maxY']]]></code>
     </InvalidArrayOffset>
@@ -9819,16 +9830,9 @@
       <code>$topMargin</code>
     </ParamNameMismatch>
     <PossiblyNullArgument>
-      <code><![CDATA[$column['Type']]]></code>
       <code>$row[$key]</code>
       <code>$txt</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayOffset>
-      <code>$comments</code>
-      <code>$mimeMap</code>
-      <code>$resRel</code>
-      <code>$resRel</code>
-    </PossiblyNullArrayOffset>
     <PossiblyNullOperand>
       <code><![CDATA[$GLOBALS['maxY']]]></code>
     </PossiblyNullOperand>
@@ -10724,6 +10728,10 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[$row['Null'] == '']]></code>
+      <code><![CDATA[$row['Null'] == '']]></code>
+    </DocblockTypeContradiction>
     <InvalidArgument>
       <code><![CDATA[$this->diagram->PageNo()]]></code>
       <code><![CDATA[$this->diagram->PageNo()]]></code>
@@ -10825,22 +10833,12 @@
       <code><![CDATA[$_REQUEST['pdf_paper']]]></code>
       <code><![CDATA[$_REQUEST['pdf_table_order']]]></code>
     </PossiblyInvalidCast>
-    <PossiblyNullArgument>
-      <code>$fieldName</code>
-      <code>$fieldName</code>
-      <code><![CDATA[$row['Type']]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullArrayOffset>
-      <code><![CDATA[$this->diagram->customLinks['RT'][$table]]]></code>
-      <code><![CDATA[$this->diagram->customLinks['doc'][$table]]]></code>
-      <code><![CDATA[$this->diagram->customLinks['doc'][$table]]]></code>
-    </PossiblyNullArrayOffset>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$row['Null']]]></code>
-    </PossiblyUndefinedArrayOffset>
     <PossiblyUnusedMethod>
       <code>isWithDataDictionary</code>
     </PossiblyUnusedMethod>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[$row['Null'] != '']]></code>
+    </RedundantConditionGivenDocblockType>
     <UnusedProperty>
       <code>$bottomMargin</code>
       <code>$rightMargin</code>
@@ -11596,8 +11594,6 @@
     </PossiblyFalseOperand>
     <PossiblyNullArgument>
       <code>$srReplicaAction</code>
-      <code><![CDATA[$val['Type']]]></code>
-      <code><![CDATA[$val['Type']]]></code>
     </PossiblyNullArgument>
     <UnusedFunctionCall>
       <code>strtok</code>
@@ -12394,7 +12390,6 @@
       <code><![CDATA[$statement->altered[0]->field->column]]></code>
     </PossiblyInvalidPropertyFetch>
     <PossiblyNullArgument>
-      <code><![CDATA[$columns[$indexColumnName]['Extra']]]></code>
       <code>$result</code>
       <code>$row[0]</code>
       <code><![CDATA[$statementInfo->parser->list]]></code>
@@ -13960,6 +13955,13 @@
     <UndefinedMethod>
       <code>expects</code>
     </UndefinedMethod>
+  </file>
+  <file src="test/classes/Controllers/Table/StructureControllerTest.php">
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $fields['datetimefield']['Type']]]></code>
+      <code><![CDATA[(string) $fields['id']['Type']]]></code>
+      <code><![CDATA[(string) $fields['name']['Type']]]></code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="test/classes/CoreTest.php">
     <InvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -784,6 +784,10 @@
       <code>$foreigners[$column]</code>
       <code><![CDATA[$row['display_field']]]></code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion>
+      <code>$comments</code>
+      <code>string[]</code>
+    </MixedReturnTypeCoercion>
     <MoreSpecificReturnType>
       <code><![CDATA[array{
      *     foreign_link: bool,
@@ -4194,7 +4198,6 @@
       <code>$attributes[$rownum]</code>
       <code>$columnsList[]</code>
       <code>$field</code>
-      <code>$rowComments[$rownum]</code>
     </MixedAssignment>
     <MixedOperand>
       <code><![CDATA[$GLOBALS['showtable']['Data_length']]]></code>
@@ -7651,7 +7654,6 @@
       <code><![CDATA[$column['pma_type']]]></code>
       <code><![CDATA[$column['pma_type']]]></code>
       <code><![CDATA[$column['pma_type']]]></code>
-      <code><![CDATA[$commentsMap[$column['Field']]]]></code>
       <code>$currCellEditedValues[$columnName]</code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -961,9 +961,6 @@
     </RedundantCast>
   </file>
   <file src="libraries/classes/Controllers/Database/DataDictionaryController.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[$row['Null'] !== '']]></code>
-    </DocblockTypeContradiction>
     <MixedAssignment>
       <code>$relation</code>
     </MixedAssignment>
@@ -977,9 +974,6 @@
     <PossiblyUnusedParam>
       <code>$request</code>
     </PossiblyUnusedParam>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$row['Null'] !== '']]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="libraries/classes/Controllers/Database/DesignerController.php">
     <InvalidArrayOffset>
@@ -3458,9 +3452,6 @@
     <PossiblyUnusedParam>
       <code>$request</code>
     </PossiblyUnusedParam>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $row['Type']]]></code>
-    </RedundantCastGivenDocblockType>
     <RiskyCast>
       <code><![CDATA[$_POST['columnIndex']]]></code>
       <code><![CDATA[$_POST['columnIndex']]]></code>
@@ -3868,9 +3859,6 @@
     <PossiblyUnusedParam>
       <code>$request</code>
     </PossiblyUnusedParam>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $row['Type']]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Controllers/Table/SqlController.php">
     <InvalidArrayOffset>
@@ -4323,9 +4311,6 @@
     <PossiblyUnusedParam>
       <code>$request</code>
     </PossiblyUnusedParam>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $row['Type']]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Controllers/TableController.php">
     <MixedArgument>
@@ -4918,9 +4903,6 @@
       <code><![CDATA[(bool) $GLOBALS['cfg']['Server']['DisableIS']]]></code>
       <code><![CDATA[(int) $GLOBALS['cfg']['MaxRows']]]></code>
     </RedundantCast>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $def['Field']]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Database/Designer.php">
     <DeprecatedMethod>
@@ -8336,9 +8318,6 @@
     <RedundantCast>
       <code>(string) $dependon</code>
     </RedundantCast>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $def['Field']]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="libraries/classes/Operations.php">
     <DeprecatedMethod>
@@ -9017,10 +8996,6 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="libraries/classes/Plugins/Export/ExportLatex.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[$row['Null'] == '']]></code>
-      <code><![CDATA[$row['Null'] == '']]></code>
-    </DocblockTypeContradiction>
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['latex_caption']]]></code>
       <code><![CDATA[$GLOBALS['latex_caption']]]></code>
@@ -9564,10 +9539,6 @@
     </PossiblyNullOperand>
   </file>
   <file src="libraries/classes/Plugins/Export/Helpers/Pdf.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[$column['Null'] == '']]></code>
-      <code><![CDATA[$column['Null'] == '']]></code>
-    </DocblockTypeContradiction>
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['maxY']]]></code>
     </InvalidArrayOffset>
@@ -10728,10 +10699,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="libraries/classes/Plugins/Schema/Pdf/PdfRelationSchema.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[$row['Null'] == '']]></code>
-      <code><![CDATA[$row['Null'] == '']]></code>
-    </DocblockTypeContradiction>
     <InvalidArgument>
       <code><![CDATA[$this->diagram->PageNo()]]></code>
       <code><![CDATA[$this->diagram->PageNo()]]></code>
@@ -10836,9 +10803,6 @@
     <PossiblyUnusedMethod>
       <code>isWithDataDictionary</code>
     </PossiblyUnusedMethod>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[$row['Null'] != '']]></code>
-    </RedundantConditionGivenDocblockType>
     <UnusedProperty>
       <code>$bottomMargin</code>
       <code>$rightMargin</code>
@@ -13955,13 +13919,6 @@
     <UndefinedMethod>
       <code>expects</code>
     </UndefinedMethod>
-  </file>
-  <file src="test/classes/Controllers/Table/StructureControllerTest.php">
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(string) $fields['datetimefield']['Type']]]></code>
-      <code><![CDATA[(string) $fields['id']['Type']]]></code>
-      <code><![CDATA[(string) $fields['name']['Type']]]></code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="test/classes/CoreTest.php">
     <InvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -686,10 +686,12 @@
       <code><![CDATA[usort($tables, 'strnatcasecmp')]]></code>
     </InvalidArgument>
     <InvalidReturnStatement>
+      <code>$comments</code>
       <code>$tableNameReplacements</code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code><![CDATA[array<string, string>]]></code>
+      <code>string[]</code>
     </InvalidReturnType>
     <LessSpecificReturnStatement>
       <code><![CDATA[[
@@ -744,7 +746,6 @@
       <code><![CDATA[$_SESSION['tmpval']['recentTables'][$GLOBALS['server']]]]></code>
     </MixedArrayAssignment>
     <MixedArrayOffset>
-      <code><![CDATA[$comments[$column['Field']]]]></code>
       <code>$foreign[$field]</code>
       <code>$foreign[$field]</code>
       <code>$foreign[$key]</code>
@@ -754,7 +755,6 @@
       <code>$childReferences</code>
       <code>$column</code>
       <code>$columns</code>
-      <code><![CDATA[$comments[$column['Field']]]]></code>
       <code>$field</code>
       <code>$foreignDb</code>
       <code>$foreignField</code>
@@ -784,10 +784,6 @@
       <code>$foreigners[$column]</code>
       <code><![CDATA[$row['display_field']]]></code>
     </MixedReturnStatement>
-    <MixedReturnTypeCoercion>
-      <code>$comments</code>
-      <code>string[]</code>
-    </MixedReturnTypeCoercion>
     <MoreSpecificReturnType>
       <code><![CDATA[array{
      *     foreign_link: bool,
@@ -807,6 +803,9 @@
     <PossiblyInvalidArgument>
       <code>$foreigners</code>
     </PossiblyInvalidArgument>
+    <PossiblyNullArrayOffset>
+      <code>$comments</code>
+    </PossiblyNullArrayOffset>
     <PossiblyUnusedMethod>
       <code>getDbComments</code>
     </PossiblyUnusedMethod>
@@ -963,17 +962,6 @@
     </RedundantCast>
   </file>
   <file src="libraries/classes/Controllers/Database/DataDictionaryController.php">
-    <MixedArgument>
-      <code><![CDATA[$row['Field']]]></code>
-      <code><![CDATA[$row['Type']]]></code>
-    </MixedArgument>
-    <MixedArrayOffset>
-      <code><![CDATA[$columnsComments[$row['Field']]]]></code>
-      <code><![CDATA[$mimeMap[$row['Field']]]]></code>
-      <code><![CDATA[$mimeMap[$row['Field']]]]></code>
-      <code><![CDATA[$primaryKeys[$row['Field']]]]></code>
-      <code><![CDATA[$rows[$row['Field']]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code>$relation</code>
     </MixedAssignment>
@@ -981,6 +969,15 @@
       <code><![CDATA[$foreigner['foreign_field']]]></code>
       <code>$relation</code>
     </MixedOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$row['Field']]]></code>
+      <code><![CDATA[$row['Type']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset>
+      <code>$columnsComments</code>
+      <code>$mimeMap</code>
+      <code>$rows</code>
+    </PossiblyNullArrayOffset>
     <PossiblyUnusedMethod>
       <code>__construct</code>
     </PossiblyUnusedMethod>
@@ -3667,7 +3664,6 @@
       <code><![CDATA[usort($tables, 'strnatcasecmp')]]></code>
     </InvalidArgument>
     <MixedArgument>
-      <code><![CDATA[$column['Field']]]></code>
       <code>$foreignDb</code>
       <code>$foreignTable</code>
       <code>$html</code>
@@ -3677,20 +3673,14 @@
                     : []]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code><![CDATA[uksort($columnArray, 'strnatcasecmp')]]></code>
       <code><![CDATA[usort($columnList, 'strnatcasecmp')]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$oneKey['ref_db_name']]]></code>
       <code><![CDATA[$oneKey['ref_table_name']]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$columnArray[$column['Field']]]]></code>
-      <code><![CDATA[$columnHashArray[$column['Field']]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['display_query']]]></code>
-      <code><![CDATA[$columnArray[$column['Field']]]]></code>
       <code>$existrelForeign</code>
       <code>$foreignDb</code>
       <code>$foreignTable</code>
@@ -3720,6 +3710,13 @@
       <code>$foreignTable</code>
       <code>$foreignTable</code>
     </PossiblyInvalidCast>
+    <PossiblyNullArgument>
+      <code><![CDATA[$column['Field']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset>
+      <code>$columnArray</code>
+      <code>$columnHashArray</code>
+    </PossiblyNullArrayOffset>
   </file>
   <file src="libraries/classes/Controllers/Table/ReplaceController.php">
     <InvalidArgument>
@@ -5542,9 +5539,6 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[array_intersect($_POST['criteriaTables'], $this->tablesNamesOnly)]]></code>
     </InvalidPropertyAssignmentValue>
-    <MixedArgument>
-      <code><![CDATA[$column['Field']]]></code>
-    </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$this->searchTypeDescription]]></code>
     </MixedAssignment>
@@ -7630,16 +7624,9 @@
     </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$columnMime['input_transformation_options']]]></code>
-      <code><![CDATA[$column['Collation']]]></code>
-      <code><![CDATA[$column['Comment']]]></code>
-      <code><![CDATA[$column['Default']]]></code>
-      <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Field']]]></code>
       <code><![CDATA[$column['Field']]]></code>
-      <code><![CDATA[$column['Field']]]></code>
-      <code><![CDATA[$column['Key']]]></code>
-      <code><![CDATA[$column['Privileges']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
@@ -7647,7 +7634,6 @@
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
-      <code><![CDATA[$column['Type']]]></code>
       <code><![CDATA[$column['Type']]]></code>
       <code><![CDATA[$column['Type']]]></code>
       <code><![CDATA[$column['Type']]]></code>
@@ -7797,6 +7783,14 @@
     <PossiblyInvalidOperand>
       <code><![CDATA[$_POST['where_clause'][0]]]></code>
     </PossiblyInvalidOperand>
+    <PossiblyNullArgument>
+      <code><![CDATA[$column['Comment']]]></code>
+      <code><![CDATA[$column['Extra']]]></code>
+      <code><![CDATA[$column['Field']]]></code>
+      <code><![CDATA[$column['Key']]]></code>
+      <code><![CDATA[$column['Privileges']]]></code>
+      <code><![CDATA[$column['Type']]]></code>
+    </PossiblyNullArgument>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$column['is_blob']]]></code>
     </PossiblyUndefinedArrayOffset>
@@ -8253,9 +8247,6 @@
       <code>$col</code>
       <code><![CDATA[$cols['nonpk']]]></code>
       <code><![CDATA[$cols['pk']]]></code>
-      <code><![CDATA[$def['Type']]]></code>
-      <code><![CDATA[$def['Type']]]></code>
-      <code><![CDATA[$def['Type']]]></code>
       <code>$dependent</code>
       <code>$dependents</code>
       <code>$dependents</code>
@@ -8320,10 +8311,6 @@
       <code><![CDATA[$def['Type']]]></code>
       <code><![CDATA[$def['Type']]]></code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$def['Type']]]></code>
-      <code><![CDATA[$def['Type']]]></code>
-    </PossiblyUndefinedArrayOffset>
     <RedundantCast>
       <code>(string) $dependon</code>
     </RedundantCast>
@@ -8945,7 +8932,6 @@
       <code><![CDATA[$column['Type']]]></code>
       <code>$comments[$fieldName]</code>
       <code><![CDATA[$extractedColumnSpec['print_type']]]></code>
-      <code>$fieldName</code>
       <code><![CDATA[$mimeMap[$fieldName]['mimetype']]]></code>
       <code><![CDATA[$trigger['action_timing']]]></code>
       <code><![CDATA[$trigger['definition']]]></code>
@@ -8961,21 +8947,12 @@
       <code><![CDATA[$trigger['event_manipulation']]]></code>
       <code><![CDATA[$trigger['name']]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$aliases[$db]['tables'][$table]['columns'][$colAs]]]></code>
-      <code><![CDATA[$aliases[$db]['tables'][$view]['columns'][$colAs]]]></code>
-      <code>$comments[$fieldName]</code>
-      <code>$mimeMap[$fieldName]</code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['what']]]></code>
       <code>$colAlias</code>
       <code>$colAs</code>
       <code>$colAs</code>
       <code>$colAs</code>
-      <code>$colAs</code>
-      <code>$colAs</code>
-      <code>$fieldName</code>
       <code>$trigger</code>
       <code>$value</code>
     </MixedAssignment>
@@ -8991,12 +8968,19 @@
       <code>$value</code>
     </PossiblyInvalidCast>
     <PossiblyNullArgument>
+      <code>$colAs</code>
+      <code>$colAs</code>
+      <code>$fieldName</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
     </PossiblyNullArgument>
+    <PossiblyNullArrayOffset>
+      <code>$comments</code>
+      <code>$mimeMap</code>
+    </PossiblyNullArrayOffset>
     <PossiblyUndefinedVariable>
       <code>$comments</code>
       <code>$mimeMap</code>
@@ -9024,29 +9008,21 @@
     <MixedArgument>
       <code>$columnsAlias[$i]</code>
       <code>$escape[$k]</code>
-      <code>$fieldName</code>
       <code><![CDATA[$mimeMap[$fieldName]['mimetype']]]></code>
-      <code><![CDATA[$row['Type']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$mimeMap[$fieldName]['mimetype']]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$aliases[$db]['tables'][$table]['columns'][$colAs]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code>$colAs</code>
       <code>$colAs</code>
-      <code>$colAs</code>
       <code>$columnsAlias[$i]</code>
-      <code>$fieldName</code>
       <code>$type</code>
     </MixedAssignment>
     <MixedOperand>
       <code>$colAs</code>
       <code>$comments[$fieldName]</code>
       <code>$escape[$k]</code>
-      <code><![CDATA[$row['Default'] ?? '']]></code>
       <code>$type</code>
     </MixedOperand>
     <ParamNameMismatch>
@@ -9064,7 +9040,9 @@
       <code><![CDATA[$GLOBALS['plugin_param']['single_table']]]></code>
     </PossiblyInvalidArrayOffset>
     <PossiblyNullArgument>
+      <code>$fieldName</code>
       <code>$record[$columns[$i]]</code>
+      <code><![CDATA[$row['Type']]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
       <code><![CDATA[$GLOBALS['plugin_param']['export_type']]]></code>
@@ -9082,21 +9060,13 @@
       <code><![CDATA[$GLOBALS['mediawiki_headers']]]></code>
       <code><![CDATA[$GLOBALS['mediawiki_headers']]]></code>
     </InvalidArrayOffset>
-    <MixedArrayOffset>
-      <code><![CDATA[$aliases[$db]['tables'][$table]['columns'][$colAs]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
-      <code>$colAs</code>
       <code>$colAs</code>
       <code>$column</code>
     </MixedAssignment>
     <MixedOperand>
       <code>$colAs</code>
       <code>$column</code>
-      <code><![CDATA[$columns[$i]['Default']]]></code>
-      <code><![CDATA[$columns[$i]['Extra']]]></code>
-      <code><![CDATA[$columns[$i]['Null']]]></code>
-      <code><![CDATA[$columns[$i]['Type']]]></code>
     </MixedOperand>
     <ParamNameMismatch>
       <code>$doComments</code>
@@ -9104,6 +9074,10 @@
       <code>$doRelation</code>
     </ParamNameMismatch>
     <PossiblyNullOperand>
+      <code><![CDATA[$columns[$i]['Default']]]></code>
+      <code><![CDATA[$columns[$i]['Extra']]]></code>
+      <code><![CDATA[$columns[$i]['Null']]]></code>
+      <code><![CDATA[$columns[$i]['Type']]]></code>
       <code>$row[$i]</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
@@ -9155,7 +9129,6 @@
       <code><![CDATA[$column['Type']]]></code>
       <code>$comments[$fieldName]</code>
       <code><![CDATA[$extractedColumnSpec['print_type']]]></code>
-      <code>$fieldName</code>
       <code><![CDATA[$mimeMap[$fieldName]['mimetype']]]></code>
       <code><![CDATA[$trigger['action_timing']]]></code>
       <code><![CDATA[$trigger['definition']]]></code>
@@ -9173,8 +9146,6 @@
       <code><![CDATA[$aliases[$db]['tables'][$rtable]]]></code>
       <code><![CDATA[$aliases[$db]['tables'][$rtable]]]></code>
       <code><![CDATA[$aliases[$db]['tables'][$rtable]['columns'][$rfield]]]></code>
-      <code><![CDATA[$aliases[$db]['tables'][$table]['columns'][$colAs]]]></code>
-      <code><![CDATA[$aliases[$db]['tables'][$view]['columns'][$colAs]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['what']]]></code>
@@ -9182,9 +9153,6 @@
       <code>$colAs</code>
       <code>$colAs</code>
       <code>$colAs</code>
-      <code>$colAs</code>
-      <code>$colAs</code>
-      <code>$fieldName</code>
       <code>$rfield</code>
       <code>$rfield</code>
       <code>$rtable</code>
@@ -9211,6 +9179,8 @@
     </PossiblyInvalidArrayOffset>
     <PossiblyNullArgument>
       <code>$colAs</code>
+      <code>$colAs</code>
+      <code>$fieldName</code>
       <code>$row[$j]</code>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
@@ -9308,9 +9278,6 @@
       <code>$colAlias</code>
       <code>$colAlias</code>
       <code>$colAs</code>
-      <code><![CDATA[$column['Comment']]]></code>
-      <code><![CDATA[$column['Default']]]></code>
-      <code><![CDATA[$column['Type']]]></code>
       <code>$engine</code>
       <code>$eventName</code>
       <code>$eventName</code>
@@ -9346,7 +9313,6 @@
     </MixedArrayAccess>
     <MixedArrayOffset>
       <code><![CDATA[$aliases[$db]['tables'][$table]['columns'][$field]]]></code>
-      <code><![CDATA[$aliases[$db]['tables'][$view]['columns'][$colAlias]]]></code>
       <code><![CDATA[$oneKey['ref_index_list'][$index]]]></code>
     </MixedArrayOffset>
     <MixedArrayTypeCoercion>
@@ -9357,7 +9323,6 @@
       <code><![CDATA[$GLOBALS['sql_drop_table']]]></code>
       <code><![CDATA[$GLOBALS['sql_indexes']]]></code>
       <code><![CDATA[$GLOBALS['sql_indexes_query']]]></code>
-      <code>$colAlias</code>
       <code>$colAlias</code>
       <code>$colAlias</code>
       <code>$colAs</code>
@@ -9381,8 +9346,6 @@
       <code>$trigger</code>
     </MixedAssignment>
     <MixedOperand>
-      <code><![CDATA[$column['Collation']]]></code>
-      <code><![CDATA[$column['Type']]]></code>
       <code><![CDATA[$definition['Type']]]></code>
       <code><![CDATA[$statement->entityOptions->has('AUTO_INCREMENT')]]></code>
       <code><![CDATA[$trigger['drop']]]></code>
@@ -9403,6 +9366,7 @@
       <code>Context::escape($alias)</code>
     </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyNullArgument>
+      <code><![CDATA[$column['Type']]]></code>
       <code>$createQuery</code>
       <code>$definition</code>
       <code><![CDATA[$field->name]]></code>
@@ -9419,6 +9383,7 @@
       <code><![CDATA[$aliases[$oldDatabase]['tables']]]></code>
     </PossiblyNullArrayOffset>
     <PossiblyNullOperand>
+      <code><![CDATA[$column['Type']]]></code>
       <code>$eventDef</code>
     </PossiblyNullOperand>
     <PossiblyNullPropertyAssignment>
@@ -9464,7 +9429,6 @@
       <code><![CDATA[$column['Default'] ?? '']]></code>
       <code><![CDATA[$column['Type']]]></code>
       <code>$comments[$fieldName]</code>
-      <code>$fieldName</code>
       <code><![CDATA[$mimeMap[$fieldName]['mimetype']]]></code>
       <code><![CDATA[$trigger['definition']]]></code>
       <code>$type</code>
@@ -9479,21 +9443,12 @@
       <code><![CDATA[$trigger['event_manipulation']]]></code>
       <code><![CDATA[$trigger['name']]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset>
-      <code><![CDATA[$aliases[$db]['tables'][$table]['columns'][$colAs]]]></code>
-      <code><![CDATA[$aliases[$db]['tables'][$view]['columns'][$colAs]]]></code>
-      <code>$comments[$fieldName]</code>
-      <code>$mimeMap[$fieldName]</code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$GLOBALS['what']]]></code>
       <code>$colAlias</code>
       <code>$colAs</code>
       <code>$colAs</code>
       <code>$colAs</code>
-      <code>$colAs</code>
-      <code>$colAs</code>
-      <code>$fieldName</code>
       <code>$trigger</code>
       <code>$type</code>
       <code>$value</code>
@@ -9515,7 +9470,13 @@
     </PossiblyInvalidArgument>
     <PossiblyNullArgument>
       <code>$colAs</code>
+      <code>$colAs</code>
+      <code>$fieldName</code>
     </PossiblyNullArgument>
+    <PossiblyNullArrayOffset>
+      <code>$comments</code>
+      <code>$mimeMap</code>
+    </PossiblyNullArrayOffset>
     <PossiblyNullOperand>
       <code>$tableAlias</code>
       <code>$tableAlias</code>
@@ -9603,7 +9564,6 @@
       <code><![CDATA[$GLOBALS['maxY'] - $this->tMargin]]></code>
       <code>$cellFontSize</code>
       <code>$colAs</code>
-      <code><![CDATA[$column['Type']]]></code>
       <code>$fullwidth + $l</code>
       <code>$fullwidth + $l</code>
       <code>$fullwidth + $l</code>
@@ -9702,10 +9662,6 @@
       <code><![CDATA[$trigger['name']]]></code>
     </MixedArrayAccess>
     <MixedArrayOffset>
-      <code>$comments[$fieldName]</code>
-      <code>$mimeMap[$fieldName]</code>
-      <code>$resRel[$fieldName]</code>
-      <code>$resRel[$fieldName]</code>
       <code><![CDATA[$this->headerset[$this->page]]]></code>
       <code><![CDATA[$this->headerset[$this->page]]]></code>
       <code><![CDATA[$this->pagedim[$oldpage]]]></code>
@@ -9733,9 +9689,6 @@
       <code>$data[]</code>
       <code>$data[]</code>
       <code>$data[]</code>
-      <code>$data[]</code>
-      <code>$data[]</code>
-      <code>$fieldName</code>
       <code>$fullwidth</code>
       <code>$fullwidth</code>
       <code>$fullwidth</code>
@@ -9866,9 +9819,16 @@
       <code>$topMargin</code>
     </ParamNameMismatch>
     <PossiblyNullArgument>
+      <code><![CDATA[$column['Type']]]></code>
       <code>$row[$key]</code>
       <code>$txt</code>
     </PossiblyNullArgument>
+    <PossiblyNullArrayOffset>
+      <code>$comments</code>
+      <code>$mimeMap</code>
+      <code>$resRel</code>
+      <code>$resRel</code>
+    </PossiblyNullArrayOffset>
     <PossiblyNullOperand>
       <code><![CDATA[$GLOBALS['maxY']]]></code>
     </PossiblyNullOperand>
@@ -10769,15 +10729,12 @@
       <code><![CDATA[$this->diagram->PageNo()]]></code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$fieldName</code>
-      <code>$fieldName</code>
       <code><![CDATA[$mimeMap[$fieldName]['mimetype']]]></code>
       <code>$oneField</code>
       <code><![CDATA[$oneKey['ref_index_list'][$index]]]></code>
       <code><![CDATA[$oneKey['ref_table_name']]]></code>
       <code><![CDATA[$rel['foreign_field']]]></code>
       <code><![CDATA[$rel['foreign_table']]]></code>
-      <code><![CDATA[$row['Type']]]></code>
       <code><![CDATA[$showTable['Check_time']]]></code>
       <code><![CDATA[$showTable['Create_time']]]></code>
       <code><![CDATA[$showTable['Update_time']]]></code>
@@ -10829,19 +10786,14 @@
       <code><![CDATA[$foreignTable[$foreigner['foreign_field']]]]></code>
       <code><![CDATA[$oneKey['ref_index_list'][$index]]]></code>
       <code><![CDATA[$this->diagram->customLinks['RT'][$table]]]></code>
-      <code><![CDATA[$this->diagram->customLinks['RT'][$table][$fieldName]]]></code>
       <code><![CDATA[$this->diagram->customLinks['doc'][$foreigner['foreign_table']]]]></code>
       <code><![CDATA[$this->diagram->customLinks['doc'][$foreigner['foreign_table']]]]></code>
       <code><![CDATA[$this->diagram->customLinks['doc'][$foreigner['foreign_table']][$foreigner['foreign_field']]]]></code>
       <code><![CDATA[$this->diagram->customLinks['doc'][$table]]]></code>
       <code><![CDATA[$this->diagram->customLinks['doc'][$table]]]></code>
-      <code><![CDATA[$this->diagram->customLinks['doc'][$table][$fieldName]]]></code>
-      <code><![CDATA[$this->diagram->customLinks['doc'][$table][$fieldName]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
       <code>$attribute</code>
-      <code>$fieldName</code>
-      <code>$fieldName</code>
       <code>$foreignTable</code>
       <code>$index</code>
       <code>$links[0]</code>
@@ -10873,6 +10825,16 @@
       <code><![CDATA[$_REQUEST['pdf_paper']]]></code>
       <code><![CDATA[$_REQUEST['pdf_table_order']]]></code>
     </PossiblyInvalidCast>
+    <PossiblyNullArgument>
+      <code>$fieldName</code>
+      <code>$fieldName</code>
+      <code><![CDATA[$row['Type']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset>
+      <code><![CDATA[$this->diagram->customLinks['RT'][$table]]]></code>
+      <code><![CDATA[$this->diagram->customLinks['doc'][$table]]]></code>
+      <code><![CDATA[$this->diagram->customLinks['doc'][$table]]]></code>
+    </PossiblyNullArrayOffset>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$row['Null']]]></code>
     </PossiblyUndefinedArrayOffset>
@@ -11590,8 +11552,6 @@
       <code>$errorMessage</code>
       <code>$serverReplicationVariable</code>
       <code>$successMessage</code>
-      <code><![CDATA[$val['Type']]]></code>
-      <code><![CDATA[$val['Type']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$GLOBALS['urlParams']]]></code>
@@ -11636,6 +11596,8 @@
     </PossiblyFalseOperand>
     <PossiblyNullArgument>
       <code>$srReplicaAction</code>
+      <code><![CDATA[$val['Type']]]></code>
+      <code><![CDATA[$val['Type']]]></code>
     </PossiblyNullArgument>
     <UnusedFunctionCall>
       <code>strtok</code>
@@ -12328,7 +12290,6 @@
       <code><![CDATA[$GLOBALS['show_as_php']]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
-      <code><![CDATA[$columns[$indexColumnName]['Extra']]]></code>
       <code><![CDATA[$extraData['error']]]></code>
       <code><![CDATA[$fieldInfoResult[0]['Type']]]></code>
       <code><![CDATA[$foreignData['foreign_field']]]></code>
@@ -12433,6 +12394,7 @@
       <code><![CDATA[$statement->altered[0]->field->column]]></code>
     </PossiblyInvalidPropertyFetch>
     <PossiblyNullArgument>
+      <code><![CDATA[$columns[$indexColumnName]['Extra']]]></code>
       <code>$result</code>
       <code>$row[0]</code>
       <code><![CDATA[$statementInfo->parser->list]]></code>
@@ -13370,7 +13332,6 @@
     </MixedArrayOffset>
     <MixedAssignment>
       <code>$array</code>
-      <code>$columnNames[]</code>
       <code>$columnNames[]</code>
       <code><![CDATA[$indexesData[$row['Key_name']][$row['Seq_in_index']]['Column_name']]]></code>
       <code><![CDATA[$indexesData[$row['Key_name']][$row['Seq_in_index']]['Sub_part']]]></code>

--- a/test/classes/Controllers/Table/StructureControllerTest.php
+++ b/test/classes/Controllers/Table/StructureControllerTest.php
@@ -117,9 +117,9 @@ class StructureControllerTest extends AbstractTestCase
             'table_stats' => null,
             'fields' => $fields,
             'extracted_columnspecs' => [
-                1 => Util::extractColumnSpec((string) $fields['id']['Type']),
-                2 => Util::extractColumnSpec((string) $fields['name']['Type']),
-                3 => Util::extractColumnSpec((string) $fields['datetimefield']['Type']),
+                1 => Util::extractColumnSpec($fields['id']['Type']),
+                2 => Util::extractColumnSpec($fields['name']['Type']),
+                3 => Util::extractColumnSpec($fields['datetimefield']['Type']),
             ],
             'columns_with_index' => [],
             'central_list' => [],

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -420,7 +420,7 @@ class InsertEditTest extends AbstractTestCase
             $this->insertEdit,
             InsertEdit::class,
             'analyzeTableColumnsArray',
-            [$column, [], -1],
+            [$column, [], -1, false],
         );
 
         $this->assertEquals($result['Field_md5'], '4342210df36bf2ff2c4e2a997a6d4089');

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -420,7 +420,7 @@ class InsertEditTest extends AbstractTestCase
             $this->insertEdit,
             InsertEdit::class,
             'analyzeTableColumnsArray',
-            [$column, []],
+            [$column, [], -1],
         );
 
         $this->assertEquals($result['Field_md5'], '4342210df36bf2ff2c4e2a997a6d4089');
@@ -2411,11 +2411,6 @@ class InsertEditTest extends AbstractTestCase
             'input_transformation_options' => '150',
         ];
 
-        $resultStub = $this->createMock(DummyResult::class);
-        $resultStub->expects($this->any())
-            ->method('getFieldsMeta')
-            ->will($this->returnValue([FieldHelper::fromArray(['type' => 0, 'length' => -1])]));
-
         // Test w/ input transformation
         $actual = $this->callFunction(
             $this->insertEdit,
@@ -2425,7 +2420,7 @@ class InsertEditTest extends AbstractTestCase
                 $tableColumn,
                 0,
                 [],
-                $resultStub,
+                -1,
                 false,
                 [],
                 0,
@@ -2470,7 +2465,7 @@ class InsertEditTest extends AbstractTestCase
                 $tableColumn,
                 0,
                 [],
-                $resultStub,
+                -1,
                 true,
                 [],
                 0,

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -1643,11 +1643,11 @@ class DbiDummy implements DbiExtension
             ],
             [
                 'query' => 'SHOW FULL COLUMNS FROM `test_db`.`test_table`',
-                'columns' => ['Field', 'Type', 'Null', 'Key', 'Default', 'Extra'],
+                'columns' => ['Field', 'Type', 'Collation', 'Null', 'Key', 'Default', 'Extra', 'Privileges', 'Comment'],
                 'result' => [
-                    ['id', 'int(11)', 'NO', 'PRI', 'NULL', 'auto_increment'],
-                    ['name', 'varchar(20)', 'NO', '', 'NULL', ''],
-                    ['datetimefield', 'datetime', 'NO', '', 'NULL', ''],
+                    ['id', 'int(11)', null, 'NO', 'PRI', 'NULL', 'auto_increment', '', ''],
+                    ['name', 'varchar(20)', null, 'NO', '', 'NULL', '', '', ''],
+                    ['datetimefield', 'datetime', null, 'NO', '', 'NULL', '', '', ''],
                 ],
             ],
             [


### PR DESCRIPTION
This is not the end state I wanted to achieve and I will continue refactoring this in future PRs. This PR introduces a new DTO that eventually should be adopted by `DatabaseInterface`. I am thinking of adding another one called just `Column` but not sure how it will play out. 

The goal of this PR was to untangle the logic in InsertEdit a little bit by distinguishing which information is fetched from database and is readonly and which is analysed by the class itself. Previously it was all `$column` array with no types. Now, it's split into a DTO coming from the database `SHOW FULL COLUMNS` and the remaining analysed `$column` array. Thanks to better type hints, it was also possible to eliminate a lot of unnecessary logic and simplify the tests. I feel like this is a small win that could only be improved by my further PRs. The next PR will focus on untangling the analysed column data and providing proper types instead of convoluted array shape. 