### PR TITLE
fix: table columns with names of ' or "" or `` could not be dropped

### DIFF
--- a/js/src/table/structure.ts
+++ b/js/src/table/structure.ts
@@ -7,7 +7,7 @@ import highlightSql from '../modules/sql-highlight.ts';
 import { ajaxRemoveMessage, ajaxShowMessage } from '../modules/ajax-message.ts';
 import { Indexes } from '../modules/indexes.ts';
 import getJsConfirmCommonParam from '../modules/functions/getJsConfirmCommonParam.ts';
-import { escapeHtml } from '../modules/functions/escape.ts';
+import { escapeHtml, escapeJsString } from '../modules/functions/escape.ts';
 import refreshMainContent from '../modules/functions/refreshMainContent.ts';
 
 /**
@@ -191,7 +191,7 @@ AJAX.registerOnload('table/structure.js', function () {
          * @var currColumnName    String containing name of the field referred to by {@link curr_row}
          */
         var currColumnName = $currRow.children('th').children('label').text().trim();
-        currColumnName = escapeHtml(currColumnName);
+        currColumnName = escapeJsString(escapeHtml(currColumnName));
         /**
          * @var $afterFieldItem    Corresponding entry in the 'After' field.
          */

--- a/js/src/table/structure.ts
+++ b/js/src/table/structure.ts
@@ -192,6 +192,7 @@ AJAX.registerOnload('table/structure.js', function () {
          */
         var currColumnName = $currRow.children('th').children('label').text().trim();
         currColumnName = escapeJsString(escapeHtml(currColumnName));
+
         /**
          * @var $afterFieldItem    Corresponding entry in the 'After' field.
          */


### PR DESCRIPTION
    Unsafe javascript string was passed to the currColumnName var. By using
    escapeJsString from /modules/functions/escape.ts the unsafe string becomes
    a safe string and the rest of the code runs as expected. fixes issue #18448

    Signed-off-by: Thanasis Mpalatsoukas <thanasismpalatsoukas@gmail.com>

### Description

Please describe your pull request.

Fixes #18448

Before submitting pull request, please review the following checklist:

- [X] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [X] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [X] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [X] Every commit has a descriptive commit message.
- [X] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
