### PR TITLE
Disable AJAX for navigation sidebar links

### DIFF
--- a/libraries/classes/Navigation/NavigationTree.php
+++ b/libraries/classes/Navigation/NavigationTree.php
@@ -1037,12 +1037,6 @@ class NavigationTree
 
             $paginationParams = $this->getPaginationParamsHtml($node);
 
-            $haveAjax = ['functions', 'procedures', 'events', 'triggers', 'indexes'];
-            $parent = $node->parents(false, true);
-            $isNewView = $parent[0]->realName === 'views' && $node->isNew;
-            $linkHasAjaxClass = $parent[0]->type === NodeType::Container
-                && (in_array($parent[0]->realName, $haveAjax) || $isNewView);
-
             if (! $node->isGroup) {
                 $args = [];
                 $parents = $node->parents(true);
@@ -1061,7 +1055,6 @@ class NavigationTree
                         $node->links['icon']['params'],
                         array_intersect_key($args, $node->links['icon']['params']),
                     ),
-                    'is_ajax' => $linkHasAjaxClass,
                     'image' => $node->icon['image'],
                     'title' => $node->icon['title'],
                 ];
@@ -1073,7 +1066,6 @@ class NavigationTree
                             $node->links['second_icon']['params'],
                             array_intersect_key($args, $node->links['second_icon']['params']),
                         ),
-                        'is_ajax' => $linkHasAjaxClass,
                         'image' => $node->secondIcon['image'],
                         'title' => $node->secondIcon['title'],
                     ];
@@ -1085,7 +1077,6 @@ class NavigationTree
                         $node->links['text']['params'],
                         array_intersect_key($args, $node->links['text']['params']),
                     ),
-                    'is_ajax' => $linkHasAjaxClass,
                     'title' => $node->links['title'] ?? $node->title,
                 ];
             }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14337,7 +14337,7 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 13
+			count: 12
 			path: libraries/classes/Navigation/NavigationTree.php
 
 		-
@@ -14448,11 +14448,6 @@ parameters:
 		-
 			message: "#^Casting to string something that's already string\\.$#"
 			count: 4
-			path: libraries/classes/Navigation/NavigationTree.php
-
-		-
-			message: "#^Foreach overwrites \\$parent with its value variable\\.$#"
-			count: 1
 			path: libraries/classes/Navigation/NavigationTree.php
 
 		-

--- a/templates/navigation/main.twig
+++ b/templates/navigation/main.twig
@@ -22,7 +22,7 @@
         {% endif %}
 
         <div id="navipanellinks">
-          <a href="{{ url('/') }}" title="{% trans 'Home' %}">
+          <a href="{{ url('/') }}" class="disableAjax" title="{% trans 'Home' %}">
             {{- get_image('b_home', 'Home'|trans) -}}
           </a>
 
@@ -32,11 +32,11 @@
             </a>
           {% endif %}
 
-          <a href="{{ get_docu_link('index') }}" title="{% trans 'phpMyAdmin documentation' %}" target="_blank" rel="noopener noreferrer">
+          <a href="{{ get_docu_link('index') }}" class="disableAjax" title="{% trans 'phpMyAdmin documentation' %}" target="_blank" rel="noopener noreferrer">
             {{- get_image('b_docs', 'phpMyAdmin documentation'|trans) -}}
           </a>
 
-          <a href="{{ get_docu_url(is_mariadb) }}" title="{{ is_mariadb ? 'MariaDB Documentation'|trans : 'MySQL Documentation'|trans }}" target="_blank" rel="noopener noreferrer">
+          <a href="{{ get_docu_url(is_mariadb) }}" class="disableAjax" title="{{ is_mariadb ? 'MariaDB Documentation'|trans : 'MySQL Documentation'|trans }}" target="_blank" rel="noopener noreferrer">
             {{- get_image('b_sqlhelp', is_mariadb ? 'MariaDB Documentation'|trans : 'MySQL Documentation'|trans) -}}
           </a>
 

--- a/templates/navigation/tree/node.twig
+++ b/templates/navigation/tree/node.twig
@@ -27,20 +27,20 @@
     {% else %}
       <div class="block second{{ has_second_icon ? ' double' }}">
         {% for link in icon_links %}
-          <a href="{{ url(link.route, link.params) }}"{{ link.is_ajax ? ' class="ajax"' }}>
+          <a href="{{ url(link.route, link.params) }}" class="disableAjax">
             {{- get_image(link.image, link.title) -}}
           </a>
         {% endfor %}
       </div>
 
       {% if node_is_container %}
-        &nbsp;<a class="hover_show_full" href="{{ url(text_link.route, text_link.params) }}">{{ node.name }}</a>
+        &nbsp;<a class="hover_show_full disableAjax" href="{{ url(text_link.route, text_link.params) }}">{{ node.name }}</a>
       {% elseif 'index' in node.classes %}
