### PR TITLE
InsertEdit refactoring - part 4

### DIFF
--- a/libraries/classes/Controllers/Table/ReplaceController.php
+++ b/libraries/classes/Controllers/Table/ReplaceController.php
@@ -18,6 +18,7 @@ use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\InsertEdit;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Plugins\IOTransformationsPlugin;
+use PhpMyAdmin\Query\Generator as QueryGenerator;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Table;
 use PhpMyAdmin\Template;
@@ -286,7 +287,7 @@ final class ReplaceController extends AbstractController
 
         // Builds the sql query
         if ($isInsert && $valueSets !== []) {
-            $GLOBALS['query'] = (array) $this->insertEdit->buildInsertSqlQuery(
+            $GLOBALS['query'] = (array) QueryGenerator::buildInsertSqlQuery(
                 $GLOBALS['table'],
                 $isInsertignore,
                 $queryFields,

--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -1357,17 +1357,17 @@ class Routines
                 ) {
                     $params[$i]['generator'] = null;
                 } else {
-                    $field = [
-                        'True_Type' => mb_strtolower($routine['item_param_type'][$i]),
-                        'Type' => '',
-                        'Key' => '',
-                        'Field' => '',
-                        'Default' => '',
-                        'first_timestamp' => false,
-                    ];
-
-                    $generator = Generator::getFunctionsForField($field, false, []);
-                    $params[$i]['generator'] = $generator;
+                    $defaultFunction = Generator::getDefaultFunctionForField(
+                        mb_strtolower($routine['item_param_type'][$i]),
+                        false,
+                        '',
+                        '',
+                        false,
+                        '',
+                        '',
+                        false,
+                    );
+                    $params[$i]['generator'] = Generator::getFunctionsForField($defaultFunction, []);
                 }
             }
 

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -937,27 +937,6 @@ class InsertEdit
     }
 
     /**
-     * Builds the SQL insert query
-     *
-     * @param bool     $isInsertIgnore $_POST['submit_type'] === 'insertignore'
-     * @param string[] $queryFields    column names array
-     * @param string[] $valueSets      array of query values
-     *
-     * @todo move this to Query generator class
-     */
-    public function buildInsertSqlQuery(
-        string $table,
-        bool $isInsertIgnore,
-        array $queryFields,
-        array $valueSets,
-    ): string {
-        return ($isInsertIgnore ? 'INSERT IGNORE ' : 'INSERT ') . 'INTO '
-            . Util::backquote($table)
-            . ' (' . implode(', ', $queryFields) . ') VALUES ('
-            . implode('), (', $valueSets) . ')';
-    }
-
-    /**
      * Executes the sql query and get the result, then move back to the calling page
      *
      * @param mixed[] $query built query from buildSqlQuery()

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1873,6 +1873,7 @@ class InsertEdit
         $textareaCols = $GLOBALS['cfg']['TextareaCols'];
         $maxlength = '';
         $enumSelectedValue = '';
+        $enumValues = [];
         $columnSetValues = [];
         $setSelectSize = 0;
         $isColumnProtectedBlob = false;
@@ -1904,9 +1905,9 @@ class InsertEdit
             }
 
             if ($column['pma_type'] === 'enum') {
-                $column['values'] ??= $extractedColumnspec['enum_set_values'];
+                $enumValues = $extractedColumnspec['enum_set_values'];
 
-                foreach ($column['values'] as $enumValue) {
+                foreach ($enumValues as $enumValue) {
                     if (
                         $data == $enumValue || ($data == ''
                             && (! isset($_POST['where_clause']) || $column['Null'] !== 'YES')
@@ -1917,10 +1918,8 @@ class InsertEdit
                     }
                 }
             } elseif ($column['pma_type'] === 'set') {
-                $columnSetValues = $column['values'] ?? $extractedColumnspec['enum_set_values'];
-                $setSelectSize = ! isset($column['values'])
-                    ? min(4, count($extractedColumnspec['enum_set_values']))
-                    : $column['select_size'];
+                $columnSetValues = $extractedColumnspec['enum_set_values'];
+                $setSelectSize = min(4, count($extractedColumnspec['enum_set_values']));
             } elseif ($column['is_binary'] || $column['is_blob']) {
                 $isColumnProtectedBlob = ($GLOBALS['cfg']['ProtectBinary'] === 'blob' && $column['is_blob'])
                     || ($GLOBALS['cfg']['ProtectBinary'] === 'all')
@@ -1998,6 +1997,7 @@ class InsertEdit
             'max_length' => $maxlength,
             'longtext_double_textarea' => $GLOBALS['cfg']['LongtextDoubleTextarea'],
             'enum_selected_value' => $enumSelectedValue,
+            'enum_values' => $enumValues,
             'set_values' => $columnSetValues,
             'set_select_size' => $setSelectSize,
             'is_column_protected_blob' => $isColumnProtectedBlob,

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -1845,8 +1845,6 @@ class InsertEdit
 
                     if ($transformationPlugin instanceof IOTransformationsPlugin) {
                         $transformedHtml = $transformationPlugin->getInputHtml(
-                            $column,
-                            $rowId,
                             $columnNameAppendix,
                             $transformationOptions,
                             $currentValue,

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -303,7 +303,6 @@ class InsertEdit
      * Analyze the table column array
      *
      * @param ColumnFull $tableColumn  description of column in given table
-     * @param string[]   $commentsMap  comments for every column that has a comment
      * @param int        $columnLength length of the current column taken from field metadata
      * @param bool       $insertMode   whether insert mode
      *
@@ -311,7 +310,6 @@ class InsertEdit
      */
     private function analyzeTableColumnsArray(
         ColumnFull $tableColumn,
-        array $commentsMap,
         int $columnLength,
         bool $insertMode,
     ): array {
@@ -336,7 +334,6 @@ class InsertEdit
             $column['len'] = 30;
         }
 
-        $column['Field_title'] = $this->getColumnTitle($tableColumn->field, $commentsMap);
         $column['is_binary'] = $this->isColumn(
             $tableColumn->type,
             ['binary', 'varbinary'],
@@ -1735,7 +1732,7 @@ class InsertEdit
         array $columnMime,
         string $whereClause,
     ): string {
-        $column = $this->analyzeTableColumnsArray($tableColumn, $commentsMap, $columnLength, $insertMode);
+        $column = $this->analyzeTableColumnsArray($tableColumn, $columnLength, $insertMode);
 
         $asIs = false;
         /** @var string $fieldHashMd5 */
@@ -2008,6 +2005,7 @@ class InsertEdit
             'select_option_for_upload' => $selectOptionForUpload,
             'limit_chars' => $GLOBALS['cfg']['LimitChars'],
             'input_field_html' => $inputFieldHtml,
+            'field_title' => $this->getColumnTitle($column['Field'], $commentsMap),
         ]);
     }
 

--- a/libraries/classes/InsertEditColumn.php
+++ b/libraries/classes/InsertEditColumn.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin;
+
+use function date;
+use function md5;
+use function preg_match;
+use function preg_replace;
+
+final class InsertEditColumn
+{
+    public readonly string|null $default;
+    public readonly string $md5;
+    /**
+     * trueType contains only the type (stops at first bracket)
+     */
+    public readonly string $trueType;
+    public readonly string $pmaType;
+    public readonly int $length;
+    public readonly bool $firstTimestamp;
+
+    public function __construct(
+        public readonly string $field,
+        public readonly string $type,
+        public readonly bool $isNull,
+        public readonly string $key,
+        string|null $default,
+        public readonly string $extra,
+        int $columnLength,
+        public readonly bool $isBinary,
+        public readonly bool $isBlob,
+        public readonly bool $isChar,
+        bool $insertMode,
+    ) {
+        if (
+            $this->type === 'datetime'
+            && ! $this->isNull
+            && $default === null
+            && $insertMode
+        ) {
+            $this->default = date('Y-m-d H:i:s');
+        } else {
+            $this->default = $default;
+        }
+
+        $this->md5 = md5($this->field);
+        $this->trueType = preg_replace('@\(.*@s', '', $this->type);
+        // length is unknown for geometry fields,
+        // make enough space to edit very simple WKTs
+        if ($columnLength === -1) {
+            $columnLength = 30;
+        }
+
+        $this->length = preg_match('@float|double@', $this->type) ? 100 : $columnLength;
+        $this->pmaType = match ($this->trueType) {
+            'set', 'enum' => $this->trueType,
+            default => $this->type,
+        };
+        /**
+         * TODO: This property is useless at the moment.
+         * It seems like a long time ago before refactoring into classes,
+         * this kept track of how many timestamps are in the table.
+         */
+        $this->firstTimestamp = $this->trueType === 'timestamp';
+    }
+}

