### PR TITLE
Strict boolean conditions

### DIFF
--- a/libraries/classes/Bookmark.php
+++ b/libraries/classes/Bookmark.php
@@ -195,7 +195,7 @@ class Bookmark
             $allUsers = false;
         }
 
-        if (! $allUsers && ! strlen((string) $bkmFields['bkm_user'])) {
+        if (! $allUsers && (string) $bkmFields['bkm_user'] === '') {
             return false;
         }
 

--- a/libraries/classes/BrowseForeigners.php
+++ b/libraries/classes/BrowseForeigners.php
@@ -83,7 +83,7 @@ class BrowseForeigners
 
         $indexByDescription++;
 
-        if (! empty($currentValue)) {
+        if ($currentValue !== '') {
             $rightKeynameIsSelected = $rightKeyname == $currentValue;
             $leftKeynameIsSelected = $leftKeyname == $currentValue;
         }

--- a/libraries/classes/Command/TwigLintCommand.php
+++ b/libraries/classes/Command/TwigLintCommand.php
@@ -223,7 +223,7 @@ class TwigLintCommand extends Command
     ): void {
         $line = $exception->getTemplateLine();
 
-        if ($file) {
+        if ($file !== null && $file !== '') {
             $output->text(sprintf('<error> ERROR </error> in %s (line %s)', $file, $line));
         } else {
             $output->text(sprintf('<error> ERROR </error> (line %s)', $line));

--- a/libraries/classes/Config.php
+++ b/libraries/classes/Config.php
@@ -200,7 +200,7 @@ class Config
     public function checkClient(): void
     {
         $httpUserAgent = '';
-        if (Core::getenv('HTTP_USER_AGENT')) {
+        if (Core::getenv('HTTP_USER_AGENT') !== '') {
             $httpUserAgent = Core::getenv('HTTP_USER_AGENT');
         }
 
@@ -570,7 +570,7 @@ class Config
     /** @throws ConfigException */
     public function checkConfigSource(): bool
     {
-        if (! $this->getSource()) {
+        if ($this->getSource() === '') {
             // no configuration file set at all
             return false;
         }

--- a/libraries/classes/Config/FormDisplay.php
+++ b/libraries/classes/Config/FormDisplay.php
@@ -794,7 +794,7 @@ class FormDisplay
             }
 
             if (! function_exists($funcs[$systemPath][1])) {
-                $comment .= ($comment ? '; ' : '') . sprintf(
+                $comment .= ($comment !== '' ? '; ' : '') . sprintf(
                     __(
                         'Compressed export will not work due to missing function %s.',
                     ),

--- a/libraries/classes/Config/PageSettings.php
+++ b/libraries/classes/Config/PageSettings.php
@@ -59,7 +59,7 @@ class PageSettings
             return;
         }
 
-        if (! empty($elemId)) {
+        if ($elemId !== null && $elemId !== '') {
             $this->elemId = $elemId;
         }
 

--- a/libraries/classes/Config/ServerConfigChecks.php
+++ b/libraries/classes/Config/ServerConfigChecks.php
@@ -390,7 +390,7 @@ class ServerConfigChecks
         }
 
         $functions = $this->functionExists('bzopen') ? '' : 'bzopen';
-        $functions .= $this->functionExists('bzcompress') ? '' : ($functions ? ', ' : '') . 'bzcompress';
+        $functions .= $this->functionExists('bzcompress') ? '' : ($functions !== '' ? ', ' : '') . 'bzcompress';
         SetupIndex::messagesSet(
             'error',
             'BZipDump',

--- a/libraries/classes/ConfigStorage/Relation.php
+++ b/libraries/classes/ConfigStorage/Relation.php
@@ -872,7 +872,7 @@ class Relation
             $key = $relrow[$foreignField];
 
             // if the display field has been defined for this foreign table
-            if ($foreignDisplay) {
+            if ($foreignDisplay !== '') {
                 $value = $relrow[$foreignDisplay];
             } else {
                 $value = '';
@@ -884,7 +884,7 @@ class Relation
         // put the dropdown sections in correct order
         $top = [];
         $bottom = [];
-        if ($foreignDisplay) {
+        if ($foreignDisplay !== '') {
             if (
                 isset($GLOBALS['cfg']['ForeignKeyDropdownOrder'])
                 && is_array($GLOBALS['cfg']['ForeignKeyDropdownOrder'])
@@ -932,7 +932,7 @@ class Relation
             }
         }
 
-        if ($foreignDisplay) {
+        if ($foreignDisplay !== '') {
             $ret .= implode('', $bottom);
         }
 
@@ -973,7 +973,7 @@ class Relation
         $foreignLink = false;
         $dispRow = $foreignDisplay = $theTotal = $foreignField = null;
         do {
-            if (! $foreigners) {
+            if ($foreigners === false || $foreigners === []) {
                 break;
             }
 
@@ -1302,7 +1302,10 @@ class Relation
             . ' (db_name, page_descr)'
             . ' VALUES ('
             . $this->dbi->quoteString($db, Connection::TYPE_CONTROL) . ', '
-            . $this->dbi->quoteString($newpage ?: __('no description'), Connection::TYPE_CONTROL) . ')';
+            . $this->dbi->quoteString(
+                $newpage !== null && $newpage !== '' ? $newpage : __('no description'),
+                Connection::TYPE_CONTROL,
+            ) . ')';
         $this->dbi->tryQueryAsControlUser($insQuery);
 
         return $this->dbi->insertId(Connection::TYPE_CONTROL);
@@ -1328,7 +1331,7 @@ class Relation
                 . $this->dbi->quoteString($table)
                 . ' AND `referenced_table_schema` = '
                 . $this->dbi->quoteString($db);
-            if ($column) {
+            if ($column !== '') {
                 $relQuery .= ' AND `referenced_column_name` = '
                     . $this->dbi->quoteString($column);
             }
@@ -1482,7 +1485,7 @@ class Relation
         );
 
         $error = $this->dbi->getError(Connection::TYPE_CONTROL);
-        if (! $error) {
+        if ($error === '') {
             // Re-build the cache to show the list of tables created or not
             // This is the case when the DB could be created but no tables just after
             // So just purge the cache and show the new configuration storage state
@@ -1574,7 +1577,7 @@ class Relation
                 $this->dbi->tryQuery($createQueries[$table], Connection::TYPE_CONTROL);
 
                 $error = $this->dbi->getError(Connection::TYPE_CONTROL);
-                if ($error) {
+                if ($error !== '') {
                     $GLOBALS['message'] = $error;
 
                     return;

--- a/libraries/classes/Controllers/Database/DesignerController.php
+++ b/libraries/classes/Controllers/Database/DesignerController.php
@@ -42,6 +42,7 @@ class DesignerController extends AbstractController
         $table = $request->getParsedBodyParam('table');
 
         if ($request->hasBodyParam('dialog')) {
+            $html = '';
             $dialog = $request->getParsedBodyParam('dialog');
             if ($dialog === 'edit') {
                 $html = $this->databaseDesigner->getHtmlForEditOrDeletePages($db, 'editPage');
@@ -72,7 +73,7 @@ class DesignerController extends AbstractController
                 );
             }
 
-            if (! empty($html)) {
+            if ($html !== '') {
                 $this->response->addHTML($html);
             }
 

--- a/libraries/classes/Controllers/Database/EventsController.php
+++ b/libraries/classes/Controllers/Database/EventsController.php
@@ -209,7 +209,7 @@ final class EventsController extends AbstractController
             $itemName = $_GET['item_name'];
             $exportData = Events::getDefinition($this->dbi, $GLOBALS['db'], $itemName);
 
-            if (! $exportData) {
+            if ($exportData === null || $exportData === '') {
                 $exportData = false;
             }
 

--- a/libraries/classes/Controllers/Database/RoutinesController.php
+++ b/libraries/classes/Controllers/Database/RoutinesController.php
@@ -175,7 +175,7 @@ class RoutinesController extends AbstractController
                 $mode = 'add';
             } elseif (! empty($_REQUEST['edit_item'])) {
                 $title = __('Edit routine');
-                if (! $operation && ! empty($_GET['item_name']) && empty($_POST['editor_process_edit'])) {
+                if ($operation === '' && ! empty($_GET['item_name']) && empty($_POST['editor_process_edit'])) {
                     $routine = $this->routines->getDataFromName($_GET['item_name'], $_GET['item_type']);
                     if ($routine !== null) {
                         $routine['item_original_name'] = $routine['item_name'];

--- a/libraries/classes/Controllers/Database/Structure/DropFormController.php
+++ b/libraries/classes/Controllers/Database/Structure/DropFormController.php
@@ -42,19 +42,19 @@ final class DropFormController extends AbstractController
         foreach ($selected as $selectedValue) {
             $current = $selectedValue;
             if ($views !== [] && in_array($current, $views)) {
-                $fullQueryViews .= (empty($fullQueryViews) ? 'DROP VIEW ' : ', ')
+                $fullQueryViews .= ($fullQueryViews === '' ? 'DROP VIEW ' : ', ')
                     . Util::backquote(htmlspecialchars($current));
             } else {
-                $fullQuery .= (empty($fullQuery) ? 'DROP TABLE ' : ', ')
+                $fullQuery .= ($fullQuery === '' ? 'DROP TABLE ' : ', ')
                     . Util::backquote(htmlspecialchars($current));
             }
         }
 
-        if (! empty($fullQuery)) {
+        if ($fullQuery !== '') {
             $fullQuery .= ';<br>' . "\n";
         }
 
-        if (! empty($fullQueryViews)) {
+        if ($fullQueryViews !== '') {
             $fullQuery .= $fullQueryViews . ';<br>' . "\n";
         }
 

--- a/libraries/classes/Controllers/Database/Structure/DropTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/DropTableController.php
@@ -59,7 +59,7 @@ final class DropTableController extends AbstractController
             $current = $selected[$i];
 
             if ($views !== [] && in_array($current, $views)) {
-                $sqlQueryViews .= (empty($sqlQueryViews) ? 'DROP VIEW ' : ', ') . Util::backquote($current);
+                $sqlQueryViews .= ($sqlQueryViews === '' ? 'DROP VIEW ' : ', ') . Util::backquote($current);
             } else {
                 $GLOBALS['sql_query'] .= (empty($GLOBALS['sql_query']) ? 'DROP TABLE ' : ', ')
                     . Util::backquote($current);
@@ -70,9 +70,9 @@ final class DropTableController extends AbstractController
 
         if (! empty($GLOBALS['sql_query'])) {
             $GLOBALS['sql_query'] .= ';';
-        } elseif (! empty($sqlQueryViews)) {
+        } elseif ($sqlQueryViews !== '') {
             $GLOBALS['sql_query'] = $sqlQueryViews . ';';
-            unset($sqlQueryViews);
+            $sqlQueryViews = '';
         }
 
         // Unset cache values for tables count, issue #14205
@@ -95,7 +95,7 @@ final class DropTableController extends AbstractController
             $GLOBALS['message'] = Message::error($this->dbi->getError());
         }
 
-        if ($result && ! empty($sqlQueryViews)) {
+        if ($result && $sqlQueryViews !== '') {
             $GLOBALS['sql_query'] .= ' ' . $sqlQueryViews . ';';
             $result = $this->dbi->tryQuery($sqlQueryViews);
             unset($sqlQueryViews);

--- a/libraries/classes/Controllers/Import/SimulateDmlController.php
+++ b/libraries/classes/Controllers/Import/SimulateDmlController.php
@@ -77,7 +77,7 @@ final class SimulateDmlController extends AbstractController
             $sqlData[] = $result;
         }
 
-        if ($error) {
+        if ($error !== '') {
             $message = Message::rawError($error);
             $this->response->addJSON('message', $message);
             $this->response->addJSON('sql_data', false);

--- a/libraries/classes/Controllers/Preferences/ExportController.php
+++ b/libraries/classes/Controllers/Preferences/ExportController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Config\Forms\User\ExportForm;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Http\ServerRequest;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Theme\ThemeManager;
@@ -86,7 +87,7 @@ class ExportController extends AbstractController
         $formErrors = $formDisplay->displayErrors();
 
         $this->render('preferences/forms/main', [
-            'error' => $GLOBALS['error'] ? $GLOBALS['error']->getDisplay() : '',
+            'error' => $GLOBALS['error'] instanceof Message ? $GLOBALS['error']->getDisplay() : '',
             'has_errors' => $formDisplay->hasErrors(),
             'errors' => $formErrors,
             'form' => $formDisplay->getDisplay(

--- a/libraries/classes/Controllers/Preferences/FeaturesController.php
+++ b/libraries/classes/Controllers/Preferences/FeaturesController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Config\Forms\User\FeaturesForm;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Http\ServerRequest;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Theme\ThemeManager;
@@ -86,7 +87,7 @@ class FeaturesController extends AbstractController
         $formErrors = $formDisplay->displayErrors();
 
         $this->render('preferences/forms/main', [
-            'error' => $GLOBALS['error'] ? $GLOBALS['error']->getDisplay() : '',
+            'error' => $GLOBALS['error'] instanceof Message ? $GLOBALS['error']->getDisplay() : '',
             'has_errors' => $formDisplay->hasErrors(),
             'errors' => $formErrors,
             'form' => $formDisplay->getDisplay(

--- a/libraries/classes/Controllers/Preferences/ImportController.php
+++ b/libraries/classes/Controllers/Preferences/ImportController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Config\Forms\User\ImportForm;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Http\ServerRequest;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Theme\ThemeManager;
@@ -86,7 +87,7 @@ class ImportController extends AbstractController
         $formErrors = $formDisplay->displayErrors();
 
         $this->render('preferences/forms/main', [
-            'error' => $GLOBALS['error'] ? $GLOBALS['error']->getDisplay() : '',
+            'error' => $GLOBALS['error'] instanceof Message ? $GLOBALS['error']->getDisplay() : '',
             'has_errors' => $formDisplay->hasErrors(),
             'errors' => $formErrors,
             'form' => $formDisplay->getDisplay(

--- a/libraries/classes/Controllers/Preferences/MainPanelController.php
+++ b/libraries/classes/Controllers/Preferences/MainPanelController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Config\Forms\User\MainForm;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Http\ServerRequest;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Theme\ThemeManager;
@@ -86,7 +87,7 @@ class MainPanelController extends AbstractController
         $formErrors = $formDisplay->displayErrors();
 
         $this->render('preferences/forms/main', [
-            'error' => $GLOBALS['error'] ? $GLOBALS['error']->getDisplay() : '',
+            'error' => $GLOBALS['error'] instanceof Message ? $GLOBALS['error']->getDisplay() : '',
             'has_errors' => $formDisplay->hasErrors(),
             'errors' => $formErrors,
             'form' => $formDisplay->getDisplay(

--- a/libraries/classes/Controllers/Preferences/NavigationController.php
+++ b/libraries/classes/Controllers/Preferences/NavigationController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Config\Forms\User\NaviForm;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Http\ServerRequest;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Theme\ThemeManager;
@@ -86,7 +87,7 @@ class NavigationController extends AbstractController
         $formErrors = $formDisplay->displayErrors();
 
         $this->render('preferences/forms/main', [
-            'error' => $GLOBALS['error'] ? $GLOBALS['error']->getDisplay() : '',
+            'error' => $GLOBALS['error'] instanceof Message ? $GLOBALS['error']->getDisplay() : '',
             'has_errors' => $formDisplay->hasErrors(),
             'errors' => $formErrors,
             'form' => $formDisplay->getDisplay(

--- a/libraries/classes/Controllers/Preferences/SqlController.php
+++ b/libraries/classes/Controllers/Preferences/SqlController.php
@@ -10,6 +10,7 @@ use PhpMyAdmin\Config\Forms\User\SqlForm;
 use PhpMyAdmin\ConfigStorage\Relation;
 use PhpMyAdmin\Controllers\AbstractController;
 use PhpMyAdmin\Http\ServerRequest;
+use PhpMyAdmin\Message;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Theme\ThemeManager;
@@ -86,7 +87,7 @@ class SqlController extends AbstractController
         $formErrors = $formDisplay->displayErrors();
 
         $this->render('preferences/forms/main', [
-            'error' => $GLOBALS['error'] ? $GLOBALS['error']->getDisplay() : '',
+            'error' => $GLOBALS['error'] instanceof Message ? $GLOBALS['error']->getDisplay() : '',
             'has_errors' => $formDisplay->hasErrors(),
             'errors' => $formErrors,
             'form' => $formDisplay->getDisplay(

--- a/libraries/classes/Controllers/Table/CreateController.php
+++ b/libraries/classes/Controllers/Table/CreateController.php
@@ -68,7 +68,7 @@ class CreateController extends AbstractController
             );
         }
 
-        if ($this->dbi->getColumns($GLOBALS['db'], $GLOBALS['table'])) {
+        if ($this->dbi->getColumns($GLOBALS['db'], $GLOBALS['table']) !== []) {
             // table exists already
             Generator::mysqlDie(
                 sprintf(__('Table %s already exists!'), htmlspecialchars($GLOBALS['table'])),

--- a/libraries/classes/Controllers/Table/GetFieldController.php
+++ b/libraries/classes/Controllers/Table/GetFieldController.php
@@ -50,7 +50,7 @@ class GetFieldController extends AbstractController
         }
 
         /* Check if table exists */
-        if (! $this->dbi->getColumns($GLOBALS['db'], $GLOBALS['table'])) {
+        if ($this->dbi->getColumns($GLOBALS['db'], $GLOBALS['table']) === []) {
             Generator::mysqlDie(__('Invalid table name'));
         }
 

--- a/libraries/classes/Controllers/Table/OperationsController.php
+++ b/libraries/classes/Controllers/Table/OperationsController.php
@@ -185,13 +185,12 @@ class OperationsController extends AbstractController
             return;
         }
 
+        $newMessage = '';
         $warningMessages = [];
         /**
          * Updates table comment, type and options if required
          */
         if ($request->hasBodyParam('submitoptions')) {
-            $newMessage = '';
-
             /** @var mixed $newName */
             $newName = $request->getParsedBodyParam('new_name');
             if (is_string($newName)) {
@@ -351,7 +350,7 @@ class OperationsController extends AbstractController
         unset($GLOBALS['reread_info']);
 
         if (isset($GLOBALS['result']) && empty($GLOBALS['message_to_show'])) {
-            if (empty($newMessage)) {
+            if ($newMessage === '') {
                 if (empty($GLOBALS['sql_query'])) {
                     $newMessage = Message::success(__('No change'));
                 } else {

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -373,7 +373,7 @@ class ZoomSearchController extends AbstractController
                 'where_clause' => $uniqueCondition,
                 'where_clause_sign' => Core::signSqlQuery($uniqueCondition),
             ];
-            $tmpData[$dataLabel] = $dataLabel ? $row[$dataLabel] : '';
+            $tmpData[$dataLabel] = $dataLabel !== '' ? $row[$dataLabel] : '';
             $data[] = $tmpData;
         }
 
@@ -392,8 +392,8 @@ class ZoomSearchController extends AbstractController
                 $columnName,
             );
             if (
-                ! $this->foreigners
-                || ! $searchColumnInForeigners[$columnIndex]
+                $this->foreigners === []
+                || ($searchColumnInForeigners[$columnIndex] === [] || $searchColumnInForeigners[$columnIndex] === false)
                 || ! is_array($foreignData[$columnIndex]['disp_row'])
             ) {
                 continue;

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -393,7 +393,8 @@ class ZoomSearchController extends AbstractController
             );
             if (
                 $this->foreigners === []
-                || ($searchColumnInForeigners[$columnIndex] === [] || $searchColumnInForeigners[$columnIndex] === false)
+                || $searchColumnInForeigners[$columnIndex] === []
+                || $searchColumnInForeigners[$columnIndex] === false
                 || ! is_array($foreignData[$columnIndex]['disp_row'])
             ) {
                 continue;

--- a/libraries/classes/Controllers/View/OperationsController.php
+++ b/libraries/classes/Controllers/View/OperationsController.php
@@ -106,7 +106,7 @@ class OperationsController extends AbstractController
         if (isset($GLOBALS['result'])) {
             // set to success by default, because result set could be empty
             // (for example, a table rename)
-            if (empty($message->getString())) {
+            if ($message->getString() === '') {
                 if ($GLOBALS['result']) {
                     $message->addText(
                         __('Your SQL query has been executed successfully.'),

--- a/libraries/classes/Database/CentralColumns.php
+++ b/libraries/classes/Database/CentralColumns.php
@@ -582,12 +582,12 @@ class CentralColumns
         if ($origColName == '') {
             $def = [];
             $def['Type'] = $colType;
-            if ($colLength) {
+            if ($colLength !== '') {
                 $def['Type'] .= '(' . $colLength . ')';
             }
 
             $def['Collation'] = $collation;
-            $def['Null'] = $colIsNull ? __('YES') : __('NO');
+            $def['Null'] = $colIsNull !== 0 ? __('YES') : __('NO');
             $def['Extra'] = $colExtra;
             $def['Attribute'] = $colAttribute;
             $def['Default'] = $colDefault;

--- a/libraries/classes/Database/Designer/Common.php
+++ b/libraries/classes/Database/Designer/Common.php
@@ -703,7 +703,7 @@ class Common
                 Connection::TYPE_CONTROL,
             );
 
-            if (! empty($origData)) {
+            if ($origData !== null && $origData !== []) {
                 $origData = json_decode($origData['settings_data'], true);
                 $origData[$index] = $value;
                 $origData = json_encode($origData);

--- a/libraries/classes/Database/Events.php
+++ b/libraries/classes/Database/Events.php
@@ -13,7 +13,6 @@ use PhpMyAdmin\Util;
 use function __;
 use function array_column;
 use function array_multisort;
-use function count;
 use function explode;
 use function htmlspecialchars;
 use function in_array;
@@ -75,7 +74,7 @@ class Events
         $itemQuery = $this->getQueryFromRequest();
 
         // set by getQueryFromRequest()
-        if (! count($GLOBALS['errors'])) {
+        if ($GLOBALS['errors'] === []) {
             // Execute the created query
             if (! empty($_POST['editor_process_edit'])) {
                 // Backup the old trigger, in case something goes wrong
@@ -138,7 +137,7 @@ class Events
             }
         }
 
-        if (count($GLOBALS['errors'])) {
+        if ($GLOBALS['errors'] !== []) {
             $GLOBALS['message'] = Message::error(
                 '<b>'
                 . __(
@@ -211,7 +210,7 @@ class Events
                  . ' AND EVENT_NAME=' . $this->dbi->quoteString($name);
         $query = 'SELECT ' . $columns . ' FROM `INFORMATION_SCHEMA`.`EVENTS` WHERE ' . $where . ';';
         $item = $this->dbi->fetchSingleRow($query);
-        if (! $item) {
+        if ($item === null || $item === []) {
             return null;
         }
 

--- a/libraries/classes/Database/Routines.php
+++ b/libraries/classes/Database/Routines.php
@@ -412,7 +412,7 @@ class Routines
 
         $routine = $this->dbi->fetchSingleRow($query);
 
-        if (! $routine) {
+        if ($routine === null || $routine === []) {
             return null;
         }
 

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -484,7 +484,7 @@ class DatabaseInterface implements DbalInterface
         // this is why we fall back to SHOW TABLE STATUS even for MySQL >= 50002
         if ($tables === []) {
             $sql = 'SHOW TABLE STATUS FROM ' . Util::backquote($database);
-            if (($table !== '' && $table !== []) || $tableIsGroup || $tableType) {
+            if (($table !== '' && $table !== []) || $tableIsGroup || ($tableType !== null && $tableType !== '')) {
                 $sql .= ' WHERE';
                 $needAnd = false;
                 if (($table !== '' && $table !== []) || $tableIsGroup) {

--- a/libraries/classes/DatabaseInterface.php
+++ b/libraries/classes/DatabaseInterface.php
@@ -505,7 +505,7 @@ class DatabaseInterface implements DbalInterface
                     $needAnd = true;
                 }
 
-                if ($tableType) {
+                if ($tableType !== null && $tableType !== '') {
                     if ($needAnd) {
                         $sql .= ' AND';
                     }
@@ -564,7 +564,7 @@ class DatabaseInterface implements DbalInterface
                     }
                 }
 
-                if ($sortValues) {
+                if ($sortValues !== []) {
                     if ($sortOrder === 'DESC') {
                         array_multisort($sortValues, SORT_DESC, $eachTables);
                     } else {
@@ -1074,7 +1074,7 @@ class DatabaseInterface implements DbalInterface
 
         /* Locale for messages */
         $locale = LanguageManager::getInstance()->getCurrentLanguage()->getMySQLLocale();
-        if ($locale) {
+        if ($locale !== '') {
             $this->query("SET lc_messages = '" . $locale . "';");
         }
 

--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -3539,7 +3539,7 @@ class Results
     ): string {
         $fieldsMeta = $this->properties['fields_meta']; // To use array indexes
 
-        if (empty($sortExpressionNoDirection)) {
+        if ($sortExpressionNoDirection === null || $sortExpressionNoDirection === '') {
             return '';
         }
 
@@ -3580,7 +3580,7 @@ class Results
         if ($isBlobOrGeometryOrBinary) {
             $columnForFirstRow = $this->handleNonPrintableContents(
                 $meta->getMappedType(),
-                $row ? $row[$sortedColumnIndex] : '',
+                $row !== [] ? $row[$sortedColumnIndex] : '',
                 null,
                 [],
                 $meta,
@@ -3606,7 +3606,7 @@ class Results
         if ($isBlobOrGeometryOrBinary) {
             $columnForLastRow = $this->handleNonPrintableContents(
                 $meta->getMappedType(),
-                $row ? $row[$sortedColumnIndex] : '',
+                $row !== [] ? $row[$sortedColumnIndex] : '',
                 null,
                 [],
                 $meta,
@@ -3885,7 +3885,7 @@ class Results
 
             // In case this query doesn't involve any tables,
             // implies only raw query is to be exported
-            if (! $statementInfo->selectTables) {
+            if ($statementInfo->selectTables === []) {
                 $urlParams['raw_query'] = 'true';
             }
 

--- a/libraries/classes/ErrorHandler.php
+++ b/libraries/classes/ErrorHandler.php
@@ -199,7 +199,7 @@ class ErrorHandler
              * user errors even in this case.
              * See: https://github.com/phpmyadmin/phpmyadmin/issues/16729
              */
-            $isSilenced = ! (error_reporting() & $errno);
+            $isSilenced = (error_reporting() & $errno) === 0;
 
             if (
                 isset($GLOBALS['cfg']['environment'])
@@ -471,7 +471,7 @@ class ErrorHandler
     public function countUserErrors(): int
     {
         $count = 0;
-        if ($this->countErrors()) {
+        if ($this->countErrors() !== 0) {
             foreach ($this->getErrors() as $error) {
                 if (! $error->isUserError()) {
                     continue;

--- a/libraries/classes/Export/Export.php
+++ b/libraries/classes/Export/Export.php
@@ -194,7 +194,7 @@ class Export
 
                 // Here, use strlen rather than mb_strlen to get the length
                 // in bytes to compare against the number of bytes written.
-                if (! $writeResult || $writeResult != strlen($line)) {
+                if ($writeResult === 0 || $writeResult === false || $writeResult != strlen($line)) {
                     $GLOBALS['message'] = Message::error(
                         __('Insufficient space to save the file %s.'),
                     );

--- a/libraries/classes/Footer.php
+++ b/libraries/classes/Footer.php
@@ -111,7 +111,7 @@ class Footer
             $retval = (string) json_encode($_SESSION['debug']);
             $_SESSION['debug'] = [];
 
-            return json_last_error() ? '\'false\'' : $retval;
+            return json_last_error() !== 0 ? '\'false\'' : $retval;
         }
 
         $_SESSION['debug'] = [];
@@ -237,7 +237,7 @@ class Footer
         $this->setHistory();
         if ($this->isEnabled) {
             if (! $this->isAjax && ! $this->isMinimal) {
-                if (Core::getenv('SCRIPT_NAME')) {
+                if (Core::getenv('SCRIPT_NAME') !== '') {
                     $url = $this->getSelfUrl();
                 }
 

--- a/libraries/classes/Gis/GisGeometry.php
+++ b/libraries/classes/Gis/GisGeometry.php
@@ -329,7 +329,7 @@ abstract class GisGeometry
     {
         $ol = 'new ' . $constructor . '(' . json_encode($coordinates) . ')';
         if ($srid != 3857) {
-            $ol .= '.transform(\'EPSG:' . ($srid ?: 4326) . '\', \'EPSG:3857\')';
+            $ol .= '.transform(\'EPSG:' . ($srid !== 0 ? $srid : 4326) . '\', \'EPSG:3857\')';
         }
 
         return $ol;

--- a/libraries/classes/Git.php
+++ b/libraries/classes/Git.php
@@ -547,7 +547,7 @@ class Git
 
         $refHead = @file_get_contents($gitFolder . '/HEAD');
 
-        if (! $refHead) {
+        if ($refHead === '' || $refHead === false) {
             $this->hasGit = false;
 
             return null;

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -494,11 +494,11 @@ class Header
     {
         if (strlen($this->title) == 0) {
             if ($GLOBALS['server'] > 0) {
-                if (strlen($GLOBALS['table'])) {
+                if ($GLOBALS['table'] !== '') {
                     $tempTitle = $GLOBALS['cfg']['TitleTable'];
-                } elseif (strlen($GLOBALS['db'])) {
+                } elseif ($GLOBALS['db'] !== '') {
                     $tempTitle = $GLOBALS['cfg']['TitleDatabase'];
-                } elseif (strlen($GLOBALS['cfg']['Server']['host'])) {
+                } elseif ($GLOBALS['cfg']['Server']['host'] !== '') {
                     $tempTitle = $GLOBALS['cfg']['TitleServer'];
                 } else {
                     $tempTitle = $GLOBALS['cfg']['TitleDefault'];

--- a/libraries/classes/Html/MySQLDocumentation.php
+++ b/libraries/classes/Html/MySQLDocumentation.php
@@ -93,7 +93,7 @@ class MySQLDocumentation
     {
         /* Construct base URL */
         $url = $page . '.html';
-        if (! empty($anchor)) {
+        if ($anchor !== '') {
             $url .= '#' . $anchor;
         }
 

--- a/libraries/classes/Import/SimulateDml.php
+++ b/libraries/classes/Import/SimulateDml.php
@@ -94,12 +94,12 @@ final class SimulateDml
     {
         $tableReferences = Query::getTables($statement);
         $where = Query::getClause($statement, $parser->list, 'WHERE');
-        if (empty($where)) {
+        if ($where === '') {
             $where = '1';
         }
 
         $orderAndLimit = '';
-        if (! empty($statement->order)) {
+        if ($statement->order !== null && $statement->order !== []) {
             $orderAndLimit .= ' ORDER BY ' . Query::getClause($statement, $parser->list, 'ORDER BY');
         }
 
@@ -119,7 +119,7 @@ final class SimulateDml
     {
         $tableReferences = Query::getTables($statement);
         $where = Query::getClause($statement, $parser->list, 'WHERE');
-        if (empty($where)) {
+        if ($where === '') {
             $where = '1';
         }
 

--- a/libraries/classes/Index.php
+++ b/libraries/classes/Index.php
@@ -155,7 +155,7 @@ class Index
                 $indexes[] = $index;
             }
 
-            if ((! ($choices & self::FULLTEXT)) || $index->getChoice() !== 'FULLTEXT') {
+            if ((($choices & self::FULLTEXT) === 0) || $index->getChoice() !== 'FULLTEXT') {
                 continue;
             }
 

--- a/libraries/classes/IndexColumn.php
+++ b/libraries/classes/IndexColumn.php
@@ -147,7 +147,7 @@ class IndexColumn
     public function getNull(bool $asText = false): string
     {
         if ($asText) {
-            if (! $this->null || $this->null === 'NO') {
+            if ($this->null === '' || $this->null === 'NO') {
                 return __('No');
             }
 

--- a/libraries/classes/InsertEdit.php
+++ b/libraries/classes/InsertEdit.php
@@ -419,7 +419,7 @@ class InsertEdit
             . ' cols="' . $textareaCols . '"'
             . ' dir="' . $textDir . '"'
             . ' id="field_' . $this->fieldIndex . '_3"'
-            . ($onChangeClause ? ' onchange="' . htmlspecialchars($onChangeClause, ENT_COMPAT) . '"' : '')
+            . ($onChangeClause !== '' ? ' onchange="' . htmlspecialchars($onChangeClause, ENT_COMPAT) . '"' : '')
             . ' tabindex="' . $this->fieldIndex . '"'
             . ' data-type="' . $dataType . '">'
             . $specialCharsEncoded
@@ -475,7 +475,7 @@ class InsertEdit
             . ($column->isChar
                 ? ' data-maxlength="' . $fieldsize . '"'
                 : '')
-            . ($inputMinMax ? ' ' . $inputMinMax : '')
+            . ($inputMinMax !== '' ? ' ' . $inputMinMax : '')
             . ' data-type="' . $dataType . '"'
             . ' class="' . $theClass . '" onchange="' . htmlspecialchars($onChangeClause, ENT_COMPAT) . '"'
             . ' tabindex="' . $this->fieldIndex . '"'
@@ -969,7 +969,7 @@ class InsertEdit
                 $totalAffectedRows += $this->dbi->affectedRows();
 
                 $insertId = $this->dbi->insertId();
-                if ($insertId) {
+                if ($insertId !== 0) {
                     // insert_id is id of FIRST record inserted in one insert, so if we
                     // inserted multiple rows, we had to increment this
 
@@ -1070,7 +1070,7 @@ class InsertEdit
         if ($_SESSION['tmpval']['relational_display'] === 'K') {
             // user chose "relational key" in the display options, so
             // the title contains the display field
-            $title = $dispval
+            $title = $dispval !== ''
                 ? ' title="' . htmlspecialchars($dispval) . '"'
                 : '';
         } else {
@@ -1669,7 +1669,7 @@ class InsertEdit
         $gisDataTypes = Gis::getDataTypes();
 
         // Prepares the field value
-        if ($currentRow) {
+        if ($currentRow !== []) {
             // (we are editing)
             [
                 $realNullValue,
@@ -1798,7 +1798,7 @@ class InsertEdit
         $maxUploadSize = 0;
         $selectOptionForUpload = '';
         $inputFieldHtml = '';
-        if (empty($transformedHtml)) {
+        if ($transformedHtml === '') {
             if (is_array($foreignData['disp_row'])) {
                 $foreignDropdown = $this->relation->foreignDropdown(
                     $foreignData['disp_row'],

--- a/libraries/classes/IpAllowDeny.php
+++ b/libraries/classes/IpAllowDeny.php
@@ -238,7 +238,7 @@ class IpAllowDeny
     {
         // Grabs true IP of the user and returns if it can't be found
         $remoteIp = Core::getIp();
-        if (empty($remoteIp)) {
+        if ($remoteIp === '' || $remoteIp === false) {
             return false;
         }
 
@@ -259,7 +259,7 @@ class IpAllowDeny
         $shortcuts = ['all' => '0.0.0.0/0', 'localhost' => '127.0.0.1/8'];
 
         // Provide some useful shortcuts if server gives us address:
-        if (Core::getenv('SERVER_ADDR')) {
+        if (Core::getenv('SERVER_ADDR') !== '') {
             $shortcuts['localnetA'] = Core::getenv('SERVER_ADDR') . '/8';
             $shortcuts['localnetB'] = Core::getenv('SERVER_ADDR') . '/16';
             $shortcuts['localnetC'] = Core::getenv('SERVER_ADDR') . '/24';

--- a/libraries/classes/Language.php
+++ b/libraries/classes/Language.php
@@ -68,7 +68,7 @@ class Language
      */
     public function getName(): string
     {
-        if (! empty($this->native)) {
+        if ($this->native !== '') {
             return $this->native . ' - ' . $this->name;
         }
 

--- a/libraries/classes/LanguageManager.php
+++ b/libraries/classes/LanguageManager.php
@@ -781,7 +781,7 @@ class LanguageManager
      */
     public function availableLocales(): array
     {
-        if (! $this->availableLocales) {
+        if ($this->availableLocales === []) {
             $config = Config::getInstance();
             if (empty($config->get('FilterLanguages'))) {
                 $this->availableLocales = $this->listLocaleDir();
@@ -811,7 +811,7 @@ class LanguageManager
      */
     public function availableLanguages(): array
     {
-        if (! $this->availableLanguages) {
+        if ($this->availableLanguages === []) {
             $this->availableLanguages = [];
 
             foreach ($this->availableLocales() as $lang) {
@@ -925,7 +925,7 @@ class LanguageManager
 
         // try to find out user's language by checking its HTTP_ACCEPT_LANGUAGE variable;
         $acceptedLanguages = Core::getenv('HTTP_ACCEPT_LANGUAGE');
-        if ($acceptedLanguages) {
+        if ($acceptedLanguages !== '') {
             foreach (explode(',', $acceptedLanguages) as $header) {
                 foreach ($langs as $language) {
                     if ($language->matchesAcceptLanguage($header)) {

--- a/libraries/classes/ListDatabase.php
+++ b/libraries/classes/ListDatabase.php
@@ -101,7 +101,7 @@ class ListDatabase extends ListAbstract
             }
         }
 
-        if ($command) {
+        if ($command !== '') {
             $databaseList = $GLOBALS['dbi']->fetchResult($command, null, null);
         }
 

--- a/libraries/classes/Logging.php
+++ b/libraries/classes/Logging.php
@@ -82,7 +82,7 @@ class Logging
         }
 
         $logFile = self::getLogDestination($settings->authLog);
-        if (empty($logFile)) {
+        if ($logFile === '') {
             return;
         }
 

--- a/libraries/classes/Message.php
+++ b/libraries/classes/Message.php
@@ -147,7 +147,7 @@ class Message implements Stringable
      */
     public static function success(string $string = ''): self
     {
-        if (empty($string)) {
+        if ($string === '') {
             $string = __('Your SQL query has been executed successfully.');
         }
 
@@ -165,7 +165,7 @@ class Message implements Stringable
      */
     public static function error(string $string = ''): self
     {
-        if (empty($string)) {
+        if ($string === '') {
             $string = __('Error');
         }
 
@@ -470,7 +470,7 @@ class Message implements Stringable
      */
     private function addMessageToList(self $message, string $separator): void
     {
-        if (! empty($separator)) {
+        if ($separator !== '') {
             $this->addedMessages[] = $separator;
         }
 

--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -493,15 +493,15 @@ class NavigationTree
     {
         $retval = [];
         if (! $table->hasChildren()) {
-            if ($table->getPresence('columns')) {
+            if ($table->getPresence('columns') !== 0) {
                 $retval['columns'] = new NodeColumnContainer();
             }
 
-            if ($table->getPresence('indexes')) {
+            if ($table->getPresence('indexes') !== 0) {
                 $retval['indexes'] = new NodeIndexContainer();
             }
 
-            if ($table->getPresence('triggers')) {
+            if ($table->getPresence('triggers') !== 0) {
                 $retval['triggers'] = new NodeTriggerContainer();
             }
 

--- a/libraries/classes/Navigation/Nodes/Node.php
+++ b/libraries/classes/Navigation/Nodes/Node.php
@@ -493,7 +493,7 @@ class Node
     private function getDatabasesToSearch(string $searchClause): array
     {
         $databases = [];
-        if (! empty($searchClause)) {
+        if ($searchClause !== '') {
             $databases = ['%' . $GLOBALS['dbi']->escapeString($searchClause) . '%'];
         } elseif (! empty($GLOBALS['cfg']['Server']['only_db'])) {
             $databases = $GLOBALS['cfg']['Server']['only_db'];
@@ -516,7 +516,7 @@ class Node
     private function getWhereClause(string $columnName, string $searchClause = ''): string
     {
         $whereClause = 'WHERE TRUE ';
-        if (! empty($searchClause)) {
+        if ($searchClause !== '') {
             $whereClause .= 'AND ' . Util::backquote($columnName)
                 . " LIKE '%";
             $whereClause .= $GLOBALS['dbi']->escapeString($searchClause);

--- a/libraries/classes/Plugins/Auth/AuthenticationCookie.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationCookie.php
@@ -145,11 +145,11 @@ class AuthenticationCookie extends AuthenticationPlugin
         $formParams = [];
         $formParams['route'] = Routing::$route;
 
-        if (strlen($GLOBALS['db'])) {
+        if ($GLOBALS['db'] !== '') {
             $formParams['db'] = $GLOBALS['db'];
         }
 
-        if (strlen($GLOBALS['table'])) {
+        if ($GLOBALS['table'] !== '') {
             $formParams['table'] = $GLOBALS['table'];
         }
 
@@ -436,7 +436,7 @@ class AuthenticationCookie extends AuthenticationPlugin
 
             if ($GLOBALS['cfg']['Server']['host'] != $GLOBALS['pma_auth_server']) {
                 $GLOBALS['cfg']['Server']['host'] = $tmpHost;
-                if (! empty($tmpPort)) {
+                if ($tmpPort !== '') {
                     $GLOBALS['cfg']['Server']['port'] = $tmpPort;
                 }
             }

--- a/libraries/classes/Plugins/Auth/AuthenticationHttp.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationHttp.php
@@ -102,22 +102,22 @@ class AuthenticationHttp extends AuthenticationPlugin
             $this->user = $GLOBALS['PHP_AUTH_USER'];
         }
 
-        if (empty($this->user)) {
-            if (Core::getenv('PHP_AUTH_USER')) {
+        if ($this->user === '') {
+            if (Core::getenv('PHP_AUTH_USER') !== '') {
                 $this->user = Core::getenv('PHP_AUTH_USER');
-            } elseif (Core::getenv('REMOTE_USER')) {
+            } elseif (Core::getenv('REMOTE_USER') !== '') {
                 // CGI, might be encoded, see below
                 $this->user = Core::getenv('REMOTE_USER');
-            } elseif (Core::getenv('REDIRECT_REMOTE_USER')) {
+            } elseif (Core::getenv('REDIRECT_REMOTE_USER') !== '') {
                 // CGI, might be encoded, see below
                 $this->user = Core::getenv('REDIRECT_REMOTE_USER');
-            } elseif (Core::getenv('AUTH_USER')) {
+            } elseif (Core::getenv('AUTH_USER') !== '') {
                 // WebSite Professional
                 $this->user = Core::getenv('AUTH_USER');
-            } elseif (Core::getenv('HTTP_AUTHORIZATION')) {
+            } elseif (Core::getenv('HTTP_AUTHORIZATION') !== '') {
                 // IIS, might be encoded, see below
                 $this->user = Core::getenv('HTTP_AUTHORIZATION');
-            } elseif (Core::getenv('Authorization')) {
+            } elseif (Core::getenv('Authorization') !== '') {
                 // FastCGI, might be encoded, see below
                 $this->user = Core::getenv('Authorization');
             }
@@ -129,12 +129,12 @@ class AuthenticationHttp extends AuthenticationPlugin
         }
 
         if ($this->password === '') {
-            if (Core::getenv('PHP_AUTH_PW')) {
+            if (Core::getenv('PHP_AUTH_PW') !== '') {
                 $this->password = Core::getenv('PHP_AUTH_PW');
-            } elseif (Core::getenv('REMOTE_PASSWORD')) {
+            } elseif (Core::getenv('REMOTE_PASSWORD') !== '') {
                 // Apache/CGI
                 $this->password = Core::getenv('REMOTE_PASSWORD');
-            } elseif (Core::getenv('AUTH_PASSWORD')) {
+            } elseif (Core::getenv('AUTH_PASSWORD') !== '') {
                 // WebSite Professional
                 $this->password = Core::getenv('AUTH_PASSWORD');
             }

--- a/libraries/classes/Plugins/Auth/AuthenticationSignon.php
+++ b/libraries/classes/Plugins/Auth/AuthenticationSignon.php
@@ -192,7 +192,7 @@ class AuthenticationSignon extends AuthenticationPlugin
                     session_name($oldSession);
                 }
 
-                if (! empty($oldId)) {
+                if ($oldId !== '' && $oldId !== false) {
                     session_id($oldId);
                 }
 
@@ -221,7 +221,7 @@ class AuthenticationSignon extends AuthenticationPlugin
         }
 
         // Returns whether we get authentication settings or not
-        if (empty($this->user)) {
+        if ($this->user === '') {
             unset($_SESSION['LAST_SIGNON_URL']);
 
             return false;

--- a/libraries/classes/Plugins/Export/ExportCodegen.php
+++ b/libraries/classes/Plugins/Export/ExportCodegen.php
@@ -217,7 +217,7 @@ class ExportCodegen extends ExportPlugin
         $tableProperties = [];
         while ($row = $result->fetchRow()) {
             $colAs = $this->getAlias($aliases, $row[0], 'col', $db, $table);
-            if (! empty($colAs)) {
+            if ($colAs !== '') {
                 $row[0] = $colAs;
             }
 
@@ -327,7 +327,7 @@ class ExportCodegen extends ExportPlugin
 
         while ($row = $result->fetchRow()) {
             $colAs = $this->getAlias($aliases, $row[0], 'col', $db, $table);
-            if (! empty($colAs)) {
+            if ($colAs !== '') {
                 $row[0] = $colAs;
             }
 

--- a/libraries/classes/Plugins/Export/ExportJson.php
+++ b/libraries/classes/Plugins/Export/ExportJson.php
@@ -290,7 +290,7 @@ class ExportJson extends ExportPlugin
             }
 
             $encodedData = $this->encode($data);
-            if (! $encodedData) {
+            if ($encodedData === '' || $encodedData === false) {
                 return false;
             }
 

--- a/libraries/classes/Plugins/Export/ExportOdt.php
+++ b/libraries/classes/Plugins/Export/ExportOdt.php
@@ -173,7 +173,7 @@ class ExportOdt extends ExportPlugin
      */
     public function exportDBHeader(string $db, string $dbAlias = ''): bool
     {
-        if (empty($dbAlias)) {
+        if ($dbAlias === '') {
             $dbAlias = $db;
         }
 
@@ -694,7 +694,7 @@ class ExportOdt extends ExportPlugin
      */
     protected function formatOneColumnDefinition(array $column, string $colAs = ''): string
     {
-        if (empty($colAs)) {
+        if ($colAs === '') {
             $colAs = $column['Field'];
         }
 
@@ -705,7 +705,7 @@ class ExportOdt extends ExportPlugin
 
         $extractedColumnSpec = Util::extractColumnSpec($column['Type']);
         $type = htmlspecialchars($extractedColumnSpec['print_type']);
-        if (empty($type)) {
+        if ($type === '') {
             $type = '&nbsp;';
         }
 

--- a/libraries/classes/Plugins/Export/ExportPhparray.php
+++ b/libraries/classes/Plugins/Export/ExportPhparray.php
@@ -103,7 +103,7 @@ class ExportPhparray extends ExportPlugin
      */
     public function exportDBHeader(string $db, string $dbAlias = ''): bool
     {
-        if (empty($dbAlias)) {
+        if ($dbAlias === '') {
             $dbAlias = $db;
         }
 

--- a/libraries/classes/Plugins/Export/ExportSql.php
+++ b/libraries/classes/Plugins/Export/ExportSql.php
@@ -566,7 +566,7 @@ class ExportSql extends ExportPlugin
             $text .= "\n"
                 . 'DELIMITER ' . $delimiter . "\n";
 
-            if ($procedureNames) {
+            if ($procedureNames !== []) {
                 $text .= $this->exportRoutineSQL(
                     $db,
                     $aliases,
@@ -577,7 +577,7 @@ class ExportSql extends ExportPlugin
                 );
             }
 
-            if ($functionNames) {
+            if ($functionNames !== []) {
                 $text .= $this->exportRoutineSQL(
                     $db,
                     $aliases,
@@ -2580,9 +2580,9 @@ class ExportSql extends ExportPlugin
                 $isKeyword = $token->type === Token::TYPE_KEYWORD;
                 $isNone = $token->type === Token::TYPE_NONE;
                 $replaceToken = $isSymbol
-                    && (! ($token->flags & Token::FLAG_SYMBOL_VARIABLE))
+                    && (($token->flags & Token::FLAG_SYMBOL_VARIABLE) === 0)
                     || ($isKeyword
-                    && (! ($token->flags & Token::FLAG_KEYWORD_RESERVED))
+                    && (($token->flags & Token::FLAG_KEYWORD_RESERVED) === 0)
                     || $isNone);
 
                 if (! $replaceToken) {

--- a/libraries/classes/Plugins/Export/Helpers/Pdf.php
+++ b/libraries/classes/Plugins/Export/Helpers/Pdf.php
@@ -162,7 +162,11 @@ class Pdf extends PdfLib
         if (! isset($this->headerset[$this->page])) {
             $this->setY($this->tMargin - ($this->FontSizePt / $this->k) * 5);
             $cellFontSize = $this->FontSizePt;
-            $this->setFont(PdfLib::PMA_PDF_FONT, '', ($this->titleFontSize ?: $this->FontSizePt));
+            $this->setFont(
+                PdfLib::PMA_PDF_FONT,
+                '',
+                ($this->titleFontSize !== 0 ? $this->titleFontSize : $this->FontSizePt),
+            );
             $this->Cell(0, $this->FontSizePt, $this->titleText, 0, 1, 'C');
             $this->setFont(PdfLib::PMA_PDF_FONT, '', $cellFontSize);
             $this->setY($this->tMargin - ($this->FontSizePt / $this->k) * 2.5);

--- a/libraries/classes/Plugins/Import/ImportCsv.php
+++ b/libraries/classes/Plugins/Import/ImportCsv.php
@@ -702,7 +702,7 @@ class ImportCsv extends AbstractImportCsv
             return $_REQUEST['csv_new_tbl_name'];
         }
 
-        if (mb_strlen($databaseName)) {
+        if ($databaseName !== '') {
             $result = $GLOBALS['dbi']->fetchResult('SHOW TABLES');
 
             // logic to get table name from filename

--- a/libraries/classes/Plugins/Import/ImportMediawiki.php
+++ b/libraries/classes/Plugins/Import/ImportMediawiki.php
@@ -323,7 +323,7 @@ class ImportMediawiki extends ImportPlugin
      */
     private function setTableName(string &$tableName): void
     {
-        if (! empty($tableName)) {
+        if ($tableName !== '') {
             return;
         }
 

--- a/libraries/classes/Plugins/Import/ImportOds.php
+++ b/libraries/classes/Plugins/Import/ImportOds.php
@@ -265,7 +265,7 @@ class ImportOds extends ImportPlugin
             if ($text->count() != 0) {
                 $attr = $cell->attributes('table', true);
                 $numRepeat = (int) $attr['number-columns-repeated'];
-                $numIterations = $numRepeat ?: 1;
+                $numIterations = $numRepeat !== 0 ? $numRepeat : 1;
 
                 for ($k = 0; $k < $numIterations; $k++) {
                     $value = $this->getValue($cellAttrs, $text);
@@ -291,7 +291,7 @@ class ImportOds extends ImportPlugin
             $attr = $cell->attributes('table', true);
             $numNull = (int) $attr['number-columns-repeated'];
 
-            if ($numNull) {
+            if ($numNull !== 0) {
                 if (! $colNamesInFirstRow) {
                     for ($i = 0; $i < $numNull; ++$i) {
                         $tempRow[] = 'NULL';

--- a/libraries/classes/Plugins/Import/Upload/UploadProgress.php
+++ b/libraries/classes/Plugins/Import/Upload/UploadProgress.php
@@ -68,7 +68,7 @@ class UploadProgress implements UploadInterface
             $status = \uploadprogress_get_info($id);
         }
 
-        if ($status) {
+        if ($status !== null && $status !== []) {
             $ret['finished'] = false;
 
             if ($status['bytes_uploaded'] == $status['bytes_total']) {

--- a/libraries/classes/Plugins/Schema/ExportRelationSchema.php
+++ b/libraries/classes/Plugins/Schema/ExportRelationSchema.php
@@ -254,7 +254,7 @@ class ExportRelationSchema
     public static function dieSchema(int $pageNumber, string $type = '', string $errorMessage = ''): never
     {
         echo '<p><strong>' , __('SCHEMA ERROR: ') , $type , '</strong></p>' , "\n";
-        if (! empty($errorMessage)) {
+        if ($errorMessage !== '') {
             $errorMessage = htmlspecialchars($errorMessage);
         }
 

--- a/libraries/classes/Plugins/Transformations/Abs/CodeMirrorEditorTransformationPlugin.php
+++ b/libraries/classes/Plugins/Transformations/Abs/CodeMirrorEditorTransformationPlugin.php
@@ -50,7 +50,7 @@ abstract class CodeMirrorEditorTransformationPlugin extends IOTransformationsPlu
         int $fieldIndex,
     ): string {
         $html = '';
-        if (! empty($value)) {
+        if ($value !== '') {
             $html = '<input type="hidden" name="fields_prev' . $columnNameAppendix
                 . '" value="' . htmlspecialchars($value) . '">';
         }

--- a/libraries/classes/Plugins/Transformations/Abs/TextFileUploadTransformationsPlugin.php
+++ b/libraries/classes/Plugins/Transformations/Abs/TextFileUploadTransformationsPlugin.php
@@ -59,7 +59,7 @@ abstract class TextFileUploadTransformationsPlugin extends IOTransformationsPlug
         int $fieldIndex,
     ): string {
         $html = '';
-        if (! empty($value)) {
+        if ($value !== '') {
             $html = '<input type="hidden" name="fields_prev' . $columnNameAppendix
                 . '" value="' . htmlspecialchars($value) . '">';
             $html .= '<input type="hidden" name="fields' . $columnNameAppendix

--- a/libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptobinary.php
+++ b/libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptobinary.php
@@ -67,7 +67,7 @@ class Text_Plain_Iptobinary extends IOTransformationsPlugin
     ): string {
         $html = '';
         $val = '';
-        if (! empty($value)) {
+        if ($value !== '') {
             $length = strlen($value);
             if ($length == 4 || $length == 16) {
                 $ip = @inet_ntop(pack('A' . $length, $value));

--- a/libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptolong.php
+++ b/libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptolong.php
@@ -65,7 +65,7 @@ class Text_Plain_Iptolong extends IOTransformationsPlugin
         $html = '';
         $val = '';
 
-        if (! empty($value)) {
+        if ($value !== '') {
             $val = FormatConverter::longToIp($value);
 
             if ($value !== $val) {

--- a/libraries/classes/Plugins/TwoFactorPlugin.php
+++ b/libraries/classes/Plugins/TwoFactorPlugin.php
@@ -52,7 +52,7 @@ class TwoFactorPlugin
     public function getError(): string
     {
         if ($this->provided) {
-            if (! empty($this->message)) {
+            if ($this->message !== '') {
                 return Message::rawError(
                     sprintf(__('Two-factor authentication failed: %s'), $this->message),
                 )->getDisplay();

--- a/libraries/classes/Replication/ReplicationInfo.php
+++ b/libraries/classes/Replication/ReplicationInfo.php
@@ -76,10 +76,10 @@ final class ReplicationInfo
 
         $this->setPrimaryStatus();
 
-        if (! empty($connection)) {
+        if ($connection !== null && $connection !== '') {
             $this->setMultiPrimaryStatus();
 
-            if ($this->multiPrimaryStatus) {
+            if ($this->multiPrimaryStatus !== []) {
                 $this->setDefaultPrimaryConnection($connection);
                 $GLOBALS['urlParams']['primary_connection'] = $connection;
             }

--- a/libraries/classes/Server/Privileges.php
+++ b/libraries/classes/Server/Privileges.php
@@ -2078,7 +2078,7 @@ class Privileges
         if (isset($_POST['change_copy'])) {
             $userHostCondition = $this->getUserHostCondition($oldUsername, $oldHostname);
             $row = $this->dbi->fetchSingleRow('SELECT * FROM `mysql`.`user` ' . $userHostCondition . ';');
-            if (! $row) {
+            if ($row === null || $row === []) {
                 $response = ResponseRenderer::getInstance();
                 $response->addHTML(
                     Message::notice(__('No user found.'))->getDisplay(),

--- a/libraries/classes/Server/Status/Monitor.php
+++ b/libraries/classes/Server/Status/Monitor.php
@@ -60,7 +60,7 @@ class Monitor
 
         // Retrieve all required status variables
         $statusVarValues = [];
-        if (count($statusVars)) {
+        if ($statusVars !== []) {
             $statusVarValues = $this->dbi->fetchResult(
                 "SHOW GLOBAL STATUS WHERE Variable_name='"
                 . implode("' OR Variable_name='", $statusVars) . "'",
@@ -71,7 +71,7 @@ class Monitor
 
         // Retrieve all required server variables
         $serverVarValues = [];
-        if (count($serverVars)) {
+        if ($serverVars !== []) {
             $serverVarValues = $this->dbi->fetchResult(
                 "SHOW GLOBAL VARIABLES WHERE Variable_name='"
                 . implode("' OR Variable_name='", $serverVars) . "'",

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -342,7 +342,7 @@ class Sql
                 || $statementInfo->isFunction
                 || $statementInfo->isAnalyse)
             && $statementInfo->selectFrom
-            && (empty($statementInfo->selectExpression)
+            && ($statementInfo->selectExpression === []
                 || ((count($statementInfo->selectExpression) === 1)
                     && ($statementInfo->selectExpression[0] === '*')))
             && count($statementInfo->selectTables) === 1;
@@ -395,9 +395,8 @@ class Sql
      */
     private function isDeleteTransformationInfo(StatementInfo $statementInfo): bool
     {
-        return ! empty($statementInfo->queryType)
-            && (($statementInfo->queryType === 'ALTER')
-                || ($statementInfo->queryType === 'DROP'));
+        return $statementInfo->queryType !== '' && $statementInfo->queryType !== false
+            && ($statementInfo->queryType === 'ALTER' || $statementInfo->queryType === 'DROP');
     }
 
     /**
@@ -766,7 +765,7 @@ class Sql
         $error = $this->dbi->getError();
         if ($error && $GLOBALS['cfg']['IgnoreMultiSubmitErrors']) {
             $errorMessage = $error;
-        } elseif ($error) {
+        } elseif ($error !== '') {
             $this->handleQueryExecuteError($isGotoFile, $error, $fullSqlQuery);
         }
 

--- a/libraries/classes/SqlQueryForm.php
+++ b/libraries/classes/SqlQueryForm.php
@@ -54,7 +54,7 @@ class SqlQueryForm
         bool|string $displayTab = false,
         string $delimiter = ';',
     ): string {
-        if (! $displayTab) {
+        if ($displayTab === false || $displayTab === '') {
             $displayTab = 'full';
         }
 

--- a/libraries/classes/StorageEngine.php
+++ b/libraries/classes/StorageEngine.php
@@ -314,7 +314,7 @@ class StorageEngine
                   . '</tr>' . "\n";
         }
 
-        if (! $ret) {
+        if ($ret === '') {
             return '<p>' . "\n"
                 . '    '
                 . __('There is no detailed status information available for this storage engine.')
@@ -354,7 +354,7 @@ class StorageEngine
         $variables = $this->getVariables();
         $like = $this->getVariablesLikePattern();
 
-        if ($like) {
+        if ($like !== '') {
             $like = " LIKE '" . $like . "' ";
         } else {
             $like = '';
@@ -367,7 +367,7 @@ class StorageEngine
         foreach ($res as $row) {
             if (isset($variables[$row['Variable_name']])) {
                 $mysqlVars[$row['Variable_name']] = $variables[$row['Variable_name']];
-            } elseif (! $like && mb_stripos($row['Variable_name'], $this->engine) !== 0) {
+            } elseif ($like === '' && mb_stripos($row['Variable_name'], $this->engine) !== 0) {
                 continue;
             }
 

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -532,7 +532,7 @@ class Table implements Stringable
             $query .= ' AS (' . $expression . ') ' . $virtuality;
         }
 
-        if (! $virtuality || $isVirtualColMysql) {
+        if ($virtuality === '' || $isVirtualColMysql) {
             if ($null !== false) {
                 if ($null === 'YES') {
                     $query .= ' NULL';
@@ -541,7 +541,7 @@ class Table implements Stringable
                 }
             }
 
-            if (! $virtuality) {
+            if ($virtuality === '') {
                 switch ($defaultType) {
                     case 'USER_DEFINED':
                         if ($isTimestamp && $defaultValue === '0') {
@@ -606,7 +606,7 @@ class Table implements Stringable
             }
 
             if ($extra !== '') {
-                if ($virtuality) {
+                if ($virtuality !== '') {
                     $extra = trim((string) preg_replace('~^\s*AUTO_INCREMENT\s*~is', ' ', $extra));
                 }
 
@@ -625,7 +625,7 @@ class Table implements Stringable
             $query .= ' AFTER ' . Util::backquote($moveTo);
         }
 
-        if (! $virtuality && $extra !== '') {
+        if ($virtuality === '' && $extra !== '') {
             if ($oldColumnName === null) {
                 if (is_array($columnsWithIndex) && ! in_array($name, $columnsWithIndex)) {
                     $query .= ', add PRIMARY KEY (' . Util::backquote($name) . ')';
@@ -1983,7 +1983,7 @@ class Table implements Stringable
                     ' ADD %s',
                     $index->getChoice(),
                 );
-                if ($index->getName()) {
+                if ($index->getName() !== '') {
                     $sqlQuery .= ' ' . Util::backquote($index->getName());
                 }
 

--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -528,7 +528,7 @@ class Table implements Stringable
             );
         }
 
-        if ($virtuality) {
+        if ($virtuality !== '') {
             $query .= ' AS (' . $expression . ') ' . $virtuality;
         }
 

--- a/libraries/classes/Table/Maintenance.php
+++ b/libraries/classes/Table/Maintenance.php
@@ -109,7 +109,7 @@ final class Maintenance
         foreach ($tables as $table) {
             $check = Index::findDuplicates($table->getName(), $db->getName());
 
-            if (empty($check)) {
+            if ($check === '') {
                 continue;
             }
 

--- a/libraries/classes/Table/Search.php
+++ b/libraries/classes/Table/Search.php
@@ -108,7 +108,7 @@ final class Search
                 $tmpGeomFunc,
             );
 
-            if (! $whereClause) {
+            if ($whereClause === '') {
                 continue;
             }
 
@@ -143,7 +143,7 @@ final class Search
         string|null $geomFunc = null,
     ): string {
         // If geometry function is set
-        if (! empty($geomFunc)) {
+        if ($geomFunc !== null && $geomFunc !== '') {
             return $this->getGeomWhereClause($criteriaValues, $names, $funcType, $types, $geomFunc);
         }
 

--- a/libraries/classes/Tracking/Tracking.php
+++ b/libraries/classes/Tracking/Tracking.php
@@ -76,7 +76,7 @@ class Tracking
             $this->dbi->quoteString($dbName, Connection::TYPE_CONTROL),
             $this->dbi->quoteString($tableName, Connection::TYPE_CONTROL),
         );
-        if ($version) {
+        if ($version !== '') {
             $sqlQuery .= ' AND `version` = ' . $this->dbi->quoteString($version, Connection::TYPE_CONTROL);
         }
 

--- a/libraries/classes/Triggers/Triggers.php
+++ b/libraries/classes/Triggers/Triggers.php
@@ -14,7 +14,6 @@ use Webmozart\Assert\Assert;
 use function __;
 use function array_column;
 use function array_multisort;
-use function count;
 use function explode;
 use function htmlspecialchars;
 use function in_array;
@@ -69,7 +68,7 @@ class Triggers
         $itemQuery = $this->getQueryFromRequest();
 
         // set by getQueryFromRequest()
-        if (! count($GLOBALS['errors'])) {
+        if ($GLOBALS['errors'] === []) {
             // Execute the created query
             if (! empty($_POST['editor_process_edit'])) {
                 // Backup the old trigger, in case something goes wrong
@@ -132,7 +131,7 @@ class Triggers
             }
         }
 
-        if (count($GLOBALS['errors'])) {
+        if ($GLOBALS['errors'] !== []) {
             $GLOBALS['message'] = Message::error(
                 '<b>'
                 . __(

--- a/libraries/classes/UserPreferences.php
+++ b/libraries/classes/UserPreferences.php
@@ -267,7 +267,7 @@ class UserPreferences
             $urlParams = array_merge($params, $urlParams);
         }
 
-        if ($hash) {
+        if ($hash !== null && $hash !== '') {
             $hash = '#' . urlencode($hash);
         }
 

--- a/libraries/classes/Util.php
+++ b/libraries/classes/Util.php
@@ -806,10 +806,10 @@ class Util
         $clauseIsUnique = true;
 
         $conditionArray = [];
-        if ($primaryKey) {
+        if ($primaryKey !== '') {
             $preferredCondition = $primaryKey;
             $conditionArray = $primaryKeyArray;
-        } elseif ($uniqueKey) {
+        } elseif ($uniqueKey !== '') {
             $preferredCondition = $uniqueKey;
             $conditionArray = $uniqueKeyArray;
         } elseif (! $forceUnique) {

--- a/libraries/classes/Utils/HttpRequest.php
+++ b/libraries/classes/Utils/HttpRequest.php
@@ -162,7 +162,7 @@ class HttpRequest
             $curlStatus &= (int) curl_setopt($curlHandle, CURLOPT_CUSTOMREQUEST, $method);
         }
 
-        if ($header) {
+        if ($header !== '') {
             $curlStatus &= (int) curl_setopt($curlHandle, CURLOPT_HTTPHEADER, [$header]);
         }
 
@@ -186,7 +186,7 @@ class HttpRequest
         $curlStatus &= (int) curl_setopt($curlHandle, CURLOPT_TIMEOUT, 10);
         $curlStatus &= (int) curl_setopt($curlHandle, CURLOPT_CONNECTTIMEOUT, 10);
 
-        if (! $curlStatus) {
+        if ($curlStatus === 0) {
             return null;
         }
 
@@ -226,7 +226,7 @@ class HttpRequest
             ],
             'ssl' => ['verify_peer' => true, 'verify_peer_name' => true],
         ];
-        if ($header) {
+        if ($header !== '') {
             $context['http']['header'] .= "\n" . $header;
         }
 

--- a/libraries/classes/VersionInformation.php
+++ b/libraries/classes/VersionInformation.php
@@ -107,7 +107,7 @@ class VersionInformation
             $result += (int) $parts[3];
         }
 
-        if (! empty($suffix)) {
+        if ($suffix !== '') {
             $matches = [];
             if (preg_match('/^(\D+)(\d+)$/', $suffix, $matches)) {
                 $suffix = $matches[1];

--- a/libraries/classes/WebAuthn/CBORDecoder.php
+++ b/libraries/classes/WebAuthn/CBORDecoder.php
@@ -223,7 +223,7 @@ final class CBORDecoder
             $val = $mant === 0 ? INF : NAN;
         }
 
-        return $half & 0x8000 ? -$val : $val;
+        return ($half & 0x8000) !== 0 ? -$val : $val;
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,11 +66,6 @@ parameters:
 			path: libraries/classes/Bookmark.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Bookmark.php
-
-		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:escapeString\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Bookmark.php
@@ -112,11 +107,6 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: libraries/classes/BrowseForeigners.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: libraries/classes/BrowseForeigners.php
 
@@ -261,11 +251,6 @@ parameters:
 			path: libraries/classes/Command/TwigLintCommand.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Command/TwigLintCommand.php
-
-		-
 			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int\\)\\: bool\\)\\|null, Closure\\(int, string, string, int\\)\\: mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Command/TwigLintCommand.php
@@ -406,11 +391,6 @@ parameters:
 			path: libraries/classes/Config.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
-			count: 1
-			path: libraries/classes/Config.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
 			count: 3
 			path: libraries/classes/Config.php
@@ -432,11 +412,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Config.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
 			count: 1
 			path: libraries/classes/Config.php
 
@@ -716,11 +691,6 @@ parameters:
 			path: libraries/classes/Config/FormDisplay.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
-			count: 1
-			path: libraries/classes/Config/FormDisplay.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 2
 			path: libraries/classes/Config/FormDisplay.php
@@ -896,11 +866,6 @@ parameters:
 			path: libraries/classes/Config/Forms/User/FeaturesForm.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Config/PageSettings.php
-
-		-
 			message: "#^Parameter \\#1 \\$url of method PhpMyAdmin\\\\ResponseRenderer\\:\\:redirect\\(\\) expects non\\-empty\\-string, string given\\.$#"
 			count: 1
 			path: libraries/classes/Config/PageSettings.php
@@ -913,11 +878,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 6
-			path: libraries/classes/Config/ServerConfigChecks.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
-			count: 1
 			path: libraries/classes/Config/ServerConfigChecks.php
 
 		-
@@ -1491,18 +1451,8 @@ parameters:
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\|bool given\\.$#"
-			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 3
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
-			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
@@ -1523,11 +1473,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, bool\\|string\\|null given\\.$#"
 			count: 1
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 5
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
@@ -1618,11 +1563,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$tableName of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTable\\(\\) expects string, mixed given\\.$#"
 			count: 2
-			path: libraries/classes/ConfigStorage/Relation.php
-
-		-
-			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
-			count: 1
 			path: libraries/classes/ConfigStorage/Relation.php
 
 		-
@@ -1986,11 +1926,6 @@ parameters:
 			path: libraries/classes/Controllers/Database/DesignerController.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/DesignerController.php
-
-		-
 			message: "#^Parameter \\#1 \\$db of method PhpMyAdmin\\\\Database\\\\Designer\\:\\:getDatabaseTables\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/DesignerController.php
@@ -2188,11 +2123,6 @@ parameters:
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 18
-			path: libraries/classes/Controllers/Database/EventsController.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, string\\|null given\\.$#"
-			count: 1
 			path: libraries/classes/Controllers/Database/EventsController.php
 
 		-
@@ -2731,11 +2661,6 @@ parameters:
 			path: libraries/classes/Controllers/Database/RoutinesController.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Database/RoutinesController.php
-
-		-
 			message: "#^Parameter \\#1 \\$database of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTables\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Database/RoutinesController.php
@@ -3107,7 +3032,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 5
+			count: 1
 			path: libraries/classes/Controllers/Database/Structure/DropFormController.php
 
 		-
@@ -3142,7 +3067,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 5
+			count: 2
 			path: libraries/classes/Controllers/Database/Structure/DropTableController.php
 
 		-
@@ -4856,11 +4781,6 @@ parameters:
 			path: libraries/classes/Controllers/Import/SimulateDmlController.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Import/SimulateDmlController.php
-
-		-
 			message: "#^Parameter \\#1 \\$separator of function explode expects non\\-empty\\-string, string given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Import/SimulateDmlController.php
@@ -5186,11 +5106,6 @@ parameters:
 			path: libraries/classes/Controllers/Preferences/ExportController.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, PhpMyAdmin\\\\Message\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Preferences/ExportController.php
-
-		-
 			message: "#^Parameter \\#1 \\$configArray of method PhpMyAdmin\\\\UserPreferences\\:\\:save\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Preferences/ExportController.php
@@ -5217,11 +5132,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method getConfigArray\\(\\) on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Preferences/FeaturesController.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, PhpMyAdmin\\\\Message\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Preferences/FeaturesController.php
 
@@ -5256,11 +5166,6 @@ parameters:
 			path: libraries/classes/Controllers/Preferences/ImportController.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, PhpMyAdmin\\\\Message\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Preferences/ImportController.php
-
-		-
 			message: "#^Parameter \\#1 \\$configArray of method PhpMyAdmin\\\\UserPreferences\\:\\:save\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Preferences/ImportController.php
@@ -5287,11 +5192,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method getConfigArray\\(\\) on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Preferences/MainPanelController.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, PhpMyAdmin\\\\Message\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Preferences/MainPanelController.php
 
@@ -5416,11 +5316,6 @@ parameters:
 			path: libraries/classes/Controllers/Preferences/NavigationController.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, PhpMyAdmin\\\\Message\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Preferences/NavigationController.php
-
-		-
 			message: "#^Parameter \\#1 \\$configArray of method PhpMyAdmin\\\\UserPreferences\\:\\:save\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Preferences/NavigationController.php
@@ -5447,11 +5342,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method getConfigArray\\(\\) on mixed\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Preferences/SqlController.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, PhpMyAdmin\\\\Message\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Preferences/SqlController.php
 
@@ -7006,11 +6896,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/CreateController.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, array\\<array\\<string, string\\|null\\>\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/CreateController.php
-
-		-
 			message: "#^Parameter \\#1 \\$database of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumns\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/CreateController.php
@@ -7381,11 +7266,6 @@ parameters:
 			path: libraries/classes/Controllers/Table/GetFieldController.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<array\\<string, string\\|null\\>\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/GetFieldController.php
-
-		-
 			message: "#^Parameter \\#1 \\$database of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumns\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/GetFieldController.php
@@ -7742,7 +7622,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 10
+			count: 9
 			path: libraries/classes/Controllers/Table/OperationsController.php
 
 		-
@@ -9636,27 +9516,12 @@ parameters:
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/ZoomSearchController.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\|false given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/ZoomSearchController.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/Table/ZoomSearchController.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/Table/ZoomSearchController.php
 
@@ -10136,11 +10001,6 @@ parameters:
 			path: libraries/classes/Controllers/View/OperationsController.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Controllers/View/OperationsController.php
-
-		-
 			message: "#^Parameter \\#1 \\$dbName of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTable\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Controllers/View/OperationsController.php
@@ -10576,11 +10436,6 @@ parameters:
 			path: libraries/classes/Database/CentralColumns.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, int given\\.$#"
-			count: 1
-			path: libraries/classes/Database/CentralColumns.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Database/CentralColumns.php
@@ -10588,11 +10443,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
 			count: 3
-			path: libraries/classes/Database/CentralColumns.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
 			path: libraries/classes/Database/CentralColumns.php
 
 		-
@@ -10887,7 +10737,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 3
+			count: 2
 			path: libraries/classes/Database/Designer/Common.php
 
 		-
@@ -10987,7 +10837,7 @@ parameters:
 
 		-
 			message: "#^Cannot access an offset on mixed\\.$#"
-			count: 9
+			count: 6
 			path: libraries/classes/Database/Events.php
 
 		-
@@ -11026,21 +10876,6 @@ parameters:
 			path: libraries/classes/Database/Events.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Events.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Events.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Database/Events.php
-
-		-
 			message: "#^Parameter \\#1 \\$haystack of function str_contains expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Database/Events.php
@@ -11063,11 +10898,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$str of method PhpMyAdmin\\\\DatabaseInterface\\:\\:quoteString\\(\\) expects string, mixed given\\.$#"
 			count: 5
-			path: libraries/classes/Database/Events.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 2
 			path: libraries/classes/Database/Events.php
 
 		-
@@ -11258,11 +11088,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
 			count: 4
-			path: libraries/classes/Database/Routines.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\|null given\\.$#"
-			count: 1
 			path: libraries/classes/Database/Routines.php
 
 		-
@@ -11601,22 +11426,7 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, array\\<string\\> given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, bool\\|string given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
 
@@ -12072,7 +11882,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 27
+			count: 26
 			path: libraries/classes/Display/Results.php
 
 		-
@@ -12126,11 +11936,6 @@ parameters:
 			path: libraries/classes/Display/Results.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<int, array\\<int, string\\|null\\>\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, bool\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Display/Results.php
@@ -12148,11 +11953,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
-			path: libraries/classes/Display/Results.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, array\\<int, string\\|null\\> given\\.$#"
-			count: 2
 			path: libraries/classes/Display/Results.php
 
 		-
@@ -12631,16 +12431,6 @@ parameters:
 			path: libraries/classes/ErrorHandler.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
-			count: 1
-			path: libraries/classes/ErrorHandler.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
-			count: 1
-			path: libraries/classes/ErrorHandler.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/ErrorHandler.php
@@ -12777,7 +12567,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, int\\<0, max\\>\\|false given\\.$#"
-			count: 3
+			count: 2
 			path: libraries/classes/Export/Export.php
 
 		-
@@ -13231,16 +13021,6 @@ parameters:
 			path: libraries/classes/Footer.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, int given\\.$#"
-			count: 1
-			path: libraries/classes/Footer.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
-			path: libraries/classes/Footer.php
-
-		-
 			message: "#^Parameter \\#1 \\$dbi of class PhpMyAdmin\\\\ConfigStorage\\\\Relation constructor expects PhpMyAdmin\\\\DatabaseInterface, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Footer.php
@@ -13282,11 +13062,6 @@ parameters:
 
 		-
 			message: "#^Only numeric types are allowed in \\-, int\\<0, max\\>\\|false given on the left side\\.$#"
-			count: 1
-			path: libraries/classes/Gis/GisGeometry.php
-
-		-
-			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: libraries/classes/Gis/GisGeometry.php
 
@@ -13751,11 +13526,6 @@ parameters:
 			path: libraries/classes/Git.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
-			count: 1
-			path: libraries/classes/Git.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Git.php
@@ -13976,16 +13746,6 @@ parameters:
 			path: libraries/classes/Header.php
 
 		-
-			message: "#^Only booleans are allowed in an elseif condition, int\\<0, max\\> given\\.$#"
-			count: 2
-			path: libraries/classes/Header.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Header.php
-
-		-
 			message: "#^Parameter \\#1 \\$db of method PhpMyAdmin\\\\Header\\:\\:addRecentTable\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Header.php
@@ -14008,11 +13768,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$message of static method PhpMyAdmin\\\\Html\\\\Generator\\:\\:getMessage\\(\\) expects PhpMyAdmin\\\\Message\\|string, mixed given\\.$#"
 			count: 1
-			path: libraries/classes/Header.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
-			count: 3
 			path: libraries/classes/Header.php
 
 		-
@@ -14426,11 +14181,6 @@ parameters:
 			path: libraries/classes/Html/Generator.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Html/MySQLDocumentation.php
-
-		-
 			message: "#^Parameter \\#1 \\$method of method PhpMyAdmin\\\\Http\\\\Factory\\\\ServerRequestFactory\\:\\:createServerRequest\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Http/Factory/ServerRequestFactory.php
@@ -14777,7 +14527,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 6
+			count: 3
 			path: libraries/classes/Import/SimulateDml.php
 
 		-
@@ -14827,11 +14577,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in &&, int\\<0, 8\\> given on the left side\\.$#"
-			count: 1
-			path: libraries/classes/Index.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<0, 16\\> given\\.$#"
 			count: 1
 			path: libraries/classes/Index.php
 
@@ -14903,11 +14648,6 @@ parameters:
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 3
-			path: libraries/classes/IndexColumn.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
-			count: 1
 			path: libraries/classes/IndexColumn.php
 
 		-
@@ -15057,7 +14797,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 4
+			count: 3
 			path: libraries/classes/InsertEdit.php
 
 		-
@@ -15151,22 +14891,7 @@ parameters:
 			path: libraries/classes/InsertEdit.php
 
 		-
-			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
-			count: 3
-			path: libraries/classes/InsertEdit.php
-
-		-
 			message: "#^Only booleans are allowed in an elseif condition, string\\|false given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, array given\\.$#"
-			count: 1
-			path: libraries/classes/InsertEdit.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
 			count: 1
 			path: libraries/classes/InsertEdit.php
 
@@ -15376,18 +15101,8 @@ parameters:
 			path: libraries/classes/IpAllowDeny.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/IpAllowDeny.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 3
-			path: libraries/classes/IpAllowDeny.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
 			path: libraries/classes/IpAllowDeny.php
 
 		-
@@ -15426,11 +15141,6 @@ parameters:
 			path: libraries/classes/Language.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Language.php
-
-		-
 			message: "#^Parameter \\#2 \\$path of function _bindtextdomain expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Language.php
@@ -15442,21 +15152,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\LanguageManager\\:\\:availableLocales\\(\\) should return array but returns array\\|false\\.$#"
-			count: 1
-			path: libraries/classes/LanguageManager.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array given\\.$#"
-			count: 1
-			path: libraries/classes/LanguageManager.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<PhpMyAdmin\\\\Language\\> given\\.$#"
-			count: 1
-			path: libraries/classes/LanguageManager.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
 			count: 1
 			path: libraries/classes/LanguageManager.php
 
@@ -15556,11 +15251,6 @@ parameters:
 			path: libraries/classes/ListDatabase.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
-			path: libraries/classes/ListDatabase.php
-
-		-
 			message: "#^Parameter \\#1 \\$array of function sort expects TArray of array\\<T\\>, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/ListDatabase.php
@@ -15594,11 +15284,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/ListDatabase.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Logging.php
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
@@ -15708,11 +15393,6 @@ parameters:
 		-
 			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
-			path: libraries/classes/Message.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 3
 			path: libraries/classes/Message.php
 
 		-
@@ -16081,11 +15761,6 @@ parameters:
 			path: libraries/classes/Navigation/NavigationTree.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
-			count: 3
-			path: libraries/classes/Navigation/NavigationTree.php
-
-		-
 			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
 			count: 1
 			path: libraries/classes/Navigation/NavigationTree.php
@@ -16342,7 +16017,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 7
+			count: 5
 			path: libraries/classes/Navigation/Nodes/Node.php
 
 		-
@@ -17617,7 +17292,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 23
+			count: 22
 			path: libraries/classes/Plugins/Auth/AuthenticationCookie.php
 
 		-
@@ -17633,11 +17308,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an elseif condition, string\\|false given\\.$#"
 			count: 1
-			path: libraries/classes/Plugins/Auth/AuthenticationCookie.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\> given\\.$#"
-			count: 2
 			path: libraries/classes/Plugins/Auth/AuthenticationCookie.php
 
 		-
@@ -17687,7 +17357,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
-			count: 6
+			count: 4
 			path: libraries/classes/Plugins/Auth/AuthenticationCookie.php
 
 		-
@@ -17762,22 +17432,12 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 5
-			path: libraries/classes/Plugins/Auth/AuthenticationHttp.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, string given\\.$#"
-			count: 7
+			count: 4
 			path: libraries/classes/Plugins/Auth/AuthenticationHttp.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
-			path: libraries/classes/Plugins/Auth/AuthenticationHttp.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 2
 			path: libraries/classes/Plugins/Auth/AuthenticationHttp.php
 
 		-
@@ -17847,7 +17507,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 4
+			count: 2
 			path: libraries/classes/Plugins/Auth/AuthenticationSignon.php
 
 		-
@@ -18038,11 +17698,6 @@ parameters:
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
-			path: libraries/classes/Plugins/Export/ExportCodegen.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
 			path: libraries/classes/Plugins/Export/ExportCodegen.php
 
 		-
@@ -18242,11 +17897,6 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/ExportJson.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/ExportJson.php
 
@@ -18687,7 +18337,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 8
+			count: 5
 			path: libraries/classes/Plugins/Export/ExportOdt.php
 
 		-
@@ -18827,7 +18477,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
+			count: 1
 			path: libraries/classes/Plugins/Export/ExportPhparray.php
 
 		-
@@ -19171,16 +18821,6 @@ parameters:
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<0, 1\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/ExportSql.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<0, 2\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/ExportSql.php
-
-		-
 			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Export/ExportSql.php
@@ -19193,11 +18833,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an elseif condition, mixed given\\.$#"
 			count: 1
-			path: libraries/classes/Plugins/Export/ExportSql.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, array\\<int, string\\> given\\.$#"
-			count: 2
 			path: libraries/classes/Plugins/Export/ExportSql.php
 
 		-
@@ -20076,11 +19711,6 @@ parameters:
 			path: libraries/classes/Plugins/Export/Helpers/Pdf.php
 
 		-
-			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Export/Helpers/Pdf.php
-
-		-
 			message: "#^Variable \\$columnsCnt might not be defined\\.$#"
 			count: 6
 			path: libraries/classes/Plugins/Export/Helpers/Pdf.php
@@ -20226,11 +19856,6 @@ parameters:
 			path: libraries/classes/Plugins/Import/ImportCsv.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportCsv.php
-
-		-
 			message: "#^Parameter \\#1 \\$csvTerminated of method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportCsv\\:\\:buildErrorsForParams\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportCsv.php
@@ -20371,11 +19996,6 @@ parameters:
 			path: libraries/classes/Plugins/Import/ImportMediawiki.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportMediawiki.php
-
-		-
 			message: "#^Method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportMediawiki\\:\\:doImport\\(\\) should return array\\<string\\> but returns mixed\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportMediawiki.php
@@ -20491,11 +20111,6 @@ parameters:
 			path: libraries/classes/Plugins/Import/ImportOds.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportOds.php
-
-		-
 			message: "#^Parameter \\#1 \\$cellAttrs of method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportOds\\:\\:getValue\\(\\) expects SimpleXMLElement, SimpleXMLElement\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportOds.php
@@ -20537,11 +20152,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#6 \\$maxCols of method PhpMyAdmin\\\\Plugins\\\\Import\\\\ImportOds\\:\\:iterateOverRows\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Import/ImportOds.php
-
-		-
-			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/ImportOds.php
 
@@ -20821,12 +20431,12 @@ parameters:
 			path: libraries/classes/Plugins/Import/Upload/UploadProgress.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, array\\<string, int\\|string\\>\\|null given\\.$#"
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/Upload/UploadProgress.php
 
 		-
-			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			message: "#^Strict comparison using \\!\\=\\= between array\\{upload_id\\: string, fieldname\\: string, filename\\: string, time_start\\: int, time_last\\: int, speed_average\\: int, speed_last\\: int, bytes_uploaded\\: int, \\.\\.\\.\\} and array\\{\\} will always evaluate to true\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Import/Upload/UploadProgress.php
 
@@ -21097,11 +20707,6 @@ parameters:
 
 		-
 			message: "#^Cannot cast mixed to int\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Schema/ExportRelationSchema.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Schema/ExportRelationSchema.php
 
@@ -21646,11 +21251,6 @@ parameters:
 			path: libraries/classes/Plugins/Transformations/Abs/Bool2TextTransformationsPlugin.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Transformations/Abs/CodeMirrorEditorTransformationPlugin.php
-
-		-
 			message: "#^Binary operation \"\\-\\=\" between int\\<0, max\\>\\|string\\|false and int results in an error\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Transformations/Abs/DateFormatTransformationsPlugin.php
@@ -21871,11 +21471,6 @@ parameters:
 			path: libraries/classes/Plugins/Transformations/Abs/SubstringTransformationsPlugin.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Transformations/Abs/TextFileUploadTransformationsPlugin.php
-
-		-
 			message: "#^Cannot access offset 'DefaultTransformati…' on mixed\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Transformations/Abs/TextImageLinkTransformationsPlugin.php
@@ -21914,16 +21509,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$defaults of method PhpMyAdmin\\\\Plugins\\\\TransformationsPlugin\\:\\:getOptions\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Plugins/Transformations/Abs/TextLinkTransformationsPlugin.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptobinary.php
-
-		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Plugins/Transformations/Input/Text_Plain_Iptolong.php
 
 		-
 			message: "#^Cannot access offset 'CodemirrorEnable' on mixed\\.$#"
@@ -22057,7 +21642,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
+			count: 1
 			path: libraries/classes/Plugins/TwoFactorPlugin.php
 
 		-
@@ -22772,11 +22357,6 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 2
-			path: libraries/classes/Replication/ReplicationInfo.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, array given\\.$#"
 			count: 1
 			path: libraries/classes/Replication/ReplicationInfo.php
 
@@ -23153,11 +22733,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
 			count: 14
-			path: libraries/classes/Server/Privileges.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\|null given\\.$#"
-			count: 1
 			path: libraries/classes/Server/Privileges.php
 
 		-
@@ -23616,11 +23191,6 @@ parameters:
 			path: libraries/classes/Server/Status/Monitor.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\> given\\.$#"
-			count: 2
-			path: libraries/classes/Server/Status/Monitor.php
-
-		-
 			message: "#^Parameter \\#1 \\$haystack of function mb_strpos expects string, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/Server/Status/Monitor.php
@@ -23658,11 +23228,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$type of method PhpMyAdmin\\\\Server\\\\Status\\\\Monitor\\:\\:getJsonForChartingDataSwitch\\(\\) expects string, mixed given\\.$#"
 			count: 1
-			path: libraries/classes/Server/Status/Monitor.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 2
 			path: libraries/classes/Server/Status/Monitor.php
 
 		-
@@ -23992,7 +23557,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 14
+			count: 12
 			path: libraries/classes/Sql.php
 
 		-
@@ -24047,11 +23612,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, bool\\|string given\\.$#"
-			count: 1
-			path: libraries/classes/Sql.php
-
-		-
-			message: "#^Only booleans are allowed in an elseif condition, string given\\.$#"
 			count: 1
 			path: libraries/classes/Sql.php
 
@@ -24291,11 +23851,6 @@ parameters:
 			path: libraries/classes/SqlQueryForm.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, bool\\|string given\\.$#"
-			count: 1
-			path: libraries/classes/SqlQueryForm.php
-
-		-
 			message: "#^Parameter \\#1 \\$database of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getColumns\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/SqlQueryForm.php
@@ -24462,16 +24017,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\StorageEngine\\:\\:getStorageEngines\\(\\) should return array\\<array\\> but returns mixed\\.$#"
-			count: 1
-			path: libraries/classes/StorageEngine.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
-			count: 2
-			path: libraries/classes/StorageEngine.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
 			count: 1
 			path: libraries/classes/StorageEngine.php
 
@@ -24836,11 +24381,6 @@ parameters:
 			path: libraries/classes/Table.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
-			count: 3
-			path: libraries/classes/Table.php
-
-		-
 			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Table.php
@@ -24857,7 +24397,7 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 3
+			count: 1
 			path: libraries/classes/Table.php
 
 		-
@@ -25211,11 +24751,6 @@ parameters:
 			path: libraries/classes/Table/Indexes.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 1
-			path: libraries/classes/Table/Maintenance.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 2
 			path: libraries/classes/Table/Search.php
@@ -25232,12 +24767,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 4
-			path: libraries/classes/Table/Search.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, string given\\.$#"
-			count: 1
+			count: 3
 			path: libraries/classes/Table/Search.php
 
 		-
@@ -25696,11 +25226,6 @@ parameters:
 			path: libraries/classes/Tracking/Tracking.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
-			path: libraries/classes/Tracking/Tracking.php
-
-		-
 			message: "#^Only booleans are allowed in \\|\\|, string\\|false given on the left side\\.$#"
 			count: 1
 			path: libraries/classes/Tracking/Tracking.php
@@ -25832,7 +25357,7 @@ parameters:
 
 		-
 			message: "#^Cannot access an offset on mixed\\.$#"
-			count: 9
+			count: 6
 			path: libraries/classes/Triggers/Triggers.php
 
 		-
@@ -25866,16 +25391,6 @@ parameters:
 			path: libraries/classes/Triggers/Triggers.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Triggers/Triggers.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\> given\\.$#"
-			count: 1
-			path: libraries/classes/Triggers/Triggers.php
-
-		-
 			message: "#^Parameter \\#1 \\$database of method PhpMyAdmin\\\\DatabaseInterface\\:\\:getTables\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/Triggers/Triggers.php
@@ -25898,11 +25413,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$message of static method PhpMyAdmin\\\\Html\\\\Generator\\:\\:getMessage\\(\\) expects PhpMyAdmin\\\\Message\\|string, mixed given\\.$#"
 			count: 1
-			path: libraries/classes/Triggers/Triggers.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 2
 			path: libraries/classes/Triggers/Triggers.php
 
 		-
@@ -26102,11 +25612,6 @@ parameters:
 
 		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false\\|null given\\.$#"
-			count: 1
-			path: libraries/classes/UserPreferences.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
 			count: 1
 			path: libraries/classes/UserPreferences.php
 
@@ -26416,22 +25921,12 @@ parameters:
 			path: libraries/classes/Util.php
 
 		-
-			message: "#^Only booleans are allowed in an elseif condition, string given\\.$#"
-			count: 1
-			path: libraries/classes/Util.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, int\\<0, max\\>\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Util.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
-			count: 1
-			path: libraries/classes/Util.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
 			count: 1
 			path: libraries/classes/Util.php
 
@@ -26626,16 +26121,6 @@ parameters:
 			path: libraries/classes/Utils/HttpRequest.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
-			count: 1
-			path: libraries/classes/Utils/HttpRequest.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 2
-			path: libraries/classes/Utils/HttpRequest.php
-
-		-
 			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
 			count: 1
 			path: libraries/classes/Utils/HttpRequest.php
@@ -26747,7 +26232,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 4
+			count: 3
 			path: libraries/classes/VersionInformation.php
 
 		-
@@ -26794,11 +26279,6 @@ parameters:
 			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
 			count: 1
 			path: libraries/classes/VersionInformation.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, int\\<0, 32768\\> given\\.$#"
-			count: 1
-			path: libraries/classes/WebAuthn/CBORDecoder.php
 
 		-
 			message: "#^Method PhpMyAdmin\\\\ZipExtension\\:\\:getContents\\(\\) should return array\\{error\\: string, data\\: string\\} but returns array\\{error\\: '', data\\: string\\|false\\}\\.$#"
@@ -27143,11 +26623,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'pma_testform' on mixed\\.$#"
 			count: 1
-			path: test/classes/Config/FormDisplayTest.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
-			count: 3
 			path: test/classes/Config/FormDisplayTest.php
 
 		-
@@ -30296,11 +29771,6 @@ parameters:
 			path: test/classes/Plugins/Auth/AuthenticationCookieTest.php
 
 		-
-			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 3
-			path: test/classes/Plugins/Auth/AuthenticationCookieTest.php
-
-		-
 			message: "#^Cannot access offset 'LogoutURL' on mixed\\.$#"
 			count: 1
 			path: test/classes/Plugins/Auth/AuthenticationHttpTest.php
@@ -31566,11 +31036,6 @@ parameters:
 			path: test/classes/Stubs/DbiDummy.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<string, array\\<int, array\\<int, float\\|int\\|string\\|null\\>\\|PhpMyAdmin\\\\FieldMetadata\\|string\\>\\|bool\\|string\\>\\|null given\\.$#"
-			count: 1
-			path: test/classes/Stubs/DbiDummy.php
-
-		-
 			message: "#^Foreach overwrites \\$value with its value variable\\.$#"
 			count: 1
 			path: test/classes/Stubs/ResponseRenderer.php
@@ -31808,16 +31273,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'user' on mixed\\.$#"
 			count: 3
-			path: test/classes/Tracking/TrackerTest.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, string\\|null given\\.$#"
-			count: 1
-			path: test/classes/Tracking/TrackerTest.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
-			count: 1
 			path: test/classes/Tracking/TrackerTest.php
 
 		-
@@ -32091,16 +31546,6 @@ parameters:
 			path: test/classes/TypesByDatabaseVersionTest.php
 
 		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<string\\> given\\.$#"
-			count: 3
-			path: test/classes/TypesByDatabaseVersionTest.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, array\\<string\\> given\\.$#"
-			count: 3
-			path: test/classes/TypesByDatabaseVersionTest.php
-
-		-
 			message: "#^Cannot access offset 'ServerDefault' on mixed\\.$#"
 			count: 4
 			path: test/classes/UrlTest.php
@@ -32217,11 +31662,6 @@ parameters:
 
 		-
 			message: "#^Method PhpMyAdmin\\\\Tests\\\\UtilTest\\:\\:providerForTestGetMySQLDocuURL\\(\\) should return array\\<int, array\\{string, string, int, string\\}\\> but returns array\\{array\\{'ALTER_TABLE', 'alter\\-table\\-index', '8\\.0\\.0', 'index\\.php\\?route\\=…'\\}, array\\{'ALTER_TABLE', 'alter\\-table\\-index', '5\\.7\\.0', 'index\\.php\\?route\\=…'\\}, array\\{'', 'alter\\-table\\-index', '5\\.6\\.0', 'index\\.php\\?route\\=…'\\}, array\\{'ALTER_TABLE', '', '5\\.5\\.0', 'index\\.php\\?route\\=…'\\}, array\\{'', '', '5\\.7\\.0', 'index\\.php\\?route\\=…'\\}\\}\\.$#"
-			count: 1
-			path: test/classes/UtilTest.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, int\\<0, 2\\> given\\.$#"
 			count: 1
 			path: test/classes/UtilTest.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11431,11 +11431,6 @@ parameters:
 			path: libraries/classes/DatabaseInterface.php
 
 		-
-			message: "#^Only booleans are allowed in \\|\\|, string\\|null given on the right side\\.$#"
-			count: 1
-			path: libraries/classes/DatabaseInterface.php
-
-		-
 			message: "#^Parameter \\#1 \\$a of static method PhpMyAdmin\\\\Query\\\\Utilities\\:\\:usortComparisonCallback\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: libraries/classes/DatabaseInterface.php
@@ -24393,11 +24388,6 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
 			count: 2
-			path: libraries/classes/Table.php
-
-		-
-			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
-			count: 1
 			path: libraries/classes/Table.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -891,7 +891,6 @@
       <code>$db</code>
       <code>$db</code>
       <code>$db</code>
-      <code>$html</code>
       <code>$page</code>
       <code><![CDATA[$position['dbName']]]></code>
       <code><![CDATA[$position['tableName']]]></code>
@@ -3446,10 +3445,6 @@
       <code><![CDATA[$GLOBALS['tbl_collation']]]></code>
       <code><![CDATA[$GLOBALS['tbl_is_view']]]></code>
     </InvalidArrayOffset>
-    <MixedArgument>
-      <code>$newMessage</code>
-      <code>$newMessage</code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$tableAlters</code>
       <code>is_array($partitionNames) ? $partitionNames : []</code>
@@ -4837,8 +4832,6 @@
       <code><![CDATA[$GLOBALS['errors']]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
-      <code><![CDATA[$GLOBALS['errors']]]></code>
-      <code><![CDATA[$GLOBALS['errors']]]></code>
       <code><![CDATA[$GLOBALS['errors']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
@@ -8776,7 +8769,7 @@
       <code><![CDATA[$this->tablewidths[$col]]]></code>
       <code><![CDATA[$this->tablewidths[$col]]]></code>
       <code><![CDATA[$this->tablewidths[$col]]]></code>
-      <code><![CDATA[$this->titleFontSize ?: $this->FontSizePt]]></code>
+      <code><![CDATA[$this->titleFontSize !== 0 ? $this->titleFontSize : $this->FontSizePt]]></code>
       <code><![CDATA[$txt ?? 'NULL']]></code>
       <code><![CDATA[$txt ?? 'NULL']]></code>
       <code><![CDATA[$txt ?? 'NULL']]></code>
@@ -9535,6 +9528,10 @@
       <code>$_SESSION</code>
       <code>$_SESSION</code>
     </PossiblyNullArrayOffset>
+    <RedundantCondition>
+      <code>$status !== []</code>
+      <code><![CDATA[$status !== null && $status !== []]]></code>
+    </RedundantCondition>
     <UnusedClass>
       <code>UploadProgress</code>
     </UnusedClass>
@@ -11177,8 +11174,6 @@
       <code>$ret[$chartId][$nodeId][$pointId]</code>
       <code>$serverVars</code>
       <code>$serverVars</code>
-      <code>$serverVars</code>
-      <code>$statusVars</code>
       <code>$statusVars</code>
       <code>$statusVars</code>
       <code>$temp[strlen($temp) - 1]</code>
@@ -12226,8 +12221,6 @@
       <code><![CDATA[$GLOBALS['errors']]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
-      <code><![CDATA[$GLOBALS['errors']]]></code>
-      <code><![CDATA[$GLOBALS['errors']]]></code>
       <code><![CDATA[$GLOBALS['errors']]]></code>
     </MixedArgument>
     <MixedArrayAssignment>

--- a/test/classes/Config/FormDisplayTest.php
+++ b/test/classes/Config/FormDisplayTest.php
@@ -343,7 +343,7 @@ class FormDisplayTest extends AbstractTestCase
         }
 
         if (! function_exists('gzcompress')) {
-            $comment .= ($comment ? '; ' : '') . 'Compressed export will not work ' .
+            $comment .= ($comment !== '' ? '; ' : '') . 'Compressed export will not work ' .
             'due to missing function gzcompress.';
         }
 
@@ -362,7 +362,7 @@ class FormDisplayTest extends AbstractTestCase
         }
 
         if (! function_exists('gzencode')) {
-            $comment .= ($comment ? '; ' : '') . 'Compressed export will not work ' .
+            $comment .= ($comment !== '' ? '; ' : '') . 'Compressed export will not work ' .
             'due to missing function gzencode.';
         }
 
@@ -381,7 +381,7 @@ class FormDisplayTest extends AbstractTestCase
         }
 
         if (! function_exists('bzcompress')) {
-            $comment .= ($comment ? '; ' : '') . 'Compressed export will not work ' .
+            $comment .= ($comment !== '' ? '; ' : '') . 'Compressed export will not work ' .
             'due to missing function bzcompress.';
         }
 

--- a/test/classes/Plugins/Auth/AuthenticationCookieTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -1026,7 +1026,7 @@ class AuthenticationCookieTest extends AbstractTestCase
         $GLOBALS['cfg']['Server']['AllowNoPassword'] = $nopass;
         $GLOBALS['cfg']['Server']['AllowDeny'] = $rules;
 
-        if (! empty($expected)) {
+        if ($expected !== '') {
             $this->getAuthErrorMockResponse();
         }
 
@@ -1040,11 +1040,11 @@ class AuthenticationCookieTest extends AbstractTestCase
 
         $result = $responseStub->getHTMLResult();
 
-        if (! empty($expected)) {
+        if ($expected !== '') {
             $this->assertInstanceOf(ExitException::class, $throwable ?? null);
         }
 
-        if (empty($expected)) {
+        if ($expected === '') {
             $this->assertEquals($expected, $result);
         } else {
             $this->assertStringContainsString($expected, $result);

--- a/test/classes/Stubs/DbiDummy.php
+++ b/test/classes/Stubs/DbiDummy.php
@@ -175,7 +175,7 @@ class DbiDummy implements DbiExtension
     {
         $query = trim((string) preg_replace('/  */', ' ', str_replace("\n", ' ', $query)));
         $found = $this->findFifoQuery($query) ?? $this->findDummyQuery($query);
-        if (! $found) {
+        if ($found === null) {
             Assert::fail('Not supported query: ' . $query);
         }
 

--- a/test/classes/Tracking/TrackerTest.php
+++ b/test/classes/Tracking/TrackerTest.php
@@ -340,11 +340,11 @@ class TrackerTest extends AbstractTestCase
 
         $this->assertEquals($tableName, $result['tablename']);
 
-        if ($db) {
+        if ($db !== null && $db !== '') {
             $this->assertEquals($db, $GLOBALS['db']);
         }
 
-        if (! $tableNameAfterRename) {
+        if ($tableNameAfterRename === null || $tableNameAfterRename === '') {
             return;
         }
 

--- a/test/classes/TypesByDatabaseVersionTest.php
+++ b/test/classes/TypesByDatabaseVersionTest.php
@@ -62,13 +62,13 @@ class TypesByDatabaseVersionTest extends AbstractTestCase
 
         $result = $this->object->getFunctionsClass($class);
 
-        if ($includes) {
+        if ($includes !== []) {
             foreach ($includes as $value) {
                 $this->assertContains($value, $result);
             }
         }
 
-        if (! $excludes) {
+        if ($excludes === []) {
             return;
         }
 
@@ -281,13 +281,13 @@ class TypesByDatabaseVersionTest extends AbstractTestCase
 
         $result = $this->object->getFunctions('enum');
 
-        if ($includes) {
+        if ($includes !== []) {
             foreach ($includes as $value) {
                 $this->assertContains($value, $result);
             }
         }
 
-        if (! $excludes) {
+        if ($excludes === []) {
             return;
         }
 
@@ -356,13 +356,13 @@ class TypesByDatabaseVersionTest extends AbstractTestCase
 
         $result = $this->object->getAllFunctions();
 
-        if ($includes) {
+        if ($includes !== []) {
             foreach ($includes as $value) {
                 $this->assertContains($value, $result);
             }
         }
 
-        if (! $excludes) {
+        if ($excludes === []) {
             return;
         }
 

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -1159,7 +1159,7 @@ class UtilTest extends AbstractTestCase
         Context::load();
         foreach (Context::$keywords as $keyword => $type) {
             $expected = $keyword;
-            if ($type & Token::FLAG_KEYWORD_RESERVED) {
+            if (($type & Token::FLAG_KEYWORD_RESERVED) !== 0) {
                 $expected = '`' . $keyword . '`';
             }
 


### PR DESCRIPTION
Risky! This is done using Rector's set `STRICT_BOOLEANS`. I picked out the safer changes only, and even then this is risky because we relied on loose type checking before. 

This change treats all uses of strings in boolean conditions as comparing only empty string. Thus every loose comparison that intentionally compared for 0-string is considered a bug. 

Hopefully this fixes more bugs than it creates. 