### PR TITLE
Fix #18561 - Add chart to System monitor increments the number with each new chart added

### DIFF
--- a/js/src/server/status/monitor.ts
+++ b/js/src/server/status/monitor.ts
@@ -570,7 +570,7 @@ AJAX.registerOnload('server/status/monitor.js', function () {
     });
 
     $('#monitorAddNewChartButton').on('click', function (event) {
-        $('#addChartButton').on('click', function () {
+        $('#addChartButton').one('click', function () {
             var type = $('input[name="chartType"]:checked').val();
 
             if (type === 'preset') {
@@ -583,6 +583,16 @@ AJAX.registerOnload('server/status/monitor.js', function () {
                     alert(window.Messages.strAddOneSeriesWarning);
 
                     return;
+                }
+            }
+
+            var numCharts = $('#chartGrid').find('.monitorChart').length;
+
+            /* Checking for duplicate charts */
+            for (let i = 0; i < numCharts; i++) {
+                if($('#' + 'gridchart' + i).find('.jqplot-title').text() === escapeHtml(newChart.title)) {
+                    alert('A chart with the same name exists');
+                    return
                 }
             }
 


### PR DESCRIPTION
### Description

This pull request was for the issue https://github.com/phpmyadmin/phpmyadmin/issues/18561. This PR does not affect the yarn.lock file and passes the js-lint. 

Fixes #

- Each time a new chart is added to System monitor, it is only added once and an attempt to add a duplicate one is returned.

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
