### PR TITLE
Fix #18403 - Uncaught SyntaxError: JSON.parse on makegrid conditions

### DIFF
--- a/js/src/makegrid.js
+++ b/js/src/makegrid.js
@@ -1215,7 +1215,11 @@ var makeGrid = function (t, enableResize, enableReorder, enableVisib, enableGrid
                     whereClause = '';
                 }
                 fullWhereClause.push(whereClause);
-                var conditionArray = JSON.parse($tr.find('.condition_array').val());
+                var conditionArrayContent = $tr.find('.condition_array').val();
+                if (typeof conditionArrayContent === 'undefined') {
+                    conditionArrayContent = '{}';
+                }
+                var conditionArray = JSON.parse(conditionArrayContent);
 
                 /**
                  * multi edit variables, for current row


### PR DESCRIPTION
### Description

This pull request addresses a JSON parsing error that occurs when modifying a row in a table after executing a custom query. The error message "Uncaught SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data" is triggered during the parsing of the conditionArray value. The fix involves implementing a resilient approach to handle the conditionArray value, preventing the error from occurring. Please review the changes and consider merging them into the main codebase.

Fixes #18403

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
