### PR TITLE
Fix result cell title attribute escape

### DIFF
--- a/libraries/classes/Display/Results.php
+++ b/libraries/classes/Display/Results.php
@@ -4484,9 +4484,9 @@ class Results
                 if ($relationalDisplay === self::RELATIONAL_KEY) {
                     // user chose "relational key" in the display options, so
                     // the title contains the display field
-                    $title = htmlspecialchars($dispval ?? '');
+                    $title = $dispval ?? '';
                 } else {
-                    $title = htmlspecialchars($data);
+                    $title = $data;
                 }
 
                 $tagParams = ['title' => $title];

--- a/test/classes/Html/GeneratorTest.php
+++ b/test/classes/Html/GeneratorTest.php
@@ -332,6 +332,16 @@ class GeneratorTest extends AbstractTestCase
                 100,
                 '<a href="index.php?route=/server/databases" >text</a>',
             ],
+            [
+                [
+                    'index.php',
+                    null,
+                    'text',
+                    ['title' => '"'],
+                ],
+                100,
+                '<a href="index.php" title="&quot;">text</a>',
+            ],
         ];
     }
 


### PR DESCRIPTION
An escaped string was displayed when browsing a table with foreign key relation where the displayed title for a foreign key link contained special characters.

