### PR TITLE
Add a wrapper around the `exit` language construct

### DIFF
--- a/libraries/classes/Config/PageSettings.php
+++ b/libraries/classes/Config/PageSettings.php
@@ -98,7 +98,7 @@ class PageSettings
             // reload page
             $response = ResponseRenderer::getInstance();
             Core::sendHeaderLocation($response->getSelfUrl());
-            exit;
+            $response->callExit();
         }
 
         return $result;

--- a/libraries/classes/Controllers/AbstractController.php
+++ b/libraries/classes/Controllers/AbstractController.php
@@ -133,9 +133,7 @@ abstract class AbstractController
         $this->response->setRequestStatus(false);
         $this->response->addHTML(Message::error($errorMessage)->getDisplay());
 
-        if (! defined('TESTSUITE')) {
-            exit;
-        }
+        $this->response->callExit();
     }
 
     /** @psalm-param int<400,599> $statusCode */

--- a/libraries/classes/Controllers/Export/ExportController.php
+++ b/libraries/classes/Controllers/Export/ExportController.php
@@ -311,7 +311,7 @@ final class ExportController extends AbstractController
                     /** @var DatabaseExportController $controller */
                     $controller = Core::getContainerBuilder()->get(DatabaseExportController::class);
                     $controller($request);
-                    exit;
+                    $this->response->callExit();
                 }
             }
 

--- a/libraries/classes/Controllers/Table/RelationController.php
+++ b/libraries/classes/Controllers/Table/RelationController.php
@@ -269,7 +269,7 @@ final class RelationController extends AbstractController
         if (isset($_POST['preview_sql'])) {
             Core::previewSQL($previewSqlData);
 
-            exit;
+            $this->response->callExit();
         }
 
         if (empty($displayQuery) || $seenError) {

--- a/libraries/classes/Controllers/Table/Structure/SaveController.php
+++ b/libraries/classes/Controllers/Table/Structure/SaveController.php
@@ -147,7 +147,7 @@ final class SaveController extends AbstractController
             if (isset($_POST['preview_sql'])) {
                 Core::previewSQL($changes !== [] ? $sqlQuery : '');
 
-                exit;
+                $this->response->callExit();
             }
 
             $columnsWithIndex = $this->dbi

--- a/libraries/classes/Database/Events.php
+++ b/libraries/classes/Database/Events.php
@@ -200,7 +200,7 @@ class Events
                 }
 
                 $this->response->addJSON('tableType', 'events');
-                exit;
+                $this->response->callExit();
             }
         }
 
@@ -508,7 +508,7 @@ class Events
                 unset($_POST);
             }
 
-            exit;
+            $this->response->callExit();
         }
 
         $message = __('Error in processing request:') . ' ';
@@ -521,7 +521,7 @@ class Events
         if ($this->response->isAjax()) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message);
-            exit;
+            $this->response->callExit();
         }
 
         echo $message->getDisplay();
@@ -549,7 +549,7 @@ class Events
                 $this->response->addJSON('message', $exportData);
                 $this->response->addJSON('title', $title);
 
-                exit;
+                $this->response->callExit();
             }
 
             $output = '<div class="container">';
@@ -574,7 +574,7 @@ class Events
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message);
 
-            exit;
+            $this->response->callExit();
         }
 
         $this->response->addHTML($message->getDisplay());

--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -134,7 +134,7 @@ class Routines
                 echo "\n\n<h2>" . $title . "</h2>\n\n" . $editor;
             }
 
-            exit;
+            $this->response->callExit();
         }
 
         $message = __('Error in processing request:') . ' ';
@@ -153,7 +153,7 @@ class Routines
         if ($this->response->isAjax()) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message);
-            exit;
+            $this->response->callExit();
         }
 
         echo $message->getDisplay();
@@ -268,7 +268,7 @@ class Routines
         if (! $GLOBALS['message']->isSuccess()) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $output);
-            exit;
+            $this->response->callExit();
         }
 
         $routines = self::getDetails($this->dbi, $db, $_POST['item_type'], $_POST['item_name']);
@@ -283,7 +283,7 @@ class Routines
         $this->response->addJSON('insert', ! empty($routine));
         $this->response->addJSON('message', $output);
         $this->response->addJSON('tableType', 'routines');
