### PR TITLE
Remove func_overload check

### DIFF
--- a/libraries/classes/Application.php
+++ b/libraries/classes/Application.php
@@ -99,6 +99,11 @@ final class Application
             return $this->getGenericErrorResponse($exception->getMessage());
         }
 
+        $resultOfServerConfigurationCheck = $this->checkServerConfiguration();
+        if ($resultOfServerConfigurationCheck !== null) {
+            return $this->getGenericErrorResponse($resultOfServerConfigurationCheck);
+        }
+
         $this->configurePhpSettings();
 
         try {
@@ -170,7 +175,6 @@ final class Application
         }
 
         try {
-            $this->checkServerConfiguration();
             $this->checkRequest();
         } catch (RuntimeException $exception) {
             return $this->getGenericErrorResponse($exception->getMessage());
@@ -490,19 +494,17 @@ final class Application
     /**
      * Check whether PHP configuration matches our needs.
      */
-    private function checkServerConfiguration(): void
+    private function checkServerConfiguration(): string|null
     {
         /**
          * The ini_set and ini_get functions can be disabled using
          * disable_functions but we're relying quite a lot of them.
          */
         if (function_exists('ini_get') && function_exists('ini_set')) {
-            return;
+            return null;
         }
 
-        throw new RuntimeException(__(
-            'The ini_get and/or ini_set functions are disabled in php.ini. phpMyAdmin requires these functions!',
-        ));
+        return __('The ini_get and/or ini_set functions are disabled in php.ini. phpMyAdmin requires these functions!');
     }
 
     /**

--- a/libraries/classes/Application.php
+++ b/libraries/classes/Application.php
@@ -34,10 +34,8 @@ use function count;
 use function date_default_timezone_get;
 use function date_default_timezone_set;
 use function define;
-use function extension_loaded;
 use function function_exists;
 use function hash_equals;
-use function ini_get;
 use function ini_set;
 use function is_array;
 use function is_scalar;
@@ -494,21 +492,6 @@ final class Application
      */
     private function checkServerConfiguration(): void
     {
-        /**
-         * As we try to handle charsets by ourself, mbstring overloads just
-         * break it, see bug 1063821.
-         *
-         * We specifically use empty here as we are looking for anything else than
-         * empty value or 0.
-         */
-        if (extension_loaded('mbstring') && ! empty(ini_get('mbstring.func_overload'))) {
-            throw new RuntimeException(__(
-                'You have enabled mbstring.func_overload in your PHP '
-                . 'configuration. This option is incompatible with phpMyAdmin '
-                . 'and might cause some data to be corrupted!',
-            ));
-        }
-
         /**
          * The ini_set and ini_get functions can be disabled using
          * disable_functions but we're relying quite a lot of them.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -72,7 +72,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
+			count: 1
 			path: libraries/classes/Application.php
 
 		-


### PR DESCRIPTION
This deathtrap is gone as of PHP 8.0. We don't need to check for it anymore. 

Regarding the rest of this method, it works fine as long as we actually perform this check before we try to use either of these functions. 