### PR TITLE
Prefill the field field_default_value

### DIFF
--- a/templates/database/central_columns/edit_table_row.twig
+++ b/templates/database/central_columns/edit_table_row.twig
@@ -40,9 +40,9 @@
       </option>
     </select>
     {% if char_editing == 'textarea' %}
-      <textarea name="field_default_value[{{ row_num }}]" cols="15" class="textfield default_value"></textarea>
+      <textarea name="field_default_value[{{ row_num }}]" cols="15" class="textfield default_value">{{ row['col_default'] }}</textarea>
     {% else %}
-      <input type="text" name="field_default_value[{{ row_num }}]" size="12" value="" class="textfield default_value">
+      <input type="text" name="field_default_value[{{ row_num }}]" size="12" value="{{ row['col_default'] }}" class="textfield default_value">
     {% endif %}
   </td>
 


### PR DESCRIPTION
When editing a central column by means of select+edit (not inline), the value for default value is not prefilled. This could lead to a loss of information when editing central column. The current value for default value must be prefilled. 