### PR TITLE
Extract some dependencies from the Application class

### DIFF
--- a/libraries/classes/Template.php
+++ b/libraries/classes/Template.php
@@ -44,12 +44,11 @@ class Template
 
     public const TEMPLATES_FOLDER = ROOT_PATH . 'templates';
 
-    private Config|null $config;
+    private Config $config;
 
     public function __construct(Config|null $config = null)
     {
-        $config = $config ?? $GLOBALS['config'] ?? null;
-        $this->config = $config instanceof Config ? $config : null;
+        $this->config = $config ?? $GLOBALS['config'];
     }
 
     public static function getTwigEnvironment(string|null $cacheDir): Environment
@@ -101,7 +100,7 @@ class Template
     private function load(string $templateName): TemplateWrapper
     {
         if (static::$twig === null) {
-            static::$twig = self::getTwigEnvironment($this->config?->getTempDir('twig'));
+            static::$twig = self::getTwigEnvironment($this->config->getTempDir('twig'));
         }
 
         try {
@@ -136,5 +135,14 @@ class Template
     public function render(string $template, array $data = []): string
     {
         return $this->load($template)->render($data);
+    }
+
+    public function disableCache(): void
+    {
+        if (static::$twig === null) {
+            static::$twig = self::getTwigEnvironment(null);
+        }
+
+        static::$twig->setCache(false);
     }
 }

--- a/libraries/services.php
+++ b/libraries/services.php
@@ -63,7 +63,10 @@ return [
             'class' => Advisor::class,
             'arguments' => ['$dbi' => '@dbi', '$expression' => '@expression_language'],
         ],
-        Application::class => ['class' => Application::class],
+        Application::class => [
+            'class' => Application::class,
+            'arguments' => ['$errorHandler' => '@error_handler', '$config' => '@config', '$template' => '@template'],
+        ],
         'browse_foreigners' => [
             'class' => BrowseForeigners::class,
             'arguments' => ['@template', '@config'],

--- a/test/classes/TemplateTest.php
+++ b/test/classes/TemplateTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use ReflectionProperty;
+use Twig\Cache\CacheInterface;
+use Twig\Environment;
 use Twig\Error\LoaderError;
 
 #[CoversClass(Template::class)]
@@ -175,5 +178,20 @@ class TemplateTest extends AbstractTestCase
 
         $template2 = new Template($config);
         $this->assertSame('static content', $template2->render('test/static'));
+    }
+
+    public function testDisableCache(): void
+    {
+        (new ReflectionProperty(Template::class, 'twig'))->setValue(null);
+        $template = new Template($this->createStub(Config::class));
+        $template->disableCache();
+        $twig = (new ReflectionProperty(Template::class, 'twig'))->getValue();
+        $this->assertInstanceOf(Environment::class, $twig);
+        $this->assertFalse($twig->getCache());
+        $twig->setCache($this->createStub(CacheInterface::class));
+        $this->assertNotFalse($twig->getCache());
+        $template->disableCache();
+        $this->assertFalse($twig->getCache());
+        (new ReflectionProperty(Template::class, 'twig'))->setValue(null);
     }
 }


### PR DESCRIPTION
- Extracts the ErrorHandler, Config and Template dependencies from the Application class.
- Loads HTTP ServerRequest object after loading the user config.
- Requires a Config object for the Template class, since the Config object is always available now.
- Disables Twig's cache if an exception is thrown before loading the user config. This way a possible different cache directory will not be used.
