### PR TITLE
Remove empty option from enum select

### DIFF
--- a/templates/sql/enum_column_dropdown.twig
+++ b/templates/sql/enum_column_dropdown.twig
@@ -1,5 +1,4 @@
 <select>
-  <option value="">&nbsp;</option>
   {% for value in values %}
     <option value="{{ value|raw }}"{{ value in selected_values ? " selected" }}>{{ value|raw }}</option>
   {% endfor %}


### PR DESCRIPTION
Hello 👋🏻 

In this PR I have removed an unnecessary empty option (Not included in ENUM) from enum select.

### Before
![image](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/3a13057a-de65-4e05-994e-e1871dc411b9)

### After merging this PR
![image](https://github.com/phpmyadmin/phpmyadmin/assets/60013703/a2b65be1-6681-4d6e-bde3-7e6ae8a34d9f)