-        <a class="hover_show_full" href="{{ url(text_link.route) }}" data-post="{{ get_common(text_link.params|merge({'is_from_nav': true})) }}" title="{{ text_link.title }}">
+        <a class="hover_show_full disableAjax" href="{{ url(text_link.route) }}" data-post="{{ get_common(text_link.params|merge({'is_from_nav': true})) }}" title="{{ text_link.title }}">
           {{- node.displayName ?? node.realName -}}
         </a>
       {% else %}
-        <a class="hover_show_full{{ text_link.is_ajax ? ' ajax' }}" href="{{ url(text_link.route, text_link.params) }}" title="{{ text_link.title }}">
+        <a class="hover_show_full disableAjax" href="{{ url(text_link.route, text_link.params) }}" title="{{ text_link.title }}">
           {{- node.displayName ?? node.realName -}}
         </a>
       {% endif %}

--- a/test/classes/Controllers/NavigationControllerTest.php
+++ b/test/classes/Controllers/NavigationControllerTest.php
@@ -158,12 +158,12 @@ class NavigationControllerTest extends AbstractTestCase
             . '    ' . "\n"
             . '          <div class="block second">' . "\n"
             . '                  <a href="index.php?route=/database/operations'
-                                . '&db=air-balloon_burner_dev2&lang=en">'
+                                . '&db=air-balloon_burner_dev2&lang=en" class="disableAjax">'
                                 . '<img src="themes/dot.gif" title="Database operations"'
                                 . ' alt="Database operations" class="icon ic_s_db"></a>' . "\n"
             . '              </div>' . "\n"
             . "\n"
-            . '              <a class="hover_show_full"'
+            . '              <a class="hover_show_full disableAjax"'
                     . ' href="index.php?route=/database/structure&db=air-balloon_burner_dev2&lang=en"'
                     . ' title="Structure">air-balloon_burner_dev2</a>' . "\n"
             . '          ' . "\n"
@@ -302,13 +302,13 @@ class NavigationControllerTest extends AbstractTestCase
             . '          </div>' . "\n"
             . '    ' . "\n"
             . '          <div class="block second">' . "\n"
-            . '                  <a href="index.php?route=/database/operations&db=%s&lang=en">'
+            . '                  <a href="index.php?route=/database/operations&db=%s&lang=en" class="disableAjax">'
             . '<img src="themes/dot.gif" title="Database operations" alt="Database operations"'
             . ' class="icon ic_s_db"></a>' . "\n"
             . '              </div>' . "\n"
             . "\n"
-            . '              <a class="hover_show_full" href="index.php?route=/database/structure&db=%s&lang=en"'
-            . ' title="Structure">%s</a>' . "\n"
+            . '              <a class="hover_show_full disableAjax"'
+            . ' href="index.php?route=/database/structure&db=%s&lang=en" title="Structure">%s</a>' . "\n"
             . '          ' . "\n"
             . '    ' . "\n"
             . "\n"
@@ -331,13 +331,13 @@ class NavigationControllerTest extends AbstractTestCase
             . '          </div>' . "\n"
             . '    ' . "\n"
             . '          <div class="block second">' . "\n"
-            . '                  <a href="index.php?route=/database/operations&db=%s&lang=en">'
+            . '                  <a href="index.php?route=/database/operations&db=%s&lang=en" class="disableAjax">'
             . '<img src="themes/dot.gif" title="Database operations" alt="Database operations"'
             . ' class="icon ic_s_db"></a>' . "\n"
             . '              </div>' . "\n"
             . "\n"
-            . '              <a class="hover_show_full" href="index.php?route=/database/structure&db=%s&lang=en"'
-            . ' title="Structure">%s</a>' . "\n"
+            . '              <a class="hover_show_full disableAjax"'
+            . ' href="index.php?route=/database/structure&db=%s&lang=en" title="Structure">%s</a>' . "\n"
             . '          ' . "\n"
             . '    ' . "\n"
             . "\n"
@@ -359,13 +359,13 @@ class NavigationControllerTest extends AbstractTestCase
             . '          </div>' . "\n"
             . '    ' . "\n"
             . '          <div class="block second">' . "\n"
-            . '                  <a href="index.php?route=/database/operations&db=%s&lang=en">'
+            . '                  <a href="index.php?route=/database/operations&db=%s&lang=en" class="disableAjax">'
             . '<img src="themes/dot.gif" title="Database operations" alt="Database operations"'
             . ' class="icon ic_s_db"></a>' . "\n"
             . '              </div>' . "\n"
             . "\n"
-            . '              <a class="hover_show_full" href="index.php?route=/database/structure&db=%s&lang=en"'
-            . ' title="Structure">%s</a>' . "\n"
+            . '              <a class="hover_show_full disableAjax"'
+            . ' href="index.php?route=/database/structure&db=%s&lang=en" title="Structure">%s</a>' . "\n"
             . '          ' . "\n"
             . '    ' . "\n"
             . "\n"


### PR DESCRIPTION
These links already do a full page reload using AJAX, so it's better to actually do a full page reload.