--- a/libraries/classes/Plugins/IOTransformationsPlugin.php
+++ b/libraries/classes/Plugins/IOTransformationsPlugin.php
@@ -27,8 +27,6 @@ abstract class IOTransformationsPlugin extends TransformationsPlugin
      * Returns the html for input field to override default textarea.
      * Note: Return empty string if default textarea is required.
      *
-     * @param mixed[] $column             column details
-     * @param int     $rowId              row number
      * @param string  $columnNameAppendix the name attribute
      * @param mixed[] $options            transformation options
      * @param string  $value              Current field value
@@ -38,8 +36,6 @@ abstract class IOTransformationsPlugin extends TransformationsPlugin
      * @return string the html for input field
      */
     public function getInputHtml(
-        array $column,
-        int $rowId,
         string $columnNameAppendix,
         array $options,
         string $value,

--- a/libraries/classes/Plugins/Transformations/Abs/CodeMirrorEditorTransformationPlugin.php
+++ b/libraries/classes/Plugins/Transformations/Abs/CodeMirrorEditorTransformationPlugin.php
@@ -34,8 +34,6 @@ abstract class CodeMirrorEditorTransformationPlugin extends IOTransformationsPlu
      * Returns the html for input field to override default textarea.
      * Note: Return empty string if default textarea is required.
      *
-     * @param mixed[] $column             column details
-     * @param int     $rowId              row number
      * @param string  $columnNameAppendix the name attribute
      * @param mixed[] $options            transformation options
      * @param string  $value              Current field value
@@ -45,8 +43,6 @@ abstract class CodeMirrorEditorTransformationPlugin extends IOTransformationsPlu
      * @return string the html for input field
      */
     public function getInputHtml(
-        array $column,
-        int $rowId,
         string $columnNameAppendix,
         array $options,
         string $value,

--- a/libraries/classes/Plugins/Transformations/Abs/ImageUploadTransformationsPlugin.php
+++ b/libraries/classes/Plugins/Transformations/Abs/ImageUploadTransformationsPlugin.php
@@ -48,8 +48,6 @@ abstract class ImageUploadTransformationsPlugin extends IOTransformationsPlugin
      * Returns the html for input field to override default textarea.
      * Note: Return empty string if default textarea is required.
      *
-     * @param mixed[] $column             column details
-     * @param int     $rowId              row number
      * @param string  $columnNameAppendix the name attribute
      * @param mixed[] $options            transformation options
      * @param string  $value              Current field value
@@ -59,8 +57,6 @@ abstract class ImageUploadTransformationsPlugin extends IOTransformationsPlugin
      * @return string the html for input field
      */
     public function getInputHtml(
-        array $column,
-        int $rowId,
         string $columnNameAppendix,
         array $options,
         string $value,

--- a/libraries/classes/Plugins/Transformations/Abs/TextFileUploadTransformationsPlugin.php
+++ b/libraries/classes/Plugins/Transformations/Abs/TextFileUploadTransformationsPlugin.php
@@ -43,8 +43,6 @@ abstract class TextFileUploadTransformationsPlugin extends IOTransformationsPlug
      * Returns the html for input field to override default textarea.
      * Note: Return empty string if default textarea is required.
      *
-     * @param mixed[] $column             column details
-     * @param int     $rowId              row number
      * @param string  $columnNameAppendix the name attribute
      * @param mixed[] $options            transformation options
      * @param string  $value              Current field value
@@ -54,8 +52,6 @@ abstract class TextFileUploadTransformationsPlugin extends IOTransformationsPlug
      * @return string the html for input field
      */
     public function getInputHtml(
-        array $column,
-        int $rowId,
         string $columnNameAppendix,
         array $options,
         string $value,

--- a/libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptobinary.php
+++ b/libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptobinary.php
@@ -50,8 +50,6 @@ class Text_Plain_Iptobinary extends IOTransformationsPlugin
      * Returns the html for input field to override default textarea.
      * Note: Return empty string if default textarea is required.
      *
-     * @param mixed[] $column             column details
-     * @param int     $rowId              row number
      * @param string  $columnNameAppendix the name attribute
      * @param mixed[] $options            transformation options
      * @param string  $value              Current field value
@@ -61,8 +59,6 @@ class Text_Plain_Iptobinary extends IOTransformationsPlugin
      * @return string the html for input field
      */
     public function getInputHtml(
-        array $column,
-        int $rowId,
         string $columnNameAppendix,
         array $options,
         string $value,

--- a/libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptolong.php
+++ b/libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptolong.php
@@ -47,8 +47,6 @@ class Text_Plain_Iptolong extends IOTransformationsPlugin
      * Returns the html for input field to override default textarea.
      * Note: Return empty string if default textarea is required.
      *
-     * @param mixed[] $column             column details
-     * @param int     $rowId              row number
      * @param string  $columnNameAppendix the name attribute
      * @param mixed[] $options            transformation options
      * @param string  $value              Current field value
@@ -58,8 +56,6 @@ class Text_Plain_Iptolong extends IOTransformationsPlugin
      * @return string the html for input field
      */
     public function getInputHtml(
-        array $column,
-        int $rowId,
         string $columnNameAppendix,
         array $options,
         string $value,

--- a/libraries/classes/Query/Generator.php
+++ b/libraries/classes/Query/Generator.php
@@ -429,4 +429,23 @@ class Generator
 
         return 'ALTER TABLE ' . Util::backquote($table) . ' ADD ' . $indexType . '(' . $columnsSql . ');';
     }
+
+    /**
+     * Builds the SQL insert query
+     *
+     * @param bool     $isInsertIgnore $_POST['submit_type'] === 'insertignore'
+     * @param string[] $queryFields    column names array
+     * @param string[] $valueSets      array of query values
+     */
+    public static function buildInsertSqlQuery(
+        string $table,
+        bool $isInsertIgnore,
+        array $queryFields,
+        array $valueSets,
+    ): string {
+        return ($isInsertIgnore ? 'INSERT IGNORE ' : 'INSERT ') . 'INTO '
+            . Util::backquote($table)
+            . ' (' . implode(', ', $queryFields) . ') VALUES ('
+            . implode('), (', $valueSets) . ')';
+    }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4546,6 +4546,11 @@ parameters:
 			path: libraries/classes/IndexColumn.php
 
 		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: libraries/classes/InsertEdit.php
+
+		-
 			message: "#^Cannot access offset string on mixed\\.$#"
 			count: 3
 			path: libraries/classes/InsertEdit.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4562,7 +4562,7 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 3
+			count: 2
 			path: libraries/classes/InsertEdit.php
 
 		-
@@ -4596,11 +4596,6 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#1 \\$columnSpecification of static method PhpMyAdmin\\\\Util\\:\\:extractColumnSpec\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
 			message: "#^Parameter \\#1 \\$data of static method PhpMyAdmin\\\\Utils\\\\Gis\\:\\:convertToWellKnownText\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
@@ -4611,17 +4606,7 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function mb_strstr expects string, mixed given\\.$#"
-			count: 2
-			path: libraries/classes/InsertEdit.php
-
-		-
 			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$haystack of function str_starts_with expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -4651,16 +4636,6 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Parameter \\#1 \\$type of method PhpMyAdmin\\\\Types\\:\\:getIntegerRange\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#1 \\$type of method PhpMyAdmin\\\\Types\\:\\:getTypeClass\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
@@ -4672,11 +4647,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#17 \\$whereClause of method PhpMyAdmin\\\\InsertEdit\\:\\:getHtmlForInsertEditFormColumn\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Parameter \\#2 \\$column of method PhpMyAdmin\\\\ConfigStorage\\\\Relation\\:\\:searchColumnInForeigners\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -4694,6 +4664,16 @@ parameters:
 			message: "#^Parameter \\#3 \\$row of static method PhpMyAdmin\\\\Util\\:\\:getUniqueCondition\\(\\) expects array\\<int, mixed\\>, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
+
+		-
+			message: "#^Property PhpMyAdmin\\\\InsertEditColumn\\:\\:\\$trueType \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: libraries/classes/InsertEditColumn.php
+
+		-
+			message: "#^Readonly property PhpMyAdmin\\\\InsertEditColumn\\:\\:\\$default is already assigned\\.$#"
+			count: 1
+			path: libraries/classes/InsertEditColumn.php
 
 		-
 			message: "#^Binary operation \"\\-\" between string and 1 results in an error\\.$#"
@@ -9169,51 +9149,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$columns of method PhpMyAdmin\\\\Index\\:\\:addColumns\\(\\) expects array, mixed given\\.$#"
 			count: 2
 			path: test/classes/IndexTest.php
-
-		-
-			message: "#^Cannot access offset 'Field' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
-			message: "#^Cannot access offset 'Field_md5' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
-			message: "#^Cannot access offset 'True_Type' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
-			message: "#^Cannot access offset 'is_binary' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
-			message: "#^Cannot access offset 'is_blob' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
-			message: "#^Cannot access offset 'is_char' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
-			message: "#^Cannot access offset 'len' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
-			message: "#^Cannot access offset 'pma_type' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
-			message: "#^Cannot access offset 'wrap' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$value of function strval expects bool\\|float\\|int\\|resource\\|string\\|null, bool\\|float\\|int\\|object given\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9181,11 +9181,6 @@ parameters:
 			path: test/classes/InsertEditTest.php
 
 		-
-			message: "#^Cannot access offset 'Field_title' on mixed\\.$#"
-			count: 1
-			path: test/classes/InsertEditTest.php
-
-		-
 			message: "#^Cannot access offset 'True_Type' on mixed\\.$#"
 			count: 1
 			path: test/classes/InsertEditTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -129,6 +129,13 @@
       <code><![CDATA[$GLOBALS['table_priv']]]></code>
     </MixedAssignment>
   </file>
+  <file src="libraries/classes/ColumnFull.php">
+    <PossiblyUnusedProperty>
+      <code>$collation</code>
+      <code>$comment</code>
+      <code>$privileges</code>
+    </PossiblyUnusedProperty>
+  </file>
   <file src="libraries/classes/Command/CacheWarmupCommand.php">
     <UnusedClass>
       <code>CacheWarmupCommand</code>
@@ -7194,7 +7201,6 @@
       <code><![CDATA[$GLOBALS['special_message']]]></code>
       <code>$alt</code>
       <code>$defaultFunction</code>
-      <code><![CDATA[$field['True_Type']]]></code>
       <code>$title</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
@@ -7608,34 +7614,13 @@
     </LessSpecificReturnStatement>
     <MixedArgument>
       <code><![CDATA[$columnMime['input_transformation_options']]]></code>
-      <code><![CDATA[$column['Extra']]]></code>
-      <code><![CDATA[$column['Field']]]></code>
-      <code><![CDATA[$column['Field']]]></code>
-      <code><![CDATA[$column['Field']]]></code>
-      <code><![CDATA[$column['True_Type']]]></code>
-      <code><![CDATA[$column['True_Type']]]></code>
-      <code><![CDATA[$column['True_Type']]]></code>
-      <code><![CDATA[$column['True_Type']]]></code>
-      <code><![CDATA[$column['True_Type']]]></code>
-      <code><![CDATA[$column['True_Type']]]></code>
-      <code><![CDATA[$column['True_Type']]]></code>
-      <code><![CDATA[$column['Type']]]></code>
-      <code><![CDATA[$column['Type']]]></code>
-      <code><![CDATA[$column['Type']]]></code>
-      <code><![CDATA[$column['pma_type']]]></code>
-      <code><![CDATA[$column['pma_type']]]></code>
-      <code><![CDATA[$column['pma_type']]]></code>
-      <code><![CDATA[$column['pma_type']]]></code>
-      <code><![CDATA[$column['pma_type']]]></code>
       <code>$currCellEditedValues[$columnName]</code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
+      <code><![CDATA[$currentRow[$column->field]]]></code>
+      <code><![CDATA[$currentRow[$column->field]]]></code>
+      <code><![CDATA[$currentRow[$column->field]]]></code>
+      <code><![CDATA[$currentRow[$column->field]]]></code>
+      <code><![CDATA[$currentRow[$column->field]]]></code>
+      <code><![CDATA[$currentRow[$column->field]]]></code>
       <code>$currentValue</code>
       <code>$defaultValue</code>
       <code><![CDATA[$extractedColumnspec['enum_set_values']]]></code>
@@ -7655,13 +7640,11 @@
       <code><![CDATA[$transformation[$type . '_options'] ?? '']]></code>
       <code>$whereClause</code>
       <code>$whereClause</code>
-      <code><![CDATA[min(max($column['len'], 4), $GLOBALS['cfg']['LimitChars'])]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$query</code>
       <code>$thisUrlParams</code>
       <code>$thisUrlParams</code>
-      <code>$urlParams</code>
       <code>$whereClauseArray</code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
@@ -7672,45 +7655,18 @@
       <code>$editedValues[$cellIndex][$columnName]</code>
       <code><![CDATA[$extraData['transformations'][$cellIndex]]]></code>
     </MixedArrayAssignment>
-    <MixedArrayOffset>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-    </MixedArrayOffset>
     <MixedAssignment>
       <code>$columnSetValues</code>
       <code>$currCellEditedValues</code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
-      <code><![CDATA[$currentRow[$column['Field']]]]></code>
+      <code><![CDATA[$currentRow[$column->field]]]></code>
+      <code><![CDATA[$currentRow[$column->field]]]></code>
+      <code><![CDATA[$currentRow[$column->field]]]></code>
       <code>$currentValue</code>
       <code>$data</code>
-      <code>$defaultValue</code>
       <code>$defaultValue</code>
       <code>$enumSelectedValue</code>
       <code>$enumValue</code>
       <code>$enumValues</code>
-      <code>$fieldsize</code>
       <code>$file</code>
       <code>$isUnsigned</code>
       <code>$maxlength</code>
@@ -7721,9 +7677,6 @@
       <code>$whereClause</code>
       <code>$whereClause</code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code>int</code>
-    </MixedInferredReturnType>
     <MixedMethodCall>
       <code>new $className()</code>
       <code>new $className()</code>
@@ -7732,16 +7685,6 @@
       <code>$file</code>
       <code>$maxlength</code>
     </MixedOperand>
-    <MixedReturnStatement>
-      <code><![CDATA[min(
-            max($fieldsize, $GLOBALS['cfg']['MinSizeForInputField']),
-            $GLOBALS['cfg']['MaxSizeForInputField'],
-        )]]></code>
-      <code><![CDATA[min(
-            max($fieldsize, $GLOBALS['cfg']['MinSizeForInputField']),
-            $GLOBALS['cfg']['MaxSizeForInputField'],
-        )]]></code>
-    </MixedReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[array{
      *     bool,
@@ -7771,7 +7714,6 @@
       <code><![CDATA[$column['Collation']]]></code>
       <code><![CDATA[$column['Comment']]]></code>
       <code><![CDATA[$column['Privileges']]]></code>
-      <code><![CDATA[$column['is_blob']]]></code>
     </PossiblyUndefinedArrayOffset>
     <RedundantCast>
       <code><![CDATA[(int) $GLOBALS['cfg']['InsertRows']]]></code>
@@ -14301,17 +14243,6 @@
     </MixedArrayAssignment>
   </file>
   <file src="test/classes/InsertEditTest.php">
-    <MixedArrayAccess>
-      <code><![CDATA[$result['Field']]]></code>
-      <code><![CDATA[$result['Field_md5']]]></code>
-      <code><![CDATA[$result['True_Type']]]></code>
-      <code><![CDATA[$result['is_binary']]]></code>
-      <code><![CDATA[$result['is_blob']]]></code>
-      <code><![CDATA[$result['is_char']]]></code>
-      <code><![CDATA[$result['len']]]></code>
-      <code><![CDATA[$result['pma_type']]]></code>
-      <code><![CDATA[$result['wrap']]]></code>
-    </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$_SESSION['tmpval']['relational_display']]]></code>
       <code><![CDATA[$_SESSION['tmpval']['relational_display']]]></code>
@@ -14319,7 +14250,6 @@
     <MixedAssignment>
       <code>$actual</code>
       <code>$actual</code>
-      <code>$result</code>
       <code>$result</code>
       <code>$result</code>
       <code>$result</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7697,7 +7697,6 @@
     </MixedArrayOffset>
     <MixedAssignment>
       <code>$columnSetValues</code>
-      <code><![CDATA[$column['values']]]></code>
       <code>$currCellEditedValues</code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>
       <code><![CDATA[$currentRow[$column['Field']]]]></code>
@@ -7709,12 +7708,12 @@
       <code>$defaultValue</code>
       <code>$enumSelectedValue</code>
       <code>$enumValue</code>
+      <code>$enumValues</code>
       <code>$fieldsize</code>
       <code>$file</code>
       <code>$isUnsigned</code>
       <code>$maxlength</code>
       <code>$maxlength</code>
-      <code>$setSelectSize</code>
       <code>$singleQuery</code>
       <code>$specialChars</code>
       <code>$whereClause</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7611,6 +7611,7 @@
       <code><![CDATA[$column['Extra']]]></code>
       <code><![CDATA[$column['Field']]]></code>
       <code><![CDATA[$column['Field']]]></code>
+      <code><![CDATA[$column['Field']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
       <code><![CDATA[$column['True_Type']]]></code>
@@ -14303,7 +14304,6 @@
     <MixedArrayAccess>
       <code><![CDATA[$result['Field']]]></code>
       <code><![CDATA[$result['Field_md5']]]></code>
-      <code><![CDATA[$result['Field_title']]]></code>
       <code><![CDATA[$result['True_Type']]]></code>
       <code><![CDATA[$result['is_binary']]]></code>
       <code><![CDATA[$result['is_blob']]]></code>

--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -1,6 +1,6 @@
 <tr class="noclick">
   <td class="text-center">
-    {{ column.Field_title|raw }}
+    {{ field_title|raw }}
     <input type="hidden" name="fields_name[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ column.Field }}">
   </td>
 

--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -70,12 +70,12 @@
         {% if column.Type|length > 20 %}
           <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
             <option value=""></option>
-            {% for enum_value in column.values %}
+            {% for enum_value in enum_values %}
               <option value="{{ enum_value }}"{{ enum_value == enum_selected_value ? ' selected' }}>{{ enum_value }}</option>
             {% endfor %}
           </select>
         {% else %}
-          {% for enum_value in column.values %}
+          {% for enum_value in enum_values %}
             <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ enum_value }}" class="textfield" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')"{{ enum_value == enum_selected_value ? ' checked' }}>
             <label for="field_{{ id_index }}_3_{{ loop.index0 }}">{{ enum_value }}</label>
           {% endfor %}

--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -1,23 +1,23 @@
 <tr class="noclick">
   <td class="text-center">
     {{ field_title|raw }}
-    <input type="hidden" name="fields_name[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ column.Field }}">
+    <input type="hidden" name="fields_name[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ column.field }}">
   </td>
 
   {% if show_field_types_in_data_edit_view %}
-    <td class="text-center{{ column.wrap }}">
-      <span class="column_type" dir="ltr">{{ column.pma_type }}</span>
+    <td class="text-center{{ column.trueType not in ['set', 'enum'] ? ' text-nowrap' }}">
+      <span class="column_type" dir="ltr">{{ column.pmaType }}</span>
     </td>
   {% endif %}
 
   {% if show_function_fields %}
     {% if is_column_binary %}
       <td class="text-center">{% trans 'Binary' %}</td>
-    {% elseif 'enum' in column.True_Type or 'set' in column.True_Type %}
+    {% elseif 'enum' in column.trueType or 'set' in column.trueType %}
       <td class="text-center">--</td>
     {% else %}
       <td>
-        <select name="funcs[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_1">
+        <select name="funcs[multi_edit][{{ row_id }}][{{ column.md5 }}]" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')" id="field_{{ id_index }}_1">
           {{ function_options|raw }}
         </select>
       </td>
@@ -25,12 +25,12 @@
   {% endif %}
 
   <td>
-    {% if column.Null|upper == 'YES' %}
-      <input type="hidden" name="fields_null_prev[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]"{{ real_null_value and not column.first_timestamp ? ' value="on"' }}>
-      <input type="checkbox" class="checkbox_null" name="fields_null[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_2" aria-label="{% trans 'Use the NULL value for this column.' %}"{{ real_null_value ? ' checked' }}>
-      <input type="hidden" class="nullify_code" name="nullify_code[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ nullify_code }}">
-      <input type="hidden" class="hashed_field" name="hashed_field[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ column.Field_md5 }}">
-      <input type="hidden" class="multi_edit" name="multi_edit[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ ('[multi_edit][' ~ row_id ~ ']') }}">
+    {% if column.isNull %}
+      <input type="hidden" name="fields_null_prev[multi_edit][{{ row_id }}][{{ column.md5 }}]"{{ real_null_value and not column.firstTimestamp ? ' value="on"' }}>
+      <input type="checkbox" class="checkbox_null" name="fields_null[multi_edit][{{ row_id }}][{{ column.md5 }}]" id="field_{{ id_index }}_2" aria-label="{% trans 'Use the NULL value for this column.' %}"{{ real_null_value ? ' checked' }}>
+      <input type="hidden" class="nullify_code" name="nullify_code[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ nullify_code }}">
+      <input type="hidden" class="hashed_field" name="hashed_field[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ column.md5 }}">
+      <input type="hidden" class="multi_edit" name="multi_edit[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ ('[multi_edit][' ~ row_id ~ ']') }}">
     {% endif %}
   </td>
 
@@ -43,32 +43,32 @@
     {% else %}
       {% if is_value_foreign_link %}
         {{ backup_field|raw }}
-        <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="foreign">
-        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')" id="field_{{ id_index }}_3" value="{{ data }}">
-        <a class="ajax browse_foreign" href="{{ url('/browse-foreigners') }}" data-post="{{ get_common({'db': db, 'table': table, 'field': column.Field, 'rownumber': row_id, 'data': data}) }}">{{ get_icon('b_browse', 'Browse foreign values'|trans) }}</a>
+        <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="foreign">
+        <input type="text" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')" id="field_{{ id_index }}_3" value="{{ data }}">
+        <a class="ajax browse_foreign" href="{{ url('/browse-foreigners') }}" data-post="{{ get_common({'db': db, 'table': table, 'field': column.field, 'rownumber': row_id, 'data': data}) }}">{{ get_icon('b_browse', 'Browse foreign values'|trans) }}</a>
       {% elseif foreign_dropdown is not empty %}
         {{ backup_field|raw }}
-        <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ column.is_binary ? 'hex' : 'foreign' }}">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
+        <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ column.isBinary ? 'hex' : 'foreign' }}">
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
           {{ foreign_dropdown|raw }}
         </select>
-      {% elseif (longtext_double_textarea and 'longtext' in column.pma_type) or 'json' in column.pma_type or 'text' in column.pma_type %}
+      {% elseif (longtext_double_textarea and 'longtext' in column.pmaType) or 'json' in column.pmaType or 'text' in column.pmaType %}
         {{ backup_field|raw }}
-        <textarea name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_3" data-type="{{ data_type }}" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}"
-          {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
+        <textarea name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" id="field_{{ id_index }}_3" data-type="{{ data_type }}" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}"
+          {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.isChar ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
           {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
           {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
         </textarea>
-        {% if 'text' in column.pma_type and special_chars|length > 32000 %}
+        {% if 'text' in column.pmaType and special_chars|length > 32000 %}
           </td>
           <td>
           {% trans 'Because of its length,<br> this column might not be editable.' %}
         {% endif %}
-      {% elseif column.pma_type == 'enum' %}
+      {% elseif column.pmaType == 'enum' %}
         {{ backup_field|raw }}
-        <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="enum">
-        {% if column.Type|length > 20 %}
-          <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
+        <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="enum">
+        {% if column.type|length > 20 %}
+          <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
             <option value=""></option>
             {% for enum_value in enum_values %}
               <option value="{{ enum_value }}"{{ enum_value == enum_selected_value ? ' selected' }}>{{ enum_value }}</option>
@@ -76,41 +76,41 @@
           </select>
         {% else %}
           {% for enum_value in enum_values %}
-            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="{{ enum_value }}" class="textfield" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')"{{ enum_value == enum_selected_value ? ' checked' }}>
+            <input type="radio" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="{{ enum_value }}" class="textfield" id="field_{{ id_index }}_3_{{ loop.index0 }}" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')"{{ enum_value == enum_selected_value ? ' checked' }}>
             <label for="field_{{ id_index }}_3_{{ loop.index0 }}">{{ enum_value }}</label>
           {% endfor %}
         {% endif %}
-      {% elseif column.pma_type == 'set' %}
+      {% elseif column.pmaType == 'set' %}
         {{ backup_field|raw }}
-        <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="set">
-        <select name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}][]" class="textfield" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')" multiple>
+        <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="set">
+        <select name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}][]" class="textfield" size="{{ set_select_size }}" id="field_{{ id_index }}_3" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')" multiple>
           {% for set_value in set_values %}
             <option value="{{ set_value }}"{{ set_value in data|split(',') ? ' selected' }}>{{ set_value }}</option>
           {% endfor %}
         </select>
-      {% elseif column.is_binary or column.is_blob %}
+      {% elseif column.isBinary or column.isBlob %}
         {% if is_column_protected_blob %}
           {% trans 'Binary - do not edit' %}
           ({{ blob_value }} {{ blob_value_unit }})
-          <input type="hidden" name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="">
-          <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="protected">
-        {% elseif column.is_blob or (column.len > limit_chars) %}
+          <input type="hidden" name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="">
+          <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="protected">
+        {% elseif column.isBlob or (column.length > limit_chars) %}
           {{ backup_field|raw }}
-          <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="hex">
-          <textarea name="fields[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" id="field_{{ id_index }}_3" data-type="HEX" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}"
-            {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.is_char ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
+          <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="hex">
+          <textarea name="fields[multi_edit][{{ row_id }}][{{ column.md5 }}]" id="field_{{ id_index }}_3" data-type="HEX" dir="{{ text_dir }}" rows="{{ textarea_rows }}" cols="{{ textarea_cols }}"
+            {{- max_length ? ' data-maxlength="' ~  max_length ~ '"' }}{{ column.isChar ? ' class="char charField"' }} onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
             {#- We need to duplicate the first \n or otherwise we will lose the first newline entered in a VARCHAR or TEXT column -#}
             {{- special_chars starts with "\r\n" ? "\n" }}{{ special_chars|raw -}}
           </textarea>
         {% else %}
           {{ backup_field|raw }}
-          <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" value="hex">
+          <input type="hidden" name="fields_type[multi_edit][{{ row_id }}][{{ column.md5 }}]" value="hex">
           {{ input_field_html|raw }}
         {% endif %}
-        {% if is_upload and column.is_blob %}
+        {% if is_upload and column.isBlob %}
           <br>
           {# We don't want to prevent users from using browser's default drag-drop feature on some page(s), so we add noDragDrop class to the input #}
-          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.Field_md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.Field_md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pma_type }}')">
+          <input type="file" name="fields_upload[multi_edit][{{ row_id }}][{{ column.md5 }}]" class="textfield noDragDrop" id="field_{{ id_index }}_3" size="10" onchange="return verificationsAfterFieldChange('{{ column.md5|escape('js') }}', '{{ row_id|escape('js') }}', '{{ column.pmaType }}')">
           {{ max_upload_size }}
         {% endif %}
         {{ select_option_for_upload|raw }}
@@ -118,7 +118,7 @@
         {{ value|raw }}
       {% endif %}
 
-      {% if column.pma_type in gis_data_types %}
+      {% if column.pmaType in gis_data_types %}
         <span class="open_gis_editor" data-row-id="{{ row_id }}">{{ link_or_button('#', null, get_icon('b_edit', 'Edit/Insert'|trans), [], '_blank') }}</span>
       {% endif %}
     {% endif %}

--- a/templates/table/insert/value_column_for_other_datatype.twig
+++ b/templates/table/insert/value_column_for_other_datatype.twig
@@ -3,21 +3,21 @@
   {{- html_field|raw -}}
 {% else %}
   {{- html_field|raw -}}
-  {%- if column.Extra matches '/(VIRTUAL|PERSISTENT|GENERATED)/' and 'DEFAULT_GENERATED' not in column.Extra -%}
+  {%- if column.extra matches '/(VIRTUAL|PERSISTENT|GENERATED)/' and 'DEFAULT_GENERATED' not in column.extra -%}
     <input type="hidden" name="virtual{{ columnNameAppendix }}" value="1">
   {%- endif -%}
-  {%- if column.Extra == 'auto_increment' -%}
+  {%- if column.extra == 'auto_increment' -%}
     <input type="hidden" name="auto_increment{{ columnNameAppendix }}" value="1">
   {%- endif -%}
-  {%- if column.pma_type starts with 'timestamp' -%}
+  {%- if column.pmaType starts with 'timestamp' -%}
     <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="timestamp">
   {%- endif -%}
-  {%- if column.pma_type starts with 'datetime' -%}
+  {%- if column.pmaType starts with 'datetime' -%}
     <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="datetime">
-  {%- elseif column.pma_type starts with 'date' -%}
+  {%- elseif column.pmaType starts with 'date' -%}
     <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="date">
   {%- endif -%}
-  {%- if column.True_Type == 'bit' or column.True_Type == 'uuid' -%}
-    <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="{{ column.True_Type }}">
+  {%- if column.trueType == 'bit' or column.trueType == 'uuid' -%}
+    <input type="hidden" name="fields_type{{ columnNameAppendix }}" value="{{ column.trueType }}">
   {%- endif -%}
 {% endif %}

--- a/test/classes/Html/GeneratorTest.php
+++ b/test/classes/Html/GeneratorTest.php
@@ -376,15 +376,16 @@ class GeneratorTest extends AbstractTestCase
     /**
      * Test for Generator::getDefaultFunctionForField
      *
-     * @param array  $field      field settings
-     * @param bool   $insertMode true if insert mode
-     * @param string $expected   expected result
-     * @psalm-param array<string, string|bool|null> $field
-     *
      * @dataProvider providerForTestGetDefaultFunctionForField
      */
     public function testGetDefaultFunctionForField(
-        array $field,
+        string $trueType,
+        bool $firstTimestamp,
+        string|null $defaultValue,
+        string $extra,
+        bool $isNull,
+        string $key,
+        string $type,
         bool $insertMode,
         string $expected,
     ): void {
@@ -394,7 +395,16 @@ class GeneratorTest extends AbstractTestCase
 
         $GLOBALS['dbi'] = $dbiStub;
 
-        $result = Generator::getDefaultFunctionForField($field, $insertMode);
+        $result = Generator::getDefaultFunctionForField(
+            $trueType,
+            $firstTimestamp,
+            $defaultValue,
+            $extra,
+            $isNull,
+            $key,
+            $type,
+            $insertMode,
+        );
 
         $this->assertEquals($expected, $result);
     }
@@ -402,38 +412,55 @@ class GeneratorTest extends AbstractTestCase
     /**
      * Data provider for Generator::getDefaultFunctionForField test
      *
-     * @return mixed[]
-     * @psalm-return array<int, array{array<string, string|bool|null>, bool, string}>
+     * @return array{string, bool, string|null, string, bool, string, string, bool, string}[]
      */
     public static function providerForTestGetDefaultFunctionForField(): array
     {
         return [
             [
-                [
-                    'True_Type' => 'GEOMETRY',
-                    'first_timestamp' => false,
-                    'Extra' => null,
-                    'Key' => '',
-                    'Type' => '',
-                    'Null' => 'NO',
-                ],
+                'GEOMETRY',
+                false,
+                null,
+                '',
+                false,
+                '',
+                '',
                 true,
                 'ST_GeomFromText',
             ],
             [
-                [
-                    'True_Type' => 'timestamp',
-                    'first_timestamp' => true,
-                    'Extra' => null,
-                    'Key' => '',
-                    'Type' => '',
-                    'Null' => 'NO',
-                ],
+                'timestamp',
+                true,
+                null,
+                '',
+                false,
+                '',
+                '',
                 true,
                 'NOW',
             ],
-            [['True_Type' => 'uuid', 'first_timestamp' => false, 'Key' => '', 'Type' => ''], true, ''],
-            [['True_Type' => '', 'first_timestamp' => false, 'Key' => 'PRI', 'Type' => 'char(36)'], true, 'UUID'],
+            [
+                'uuid',
+                false,
+                null,
+                '',
+                false,
+                '',
+                '',
+                true,
+                '',
+            ],
+            [
+                '',
+                false,
+                null,
+                '',
+                false,
+                'PRI',
+                'char(36)',
+                true,
+                'UUID',
+            ],
         ];
     }
 

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -1391,25 +1391,6 @@ class InsertEditTest extends AbstractTestCase
     }
 
     /**
-     * Test for buildSqlQuery
-     */
-    public function testBuildSqlQuery(): void
-    {
-        $queryFields = ['a', 'b'];
-        $valueSets = ['1', '2'];
-
-        $this->assertEquals(
-            'INSERT IGNORE INTO `table` (a, b) VALUES (1), (2)',
-            $this->insertEdit->buildInsertSqlQuery('table', true, $queryFields, $valueSets),
-        );
-
-        $this->assertEquals(
-            'INSERT INTO `table` (a, b) VALUES (1), (2)',
-            $this->insertEdit->buildInsertSqlQuery('table', false, $queryFields, $valueSets),
-        );
-    }
-
-    /**
      * Test for executeSqlQuery
      */
     public function testExecuteSqlQuery(): void

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -429,8 +429,6 @@ class InsertEditTest extends AbstractTestCase
 
         $this->assertEquals($result['len'], 100);
 
-        $this->assertEquals($result['Field_title'], '1&lt;2');
-
         $this->assertEquals($result['is_binary'], false);
 
         $this->assertEquals($result['is_blob'], false);

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -12,6 +12,7 @@ use PhpMyAdmin\Dbal\Warning;
 use PhpMyAdmin\EditField;
 use PhpMyAdmin\FileListing;
 use PhpMyAdmin\InsertEdit;
+use PhpMyAdmin\InsertEditColumn;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Table;
 use PhpMyAdmin\Template;
@@ -410,39 +411,6 @@ class InsertEditTest extends AbstractTestCase
     }
 
     /**
-     * Test for analyzeTableColumnsArray
-     */
-    public function testAnalyzeTableColumnsArray(): void
-    {
-        $column = new ColumnFull('1<2', 'float(10, 1)', null, false, '', null, '', '', '');
-
-        $result = $this->callFunction(
-            $this->insertEdit,
-            InsertEdit::class,
-            'analyzeTableColumnsArray',
-            [$column, [], -1, false],
-        );
-
-        $this->assertEquals($result['Field_md5'], '4342210df36bf2ff2c4e2a997a6d4089');
-
-        $this->assertEquals($result['True_Type'], 'float');
-
-        $this->assertEquals($result['len'], 100);
-
-        $this->assertEquals($result['is_binary'], false);
-
-        $this->assertEquals($result['is_blob'], false);
-
-        $this->assertEquals($result['is_char'], false);
-
-        $this->assertEquals($result['pma_type'], 'float(10, 1)');
-
-        $this->assertEquals($result['wrap'], ' text-nowrap');
-
-        $this->assertEquals($result['Field'], '1<2');
-    }
-
-    /**
      * Test for getColumnTitle
      */
     public function testGetColumnTitle(): void
