### PR TITLE
Fix gis editor changing geometry type and opening in search views

### DIFF
--- a/js/src/table/select.js
+++ b/js/src/table/select.js
@@ -182,7 +182,7 @@ AJAX.registerOnload('table/select.js', function () {
     });
 
     // Following section is related to the 'function based search' for geometry data types.
-    // Initially hide all the open_gis_editor spans
+    // Initially hide all the open_search_gis_editor spans
     $('span.open_search_gis_editor').hide();
 
     $('select.geom_func').on('change', function () {
@@ -251,13 +251,15 @@ AJAX.registerOnload('table/select.js', function () {
         var field = 'Parameter';
         // Column type
         var geomFunc = $span.parents('tr').find('.geom_func').val();
-        var type;
-        if (geomFunc === 'Envelope') {
-            type = 'polygon';
-        } else if (geomFunc === 'ExteriorRing') {
-            type = 'linestring';
-        } else {
-            type = 'point';
+        var type = 'GEOMETRY';
+        if (!value) {
+            if (geomFunc === 'Envelope') {
+                value = 'POLYGON()';
+            } else if (geomFunc === 'ExteriorRing') {
+                value = 'LINESTRING()';
+            } else {
+                value = 'POINT()';
+            }
         }
         // Names of input field and null checkbox
         var inputName = $span.parent('td').children('input[type=\'text\']').attr('name');

--- a/libraries/classes/Controllers/GisDataEditorController.php
+++ b/libraries/classes/Controllers/GisDataEditorController.php
@@ -44,7 +44,7 @@ class GisDataEditorController extends AbstractController
         /** @var array|null $gisDataParam */
         $gisDataParam = $request->getParsedBodyParam('gis_data');
         /** @var string $type */
-        $type = $request->getParsedBodyParam('type', '');
+        $type = $request->getParsedBodyParam('type', 'GEOMETRY');
         /** @var string|null $value */
         $value = $request->getParsedBodyParam('value');
         /** @var string|null $generate */

--- a/libraries/classes/Controllers/Table/ZoomSearchController.php
+++ b/libraries/classes/Controllers/Table/ZoomSearchController.php
@@ -115,7 +115,9 @@ class ZoomSearchController extends AbstractController
             'vendor/jqplot/plugins/jqplot.highlighter.js',
             'vendor/jqplot/plugins/jqplot.cursor.js',
             'table/zoom_plot_jqplot.js',
+            'table/select.js',
             'table/change.js',
+            'gis_data_editor.js',
         ]);
 
         /**

--- a/templates/gis_data_editor_form.twig
+++ b/templates/gis_data_editor_form.twig
@@ -4,6 +4,7 @@
         <h3>{{ 'Value for the column "%s"'|trans|format(field) }}</h3>
 
         <input type="hidden" name="field" value="{{ field }}">
+        <input type="hidden" name="type" value="{{ column_type }}">
         {# The input field to which the final result should be added and corresponding null checkbox #}
         {% if input_name is not null %}
             <input type="hidden" name="input_name" value="{{ input_name }}">

--- a/templates/table/insert/column_row.twig
+++ b/templates/table/insert/column_row.twig
@@ -119,7 +119,9 @@
       {% endif %}
 
       {% if column.pma_type in gis_data_types %}
-        <span class="open_gis_editor" data-row-id="{{ row_id }}">{{ link_or_button('#', null, get_icon('b_edit', 'Edit/Insert'|trans), [], '_blank') }}</span>
+        <span class="open_gis_editor" data-row-id="{{ row_id }}">
+          {{ link_or_button('#', null, get_icon('b_edit', 'Edit/Insert'|trans)) }}
+        </span>
       {% endif %}
     {% endif %}
   </td>

--- a/templates/table/search/input_box.twig
+++ b/templates/table/search/input_box.twig
@@ -34,9 +34,8 @@
         class="textfield"
         id="field_{{ column_index }}">
     {% if in_fbs %}
-        {% set edit_str = get_icon('b_edit', 'Edit/Insert'|trans) %}
         <span class="open_search_gis_editor">
-            {{ link_or_button(url('/gis-data-editor'), [], edit_str, [], '_blank') }}
+            {{ link_or_button('#', null, get_icon('b_edit', 'Edit/Insert'|trans)) }}
         </span>
     {% endif %}
 {% elseif column_type starts with 'enum'

--- a/templates/table/zoom_search/index.twig
+++ b/templates/table/zoom_search/index.twig
@@ -146,6 +146,9 @@
           </td>
         </tr>
       </table>
+
+      <div id="gis_editor"></div>
+      <div id="popup_background"></div>
     </div>
 
     <div class="card-footer">

--- a/test/classes/InsertEditTest.php
+++ b/test/classes/InsertEditTest.php
@@ -3353,9 +3353,8 @@ class InsertEditTest extends AbstractTestCase
             $actual
         );
         $this->assertStringContainsString(
-            '<a href="#" target="_blank"><span class="text-nowrap"><img src="themes/dot.'
-            . 'gif" title="Edit/Insert" alt="Edit/Insert" class="icon ic_b_edit">&nbsp;Edit/Insert'
-            . '</span></a>',
+            '<a href="#" ><span class="text-nowrap"><img src="themes/dot.gif" title="Edit/Insert"' .
+            ' alt="Edit/Insert" class="icon ic_b_edit">&nbsp;Edit/Insert</span></a>',
             $actual
         );
     }


### PR DESCRIPTION
After switching the geometry type once the geometry select disappeared and  cannot be  switched again
When opening the editor from the search view, it was also missing, there it should be treated like a GEOMETRY column.
