### PR TITLE
Add color mode toggle at the top nav bar

### DIFF
--- a/js/src/main.ts
+++ b/js/src/main.ts
@@ -9,6 +9,7 @@ import { Config } from './modules/config.ts';
 import checkNumberOfFields from './modules/functions/checkNumberOfFields.ts';
 import onloadNavigation from './modules/navigation/event-loader.ts';
 import { onloadFunctions, teardownFunctions } from './modules/functions/event-loader.ts';
+import { ThemeColorModeToggle } from './modules/themes-manager.ts';
 
 AJAX.registerOnload('main.js', () => AJAX.removeSubmitEvents());
 $(AJAX.loadEventHandler());
@@ -48,8 +49,14 @@ $(() => checkNumberOfFields());
 
 AJAX.registerTeardown('main.js', () => {
     PageSettings.off();
+
+    const themeColorModeToggle = document.getElementById('themeColorModeToggle') as HTMLSelectElement;
+    themeColorModeToggle?.removeEventListener('change', ThemeColorModeToggle);
 });
 
 AJAX.registerOnload('main.js', () => {
     PageSettings.on();
+
+    const themeColorModeToggle = document.getElementById('themeColorModeToggle') as HTMLSelectElement;
+    themeColorModeToggle?.addEventListener('change', ThemeColorModeToggle);
 });

--- a/js/src/modules/themes-manager.ts
+++ b/js/src/modules/themes-manager.ts
@@ -11,3 +11,21 @@ export const ThemesManager = {
         });
     }
 };
+
+function setColorModeToHtmlTag (themeColorMode: string): void {
+    const htmlTag = document.querySelector('html');
+    htmlTag.dataset.bsTheme = themeColorMode;
+}
+
+export const ThemeColorModeToggle: EventListenerObject = {
+    handleEvent: (): void => {
+        const toggleSelect = document.getElementById('themeColorModeToggle') as HTMLSelectElement;
+        setColorModeToHtmlTag(toggleSelect.options.item(toggleSelect.selectedIndex).value);
+        const toggleForm = toggleSelect.form;
+        const formData = new FormData(toggleForm);
+        formData.set('ajax_request', '1');
+        $.post(toggleForm.action, Object.fromEntries(formData.entries())).done(function (data): void {
+            setColorModeToHtmlTag(data.themeColorMode);
+        });
+    }
+};

--- a/libraries/classes/Controllers/ThemeSetController.php
+++ b/libraries/classes/Controllers/ThemeSetController.php
@@ -28,6 +28,12 @@ final class ThemeSetController extends AbstractController
     {
         $theme = $request->getParsedBodyParam('set_theme');
         if (! $GLOBALS['cfg']['ThemeManager'] || ! is_string($theme) || $theme === '') {
+            if ($request->isAjax()) {
+                $this->response->addJSON('themeColorMode', '');
+
+                return;
+            }
+
             $this->response->redirect('index.php?route=/' . Url::getCommonRaw([], '&'));
 
             return;
@@ -46,6 +52,12 @@ final class ThemeSetController extends AbstractController
         $preferences = $this->userPreferences->load();
         $preferences['config_data']['ThemeDefault'] = $theme;
         $this->userPreferences->save($preferences['config_data']);
+
+        if ($request->isAjax()) {
+            $this->response->addJSON('themeColorMode', $this->themeManager->theme->getColorMode());
+
+            return;
+        }
 
         $this->response->redirect('index.php?route=/' . Url::getCommonRaw([], '&'));
     }

--- a/libraries/classes/Header.php
+++ b/libraries/classes/Header.php
@@ -275,6 +275,8 @@ class Header
         $baseDir = defined('PMA_PATH_TO_BASEDIR') ? PMA_PATH_TO_BASEDIR : '';
         $themePath = $GLOBALS['theme'] instanceof Theme ? $GLOBALS['theme']->getPath() : '';
         $themeColorMode = $GLOBALS['theme'] instanceof Theme ? $GLOBALS['theme']->getColorMode() : 'light';
+        $themeColorModes = $GLOBALS['theme'] instanceof Theme ? $GLOBALS['theme']->getColorModes() : [];
+        $themeId = $GLOBALS['theme'] instanceof Theme ? $GLOBALS['theme']->getId() : '';
         $version = self::getVersionParameter();
 
         // The user preferences have been merged at this point
@@ -364,6 +366,8 @@ class Header
             'messages' => $messages,
             'recent_table' => $recentTable,
             'theme_color_mode' => $themeColorMode,
+            'theme_color_modes' => $themeColorModes,
+            'theme_id' => $themeId,
         ]);
     }
 

--- a/templates/header.twig
+++ b/templates/header.twig
@@ -39,13 +39,37 @@
 
   {% if is_menu_enabled and server > 0 %}
     {{ menu|raw }}
-    <span id="page_nav_icons" class="d-print-none">
-      <span id="lock_page_icon"></span>
-      <span id="page_settings_icon">
-        {{ get_image('s_cog', 'Page-related settings'|trans) }}
-      </span>
-      <a id="goto_pagetop" href="#">{{ get_image('s_top', 'Click on the bar to scroll to top of page'|trans) }}</a>
-    </span>
+    <div id="page_nav_icons" class="row row-cols-sm-auto align-items-center d-print-none">
+      {% if theme_color_modes|length > 1 %}
+        <div class="col-12">
+          <form method="post" action="{{ url('/themes/set') }}" class="disableAjax">
+            {{ get_hidden_inputs() }}
+            <input type="hidden" name="set_theme" value="{{ theme_id }}">
+            <select class="form-select form-select-sm" name="themeColorMode" id="themeColorModeToggle" aria-label="{{ 'Color mode for the theme'|trans }}">
+              {% for color_mode in theme_color_modes %}
+                <option value="{{ color_mode }}"{{ theme_color_mode == color_mode ? ' selected' }}>
+                  {%- if color_mode == 'light' -%}
+                    {% trans %}Light{% context %}Light color mode of the theme{% endtrans %}
+                  {%- elseif color_mode == 'dark' -%}
+                    {% trans %}Dark{% context %}Dark color mode of the theme{% endtrans %}
+                  {%- else -%}
+                    {{ color_mode|title }}
+                  {%- endif -%}
+                </option>
+              {% endfor %}
+            </select>
+          </form>
+        </div>
+      {% endif %}
+
+      <div class="col-12">
+        <span id="lock_page_icon"></span>
+        <span id="page_settings_icon">
+          {{ get_image('s_cog', 'Page-related settings'|trans) }}
+        </span>
+        <a id="goto_pagetop" href="#">{{ get_image('s_top', 'Click on the bar to scroll to top of page'|trans) }}</a>
+      </div>
+    </div>
   {% endif %}
 
   {{ console|raw }}


### PR DESCRIPTION
This allows toggling between light and dark (or other) color modes without leaving the page.

[Screencast from 2023-08-24 15-15-19.webm](https://github.com/phpmyadmin/phpmyadmin/assets/120970/f3a44080-ea65-44cc-b3a3-b86f2d007c9f)