### PR TITLE
ReflectionProperty setValue call deprecated in PHP 8.3

### DIFF
--- a/test/classes/AbstractNetworkTestCase.php
+++ b/test/classes/AbstractNetworkTestCase.php
@@ -90,7 +90,7 @@ abstract class AbstractNetworkTestCase extends AbstractTestCase
 
         $attrInstance = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $attrInstance->setAccessible(true);
-        $attrInstance->setValue($mockResponse);
+        $attrInstance->setValue(null, $mockResponse);
 
         return $mockResponse;
     }
@@ -103,7 +103,7 @@ abstract class AbstractNetworkTestCase extends AbstractTestCase
         parent::tearDown();
         $response = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $response->setAccessible(true);
-        $response->setValue(null);
+        $response->setValue(null, null);
         $response->setAccessible(false);
     }
 }

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -1974,7 +1974,7 @@ class RelationTest extends AbstractTestCase
         $_SESSION['tmpval'] = [];
         $recentFavoriteTableInstances = (new ReflectionClass(RecentFavoriteTable::class))->getProperty('instances');
         $recentFavoriteTableInstances->setAccessible(true);
-        $recentFavoriteTableInstances->setValue([]);
+        $recentFavoriteTableInstances->setValue(null, []);
 
         $relation = new Relation($this->dbi);
         $relation->initRelationParamsCache();

--- a/test/classes/Controllers/Server/VariablesControllerTest.php
+++ b/test/classes/Controllers/Server/VariablesControllerTest.php
@@ -153,7 +153,7 @@ class VariablesControllerTest extends AbstractTestCase
 
         $response = new ReflectionProperty(ServerVariablesProvider::class, 'instance');
         $response->setAccessible(true);
-        $response->setValue($voidProviderMock);
+        $response->setValue(null, $voidProviderMock);
 
         [$formattedValue, $isHtmlFormatted] = $this->callFunction(
             $controller,
@@ -205,7 +205,7 @@ class VariablesControllerTest extends AbstractTestCase
 
         $response = new ReflectionProperty(ServerVariablesProvider::class, 'instance');
         $response->setAccessible(true);
-        $response->setValue(null);
+        $response->setValue(null, null);
 
         $controller = new VariablesController(ResponseRenderer::getInstance(), new Template(), $GLOBALS['dbi']);
 
@@ -264,7 +264,7 @@ class VariablesControllerTest extends AbstractTestCase
     {
         $response = new ReflectionProperty(ServerVariablesProvider::class, 'instance');
         $response->setAccessible(true);
-        $response->setValue(new ServerVariablesVoidProvider());
+        $response->setValue(null, new ServerVariablesVoidProvider());
 
         $controller = new VariablesController(ResponseRenderer::getInstance(), new Template(), $GLOBALS['dbi']);
 

--- a/test/classes/ErrorHandlerTest.php
+++ b/test/classes/ErrorHandlerTest.php
@@ -321,7 +321,7 @@ class ErrorHandlerTest extends AbstractTestCase
         $responseStub = new ResponseRendererStub();
         $property = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $property->setAccessible(true);
-        $property->setValue($responseStub);
+        $property->setValue(null, $responseStub);
         $responseStub->setHeadersSent(true);
         $errorHandler = new ErrorHandler();
         $this->assertSame([], $errorHandler->getCurrentErrors());
@@ -347,7 +347,7 @@ class ErrorHandlerTest extends AbstractTestCase
         $responseStub = new ResponseRendererStub();
         $property = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $property->setAccessible(true);
-        $property->setValue($responseStub);
+        $property->setValue(null, $responseStub);
         $responseStub->setHeadersSent(true);
         $errorHandler = new ErrorHandler();
         $this->assertSame([], $errorHandler->getCurrentErrors());
@@ -373,7 +373,7 @@ class ErrorHandlerTest extends AbstractTestCase
         $responseStub = new ResponseRendererStub();
         $property = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $property->setAccessible(true);
-        $property->setValue($responseStub);
+        $property->setValue(null, $responseStub);
         $responseStub->setHeadersSent(true);
         $errorHandler = new ErrorHandler();
         $errorHandler->addError('Fatal error message!', E_ERROR, './file/name', 1);
@@ -399,7 +399,7 @@ HTML;
         $responseStub = new ResponseRendererStub();
         $property = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $property->setAccessible(true);
-        $property->setValue($responseStub);
+        $property->setValue(null, $responseStub);
         $responseStub->setHeadersSent(false);
         $errorHandler = new ErrorHandler();
         $errorHandler->addError('Fatal error message!', E_ERROR, './file/name', 1);

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -95,7 +95,7 @@ class InsertEditTest extends AbstractTestCase
         parent::tearDown();
         $response = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $response->setAccessible(true);
-        $response->setValue(null);
+        $response->setValue(null, null);
         $response->setAccessible(false);
     }
 
@@ -331,7 +331,7 @@ class InsertEditTest extends AbstractTestCase
         $restoreInstance = ResponseRenderer::getInstance();
         $response = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $response->setAccessible(true);
-        $response->setValue($responseMock);
+        $response->setValue(null, $responseMock);
 
         $result = $this->callFunction(
             $this->insertEdit,
@@ -346,7 +346,7 @@ class InsertEditTest extends AbstractTestCase
             ]
         );
 
-        $response->setValue($restoreInstance);
+        $response->setValue(null, $restoreInstance);
 
         $this->assertFalse($result);
     }
@@ -2863,7 +2863,7 @@ class InsertEditTest extends AbstractTestCase
         $restoreInstance = ResponseRenderer::getInstance();
         $response = new ReflectionProperty(ResponseRenderer::class, 'instance');
         $response->setAccessible(true);
-        $response->setValue($responseMock);
+        $response->setValue(null, $responseMock);
 
         $this->insertEdit = new InsertEdit($dbi);
 
@@ -2890,7 +2890,7 @@ class InsertEditTest extends AbstractTestCase
 
         $result = $this->insertEdit->determineInsertOrEdit(null, 'db', 'table');
 
-        $response->setValue($restoreInstance);
+        $response->setValue(null, $restoreInstance);
 
         $this->assertEquals(
             [


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#reflectionpropertysetvalue

It produces quite a few deprecation warnings https://github.com/phpmyadmin/phpmyadmin/actions/runs/5604512710/jobs/10252588257?pr=18548