### PR TITLE
Fix user accout navigation by initials

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17057,7 +17057,7 @@ parameters:
 
 		-
 			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
-			count: 18
+			count: 17
 			path: src/Server/Privileges.php
 
 		-
@@ -17167,7 +17167,7 @@ parameters:
 
 		-
 			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
-			count: 19
+			count: 18
 			path: src/Server/Privileges.php
 
 		-
@@ -17201,23 +17201,18 @@ parameters:
 			path: src/Server/Privileges.php
 
 		-
-			message: "#^Only booleans are allowed in &&, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given on the left side\\.$#"
-			count: 1
-			path: src/Server/Privileges.php
-
-		-
 			message: "#^Only booleans are allowed in &&, int\\|false given on the right side\\.$#"
 			count: 1
 			path: src/Server/Privileges.php
 
 		-
 			message: "#^Only booleans are allowed in a negated boolean, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
-			count: 14
+			count: 13
 			path: src/Server/Privileges.php
 
 		-
 			message: "#^Only booleans are allowed in an if condition, PhpMyAdmin\\\\Dbal\\\\ResultInterface\\|false given\\.$#"
-			count: 6
+			count: 5
 			path: src/Server/Privileges.php
 
 		-
@@ -17417,7 +17412,7 @@ parameters:
 
 		-
 			message: "#^Possibly invalid array key type array\\<int, string\\>\\|string\\|null\\.$#"
-			count: 3
+			count: 1
 			path: src/Server/Privileges.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11220,6 +11220,9 @@
     <DeprecatedMethod>
       <code>Config::getInstance()</code>
     </DeprecatedMethod>
+    <InvalidArgument>
+      <code>$initials</code>
+    </InvalidArgument>
     <InvalidArrayOffset>
       <code><![CDATA[$GLOBALS['Grant_priv']]]></code>
       <code><![CDATA[$GLOBALS['Grant_priv']]]></code>
@@ -11236,9 +11239,6 @@
       <code><![CDATA[$GLOBALS['x509_issuer']]]></code>
       <code><![CDATA[$GLOBALS['x509_subject']]]></code>
     </InvalidArrayOffset>
-    <InvalidScalarArgument>
-      <code><![CDATA[uksort($arrayInitials, 'strnatcasecmp')]]></code>
-    </InvalidScalarArgument>
     <MixedArgument>
       <code><![CDATA[$GLOBALS['dbname']]]></code>
       <code>$alterRealSqlQuery</code>
@@ -11455,7 +11455,6 @@
       <code><![CDATA[$row['@@old_passwords']]]></code>
     </PossiblyNullArrayAccess>
     <PossiblyNullArrayOffset>
-      <code>$arrayInitials</code>
       <code>$columns</code>
       <code>$columns</code>
       <code>$dbRights</code>
@@ -11464,8 +11463,6 @@
       <code>$dbRights</code>
       <code>$dbRights</code>
       <code>$dbRights</code>
-      <code>$dbRights</code>
-      <code><![CDATA[$dbRights[$dbRightsRow['User']]]]></code>
       <code><![CDATA[$dbRights[$row['User']]]]></code>
       <code>$groupAssignment</code>
       <code>$row</code>

--- a/templates/server/privileges/initials_row.twig
+++ b/templates/server/privileges/initials_row.twig
@@ -1,22 +1,20 @@
 <nav aria-label="{% trans 'Pagination of user accounts' %}">
   <ul id="userAccountsPagination" class="pagination">
-    {% for tmp_initial, initial_was_found in array_initials %}
-      {% if tmp_initial is not same as(null) %}
-        {% if initial_was_found %}
-          <li class="page-item{{ initial is same as(tmp_initial) ? ' active' }}"{{ initial is same as(tmp_initial) ? ' aria-current="page"' }}>
-            <a class="page-link" href="{{ url('/server/privileges', {'initial': tmp_initial}) }}">
-            {% if tmp_initial is same as('') %}
-              <span class="text-danger text-nowrap">{{ 'Any' |trans }}</span>
-            {% else %}
-              {{ tmp_initial }}
-            {% endif %}
-            </a>
-          </li>
-        {% else %}
-          <li class="page-item disabled">
-            <a class="page-link" href="#" tabindex="-1" aria-disabled="true">{{ tmp_initial }}</a>
-          </li>
-        {% endif %}
+    {% for initial, user_available in array_initials %}
+      {% if user_available %}
+        <li class="page-item{{ selected_initial is same as(initial) ? ' active' }}"{{ selected_initial is same as(initial) ? ' aria-current="page"' }}>
+          <a class="page-link" href="{{ url('/server/privileges', {'initial': initial}) }}">
+          {% if initial is same as('') %}
+            <span class="text-danger text-nowrap">{{ 'Any' |trans }}</span>
+          {% else %}
+            {{ initial }}
+          {% endif %}
+          </a>
+        </li>
+      {% else %}
+        <li class="page-item disabled">
+          <a class="page-link" href="#" tabindex="-1" aria-disabled="true">{{ initial }}</a>
+        </li>
       {% endif %}
     {% endfor %}
     <li class="page-item">

