### PR TITLE
Fix param type in getSpecialLinkUrl()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9981,6 +9981,11 @@ parameters:
 			path: src/Display/Results.php
 
 		-
+			message: "#^Parameter \\#1 \\$params of static method PhpMyAdmin\\\\Url\\:\\:getCommonRaw\\(\\) expects array\\<int\\|string, bool\\|int\\|string\\>, array\\<string, string\\|null\\> given\\.$#"
+			count: 1
+			path: src/Display/Results.php
+
+		-
 			message: "#^Parameter \\#1 \\$sqlQuery of static method PhpMyAdmin\\\\Core\\:\\:signSqlQuery\\(\\) expects string, mixed given\\.$#"
 			count: 4
 			path: src/Display/Results.php
@@ -10011,7 +10016,7 @@ parameters:
 			path: src/Display/Results.php
 
 		-
-			message: "#^Parameter \\#2 \\$columnValue of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSpecialLinkUrl\\(\\) expects string, mixed given\\.$#"
+			message: "#^Parameter \\#2 \\$columnValue of method PhpMyAdmin\\\\Display\\\\Results\\:\\:getSpecialLinkUrl\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Display/Results.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5525,6 +5525,8 @@
     </DeprecatedMethod>
     <InvalidArgument>
       <code>$added[$orgFullTableName]</code>
+      <code>$linkingUrlParams</code>
+      <code>$linkingUrlParams</code>
       <code>$multiOrderUrlParams</code>
       <code>$sortExpressionNoDirection</code>
     </InvalidArgument>
@@ -5585,7 +5587,6 @@
       <code><![CDATA[empty($field->database) ? $this->properties['db'] : $field->database]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code>$linkingUrlParams</code>
       <code>$row</code>
       <code>$sortDirection</code>
       <code>$sortExpression</code>

--- a/src/Display/Results.php
+++ b/src/Display/Results.php
@@ -2487,7 +2487,6 @@ class Results
      * Get link for display special schema links
      *
      * @param array<string,array<int,array<string,string>>|string> $linkRelations
-     * @param string                                               $columnValue   column value
      * @param mixed[]                                              $rowInfo       information about row
      * @phpstan-param array{
      *                         'link_param': string,
@@ -2502,7 +2501,7 @@ class Results
      */
     private function getSpecialLinkUrl(
         array $linkRelations,
-        string $columnValue,
+        string|null $columnValue,
         array $rowInfo,
     ): string {
         $linkingUrlParams = [];


### PR DESCRIPTION
This seems to fix #18753, but I am not sure why we do it when the value is null. Perhaps, it would be better to skip this code if the value is null. 