### PR TITLE
ReflectionProperty setValue call deprecated in PHP 8.3 (master)

### DIFF
--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -19,6 +19,7 @@ use PhpMyAdmin\Theme\ThemeManager;
 use PhpMyAdmin\Utils\HttpRequest;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionProperty;
 
 use function array_keys;
 use function in_array;
@@ -84,7 +85,7 @@ abstract class AbstractTestCase extends TestCase
         $this->setGlobalConfig();
         Cache::purge();
 
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
     }
 
     protected function loadContainerBuilder(): void

--- a/test/classes/AbstractTestCase.php
+++ b/test/classes/AbstractTestCase.php
@@ -84,7 +84,7 @@ abstract class AbstractTestCase extends TestCase
         $this->setGlobalConfig();
         Cache::purge();
 
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
     }
 
     protected function loadContainerBuilder(): void

--- a/test/classes/ApplicationTest.php
+++ b/test/classes/ApplicationTest.php
@@ -42,7 +42,7 @@ final class ApplicationTest extends AbstractTestCase
             ->willThrowException(new ConfigException('Failed to load phpMyAdmin configuration.'));
 
         $request = $this->createStub(ServerRequest::class);
-        (new ReflectionProperty(Application::class, 'request'))->setValue($request);
+        (new ReflectionProperty(Application::class, 'request'))->setValue(null, $request);
 
         $template = new Template($config);
         $expected = $template->render('error/generic', [
@@ -59,7 +59,7 @@ final class ApplicationTest extends AbstractTestCase
         $this->assertSame($config, $GLOBALS['config']);
         $this->assertSame($errorHandler, $GLOBALS['errorHandler']);
 
-        (new ReflectionProperty(Application::class, 'request'))->setValue(null);
+        (new ReflectionProperty(Application::class, 'request'))->setValue(null, null);
     }
 
     public function testCheckTokenRequestParam(): void

--- a/test/classes/Config/FormDisplayTest.php
+++ b/test/classes/Config/FormDisplayTest.php
@@ -233,20 +233,14 @@ class FormDisplayTest extends AbstractTestCase
      */
     public function testHasErrors(): void
     {
-        $attrErrors = new ReflectionProperty(FormDisplay::class, 'errors');
+        $this->assertFalse($this->object->hasErrors());
 
-        $this->assertFalse(
-            $this->object->hasErrors(),
-        );
-
-        $attrErrors->setValue(
+        (new ReflectionProperty(FormDisplay::class, 'errors'))->setValue(
             $this->object,
             [1, 2],
         );
 
-        $this->assertTrue(
-            $this->object->hasErrors(),
-        );
+        $this->assertTrue($this->object->hasErrors());
     }
 
     /**

--- a/test/classes/Config/FormTest.php
+++ b/test/classes/Config/FormTest.php
@@ -66,8 +66,7 @@ class FormTest extends AbstractTestCase
      */
     public function testGetOptionType(): void
     {
-        $attrFieldsTypes = new ReflectionProperty(Form::class, 'fieldsTypes');
-        $attrFieldsTypes->setValue(
+        (new ReflectionProperty(Form::class, 'fieldsTypes'))->setValue(
             $this->object,
             ['7' => 'Seven'],
         );

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -13,7 +13,7 @@ use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use ReflectionClass;
+use ReflectionProperty;
 
 use function implode;
 
@@ -237,7 +237,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addSelectDb('db_pma');
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $relation->fixPmaTables('db_pma', false);
 
@@ -512,7 +512,7 @@ class RelationTest extends AbstractTestCase
         $this->assertSame('', $GLOBALS['cfg']['Server']['pmadb']);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $relation->fixPmaTables('db_pma', true);
         $this->assertArrayNotHasKey('message', $GLOBALS);
@@ -796,7 +796,7 @@ class RelationTest extends AbstractTestCase
         $this->assertSame('db_pma', $GLOBALS['cfg']['Server']['pmadb']);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $dummyDbi->addSelectDb('db_pma');
         $dummyDbi->addSelectDb('db_pma');
@@ -875,7 +875,7 @@ class RelationTest extends AbstractTestCase
         $this->assertSame('', $GLOBALS['cfg']['Server']['pmadb']);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $relation->fixPmaTables('db_pma', true);
 
@@ -1437,7 +1437,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
@@ -1503,7 +1503,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', [], ['NULL']);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $dummyDbi->addSelectDb('phpmyadmin');
         $relation = new Relation($dbi);
@@ -1595,7 +1595,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', false);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $dummyDbi->addSelectDb('phpmyadmin');
         $relation = new Relation($dbi);
@@ -1688,7 +1688,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addSelectDb('PMA-storage');
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
@@ -1714,7 +1714,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addSelectDb('PMA-storage');
         /** @psalm-suppress EmptyArrayAccess */
         unset($_SESSION['relation'][$GLOBALS['server']]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
         $relationData = $relation->getRelationParameters();
         $dummyDbi->assertAllSelectsConsumed();
 
@@ -1793,7 +1793,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
@@ -1822,7 +1822,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addSelectDb('PMA-storage');
         /** @psalm-suppress EmptyArrayAccess */
         unset($_SESSION['relation'][$GLOBALS['server']]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
         $relationData = $relation->getRelationParameters();
         $dummyDbi->assertAllSelectsConsumed();
 
@@ -1998,7 +1998,7 @@ class RelationTest extends AbstractTestCase
         $GLOBALS['dbi'] = $dbi;
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $relation = new Relation($dbi);
 
@@ -2135,7 +2135,7 @@ class RelationTest extends AbstractTestCase
 
         $GLOBALS['server'] = 1;
         $relationParameters = RelationParameters::fromArray($params);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -2206,7 +2206,7 @@ class RelationTest extends AbstractTestCase
             'pdf_pages' => 'pdf_pages',
             'table_coords' => 'table`coords',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/ConfigStorage/RelationTest.php
+++ b/test/classes/ConfigStorage/RelationTest.php
@@ -237,7 +237,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addSelectDb('db_pma');
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $relation->fixPmaTables('db_pma', false);
 
@@ -512,7 +512,7 @@ class RelationTest extends AbstractTestCase
         $this->assertSame('', $GLOBALS['cfg']['Server']['pmadb']);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $relation->fixPmaTables('db_pma', true);
         $this->assertArrayNotHasKey('message', $GLOBALS);
@@ -796,7 +796,7 @@ class RelationTest extends AbstractTestCase
         $this->assertSame('db_pma', $GLOBALS['cfg']['Server']['pmadb']);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $dummyDbi->addSelectDb('db_pma');
         $dummyDbi->addSelectDb('db_pma');
@@ -875,7 +875,7 @@ class RelationTest extends AbstractTestCase
         $this->assertSame('', $GLOBALS['cfg']['Server']['pmadb']);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $relation->fixPmaTables('db_pma', true);
 
@@ -1437,7 +1437,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
@@ -1503,7 +1503,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', [], ['NULL']);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $dummyDbi->addSelectDb('phpmyadmin');
         $relation = new Relation($dbi);
@@ -1595,7 +1595,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addResult('SELECT NULL FROM `pma__userconfig` LIMIT 0', false);
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $dummyDbi->addSelectDb('phpmyadmin');
         $relation = new Relation($dbi);
@@ -1688,7 +1688,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addSelectDb('PMA-storage');
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
@@ -1714,7 +1714,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addSelectDb('PMA-storage');
         /** @psalm-suppress EmptyArrayAccess */
         unset($_SESSION['relation'][$GLOBALS['server']]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
         $relationData = $relation->getRelationParameters();
         $dummyDbi->assertAllSelectsConsumed();
 
@@ -1793,7 +1793,7 @@ class RelationTest extends AbstractTestCase
         );
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
@@ -1822,7 +1822,7 @@ class RelationTest extends AbstractTestCase
         $dummyDbi->addSelectDb('PMA-storage');
         /** @psalm-suppress EmptyArrayAccess */
         unset($_SESSION['relation'][$GLOBALS['server']]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
         $relationData = $relation->getRelationParameters();
         $dummyDbi->assertAllSelectsConsumed();
 
@@ -1914,8 +1914,8 @@ class RelationTest extends AbstractTestCase
 
         $_SESSION['relation'] = [];
         $_SESSION['tmpval'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
-        (new ReflectionClass(RecentFavoriteTable::class))->getProperty('instances')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
+        (new ReflectionProperty(RecentFavoriteTable::class, 'instances'))->setValue(null, []);
 
         $relation = new Relation($dbi);
         $relation->initRelationParamsCache();
@@ -1998,7 +1998,7 @@ class RelationTest extends AbstractTestCase
         $GLOBALS['dbi'] = $dbi;
 
         $_SESSION['relation'] = [];
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $relation = new Relation($dbi);
 
@@ -2136,6 +2136,7 @@ class RelationTest extends AbstractTestCase
         $GLOBALS['server'] = 1;
         $relationParameters = RelationParameters::fromArray($params);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -2206,6 +2207,7 @@ class RelationTest extends AbstractTestCase
             'table_coords' => 'table`coords',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/ConfigTest.php
+++ b/test/classes/ConfigTest.php
@@ -673,7 +673,7 @@ PHP;
         $this->assertDirectoryExists($dir);
         $this->assertDirectoryIsWritable($dir);
 
-        (new ReflectionProperty(Config::class, 'tempDir'))->setValue([]);
+        (new ReflectionProperty(Config::class, 'tempDir'))->setValue(null, []);
         $this->object->set('TempDir', $dir . DIRECTORY_SEPARATOR);
         // Check no double slash is here
         $this->assertEquals(

--- a/test/classes/Controllers/Console/Bookmark/AddControllerTest.php
+++ b/test/classes/Controllers/Console/Bookmark/AddControllerTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
+use ReflectionProperty;
 
 #[CoversClass(AddController::class)]
 class AddControllerTest extends AbstractTestCase
@@ -37,7 +37,7 @@ class AddControllerTest extends AbstractTestCase
     public function testWithoutRelationParameters(): void
     {
         $GLOBALS['cfg']['Server']['user'] = 'user';
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
         $dbi = $this->createDatabaseInterface();
         $GLOBALS['dbi'] = $dbi;
         $response = new ResponseRenderer();
@@ -63,7 +63,7 @@ class AddControllerTest extends AbstractTestCase
             'bookmarkwork' => true,
             'bookmark' => 'bookmark',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Controllers/Console/Bookmark/AddControllerTest.php
+++ b/test/classes/Controllers/Console/Bookmark/AddControllerTest.php
@@ -37,7 +37,7 @@ class AddControllerTest extends AbstractTestCase
     public function testWithoutRelationParameters(): void
     {
         $GLOBALS['cfg']['Server']['user'] = 'user';
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
         $dbi = $this->createDatabaseInterface();
         $GLOBALS['dbi'] = $dbi;
         $response = new ResponseRenderer();
@@ -64,6 +64,7 @@ class AddControllerTest extends AbstractTestCase
             'bookmark' => 'bookmark',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Controllers/Export/Template/CreateControllerTest.php
+++ b/test/classes/Controllers/Export/Template/CreateControllerTest.php
@@ -45,6 +45,7 @@ class CreateControllerTest extends AbstractTestCase
             'export_templates' => 'table',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Controllers/Export/Template/CreateControllerTest.php
+++ b/test/classes/Controllers/Export/Template/CreateControllerTest.php
@@ -16,7 +16,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
+use ReflectionProperty;
 
 #[CoversClass(CreateController::class)]
 class CreateControllerTest extends AbstractTestCase
@@ -44,7 +44,7 @@ class CreateControllerTest extends AbstractTestCase
             'db' => 'db',
             'export_templates' => 'table',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Controllers/Export/Template/LoadControllerTest.php
+++ b/test/classes/Controllers/Export/Template/LoadControllerTest.php
@@ -44,6 +44,7 @@ class LoadControllerTest extends AbstractTestCase
             'export_templates' => 'table',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Controllers/Export/Template/LoadControllerTest.php
+++ b/test/classes/Controllers/Export/Template/LoadControllerTest.php
@@ -15,7 +15,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
+use ReflectionProperty;
 
 #[CoversClass(LoadController::class)]
 class LoadControllerTest extends AbstractTestCase
@@ -43,7 +43,7 @@ class LoadControllerTest extends AbstractTestCase
             'db' => 'db',
             'export_templates' => 'table',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Controllers/Table/RecentFavoriteControllerTest.php
+++ b/test/classes/Controllers/Table/RecentFavoriteControllerTest.php
@@ -17,7 +17,7 @@ use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use ReflectionClass;
+use ReflectionProperty;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 #[CoversClass(RecentFavoriteController::class)]
@@ -44,7 +44,7 @@ class RecentFavoriteControllerTest extends AbstractTestCase
         $GLOBALS['text_dir'] = 'ltr';
         $_REQUEST['db'] = 'test_db';
         $_REQUEST['table'] = 'test_table';
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $_SESSION['tmpval'] = [];
         $_SESSION['tmpval']['recentTables'][2] = [['db' => 'test_db', 'table' => 'test_table']];
@@ -75,7 +75,7 @@ class RecentFavoriteControllerTest extends AbstractTestCase
         $GLOBALS['text_dir'] = 'ltr';
         $_REQUEST['db'] = 'invalid_db';
         $_REQUEST['table'] = 'invalid_table';
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         $_SESSION['tmpval'] = [];
         $_SESSION['tmpval']['recentTables'][2] = [['db' => 'invalid_db', 'table' => 'invalid_table']];

--- a/test/classes/Controllers/Table/RecentFavoriteControllerTest.php
+++ b/test/classes/Controllers/Table/RecentFavoriteControllerTest.php
@@ -44,7 +44,7 @@ class RecentFavoriteControllerTest extends AbstractTestCase
         $GLOBALS['text_dir'] = 'ltr';
         $_REQUEST['db'] = 'test_db';
         $_REQUEST['table'] = 'test_table';
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $_SESSION['tmpval'] = [];
         $_SESSION['tmpval']['recentTables'][2] = [['db' => 'test_db', 'table' => 'test_table']];
@@ -75,7 +75,7 @@ class RecentFavoriteControllerTest extends AbstractTestCase
         $GLOBALS['text_dir'] = 'ltr';
         $_REQUEST['db'] = 'invalid_db';
         $_REQUEST['table'] = 'invalid_table';
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         $_SESSION['tmpval'] = [];
         $_SESSION['tmpval']['recentTables'][2] = [['db' => 'invalid_db', 'table' => 'invalid_table']];

--- a/test/classes/Controllers/Table/ReplaceControllerTest.php
+++ b/test/classes/Controllers/Table/ReplaceControllerTest.php
@@ -24,7 +24,7 @@ use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
+use ReflectionProperty;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 #[CoversClass(ReplaceController::class)]
@@ -65,7 +65,7 @@ class ReplaceControllerTest extends AbstractTestCase
             'uiprefswork' => true,
             'table_uiprefs' => 'table_uiprefs',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Controllers/Table/ReplaceControllerTest.php
+++ b/test/classes/Controllers/Table/ReplaceControllerTest.php
@@ -66,6 +66,7 @@ class ReplaceControllerTest extends AbstractTestCase
             'table_uiprefs' => 'table_uiprefs',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
     }

--- a/test/classes/Controllers/Table/StructureControllerTest.php
+++ b/test/classes/Controllers/Table/StructureControllerTest.php
@@ -48,8 +48,8 @@ class StructureControllerTest extends AbstractTestCase
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['cfg']['ShowStats'] = false;
         $GLOBALS['cfg']['ShowPropertyComments'] = false;
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
-        (new ReflectionProperty(Template::class, 'twig'))->setValue(null);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);
 
         $this->dummyDbi->addSelectDb('test_db');
         $this->dummyDbi->addSelectDb('test_db');

--- a/test/classes/Controllers/Table/StructureControllerTest.php
+++ b/test/classes/Controllers/Table/StructureControllerTest.php
@@ -18,7 +18,6 @@ use PhpMyAdmin\Transformations;
 use PhpMyAdmin\UserPreferences;
 use PhpMyAdmin\Util;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
 use ReflectionProperty;
 
 #[CoversClass(StructureController::class)]
@@ -48,7 +47,7 @@ class StructureControllerTest extends AbstractTestCase
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['cfg']['ShowStats'] = false;
         $GLOBALS['cfg']['ShowPropertyComments'] = false;
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
         (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);
 
         $this->dummyDbi->addSelectDb('test_db');

--- a/test/classes/Database/CentralColumnsTest.php
+++ b/test/classes/Database/CentralColumnsTest.php
@@ -15,7 +15,7 @@ use PhpMyAdmin\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
-use ReflectionClass;
+use ReflectionProperty;
 
 use function array_slice;
 
@@ -118,7 +118,7 @@ class CentralColumnsTest extends AbstractTestCase
             'relation' => 'relation',
             'central_columns' => 'pma_central_columns',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Database/CentralColumnsTest.php
+++ b/test/classes/Database/CentralColumnsTest.php
@@ -119,6 +119,7 @@ class CentralColumnsTest extends AbstractTestCase
             'central_columns' => 'pma_central_columns',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Database/Designer/CommonTest.php
+++ b/test/classes/Database/Designer/CommonTest.php
@@ -356,6 +356,7 @@ class CommonTest extends AbstractTestCase
             'relation' => 'rel db',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -381,6 +382,7 @@ class CommonTest extends AbstractTestCase
             'relation' => 'rel db',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -425,6 +427,7 @@ class CommonTest extends AbstractTestCase
             'relation' => 'rel db',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -489,6 +492,7 @@ class CommonTest extends AbstractTestCase
             'relation' => 'rel db',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Database/Designer/CommonTest.php
+++ b/test/classes/Database/Designer/CommonTest.php
@@ -14,7 +14,7 @@ use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Version;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
+use ReflectionProperty;
 
 use function sprintf;
 
@@ -355,7 +355,7 @@ class CommonTest extends AbstractTestCase
             'db' => 'pmadb',
             'relation' => 'rel db',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -381,7 +381,7 @@ class CommonTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'rel db',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -426,7 +426,7 @@ class CommonTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'rel db',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -491,7 +491,7 @@ class CommonTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'rel db',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -26,7 +26,7 @@ use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use ReflectionClass;
+use ReflectionProperty;
 use stdClass;
 
 use function count;
@@ -657,7 +657,7 @@ class ResultsTest extends AbstractTestCase
             'mimework' => true,
             'column_info' => 'column_info',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Display/ResultsTest.php
+++ b/test/classes/Display/ResultsTest.php
@@ -658,6 +658,7 @@ class ResultsTest extends AbstractTestCase
             'column_info' => 'column_info',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
         $GLOBALS['cfg']['BrowseMIME'] = true;

--- a/test/classes/Http/Factory/ResponseFactoryTest.php
+++ b/test/classes/Http/Factory/ResponseFactoryTest.php
@@ -58,7 +58,7 @@ final class ResponseFactoryTest extends TestCase
     public function testCreate(string $provider): void
     {
         $this->skipIfNotAvailable($provider);
-        (new ReflectionProperty(ResponseFactory::class, 'providers'))->setValue([$provider]);
+        (new ReflectionProperty(ResponseFactory::class, 'providers'))->setValue(null, [$provider]);
         $responseFactory = ResponseFactory::create();
         $actual = (new ReflectionProperty(ResponseFactory::class, 'responseFactory'))->getValue($responseFactory);
         $this->assertInstanceOf($provider, $actual);
@@ -77,7 +77,7 @@ final class ResponseFactoryTest extends TestCase
     #[BackupStaticProperties(true)]
     public function testCreateWithoutProvider(): void
     {
-        (new ReflectionProperty(ResponseFactory::class, 'providers'))->setValue(['InvalidResponseFactoryClass']);
+        (new ReflectionProperty(ResponseFactory::class, 'providers'))->setValue(null, ['InvalidResponseFactoryClass']);
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No HTTP response factories found.');
         ResponseFactory::create();

--- a/test/classes/Http/Factory/ServerRequestFactoryTest.php
+++ b/test/classes/Http/Factory/ServerRequestFactoryTest.php
@@ -72,7 +72,7 @@ final class ServerRequestFactoryTest extends TestCase
     public function testCreate(string $provider): void
     {
         $this->skipIfNotAvailable($provider);
-        (new ReflectionProperty(ServerRequestFactory::class, 'providers'))->setValue([$provider]);
+        (new ReflectionProperty(ServerRequestFactory::class, 'providers'))->setValue(null, [$provider]);
         $serverRequestFactory = ServerRequestFactory::create();
         $actual = (new ReflectionProperty(ServerRequestFactory::class, 'serverRequestFactory'))
             ->getValue($serverRequestFactory);
@@ -93,7 +93,7 @@ final class ServerRequestFactoryTest extends TestCase
     public function testCreateWithoutProvider(): void
     {
         (new ReflectionProperty(ServerRequestFactory::class, 'providers'))
-            ->setValue(['InvalidServerRequestFactoryClass']);
+            ->setValue(null, ['InvalidServerRequestFactoryClass']);
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No HTTP server request factories found.');
         ServerRequestFactory::create();
@@ -110,7 +110,7 @@ final class ServerRequestFactoryTest extends TestCase
     {
         $this->skipIfNotAvailable($provider);
         $this->skipIfNotAvailable($uriFactoryProvider);
-        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue([$uriFactoryProvider]);
+        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue(null, [$uriFactoryProvider]);
         $serverRequestFactory = new ServerRequestFactory(new $provider());
 
         $_GET['foo'] = 'bar';
@@ -120,7 +120,7 @@ final class ServerRequestFactoryTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = 'GET';
         $_SERVER['HTTP_HOST'] = 'phpmyadmin.local';
 
-        (new ReflectionProperty(ServerRequestFactory::class, 'getAllHeaders'))->setValue(null);
+        (new ReflectionProperty(ServerRequestFactory::class, 'getAllHeaders'))->setValue(null, null);
 
         $serverRequest = $serverRequestFactory->fromGlobals();
 
@@ -148,7 +148,7 @@ final class ServerRequestFactoryTest extends TestCase
     {
         $this->skipIfNotAvailable($provider);
         $this->skipIfNotAvailable($uriFactoryProvider);
-        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue([$uriFactoryProvider]);
+        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue(null, [$uriFactoryProvider]);
         $serverRequestFactory = new ServerRequestFactory(new $provider());
 
         $_GET['foo'] = 'bar';
@@ -162,7 +162,7 @@ final class ServerRequestFactoryTest extends TestCase
         $_SERVER['HTTP_HOST'] = 'phpmyadmin.local';
 
         $getAllHeaders = static fn (): array => ['Content-Type' => 'application/x-www-form-urlencoded'];
-        (new ReflectionProperty(ServerRequestFactory::class, 'getAllHeaders'))->setValue($getAllHeaders);
+        (new ReflectionProperty(ServerRequestFactory::class, 'getAllHeaders'))->setValue(null, $getAllHeaders);
 
         $serverRequest = $serverRequestFactory->fromGlobals();
 
@@ -199,7 +199,7 @@ final class ServerRequestFactoryTest extends TestCase
     {
         $this->skipIfNotAvailable($provider);
         $this->skipIfNotAvailable($uriFactoryProvider);
-        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue([$uriFactoryProvider]);
+        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue(null, [$uriFactoryProvider]);
         $serverRequestFactory = new ServerRequestFactory(new $provider());
 
         $_GET = [];
@@ -208,7 +208,7 @@ final class ServerRequestFactoryTest extends TestCase
         $_SERVER['HTTP_HOST'] = 'example.com';
 
         $getAllHeaders = static fn (): array => ['Content-Type' => 'application/json', 'Content-Length' => '123'];
-        (new ReflectionProperty(ServerRequestFactory::class, 'getAllHeaders'))->setValue($getAllHeaders);
+        (new ReflectionProperty(ServerRequestFactory::class, 'getAllHeaders'))->setValue(null, $getAllHeaders);
 
         $serverRequest = $serverRequestFactory->fromGlobals();
 

--- a/test/classes/Http/Factory/UriFactoryTest.php
+++ b/test/classes/Http/Factory/UriFactoryTest.php
@@ -54,7 +54,7 @@ final class UriFactoryTest extends TestCase
     public function testCreate(string $provider): void
     {
         $this->skipIfNotAvailable($provider);
-        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue([$provider]);
+        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue(null, [$provider]);
         $uriFactory = UriFactory::create();
         $actual = (new ReflectionProperty(UriFactory::class, 'uriFactory'))->getValue($uriFactory);
         $this->assertInstanceOf($provider, $actual);
@@ -73,7 +73,7 @@ final class UriFactoryTest extends TestCase
     #[BackupStaticProperties(true)]
     public function testCreateWithoutProvider(): void
     {
-        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue(['InvalidUriFactoryClass']);
+        (new ReflectionProperty(UriFactory::class, 'providers'))->setValue(null, ['InvalidUriFactoryClass']);
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('No URI factories found.');
         UriFactory::create();

--- a/test/classes/Navigation/Nodes/NodeDatabaseChildTest.php
+++ b/test/classes/Navigation/Nodes/NodeDatabaseChildTest.php
@@ -45,6 +45,7 @@ class NodeDatabaseChildTest extends AbstractTestCase
             'navigationhiding' => 'navigationhiding',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
         $this->object = $this->getMockForAbstractClass(

--- a/test/classes/Navigation/Nodes/NodeDatabaseChildTest.php
+++ b/test/classes/Navigation/Nodes/NodeDatabaseChildTest.php
@@ -12,7 +12,7 @@ use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Url;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
-use ReflectionClass;
+use ReflectionProperty;
 
 #[CoversClass(NodeDatabaseChild::class)]
 #[CoversClass(NodeDatabase::class)]
@@ -44,7 +44,7 @@ class NodeDatabaseChildTest extends AbstractTestCase
             'navwork' => true,
             'navigationhiding' => 'navigationhiding',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Plugins/Export/ExportHtmlwordTest.php
+++ b/test/classes/Plugins/Export/ExportHtmlwordTest.php
@@ -21,7 +21,6 @@ use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -430,7 +429,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -502,7 +501,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -544,7 +543,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Plugins/Export/ExportHtmlwordTest.php
+++ b/test/classes/Plugins/Export/ExportHtmlwordTest.php
@@ -431,6 +431,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -502,6 +503,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -543,6 +545,7 @@ class ExportHtmlwordTest extends AbstractTestCase
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Plugins/Export/ExportLatexTest.php
+++ b/test/classes/Plugins/Export/ExportLatexTest.php
@@ -20,8 +20,8 @@ use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use ReflectionClass;
 use ReflectionMethod;
+use ReflectionProperty;
 
 use function __;
 use function ob_get_clean;
@@ -597,7 +597,7 @@ class ExportLatexTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -689,7 +689,7 @@ class ExportLatexTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -750,7 +750,7 @@ class ExportLatexTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Plugins/Export/ExportLatexTest.php
+++ b/test/classes/Plugins/Export/ExportLatexTest.php
@@ -598,6 +598,7 @@ class ExportLatexTest extends AbstractTestCase
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -689,6 +690,7 @@ class ExportLatexTest extends AbstractTestCase
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -749,6 +751,7 @@ class ExportLatexTest extends AbstractTestCase
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -626,6 +626,7 @@ class ExportOdtTest extends AbstractTestCase
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -708,6 +709,7 @@ class ExportOdtTest extends AbstractTestCase
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Plugins/Export/ExportOdtTest.php
+++ b/test/classes/Plugins/Export/ExportOdtTest.php
@@ -24,8 +24,8 @@ use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
-use ReflectionClass;
 use ReflectionMethod;
+use ReflectionProperty;
 
 use function __;
 use function bin2hex;
@@ -625,7 +625,7 @@ class ExportOdtTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -708,7 +708,7 @@ class ExportOdtTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -880,6 +880,7 @@ SQL;
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
         $GLOBALS['sql_include_comments'] = true;

--- a/test/classes/Plugins/Export/ExportSqlTest.php
+++ b/test/classes/Plugins/Export/ExportSqlTest.php
@@ -27,8 +27,8 @@ use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use ReflectionClass;
 use ReflectionMethod;
+use ReflectionProperty;
 
 use function ob_get_clean;
 use function ob_start;
@@ -879,7 +879,7 @@ SQL;
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Plugins/Export/ExportTexytextTest.php
+++ b/test/classes/Plugins/Export/ExportTexytextTest.php
@@ -20,7 +20,6 @@ use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Transformations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
-use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 
@@ -306,7 +305,7 @@ class ExportTexytextTest extends AbstractTestCase
             'relation' => 'rel',
             'column_info' => 'col',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Plugins/Export/ExportTexytextTest.php
+++ b/test/classes/Plugins/Export/ExportTexytextTest.php
@@ -307,6 +307,7 @@ class ExportTexytextTest extends AbstractTestCase
             'column_info' => 'col',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Server/PrivilegesTest.php
+++ b/test/classes/Server/PrivilegesTest.php
@@ -1140,6 +1140,7 @@ class PrivilegesTest extends AbstractTestCase
             'menuswork' => true,
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -1170,6 +1171,7 @@ class PrivilegesTest extends AbstractTestCase
             'tracking' => 'tracking',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -1267,6 +1269,7 @@ class PrivilegesTest extends AbstractTestCase
         $_POST['old_username'] = 'old_username';
         $relationParameters = RelationParameters::fromArray([]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Server/PrivilegesTest.php
+++ b/test/classes/Server/PrivilegesTest.php
@@ -24,8 +24,8 @@ use PhpMyAdmin\Util;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
-use ReflectionClass;
 use ReflectionMethod;
+use ReflectionProperty;
 
 use function __;
 use function _pgettext;
@@ -1139,7 +1139,7 @@ class PrivilegesTest extends AbstractTestCase
             'usergroups' => 'usergroups',
             'menuswork' => true,
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -1170,7 +1170,7 @@ class PrivilegesTest extends AbstractTestCase
             'trackingwork' => true,
             'tracking' => 'tracking',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -1268,7 +1268,7 @@ class PrivilegesTest extends AbstractTestCase
         $_POST['old_hostname'] = 'old_hostname';
         $_POST['old_username'] = 'old_username';
         $relationParameters = RelationParameters::fromArray([]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/SqlQueryFormTest.php
+++ b/test/classes/SqlQueryFormTest.php
@@ -14,7 +14,7 @@ use PhpMyAdmin\Template;
 use PhpMyAdmin\Tests\Stubs\DbiDummy;
 use PhpMyAdmin\Url;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
+use ReflectionProperty;
 
 use function __;
 use function htmlspecialchars;
@@ -81,7 +81,7 @@ class SqlQueryFormTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'relation',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$relationParameters]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$relationParameters]);
 
         $GLOBALS['cfg']['Server']['user'] = 'user';
         $GLOBALS['cfg']['Server']['pmadb'] = 'pmadb';

--- a/test/classes/SqlQueryFormTest.php
+++ b/test/classes/SqlQueryFormTest.php
@@ -81,7 +81,7 @@ class SqlQueryFormTest extends AbstractTestCase
             'relwork' => true,
             'relation' => 'relation',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([$relationParameters]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$relationParameters]);
 
         $GLOBALS['cfg']['Server']['user'] = 'user';
         $GLOBALS['cfg']['Server']['pmadb'] = 'pmadb';

--- a/test/classes/SystemDatabaseTest.php
+++ b/test/classes/SystemDatabaseTest.php
@@ -63,6 +63,7 @@ class SystemDatabaseTest extends AbstractTestCase
             'relation' => 'relation',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/SystemDatabaseTest.php
+++ b/test/classes/SystemDatabaseTest.php
@@ -11,7 +11,7 @@ use PhpMyAdmin\SystemColumn;
 use PhpMyAdmin\SystemDatabase;
 use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
+use ReflectionProperty;
 
 use const MYSQLI_TYPE_STRING;
 
@@ -62,7 +62,7 @@ class SystemDatabaseTest extends AbstractTestCase
             'column_info' => 'column_info',
             'relation' => 'relation',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/TemplateTest.php
+++ b/test/classes/TemplateTest.php
@@ -182,7 +182,7 @@ class TemplateTest extends AbstractTestCase
 
     public function testDisableCache(): void
     {
-        (new ReflectionProperty(Template::class, 'twig'))->setValue(null);
+        (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);
         $template = new Template($this->createStub(Config::class));
         $template->disableCache();
         $twig = (new ReflectionProperty(Template::class, 'twig'))->getValue();
@@ -192,6 +192,6 @@ class TemplateTest extends AbstractTestCase
         $this->assertNotFalse($twig->getCache());
         $template->disableCache();
         $this->assertFalse($twig->getCache());
-        (new ReflectionProperty(Template::class, 'twig'))->setValue(null);
+        (new ReflectionProperty(Template::class, 'twig'))->setValue(null, null);
     }
 }

--- a/test/classes/Tracking/TrackerTest.php
+++ b/test/classes/Tracking/TrackerTest.php
@@ -51,6 +51,7 @@ class TrackerTest extends AbstractTestCase
             'tracking' => 'tracking',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -92,6 +93,7 @@ class TrackerTest extends AbstractTestCase
 
         $relationParameters = RelationParameters::fromArray([]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -105,6 +107,7 @@ class TrackerTest extends AbstractTestCase
             'tracking' => 'tracking',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -130,6 +133,7 @@ class TrackerTest extends AbstractTestCase
 
         $relationParameters = RelationParameters::fromArray([]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 
@@ -143,6 +147,7 @@ class TrackerTest extends AbstractTestCase
             'tracking' => 'tracking',
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Tracking/TrackerTest.php
+++ b/test/classes/Tracking/TrackerTest.php
@@ -15,8 +15,8 @@ use PhpMyAdmin\Tracking\Tracker;
 use PhpMyAdmin\Util;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use ReflectionClass;
 use ReflectionMethod;
+use ReflectionProperty;
 
 #[CoversClass(Tracker::class)]
 class TrackerTest extends AbstractTestCase
@@ -50,7 +50,7 @@ class TrackerTest extends AbstractTestCase
             'trackingwork' => true,
             'tracking' => 'tracking',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -92,7 +92,7 @@ class TrackerTest extends AbstractTestCase
         Tracker::enable();
 
         $relationParameters = RelationParameters::fromArray([]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -106,7 +106,7 @@ class TrackerTest extends AbstractTestCase
             'db' => 'pmadb',
             'tracking' => 'tracking',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -132,7 +132,7 @@ class TrackerTest extends AbstractTestCase
         Tracker::enable();
 
         $relationParameters = RelationParameters::fromArray([]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );
@@ -146,7 +146,7 @@ class TrackerTest extends AbstractTestCase
             'db' => 'pmadb',
             'tracking' => 'tracking',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Tracking/TrackingCheckerTest.php
+++ b/test/classes/Tracking/TrackingCheckerTest.php
@@ -35,6 +35,7 @@ class TrackingCheckerTest extends AbstractTestCase
             'trackingwork' => true,
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/Tracking/TrackingCheckerTest.php
+++ b/test/classes/Tracking/TrackingCheckerTest.php
@@ -13,7 +13,7 @@ use PhpMyAdmin\Tracking\TrackedTable;
 use PhpMyAdmin\Tracking\Tracker;
 use PhpMyAdmin\Tracking\TrackingChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
+use ReflectionProperty;
 
 #[CoversClass(TrackingChecker::class)]
 class TrackingCheckerTest extends AbstractTestCase
@@ -34,7 +34,7 @@ class TrackingCheckerTest extends AbstractTestCase
             'tracking' => 'tracking',
             'trackingwork' => true,
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Tracking/TrackingTest.php
+++ b/test/classes/Tracking/TrackingTest.php
@@ -20,7 +20,7 @@ use PhpMyAdmin\Url;
 use PhpMyAdmin\Util;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use ReflectionClass;
+use ReflectionProperty;
 
 use function __;
 use function _pgettext;
@@ -60,7 +60,7 @@ class TrackingTest extends AbstractTestCase
             'tracking' => 'tracking',
             'trackingwork' => true,
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(
             null,
             [$GLOBALS['server'] => $relationParameters],
         );

--- a/test/classes/Tracking/TrackingTest.php
+++ b/test/classes/Tracking/TrackingTest.php
@@ -61,6 +61,7 @@ class TrackingTest extends AbstractTestCase
             'trackingwork' => true,
         ]);
         (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(
+            null,
             [$GLOBALS['server'] => $relationParameters],
         );
 

--- a/test/classes/TransformationsTest.php
+++ b/test/classes/TransformationsTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use ReflectionClass;
+use ReflectionProperty;
 
 #[CoversClass(Transformations::class)]
 class TransformationsTest extends AbstractTestCase
@@ -174,7 +174,7 @@ class TransformationsTest extends AbstractTestCase
             'trackingwork' => true,
             'column_info' => 'column_info',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
         $this->assertEquals(
             [
                 'o' => [
@@ -212,7 +212,7 @@ class TransformationsTest extends AbstractTestCase
             ->will($this->returnValue($this->createStub(DummyResult::class)));
         $GLOBALS['dbi'] = $dbi;
 
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, []);
 
         // Case 1 : no configuration storage
         $actual = $this->transformations->clear('db');
@@ -223,7 +223,7 @@ class TransformationsTest extends AbstractTestCase
             'mimework' => true,
             'column_info' => 'column_info',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
 
         // Case 2 : database delete
         $actual = $this->transformations->clear('db');

--- a/test/classes/TransformationsTest.php
+++ b/test/classes/TransformationsTest.php
@@ -174,7 +174,7 @@ class TransformationsTest extends AbstractTestCase
             'trackingwork' => true,
             'column_info' => 'column_info',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([$GLOBALS['server'] => $relation]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
         $this->assertEquals(
             [
                 'o' => [
@@ -212,7 +212,7 @@ class TransformationsTest extends AbstractTestCase
             ->will($this->returnValue($this->createStub(DummyResult::class)));
         $GLOBALS['dbi'] = $dbi;
 
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, []);
 
         // Case 1 : no configuration storage
         $actual = $this->transformations->clear('db');
@@ -223,7 +223,7 @@ class TransformationsTest extends AbstractTestCase
             'mimework' => true,
             'column_info' => 'column_info',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([$GLOBALS['server'] => $relation]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
 
         // Case 2 : database delete
         $actual = $this->transformations->clear('db');

--- a/test/classes/UserPreferencesTest.php
+++ b/test/classes/UserPreferencesTest.php
@@ -59,7 +59,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
     public function testLoad(): void
     {
         $relation = RelationParameters::fromArray([]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([$GLOBALS['server'] => $relation]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
 
         unset($_SESSION['userconfig']);
 
@@ -89,7 +89,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
             'userconfig' => 'testconf',
             'userconfigwork' => true,
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([$GLOBALS['server'] => $relation]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
 
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
@@ -127,7 +127,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['server'] = 2;
         $relation = RelationParameters::fromArray([]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([$GLOBALS['server'] => $relation]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
 
         unset($_SESSION['userconfig']);
 
@@ -166,7 +166,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
             'userconfig' => 'testconf',
             'user' => 'user',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([$GLOBALS['server'] => $relation]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
 
         $query1 = 'SELECT `username` FROM `pmadb`.`testconf` WHERE `username` = \'user\'';
 
@@ -285,14 +285,14 @@ class UserPreferencesTest extends AbstractNetworkTestCase
     public function testPersistOption(): void
     {
         $relation = RelationParameters::fromArray([]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([$GLOBALS['server'] => $relation]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
 
         $_SESSION['userconfig'] = [];
         $_SESSION['userconfig']['ts'] = '123';
         $_SESSION['userconfig']['db'] = ['Server/hide_db' => true, 'Server/only_db' => true];
 
         $GLOBALS['server'] = 2;
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue([$GLOBALS['server'] => $relation]);
+        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
 
         $userPreferences = new UserPreferences($GLOBALS['dbi']);
         $this->assertTrue(

--- a/test/classes/UserPreferencesTest.php
+++ b/test/classes/UserPreferencesTest.php
@@ -14,7 +14,7 @@ use PhpMyAdmin\Tests\Stubs\DummyResult;
 use PhpMyAdmin\Url;
 use PhpMyAdmin\UserPreferences;
 use PHPUnit\Framework\Attributes\CoversClass;
-use ReflectionClass;
+use ReflectionProperty;
 
 use function json_encode;
 use function time;
@@ -59,7 +59,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
     public function testLoad(): void
     {
         $relation = RelationParameters::fromArray([]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
 
         unset($_SESSION['userconfig']);
 
@@ -89,7 +89,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
             'userconfig' => 'testconf',
             'userconfigwork' => true,
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
 
         $dbi = $this->getMockBuilder(DatabaseInterface::class)
             ->disableOriginalConstructor()
@@ -127,7 +127,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
         $GLOBALS['cfg']['Server']['DisableIS'] = true;
         $GLOBALS['server'] = 2;
         $relation = RelationParameters::fromArray([]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
 
         unset($_SESSION['userconfig']);
 
@@ -166,7 +166,7 @@ class UserPreferencesTest extends AbstractNetworkTestCase
             'userconfig' => 'testconf',
             'user' => 'user',
         ]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
 
         $query1 = 'SELECT `username` FROM `pmadb`.`testconf` WHERE `username` = \'user\'';
 
@@ -285,14 +285,14 @@ class UserPreferencesTest extends AbstractNetworkTestCase
     public function testPersistOption(): void
     {
         $relation = RelationParameters::fromArray([]);
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
 
         $_SESSION['userconfig'] = [];
         $_SESSION['userconfig']['ts'] = '123';
         $_SESSION['userconfig']['db'] = ['Server/hide_db' => true, 'Server/only_db' => true];
 
         $GLOBALS['server'] = 2;
-        (new ReflectionClass(Relation::class))->getProperty('cache')->setValue(null, [$GLOBALS['server'] => $relation]);
+        (new ReflectionProperty(Relation::class, 'cache'))->setValue(null, [$GLOBALS['server'] => $relation]);
 
         $userPreferences = new UserPreferences($GLOBALS['dbi']);
         $this->assertTrue(


### PR DESCRIPTION
There were a lot more of these in the master branch.
Feel free to first merge the 5.2 branch and I'll rebase.