### PR TITLE
fix #18563 - can't access property toString, data[j][0] is null

### DIFF
--- a/js/src/chart.js
+++ b/js/src/chart.js
@@ -287,7 +287,7 @@ JQPlotLineChart.prototype.populateOptions = function (dataTable, options) {
     if (optional.axes.xaxis.ticks.length === 0) {
         var data = dataTable.getData();
         for (var j = 0; j < data.length; j++) {
-            optional.axes.xaxis.ticks.push(data[j][0]?.toString());
+            optional.axes.xaxis.ticks.push(data[j][0] !== null ? data[j][0].toString() : null);
         }
     }
     return optional;

--- a/js/src/chart.js
+++ b/js/src/chart.js
@@ -287,7 +287,7 @@ JQPlotLineChart.prototype.populateOptions = function (dataTable, options) {
     if (optional.axes.xaxis.ticks.length === 0) {
         var data = dataTable.getData();
         for (var j = 0; j < data.length; j++) {
-            optional.axes.xaxis.ticks.push(data[j][0].toString());
+            optional.axes.xaxis.ticks.push(data[j][0]?.toString());
         }
     }
     return optional;


### PR DESCRIPTION
### Description

I fixed the issue of not being able to access the 'toString' property because 'data[j][0]' is null.

Fixes #18563

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
