### PR TITLE
Fix editing geometries

### DIFF
--- a/js/src/gis_data_editor.js
+++ b/js/src/gis_data_editor.js
@@ -375,7 +375,7 @@ AJAX.registerOnload('gis_data_editor.js', function () {
         var noOfGeoms = parseInt($noOfGeomsInput.val(), 10);
 
         var html1 = Messages.strGeometry + ' ' + (noOfGeoms + 1) + ':<br>';
-        var $geomType = $('select[name=\'gis_data[' + (noOfGeoms - 1) + '][gis_type]\']').clone();
+        var $geomType = $('#gis_type_template').contents().filter('select').clone();
         $geomType.attr('name', 'gis_data[' + noOfGeoms + '][gis_type]').val('POINT');
         var html2 = '<br>' + Messages.strPoint + ' :' +
             '<label for="x"> ' + Messages.strX + ' </label>' +
@@ -384,9 +384,7 @@ AJAX.registerOnload('gis_data_editor.js', function () {
             '<input type="text" name="gis_data[' + noOfGeoms + '][POINT][y]" value="">' +
             '<br><br>';
 
-        $a.before(html1);
-        $geomType.insertBefore($a);
-        $a.before(html2);
+        $a.before(html1, $geomType, html2);
         $noOfGeomsInput.val(noOfGeoms + 1);
     });
 });

--- a/libraries/classes/Controllers/GisDataEditorController.php
+++ b/libraries/classes/Controllers/GisDataEditorController.php
@@ -132,6 +132,7 @@ class GisDataEditorController extends AbstractController
             'srid' => $srid,
             'visualization' => $visualization,
             'open_layers' => $open_layers,
