### PR TITLE
Geometry type selection only for Geometry column type

### DIFF
--- a/libraries/classes/Controllers/GisDataEditorController.php
+++ b/libraries/classes/Controllers/GisDataEditorController.php
@@ -132,6 +132,7 @@ class GisDataEditorController extends AbstractController
             'srid' => $srid,
             'visualization' => $visualization,
             'open_layers' => $open_layers,
+            'column_type' => mb_strtoupper($type),
             'gis_types' => self::GIS_TYPES,
             'geom_type' => $geom_type,
             'geom_count' => $geom_count,

--- a/templates/gis_data_editor_form.twig
+++ b/templates/gis_data_editor_form.twig
@@ -27,7 +27,7 @@
 
         {# Header section - Inclueds GIS type selector and input field for SRID #}
         <div id="gis_data_header">
-            <select name="gis_data[gis_type]" class="gis_type">
+            <select name="gis_data[gis_type]" class="gis_type{{ column_type != 'GEOMETRY' ? ' hide' }}">
                 {% for gis_type in gis_types %}
                     <option value="{{ gis_type }}"{{ geom_type == gis_type ? ' selected="selected"' }}>
                         {{ gis_type }}


### PR DESCRIPTION
When editing a geometry in the editor, the geometry type should only be selectable for columns of type Geometry