-        exit;
+        $this->response->callExit();
     }
 
     /**
@@ -1127,7 +1127,7 @@ class Routines
             if ($this->response->isAjax()) {
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', $message);
-                exit;
+                $this->response->callExit();
             }
 
             echo $message->getDisplay();
@@ -1237,14 +1237,14 @@ class Routines
             $this->response->setRequestStatus($message->isSuccess());
             $this->response->addJSON('message', $message->getDisplay() . $output);
             $this->response->addJSON('dialog', false);
-            exit;
+            $this->response->callExit();
         }
 
         echo $message->getDisplay() , $output;
         if ($message->isError()) {
             // At least one query has failed, so shouldn't
             // execute any more queries, so we quit.
-            exit;
+            $this->response->callExit();
         }
 
         unset($_POST);
@@ -1280,7 +1280,7 @@ class Routines
                     echo $form;
                 }
 
-                exit;
+                $this->response->callExit();
             }
 
             if ($this->response->isAjax()) {
@@ -1294,7 +1294,7 @@ class Routines
 
                 $this->response->setRequestStatus(false);
                 $this->response->addJSON('message', $message);
-                exit;
+                $this->response->callExit();
             }
         }
     }
@@ -1545,7 +1545,7 @@ class Routines
                 $this->response->addJSON('message', $exportData);
                 $this->response->addJSON('title', $title);
 
-                exit;
+                $this->response->callExit();
             }
 
             $output = '<div class="container">';
@@ -1573,7 +1573,7 @@ class Routines
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message);
 
-            exit;
+            $this->response->callExit();
         }
 
         $this->response->addHTML($message->getDisplay());

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -165,7 +165,7 @@ class DatabaseInterface implements DbalInterface
             // The following statement will exit
             Generator::mysqlDie($this->getError($connectionType), $query);
 
-            exit;
+            ResponseRenderer::getInstance()->callExit();
         }
 
         return $result;

--- a/libraries/classes/DbTableExists.php
+++ b/libraries/classes/DbTableExists.php
@@ -46,7 +46,7 @@ final class DbTableExists
                 Message::error(__('No databases selected.')),
             );
 
-            exit;
+            $response->callExit();
         }
 
         $urlParams = ['reload' => 1];
@@ -65,7 +65,7 @@ final class DbTableExists
 
         Core::sendHeaderLocation('./index.php?route=/' . Url::getCommonRaw($urlParams, '&'));
 
-        exit;
+        $response->callExit();
     }
 
     private static function checkTable(string $db, string $table, bool $isTransformationWrapper): void
@@ -90,7 +90,7 @@ final class DbTableExists
         }
 
         if ($isTransformationWrapper) {
-            exit;
+            ResponseRenderer::getInstance()->callExit();
         }
 
         if ($table !== '') {
@@ -110,6 +110,6 @@ final class DbTableExists
         $controller = Core::getContainerBuilder()->get(SqlController::class);
         $controller(Common::getRequest());
 
-        exit;
+        ResponseRenderer::getInstance()->callExit();
     }
 }

--- a/libraries/classes/ErrorHandler.php
+++ b/libraries/classes/ErrorHandler.php
@@ -300,9 +300,6 @@ class ErrorHandler
             default:
                 // FATAL error, display it and exit
                 $this->dispFatalError($error);
-                if (! defined('TESTSUITE')) {
-                    exit;
-                }
         }
     }
 
@@ -325,7 +322,7 @@ class ErrorHandler
      *
      * @param Error $error the error
      */
-    protected function dispFatalError(Error $error): void
+    protected function dispFatalError(Error $error): never
     {
         $response = ResponseRenderer::getInstance();
         if (! $response->headersSent()) {
@@ -337,9 +334,7 @@ class ErrorHandler
 
         $response->addHTML($error->getDisplay());
         $response->addHTML('</body></html>');
-        if (! defined('TESTSUITE')) {
-            exit;
-        }
+        $response->callExit();
     }
 
     /**

--- a/libraries/classes/Exceptions/ExitException.php
+++ b/libraries/classes/Exceptions/ExitException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\Exceptions;
+
+use Exception;
+
+/**
+ * Used in tests as a replacement for the 'exit' language construct.
+ */
+final class ExitException extends Exception
+{
+}

--- a/libraries/classes/Html/Generator.php
+++ b/libraries/classes/Html/Generator.php
@@ -889,7 +889,7 @@ class Generator
         if ($response->isAjax()) {
             $response->setRequestStatus(false);
             $response->addJSON('message', $errorMessage);
-            exit;
+            $response->callExit();
         }
 
         if ($backUrl !== '') {
@@ -906,7 +906,7 @@ class Generator
                 . '</fieldset>' . "\n\n";
         }
 
-        exit($errorMessage);
+        $response->callExit($errorMessage);
     }
 
     /**

--- a/libraries/classes/Import.php
+++ b/libraries/classes/Import.php
@@ -1024,7 +1024,7 @@ class Import
 
             /* TODO: Do more checking here to make sure they really are matched */
             if (count($tables) != count($analyses)) {
-                exit;
+                ResponseRenderer::getInstance()->callExit();
             }
 
             /* Create SQL code to create the tables */
