### PR TITLE
Avoid auto-updating 'timestamp' fields to NOW()

### DIFF
--- a/src/InsertEditColumn.php
+++ b/src/InsertEditColumn.php
@@ -63,6 +63,13 @@ final class InsertEditColumn
          * It seems like a long time ago before refactoring into classes,
          * this kept track of how many timestamps are in the table.
          */
-        $this->firstTimestamp = $this->trueType === 'timestamp';
+
+        /** 
+         * Fix: By setting 'firstTimestamp' to false, we no longer make the assumption 
+         * that all fields of type "timestamp" should be set to NOW(). 
+         * This resolves the issue of incorrectly updating "timestamp" fields that do not have 
+         * a default value of "CURRENT_TIMESTAMP" or an "extra" attribute of "ON UPDATE CURRENT_TIMESTAMP".
+         */
+        $this->firstTimestamp = false; // $this->trueType === 'timestamp';
     }
 }


### PR DESCRIPTION
### Description

The 'firstTimestamp' variable was being set to true for all fields of type 'timestamp', regardless of their default or extra attributes. This led to unintentional updates of these fields to NOW().

Fixes #18677
Row edit has now() preselected on timestamp columns

Solution:
Explicitly set 'firstTimestamp' to false to prevent auto-updating of 'timestamp' fields that don't have a default of "CURRENT_TIMESTAMP" or an extra of "ON UPDATE CURRENT_TIMESTAMP".

### Description

Please describe your pull request.

Fixes #

Before submitting pull request, please review the following checklist:

- [ ] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [ ] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [ ] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [ ] Every commit has a descriptive commit message.
- [ ] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
