### PR TITLE
Fix #18392 - Format query not working inside view modal

### DIFF
--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -995,6 +995,9 @@ class Sql
 
         $response = ResponseRenderer::getInstance();
         $response->addJSON($extraData ?? []);
+        $header = $response->getHeader();
+        $scripts = $header->getScripts();
+        $scripts->addFile('sql.js');
 
         if (! $statementInfo->isSelect || isset($extraData['error'])) {
             return $queryMessage;
@@ -1024,10 +1027,6 @@ class Sql
 
         $profilingChart = '';
         if ($profilingResults !== []) {
-            $header = $response->getHeader();
-            $scripts = $header->getScripts();
-            $scripts->addFile('sql.js');
-
             $profiling = $this->getDetailedProfilingStats($profilingResults);
             if ($profiling !== []) {
                 $profilingChart = $this->template->render('sql/profiling_chart', ['profiling' => $profiling]);


### PR DESCRIPTION
### Description

The query formatting was not working inside the Create view modal when the table had 0 rows. It seems that sql.js was not being added to the header scripts when the query returned no results, such as when browsing an empty table. However, it was being added when the profiling checkbox was checked. I have moved that outside of this conditional, and now the formatting is functioning correctly.

Fixes #18392.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