@@ -1321,7 +1321,7 @@ class Import
             $response = ResponseRenderer::getInstance();
             $message = Message::rawError($error);
             $response->addJSON('message', $message);
-            exit;
+            $response->callExit();
         }
 
         // If everything fine, START a transaction.

--- a/libraries/classes/Pdf.php
+++ b/libraries/classes/Pdf.php
@@ -135,6 +135,6 @@ class Pdf extends TCPDF
         echo Message::error(
             __('Error while creating PDF:') . ' ' . $errorMessage,
         )->getDisplay();
-        exit;
+        ResponseRenderer::getInstance()->callExit();
     }
 }

--- a/libraries/classes/Plugins/Auth/AuthenticationConfig.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationConfig.php
@@ -15,7 +15,6 @@ use PhpMyAdmin\Util;
 
 use function __;
 use function count;
-use function defined;
 use function sprintf;
 use function trigger_error;
 
@@ -39,11 +38,7 @@ class AuthenticationConfig extends AuthenticationPlugin
             $response->setRequestStatus(false);
             // reload_flag removes the token parameter from the URL and reloads
             $response->addJSON('reload_flag', '1');
-            if (defined('TESTSUITE')) {
-                return true;
-            }
-
-            exit;
+            $response->callExit();
         }
 
         return true;
@@ -160,8 +155,6 @@ class AuthenticationConfig extends AuthenticationPlugin
         }
 
         echo '</table>' , "\n";
-        if (! defined('TESTSUITE')) {
-            exit;
-        }
+        $response->callExit();
     }
 }

--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -29,7 +29,6 @@ use function array_keys;
 use function base64_decode;
 use function base64_encode;
 use function count;
-use function defined;
 use function explode;
 use function function_exists;
 use function in_array;
@@ -77,11 +76,7 @@ class AuthenticationCookie extends AuthenticationPlugin
          */
         $sessionExpired = isset($_REQUEST['check_timeout']) || isset($_REQUEST['session_timedout']);
         if (! $sessionExpired && $response->loginPage()) {
-            if (defined('TESTSUITE')) {
-                return true;
-            }
-
-            exit;
+            $response->callExit();
         }
 
         /**
@@ -202,11 +197,7 @@ class AuthenticationCookie extends AuthenticationPlugin
             'config_footer' => $configFooter,
         ]);
 
-        if (! defined('TESTSUITE')) {
-            exit;
-        }
-
-        return true;
+        $response->callExit();
     }
 
     /**
@@ -336,7 +327,7 @@ class AuthenticationCookie extends AuthenticationPlugin
                     'error_message' => $exception->getMessage(),
                 ]);
 
-                exit;
+                ResponseRenderer::getInstance()->callExit();
             }
 
             return true;
@@ -388,11 +379,7 @@ class AuthenticationCookie extends AuthenticationPlugin
             SessionCache::remove('proc_priv');
 
             $this->showFailure('no-activity');
-            if (! defined('TESTSUITE')) {
-                exit;
-            }
-
-            return false;
+            ResponseRenderer::getInstance()->callExit();
         }
 
         // check password cookie
@@ -492,11 +479,7 @@ class AuthenticationCookie extends AuthenticationPlugin
             $response->addJSON('success', 1);
             $response->addJSON('new_token', $_SESSION[' PMA_token ']);
 
-            if (! defined('TESTSUITE')) {
-                exit;
-            }
-
-            return;
+            $response->callExit();
         }
 
         // Set server cookies if required (once per session) and, in this case,
@@ -510,16 +493,15 @@ class AuthenticationCookie extends AuthenticationPlugin
          */
         Util::clearUserCache();
 
