### PR TITLE
Add a documentation note to the nopassword config

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -685,6 +685,11 @@ Server connection settings
     login is still tried first, but as fallback, no password method is
     tried.
 
+    .. note::
+
+        It is possible to allow logging in with no password with
+        the :config:option:`$cfg['Servers'][$i]['AllowNoPassword']` directive.
+
 .. _servers_only_db:
 .. config:option:: $cfg['Servers'][$i]['only_db']
 


### PR DESCRIPTION
Adds a note to the `$cfg['Servers'][$i]['nopassword']` directive to add a reference to the `$cfg['Servers'][$i]['AllowNoPassword']`.

- Fixes https://github.com/phpmyadmin/phpmyadmin/issues/18680.
