### PR TITLE
Fix datefield calendar display when changing NULL state

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -879,6 +879,8 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                             if ($editArea.find('select').length > 0) {
                                 $editArea.find('select').val('');
                             }
+                        } else if ($td.is('.datefield')) {
+                            $('.ui-datepicker-trigger').trigger('click');
                         } else {
                             $editArea.find('textarea').val('');
                         }


### PR DESCRIPTION
In this PR I have made `datefields` calendar shows/hides automatically depending on NULL state.

### Before
As you can see here the calendar doesn't show up when unchecking the NULL checkbox until you do it manually using the calendar icon, same when checking NULL checkbox the calendar doesn't hide until you do it manually.

https://github.com/phpmyadmin/phpmyadmin/assets/60013703/f4bcdc02-4eee-4f53-9886-524974203246

### After
After merging this PR you don't need to do it manually every time.

https://github.com/phpmyadmin/phpmyadmin/assets/60013703/8cff458e-833c-4043-89fa-cafa0363d178