@@ -532,11 +500,21 @@ class InsertEditTest extends AbstractTestCase
      */
     public function testGetNullifyCodeForNullColumn(): void
     {
-        $column = $foreignData = [];
+        $foreignData = [];
         $foreigners = ['foreign_keys_data' => []];
-        $column['Field'] = 'f';
-        $column['True_Type'] = 'enum';
-        $column['Type'] = 'ababababababababababa';
+        $column = new InsertEditColumn(
+            'f',
+            'enum(ababababababababababa)',
+            false,
+            '',
+            null,
+            '',
+            -1,
+            false,
+            false,
+            false,
+            false,
+        );
         $this->assertEquals(
             '1',
             $this->callFunction(
@@ -547,8 +525,19 @@ class InsertEditTest extends AbstractTestCase
             ),
         );
 
-        $column['True_Type'] = 'enum';
-        $column['Type'] = 'abababababababababab';
+        $column = new InsertEditColumn(
+            'f',
+            'enum(abababababab20)',
+            false,
+            '',
+            null,
+            '',
+            -1,
+            false,
+            false,
+            false,
+            false,
+        );
         $this->assertEquals(
             '2',
             $this->callFunction(
@@ -559,7 +548,7 @@ class InsertEditTest extends AbstractTestCase
             ),
         );
 
-        $column['True_Type'] = 'set';
+        $column = new InsertEditColumn('f', 'set', false, '', null, '', -1, false, false, false, false);
         $this->assertEquals(
             '3',
             $this->callFunction(
@@ -570,7 +559,7 @@ class InsertEditTest extends AbstractTestCase
             ),
         );
 
-        $column['True_Type'] = '';
+        $column = new InsertEditColumn('f', '', false, '', null, '', -1, false, false, false, false);
         $foreigners['f'] = ['something'/* What should the mocked value actually be? */];
         $foreignData['foreign_link'] = '';
         $this->assertEquals(
@@ -595,10 +584,19 @@ class InsertEditTest extends AbstractTestCase
         $GLOBALS['cfg']['CharTextareaCols'] = 1;
         $GLOBALS['cfg']['LimitChars'] = 20;
 
-        $column = [];
-        $column['is_char'] = true;
-        $column['Type'] = 'char(10)';
-        $column['True_Type'] = 'char';
+        $column = new InsertEditColumn(
+            'f',
+            'char(10)',
+            false,
+            '',
+            null,
+            'auto_increment',
+            20,
+            false,
+            false,
+            true,
+            false,
+        );
         (new ReflectionProperty(InsertEdit::class, 'fieldIndex'))->setValue($this->insertEdit, 2);
         $result = $this->callFunction(
             $this->insertEdit,
@@ -623,9 +621,7 @@ class InsertEditTest extends AbstractTestCase
     public function testGetHTMLinput(): void
     {
         $GLOBALS['cfg']['ShowFunctionFields'] = true;
-        $column = [];
-        $column['pma_type'] = 'date';
-        $column['True_Type'] = 'date';
+        $column = new InsertEditColumn('f', 'date', false, 'PRI', null, '', -1, false, false, false, false);
         (new ReflectionProperty(InsertEdit::class, 'fieldIndex'))->setValue($this->insertEdit, 23);
         $result = $this->callFunction(
             $this->insertEdit,
@@ -641,8 +637,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // case 2 datetime
-        $column['pma_type'] = 'datetime';
-        $column['True_Type'] = 'datetime';
+        $column = new InsertEditColumn('f', 'datetime', false, 'PRI', null, '', -1, false, false, false, false);
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
@@ -656,8 +651,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // case 3 timestamp
-        $column['pma_type'] = 'timestamp';
-        $column['True_Type'] = 'timestamp';
+        $column = new InsertEditColumn('f', 'timestamp', false, 'PRI', null, '', -1, false, false, false, false);
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
@@ -671,9 +665,7 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // case 4 int
-        $column['pma_type'] = 'int';
-        $column['True_Type'] = 'int';
-        $column['Type'] = 'int(11)';
+        $column = new InsertEditColumn('f', 'int(11)', false, 'PRI', null, '', -1, false, false, false, false);
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
@@ -721,11 +713,7 @@ class InsertEditTest extends AbstractTestCase
      */
     public function testGetValueColumnForOtherDatatypes(): void
     {
-        $column = [];
-        $column['len'] = 20;
-        $column['is_char'] = true;
-        $column['Type'] = 'char(25)';
-        $column['True_Type'] = 'char';
+        $column = new InsertEditColumn('f', 'char(25)', false, '', null, '', 20, false, false, true, false);
         $GLOBALS['cfg']['CharEditing'] = '';
         $GLOBALS['cfg']['MaxSizeForInputField'] = 30;
         $GLOBALS['cfg']['MinSizeForInputField'] = 10;
@@ -767,10 +755,19 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // case 2: (else)
-        $column['is_char'] = false;
-        $column['Extra'] = 'auto_increment';
-        $column['pma_type'] = 'timestamp';
-        $column['True_Type'] = 'timestamp';
+        $column = new InsertEditColumn(
+            'f',
+            'timestamp',
+            false,
+            '',
+            null,
+            'auto_increment',
+            20,
+            false,
+            false,
+            false,
+            false,
+        );
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
@@ -799,7 +796,19 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // case 3: (else -> datetime)
-        $column['pma_type'] = 'datetime';
+        $column = new InsertEditColumn(
+            'f',
+            'datetime',
+            false,
+            '',
+            null,
+            'auto_increment',
+            20,
+            false,
+            false,
+            false,
+            false,
+        );
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
@@ -823,7 +832,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="datetime">', $result);
 
         // case 4: (else -> date)
-        $column['pma_type'] = 'date';
+        $column = new InsertEditColumn('f', 'date', false, '', null, 'auto_increment', 20, false, false, false, false);
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
@@ -847,7 +856,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="date">', $result);
 
         // case 5: (else -> bit)
-        $column['True_Type'] = 'bit';
+        $column = new InsertEditColumn('f', 'bit', false, '', null, 'auto_increment', 20, false, false, false, false);
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
@@ -871,7 +880,7 @@ class InsertEditTest extends AbstractTestCase
         $this->assertStringContainsString('<input type="hidden" name="fields_typeb" value="bit">', $result);
 
         // case 6: (else -> uuid)
-        $column['True_Type'] = 'uuid';
+        $column = new InsertEditColumn('f', 'uuid', false, '', null, 'auto_increment', 20, false, false, false, false);
         $result = $this->callFunction(
             $this->insertEdit,
             InsertEdit::class,
@@ -900,8 +909,19 @@ class InsertEditTest extends AbstractTestCase
      */
     public function testGetColumnSize(): void
     {
-        $column = [];
-        $column['is_char'] = true;
+        $column = new InsertEditColumn(
+            'f',
+            'char(10)',
+            false,
+            '',
+            null,
+            'auto_increment',
+            20,
+            false,
+            false,
+            true,
+            false,
+        );
         $specInBrackets = '45';
         $GLOBALS['cfg']['MinSizeForInputField'] = 30;
         $GLOBALS['cfg']['MaxSizeForInputField'] = 40;
@@ -919,8 +939,19 @@ class InsertEditTest extends AbstractTestCase
         $this->assertEquals('textarea', $GLOBALS['cfg']['CharEditing']);
 
         // case 2
-        $column['is_char'] = false;
-        $column['len'] = 20;
+        $column = new InsertEditColumn(
+            'f',
+            'char(10)',
+            false,
+            '',
+            null,
+            'auto_increment',
+            20,
+            false,
+            false,
+            false,
+            false,
+        );
         $this->assertEquals(
             30,
             $this->callFunction(
@@ -1007,12 +1038,22 @@ class InsertEditTest extends AbstractTestCase
      */
     public function testGetSpecialCharsAndBackupFieldForExistingRow(): void
     {
-        $column = $currentRow = $extractedColumnSpec = [];
-        $column['Field'] = 'f';
+        $currentRow = $extractedColumnSpec = [];
         $currentRow['f'] = null;
         $_POST['default_action'] = 'insert';
-        $column['Key'] = 'PRI';
-        $column['Extra'] = 'fooauto_increment';
+        $column = new InsertEditColumn(
+            'f',
+            'char(10)',
+            false,
+            'PRI',
+            null,
+            'fooauto_increment',
+            20,
+            false,
+            false,
+            true,
+            false,
+        );
 
         $result = $this->callFunction(
             $this->insertEdit,
@@ -1031,7 +1072,19 @@ class InsertEditTest extends AbstractTestCase
 
         $currentRow['f'] = '123';
         $extractedColumnSpec['spec_in_brackets'] = '20';
-        $column['True_Type'] = 'bit';
+        $column = new InsertEditColumn(
+            'f',
+            'bit',
+            false,
+            'PRI',
+            null,
+            'fooauto_increment',
+            20,
+            false,
+            false,
+            true,
+            false,
+        );
 
         $result = $this->callFunction(
             $this->insertEdit,
@@ -1074,7 +1127,19 @@ class InsertEditTest extends AbstractTestCase
 
         $currentRow['f'] = '123';
         $extractedColumnSpec['spec_in_brackets'] = '20';
-        $column['True_Type'] = 'int';
+        $column = new InsertEditColumn(
+            'f',
+            'int',
+            false,
+            'PRI',
+            null,
+            'fooauto_increment',
+            20,
+            false,
+            false,
+            true,
+            false,
+        );
 
         $result = $this->callFunction(
             $this->insertEdit,
@@ -1089,12 +1154,22 @@ class InsertEditTest extends AbstractTestCase
         );
 
         // Case 4 (else)
-        $column['is_binary'] = false;
-        $column['is_blob'] = true;
+        $column = new InsertEditColumn(
+            'f',
+            'char',
+            false,
+            'PRI',
+            null,
+            'fooauto_increment',
+            20,
+            false,
+            true,
+            true,
+            false,
+        );
         $GLOBALS['cfg']['ProtectBinary'] = false;
         $currentRow['f'] = '11001';
         $extractedColumnSpec['spec_in_brackets'] = '20';
-        $column['True_Type'] = 'char';
         $GLOBALS['cfg']['ShowFunctionFields'] = true;
 
         $result = $this->callFunction(
@@ -1140,14 +1215,11 @@ class InsertEditTest extends AbstractTestCase
     /**
      * Test for getSpecialCharsForInsertingMode
      *
-     * @param array  $column   Column parameters
-     * @param string $expected Expected result
-     * @psalm-param array<string, string|bool|null> $column
-     *
      * @dataProvider providerForTestGetSpecialCharsForInsertingMode
      */
     public function testGetSpecialCharsForInsertingMode(
-        array $column,
+        string|null $defaultValue,
+        string $trueType,
         string $expected,
     ): void {
         $GLOBALS['cfg']['ProtectBinary'] = false;
@@ -1158,7 +1230,7 @@ class InsertEditTest extends AbstractTestCase
             $this->insertEdit,
             InsertEdit::class,
             'getSpecialCharsForInsertingMode',
-            [$column['Default'] ?? null, $column['True_Type']],
+            [$defaultValue, $trueType],
         );
 
         $this->assertEquals($expected, $result);
@@ -1167,38 +1239,49 @@ class InsertEditTest extends AbstractTestCase
     /**
      * Data provider for test getSpecialCharsForInsertingMode()
      *
-     * @return array<string, array{array<string, string|bool|null>, string}>
+     * @return array<string, array{string|null, string, string}>
      */
     public static function providerForTestGetSpecialCharsForInsertingMode(): array
     {
         return [
             'bit' => [
-                ['True_Type' => 'bit', 'Default' => 'b\'101\'', 'is_binary' => true],
+                'b\'101\'',
+                'bit',
                 '101',
             ],
-            'char' => [['True_Type' => 'char', 'is_binary' => true], ''],
+            'char' => [
+                null,
+                'char',
+                '',
+            ],
             'time with CURRENT_TIMESTAMP value' => [
-                ['True_Type' => 'time', 'Default' => 'CURRENT_TIMESTAMP'],
+                'CURRENT_TIMESTAMP',
+                'time',
                 'CURRENT_TIMESTAMP',
             ],
             'time with current_timestamp() value' => [
-                ['True_Type' => 'time', 'Default' => 'current_timestamp()'],
+                'current_timestamp()',
+                'time',
                 'current_timestamp()',
             ],
             'time with no dot value' => [
-                ['True_Type' => 'time', 'Default' => '10'],
+                '10',
+                'time',
                 '10.000000',
             ],
             'time with dot value' => [
-                ['True_Type' => 'time', 'Default' => '10.08'],
+                '10.08',
+                'time',
                 '10.080000',
             ],
             'any text with escape text default' => [
-                ['True_Type' => 'text', 'Default' => '"lorem\"ipsem"'],
+                '"lorem\"ipsem"',
+                'text',
                 'lorem"ipsem',
             ],
             'varchar with html special chars' => [
-                ['True_Type' => 'varchar', 'Default' => 'hello world<br><b>lorem</b> ipsem'],
+                'hello world<br><b>lorem</b> ipsem',
+                'varchar',
                 'hello world&lt;br&gt;&lt;b&gt;lorem&lt;/b&gt; ipsem',
             ],
         ];

--- a/test/classes/Plugins/Transformations/TransformationPluginsTest.php
+++ b/test/classes/Plugins/Transformations/TransformationPluginsTest.php
@@ -90,7 +90,7 @@ class TransformationPluginsTest extends AbstractTestCase
                 '<img src="" width="150" height="100" '
                 . 'alt="Image preview here"><br><input type="file" '
                 . 'name="fields_uploadtest" accept="image/*" class="image-upload">',
-                [[], 0, 'test', ['150'], '', 'ltr', 0, 0],
+                ['test', ['150'], '', 'ltr', 0, 0],
             ],
             [
                 new Image_JPEG_Upload(),
@@ -103,8 +103,6 @@ class TransformationPluginsTest extends AbstractTestCase
                 . 'name="fields_upload2ndtest" accept="image/*" '
                 . 'class="image-upload">',
                 [
-                    [],
-                    0,
                     '2ndtest',
                     ['wrapper_link' => '?table=a', 'wrapper_params' => ['key' => 'value']],
                     'something',
@@ -127,7 +125,7 @@ class TransformationPluginsTest extends AbstractTestCase
                 new Text_Plain_FileUpload(),
                 'getInputHtml',
                 '<input type="file" name="fields_uploadtest">',
-                [[], 0, 'test', [], '', 'ltr', 0, 0],
+                ['test', [], '', 'ltr', 0, 0],
             ],
             [
                 new Text_Plain_FileUpload(),
@@ -136,7 +134,7 @@ class TransformationPluginsTest extends AbstractTestCase
                 . 'value="something"><input type="hidden" name="fields2ndtest" '
                 . 'value="something"><input type="file" '
                 . 'name="fields_upload2ndtest">',
-                [[], 0, '2ndtest', [], 'something', 'ltr', 0, 0],
+                ['2ndtest', [], 'something', 'ltr', 0, 0],
             ],
             // Test data for Text_Plain_Regexvalidation plugin
             [new Text_Plain_RegexValidation(), 'getName', 'Regex Validation'],
@@ -149,7 +147,7 @@ class TransformationPluginsTest extends AbstractTestCase
             ],
             [new Text_Plain_RegexValidation(), 'getMIMEType', 'Text'],
             [new Text_Plain_RegexValidation(), 'getMIMESubtype', 'Plain'],
-            [new Text_Plain_RegexValidation(), 'getInputHtml', '', [[], 0, '', [], '', 'ltr', 0, 0]],
+            [new Text_Plain_RegexValidation(), 'getInputHtml', '', ['', [], '', 'ltr', 0, 0]],
             // Test data for PhpMyAdmin\Plugins\Transformations\Output\Application_Octetstream_Download plugin
             [new Application_Octetstream_Download(), 'getName', 'Download'],
             [

--- a/test/classes/Query/GeneratorTest.php
+++ b/test/classes/Query/GeneratorTest.php
@@ -158,4 +158,23 @@ class GeneratorTest extends AbstractTestCase
             ),
         );
     }
+
+    /**
+     * Test for buildSqlQuery
+     */
+    public function testBuildSqlQuery(): void
+    {
+        $queryFields = ['a', 'b'];
+        $valueSets = ['1', '2'];
+
+        $this->assertEquals(
+            'INSERT IGNORE INTO `table` (a, b) VALUES (1), (2)',
+            Generator::buildInsertSqlQuery('table', true, $queryFields, $valueSets),
+        );
+
+        $this->assertEquals(
+            'INSERT INTO `table` (a, b) VALUES (1), (2)',
+            Generator::buildInsertSqlQuery('table', false, $queryFields, $valueSets),
+        );
+    }
 }


### PR DESCRIPTION
This is based on the PR #18434. 

This PR introduces another value object that replaces the flat array `$column` that was passed around the `InsertEdit` class. Values that didn't need to be precomputed were taken out and the rest was moved to the new constructor. IO plugins still had unused params which didn't have a clearly defined purpose. They are now gone. `Generator::getFunctionsForField` has been refactored to remove the false dependency on the new value object. The new value object should remain internal to `InsertEdit` class. 