### PR TITLE
Optimize autocomplete

### DIFF
--- a/js/src/modules/functions.ts
+++ b/js/src/modules/functions.ts
@@ -1212,24 +1212,15 @@ function codeMirrorAutoCompleteOnInputRead (instance) {
                                     columns: []
                                 };
 
-                                for (var column in columns) {
-                                    if (columns.hasOwnProperty(column)) {
-                                        var displayText = columns[column].Type;
-                                        if (columns[column].Key === 'PRI') {
-                                            displayText += ' | Primary';
-                                        } else if (columns[column].Key === 'UNI') {
-                                            displayText += ' | Unique';
-                                        }
-
-                                        // @ts-ignore
-                                        table.columns.push({
-                                            text: column,
-                                            displayText: column + ' | ' + displayText,
-                                            columnName: column,
-                                            columnHint: displayText,
-                                            render: columnHintRender
-                                        });
-                                    }
+                                for (let column of columns) {
+                                    // @ts-ignore
+                                    table.columns.push({
+                                        text: column.field,
+                                        displayText: column.field + ' | ' + column.columnHint,
+                                        columnName: column.field,
+                                        columnHint: column.columnHint,
+                                        render: columnHintRender
+                                    });
                                 }
                             }
 


### PR DESCRIPTION
Technically a microoptimization, but it might help on large databases with lots of columns. 

On my test database, the payload size dropped from 25.7kB to 18.1kB. I know it's not a very scientific measurement, but in theory, it should improve performance on slow connections. 