### PR TITLE
Improve copy to clipboard code

### DIFF
--- a/js/src/modules/functions.ts
+++ b/js/src/modules/functions.ts
@@ -1519,7 +1519,7 @@ function dismissNotifications () {
             var copyText = $(this).attr('data-text');
             var copyTarget = $(this).attr('data-target');
             if (copyTarget) {
-                copyText = String($(copyTarget).val());
+                copyText = $(copyTarget).val();
             }
 
             if (Functions.copyToClipboard(copyText)) {

--- a/js/src/modules/functions.ts
+++ b/js/src/modules/functions.ts
@@ -1516,22 +1516,28 @@ function dismissNotifications () {
 
         $(document).on('click', 'a.copyQueryBtn', function (event) {
             event.preventDefault();
-            var copyText = $(this).attr('data-text');
-            var copyTarget = $(this).attr('data-target');
-            if (copyTarget) {
-                copyText = $(copyTarget).val();
-            }
+            var copyStatus = Functions.copyToClipboard($(this).attr('data-text'));
+            displayCopyStatus(this, copyStatus);
+        });
 
-            if (Functions.copyToClipboard(copyText)) {
-                $(this).after('<span id=\'copyStatus\'> (' + window.Messages.strCopyQueryButtonSuccess + ')</span>');
+        $(document).on('click', 'a.copyExportBtn', function (event) {
+            event.preventDefault();
+            var copyTarget = $(this).attr('data-target');
+            var copyStatus = Functions.copyToClipboard($(copyTarget).val());
+            displayCopyStatus(this, copyStatus);
+        });
+
+        function displayCopyStatus (copyButton, copyStatus) {
+            if (copyStatus) {
+                $(copyButton).after('<span id=\'copyStatus\'> (' + window.Messages.strCopyQueryButtonSuccess + ')</span>');
             } else {
-                $(this).after('<span id=\'copyStatus\'> (' + window.Messages.strCopyQueryButtonFailure + ')</span>');
+                $(copyButton).after('<span id=\'copyStatus\'> (' + window.Messages.strCopyQueryButtonFailure + ')</span>');
             }
 
             setTimeout(function () {
                 $('#copyStatus').remove();
             }, 2000);
-        });
+        }
     };
 }
 

--- a/js/src/modules/functions.ts
+++ b/js/src/modules/functions.ts
@@ -1527,7 +1527,13 @@ function dismissNotifications () {
             displayCopyStatus(this, copyStatus);
         });
 
-        function displayCopyStatus (copyButton, copyStatus) {
+        /**
+         * displaying status of copy to clipboard action next to the copy button
+         *
+         * @param {JQuery<HTMLInputElement>} copyButton jQuery the clicked button object
+         * @param {boolean} copyStatus status of copyToClipboard
+         */
+        function displayCopyStatus (copyButton: JQuery<HTMLInputElement>, copyStatus: boolean) {
             if (copyStatus) {
                 $(copyButton).after('<span id=\'copyStatus\'> (' + window.Messages.strCopyQueryButtonSuccess + ')</span>');
             } else {

--- a/js/src/modules/functions.ts
+++ b/js/src/modules/functions.ts
@@ -1450,7 +1450,7 @@ function checkReservedWordColumns ($form) {
  * @return {boolean}
  */
 function copyToClipboard (text) {
-    var $temp = $('<input>');
+    var $temp = $('<textarea>');
     $temp.css({
         'position': 'fixed',
         'width': '2em',
@@ -1516,8 +1516,13 @@ function dismissNotifications () {
 
         $(document).on('click', 'a.copyQueryBtn', function (event) {
             event.preventDefault();
-            var res = Functions.copyToClipboard($(this).attr('data-text'));
-            if (res) {
+            var copyText = $(this).attr('data-text');
+            var copyTarget = $(this).attr('data-target');
+            if (copyTarget) {
+                copyText = String($(copyTarget).val());
+            }
+
+            if (Functions.copyToClipboard(copyText)) {
                 $(this).after('<span id=\'copyStatus\'> (' + window.Messages.strCopyQueryButtonSuccess + ')</span>');
             } else {
                 $(this).after('<span id=\'copyStatus\'> (' + window.Messages.strCopyQueryButtonFailure + ')</span>');

--- a/libraries/classes/Export/Export.php
+++ b/libraries/classes/Export/Export.php
@@ -1314,7 +1314,7 @@ class Export
 
     private function getHTMLForCopyButton(): string
     {
-        return '[ <a href="#" class="copyQueryBtn" data-target="#textSQLDUMP">'
+        return '[ <a href="#" class="copyExportBtn" data-target="#textSQLDUMP">'
             . __('Copy') . '</a> ]';
     }
 

--- a/libraries/classes/Export/Export.php
+++ b/libraries/classes/Export/Export.php
@@ -1312,9 +1312,6 @@ class Export
         return $backButton;
     }
 
-    /**
-     * @return string
-     */
     private function getHTMLForCopyButton(): string
     {
         return '[ <a href="#" class="copyQueryBtn" data-target="#textSQLDUMP">'

--- a/libraries/classes/Export/Export.php
+++ b/libraries/classes/Export/Export.php
@@ -243,6 +243,7 @@ class Export
         return '</textarea>'
             . '    </form>'
             . '<br>'
+            . $this->getHTMLForCopyButton()
             // bottom back button
             . $this->getHTMLForBackButton($exportType, $db, $table)
             . $this->getHTMLForRefreshButton($exportType)
@@ -544,6 +545,7 @@ class Export
             . $this->getHTMLForBackButton($exportType, $db, $table)
             . $this->getHTMLForRefreshButton($exportType)
             . '<br>'
+            . $this->getHTMLForCopyButton()
             . '<form name="nofunction">'
             . '<textarea name="sqldump" cols="50" rows="30" '
             . 'id="textSQLDUMP" wrap="OFF">';
@@ -1308,6 +1310,15 @@ class Export
         $backButton .= '&amp;repopulate=1">' . __('Back') . '</a> ]</p>';
 
         return $backButton;
+    }
+
+    /**
+     * @return string
+     */
+    private function getHTMLForCopyButton(): string
+    {
+        return '[ <a href="#" class="copyQueryBtn" data-target="#textSQLDUMP">'
+            . __('Copy') . '</a> ]';
     }
 
     /** @return mixed[] */


### PR DESCRIPTION
### Description

This is a PR for adding a **copy** to the clipboard on the export page that was requested (#18529). 

<img width="454" alt="phpmyadmin_copy_export" src="https://github.com/phpmyadmin/phpmyadmin/assets/3734100/6c0d0d24-56cd-4a87-9c3d-1e8648042d5e">

To keep the text format copied to the clipboard temporary `input` has changed to the `textarea`.