+            'column_type' => mb_strtoupper($type),
             'gis_types' => self::GIS_TYPES,
             'geom_type' => $geom_type,
             'geom_count' => $geom_count,

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -298,7 +298,7 @@ class GisMultiLineString extends GisGeometry
      */
     public function generateWkt(array $gis_data, $index, $empty = '')
     {
-        $data_row = $gis_data[$index]['MULTILINESTRING'];
+        $data_row = $gis_data[$index]['MULTILINESTRING'] ?? null;
 
         $no_of_lines = $data_row['no_of_lines'] ?? 1;
         if ($no_of_lines < 1) {

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -377,7 +377,7 @@ class GisMultiPolygon extends GisGeometry
      */
     public function generateWkt(array $gis_data, $index, $empty = '')
     {
-        $data_row = $gis_data[$index]['MULTIPOLYGON'];
+        $data_row = $gis_data[$index]['MULTIPOLYGON'] ?? null;
 
         $no_of_polygons = $data_row['no_of_polygons'] ?? 1;
         if ($no_of_polygons < 1) {

--- a/templates/gis_data_editor_form.twig
+++ b/templates/gis_data_editor_form.twig
@@ -27,7 +27,7 @@
 
         {# Header section - Inclueds GIS type selector and input field for SRID #}
         <div id="gis_data_header">
-            <select name="gis_data[gis_type]" class="gis_type">
+            <select name="gis_data[gis_type]" class="gis_type{{ column_type != 'GEOMETRY' ? ' hide' }}">
                 {% for gis_type in gis_types %}
                     <option value="{{ gis_type }}"{{ geom_type == gis_type ? ' selected="selected"' }}>
                         {{ gis_type }}

--- a/templates/gis_data_editor_form.twig
+++ b/templates/gis_data_editor_form.twig
@@ -46,6 +46,14 @@
                 <input type="hidden" name="gis_data[GEOMETRYCOLLECTION][geom_count]" value="{{ geom_count }}">
             {% endif %}
 
+            <template id="gis_type_template">
+                <select class="gis_type">
+                    {% for gis_type in gis_types|slice(0, 6) %}
+                        <option value="{{ gis_type }}">{{ gis_type }}</option>
+                    {% endfor %}
+                </select>
+            </template>
+
             {% for a in 0..geom_count - 1 %}
               {% if gis_data[a] is not null %}
                 {% if geom_type == 'GEOMETRYCOLLECTION' %}

--- a/test/classes/Gis/GisGeomTestCase.php
+++ b/test/classes/Gis/GisGeomTestCase.php
@@ -9,7 +9,11 @@ namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisGeometry;
 use PhpMyAdmin\Gis\GisPolygon;
+use PhpMyAdmin\Image\ImageWrapper;
 use PhpMyAdmin\Tests\AbstractTestCase;
+use TCPDF;
+
+use function preg_match;
 
 /**
  * Abstract parent class for all Gis<Geom_type> test classes
@@ -18,6 +22,24 @@ abstract class GisGeomTestCase extends AbstractTestCase
 {
     /** @var GisGeometry */
     protected $object;
+
+    /**
+     * Test for generateWkt
+     *
+     * @param array       $gis_data array of GIS data
+     * @param int         $index    index in $gis_data
+     * @param string|null $empty    empty parameter
+     * @param string      $output   expected output
+     *
+     * @dataProvider providerForTestGenerateWkt
+     */
+    public function testGenerateWkt(array $gis_data, int $index, ?string $empty, string $output): void
+    {
+        $this->assertEquals(
+            $output,
+            $this->object->generateWkt($gis_data, $index, $empty)
+        );
+    }
 
     /**
      * test generateParams method
@@ -61,5 +83,130 @@ abstract class GisGeomTestCase extends AbstractTestCase
             $min_max,
             $this->object->scaleRow($spatial)
         );
+    }
+
+    /**
+     * test prepareRowAsPng method
+     *
+     * @dataProvider providerForTestPrepareRowAsPng
+     * @requires extension gd
+     */
+    public function testPrepareRowAsPng(string $wkt): void
+    {
+        $image = ImageWrapper::create(120, 150);
+        $this->assertNotNull($image);
+        $return = $this->object->prepareRowAsPng(
+            $wkt,
+            'image',
+            '#B02EE0',
+            ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
+            $image
+        );
+        $this->assertEquals(120, $return->width());
+        $this->assertEquals(150, $return->height());
+    }
+
+    /**
+     * test case for prepareRowAsPdf() method
+     *
+     * @param string $spatial    GIS object
+     * @param string $label      label for the GIS object
+     * @param string $color      color for the GIS object
+     * @param array  $scale_data array containing data related to scaling
+     * @param TCPDF  $pdf        TCPDF instance
+     * @psalm-param array{
+     *   x: float,
+     *   y: float,
+     *   height: int,
+     *   scale: float,
+     *   minX: float,
+     *   maxX: float,
+     *   minY: float,
+     *   maxY: float,
+     * } $scale_data
+     *
+     * @dataProvider providerForTestPrepareRowAsPdf
+     */
+    public function testPrepareRowAsPdf(
+        string $spatial,
+        string $label,
+        string $color,
+        array $scale_data,
+        TCPDF $pdf
+    ): void {
+        $return = $this->object->prepareRowAsPdf($spatial, $label, $color, $scale_data, $pdf);
+        $this->assertInstanceOf(TCPDF::class, $return);
+    }
+
+    /**
+     * test case for prepareRowAsSvg() method
+     *
+     * @param string $spatial   GIS object
+     * @param string $label     label for the GIS object
+     * @param string $color     color for the GIS object
+     * @param array  $scaleData array containing data related to scaling
+     * @param string $output    expected output
+     * @psalm-param array{
+     *   x: float,
+     *   y: float,
+     *   height: int,
+     *   scale: float,
+     *   minX: float,
+     *   maxX: float,
+     *   minY: float,
+     *   maxY: float,
+     * } $scaleData
+     *
+     * @dataProvider providerForTestPrepareRowAsSvg
+     */
+    public function testPrepareRowAsSvg(
+        string $spatial,
+        string $label,
+        string $color,
+        array $scaleData,
+        string $output
+    ): void {
+        $string = $this->object->prepareRowAsSvg($spatial, $label, $color, $scaleData);
+        $this->assertEquals(1, preg_match($output, $string));
+    }
+
+    /**
+     * test case for prepareRowAsOl() method
+     *
+     * @param string $spatial    GIS object
+     * @param int    $srid       spatial reference ID
+     * @param string $label      label for the GIS object
+     * @param int[]  $color      color for the GIS object
+     * @param array  $scale_data array containing data related to scaling
+     * @param string $expected   expected output
+     * @psalm-param array{
+     *   x: float,
+     *   y: float,
+     *   height: int,
+     *   scale: float,
+     *   minX: float,
+     *   maxX: float,
+     *   minY: float,
+     *   maxY: float,
+     * } $scale_data
+     *
+     * @dataProvider providerForTestPrepareRowAsOl
+     */
+    public function testPrepareRowAsOl(
+        string $spatial,
+        int $srid,
+        string $label,
+        array $color,
+        array $scale_data,
+        string $expected
+    ): void {
+        $actual = $this->object->prepareRowAsOl(
+            $spatial,
+            $srid,
+            $label,
+            $color,
+            $scale_data
+        );
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/test/classes/Gis/GisGeometryCollectionTest.php
+++ b/test/classes/Gis/GisGeometryCollectionTest.php
@@ -5,19 +5,14 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisGeometryCollection;
-use PhpMyAdmin\Image\ImageWrapper;
-use PhpMyAdmin\Tests\AbstractTestCase;
 use TCPDF;
-
-use function method_exists;
-use function preg_match;
 
 /**
  * @covers \PhpMyAdmin\Gis\GisGeometryCollection
  */
-class GisGeometryCollectionTest extends AbstractTestCase
+class GisGeometryCollectionTest extends GisGeomTestCase
 {
-    /** @var GisGeometryCollection */
+    /** @var    GisGeometryCollection */
     protected $object;
 
     /**
@@ -41,24 +36,11 @@ class GisGeometryCollectionTest extends AbstractTestCase
     }
 
     /**
-     * Test for scaleRow
-     *
-     * @param string $spatial string to parse
-     * @param array  $output  expected parsed output
-     *
-     * @dataProvider providerForScaleRow
-     */
-    public function testScaleRow(string $spatial, array $output): void
-    {
-        $this->assertEquals($output, $this->object->scaleRow($spatial));
-    }
-
-    /**
      * Data provider for testScaleRow() test case
      *
      * @return array test data for testScaleRow() test case
      */
-    public function providerForScaleRow(): array
+    public function providerForTestScaleRow(): array
     {
         return [
             [
@@ -74,29 +56,11 @@ class GisGeometryCollectionTest extends AbstractTestCase
     }
 
     /**
-     * Test for generateWkt
-     *
-     * @param array       $gis_data array of GIS data
-     * @param int         $index    index in $gis_data
-     * @param string|null $empty    empty parameter
-     * @param string      $output   expected output
-     *
-     * @dataProvider providerForGenerateWkt
-     */
-    public function testGenerateWkt(array $gis_data, int $index, ?string $empty, string $output): void
-    {
-        $this->assertEquals(
-            $output,
-            $this->object->generateWkt($gis_data, $index, $empty)
-        );
-    }
-
-    /**
      * Data provider for testGenerateWkt() test case
      *
      * @return array test data for testGenerateWkt() test case
      */
-    public function providerForGenerateWkt(): array
+    public function providerForTestGenerateWkt(): array
     {
         $temp1 = [
             0 => [
@@ -126,28 +90,16 @@ class GisGeometryCollectionTest extends AbstractTestCase
     }
 
     /**
-     * Test for generateParams
-     *
-     * @param string $value  string to parse
-     * @param array  $output expected parsed output
-     *
-     * @dataProvider providerForGenerateParams
-     */
-    public function testGenerateParams(string $value, array $output): void
-    {
-        $this->assertEquals($output, $this->object->generateParams($value));
-    }
-
-    /**
      * Data provider for testGenerateParams() test case
      *
      * @return array test data for testGenerateParams() test case
      */
-    public function providerForGenerateParams(): array
+    public function providerForTestGenerateParams(): array
     {
         return [
             [
                 'GEOMETRYCOLLECTION(LINESTRING(5.02 8.45,6.14 0.15))',
+                null,
                 [
                     'srid' => 0,
                     'GEOMETRYCOLLECTION' => ['geom_count' => 1],
@@ -171,43 +123,15 @@ class GisGeometryCollectionTest extends AbstractTestCase
     }
 
     /**
-     * @requires extension gd
+     * Data provider for testPrepareRowAsPng
+     *
+     * @return string[]
      */
-    public function testPrepareRowAsPng(): void
+    public function providerForTestPrepareRowAsPng(): array
     {
-        $image = ImageWrapper::create(120, 150);
-        $this->assertNotNull($image);
-        $return = $this->object->prepareRowAsPng(
-            'GEOMETRYCOLLECTION(POLYGON((35 10,10 20,15 40,45 45,35 10),(20 30,35 32,30 20,20 30)))',
-            'image',
-            '#B02EE0',
-            ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
-            $image
-        );
-        $this->assertEquals(120, $return->width());
-        $this->assertEquals(150, $return->height());
-    }
-
-    /**
-     * Test for prepareRowAsPdf
-     *
-     * @param string $spatial    string to parse
-     * @param string $label      field label
-     * @param string $line_color line color
-     * @param array  $scale_data scaling parameters
-     * @param TCPDF  $pdf        expected output
-     *
-     * @dataProvider providerForPrepareRowAsPdf
-     */
-    public function testPrepareRowAsPdf(
-        string $spatial,
-        string $label,
-        string $line_color,
-        array $scale_data,
-        TCPDF $pdf
-    ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $line_color, $scale_data, $pdf);
-        $this->assertInstanceOf(TCPDF::class, $return);
+        return [
+            ['GEOMETRYCOLLECTION(POLYGON((35 10,10 20,15 40,45 45,35 10),(20 30,35 32,30 20,20 30)))'],
+        ];
     }
 
     /**
@@ -215,7 +139,7 @@ class GisGeometryCollectionTest extends AbstractTestCase
      *
      * @return array test data for testPrepareRowAsPdf() test case
      */
-    public function providerForPrepareRowAsPdf(): array
+    public function providerForTestPrepareRowAsPdf(): array
     {
         return [
             [
@@ -234,46 +158,11 @@ class GisGeometryCollectionTest extends AbstractTestCase
     }
 
     /**
-     * Test for prepareRowAsSvg
-     *
-     * @param string $spatial   string to parse
-     * @param string $label     field label
-     * @param string $lineColor line color
-     * @param array  $scaleData scaling parameters
-     * @param string $output    expected output
-     *
-     * @dataProvider providerForPrepareRowAsSvg
-     */
-    public function testPrepareRowAsSvg(
-        string $spatial,
-        string $label,
-        string $lineColor,
-        array $scaleData,
-        string $output
-    ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
-
-        if (method_exists($this, 'assertMatchesRegularExpression')) {
-            $this->assertMatchesRegularExpression(
-                $output,
-                $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData)
-            );
-        } else {
-            /** @psalm-suppress DeprecatedMethod */
-            $this->assertRegExp(
-                $output,
-                $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData)
-            );
-        }
-    }
-
-    /**
      * Data provider for testPrepareRowAsSvg() test case
      *
      * @return array test data for testPrepareRowAsSvg() test case
      */
-    public function providerForPrepareRowAsSvg(): array
+    public function providerForTestPrepareRowAsSvg(): array
     {
         return [
             [
@@ -295,43 +184,11 @@ class GisGeometryCollectionTest extends AbstractTestCase
     }
 
     /**
-     * Test for prepareRowAsOl
-     *
-     * @param string $spatial    string to parse
-     * @param int    $srid       SRID
-     * @param string $label      field label
-     * @param array  $line_color line color
-     * @param array  $scale_data scaling parameters
-     * @param string $output     expected output
-     *
-     * @dataProvider providerForPrepareRowAsOl
-     */
-    public function testPrepareRowAsOl(
-        string $spatial,
-        int $srid,
-        string $label,
-        array $line_color,
-        array $scale_data,
-        string $output
-    ): void {
-        $this->assertEquals(
-            $output,
-            $this->object->prepareRowAsOl(
-                $spatial,
-                $srid,
-                $label,
-                $line_color,
-                $scale_data
-            )
-        );
-    }
-
-    /**
      * Data provider for testPrepareRowAsOl() test case
      *
      * @return array test data for testPrepareRowAsOl() test case
      */
-    public function providerForPrepareRowAsOl(): array
+    public function providerForTestPrepareRowAsOl(): array
     {
         return [
             [

--- a/test/classes/Gis/GisGeometryCollectionTest.php
+++ b/test/classes/Gis/GisGeometryCollectionTest.php
@@ -81,6 +81,96 @@ class GisGeometryCollectionTest extends GisGeomTestCase
 
         return [
             [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => [
+                        'geom_count' => '1',
+                    ],
+                    0 => [
+                        'gis_type' => 'POINT',
+                    ],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(POINT( ))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => [
+                        'geom_count' => '1',
+                    ],
+                    0 => [
+                        'gis_type' => 'LINESTRING',
+                    ],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(LINESTRING( , ))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => [
+                        'geom_count' => '1',
+                    ],
+                    0 => [
+                        'gis_type' => 'POLYGON',
+                    ],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(POLYGON(( , , , )))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => [
+                        'geom_count' => '1',
+                    ],
+                    0 => [
+                        'gis_type' => 'MULTIPOINT',
+                    ],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(MULTIPOINT( ))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => [
+                        'geom_count' => '1',
+                    ],
+                    0 => [
+                        'gis_type' => 'MULTILINESTRING',
+                    ],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(MULTILINESTRING(( , )))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => [
+                        'geom_count' => '1',
+                    ],
+                    0 => [
+                        'gis_type' => 'MULTIPOLYGON',
+                    ],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(MULTIPOLYGON((( , , , ))))',
+            ],
+            [
                 $temp1,
                 0,
                 null,

--- a/test/classes/Gis/GisLineStringTest.php
+++ b/test/classes/Gis/GisLineStringTest.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisLineString;
-use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
-
-use function preg_match;
 
 /**
  * @covers \PhpMyAdmin\Gis\GisLineString
@@ -164,43 +161,15 @@ class GisLineStringTest extends GisGeomTestCase
     }
 
     /**
-     * @requires extension gd
+     * Data provider for testPrepareRowAsPng
+     *
+     * @return string[][]
      */
-    public function testPrepareRowAsPng(): void
+    public function providerForTestPrepareRowAsPng(): array
     {
-        $image = ImageWrapper::create(120, 150);
-        $this->assertNotNull($image);
-        $return = $this->object->prepareRowAsPng(
-            'LINESTRING(12 35,48 75,69 23,25 45,14 53,35 78)',
-            'image',
-            '#B02EE0',
-            ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
-            $image
-        );
-        $this->assertEquals(120, $return->width());
-        $this->assertEquals(150, $return->height());
-    }
-
-    /**
-     * test case for prepareRowAsPdf() method
-     *
-     * @param string $spatial    GIS LINESTRING object
-     * @param string $label      label for the GIS LINESTRING object
-     * @param string $line_color color for the GIS LINESTRING object
-     * @param array  $scale_data array containing data related to scaling
-     * @param TCPDF  $pdf        TCPDF instance
-     *
-     * @dataProvider providerForPrepareRowAsPdf
-     */
-    public function testPrepareRowAsPdf(
-        string $spatial,
-        string $label,
-        string $line_color,
-        array $scale_data,
-        TCPDF $pdf
-    ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $line_color, $scale_data, $pdf);
-        $this->assertInstanceOf(TCPDF::class, $return);
+        return [
+            ['LINESTRING(12 35,48 75,69 23,25 45,14 53,35 78)'],
+        ];
     }
 
     /**
@@ -208,7 +177,7 @@ class GisLineStringTest extends GisGeomTestCase
      *
      * @return array test data for testPrepareRowAsPdf() test case
      */
-    public function providerForPrepareRowAsPdf(): array
+    public function providerForTestPrepareRowAsPdf(): array
     {
         return [
             [
@@ -227,33 +196,11 @@ class GisLineStringTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsSvg() method
-     *
-     * @param string $spatial   GIS LINESTRING object
-     * @param string $label     label for the GIS LINESTRING object
-     * @param string $lineColor color for the GIS LINESTRING object
-     * @param array  $scaleData array containing data related to scaling
-     * @param string $output    expected output
-     *
-     * @dataProvider providerForPrepareRowAsSvg
-     */
-    public function testPrepareRowAsSvg(
-        string $spatial,
-        string $label,
-        string $lineColor,
-        array $scaleData,
-        string $output
-    ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
-    }
-
-    /**
      * data provider for testPrepareRowAsSvg() test case
      *
      * @return array test data for testPrepareRowAsSvg() test case
      */
-    public function providerForPrepareRowAsSvg(): array
+    public function providerForTestPrepareRowAsSvg(): array
     {
         return [
             [
@@ -274,43 +221,11 @@ class GisLineStringTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsOl() method
-     *
-     * @param string $spatial    GIS LINESTRING object
-     * @param int    $srid       spatial reference ID
-     * @param string $label      label for the GIS LINESTRING object
-     * @param array  $line_color color for the GIS LINESTRING object
-     * @param array  $scale_data array containing data related to scaling
-     * @param string $output     expected output
-     *
-     * @dataProvider providerForPrepareRowAsOl
-     */
-    public function testPrepareRowAsOl(
-        string $spatial,
-        int $srid,
-        string $label,
-        array $line_color,
-        array $scale_data,
-        string $output
-    ): void {
-        $this->assertEquals(
-            $this->object->prepareRowAsOl(
-                $spatial,
-                $srid,
-                $label,
-                $line_color,
-                $scale_data
-            ),
-            $output
-        );
-    }
-
-    /**
      * data provider for testPrepareRowAsOl() test case
      *
      * @return array test data for testPrepareRowAsOl() test case
      */
-    public function providerForPrepareRowAsOl(): array
+    public function providerForTestPrepareRowAsOl(): array
     {
         return [
             [

--- a/test/classes/Gis/GisMultiLineStringTest.php
+++ b/test/classes/Gis/GisMultiLineStringTest.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisMultiLineString;
-use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
-
-use function preg_match;
 
 /**
  * @covers \PhpMyAdmin\Gis\GisMultiLineString
@@ -246,43 +243,15 @@ class GisMultiLineStringTest extends GisGeomTestCase
     }
 
     /**
-     * @requires extension gd
+     * Data provider for testPrepareRowAsPng
+     *
+     * @return string[][]
      */
-    public function testPrepareRowAsPng(): void
+    public function providerForTestPrepareRowAsPng(): array
     {
-        $image = ImageWrapper::create(120, 150);
-        $this->assertNotNull($image);
-        $return = $this->object->prepareRowAsPng(
-            'MULTILINESTRING((36 14,47 23,62 75),(36 10,17 23,178 53))',
-            'image',
-            '#B02EE0',
-            ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
-            $image
-        );
-        $this->assertEquals(120, $return->width());
-        $this->assertEquals(150, $return->height());
-    }
-
-    /**
-     * test case for prepareRowAsPdf() method
-     *
-     * @param string $spatial    GIS MULTILINESTRING object
-     * @param string $label      label for the GIS MULTILINESTRING object
-     * @param string $line_color color for the GIS MULTILINESTRING object
-     * @param array  $scale_data array containing data related to scaling
-     * @param TCPDF  $pdf        TCPDF instance
-     *
-     * @dataProvider providerForPrepareRowAsPdf
-     */
-    public function testPrepareRowAsPdf(
-        string $spatial,
-        string $label,
-        string $line_color,
-        array $scale_data,
-        TCPDF $pdf
-    ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $line_color, $scale_data, $pdf);
-        $this->assertInstanceOf(TCPDF::class, $return);
+        return [
+            ['MULTILINESTRING((36 14,47 23,62 75),(36 10,17 23,178 53))'],
+        ];
     }
 
     /**
@@ -290,7 +259,7 @@ class GisMultiLineStringTest extends GisGeomTestCase
      *
      * @return array test data for testPrepareRowAsPdf() test case
      */
-    public function providerForPrepareRowAsPdf(): array
+    public function providerForTestPrepareRowAsPdf(): array
     {
         return [
             [
@@ -309,33 +278,11 @@ class GisMultiLineStringTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsSvg() method
-     *
-     * @param string $spatial   GIS MULTILINESTRING object
-     * @param string $label     label for the GIS MULTILINESTRING object
-     * @param string $lineColor color for the GIS MULTILINESTRING object
-     * @param array  $scaleData array containing data related to scaling
-     * @param string $output    expected output
-     *
-     * @dataProvider providerForPrepareRowAsSvg
-     */
-    public function testPrepareRowAsSvg(
-        string $spatial,
-        string $label,
-        string $lineColor,
-        array $scaleData,
-        string $output
-    ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $lineColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
-    }
-
-    /**
      * data provider for testPrepareRowAsSvg() test case
      *
      * @return array test data for testPrepareRowAsSvg() test case
      */
-    public function providerForPrepareRowAsSvg(): array
+    public function providerForTestPrepareRowAsSvg(): array
     {
         return [
             [
@@ -358,43 +305,11 @@ class GisMultiLineStringTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsOl() method
-     *
-     * @param string $spatial    GIS MULTILINESTRING object
-     * @param int    $srid       spatial reference ID
-     * @param string $label      label for the GIS MULTILINESTRING object
-     * @param array  $line_color color for the GIS MULTILINESTRING object
-     * @param array  $scale_data array containing data related to scaling
-     * @param string $output     expected output
-     *
-     * @dataProvider providerForPrepareRowAsOl
-     */
-    public function testPrepareRowAsOl(
-        string $spatial,
-        int $srid,
-        string $label,
-        array $line_color,
-        array $scale_data,
-        string $output
-    ): void {
-        $this->assertEquals(
-            $output,
-            $this->object->prepareRowAsOl(
-                $spatial,
-                $srid,
-                $label,
-                $line_color,
-                $scale_data
-            )
-        );
-    }
-
-    /**
      * data provider for testPrepareRowAsOl() test case
      *
      * @return array test data for testPrepareRowAsOl() test case
      */
-    public function providerForPrepareRowAsOl(): array
+    public function providerForTestPrepareRowAsOl(): array
     {
         return [
             [

--- a/test/classes/Gis/GisMultiPointTest.php
+++ b/test/classes/Gis/GisMultiPointTest.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisMultiPoint;
-use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
-
-use function preg_match;
 
 /**
  * @covers \PhpMyAdmin\Gis\GisMultiPoint
@@ -166,43 +163,15 @@ class GisMultiPointTest extends GisGeomTestCase
     }
 
     /**
-     * @requires extension gd
+     * Data provider for testPrepareRowAsPng
+     *
+     * @return string[][]
      */
-    public function testPrepareRowAsPng(): void
+    public function providerForTestPrepareRowAsPng(): array
     {
-        $image = ImageWrapper::create(120, 150);
-        $this->assertNotNull($image);
-        $return = $this->object->prepareRowAsPng(
-            'MULTIPOINT(12 35,48 75,69 23,25 45,14 53,35 78)',
-            'image',
-            '#B02EE0',
-            ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
-            $image
-        );
-        $this->assertEquals(120, $return->width());
-        $this->assertEquals(150, $return->height());
-    }
-
-    /**
-     * test case for prepareRowAsPdf() method
-     *
-     * @param string $spatial     GIS MULTIPOINT object
-     * @param string $label       label for the GIS MULTIPOINT object
-     * @param string $point_color color for the GIS MULTIPOINT object
-     * @param array  $scale_data  array containing data related to scaling
-     * @param TCPDF  $pdf         TCPDF instance
-     *
-     * @dataProvider providerForPrepareRowAsPdf
-     */
-    public function testPrepareRowAsPdf(
-        string $spatial,
-        string $label,
-        string $point_color,
-        array $scale_data,
-        TCPDF $pdf
-    ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $point_color, $scale_data, $pdf);
-        $this->assertInstanceOf(TCPDF::class, $return);
+        return [
+            ['MULTIPOINT(12 35,48 75,69 23,25 45,14 53,35 78)'],
+        ];
     }
 
     /**
@@ -210,7 +179,7 @@ class GisMultiPointTest extends GisGeomTestCase
      *
      * @return array test data for testPrepareRowAsPdf() test case
      */
-    public function providerForPrepareRowAsPdf(): array
+    public function providerForTestPrepareRowAsPdf(): array
     {
         return [
             [
@@ -229,33 +198,11 @@ class GisMultiPointTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsSvg() method
-     *
-     * @param string $spatial    GIS MULTIPOINT object
-     * @param string $label      label for the GIS MULTIPOINT object
-     * @param string $pointColor color for the GIS MULTIPOINT object
-     * @param array  $scaleData  array containing data related to scaling
-     * @param string $output     expected output
-     *
-     * @dataProvider providerForPrepareRowAsSvg
-     */
-    public function testPrepareRowAsSvg(
-        string $spatial,
-        string $label,
-        string $pointColor,
-        array $scaleData,
-        string $output
-    ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $pointColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
-    }
-
-    /**
      * data provider for testPrepareRowAsSvg() test case
      *
      * @return array test data for testPrepareRowAsSvg() test case
      */
-    public function providerForPrepareRowAsSvg(): array
+    public function providerForTestPrepareRowAsSvg(): array
     {
         return [
             [
@@ -284,43 +231,11 @@ class GisMultiPointTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsOl() method
-     *
-     * @param string $spatial     GIS MULTIPOINT object
-     * @param int    $srid        spatial reference ID
-     * @param string $label       label for the GIS MULTIPOINT object
-     * @param array  $point_color color for the GIS MULTIPOINT object
-     * @param array  $scale_data  array containing data related to scaling
-     * @param string $output      expected output
-     *
-     * @dataProvider providerForPrepareRowAsOl
-     */
-    public function testPrepareRowAsOl(
-        string $spatial,
-        int $srid,
-        string $label,
-        array $point_color,
-        array $scale_data,
-        string $output
-    ): void {
-        $this->assertEquals(
-            $output,
-            $this->object->prepareRowAsOl(
-                $spatial,
-                $srid,
-                $label,
-                $point_color,
-                $scale_data
-            )
-        );
-    }
-
-    /**
      * data provider for testPrepareRowAsOl() test case
      *
      * @return array test data for testPrepareRowAsOl() test case
      */
-    public function providerForPrepareRowAsOl(): array
+    public function providerForTestPrepareRowAsOl(): array
     {
         return [
             [

--- a/test/classes/Gis/GisMultiPolygonTest.php
+++ b/test/classes/Gis/GisMultiPolygonTest.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisMultiPolygon;
-use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
-
-use function preg_match;
 
 /**
  * @covers \PhpMyAdmin\Gis\GisMultiPolygon
@@ -331,43 +328,15 @@ class GisMultiPolygonTest extends GisGeomTestCase
     }
 
     /**
-     * @requires extension gd
+     * Data provider for testPrepareRowAsPng
+     *
+     * @return string[][]
      */
-    public function testPrepareRowAsPng(): void
+    public function providerForTestPrepareRowAsPng(): array
     {
-        $image = ImageWrapper::create(120, 150);
-        $this->assertNotNull($image);
-        $return = $this->object->prepareRowAsPng(
-            'MULTIPOLYGON(((136 40,147 83,16 75,136 40)),((105 0,56 20,78 73,105 0)))',
-            'image',
-            '#B02EE0',
-            ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
-            $image
-        );
-        $this->assertEquals(120, $return->width());
-        $this->assertEquals(150, $return->height());
-    }
-
-    /**
-     * test case for prepareRowAsPdf() method
-     *
-     * @param string $spatial    GIS MULTIPOLYGON object
-     * @param string $label      label for the GIS MULTIPOLYGON object
-     * @param string $fill_color color for the GIS MULTIPOLYGON object
-     * @param array  $scale_data array containing data related to scaling
-     * @param TCPDF  $pdf        TCPDF instance
-     *
-     * @dataProvider providerForPrepareRowAsPdf
-     */
-    public function testPrepareRowAsPdf(
-        string $spatial,
-        string $label,
-        string $fill_color,
-        array $scale_data,
-        TCPDF $pdf
-    ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $fill_color, $scale_data, $pdf);
-        $this->assertInstanceOf(TCPDF::class, $return);
+        return [
+            ['MULTIPOLYGON(((136 40,147 83,16 75,136 40)),((105 0,56 20,78 73,105 0)))'],
+        ];
     }
 
     /**
@@ -375,7 +344,7 @@ class GisMultiPolygonTest extends GisGeomTestCase
      *
      * @return array test data for testPrepareRowAsPdf() test case
      */
-    public function providerForPrepareRowAsPdf(): array
+    public function providerForTestPrepareRowAsPdf(): array
     {
         return [
             [
@@ -394,33 +363,11 @@ class GisMultiPolygonTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsSvg() method
-     *
-     * @param string $spatial   GIS MULTIPOLYGON object
-     * @param string $label     label for the GIS MULTIPOLYGON object
-     * @param string $fillColor color for the GIS MULTIPOLYGON object
-     * @param array  $scaleData array containing data related to scaling
-     * @param string $output    expected output
-     *
-     * @dataProvider providerForPrepareRowAsSvg
-     */
-    public function testPrepareRowAsSvg(
-        string $spatial,
-        string $label,
-        string $fillColor,
-        array $scaleData,
-        string $output
-    ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $fillColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
-    }
-
-    /**
      * data provider for testPrepareRowAsSvg() test case
      *
      * @return array test data for testPrepareRowAsSvg() test case
      */
-    public function providerForPrepareRowAsSvg(): array
+    public function providerForTestPrepareRowAsSvg(): array
     {
         return [
             [
@@ -445,43 +392,11 @@ class GisMultiPolygonTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsOl() method
-     *
-     * @param string $spatial    GIS MULTIPOLYGON object
-     * @param int    $srid       spatial reference ID
-     * @param string $label      label for the GIS MULTIPOLYGON object
-     * @param array  $fill_color color for the GIS MULTIPOLYGON object
-     * @param array  $scale_data array containing data related to scaling
-     * @param string $output     expected output
-     *
-     * @dataProvider providerForPrepareRowAsOl
-     */
-    public function testPrepareRowAsOl(
-        string $spatial,
-        int $srid,
-        string $label,
-        array $fill_color,
-        array $scale_data,
-        string $output
-    ): void {
-        $this->assertEquals(
-            $output,
-            $this->object->prepareRowAsOl(
-                $spatial,
-                $srid,
-                $label,
-                $fill_color,
-                $scale_data
-            )
-        );
-    }
-
-    /**
      * data provider for testPrepareRowAsOl() test case
      *
      * @return array test data for testPrepareRowAsOl() test case
      */
-    public function providerForPrepareRowAsOl(): array
+    public function providerForTestPrepareRowAsOl(): array
     {
         return [
             [

--- a/test/classes/Gis/GisPointTest.php
+++ b/test/classes/Gis/GisPointTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisPoint;
-use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
 
 /**
@@ -180,51 +179,23 @@ class GisPointTest extends GisGeomTestCase
     }
 
     /**
-     * @requires extension gd
+     * Data provider for testPrepareRowAsPng
+     *
+     * @return string[][]
      */
-    public function testPrepareRowAsPng(): void
+    public function providerForTestPrepareRowAsPng(): array
     {
-        $image = ImageWrapper::create(120, 150);
-        $this->assertNotNull($image);
-        $return = $this->object->prepareRowAsPng(
-            'POINT(12 35)',
-            'image',
-            '#B02EE0',
-            ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
-            $image
-        );
-        $this->assertEquals(120, $return->width());
-        $this->assertEquals(150, $return->height());
+        return [
+            ['POINT(12 35)'],
+        ];
     }
 
     /**
-     * test case for prepareRowAsPdf() method
+     * data provider for testPrepareRowAsPdf() test case
      *
-     * @param string $spatial     GIS POINT object
-     * @param string $label       label for the GIS POINT object
-     * @param string $point_color color for the GIS POINT object
-     * @param array  $scale_data  array containing data related to scaling
-     * @param TCPDF  $pdf         TCPDF instance
-     *
-     * @dataProvider providerForPrepareRowAsPdf
+     * @return array test data for testPrepareRowAsPdf() test case
      */
-    public function testPrepareRowAsPdf(
-        string $spatial,
-        string $label,
-        string $point_color,
-        array $scale_data,
-        TCPDF $pdf
-    ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $point_color, $scale_data, $pdf);
-        $this->assertInstanceOf(TCPDF::class, $return);
-    }
-
-    /**
-     * data provider for prepareRowAsPdf() test case
-     *
-     * @return array test data for prepareRowAsPdf() test case
-     */
-    public function providerForPrepareRowAsPdf(): array
+    public function providerForTestPrepareRowAsPdf(): array
     {
         return [
             [
@@ -243,40 +214,11 @@ class GisPointTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsSvg() method
+     * data provider for testPrepareRowAsSvg() test case
      *
-     * @param string $spatial    GIS POINT object
-     * @param string $label      label for the GIS POINT object
-     * @param string $pointColor color for the GIS POINT object
-     * @param array  $scaleData  array containing data related to scaling
-     * @param string $output     expected output
-     *
-     * @dataProvider providerForPrepareRowAsSvg
+     * @return array test data for testPrepareRowAsSvg() test case
      */
-    public function testPrepareRowAsSvg(
-        string $spatial,
-        string $label,
-        string $pointColor,
-        array $scaleData,
-        string $output
-    ): void {
-        $this->assertEquals(
-            $output,
-            $this->object->prepareRowAsSvg(
-                $spatial,
-                $label,
-                $pointColor,
-                $scaleData
-            )
-        );
-    }
-
-    /**
-     * data provider for prepareRowAsSvg() test case
-     *
-     * @return array test data for prepareRowAsSvg() test case
-     */
-    public function providerForPrepareRowAsSvg(): array
+    public function providerForTestPrepareRowAsSvg(): array
     {
         return [
             [
@@ -289,41 +231,9 @@ class GisPointTest extends GisGeomTestCase
                     'scale' => 2,
                     'height' => 150,
                 ],
-                '',
+                '/^$/',
             ],
         ];
-    }
-
-    /**
-     * test case for prepareRowAsOl() method
-     *
-     * @param string $spatial     GIS POINT object
-     * @param int    $srid        spatial reference ID
-     * @param string $label       label for the GIS POINT object
-     * @param array  $point_color color for the GIS POINT object
-     * @param array  $scale_data  array containing data related to scaling
-     * @param string $output      expected output
-     *
-     * @dataProvider providerForPrepareRowAsOl
-     */
-    public function testPrepareRowAsOl(
-        string $spatial,
-        int $srid,
-        string $label,
-        array $point_color,
-        array $scale_data,
-        string $output
-    ): void {
-        $this->assertEquals(
-            $output,
-            $this->object->prepareRowAsOl(
-                $spatial,
-                $srid,
-                $label,
-                $point_color,
-                $scale_data
-            )
-        );
     }
 
     /**
@@ -331,7 +241,7 @@ class GisPointTest extends GisGeomTestCase
      *
      * @return array test data for testPrepareRowAsOl() test case
      */
-    public function providerForPrepareRowAsOl(): array
+    public function providerForTestPrepareRowAsOl(): array
     {
         return [
             [

--- a/test/classes/Gis/GisPolygonTest.php
+++ b/test/classes/Gis/GisPolygonTest.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace PhpMyAdmin\Tests\Gis;
 
 use PhpMyAdmin\Gis\GisPolygon;
-use PhpMyAdmin\Image\ImageWrapper;
 use TCPDF;
-
-use function preg_match;
 
 /**
  * @covers \PhpMyAdmin\Gis\GisPolygon
@@ -417,43 +414,15 @@ class GisPolygonTest extends GisGeomTestCase
     }
 
     /**
-     * @requires extension gd
+     * Data provider for testPrepareRowAsPng
+     *
+     * @return string[][]
      */
-    public function testPrepareRowAsPng(): void
+    public function providerForTestPrepareRowAsPng(): array
     {
-        $image = ImageWrapper::create(120, 150);
-        $this->assertNotNull($image);
-        $return = $this->object->prepareRowAsPng(
-            'POLYGON((123 0,23 30,17 63,123 0))',
-            'image',
-            '#B02EE0',
-            ['x' => 12, 'y' => 69, 'scale' => 2, 'height' => 150],
-            $image
-        );
-        $this->assertEquals(120, $return->width());
-        $this->assertEquals(150, $return->height());
-    }
-
-    /**
-     * test case for prepareRowAsPdf() method
-     *
-     * @param string $spatial    GIS POLYGON object
-     * @param string $label      label for the GIS POLYGON object
-     * @param string $fill_color color for the GIS POLYGON object
-     * @param array  $scale_data array containing data related to scaling
-     * @param TCPDF  $pdf        TCPDF instance
-     *
-     * @dataProvider providerForPrepareRowAsPdf
-     */
-    public function testPrepareRowAsPdf(
-        string $spatial,
-        string $label,
-        string $fill_color,
-        array $scale_data,
-        TCPDF $pdf
-    ): void {
-        $return = $this->object->prepareRowAsPdf($spatial, $label, $fill_color, $scale_data, $pdf);
-        $this->assertInstanceOf(TCPDF::class, $return);
+        return [
+            ['POLYGON((123 0,23 30,17 63,123 0))'],
+        ];
     }
 
     /**
@@ -461,7 +430,7 @@ class GisPolygonTest extends GisGeomTestCase
      *
      * @return array test data for testPrepareRowAsPdf() test case
      */
-    public function providerForPrepareRowAsPdf(): array
+    public function providerForTestPrepareRowAsPdf(): array
     {
         return [
             [
@@ -480,33 +449,11 @@ class GisPolygonTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsSvg() method
-     *
-     * @param string $spatial   GIS POLYGON object
-     * @param string $label     label for the GIS POLYGON object
-     * @param string $fillColor color for the GIS POLYGON object
-     * @param array  $scaleData array containing data related to scaling
-     * @param string $output    expected output
-     *
-     * @dataProvider providerForPrepareRowAsSvg
-     */
-    public function testPrepareRowAsSvg(
-        string $spatial,
-        string $label,
-        string $fillColor,
-        array $scaleData,
-        string $output
-    ): void {
-        $string = $this->object->prepareRowAsSvg($spatial, $label, $fillColor, $scaleData);
-        $this->assertEquals(1, preg_match($output, $string));
-    }
-
-    /**
      * data provider for testPrepareRowAsSvg() test case
      *
      * @return array test data for testPrepareRowAsSvg() test case
      */
-    public function providerForPrepareRowAsSvg(): array
+    public function providerForTestPrepareRowAsSvg(): array
     {
         return [
             [
@@ -528,43 +475,11 @@ class GisPolygonTest extends GisGeomTestCase
     }
 
     /**
-     * test case for prepareRowAsOl() method
-     *
-     * @param string $spatial    GIS POLYGON object
-     * @param int    $srid       spatial reference ID
-     * @param string $label      label for the GIS POLYGON object
-     * @param array  $fill_color color for the GIS POLYGON object
-     * @param array  $scale_data array containing data related to scaling
-     * @param string $output     expected output
-     *
-     * @dataProvider providerForPrepareRowAsOl
-     */
-    public function testPrepareRowAsOl(
-        string $spatial,
-        int $srid,
-        string $label,
-        array $fill_color,
-        array $scale_data,
-        string $output
-    ): void {
-        $this->assertEquals(
-            $output,
-            $this->object->prepareRowAsOl(
-                $spatial,
-                $srid,
-                $label,
-                $fill_color,
-                $scale_data
-            )
-        );
-    }
-
-    /**
      * data provider for testPrepareRowAsOl() test case
      *
      * @return array test data for testPrepareRowAsOl() test case
      */
-    public function providerForPrepareRowAsOl(): array
+    public function providerForTestPrepareRowAsOl(): array
     {
         return [
             [
@@ -602,7 +517,7 @@ class GisPolygonTest extends GisGeomTestCase
      *
      * @param array $ring coordinates of the points in a ring
      *
-     * @dataProvider providerForIsOuterRing
+     * @dataProvider providerForTestIsOuterRing
      */
     public function testIsOuterRing(array $ring): void
     {
@@ -614,7 +529,7 @@ class GisPolygonTest extends GisGeomTestCase
      *
      * @return array test data for testIsOuterRing() test case
      */
-    public function providerForIsOuterRing(): array
+    public function providerForTestIsOuterRing(): array
     {
         return [
             [


### PR DESCRIPTION
Fixes
- Empty geometry collection columns cannot be edited because no select input for the geometry type is available
- The test for generateWkt was only executed for GeometryCollection, other classes had providers but no test method
- An error occured when switching geometry type of a geometry inside a GeometryCollection to MultiLineString or MultiPolygon
- The geometry type should only  be selectable for columns of type Geometry

I reorganized the Gis tests to have only one test method in GisGeomTestCase.php in most cases