### PR TITLE
Limit label width in create-view table

### DIFF
--- a/templates/view_create.twig
+++ b/templates/view_create.twig
@@ -20,6 +20,11 @@
 
     <div class="card-body">
       <table class="table align-middle rte_table">
+        <colgroup>
+          <col>
+          <col width="100%">
+        </colgroup>
+
         {% if view['operation'] == 'create' %}
           <tr>
             <td class="text-nowrap"><label for="or_replace">OR REPLACE</label></td>


### PR DESCRIPTION
This limits the label column width  of the create/edit view form.

Currently the label column may grow beyond what is necessary.

See also #18310