### PR TITLE
Fix copy table with spaces

### DIFF
--- a/libraries/classes/Table.php
+++ b/libraries/classes/Table.php
@@ -977,6 +977,8 @@ class Table implements Stringable
                 'export_type' => 'table',
                 'single_table' => false,
             ]);
+            // It is better that all identifiers are quoted
+            $exportSqlPlugin->useSqlBackquotes(true);
 
             $noConstraintsComments = true;
             $GLOBALS['sql_constraints_query'] = '';


### PR DESCRIPTION
Fixes #18664. It seems I introduced this regression, but I do not know how it happened. 

After thinking about it for a while, I think we need a change in the parser because it makes no sense to allow users to disable quoting identifiers. At least, we should introduce some guards for this. 