### PR TITLE
fix: simulate query matched rows wrong count

### DIFF
--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -135,7 +135,7 @@ final class SimulateDml
         }
 
         if (! empty($diff)) {
-            $where .= ' AND (' . implode(' OR ', $diff) . ')';
+            $where = '(' . $where . ') AND (' . implode(' OR ', $diff) . ')';
         }
 
         $orderAndLimit = '';

--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -132,12 +132,11 @@ final class SimulateDml
         $diff = [];
         foreach ($statement->set as $set) {
             $columns[] = $set->column;
-            $notEqualOperator = ' <> ';
             if (strtoupper($set->value) === 'NULL') {
-                $notEqualOperator = ' IS NOT ';
+                $diff[] = $set->column . ' IS NOT ' . $set->value;
+            }else{
+                $diff[] = '(' . $set->column . ' <> ' . $set->value . ' OR ' . $set->column . ' IS NULL)';
             }
-
-            $diff[] = $set->column . $notEqualOperator . $set->value;
         }
 
         if (! empty($diff)) {

--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -15,7 +15,6 @@ use PhpMyAdmin\SqlParser\Utils\Query;
 use PhpMyAdmin\Url;
 
 use function implode;
-use function strtoupper;
 
 final class SimulateDml
 {
@@ -132,11 +131,7 @@ final class SimulateDml
         $diff = [];
         foreach ($statement->set as $set) {
             $columns[] = $set->column;
-            if (strtoupper($set->value) === 'NULL') {
-                $diff[] = $set->column . ' IS NOT ' . $set->value;
-            } else {
-                $diff[] = $set->column . ' <> ' . $set->value . ' OR ' . $set->column . ' IS NULL';
-            }
+            $diff[] = 'NOT ' . $set->column . ' <=> (' . $set->value . ')';
         }
 
         if (! empty($diff)) {

--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -134,8 +134,8 @@ final class SimulateDml
             $columns[] = $set->column;
             if (strtoupper($set->value) === 'NULL') {
                 $diff[] = $set->column . ' IS NOT ' . $set->value;
-            }else{
-                $diff[] = '(' . $set->column . ' <> ' . $set->value . ' OR ' . $set->column . ' IS NULL)';
+            } else {
+                $diff[] = $set->column . ' <> ' . $set->value . ' OR ' . $set->column . ' IS NULL';
             }
         }
 

--- a/test/classes/Import/SimulateDmlTest.php
+++ b/test/classes/Import/SimulateDmlTest.php
@@ -50,7 +50,7 @@ class SimulateDmlTest extends AbstractTestCase
         return [
             'update statement' => [
                 'UPDATE `table_1` SET `id` = 20 WHERE `id` > 10',
-                'SELECT `id` FROM `table_1` WHERE `id` > 10 AND (`id` <> 20)',
+                'SELECT `id` FROM `table_1` WHERE (`id` > 10) AND (NOT `id` <=> (20))',
             ],
             'delete statement' => [
                 'DELETE FROM `table_1` WHERE `id` > 10',

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -2229,7 +2229,7 @@ class DbiDummy implements DbiExtension
                 'result' => [['PMA_table', 'InnoDB']],
             ],
             [
-                'query' => 'SELECT `id` FROM `table_1` WHERE `id` > 10 AND (`id` <> 20)',
+                'query' => 'SELECT `id` FROM `table_1` WHERE (`id` > 10) AND (NOT `id` <=> (20))',
                 'columns' => ['id'],
                 'result' => [['11'], ['12']],
             ],


### PR DESCRIPTION
This is a bug fix for #18533 
The `<>` operator excludes `NULL` values. [read more](https://stackoverflow.com/a/38375786)

Fixes: #18533

