### PR TITLE
Remove support for the Recode extension

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,7 +135,7 @@ jobs:
       matrix:
         php-version: ["8.1"]
         os: [ubuntu-latest]
-        extension: ["dbase", "recode"]
+        extension: ["dbase"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -2993,17 +2993,20 @@ Languages
     You can select here which functions will be used for character set
     conversion. Possible values are:
 
-    * auto - automatically use available one (first is tested iconv, then
-      recode)
-    * iconv - use iconv or libiconv functions
-    * recode - use recode\_string function
-    * mb - use :term:`mbstring` extension
-    * none - disable encoding conversion
+    * ``'auto'`` - automatically use available one (first is tested iconv, then mbstring)
+    * ``'iconv'`` - use iconv or libiconv functions
+    * ``'mb'`` - use :term:`mbstring` extension
+    * ``'none'`` - disable encoding conversion
 
     Enabled charset conversion activates a pull-down menu in the Export
     and Import pages, to choose the character set when exporting a file.
     The default value in this menu comes from
     :config:option:`$cfg['Export']['charset']` and :config:option:`$cfg['Import']['charset']`.
+
+    .. versionchanged:: 6.0.0
+
+        Support for the Recode extension has been removed. The ``'recode'`` value is ignored and the
+        default value (``'auto'``) is used instead.
 
 .. config:option:: $cfg['IconvExtraParams']
 
@@ -3022,7 +3025,7 @@ Languages
     :default: array(...)
 
     Available character sets for MySQL conversion. You can add your own
-    (any of supported by recode/iconv) or remove these which you don't
+    (any of supported by mbstring/iconv) or remove these which you don't
     use. Character sets will be shown in same order as here listed, so if
     you frequently use some of these move them to the top.
 

--- a/libraries/classes/Config/ConfigFile.php
+++ b/libraries/classes/Config/ConfigFile.php
@@ -514,7 +514,7 @@ class ConfigFile
                     'only_db' => 'array',
                 ],
             ],
-            'RecodingEngine' => ['auto', 'iconv', 'recode', 'mb', 'none'],
+            'RecodingEngine' => ['auto', 'iconv', 'mb', 'none'],
             'OBGzip' => ['auto', true, false],
             'MemoryLimit' => 'short_string',
             'NavigationLogoLinkWindow' => ['main', 'new'],

--- a/libraries/classes/Config/FormDisplay.php
+++ b/libraries/classes/Config/FormDisplay.php
@@ -777,15 +777,6 @@ class FormDisplay
                 );
             }
 
-            if (! function_exists('recode_string')) {
-                $opts['values']['recode'] .= ' (' . __('unavailable') . ')';
-                $comment .= ($comment ? ', ' : '') . sprintf(
-                    __('"%s" requires %s extension'),
-                    'recode',
-                    'recode',
-                );
-            }
-
             /* mbstring is always there thanks to polyfill */
             $opts['comment'] = $comment;
             $opts['comment_warning'] = true;

--- a/libraries/classes/Config/Settings.php
+++ b/libraries/classes/Config/Settings.php
@@ -1642,9 +1642,8 @@ final class Settings
     /**
      * You can select here which functions will be used for character set conversion.
      * Possible values are:
-     *      auto   - automatically use available one (first is tested iconv, then recode)
+     *      auto   - automatically use available one (first is tested iconv, then mbstring)
      *      iconv  - use iconv or libiconv functions
-     *      recode - use recode_string function
      *      mb     - use mbstring extension
      *      none   - disable encoding conversion
      *
@@ -1654,7 +1653,7 @@ final class Settings
      *
      * @link https://docs.phpmyadmin.net/en/latest/config.html#cfg_RecodingEngine
      *
-     * @psalm-var 'auto'|'iconv'|'recode'|'mb'|'none'
+     * @psalm-var 'auto'|'iconv'|'mb'|'none'
      */
     public string $RecodingEngine;
 
