### PR TITLE
Qa fix editing geometry collection

### DIFF
--- a/js/src/gis_data_editor.js
+++ b/js/src/gis_data_editor.js
@@ -375,7 +375,7 @@ AJAX.registerOnload('gis_data_editor.js', function () {
         var noOfGeoms = parseInt($noOfGeomsInput.val(), 10);
 
         var html1 = Messages.strGeometry + ' ' + (noOfGeoms + 1) + ':<br>';
-        var $geomType = $('select[name=\'gis_data[' + (noOfGeoms - 1) + '][gis_type]\']').clone();
+        var $geomType = $('#gis_type_template').contents().filter('select').clone();
         $geomType.attr('name', 'gis_data[' + noOfGeoms + '][gis_type]').val('POINT');
         var html2 = '<br>' + Messages.strPoint + ' :' +
             '<label for="x"> ' + Messages.strX + ' </label>' +
@@ -384,9 +384,7 @@ AJAX.registerOnload('gis_data_editor.js', function () {
             '<input type="text" name="gis_data[' + noOfGeoms + '][POINT][y]" value="">' +
             '<br><br>';
 
-        $a.before(html1);
-        $geomType.insertBefore($a);
-        $a.before(html2);
+        $a.before(html1, $geomType, html2);
         $noOfGeomsInput.val(noOfGeoms + 1);
     });
 });

--- a/libraries/classes/Gis/GisMultiLineString.php
+++ b/libraries/classes/Gis/GisMultiLineString.php
@@ -298,7 +298,7 @@ class GisMultiLineString extends GisGeometry
      */
     public function generateWkt(array $gis_data, $index, $empty = '')
     {
-        $data_row = $gis_data[$index]['MULTILINESTRING'];
+        $data_row = $gis_data[$index]['MULTILINESTRING'] ?? null;
 
         $no_of_lines = $data_row['no_of_lines'] ?? 1;
         if ($no_of_lines < 1) {

--- a/libraries/classes/Gis/GisMultiPolygon.php
+++ b/libraries/classes/Gis/GisMultiPolygon.php
@@ -377,7 +377,7 @@ class GisMultiPolygon extends GisGeometry
      */
     public function generateWkt(array $gis_data, $index, $empty = '')
     {
-        $data_row = $gis_data[$index]['MULTIPOLYGON'];
+        $data_row = $gis_data[$index]['MULTIPOLYGON'] ?? null;
 
         $no_of_polygons = $data_row['no_of_polygons'] ?? 1;
         if ($no_of_polygons < 1) {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6969,10 +6969,9 @@
       <code>$temp_point[1]</code>
       <code>$wkt</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="22">
+    <MixedArrayAccess occurrences="21">
       <code>$data_row[$i]</code>
       <code>$data_row['no_of_lines']</code>
-      <code>$gis_data[$index]['MULTILINESTRING']</code>
       <code>$point['x']</code>
       <code>$point['y']</code>
       <code>$point[0]</code>
@@ -7030,6 +7029,10 @@
       <code>$black</code>
       <code>$color</code>
     </PossiblyFalseArgument>
+    <PossiblyNullArrayAccess occurrences="2">
+      <code>$data_row[$i]</code>
+      <code>$data_row['no_of_lines']</code>
+    </PossiblyNullArrayAccess>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset(self::$instance)</code>
     </RedundantPropertyInitializationCheck>
@@ -7120,11 +7123,10 @@
       <code>$ring['points']</code>
       <code>$wkt</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="38">
+    <MixedArrayAccess occurrences="37">
       <code>$data_row[$k]</code>
       <code>$data_row[$k]</code>
       <code>$data_row['no_of_polygons']</code>
-      <code>$gis_data[$index]['MULTIPOLYGON']</code>
       <code>$innerPoint['x']</code>
       <code>$innerPoint['y']</code>
       <code>$label_point[0]</code>
@@ -7229,6 +7231,11 @@
       <code>$black</code>
       <code>$color</code>
     </PossiblyFalseArgument>
+    <PossiblyNullArrayAccess occurrences="3">
+      <code>$data_row[$k]</code>
+      <code>$data_row[$k]</code>
+      <code>$data_row['no_of_polygons']</code>
+    </PossiblyNullArrayAccess>
     <RedundantPropertyInitializationCheck occurrences="1">
       <code>isset(self::$instance)</code>
     </RedundantPropertyInitializationCheck>

--- a/templates/gis_data_editor_form.twig
+++ b/templates/gis_data_editor_form.twig
@@ -46,6 +46,14 @@
                 <input type="hidden" name="gis_data[GEOMETRYCOLLECTION][geom_count]" value="{{ geom_count }}">
             {% endif %}
 
+            <template id="gis_type_template">
+                <select class="gis_type">
+                    {% for gis_type in gis_types|slice(0, 6) %}
+                        <option value="{{ gis_type }}">{{ gis_type }}</option>
+                    {% endfor %}
+                </select>
+            </template>
+
             {% for a in 0..geom_count - 1 %}
               {% if gis_data[a] is not null %}
                 {% if geom_type == 'GEOMETRYCOLLECTION' %}

--- a/test/classes/Gis/GisGeometryCollectionTest.php
+++ b/test/classes/Gis/GisGeometryCollectionTest.php
@@ -117,6 +117,72 @@ class GisGeometryCollectionTest extends AbstractTestCase
 
         return [
             [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => ['geom_count' => '1'],
+                    0 => ['gis_type' => 'POINT'],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(POINT( ))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => ['geom_count' => '1'],
+                    0 => ['gis_type' => 'LINESTRING'],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(LINESTRING( , ))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => ['geom_count' => '1'],
+                    0 => ['gis_type' => 'POLYGON'],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(POLYGON(( , , , )))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => ['geom_count' => '1'],
+                    0 => ['gis_type' => 'MULTIPOINT'],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(MULTIPOINT( ))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => ['geom_count' => '1'],
+                    0 => ['gis_type' => 'MULTILINESTRING'],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(MULTILINESTRING(( , )))',
+            ],
+            [
+                [
+                    'gis_type' => 'GEOMETRYCOLLECTION',
+                    'srid' => '0',
+                    'GEOMETRYCOLLECTION' => ['geom_count' => '1'],
+                    0 => ['gis_type' => 'MULTIPOLYGON'],
+                ],
+                0,
+                null,
+                'GEOMETRYCOLLECTION(MULTIPOLYGON((( , , , ))))',
+            ],
+            [
                 $temp1,
                 0,
                 null,


### PR DESCRIPTION
- Type of geometry could not be changed when editing an empty geometry collection because no select input for the geometry type is available
- An error occurred when switching geometry type of a geometry inside a GeometryCollection to MultiLineString or MultiPolygon