### PR TITLE
Fix max execution time exceeded error in tests

### DIFF
--- a/test/classes/Http/Factory/ServerRequestFactoryTest.php
+++ b/test/classes/Http/Factory/ServerRequestFactoryTest.php
@@ -17,10 +17,11 @@ use Nyholm\Psr7\ServerRequest as NyholmServerRequest;
 use PhpMyAdmin\Http\Factory\ServerRequestFactory;
 use PhpMyAdmin\Http\Factory\UriFactory;
 use PhpMyAdmin\Http\ServerRequest;
-use PHPUnit\Framework\Attributes\BackupStaticProperties;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Medium;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -70,7 +71,8 @@ final class ServerRequestFactoryTest extends TestCase
 
     /** @psalm-param class-string<ServerRequestFactoryInterface> $provider */
     #[DataProvider('providerForTestCreate')]
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testCreate(string $provider): void
     {
         $this->skipIfNotAvailable($provider);
@@ -91,7 +93,8 @@ final class ServerRequestFactoryTest extends TestCase
         yield 'httpsoft/http-message' => [HttpSoftServerRequestFactory::class];
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testCreateWithoutProvider(): void
     {
         (new ReflectionProperty(ServerRequestFactory::class, 'providers'))
@@ -107,7 +110,8 @@ final class ServerRequestFactoryTest extends TestCase
      * @psalm-param class-string<UriInterface> $expectedUri
      */
     #[DataProvider('providerForTestFromGlobals')]
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testFromGlobals(string $provider, string $uriFactoryProvider, string $expectedUri): void
     {
         $this->skipIfNotAvailable($provider);
@@ -145,7 +149,8 @@ final class ServerRequestFactoryTest extends TestCase
      * @psalm-param class-string<UriInterface> $expectedUri
      */
     #[DataProvider('providerForTestFromGlobals')]
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testFromGlobals2(string $provider, string $uriFactoryProvider, string $expectedUri): void
     {
         $this->skipIfNotAvailable($provider);
@@ -198,7 +203,8 @@ final class ServerRequestFactoryTest extends TestCase
      * @psalm-param class-string<UriInterface> $expectedUri
      */
     #[DataProvider('providerForTestFromGlobals')]
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testFromGlobals3(string $provider, string $uriFactoryProvider, string $expectedUri): void
     {
         $this->skipIfNotAvailable($provider);

--- a/test/classes/Plugins/Auth/AuthenticationConfigTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationConfigTest.php
@@ -10,9 +10,10 @@ use PhpMyAdmin\Exceptions\ExitException;
 use PhpMyAdmin\Plugins\Auth\AuthenticationConfig;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
-use PHPUnit\Framework\Attributes\BackupStaticProperties;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Medium;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use Throwable;
 
@@ -57,7 +58,8 @@ class AuthenticationConfigTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuth(): void
     {
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
@@ -81,7 +83,8 @@ class AuthenticationConfigTest extends AbstractTestCase
         );
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthFails(): void
     {
         Config::getInstance()->settings['Servers'] = [1];

--- a/test/classes/Plugins/Auth/AuthenticationCookieTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationCookieTest.php
@@ -12,11 +12,12 @@ use PhpMyAdmin\Plugins\Auth\AuthenticationCookie;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
-use PHPUnit\Framework\Attributes\BackupStaticProperties;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionException;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -78,7 +79,8 @@ class AuthenticationCookieTest extends AbstractTestCase
     }
 
     #[Group('medium')]
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthErrorAJAX(): void
     {
         $GLOBALS['conn_error'] = true;
@@ -116,7 +118,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         ErrorHandler::$instance = $mockErrorHandler;
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     #[Group('medium')]
     public function testAuthError(): void
     {
@@ -192,7 +195,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         $this->assertStringContainsString('<input type="hidden" name="table" value="testTable">', $result);
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     #[Group('medium')]
     public function testAuthCaptcha(): void
     {
@@ -254,7 +258,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         );
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     #[Group('medium')]
     public function testAuthCaptchaCheckbox(): void
     {
@@ -318,7 +323,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         );
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthHeader(): void
     {
         $config = Config::getInstance();
@@ -338,7 +344,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         $this->assertSame(302, $response->getStatusCode());
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthHeaderPartial(): void
     {
         $config = Config::getInstance();
@@ -381,7 +388,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         );
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testLogoutDelete(): void
     {
         $responseStub = new ResponseRendererStub();
@@ -409,7 +417,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         $this->assertArrayNotHasKey('pmaAuth-0', $_COOKIE);
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testLogout(): void
     {
         $responseStub = new ResponseRendererStub();
@@ -666,7 +675,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         $this->object->rememberCredentials();
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthFailsNoPass(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -741,7 +751,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         $this->assertEquals($GLOBALS['conn_error'], $connError);
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthFailsDeny(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -773,7 +784,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         $this->assertEquals($GLOBALS['conn_error'], 'Access denied!');
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthFailsActivity(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -812,7 +824,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         );
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthFailsDBI(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -855,7 +868,8 @@ class AuthenticationCookieTest extends AbstractTestCase
         $this->assertEquals($GLOBALS['conn_error'], '#42 Cannot log in to the MySQL server');
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthFailsErrno(): void
     {
         $this->object = $this->getMockBuilder(AuthenticationCookie::class)
@@ -1022,7 +1036,8 @@ class AuthenticationCookieTest extends AbstractTestCase
      * @param mixed[] $rules    rules
      * @param string  $expected expected result
      */
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     #[DataProvider('checkRulesProvider')]
     public function testCheckRules(
         string $user,

--- a/test/classes/Plugins/Auth/AuthenticationHttpTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationHttpTest.php
@@ -11,11 +11,11 @@ use PhpMyAdmin\Plugins\Auth\AuthenticationHttp;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
-use PHPUnit\Framework\Attributes\BackupStaticProperties;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use Throwable;
@@ -63,7 +63,8 @@ class AuthenticationHttpTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthLogoutUrl(): void
     {
         $config = Config::getInstance();
@@ -80,7 +81,8 @@ class AuthenticationHttpTest extends AbstractTestCase
         $this->assertSame(302, $response->getStatusCode());
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthVerbose(): void
     {
         $config = Config::getInstance();
@@ -101,7 +103,8 @@ class AuthenticationHttpTest extends AbstractTestCase
         $this->assertSame(401, $response->getStatusCode());
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthHost(): void
     {
         $config = Config::getInstance();
@@ -123,7 +126,8 @@ class AuthenticationHttpTest extends AbstractTestCase
         $this->assertSame(401, $response->getStatusCode());
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthRealm(): void
     {
         $config = Config::getInstance();
@@ -278,6 +282,7 @@ class AuthenticationHttpTest extends AbstractTestCase
 
     #[Group('medium')]
     #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthFails(): void
     {
         $config = Config::getInstance();

--- a/test/classes/Plugins/Auth/AuthenticationSignonTest.php
+++ b/test/classes/Plugins/Auth/AuthenticationSignonTest.php
@@ -12,8 +12,9 @@ use PhpMyAdmin\Plugins\Auth\AuthenticationSignon;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
-use PHPUnit\Framework\Attributes\BackupStaticProperties;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use Throwable;
 
@@ -58,7 +59,8 @@ class AuthenticationSignonTest extends AbstractTestCase
         unset($this->object);
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuth(): void
     {
         (new ReflectionProperty(ResponseRenderer::class, 'instance'))->setValue(null, null);
@@ -81,7 +83,8 @@ class AuthenticationSignonTest extends AbstractTestCase
         $this->assertStringContainsString('You must set SignonURL!', $result);
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthLogoutURL(): void
     {
         $responseStub = new ResponseRendererStub();
@@ -98,7 +101,8 @@ class AuthenticationSignonTest extends AbstractTestCase
         $this->assertSame(302, $response->getStatusCode());
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthLogout(): void
     {
         $responseStub = new ResponseRendererStub();
@@ -149,7 +153,8 @@ class AuthenticationSignonTest extends AbstractTestCase
         $this->assertEquals('https://example.com/SignonURL', $_SESSION['LAST_SIGNON_URL']);
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testAuthCheckToken(): void
     {
         $_SESSION = [' PMA_token ' => 'eefefef'];

--- a/test/classes/Setup/FormProcessingTest.php
+++ b/test/classes/Setup/FormProcessingTest.php
@@ -12,8 +12,9 @@ use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Setup\FormProcessing;
 use PhpMyAdmin\Tests\AbstractTestCase;
 use PhpMyAdmin\Tests\Stubs\ResponseRenderer as ResponseRendererStub;
-use PHPUnit\Framework\Attributes\BackupStaticProperties;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use ReflectionProperty;
 use Throwable;
 
@@ -38,7 +39,8 @@ class FormProcessingTest extends AbstractTestCase
         Config::getInstance()->settings['ServerDefault'] = 1;
     }
 
-    #[BackupStaticProperties(true)]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testProcessFormSet(): void
     {
         DatabaseInterface::$instance = $this->createDatabaseInterface();


### PR DESCRIPTION
Runs these tests in isolation because they are causing a time out error when backing up the global state.