### PR TITLE
Fix: Cannot execute stored procedure with SELECT using the SQL tab

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -4191,7 +4191,7 @@ class Results
         // display the Export link).
         if (
             ($analyzedSqlResults['querytype'] === self::QUERY_TYPE_SELECT)
-            && empty($analyzedSqlResults['procedure'])
+            && empty($analyzedSqlResults['is_procedure'])
         ) {
             if (count($analyzedSqlResults['select_tables']) === 1) {
                 $urlParams['single_table'] = 'true';
@@ -4227,7 +4227,7 @@ class Results
         }
 
         return [
-            'has_procedure' => ! empty($analyzedSqlResults['procedure']),
+            'has_procedure' => ! empty($analyzedSqlResults['is_procedure']),
             'has_geometry' => $geometryFound,
             'has_print_link' => $printLink == '1',
             'has_export_link' => $analyzedSqlResults['querytype'] === self::QUERY_TYPE_SELECT,

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -1061,7 +1061,7 @@ class Sql
         $response = ResponseRenderer::getInstance();
         $response->addJSON($extraData ?? []);
 
-        if (empty($analyzedSqlResults['is_select']) || isset($extraData['error'])) {
+        if (($result instanceof ResultInterface && $result->numFields() === 0) || isset($extraData['error'])) {
             return $queryMessage;
         }
 
@@ -1125,7 +1125,7 @@ class Sql
             'db' => $db,
             'table' => $table,
             'sql_query' => $sqlQuery,
-            'is_procedure' => ! empty($analyzedSqlResults['procedure']),
+            'is_procedure' => ! empty($analyzedSqlResults['is_procedure']),
         ]);
     }
 
@@ -1723,10 +1723,6 @@ class Sql
             $sqlQueryForBookmark,
             $extraData
         );
-
-        if ($this->dbi->moreResults()) {
-            $this->dbi->nextResult();
-        }
 
         $warningMessages = $this->operations->getWarningMessagesArray();
 

--- a/test/classes/Controllers/Import/ImportControllerTest.php
+++ b/test/classes/Controllers/Import/ImportControllerTest.php
@@ -41,7 +41,8 @@ class ImportControllerTest extends AbstractTestCase
         $this->dummyDbi->addResult(
             'SELECT A.* FROM table1 A WHERE A.nomEtablissement = \'Saint-Louis - Châteaulin\''
             . ' AND foo = 4 AND `:a` IS NULL LIMIT 0, 25',
-            []
+            [],
+            ['nomEtablissement', 'foo']
         );
 
         $this->dummyDbi->addResult(

--- a/test/selenium/CreateDropDatabaseTest.php
+++ b/test/selenium/CreateDropDatabaseTest.php
@@ -82,7 +82,8 @@ class CreateDropDatabaseTest extends TestBase
         $this->dbQuery(
             'SHOW DATABASES LIKE \'' . $this->databaseName . '\';',
             function (): void {
-                $this->assertFalse($this->isElementPresent('className', 'table_results'));
+                $this->assertTrue($this->isElementPresent('className', 'table_results'));
+                $this->assertFalse($this->isElementPresent('cssSelector', '.table_results tbody tr'));
             }
         );
     }

--- a/test/selenium/Database/EventsTest.php
+++ b/test/selenium/Database/EventsTest.php
@@ -215,7 +215,8 @@ class EventsTest extends TestBase
             'USE `' . $this->databaseName . '`;'
             . 'SHOW EVENTS WHERE Db=\'' . $this->databaseName . '\' AND Name=\'test_event\';',
             function (): void {
-                $this->assertFalse($this->isElementPresent('className', 'table_results'));
+                $this->assertTrue($this->isElementPresent('className', 'table_results'));
+                $this->assertFalse($this->isElementPresent('cssSelector', '.table_results tbody tr'));
             }
         );
     }

--- a/test/selenium/Database/OperationsTest.php
+++ b/test/selenium/Database/OperationsTest.php
@@ -86,7 +86,8 @@ class OperationsTest extends TestBase
         $this->dbQuery(
             'SHOW DATABASES LIKE \'' . $this->databaseName . '\'',
             function (): void {
-                $this->assertFalse($this->isElementPresent('className', 'table_results'));
+                $this->assertTrue($this->isElementPresent('className', 'table_results'));
+                $this->assertFalse($this->isElementPresent('cssSelector', '.table_results tbody tr'));
             }
         );
 

--- a/test/selenium/Database/ProceduresTest.php
+++ b/test/selenium/Database/ProceduresTest.php
@@ -216,7 +216,8 @@ class ProceduresTest extends TestBase
         $this->dbQuery(
             "SHOW PROCEDURE STATUS WHERE Db='" . $this->databaseName . "'",
             function (): void {
-                $this->assertFalse($this->isElementPresent('className', 'table_results'));
+                $this->assertTrue($this->isElementPresent('className', 'table_results'));
+                $this->assertFalse($this->isElementPresent('cssSelector', '.table_results tbody tr'));
             }
         );
     }

--- a/test/selenium/Database/StructureTest.php
+++ b/test/selenium/Database/StructureTest.php
@@ -90,7 +90,8 @@ class StructureTest extends TestBase
         $this->dbQuery(
             'SHOW TABLES FROM `' . $this->databaseName . '`;',
             function (): void {
-                $this->assertFalse($this->isElementPresent('className', 'table_results'));
+                $this->assertTrue($this->isElementPresent('className', 'table_results'));
+                $this->assertFalse($this->isElementPresent('cssSelector', '.table_results tbody tr'));
             }
         );
     }

--- a/test/selenium/Database/TriggersTest.php
+++ b/test/selenium/Database/TriggersTest.php
@@ -200,7 +200,8 @@ class TriggersTest extends TestBase
         $this->dbQuery(
             'SHOW TRIGGERS FROM `' . $this->databaseName . '`;',
             function (): void {
-                $this->assertFalse($this->isElementPresent('className', 'table_results'));
+                $this->assertTrue($this->isElementPresent('className', 'table_results'));
+                $this->assertFalse($this->isElementPresent('cssSelector', '.table_results tbody tr'));
             }
         );
     }

--- a/test/selenium/Table/OperationsTest.php
+++ b/test/selenium/Table/OperationsTest.php
@@ -226,7 +226,8 @@ class OperationsTest extends TestBase
             'USE `' . $this->databaseName . '`;'
             . 'SHOW TABLES',
             function (): void {
-                $this->assertFalse($this->isElementPresent('className', 'table_results'));
+                $this->assertTrue($this->isElementPresent('className', 'table_results'));
+                $this->assertFalse($this->isElementPresent('cssSelector', '.table_results tbody tr'));
             }
         );
     }


### PR DESCRIPTION
Fixes #18605 and #14614 but it's not an ideal fix. This is a workaround. 

What the logic here did was it checked if the executed query was a SELECT statement. If it was, it added additional stuff on UI, such as "create view" and bookmarks. My workaround enables the same for any query that produces a result set. It could be `SHOW TABLES`, `CALL` or `SELECT`. This obviously is wrong. 