### PR TITLE
Require min php 80102 (8.1.2)

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -12,8 +12,8 @@ if (! defined('ROOT_PATH')) {
 define('PHPMYADMIN', true);
 // phpcs:enable
 
-if (PHP_VERSION_ID < 80100) {
-    die('<p>PHP 8.1.0+ is required.</p><p>Currently installed version is: ' . PHP_VERSION . '</p>');
+if (PHP_VERSION_ID < 80102) {
+    die('<p>PHP 8.1.2+ is required.</p><p>Currently installed version is: ' . PHP_VERSION . '</p>');
 }
 
 require_once ROOT_PATH . 'libraries/constants.php';


### PR DESCRIPTION
On #18217 I have required minimum php version to 8.1.2 because of a php bug.
In this PR I'm updating its check from `index.php`