### PR TITLE
Fix search using enums

### DIFF
--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -125,9 +125,7 @@ class SearchController extends AbstractController
             }
 
             // reformat mysql query output
-            if (strncasecmp($type, 'set', 3) == 0 || strncasecmp($type, 'enum', 4) == 0) {
-                $type = str_replace(',', ', ', $type);
-            } else {
+            if (strncasecmp($type, 'set', 3) !== 0 && strncasecmp($type, 'enum', 4) !== 0) {
                 // strip the "BINARY" attribute, except if we find "BINARY(" because
                 // this would be a BINARY or VARBINARY column type
                 if (! preg_match('@BINARY[\(]@i', $type)) {

--- a/src/Controllers/Table/SearchController.php
+++ b/src/Controllers/Table/SearchController.php
@@ -35,7 +35,6 @@ use function md5;
 use function preg_match;
 use function preg_replace;
 use function str_ireplace;
-use function str_replace;
 use function strncasecmp;
 use function strtoupper;
 

--- a/src/Controllers/Table/ZoomSearchController.php
+++ b/src/Controllers/Table/ZoomSearchController.php
@@ -211,9 +211,7 @@ class ZoomSearchController extends AbstractController
             }
 
             // reformat mysql query output
-            if (strncasecmp($type, 'set', 3) == 0 || strncasecmp($type, 'enum', 4) == 0) {
-                $type = str_replace(',', ', ', $type);
-            } else {
+            if (strncasecmp($type, 'set', 3) !== 0 && strncasecmp($type, 'enum', 4) !== 0) {
                 // strip the "BINARY" attribute, except if we find "BINARY(" because
                 // this would be a BINARY or VARBINARY column type
                 if (! preg_match('@BINARY[\(]@i', $type)) {

--- a/src/Controllers/Table/ZoomSearchController.php
+++ b/src/Controllers/Table/ZoomSearchController.php
@@ -36,7 +36,6 @@ use function md5;
 use function preg_match;
 use function preg_replace;
 use function str_ireplace;
-use function str_replace;
 use function strncasecmp;
 use function strtoupper;
 


### PR DESCRIPTION
### Description

#18693 broke the selection of enums on searches as it couldn't deal with the space after a comma anymore. This PR removes the added spaces which restores the ability to use the select inputs on searches again

Before:
![grafik](https://github.com/phpmyadmin/phpmyadmin/assets/4395417/b56708ea-ea92-4ae8-8a4b-5351141ab157)

After:
![grafik](https://github.com/phpmyadmin/phpmyadmin/assets/4395417/71cb1581-4877-4bdf-b9c4-cea43c0d0e8d)


Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [ ] Any new functionality is covered by tests.
