### PR TITLE
Fix simulate query #2

### DIFF
--- a/js/src/functions.js
+++ b/js/src/functions.js
@@ -1135,15 +1135,10 @@ Functions.setQuery = function (query) {
  * @return {void}
  */
 Functions.handleSimulateQueryButton = function () {
-    var updateRegExp = new RegExp('^\\s*UPDATE\\s+((`[^`]+`)|([A-Za-z0-9_$]+))\\s+SET\\s', 'i');
-    var deleteRegExp = new RegExp('^\\s*DELETE\\s+FROM\\s', 'i');
-    var query = '';
+    var updateRegExp = /^\s*UPDATE\b\s*(((`([^`]|``)+`)|([a-z0-9_$]+))\s*\.\s*)?((`([^`]|``)+`)|([a-z0-9_$]+))\s*\bSET\b/i;
+    var deleteRegExp = /^\s*DELETE\b\s*((((`([^`]|``)+`)|([a-z0-9_$]+))\s*\.\s*)?((`([^`]|``)+`)|([a-z0-9_$]+))\s*)?\bFROM\b/i;
 
-    if (codeMirrorEditor) {
-        query = codeMirrorEditor.getValue();
-    } else {
-        query = $('#sqlquery').val();
-    }
+    var query = codeMirrorEditor ? codeMirrorEditor.getValue() : $('#sqlquery').val();
 
     var $simulateDml = $('#simulate_dml');
     if (updateRegExp.test(query) || deleteRegExp.test(query)) {


### PR DESCRIPTION
Allows showing the updated values by clicking on the affected row number https://github.com/phpmyadmin/phpmyadmin/pull/18583#discussion_r1306655772.

- Did not work when setting value to other column value, e.g. `SET a=a+1`
- Show updated data when clicking on the affected rows number
  Now shows all table columns plus the new value as a column
- The button now also appears when using an update statement that uses schema.table format,
and delete statements like `DELETE a FROM a ...`