### PR TITLE
Remove hasCommandsOutOfSyncError method

### DIFF
--- a/libraries/classes/DbTableExists.php
+++ b/libraries/classes/DbTableExists.php
@@ -9,7 +9,6 @@ use PhpMyAdmin\Identifiers\TableName;
 
 use function in_array;
 use function sprintf;
-use function str_starts_with;
 
 final class DbTableExists
 {
@@ -29,7 +28,7 @@ final class DbTableExists
             return true;
         }
 
-        if ($this->dbi->selectDb($databaseName) || $this->hasCommandsOutOfSyncError()) {
+        if ($this->dbi->selectDb($databaseName)) {
             $this->databases[] = $databaseName->getName();
 
             return true;
@@ -55,17 +54,6 @@ final class DbTableExists
         }
 
         return false;
-    }
-
-    /**
-     * This "Commands out of sync" 2014 error may happen, for example after calling a MySQL procedure;
-     * at this point we can't select the db, but it's not necessarily wrong.
-     *
-     * @see https://dev.mysql.com/doc/mysql-errors/8.0/en/client-error-reference.html#error_cr_commands_out_of_sync
-     */
-    private function hasCommandsOutOfSyncError(): bool
-    {
-        return str_starts_with($this->dbi->getError(), '#2014 ');
     }
 
     private function hasCachedTableContent(DatabaseName $database, TableName $table): bool

--- a/test/classes/DbTableExistsTest.php
+++ b/test/classes/DbTableExistsTest.php
@@ -26,24 +26,11 @@ final class DbTableExistsTest extends AbstractTestCase
         $dbiDummy->assertAllSelectsConsumed();
     }
 
-    public function testHasDatabaseWithOutOfSyncError(): void
-    {
-        $db = DatabaseName::from('test_db');
-        $dbi = $this->createMock(DatabaseInterface::class);
-        $dbi->expects($this->once())->method('selectDb')->with($db)->willReturn(false);
-        $dbi->expects($this->once())->method('getError')->willReturn('#2014 - Commands out of sync');
-        $dbTableExists = new DbTableExists($dbi);
-        $this->assertTrue($dbTableExists->hasDatabase($db));
-        // cached result
-        $this->assertTrue($dbTableExists->hasDatabase(DatabaseName::from('test_db')));
-    }
-
     public function testHasDatabaseWithNoDatabase(): void
     {
         $db = DatabaseName::from('test_db');
         $dbi = $this->createMock(DatabaseInterface::class);
         $dbi->expects($this->once())->method('selectDb')->with($db)->willReturn(false);
-        $dbi->expects($this->once())->method('getError')->willReturn('#1049 - Unknown database \'test_db\'');
         $dbTableExists = new DbTableExists($dbi);
         $this->assertFalse($dbTableExists->hasDatabase($db));
     }


### PR DESCRIPTION
I really do not see any reason this method should exist. If there is an error about operations being executed out of sync, then it's software error that needs to be fixed. Checking for this error as part of the application logic doesn't make any sense. 
If it turns out that removing this brings back the original bug, we will fix it properly. 