-        ResponseRenderer::getInstance()->disable();
+        $response = ResponseRenderer::getInstance();
+        $response->disable();
 
         Core::sendHeaderLocation(
             './index.php?route=/' . Url::getCommonRaw($urlParams, '&'),
             true,
         );
 
-        if (! defined('TESTSUITE')) {
-            exit;
-        }
+        $response->callExit();
     }
 
     /**

--- a/libraries/classes/Plugins/Auth/AuthenticationHttp.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationHttp.php
@@ -16,7 +16,6 @@ use PhpMyAdmin\ResponseRenderer;
 
 use function __;
 use function base64_decode;
-use function defined;
 use function hash_equals;
 use function preg_replace;
 use function sprintf;
@@ -41,11 +40,7 @@ class AuthenticationHttp extends AuthenticationPlugin
             $response->setRequestStatus(false);
             // reload_flag removes the token parameter from the URL and reloads
             $response->addJSON('reload_flag', '1');
-            if (defined('TESTSUITE')) {
-                return true;
-            }
-
-            exit;
+            $response->callExit();
         }
 
         return $this->authForm();
@@ -95,11 +90,7 @@ class AuthenticationHttp extends AuthenticationPlugin
 
         $response->addHTML(Config::renderFooter());
 
-        if (! defined('TESTSUITE')) {
-            exit;
-        }
-
-        return false;
+        $response->callExit();
     }
 
     /**
@@ -200,9 +191,7 @@ class AuthenticationHttp extends AuthenticationPlugin
                 'error_message' => $error,
             ]);
 
-            if (! defined('TESTSUITE')) {
-                exit;
-            }
+            ResponseRenderer::getInstance()->callExit();
         }
 
         $this->authForm();

--- a/libraries/classes/Plugins/Auth/AuthenticationSignon.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationSignon.php
@@ -31,12 +31,11 @@ class AuthenticationSignon extends AuthenticationPlugin
 {
     /**
      * Displays authentication form
-     *
-     * @return bool always true (no return indeed)
      */
     public function showLoginForm(): bool
     {
-        ResponseRenderer::getInstance()->disable();
+        $response = ResponseRenderer::getInstance();
+        $response->disable();
         unset($_SESSION['LAST_SIGNON_URL']);
         if (empty($GLOBALS['cfg']['Server']['SignonURL'])) {
             echo $this->template->render('error/generic', [
@@ -45,18 +44,12 @@ class AuthenticationSignon extends AuthenticationPlugin
                 'error_message' => 'You must set SignonURL!',
             ]);
 
-            if (! defined('TESTSUITE')) {
-                exit;
-            }
+            $response->callExit();
         } else {
             Core::sendHeaderLocation($GLOBALS['cfg']['Server']['SignonURL']);
         }
 
-        if (! defined('TESTSUITE')) {
-            exit;
-        }
-
-        return false;
+        $response->callExit();
     }
 
     /**
@@ -136,7 +129,7 @@ class AuthenticationSignon extends AuthenticationPlugin
                     'error_message' => __('Can not find signon authentication script:') . ' ' . $scriptName,
                 ]);
 
-                exit;
+                ResponseRenderer::getInstance()->callExit();
             }
 
             include $scriptName;

--- a/libraries/classes/Plugins/AuthenticationPlugin.php
+++ b/libraries/classes/Plugins/AuthenticationPlugin.php
@@ -248,7 +248,7 @@ abstract class AuthenticationPlugin
                     'error_message' => $exception->getMessage(),
                 ]);
 
-                exit;
+                ResponseRenderer::getInstance()->callExit();
             }
 
             $this->showLoginForm();
@@ -313,11 +313,7 @@ abstract class AuthenticationPlugin
 
         $response = ResponseRenderer::getInstance();
         if ($response->loginPage()) {
-            if (defined('TESTSUITE')) {
-                return;
-            }
-
-            exit;
+            $response->callExit();
         }
 
         echo $this->template->render('login/header');
@@ -330,8 +326,6 @@ abstract class AuthenticationPlugin
         ]);
         echo $this->template->render('login/footer');
         echo Config::renderFooter();
-        if (! defined('TESTSUITE')) {
-            exit;
-        }
+        $response->callExit();
     }
 }

--- a/libraries/classes/Plugins/Schema/ExportRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/ExportRelationSchema.php
@@ -10,6 +10,7 @@ namespace PhpMyAdmin\Plugins\Schema;
 
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Identifiers\DatabaseName;
+use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 
@@ -268,6 +269,6 @@ class ExportRelationSchema
         ]);
         echo '">' . __('Back') . '</a>';
         echo "\n";
-        exit;
+        ResponseRenderer::getInstance()->callExit();
     }
 }

--- a/libraries/classes/Plugins/Schema/TableStats.php
+++ b/libraries/classes/Plugins/Schema/TableStats.php
@@ -10,6 +10,7 @@ namespace PhpMyAdmin\Plugins\Schema;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Font;
 use PhpMyAdmin\Index;
+use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Util;
 
 use function array_flip;
@@ -91,7 +92,7 @@ abstract class TableStats
         $result = $GLOBALS['dbi']->tryQuery($sql);
         if (! $result || ! $result->numRows()) {
             $this->showMissingTableError();
-            exit;
+            ResponseRenderer::getInstance()->callExit();
         }
 
         if ($this->showKeys) {

--- a/libraries/classes/ResponseRenderer.php
+++ b/libraries/classes/ResponseRenderer.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin;
 
+use PhpMyAdmin\Exceptions\ExitException;
+
 use function defined;
 use function header;
 use function headers_sent;
@@ -378,7 +380,7 @@ class ResponseRenderer
         }
 
         $this->buffer->flush();
-        exit;
+        $this->callExit();
     }
 
     /**
@@ -441,9 +443,7 @@ class ResponseRenderer
     {
         $this->setHttpResponseCode(303);
         $this->header('Location: ' . $location);
-        if (! defined('TESTSUITE')) {
-            exit;
-        }
+        $this->callExit();
     }
 
     /**
@@ -485,5 +485,18 @@ class ResponseRenderer
     public function getFooterScripts(): Scripts
     {
         return $this->footer->getScripts();
+    }
+
+    public function callExit(string $message = ''): never
+    {
+        if (defined('TESTSUITE')) {
+            throw new ExitException($message);
+        }
+
+        if ($message !== '') {
+            exit($message);
+        }
+
+        exit;
     }
 }

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -489,16 +489,16 @@ class Sql
      */
     private function handleQueryExecuteError(bool $isGotoFile, string $error, string $fullSqlQuery): never
     {
+        $response = ResponseRenderer::getInstance();
         if ($isGotoFile) {
             $message = Message::rawError($error);
-            $response = ResponseRenderer::getInstance();
             $response->setRequestStatus(false);
             $response->addJSON('message', $message);
         } else {
             Generator::mysqlDie($error, $fullSqlQuery, false);
         }
 
-        exit;
+        $response->callExit();
     }
 
     /**
@@ -1329,7 +1329,7 @@ class Sql
         // value of a transformed field, show it here
         if (isset($_POST['grid_edit']) && $_POST['grid_edit'] == true && is_object($result)) {
             $this->getResponseForGridEdit($result);
-            exit;
+            ResponseRenderer::getInstance()->callExit();
         }
 
         // Gets the list of fields properties

--- a/libraries/classes/Triggers/Triggers.php
+++ b/libraries/classes/Triggers/Triggers.php
@@ -189,7 +189,7 @@ class Triggers
                 }
 
                 $this->response->addJSON('tableType', 'triggers');
-                exit;
+                $this->response->callExit();
             }
         }
 
@@ -412,7 +412,7 @@ class Triggers
                 unset($_POST);
             }
 
-            exit;
+            $this->response->callExit();
         }
 
         $message = __('Error in processing request:') . ' ';
@@ -425,7 +425,7 @@ class Triggers
         if ($this->response->isAjax()) {
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message);
-            exit;
+            $this->response->callExit();
         }
 
         echo $message->getDisplay();
@@ -451,7 +451,7 @@ class Triggers
                 $this->response->addJSON('message', htmlspecialchars(trim($exportData)));
                 $this->response->addJSON('title', $title);
 
-                exit;
+                $this->response->callExit();
             }
 
             $this->response->addHTML($this->template->render('triggers/export', [
@@ -473,7 +473,7 @@ class Triggers
             $this->response->setRequestStatus(false);
             $this->response->addJSON('message', $message);
 
-            exit;
+            $this->response->callExit();
         }
 
         $this->response->addHTML($message->getDisplay());

--- a/libraries/classes/UrlRedirector.php
+++ b/libraries/classes/UrlRedirector.php
@@ -31,7 +31,7 @@ final class UrlRedirector
         ) {
             Core::sendHeaderLocation('./');
 
-            exit;
+            $response->callExit();
         }
 
         /**
@@ -46,6 +46,6 @@ final class UrlRedirector
         // Do not display the value of $_GET['url'] to avoid showing injected content
         echo __('Taking you to the target site.');
 
-        exit;
+        $response->callExit();
     }
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8184,6 +8184,9 @@
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['allowDeny_forbidden']]]></code>
     </InvalidArrayOffset>
+    <PossiblyUnusedReturnValue>
+      <code>bool</code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="libraries/classes/Plugins/Auth/AuthenticationCookie.php">
     <DocblockTypeContradiction>
@@ -8247,6 +8250,7 @@
     </PossiblyNullReference>
     <PossiblyUnusedReturnValue>
       <code>bool</code>
+      <code>bool</code>
     </PossiblyUnusedReturnValue>
     <RedundantCast>
       <code><![CDATA[(int) $GLOBALS['cfg']['LoginCookieStore']]]></code>
@@ -8274,6 +8278,9 @@
     <PossiblyInvalidCast>
       <code>$oldUser</code>
     </PossiblyInvalidCast>
+    <PossiblyUnusedReturnValue>
+      <code>bool</code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="libraries/classes/Plugins/Auth/AuthenticationSignon.php">
     <MixedArgument>
@@ -8326,6 +8333,9 @@
     <PossiblyNullReference>
       <code>issetCookie</code>
     </PossiblyNullReference>
+    <PossiblyUnusedReturnValue>
+      <code>bool</code>
+    </PossiblyUnusedReturnValue>
   </file>
   <file src="libraries/classes/Plugins/AuthenticationPluginFactory.php">
     <RedundantFunctionCall>

--- a/test/classes/Controllers/AbstractControllerTest.php
+++ b/test/classes/Controllers/AbstractControllerTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Controllers;
 
 use PhpMyAdmin\Controllers\AbstractController;
+use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Html\MySQLDocumentation;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
+use Throwable;
 
 /** @covers \PhpMyAdmin\Controllers\AbstractController */
 class AbstractControllerTest extends AbstractTestCase