@@ -4483,13 +4482,13 @@ final class Settings
     /**
      * @param array<int|string, mixed> $settings
      *
-     * @psalm-return 'auto'|'iconv'|'recode'|'mb'|'none'
+     * @psalm-return 'auto'|'iconv'|'mb'|'none'
      */
     private function setRecodingEngine(array $settings): string
     {
         if (
             ! isset($settings['RecodingEngine'])
-            || ! in_array($settings['RecodingEngine'], ['iconv', 'recode', 'mb', 'none'], true)
+            || ! in_array($settings['RecodingEngine'], ['iconv', 'mb', 'none'], true)
         ) {
             return 'auto';
         }

--- a/libraries/classes/Encoding.php
+++ b/libraries/classes/Encoding.php
@@ -18,7 +18,6 @@ use function mb_convert_encoding;
 use function mb_convert_kana;
 use function mb_detect_encoding;
 use function mb_list_encodings;
-use function recode_string;
 use function strtolower;
 use function tempnam;
 use function unlink;
@@ -37,11 +36,6 @@ class Encoding
      * iconv encoding conversion engine
      */
     public const ENGINE_ICONV = 1;
-
-    /**
-     * recode encoding conversion engine
-     */
-    public const ENGINE_RECODE = 2;
 
     /**
      * mbstring encoding conversion engine
@@ -66,7 +60,6 @@ class Encoding
      */
     private static array $enginemap = [
         'iconv' => ['iconv', self::ENGINE_ICONV, 'iconv'],
-        'recode' => ['recode_string', self::ENGINE_RECODE, 'recode'],
         'mb' => ['mb_convert_encoding', self::ENGINE_MB, 'mbstring'],
         'none' => ['isset', self::ENGINE_NONE, ''],
     ];
@@ -76,7 +69,7 @@ class Encoding
      *
      * @var mixed[]
      */
-    private static array $engineorder = ['iconv', 'mb', 'recode'];
+    private static array $engineorder = ['iconv', 'mb'];
 
     /**
      * Kanji encodings list
@@ -163,7 +156,6 @@ class Encoding
         }
 
         return match (self::$engine) {
-            self::ENGINE_RECODE => recode_string($srcCharset . '..' . $destCharset, $what),
             self::ENGINE_ICONV => iconv($srcCharset, $destCharset . ($GLOBALS['cfg']['IconvExtraParams'] ?? ''), $what),
             self::ENGINE_MB => mb_convert_encoding($what, $destCharset, $srcCharset),
             default => $what,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3596,7 +3596,7 @@ parameters:
 			path: libraries/classes/Encoding.php
 
 		-
-			message: "#^Function recode_string not found\\.$#"
+			message: "#^Method PhpMyAdmin\\\\Encoding\\:\\:convertString\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: libraries/classes/Encoding.php
 
@@ -3613,11 +3613,6 @@ parameters:
 		-
 			message: "#^Static property PhpMyAdmin\\\\Encoding\\:\\:\\$engine \\(int\\|null\\) does not accept mixed\\.$#"
 			count: 2
-			path: libraries/classes/Encoding.php
-
-		-
-			message: "#^Used function recode_string not found\\.$#"
-			count: 1
 			path: libraries/classes/Encoding.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -435,11 +435,9 @@
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$opts['values']['iconv']]]></code>
-      <code><![CDATA[$opts['values']['recode']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$opts['values']['iconv']]]></code>
-      <code><![CDATA[$opts['values']['recode']]]></code>
     </MixedArrayAssignment>
     <MixedArrayOffset>
       <code>$_POST[$key]</code>
@@ -496,7 +494,6 @@
       <code>$key</code>
       <code>$key</code>
       <code><![CDATA[$opts['values']['iconv']]]></code>
-      <code><![CDATA[$opts['values']['recode']]]></code>
       <code>$v</code>
     </MixedOperand>
     <PossiblyFalseArgument>

--- a/test/classes/Config/FormDisplayTest.php
+++ b/test/classes/Config/FormDisplayTest.php
@@ -315,7 +315,6 @@ class FormDisplayTest extends AbstractTestCase
         // recoding
         $opts = ['values' => []];
         $opts['values']['iconv'] = 'testIconv';
-        $opts['values']['recode'] = 'testRecode';
         $opts['values']['mb'] = 'testMB';
         $opts['comment'] = null;
         $opts['comment_warning'] = null;
@@ -331,11 +330,6 @@ class FormDisplayTest extends AbstractTestCase
         if (! function_exists('iconv')) {
             $expect['values']['iconv'] .= ' (unavailable)';
             $expect['comment'] = '"iconv" requires iconv extension';
-        }
-
-        if (! function_exists('recode_string')) {
-            $expect['values']['recode'] .= ' (unavailable)';
-            $expect['comment'] .= ($expect['comment'] ? ', ' : '') . '"recode" requires recode extension';
         }
 
         $expect['comment_warning'] = 1;

--- a/test/classes/Config/SettingsTest.php
+++ b/test/classes/Config/SettingsTest.php
@@ -731,7 +731,7 @@ class SettingsTest extends TestCase
                     ['DefaultTabServer', 'status', 'status'],
                     ['DefaultTabDatabase', 'search', 'search'],
                     ['DefaultTabTable', 'search', 'search'],
-                    ['RecodingEngine', 'recode', 'recode'],
+                    ['RecodingEngine', 'mb', 'mb'],
                     ['RowActionLinks', 'both', 'both'],
                 ],
             ],
@@ -742,7 +742,6 @@ class SettingsTest extends TestCase
                     ['DefaultTabServer', 'variables', 'variables'],
                     ['DefaultTabDatabase', 'db_structure.php', 'structure'],
                     ['DefaultTabTable', 'insert', 'insert'],
-                    ['RecodingEngine', 'mb', 'mb'],
                 ],
             ],
             'valid values 6' => [
@@ -993,6 +992,7 @@ class SettingsTest extends TestCase
                     ['TrustedProxies', [1234 => 'invalid', 'valid' => 'valid'], ['valid' => 'valid']],
                     ['DefaultFunctions', [1234 => 'invalid', 'valid' => 'valid'], ['valid' => 'valid']],
                     ['FirstDayOfCalendar', -1, 0],
+                    ['RecodingEngine', 'recode', 'auto'],
                 ],
             ],
             'invalid values 3' => [

--- a/test/classes/EncodingTest.php
+++ b/test/classes/EncodingTest.php
@@ -60,20 +60,6 @@ class EncodingTest extends AbstractTestCase
         );
     }
 
-    #[RequiresPhpExtension('recode')]
-    public function testRecode(): void
-    {
-        Encoding::setEngine(Encoding::ENGINE_RECODE);
-        $this->assertEquals(
-            'Only That ecole & Can Be My Blame',
-            Encoding::convertString(
-                'UTF-8',
-                'flat',
-                'Only That école & Can Be My Blame',
-            ),
-        );
-    }
-
     /**
      * This group is used on debian packaging to exclude the test
      *


### PR DESCRIPTION
The Recode extension is not supported in PHP >= 7.4.

- https://www.php.net/manual/en/intro.recode.php
- https://www.php.net/manual/en/migration74.removed-extensions.php