### PR TITLE
Remove globals charset_connection & collation_connection

### DIFF
--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -392,7 +392,7 @@ class Config
     private function setConnectionCollation(): void
     {
         $collationConnection = $this->get('DefaultConnectionCollation');
-        if (empty($collationConnection) || $collationConnection == $GLOBALS['collation_connection']) {
+        if (empty($collationConnection) || $collationConnection === $GLOBALS['dbi']->getDefaultCollation()) {
             return;
         }
 

--- a/libraries/classes/Controllers/HomeController.php
+++ b/libraries/classes/Controllers/HomeController.php
@@ -57,7 +57,6 @@ class HomeController extends AbstractController
     public function __invoke(ServerRequest $request): void
     {
         $GLOBALS['server'] ??= null;
-        $GLOBALS['collation_connection'] ??= null;
         $GLOBALS['message'] ??= null;
         $GLOBALS['show_query'] ??= null;
         $GLOBALS['errorUrl'] ??= null;
@@ -121,7 +120,7 @@ class HomeController extends AbstractController
                         $collationsList[] = [
                             'name' => $collation->getName(),
                             'description' => $collation->getDescription(),
-                            'is_selected' => $GLOBALS['collation_connection'] === $collation->getName(),
+                            'is_selected' => $this->dbi->getDefaultCollation() === $collation->getName(),
                         ];
                     }
 

--- a/libraries/classes/Controllers/Import/ImportController.php
+++ b/libraries/classes/Controllers/Import/ImportController.php
@@ -62,7 +62,6 @@ final class ImportController extends AbstractController
 
     public function __invoke(ServerRequest $request): void
     {
-        $GLOBALS['collation_connection'] ??= null;
         $GLOBALS['goto'] ??= null;
         $GLOBALS['display_query'] ??= null;
         $GLOBALS['ajax_reload'] ??= null;
@@ -95,7 +94,6 @@ final class ImportController extends AbstractController
         $GLOBALS['my_die'] ??= null;
         $GLOBALS['active_page'] ??= null;
         $GLOBALS['reload'] ??= null;
-        $GLOBALS['charset_connection'] ??= null;
 
         $GLOBALS['charset_of_file'] = $request->getParsedBodyParam('charset_of_file');
         $GLOBALS['format'] = $request->getParsedBodyParam('format', '');
@@ -587,8 +585,8 @@ final class ImportController extends AbstractController
 
         // Reset charset back, if we did some changes
         if ($GLOBALS['reset_charset']) {
-            $this->dbi->query('SET CHARACTER SET ' . $GLOBALS['charset_connection']);
-            $this->dbi->setCollation($GLOBALS['collation_connection']);
+            $this->dbi->query('SET CHARACTER SET ' . $this->dbi->getDefaultCharset());
+            $this->dbi->setCollation($this->dbi->getDefaultCollation());
         }
 
         // Show correct message

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -762,8 +762,8 @@ class ExportSql extends ExportPlugin
                 $setNames = Charsets::$mysqlCharsetMap['utf-8'];
             }
 
-            if ($setNames === 'utf8' && $GLOBALS['dbi']->getVersion() > 50503) {
-                $setNames = 'utf8mb4';
+            if ($setNames === 'utf8') {
+                $setNames = $GLOBALS['dbi']->getDefaultCharset();
             }
 
             $head .= "\n"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -426,6 +426,11 @@ parameters:
 			path: libraries/classes/Config.php
 
 		-
+			message: "#^Cannot call method getDefaultCollation\\(\\) on mixed\\.$#"
+			count: 1
+			path: libraries/classes/Config.php
+
+		-
 			message: "#^Cannot call method setCollation\\(\\) on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Config.php
@@ -4813,11 +4818,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 5
-			path: libraries/classes/Controllers/Import/ImportController.php
-
-		-
-			message: "#^Parameter \\#1 \\$collation of method PhpMyAdmin\\\\DatabaseInterface\\:\\:setCollation\\(\\) expects string, mixed given\\.$#"
-			count: 1
 			path: libraries/classes/Controllers/Import/ImportController.php
 
 		-
@@ -19616,6 +19616,11 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
+			message: "#^Cannot call method getDefaultCharset\\(\\) on mixed\\.$#"
+			count: 1
+			path: libraries/classes/Plugins/Export/ExportSql.php
+
+		-
 			message: "#^Cannot call method getError\\(\\) on mixed\\.$#"
 			count: 2
 			path: libraries/classes/Plugins/Export/ExportSql.php
@@ -19628,11 +19633,6 @@ parameters:
 		-
 			message: "#^Cannot call method getTable\\(\\) on mixed\\.$#"
 			count: 5
-			path: libraries/classes/Plugins/Export/ExportSql.php
-
-		-
-			message: "#^Cannot call method getVersion\\(\\) on mixed\\.$#"
-			count: 1
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2163,12 +2163,6 @@
     <PossiblyInvalidArgument>
       <code><![CDATA[$skip < $GLOBALS['read_limit'] ? $skip : $GLOBALS['read_limit']]]></code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$GLOBALS['collation_connection']]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullOperand>
-      <code><![CDATA[$GLOBALS['charset_connection']]]></code>
-    </PossiblyNullOperand>
     <PossiblyUnusedMethod>
       <code>__construct</code>
     </PossiblyUnusedMethod>

--- a/test/classes/DatabaseInterfaceTest.php
+++ b/test/classes/DatabaseInterfaceTest.php
@@ -18,6 +18,7 @@ use PhpMyAdmin\SystemDatabase;
 use PhpMyAdmin\Utils\SessionCache;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionProperty;
 
 #[CoversClass(DatabaseInterface::class)]
 class DatabaseInterfaceTest extends AbstractTestCase
@@ -343,10 +344,10 @@ class DatabaseInterfaceTest extends AbstractTestCase
         $dummyDbi->addResult('SET collation_connection = \'utf8_czech_ci\';', true);
         $dummyDbi->addResult('SET collation_connection = \'utf8_bin_ci\';', true);
 
-        $GLOBALS['charset_connection'] = 'utf8mb4';
+        (new ReflectionProperty(DatabaseInterface::class, 'versionInt'))->setValue($dbi, 50504);
         $dbi->setCollation('utf8_czech_ci');
         $dbi->setCollation('utf8mb4_bin_ci');
-        $GLOBALS['charset_connection'] = 'utf8';
+        (new ReflectionProperty(DatabaseInterface::class, 'versionInt'))->setValue($dbi, 50503);
         $dbi->setCollation('utf8_czech_ci');
         $dbi->setCollation('utf8mb4_bin_ci');
 


### PR DESCRIPTION
While this global was used in both read and write operations, I determined that it was not intended as such. Config loads only once and the import feature used it to revert back to the default one. The value is read only. 