### PR TITLE
Improve git hash info error handling in home.js

### DIFF
--- a/js/src/ajax.js
+++ b/js/src/ajax.js
@@ -894,11 +894,16 @@ $(document).on('submit', 'form', AJAX.requestHandler);
  * Gracefully handle fatal server errors
  * (e.g: 500 - Internal server error)
  */
-$(document).on('ajaxError', function (event, request) {
+$(document).on('ajaxError', function (event, request, settings) {
     if (AJAX.debug) {
         // eslint-disable-next-line no-console
         console.log('AJAX error: status=' + request.status + ', text=' + request.statusText);
     }
+
+    if (settings.url.includes('/git-revision')) {
+        return;
+    }
+
     // Don't handle aborted requests
     if (request.status !== 0 || request.statusText !== 'abort') {
         var details = '';

--- a/js/src/home.js
+++ b/js/src/home.js
@@ -105,13 +105,15 @@ const GitInfo = {
                 'server': CommonParams.get('server'),
                 'ajax_request': true,
                 'no_debug': true
-            },
-            function (data) {
-                if (typeof data !== 'undefined' && data.success === true) {
-                    $(data.message).insertAfter('#li_pma_version');
-                }
             }
-        );
+        ).done(function (data) {
+            if (typeof data !== 'undefined' && data.success === true) {
+                $(data.message).insertAfter('#li_pma_version');
+            }
+        }).fail(function () {
+            const gitHashInfoLi = '<li id="li_pma_version_git" class="list-group-item">' + window.Messages.errorLoadingGitInformation + '</li>';
+            $(gitHashInfoLi).insertAfter('#li_pma_version');
+        });
     }
 };
 

--- a/libraries/classes/Controllers/JavaScriptMessagesController.php
+++ b/libraries/classes/Controllers/JavaScriptMessagesController.php
@@ -608,6 +608,7 @@ final class JavaScriptMessagesController
             /* l10n: Latest available phpMyAdmin version */
             'strLatestAvailable' => __(', latest stable version:'),
             'strUpToDate' => __('up to date'),
+            'errorLoadingGitInformation' => __('There was an error in loading the Git information.'),
 
             /* Error Reporting */
             'strErrorOccurred' => __('A fatal JavaScript error has occurred. Would you like to send an error report?'),


### PR DESCRIPTION
Instead of showing a generic error message alert when an error occurs, it displays an error message at the same place where the success output goes.

![Screenshot showing the error message](https://github.com/phpmyadmin/phpmyadmin/assets/120970/f75a8590-09ce-4c5f-b9b5-dcbbd7d4546e)
