### PR TITLE
Fix enum/set value escaping

### DIFF
--- a/libraries/classes/Controllers/Sql/EnumValuesController.php
+++ b/libraries/classes/Controllers/Sql/EnumValuesController.php
@@ -11,9 +11,7 @@ use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
 
 use function __;
-use function htmlentities;
-
-use const ENT_COMPAT;
+use function strval;
 
 final class EnumValuesController extends AbstractController
 {
@@ -44,7 +42,7 @@ final class EnumValuesController extends AbstractController
         $this->checkUserPrivileges->getPrivileges();
 
         $column = $_POST['column'];
-        $curr_value = $_POST['curr_value'];
+        $currValue = $_POST['curr_value'];
         $values = $this->sql->getValuesForColumn($db, $table, $column);
 
         if ($values === null) {
@@ -54,12 +52,9 @@ final class EnumValuesController extends AbstractController
             return;
         }
 
-        // Converts characters of $curr_value to HTML entities.
-        $convertedCurrentValue = htmlentities($curr_value, ENT_COMPAT, 'UTF-8');
-
         $dropdown = $this->template->render('sql/enum_column_dropdown', [
             'values' => $values,
-            'selected_values' => [$convertedCurrentValue],
+            'selected_values' => [strval($currValue)],
         ]);
 
         $this->response->addJSON('dropdown', $dropdown);

--- a/libraries/classes/Controllers/Sql/SetValuesController.php
+++ b/libraries/classes/Controllers/Sql/SetValuesController.php
@@ -11,9 +11,7 @@ use PhpMyAdmin\Sql;
 use PhpMyAdmin\Template;
 
 use function __;
-use function htmlentities;
-
-use const ENT_COMPAT;
+use function explode;
 
 final class SetValuesController extends AbstractController
 {
@@ -62,12 +60,9 @@ final class SetValuesController extends AbstractController
             $currentValue = $this->sql->getFullValuesForSetColumn($db, $table, $column, $whereClause);
         }
 
-        // Converts characters of $currentValue to HTML entities.
-        $convertedCurrentValue = htmlentities($currentValue, ENT_COMPAT, 'UTF-8');
-
         $select = $this->template->render('sql/set_column', [
             'values' => $values,
-            'current_values' => $convertedCurrentValue,
+            'current_values' => explode(',', $currentValue),
         ]);
 
         $this->response->addJSON('select', $select);

--- a/libraries/classes/Sql.php
+++ b/libraries/classes/Sql.php
@@ -338,7 +338,7 @@ class Sql
             return null;
         }
 
-        return Util::parseEnumSetValues($fieldInfoResult[0]['Type']);
+        return Util::parseEnumSetValues($fieldInfoResult[0]['Type'], false);
     }
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2834,11 +2834,10 @@
     </MixedArgument>
     <PossiblyInvalidArgument occurrences="2">
       <code>$column</code>
-      <code>$curr_value</code>
+      <code>$currValue</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="2">
+    <PossiblyInvalidCast occurrences="1">
       <code>$column</code>
-      <code>$curr_value</code>
     </PossiblyInvalidCast>
   </file>
   <file src="libraries/classes/Controllers/Sql/RelationalValuesController.php">

--- a/templates/sql/enum_column_dropdown.twig
+++ b/templates/sql/enum_column_dropdown.twig
@@ -1,5 +1,5 @@
 <select>
   {% for value in values %}
-    <option value="{{ value|raw }}"{{ value in selected_values ? " selected" }}>{{ value|raw }}</option>
+    <option value="{{ value }}"{{ value in selected_values ? " selected" }}>{{ value }}</option>
   {% endfor %}
 </select>

--- a/templates/sql/set_column.twig
+++ b/templates/sql/set_column.twig
@@ -1,7 +1,6 @@
 {% set values_amount = values|length %}
-{% set selected_values = current_values|split(',') %}
 <select class="resize-vertical" size="{{ values_amount < 10 ? values_amount : 10 }}" multiple>
   {% for value in values %}
-    <option value="{{ value|raw }}"{{ value in selected_values ? ' selected' }}>{{ value|raw }}</option>
+    <option value="{{ value }}"{{ value in current_values ? ' selected' }}>{{ value }}</option>
   {% endfor %}
 </select>

--- a/test/classes/Controllers/Sql/EnumValuesControllerTest.php
+++ b/test/classes/Controllers/Sql/EnumValuesControllerTest.php
@@ -63,7 +63,7 @@ class EnumValuesControllerTest extends AbstractTestCase
             [
                 [
                     'set',
-                    'set(\'<script>alert("ok")</script>\',\'a&b\',\'b&c\',\'vrai&amp\',\'\')',
+                    "set('<script>alert(\"ok\")</script>','a&b','b&c','vrai&amp','','漢字','''','\\','\\\"\\\\''')",
                     'No',
                     '',
                     'NULL',
@@ -107,6 +107,10 @@ class EnumValuesControllerTest extends AbstractTestCase
                     . '      <option value="b&amp;c" selected>b&amp;c</option>' . "\n"
                     . '      <option value="vrai&amp;amp">vrai&amp;amp</option>' . "\n"
                     . '      <option value=""></option>' . "\n"
+                    . '      <option value="漢字">漢字</option>' . "\n"
+                    . '      <option value="&#039;">&#039;</option>' . "\n"
+                    . '      <option value="\">\</option>' . "\n"
+                    . '      <option value="\&quot;\&#039;">\&quot;\&#039;</option>' . "\n"
                     . '  </select>' . "\n",
             ],
             $this->getResponseJsonResult()

--- a/test/classes/UtilTest.php
+++ b/test/classes/UtilTest.php
@@ -809,14 +809,14 @@ class UtilTest extends AbstractTestCase
                 ],
             ],
             [
-                "ENUM('a&b', 'b''c\\'d', 'e\\\\f')",
+                "ENUM('a&b','b''c\\'d','e\\\\f')",
                 [
                     'type' => 'enum',
                     'print_type' => "enum('a&b', 'b''c\\'d', 'e\\\\f')",
                     'binary' => false,
                     'unsigned' => false,
                     'zerofill' => false,
-                    'spec_in_brackets' => "'a&b', 'b''c\\'d', 'e\\\\f'",
+                    'spec_in_brackets' => "'a&b','b''c\\'d','e\\\\f'",
                     'enum_set_values' => [
                         'a&b',
                         'b\'c\'d',


### PR DESCRIPTION
This fixes the escaping bug related to enum/set values containing quotes and backslashes. It also improves performance of this function through a completely new implementation 