### PR TITLE
Pass a ServerRequest object to the 2FA plugin

### DIFF
--- a/libraries/classes/Application.php
+++ b/libraries/classes/Application.php
@@ -259,7 +259,7 @@ class Application
 
             $this->connectToDatabaseServer($GLOBALS['dbi'], $authPlugin, $currentServer);
             $authPlugin->rememberCredentials();
-            $authPlugin->checkTwoFactor();
+            $authPlugin->checkTwoFactor($request);
 
             /* Log success */
             Logging::logUser($this->config, $currentServer->user);

--- a/libraries/classes/Controllers/Preferences/TwoFactorController.php
+++ b/libraries/classes/Controllers/Preferences/TwoFactorController.php
@@ -36,20 +36,20 @@ class TwoFactorController extends AbstractController
         $twoFactor = new TwoFactor($GLOBALS['cfg']['Server']['user']);
 
         if ($request->hasBodyParam('2fa_remove')) {
-            if (! $twoFactor->check(true)) {
-                $this->render('preferences/two_factor/confirm', ['form' => $twoFactor->render()]);
+            if (! $twoFactor->check($request, true)) {
+                $this->render('preferences/two_factor/confirm', ['form' => $twoFactor->render($request)]);
 
                 return;
             }
 
-            $twoFactor->configure('');
+            $twoFactor->configure($request, '');
             $this->response->addHTML(
                 Message::rawNotice(__('Two-factor authentication has been removed.'))->getDisplay(),
             );
         } elseif ($request->hasBodyParam('2fa_configure')) {
-            if (! $twoFactor->configure($request->getParsedBodyParam('2fa_configure'))) {
+            if (! $twoFactor->configure($request, $request->getParsedBodyParam('2fa_configure'))) {
                 $this->render('preferences/two_factor/configure', [
-                    'form' => $twoFactor->setup(),
+                    'form' => $twoFactor->setup($request),
                     'configure' => $request->getParsedBodyParam('2fa_configure'),
                 ]);
 

--- a/libraries/classes/Plugins/AuthenticationPlugin.php
+++ b/libraries/classes/Plugins/AuthenticationPlugin.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin\Plugins;
 
 use PhpMyAdmin\Config;
 use PhpMyAdmin\Exceptions\SessionHandlerException;
+use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\IpAllowDeny;
 use PhpMyAdmin\Logging;
 use PhpMyAdmin\Message;
@@ -301,12 +302,12 @@ abstract class AuthenticationPlugin
      * Checks whether two factor authentication is active
      * for given user and performs it.
      */
-    public function checkTwoFactor(): void
+    public function checkTwoFactor(ServerRequest $request): void
     {
         $twofactor = new TwoFactor($this->user);
 
         /* Do we need to show the form? */
-        if ($twofactor->check()) {
+        if ($twofactor->check($request)) {
             return;
         }
 
@@ -320,7 +321,7 @@ abstract class AuthenticationPlugin
             __('You have enabled two factor authentication, please confirm your login.'),
         )->getDisplay());
         $response->addHTML($this->template->render('login/twofactor', [
-            'form' => $twofactor->render(),
+            'form' => $twofactor->render($request),
             'show_submit' => $twofactor->showSubmit(),
         ]));
         $response->addHTML($this->template->render('login/footer'));

--- a/libraries/classes/Plugins/TwoFactor/Application.php
+++ b/libraries/classes/Plugins/TwoFactor/Application.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Plugins\TwoFactor;
 
+use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Plugins\TwoFactorPlugin;
 use PhpMyAdmin\TwoFactor;
 use PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException;
@@ -53,7 +54,7 @@ class Application extends TwoFactorPlugin
      * @throws InvalidCharactersException
      * @throws SecretKeyTooShortException
      */
-    public function check(): bool
+    public function check(ServerRequest $request): bool
     {
         $this->provided = false;
         if (! isset($_POST['2fa_code'])) {
@@ -70,7 +71,7 @@ class Application extends TwoFactorPlugin
      *
      * @return string HTML code
      */
-    public function render(): string
+    public function render(ServerRequest $request): string
     {
         return $this->template->render('login/twofactor/application');
     }
@@ -80,7 +81,7 @@ class Application extends TwoFactorPlugin
      *
      * @return string HTML code
      */
-    public function setup(): string
+    public function setup(ServerRequest $request): string
     {
         $secret = $this->twofactor->config['settings']['secret'];
         $inlineUrl = $this->google2fa->getQRCodeInline(
@@ -103,7 +104,7 @@ class Application extends TwoFactorPlugin
      * @throws InvalidCharactersException
      * @throws SecretKeyTooShortException
      */
-    public function configure(): bool
+    public function configure(ServerRequest $request): bool
     {
         if (! isset($_SESSION['2fa_application_key'])) {
             $_SESSION['2fa_application_key'] = $this->google2fa->generateSecretKey();
@@ -111,7 +112,7 @@ class Application extends TwoFactorPlugin
 
         $this->twofactor->config['settings']['secret'] = $_SESSION['2fa_application_key'];
 
-        $result = $this->check();
+        $result = $this->check($request);
         if ($result) {
             unset($_SESSION['2fa_application_key']);
         }

--- a/libraries/classes/Plugins/TwoFactor/Invalid.php
+++ b/libraries/classes/Plugins/TwoFactor/Invalid.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Plugins\TwoFactor;
 
+use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Plugins\TwoFactorPlugin;
 
 /**
@@ -21,7 +22,7 @@ class Invalid extends TwoFactorPlugin
     /**
      * Checks authentication, returns true on success
      */
-    public function check(): bool
+    public function check(ServerRequest $request): bool
     {
         return false;
     }
@@ -31,7 +32,7 @@ class Invalid extends TwoFactorPlugin
      *
      * @return string HTML code
      */
-    public function render(): string
+    public function render(ServerRequest $request): string
     {
         return $this->template->render('login/twofactor/invalid');
     }

--- a/libraries/classes/Plugins/TwoFactor/Key.php
+++ b/libraries/classes/Plugins/TwoFactor/Key.php
@@ -9,6 +9,7 @@ namespace PhpMyAdmin\Plugins\TwoFactor;
 
 use CodeLts\U2F\U2FServer\U2FException;
 use CodeLts\U2F\U2FServer\U2FServer;
+use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Plugins\TwoFactorPlugin;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\TwoFactor;
@@ -71,7 +72,7 @@ class Key extends TwoFactorPlugin
     /**
      * Checks authentication, returns true on success
      */
-    public function check(): bool
+    public function check(ServerRequest $request): bool
     {
         $this->provided = false;
         if (! isset($_POST['u2f_authentication_response'], $_SESSION['authenticationRequest'])) {
@@ -117,17 +118,17 @@ class Key extends TwoFactorPlugin
      *
      * @return string HTML code
      */
-    public function render(): string
+    public function render(ServerRequest $request): string
     {
-        $request = U2FServer::makeAuthentication(
+        $authRequest = U2FServer::makeAuthentication(
             $this->getRegistrations(),
             $this->getAppId(true),
         );
-        $_SESSION['authenticationRequest'] = $request;
+        $_SESSION['authenticationRequest'] = $authRequest;
         $this->loadScripts();
 
         return $this->template->render('login/twofactor/key', [
-            'request' => json_encode($request),
+            'request' => json_encode($authRequest),
             'is_https' => $GLOBALS['config']->isHttps(),
         ]);
     }
@@ -143,7 +144,7 @@ class Key extends TwoFactorPlugin
      * @throws RuntimeError
      * @throws SyntaxError
      */
-    public function setup(): string
+    public function setup(ServerRequest $request): string
     {
         $registrationData = U2FServer::makeRegistration(
             $this->getAppId(true),
@@ -163,7 +164,7 @@ class Key extends TwoFactorPlugin
     /**
      * Performs backend configuration
      */
-    public function configure(): bool
+    public function configure(ServerRequest $request): bool
     {
         $this->provided = false;
         if (! isset($_POST['u2f_registration_response'], $_SESSION['registrationRequest'])) {

--- a/libraries/classes/Plugins/TwoFactor/Simple.php
+++ b/libraries/classes/Plugins/TwoFactor/Simple.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\Plugins\TwoFactor;
 
+use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Plugins\TwoFactorPlugin;
 
 use function __;
@@ -23,7 +24,7 @@ class Simple extends TwoFactorPlugin
     /**
      * Checks authentication, returns true on success
      */
-    public function check(): bool
+    public function check(ServerRequest $request): bool
     {
         return isset($_POST['2fa_confirm']);
     }
@@ -33,7 +34,7 @@ class Simple extends TwoFactorPlugin
      *
      * @return string HTML code
      */
-    public function render(): string
+    public function render(ServerRequest $request): string
     {
         return $this->template->render('login/twofactor/simple');
     }

--- a/libraries/classes/Plugins/TwoFactorPlugin.php
+++ b/libraries/classes/Plugins/TwoFactorPlugin.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Plugins;
 
 use PhpMyAdmin\Core;
+use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Message;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\TwoFactor;
@@ -67,7 +68,7 @@ class TwoFactorPlugin
     /**
      * Checks authentication, returns true on success
      */
-    public function check(): bool
+    public function check(ServerRequest $request): bool
     {
         return true;
     }
@@ -77,7 +78,7 @@ class TwoFactorPlugin
      *
      * @return string HTML code
      */
-    public function render(): string
+    public function render(ServerRequest $request): string
     {
         return '';
     }
@@ -87,7 +88,7 @@ class TwoFactorPlugin
      *
      * @return string HTML code
      */
-    public function setup(): string
+    public function setup(ServerRequest $request): string
     {
         return '';
     }
@@ -95,7 +96,7 @@ class TwoFactorPlugin
     /**
      * Performs backend configuration
      */
-    public function configure(): bool
+    public function configure(ServerRequest $request): bool
     {
         return true;
     }

--- a/libraries/classes/TwoFactor.php
+++ b/libraries/classes/TwoFactor.php
@@ -10,6 +10,7 @@ namespace PhpMyAdmin;
 use BaconQrCode\Renderer\ImageRenderer;
 use CodeLts\U2F\U2FServer\U2FServer;
 use PhpMyAdmin\ConfigStorage\Relation;
+use PhpMyAdmin\Http\ServerRequest;
 use PhpMyAdmin\Plugins\TwoFactor\Application;
 use PhpMyAdmin\Plugins\TwoFactor\Invalid;
 use PhpMyAdmin\Plugins\TwoFactor\Key;
@@ -196,14 +197,14 @@ class TwoFactor
      *
      * @param bool $skipSession Skip session cache
      */
-    public function check(bool $skipSession = false): bool
+    public function check(ServerRequest $request, bool $skipSession = false): bool
     {
         if ($skipSession) {
-            return $this->backend->check();
+            return $this->backend->check($request);
         }
 
         if (empty($_SESSION['two_factor_check'])) {
-            $_SESSION['two_factor_check'] = $this->backend->check();
+            $_SESSION['two_factor_check'] = $this->backend->check($request);
         }
 
         return (bool) $_SESSION['two_factor_check'];
@@ -214,9 +215,9 @@ class TwoFactor
      *
      * @return string HTML code
      */
-    public function render(): string
+    public function render(ServerRequest $request): string
     {
-        return $this->backend->getError() . $this->backend->render();
+        return $this->backend->getError() . $this->backend->render($request);
     }
 
     /**
@@ -224,9 +225,9 @@ class TwoFactor
      *
      * @return string HTML code
      */
-    public function setup(): string
+    public function setup(ServerRequest $request): string
     {
-        return $this->backend->getError() . $this->backend->setup();
+        return $this->backend->getError() . $this->backend->setup($request);
     }
 
     /**
@@ -247,7 +248,7 @@ class TwoFactor
      *
      * @param string $name Backend name
      */
-    public function configure(string $name): bool
+    public function configure(ServerRequest $request, string $name): bool
     {
         $this->config = ['backend' => $name, 'settings' => []];
         if ($name === '') {
@@ -260,7 +261,7 @@ class TwoFactor
 
             $cls = $this->getBackendClass($name);
             $this->backend = new $cls($this);
-            if (! $this->backend->configure()) {
+            if (! $this->backend->configure($request)) {
                 return false;
             }
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5631,12 +5631,12 @@ parameters:
 			path: libraries/classes/Controllers/Preferences/TwoFactorController.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method PhpMyAdmin\\\\TwoFactor\\:\\:configure\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$user of class PhpMyAdmin\\\\TwoFactor constructor expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Preferences/TwoFactorController.php
 
 		-
-			message: "#^Parameter \\#1 \\$user of class PhpMyAdmin\\\\TwoFactor constructor expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$name of method PhpMyAdmin\\\\TwoFactor\\:\\:configure\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Preferences/TwoFactorController.php
 

--- a/test/classes/Plugins/TwoFactor/WebAuthnTest.php
+++ b/test/classes/Plugins/TwoFactor/WebAuthnTest.php
@@ -84,8 +84,7 @@ class WebAuthnTest extends AbstractTestCase
 
         $webAuthn = new WebAuthn($twoFactor);
         $webAuthn->setServer($server);
-        $webAuthn->serverRequest = $request;
-        $actual = $webAuthn->render();
+        $actual = $webAuthn->render($request);
 
         $optionsFromSession = $_SESSION['WebAuthnCredentialRequestOptions'] ?? null;
         $this->assertIsString($optionsFromSession);
@@ -138,8 +137,7 @@ class WebAuthnTest extends AbstractTestCase
 
         $webAuthn = new WebAuthn($twoFactor);
         $webAuthn->setServer($server);
-        $webAuthn->serverRequest = $request;
-        $actual = $webAuthn->setup();
+        $actual = $webAuthn->setup($request);
 
         $optionsFromSession = $_SESSION['WebAuthnCredentialCreationOptions'] ?? null;
         $this->assertIsString($optionsFromSession);
@@ -162,8 +160,7 @@ class WebAuthnTest extends AbstractTestCase
         $request = $this->createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['webauthn_creation_response', '', '']]);
         $webAuthn = new WebAuthn($this->createStub(TwoFactor::class));
-        $webAuthn->serverRequest = $request;
-        $this->assertFalse($webAuthn->configure());
+        $this->assertFalse($webAuthn->configure($request));
         $this->assertSame('', $webAuthn->getError());
     }
 
@@ -173,8 +170,7 @@ class WebAuthnTest extends AbstractTestCase
         $request = $this->createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['webauthn_creation_response', '', '{}']]);
         $webAuthn = new WebAuthn($this->createStub(TwoFactor::class));
-        $webAuthn->serverRequest = $request;
-        $this->assertFalse($webAuthn->configure());
+        $this->assertFalse($webAuthn->configure($request));
         $this->assertStringContainsString('Two-factor authentication failed:', $webAuthn->getError());
     }
 
@@ -190,8 +186,7 @@ class WebAuthnTest extends AbstractTestCase
 
         $webAuthn = new WebAuthn($this->createStub(TwoFactor::class));
         $webAuthn->setServer($server);
-        $webAuthn->serverRequest = $request;
-        $this->assertFalse($webAuthn->configure());
+        $this->assertFalse($webAuthn->configure($request));
         $this->assertStringContainsString('Two-factor authentication failed.', $webAuthn->getError());
     }
 
@@ -215,8 +210,7 @@ class WebAuthnTest extends AbstractTestCase
 
         $webAuthn = new WebAuthn($twoFactor);
         $webAuthn->setServer($server);
-        $webAuthn->serverRequest = $request;
-        $this->assertTrue($webAuthn->configure());
+        $this->assertTrue($webAuthn->configure($request));
         /** @psalm-var array{backend: string, settings: mixed[]} $config */
         $config = $twoFactor->config;
         $this->assertSame(
@@ -237,8 +231,7 @@ class WebAuthnTest extends AbstractTestCase
         $request = $this->createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['webauthn_request_response', '', '']]);
         $webAuthn = new WebAuthn($this->createStub(TwoFactor::class));
-        $webAuthn->serverRequest = $request;
-        $this->assertFalse($webAuthn->check());
+        $this->assertFalse($webAuthn->check($request));
         $this->assertSame('', $webAuthn->getError());
     }
 
@@ -248,8 +241,7 @@ class WebAuthnTest extends AbstractTestCase
         $request = $this->createStub(ServerRequest::class);
         $request->method('getParsedBodyParam')->willReturnMap([['webauthn_request_response', '', '{}']]);
         $webAuthn = new WebAuthn($this->createStub(TwoFactor::class));
-        $webAuthn->serverRequest = $request;
-        $this->assertFalse($webAuthn->check());
+        $this->assertFalse($webAuthn->check($request));
         $this->assertStringContainsString('Two-factor authentication failed:', $webAuthn->getError());
     }
 
@@ -265,8 +257,7 @@ class WebAuthnTest extends AbstractTestCase
 
         $webAuthn = new WebAuthn($this->createStub(TwoFactor::class));
         $webAuthn->setServer($server);
-        $webAuthn->serverRequest = $request;
-        $this->assertFalse($webAuthn->check());
+        $this->assertFalse($webAuthn->check($request));
         $this->assertStringContainsString('Two-factor authentication failed.', $webAuthn->getError());
     }
 
@@ -301,7 +292,6 @@ class WebAuthnTest extends AbstractTestCase
 
         $webAuthn = new WebAuthn($twoFactor);
         $webAuthn->setServer($server);
-        $webAuthn->serverRequest = $request;
-        $this->assertTrue($webAuthn->check());
+        $this->assertTrue($webAuthn->check($request));
     }
 }


### PR DESCRIPTION
Removes the `Application::getRequest()` call for the WebAuthn plugin.
