### PR TITLE
Fix: Codemirror query alignment

### DIFF
--- a/js/vendor/codemirror/lib/codemirror.css
+++ b/js/vendor/codemirror/lib/codemirror.css
@@ -6,6 +6,7 @@
   height: 300px;
   color: black;
   direction: ltr;
+  text-align: left;
 }
 
 /* PADDING */
@@ -61,7 +62,7 @@
   z-index: 1;
 }
 .cm-fat-cursor .CodeMirror-line::selection,
-.cm-fat-cursor .CodeMirror-line > span::selection, 
+.cm-fat-cursor .CodeMirror-line > span::selection,
 .cm-fat-cursor .CodeMirror-line > span > span::selection { background: transparent; }
 .cm-fat-cursor .CodeMirror-line::-moz-selection,
 .cm-fat-cursor .CodeMirror-line > span::-moz-selection,


### PR DESCRIPTION
Fixes #18437 

In this PR I have forced `Codemirror` text alignment to `left`.

### Before format
![image](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/450a5119-7f0e-4651-9fad-4606addf47c6)


### After format
![image](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/4cb9aa27-bb1e-4733-881f-1c8205bfb38d)