@@ -45,7 +47,12 @@ class AbstractControllerTest extends AbstractTestCase
         $message .= '[br]';
         $expected = Message::error($message)->getDisplay();
 
-        $controller->testCheckParameters(['param1', 'param2']);
+        try {
+            $controller->testCheckParameters(['param1', 'param2']);
+        } catch (Throwable $throwable) {
+        }
+
+        $this->assertInstanceOf(ExitException::class, $throwable ?? null);
         $this->assertSame($expected, $response->getHTMLResult());
         $this->assertSame(400, $response->getHttpResponseCode());
     }

--- a/test/classes/ErrorHandlerTest.php
+++ b/test/classes/ErrorHandlerTest.php
@@ -7,9 +7,11 @@ namespace PhpMyAdmin\Tests;
 use Exception;
 use PhpMyAdmin\Error;
 use PhpMyAdmin\ErrorHandler;
+use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
 use ReflectionProperty;
+use Throwable;
 
 use function array_keys;
 use function array_pop;
@@ -304,7 +306,12 @@ class ErrorHandlerTest extends AbstractTestCase
         $responseStub->setHeadersSent(true);
         $errorHandler = new ErrorHandler();
         $this->assertSame([], $errorHandler->getCurrentErrors());
-        $errorHandler->handleException(new Exception('Exception message.'));
+        try {
+            $errorHandler->handleException(new Exception('Exception message.'));
+        } catch (Throwable $throwable) {
+        }
+
+        $this->assertInstanceOf(ExitException::class, $throwable ?? null);
         $output = $responseStub->getHTMLResult();
         $errors = $errorHandler->getCurrentErrors();
         $this->assertCount(1, $errors);
