### PR TITLE
Fix #17528 - Fix wrong encoding of db group names

### DIFF
--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -823,7 +823,7 @@ class NavigationTree
                 }
             } else {
                 $groups[$key] = new Node(
-                    htmlspecialchars((string) $key),
+                    (string) $key,
                     Node::CONTAINER,
                     true
                 );


### PR DESCRIPTION
### Description

This PR fixes the wrong encoding of db group names.

Fixes #17528

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