--- a/test/classes/Controllers/Server/PrivilegesControllerTest.php
+++ b/test/classes/Controllers/Server/PrivilegesControllerTest.php
@@ -42,23 +42,16 @@ class PrivilegesControllerTest extends AbstractTestCase
         // phpcs:disable Generic.Files.LineLength.TooLong
         $this->dummyDbi->addSelectDb('mysql');
         $this->dummyDbi->addResult(
-            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS \'Password\' FROM `mysql`.`user` ORDER BY `User` ASC, `Host` ASC;',
+            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS `Password` FROM `mysql`.`user` ORDER BY `User` ASC, `Host` ASC',
             [
                 ['localhost', 'pma', 'password', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', '', '', '', '', '0', '0', '0', '0', 'mysql_native_password', 'password', 'N', 'N', '', '0.000000', 'Y'],
                 ['localhost', 'root', 'password', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', '', '', '', '', '0', '0', '0', '0', 'mysql_native_password', 'password', 'N', 'N', '', '0.000000', 'Y'],
             ],
             ['Host', 'User', 'Password', 'Select_priv', 'Insert_priv', 'Update_priv', 'Delete_priv', 'Create_priv', 'Drop_priv', 'Reload_priv', 'Shutdown_priv', 'Process_priv', 'File_priv', 'Grant_priv', 'References_priv', 'Index_priv', 'Alter_priv', 'Show_db_priv', 'Super_priv', 'Create_tmp_table_priv', 'Lock_tables_priv', 'Execute_priv', 'Repl_slave_priv', 'Repl_client_priv', 'Create_view_priv', 'Show_view_priv', 'Create_routine_priv', 'Alter_routine_priv', 'Create_user_priv', 'Event_priv', 'Trigger_priv', 'Create_tablespace_priv', 'Delete_history_priv', 'ssl_type', 'ssl_cipher', 'x509_issuer', 'x509_subject', 'max_questions', 'max_updates', 'max_connections', 'max_user_connections', 'plugin', 'authentication_string', 'password_expired', 'is_role', 'default_role', 'max_statement_time', 'Password'],
         );
+        $this->dummyDbi->addResult('SELECT COUNT(*) FROM `mysql`.`user`', [[2]], ['COUNT(*)']);
         $this->dummyDbi->addResult(
-            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS \'Password\' FROM `mysql`.`user` ;',
-            [
-                ['localhost', 'root', 'password', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', '', '', '', '', '0', '0', '0', '0', 'mysql_native_password', 'password', 'N', 'N', '', '0.000000', 'Y'],
-                ['localhost', 'pma', 'password', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', '', '', '', '', '0', '0', '0', '0', 'mysql_native_password', 'password', 'N', 'N', '', '0.000000', 'Y'],
-            ],
-            ['Host', 'User', 'Password', 'Select_priv', 'Insert_priv', 'Update_priv', 'Delete_priv', 'Create_priv', 'Drop_priv', 'Reload_priv', 'Shutdown_priv', 'Process_priv', 'File_priv', 'Grant_priv', 'References_priv', 'Index_priv', 'Alter_priv', 'Show_db_priv', 'Super_priv', 'Create_tmp_table_priv', 'Lock_tables_priv', 'Execute_priv', 'Repl_slave_priv', 'Repl_client_priv', 'Create_view_priv', 'Show_view_priv', 'Create_routine_priv', 'Alter_routine_priv', 'Create_user_priv', 'Event_priv', 'Trigger_priv', 'Create_tablespace_priv', 'Delete_history_priv', 'ssl_type', 'ssl_cipher', 'x509_issuer', 'x509_subject', 'max_questions', 'max_updates', 'max_connections', 'max_user_connections', 'plugin', 'authentication_string', 'password_expired', 'is_role', 'default_role', 'max_statement_time', 'Password'],
-        );
-        $this->dummyDbi->addResult(
-            'SHOW TABLES FROM `mysql`;',
+            'SHOW TABLES FROM `mysql`',
             [['columns_priv'], ['db'], ['tables_priv'], ['user']],
             ['Tables_in_mysql'],
         );

--- a/test/classes/Server/PrivilegesTest.php
+++ b/test/classes/Server/PrivilegesTest.php
@@ -131,13 +131,13 @@ class PrivilegesTest extends AbstractTestCase
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface());
 
         $ret = $serverPrivileges->rangeOfUsers('INIT');
-        $this->assertEquals(' WHERE `User` LIKE \'INIT%\' OR `User` LIKE \'init%\'', $ret);
+        $this->assertEquals('WHERE `User` LIKE \'INIT%\' OR `User` LIKE \'init%\'', $ret);
 
         $ret = $serverPrivileges->rangeOfUsers('%');
-        $this->assertEquals(' WHERE `User` LIKE \'\\\\%%\' OR `User` LIKE \'\\\\%%\'', $ret);
+        $this->assertEquals('WHERE `User` LIKE \'\\\\%%\' OR `User` LIKE \'\\\\%%\'', $ret);
 
         $ret = $serverPrivileges->rangeOfUsers('');
-        $this->assertEquals(" WHERE `User` = ''", $ret);
+        $this->assertEquals("WHERE `User` = ''", $ret);
 
         $ret = $serverPrivileges->rangeOfUsers();
         $this->assertEquals('', $ret);
@@ -1473,23 +1473,16 @@ class PrivilegesTest extends AbstractTestCase
         $dummyDbi = $this->createDbiDummy();
         // phpcs:disable Generic.Files.LineLength.TooLong
         $dummyDbi->addResult(
-            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS \'Password\' FROM `mysql`.`user` ORDER BY `User` ASC, `Host` ASC;',
+            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS `Password` FROM `mysql`.`user` ORDER BY `User` ASC, `Host` ASC',
             [
                 ['localhost', 'pma', 'password', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', '', '', '', '', '0', '0', '0', '0', 'mysql_native_password', 'password', 'N', 'N', '', '0.000000', 'Y'],
                 ['localhost', 'root', 'password', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', '', '', '', '', '0', '0', '0', '0', 'mysql_native_password', 'password', 'N', 'N', '', '0.000000', 'Y'],
             ],
             ['Host', 'User', 'Password', 'Select_priv', 'Insert_priv', 'Update_priv', 'Delete_priv', 'Create_priv', 'Drop_priv', 'Reload_priv', 'Shutdown_priv', 'Process_priv', 'File_priv', 'Grant_priv', 'References_priv', 'Index_priv', 'Alter_priv', 'Show_db_priv', 'Super_priv', 'Create_tmp_table_priv', 'Lock_tables_priv', 'Execute_priv', 'Repl_slave_priv', 'Repl_client_priv', 'Create_view_priv', 'Show_view_priv', 'Create_routine_priv', 'Alter_routine_priv', 'Create_user_priv', 'Event_priv', 'Trigger_priv', 'Create_tablespace_priv', 'Delete_history_priv', 'ssl_type', 'ssl_cipher', 'x509_issuer', 'x509_subject', 'max_questions', 'max_updates', 'max_connections', 'max_user_connections', 'plugin', 'authentication_string', 'password_expired', 'is_role', 'default_role', 'max_statement_time', 'Password'],
         );
+        $dummyDbi->addResult('SELECT COUNT(*) FROM `mysql`.`user`', [[2]]);
         $dummyDbi->addResult(
-            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS \'Password\' FROM `mysql`.`user` ;',
-            [
-                ['localhost', 'root', 'password', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', 'Y', '', '', '', '', '0', '0', '0', '0', 'mysql_native_password', 'password', 'N', 'N', '', '0.000000', 'Y'],
-                ['localhost', 'pma', 'password', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', '', '', '', '', '0', '0', '0', '0', 'mysql_native_password', 'password', 'N', 'N', '', '0.000000', 'Y'],
-            ],
-            ['Host', 'User', 'Password', 'Select_priv', 'Insert_priv', 'Update_priv', 'Delete_priv', 'Create_priv', 'Drop_priv', 'Reload_priv', 'Shutdown_priv', 'Process_priv', 'File_priv', 'Grant_priv', 'References_priv', 'Index_priv', 'Alter_priv', 'Show_db_priv', 'Super_priv', 'Create_tmp_table_priv', 'Lock_tables_priv', 'Execute_priv', 'Repl_slave_priv', 'Repl_client_priv', 'Create_view_priv', 'Show_view_priv', 'Create_routine_priv', 'Alter_routine_priv', 'Create_user_priv', 'Event_priv', 'Trigger_priv', 'Create_tablespace_priv', 'Delete_history_priv', 'ssl_type', 'ssl_cipher', 'x509_issuer', 'x509_subject', 'max_questions', 'max_updates', 'max_connections', 'max_user_connections', 'plugin', 'authentication_string', 'password_expired', 'is_role', 'default_role', 'max_statement_time', 'Password'],
-        );
-        $dummyDbi->addResult(
-            'SHOW TABLES FROM `mysql`;',
+            'SHOW TABLES FROM `mysql`',
             [['columns_priv'], ['db'], ['tables_priv'], ['user']],
             ['Tables_in_mysql'],
         );
@@ -1514,11 +1507,11 @@ class PrivilegesTest extends AbstractTestCase
         $dummyDbi = $this->createDbiDummy();
         // phpcs:disable Generic.Files.LineLength.TooLong
         $dummyDbi->addResult(
-            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS \'Password\' FROM `mysql`.`user` ORDER BY `User` ASC, `Host` ASC;',
+            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS `Password` FROM `mysql`.`user` ORDER BY `User` ASC, `Host` ASC',
             false,
         );
         $dummyDbi->addResult(
-            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS \'Password\' FROM `mysql`.`user` ;',
+            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS `Password` FROM `mysql`.`user` ',
             false,
         );
         $dummyDbi->addResult('SELECT 1 FROM `mysql`.`user`', false);
@@ -1542,17 +1535,14 @@ class PrivilegesTest extends AbstractTestCase
         $dummyDbi = $this->createDbiDummy();
         // phpcs:disable Generic.Files.LineLength.TooLong
         $dummyDbi->addResult(
-            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS \'Password\' FROM `mysql`.`user` ORDER BY `User` ASC, `Host` ASC;',
+            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS `Password` FROM `mysql`.`user` ORDER BY `User` ASC, `Host` ASC',
             false,
         );
         $dummyDbi->addResult(
-            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS \'Password\' FROM `mysql`.`user` ;',
+            'SELECT *, IF(`authentication_string` = _latin1 \'\', \'N\', \'Y\') AS `Password` FROM `mysql`.`user` ',
             false,
         );
-        $dummyDbi->addResult(
-            'SELECT 1 FROM `mysql`.`user`',
-            [['1']],
-        );
+        $dummyDbi->addResult('SELECT 1 FROM `mysql`.`user`', [[1]]);
         $serverPrivileges = $this->getPrivileges($this->createDatabaseInterface($dummyDbi));
         $actual = $serverPrivileges->getHtmlForUserOverview('ltr', null);
 
@@ -1635,9 +1625,10 @@ class PrivilegesTest extends AbstractTestCase
         $GLOBALS['lang'] = 'en';
 
         $dummyDbi = $this->createDbiDummy();
+        $dummyDbi->addResult('SELECT COUNT(*) FROM `mysql`.`user`', [[21]]);
         $dummyDbi->addResult(
-            'SELECT DISTINCT UPPER(LEFT(`User`,1)) FROM `user` ORDER BY UPPER(LEFT(`User`,1)) ASC',
-            [['-'], ['"'], ['%'], ['\\'], ['']],
+            'SELECT DISTINCT UPPER(LEFT(`User`, 1)) FROM `user`',
+            [['C'], ['-'], ['"'], ['%'], ['\\'], ['']],
         );
 
         $dbi = $this->createDatabaseInterface($dummyDbi);
@@ -1646,6 +1637,10 @@ class PrivilegesTest extends AbstractTestCase
         $actual = $serverPrivileges->getHtmlForInitials();
         $this->assertStringContainsString(
             '<a class="page-link" href="#" tabindex="-1" aria-disabled="true">A</a>',
+            $actual,
+        );
+        $this->assertMatchesRegularExpression(
+            '/<a class="page-link" href="index.php\?route=\/server\/privileges&initial=C&lang=en">\s*C\s*<\/a>/',
             $actual,
         );
         $this->assertStringContainsString(


### PR DESCRIPTION
Fixes two issues with the user account initials links and some refactoring

- Empty user names were not displayed properly in the list of initials and did not filter correctly when clicked
- User names starting with %, _, or \ were not properly filtered when clicking the initial.

Before / After
![image](https://github.com/phpmyadmin/phpmyadmin/assets/4426597/8198ecc6-3192-4cc1-bc31-d998335acd90) ![image](https://github.com/phpmyadmin/phpmyadmin/assets/4426597/845fa3d2-dc37-422e-b7a2-cb34bccb3ada)

To test, just create a bunch of  users (at least 20 for the initials to be displayed)
```sql
CREATE USER '\\';
CREATE USER '';
CREATE USER '_';
CREATE USER '%';
```