@@ -327,7 +334,12 @@ class ErrorHandlerTest extends AbstractTestCase
         $responseStub->setHeadersSent(true);
         $errorHandler = new ErrorHandler();
         $this->assertSame([], $errorHandler->getCurrentErrors());
-        $errorHandler->handleException(new Exception('Exception message.'));
+        try {
+            $errorHandler->handleException(new Exception('Exception message.'));
+        } catch (Throwable $throwable) {
+        }
+
+        $this->assertInstanceOf(ExitException::class, $throwable ?? null);
         $output = $responseStub->getHTMLResult();
         $errors = $errorHandler->getCurrentErrors();
         $this->assertCount(1, $errors);
@@ -348,7 +360,12 @@ class ErrorHandlerTest extends AbstractTestCase
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue($responseStub);
         $responseStub->setHeadersSent(true);
         $errorHandler = new ErrorHandler();
-        $errorHandler->addError('Fatal error message!', E_ERROR, './file/name', 1);
+        try {
+            $errorHandler->addError('Fatal error message!', E_ERROR, './file/name', 1);
+        } catch (Throwable $exception) {
+        }
+
+        $this->assertInstanceOf(ExitException::class, $exception ?? null);
         // phpcs:disable Generic.Files.LineLength.TooLong
         $expectedStart = <<<'HTML'
 <div class="alert alert-danger" role="alert"><p><strong>Error</strong> in name#1</p><img src="themes/dot.gif" title="" alt="" class="icon ic_s_error"> Fatal error message!<p class="mt-3"><strong>Backtrace</strong></p><ol class="list-group"><li class="list-group-item">
