### PR TITLE
If $cfg['DBG']['sql'] doesn't exist or is set to false, Debug SQL tab should be hidden

### DIFF
--- a/resources/templates/console/display.twig
+++ b/resources/templates/console/display.twig
@@ -19,9 +19,11 @@
           <span>{{ 'Bookmarks'|trans }}</span>
         </div>
       {% endif %}
-      <div class="button debug hide">
-        <span>{{ 'Debug SQL'|trans }}</span>
-      </div>
+      {% if debug %}
+        <div class="button debug hide">
+          <span>{{ 'Debug SQL'|trans }}</span>
+        </div>
+      {% endif %}
     </div>
 
     {# Console messages #}

--- a/src/Console.php
+++ b/src/Console.php
@@ -111,11 +111,13 @@ class Console
         $bookmarkFeature = $this->relation->getRelationParameters()->bookmarkFeature;
         $sqlHistory = $this->relation->getHistory($this->config->selectedServer['user']);
         $bookmarkContent = $this->getBookmarkContent();
+        $debug = isset($this->config->settings['DBG']) && $this->config->settings['DBG']['sql'];
 
         return $this->template->render('console/display', [
             'has_bookmark_feature' => $bookmarkFeature !== null,
             'sql_history' => $sqlHistory,
             'bookmark_content' => $bookmarkContent,
+            'debug' => $debug,
         ]);
     }
 }


### PR DESCRIPTION
### Description

Fixes the issue of the `Debug SQL` Tab being visible

Fixes #18716 