### PR TITLE
Fix truncate operation for views

### DIFF
--- a/libraries/classes/Controllers/Database/Structure/EmptyTableController.php
+++ b/libraries/classes/Controllers/Database/Structure/EmptyTableController.php
@@ -14,6 +14,7 @@ use PhpMyAdmin\Message;
 use PhpMyAdmin\Operations;
 use PhpMyAdmin\ResponseRenderer;
 use PhpMyAdmin\Sql;
+use PhpMyAdmin\Table;
 use PhpMyAdmin\Template;
 use PhpMyAdmin\Transformations;
 use PhpMyAdmin\Util;
@@ -21,6 +22,7 @@ use PhpMyAdmin\Utils\ForeignKey;
 
 use function __;
 use function count;
+use function is_string;
 
 final class EmptyTableController extends AbstractController
 {
@@ -82,6 +84,10 @@ final class EmptyTableController extends AbstractController
         $selectedCount = count($selected);
 
         for ($i = 0; $i < $selectedCount; $i++) {
+            if (! is_string($selected[$i]) || Table::get($selected[$i], $GLOBALS['db'], $this->dbi)->isView()) {
+                continue;
+            }
+
             $aQuery = 'TRUNCATE ';
             $aQuery .= Util::backquote($selected[$i]);
 

--- a/libraries/classes/Partitioning/Maintenance.php
+++ b/libraries/classes/Partitioning/Maintenance.php
@@ -7,8 +7,10 @@ namespace PhpMyAdmin\Partitioning;
 use PhpMyAdmin\DatabaseInterface;
 use PhpMyAdmin\Dbal\DatabaseName;
 use PhpMyAdmin\Dbal\TableName;
+use PhpMyAdmin\Table;
 use PhpMyAdmin\Util;
 
+use function __;
 use function sprintf;
 
 final class Maintenance
@@ -135,6 +137,10 @@ final class Maintenance
      */
     public function truncate(DatabaseName $db, TableName $table, string $partition): array
     {
+        if (Table::get($table->getName(), $db->getName(), $this->dbi)->isView()) {
+            return [false, __('This table is a view, it can not be truncated.')];
+        }
+
         $query = sprintf(
             'ALTER TABLE %s TRUNCATE PARTITION %s;',
             Util::backquote($table->getName()),


### PR DESCRIPTION
### Description

This pull request was for the issue #18762 
Currently, attempting to truncate a view results in an error because views cannot be truncated. I think it would be better to just skip over the views when they are included in the list of tables to truncate to prevent errors.

- Fixes #18762 

I added a check to truncate function so that if the target is a view, the TRUNCATE operation is not executed.


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