@@ -368,7 +385,12 @@ HTML;
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue($responseStub);
         $responseStub->setHeadersSent(false);
         $errorHandler = new ErrorHandler();
-        $errorHandler->addError('Fatal error message!', E_ERROR, './file/name', 1);
+        try {
+            $errorHandler->addError('Fatal error message!', E_ERROR, './file/name', 1);
+        } catch (Throwable $exception) {
+        }
+
+        $this->assertInstanceOf(ExitException::class, $exception ?? null);
         // phpcs:disable Generic.Files.LineLength.TooLong
         $expectedStart = <<<'HTML'
 <html><head><title>Error: Fatal error message!</title></head>

--- a/test/classes/Plugins/Auth/AuthenticationConfigTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationConfigTest.php
@@ -6,8 +6,11 @@ namespace PhpMyAdmin\Tests\Plugins\Auth;
 
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\ErrorHandler;
+use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Plugins\Auth\AuthenticationConfig;
+use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use Throwable;
 
 use function ob_get_clean;
 use function ob_start;
@@ -51,9 +54,9 @@ class AuthenticationConfigTest extends AbstractTestCase
 
     public function testAuth(): void
     {
-        $this->assertTrue(
-            $this->object->showLoginForm(),
-        );
+        ResponseRenderer::getInstance()->setAjax(true);
+        $this->expectException(ExitException::class);
+        $this->object->showLoginForm();
     }
 
     public function testAuthCheck(): void
@@ -83,8 +86,14 @@ class AuthenticationConfigTest extends AbstractTestCase
         $GLOBALS['dbi'] = $dbi;
 
         ob_start();
-        $this->object->showFailure('');
+        try {
+            $this->object->showFailure('');
+        } catch (Throwable $throwable) {
+        }
+
         $html = ob_get_clean();
+
+        $this->assertInstanceOf(ExitException::class, $throwable ?? null);
 
         $this->assertIsString($html);
 

--- a/test/classes/Plugins/Auth/AuthenticationCookieTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -6,12 +6,14 @@ namespace PhpMyAdmin\Tests\Plugins\Auth;
 
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\ErrorHandler;
+use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Header;
 use PhpMyAdmin\Plugins\Auth\AuthenticationCookie;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractNetworkTestCase;
 use ReflectionException;
 use ReflectionMethod;
+use Throwable;
 
 use function base64_decode;
 use function base64_encode;
@@ -86,9 +88,9 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
             ->with('redirect_flag', '1');
 
         $GLOBALS['conn_error'] = true;
-        $this->assertTrue(
-            $this->object->showLoginForm(),
-        );
+
+        $this->expectException(ExitException::class);
+        $this->object->showLoginForm();
     }
 
     private function getAuthErrorMockResponse(): void
@@ -179,8 +181,14 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
         $GLOBALS['errorHandler'] = new ErrorHandler();
 
         ob_start();
-        $this->object->showLoginForm();
+        try {
+            $this->object->showLoginForm();
+        } catch (Throwable $throwable) {
+        }
+
         $result = ob_get_clean();
+
+        $this->assertInstanceOf(ExitException::class, $throwable ?? null);
 
         $this->assertIsString($result);
 
@@ -258,8 +266,14 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
         $GLOBALS['errorHandler'] = new ErrorHandler();
 
         ob_start();
-        $this->object->showLoginForm();
+        try {
+            $this->object->showLoginForm();
+        } catch (Throwable $throwable) {
+        }
+
         $result = ob_get_clean();
+
+        $this->assertInstanceOf(ExitException::class, $throwable ?? null);
 
         $this->assertIsString($result);
 
@@ -331,8 +345,14 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
         $GLOBALS['errorHandler'] = new ErrorHandler();
 
         ob_start();
-        $this->object->showLoginForm();
+        try {
+            $this->object->showLoginForm();
+        } catch (Throwable $throwable) {
+        }
+
         $result = ob_get_clean();
+
+        $this->assertInstanceOf(ExitException::class, $throwable ?? null);
 
         $this->assertIsString($result);
 
@@ -622,9 +642,8 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
         $this->object->expects($this->once())
             ->method('showFailure');
 
-        $this->assertFalse(
-            $this->object->readCredentials(),
-        );
+        $this->expectException(ExitException::class);
+        $this->object->readCredentials();
     }
 
     public function testAuthSetUser(): void
@@ -678,6 +697,7 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
         );
 
         $this->object->storeCredentials();
+        $this->expectException(ExitException::class);
         $this->object->rememberCredentials();
     }
 
@@ -994,8 +1014,16 @@ class AuthenticationCookieTest extends AbstractNetworkTestCase
         }
 
         ob_start();
-        $this->object->checkRules();
+        try {
+            $this->object->checkRules();
+        } catch (Throwable $throwable) {
+        }
+
         $result = ob_get_clean();
+
+        if (! empty($expected)) {
+            $this->assertInstanceOf(ExitException::class, $throwable ?? null);
+        }
 
         $this->assertIsString($result);
 

--- a/test/classes/Plugins/Auth/AuthenticationSignonTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationSignonTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Plugins\Auth;
 
 use PhpMyAdmin\DatabaseInterface;
+use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Plugins\Auth\AuthenticationSignon;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractNetworkTestCase;
+use Throwable;
 
 use function ob_get_clean;
 use function ob_start;
@@ -57,8 +59,14 @@ class AuthenticationSignonTest extends AbstractNetworkTestCase
         ResponseRenderer::getInstance()->setAjax(false);
 
         ob_start();
-        $this->object->showLoginForm();
+        try {
+            $this->object->showLoginForm();
+        } catch (Throwable $throwable) {
+        }
+
         $result = ob_get_clean();
+
+        $this->assertInstanceOf(ExitException::class, $throwable ?? null);
 
         $this->assertIsString($result);
 

--- a/test/classes/Setup/FormProcessingTest.php
+++ b/test/classes/Setup/FormProcessingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Setup;
 
 use PhpMyAdmin\Config\FormDisplay;
+use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Setup\FormProcessing;
 use PhpMyAdmin\Tests\AbstractNetworkTestCase;
 
@@ -100,6 +101,7 @@ class FormProcessingTest extends AbstractNetworkTestCase
             ->with()
             ->will($this->returnValue(false));
 
+        $this->expectException(ExitException::class);
         FormProcessing::process($formDisplay);
     }
 }

--- a/test/classes/Stubs/ResponseRenderer.php
+++ b/test/classes/Stubs/ResponseRenderer.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Tests\Stubs;
 
+use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Footer;
 use PhpMyAdmin\Header;
 use PhpMyAdmin\Message;
@@ -180,5 +181,10 @@ class ResponseRenderer extends \PhpMyAdmin\ResponseRenderer
     public function setHeadersSent(bool $isHeadersSent): void
     {
         $this->isHeadersSent = $isHeadersSent;
+    }
+
+    public function callExit(string $message = ''): never
+    {
+        throw new ExitException($message);
     }
 }


### PR DESCRIPTION
Creates the `PhpMyAdmin\ResponseRenderer::callExit()` method as a wrapper to the `exit` language construct. That makes the tests more correct as the method will always stop the code execution.
